### PR TITLE
Restructure skills to align with skill-creator guidelines

### DIFF
--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -25,11 +25,11 @@ You stop at step 1. Capture context. Don't jump to plans or code.
 
 **On length**: Discussions can be thousands of lines. Length = whatever needed to fully capture discussion, debates, edge cases, false paths. Terseness preferred, but comprehensive documentation more important. Don't summarize - document.
 
-See **[meeting-assistant.md](meeting-assistant.md)** for detailed approach.
+See **[meeting-assistant.md](references/meeting-assistant.md)** for detailed approach.
 
 ## Structure
 
-Use **[template.md](template.md)** for discussions in `plan/discussion/`:
+Use **[template.md](references/template.md)** for discussions in `plan/discussion/`:
 
 - **Context**: What sparked this
 - **Options Explored**: Approaches considered
@@ -45,7 +45,7 @@ Use **[template.md](template.md)** for discussions in `plan/discussion/`:
 
 **Don't**: Transcribe verbatim, write code/implementation, create build phases, skip context
 
-See **[guidelines.md](guidelines.md)** for best practices and anti-hallucination techniques.
+See **[guidelines.md](references/guidelines.md)** for best practices and anti-hallucination techniques.
 
 ## Commit Frequently
 
@@ -60,6 +60,6 @@ See **[guidelines.md](guidelines.md)** for best practices and anti-hallucination
 
 ## Quick Reference
 
-- **Approach**: **[meeting-assistant.md](meeting-assistant.md)** - Dual role, workflow
-- **Template**: **[template.md](template.md)** - Structure
-- **Guidelines**: **[guidelines.md](guidelines.md)** - Best practices
+- **Approach**: **[meeting-assistant.md](references/meeting-assistant.md)** - Dual role, workflow
+- **Template**: **[template.md](references/template.md)** - Structure
+- **Guidelines**: **[guidelines.md](references/guidelines.md)** - Best practices

--- a/skills/technical-discussion/references/guidelines.md
+++ b/skills/technical-discussion/references/guidelines.md
@@ -1,6 +1,6 @@
 # Discussion Documentation Guidelines
 
-*Part of **[discussion-documentation](skill.md)** | See also: **[meeting-assistant.md](meeting-assistant.md)** · **[template.md](template.md)***
+*Part of **[technical-discussion](../SKILL.md)** | See also: **[meeting-assistant.md](meeting-assistant.md)** · **[template.md](template.md)***
 
 ---
 

--- a/skills/technical-discussion/references/meeting-assistant.md
+++ b/skills/technical-discussion/references/meeting-assistant.md
@@ -1,6 +1,6 @@
 # Discussion Documentation Approach
 
-*Part of **[discussion-documentation](skill.md)** | See also: **[template.md](template.md)** · **[guidelines.md](guidelines.md)***
+*Part of **[technical-discussion](../SKILL.md)** | See also: **[template.md](template.md)** · **[guidelines.md](guidelines.md)***
 
 ---
 

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -1,6 +1,6 @@
 # Discussion Document Template
 
-*Part of **[discussion-documentation](skill.md)** | See also: **[meeting-assistant.md](meeting-assistant.md)** · **[guidelines.md](guidelines.md)***
+*Part of **[technical-discussion](../SKILL.md)** | See also: **[meeting-assistant.md](meeting-assistant.md)** · **[guidelines.md](guidelines.md)***
 
 ---
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -22,7 +22,7 @@ You're at step 2. Don't implement.
 
 ## Plan Contents
 
-Use **[template.md](template.md)**:
+Use **[template.md](references/template.md)**:
 - Phases with specific tasks
 - Code examples (pseudocode/actual in plan doc)
 - Testing strategy
@@ -41,9 +41,9 @@ Use **[template.md](template.md)**:
 
 ## Reference Files
 
-- **[planning-approach.md](planning-approach.md)** - Workflow, step-by-step
-- **[template.md](template.md)** - Plan structure
-- **[guidelines.md](guidelines.md)** - Best practices, examples
+- **[planning-approach.md](references/planning-approach.md)** - Workflow, step-by-step
+- **[template.md](references/template.md)** - Plan structure
+- **[guidelines.md](references/guidelines.md)** - Best practices, examples
 
 ## Remember
 

--- a/skills/technical-planning/references/guidelines.md
+++ b/skills/technical-planning/references/guidelines.md
@@ -1,6 +1,6 @@
 # Technical Planning Guidelines
 
-*Part of **[technical-planning](SKILL.md)** | See also: **[planning-approach.md](planning-approach.md)** · **[template.md](template.md)***
+*Part of **[technical-planning](../SKILL.md)** | See also: **[planning-approach.md](planning-approach.md)** · **[template.md](template.md)***
 
 ---
 

--- a/skills/technical-planning/references/planning-approach.md
+++ b/skills/technical-planning/references/planning-approach.md
@@ -1,6 +1,6 @@
 # Technical Planning Approach
 
-*Part of **[technical-planning](SKILL.md)** | See also: **[template.md](template.md)** · **[guidelines.md](guidelines.md)***
+*Part of **[technical-planning](../SKILL.md)** | See also: **[template.md](template.md)** · **[guidelines.md](guidelines.md)***
 
 ---
 

--- a/skills/technical-planning/references/template.md
+++ b/skills/technical-planning/references/template.md
@@ -1,6 +1,6 @@
 # Implementation Plan Template
 
-*Part of **[technical-planning](SKILL.md)** | See also: **[planning-approach.md](planning-approach.md)** · **[guidelines.md](guidelines.md)***
+*Part of **[technical-planning](../SKILL.md)** | See also: **[planning-approach.md](planning-approach.md)** · **[guidelines.md](guidelines.md)***
 
 ---
 


### PR DESCRIPTION
- Organize supporting documentation into references/ directories
- Rename technical-discussion/skill.md to SKILL.md (proper naming)
- Update all internal references to use correct relative paths
- Maintain all content without loss

Both skills now follow the proper structure:
- SKILL.md (required main file)
- references/ (supporting documentation)

This aligns with the skill-creator best practices for progressive
disclosure and proper file organization.