### PR TITLE
Add /start-discussion command and update skill for directory structure

### DIFF
--- a/.claude/commands/start-discussion.md
+++ b/.claude/commands/start-discussion.md
@@ -25,10 +25,6 @@ Before beginning, ask the user these questions to properly set up the discussion
    - Should I explore any particular directories or components?
    - Is there existing code related to this discussion?
 
-5. **Participants & Stakeholders**:
-   - Who else is involved in this discussion?
-   - Are there specific perspectives or concerns to consider?
-
 ## After Gathering Information
 
 Once I have this information:

--- a/.claude/commands/start-discussion.md
+++ b/.claude/commands/start-discussion.md
@@ -1,0 +1,41 @@
+---
+description: Start a technical discussion using the technical-discussion skill. Gathers information about the topic and creates discussion documentation in plan/discussion/<topic-name>/
+---
+
+Invoke the **technical-discussion** skill for this conversation.
+
+Before beginning, ask the user these questions to properly set up the discussion:
+
+## Essential Information
+
+1. **Discussion Topic**: What are we discussing? (This will be used to create the directory name in `plan/discussion/<topic-name>/`)
+
+2. **Context & Background**:
+   - What sparked this discussion?
+   - What problem are we trying to solve?
+   - Why are we discussing this now?
+
+3. **Foundational Knowledge**:
+   - Is there any background information I need to understand before we begin?
+   - Are there specific concepts, technologies, or architectures I should know about?
+   - Any constraints, requirements, or limitations I should be aware of?
+
+4. **Codebase Review**:
+   - Are there specific files in this repository I should read first?
+   - Should I explore any particular directories or components?
+   - Is there existing code related to this discussion?
+
+5. **Participants & Stakeholders**:
+   - Who else is involved in this discussion?
+   - Are there specific perspectives or concerns to consider?
+
+## After Gathering Information
+
+Once I have this information:
+- Create directory: `plan/discussion/<topic-name>/`
+- Start documenting the discussion following the technical-discussion skill structure
+- Create initial file (e.g., `discussion.md`)
+- Add more files as the discussion evolves (research notes, supporting docs, etc.)
+- Commit frequently at natural discussion breaks
+
+Ask these questions clearly and wait for responses before proceeding with the discussion.

--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -29,7 +29,17 @@ See **[meeting-assistant.md](references/meeting-assistant.md)** for detailed app
 
 ## Structure
 
-Use **[template.md](references/template.md)** for discussions in `plan/discussion/`:
+Discussions are stored in `plan/discussion/<topic-name>/` directories. Each discussion gets its own directory containing one or more markdown files.
+
+**Single vs Multiple Files**:
+- Start with single file (e.g., `discussion.md`)
+- Break into multiple files as discussion evolves:
+  - `part-1.md`, `part-2.md` for long discussions
+  - `main-discussion.md`, `research-notes.md` for supporting material
+  - Topic-specific files if discussion naturally forks
+  - Diagrams, code examples, or other relevant artifacts
+
+Use **[template.md](references/template.md)** for structure:
 
 - **Context**: What sparked this
 - **Options Explored**: Approaches considered
@@ -49,12 +59,13 @@ See **[guidelines.md](references/guidelines.md)** for best practices and anti-ha
 
 ## Commit Frequently
 
-**Commit discussion docs often** to `plan/discussion/`:
+**Commit discussion docs often** to `plan/discussion/<topic-name>/`:
 
 - At natural breaks in discussion
 - When solutions to problems are identified
 - When discussion branches/forks to new topics
 - Before context refresh (prevents hallucination/memory loss)
+- When creating new files in the discussion directory
 
 **Why**: You lose memory on context refresh. Commits help you track, backtrack, and fill gaps. Critical for avoiding hallucination.
 

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -4,7 +4,7 @@
 
 ---
 
-Standard structure for `plan/discussion/` documents. DOCUMENT only - no plans or code.
+Standard structure for `plan/discussion/<topic-name>/` documents. Each discussion gets its own directory with one or more markdown files. DOCUMENT only - no plans or code.
 
 ## Template
 
@@ -116,10 +116,11 @@ Made decision on X, ruled out Y
 ## Usage Notes
 
 **When creating**:
-1. Create: `plan/discussion/{topic}.md`
-2. Fill header: date, status, participants
-3. Start with context: why discussing?
-4. List questions: what needs deciding?
+1. Create directory: `plan/discussion/<topic-name>/`
+2. Create initial file: `discussion.md` (or `part-1.md`, `main-discussion.md`)
+3. Fill header: date, status, participants
+4. Start with context: why discussing?
+5. List questions: what needs deciding?
 
 **During discussion**:
 - Update open questions as answered
@@ -127,6 +128,11 @@ Made decision on X, ruled out Y
 - Document false paths immediately
 - Record decisions with full rationale
 - Update current state
+- Create additional files as needed:
+  - Long discussions: `part-2.md`, `part-3.md`
+  - Supporting material: `research-notes.md`, `analysis.md`
+  - Forks/branches: Topic-specific files
+  - Artifacts: Code examples, diagrams, etc.
 
 **Optional sections**: Skip what doesn't apply. Always include Context, Decisions, Impact.
 


### PR DESCRIPTION
- Create /start-discussion command to initiate technical discussions
  - Asks questions about discussion topic and context
  - Gathers foundational knowledge requirements
  - Identifies relevant codebase files to review
  - References technical-discussion skill

- Update technical-discussion skill to use directory structure
  - Discussions stored in plan/discussion/<topic-name>/ directories
  - Support multiple files per discussion (parts, research notes, etc.)
  - Document file organization strategies
  - Update template and usage notes

The command streamlines discussion initiation by gathering all necessary
context before beginning the documentation process.