### PR TITLE
Restructure discussion template to per-question format

### DIFF
--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -29,25 +29,15 @@ See **[meeting-assistant.md](references/meeting-assistant.md)** for detailed app
 
 ## Structure
 
-Discussions are stored in `docs/specs/discussions/<topic-name>/` directories. Each discussion gets its own directory containing one or more markdown files.
-
-**Single vs Multiple Files**:
-- Start with single file (e.g., `discussion.md`)
-- Break into multiple files as discussion evolves:
-  - `part-1.md`, `part-2.md` for long discussions
-  - `main-discussion.md`, `research-notes.md` for supporting material
-  - Topic-specific files if discussion naturally forks
-  - Diagrams, code examples, or other relevant artifacts
+Discussions are stored in `docs/specs/discussions/<topic-name>/discussion.md`. Each discussion gets its own directory with a single markdown file.
 
 Use **[template.md](references/template.md)** for structure:
 
-- **Context**: What sparked this
-- **Options Explored**: Approaches considered
-- **Debates**: Back-and-forth, challenges
-- **False Paths**: What didn't work, why
-- **Decisions**: What we chose, rationale
-- **Edge Cases**: Problems solved
-- **Impact**: Why it matters
+- **Document-level**: Context, references, questions list
+- **Per-question**: Each question gets its own section with options, journey, and decision
+- **Summary**: Key insights, current state, next steps
+
+**Per-question structure** keeps the reasoning contextual. Options considered, false paths, debates, and "aha" moments belong with the specific question they relate to - not as separate top-level sections. This preserves the journey alongside the decision.
 
 ## Do / Don't
 

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -116,7 +116,7 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 **Anti-patterns**:
 - Don't pull false paths into a separate top-level section - keep them with the question they relate to
 - Don't turn into plan (no implementation steps)
-- Don't write code
+- Don't write code - unless it came up in discussion (e.g., API shape, pattern example) and is relevant to capture
 - Don't summarise the journey - document it
 
 **Complete when**:

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -6,6 +6,8 @@
 
 Standard structure for `docs/specs/discussions/<topic-name>/discussion.md`. Each discussion gets its own directory with a single markdown file. DOCUMENT only - no plans or code.
 
+**This is a guide, not a form.** Use the structure to capture what naturally emerges from discussion. Don't force sections that didn't come up. The goal is to document the reasoning journey, not fill in every field.
+
 ## Template
 
 ```markdown
@@ -45,10 +47,22 @@ What this is about, why we're discussing it, the problem or opportunity, current
 Why this question matters, what's at stake.
 
 ### Options Considered
-The approaches we looked at and their trade-offs.
+The approaches we looked at. If pros/cons naturally emerged:
+
+**Option A**
+- Pros: ...
+- Cons: ...
+
+**Option B**
+- Pros: ...
+- Cons: ...
 
 ### Journey
 The back-and-forth exploration. What we initially thought. What changed our thinking. False paths - "We considered A but realised B because C." The "aha" moments. Small details that mattered.
+
+If there was notable debate:
+- **Positions**: What each side argued
+- **Resolution**: What made us choose, what detail tipped it
 
 ### Decision
 What we chose, why, the deciding factor, trade-offs accepted, confidence level.
@@ -93,11 +107,11 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 
 **Per-question structure**:
 - **Context**: Why this specific question matters
-- **Options Considered**: Approaches explored and their trade-offs
-- **Journey**: The exploration - what we thought, what changed, false paths, insights
+- **Options Considered**: Approaches explored - include pros/cons if they naturally emerged
+- **Journey**: The exploration - what we thought, what changed, false paths, debates, insights
 - **Decision**: What we chose, why, the deciding factor
 
-**Optional sections**: Not every question needs all four sub-sections. Context and Decision are most important. Options and Journey depend on complexity.
+**Flexibility**: Not every question needs all sections. Some questions have clear options with pros/cons. Some have heated debate worth capturing. Some are straightforward. Document what naturally came up - don't force structure onto a simple discussion.
 
 **Anti-patterns**:
 - Don't pull false paths into a separate top-level section - keep them with the question they relate to

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -4,7 +4,7 @@
 
 ---
 
-Standard structure for `docs/specs/discussions/<topic-name>/` documents. Each discussion gets its own directory with one or more markdown files. DOCUMENT only - no plans or code.
+Standard structure for `docs/specs/discussions/<topic-name>/discussion.md`. Each discussion gets its own directory with a single markdown file. DOCUMENT only - no plans or code.
 
 ## Template
 
@@ -13,136 +13,99 @@ Standard structure for `docs/specs/discussions/<topic-name>/` documents. Each di
 
 **Date**: YYYY-MM-DD
 **Status**: Exploring | Deciding | Concluded
-**Participants**: {Who}
 
 ## Context
 
-Problem, why now, pain point, current state.
+What this is about, why we're discussing it, the problem or opportunity, current state.
 
-## Open Questions
+### References
 
-- [ ] Question 1?
-- [ ] Question 2?
+- [Related spec or doc](link)
+- [Prior discussion](link)
 
-(Check off as answered)
+## Questions
 
-## Options Explored
+- [ ] How should we handle X?
+      - Sub-question about edge case
+      - Context: brief note if needed
+- [ ] What's the right approach for Y?
+- [ ] Should Z be separate or combined with W?
+      - Related: how does this affect A?
+- [ ] ...
 
-### Option: {Name}
+---
 
-**Pros**: Advantages
-**Cons**: Disadvantages
-**Trade-offs**: What we gain vs give up
+*Each question above gets its own section below. Check off as concluded.*
 
-(Repeat for each option)
+---
 
-## Back-and-Forth Debates
+## How should we handle X?
 
-When discussion prolonged/challenging - capture it!
+### Context
+Why this question matters, what's at stake.
 
-### Debate: {Topic}
+### Options Considered
+The approaches we looked at and their trade-offs.
 
-**Positions**: What each side argued
-**Arguments**: Pro/con for each, counter-points
-**Resolution**: What made us choose, small details that mattered
-**Learning**: What we learned
+### Journey
+The back-and-forth exploration. What we initially thought. What changed our thinking. False paths - "We considered A but realised B because C." The "aha" moments. Small details that mattered.
 
-## Edge Cases
+### Decision
+What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 
-### Edge Case: {Description}
+---
 
-**Problem**: What's the edge case
-**Impact**: Why it matters
-**Solution**: How we'll address it
-**Status**: Solved | Needs Research | Acceptable Risk
+## What's the right approach for Y?
 
-## False Paths
+*(Same structure: Context → Options → Journey → Decision)*
 
-### False Path: {Name}
+---
 
-**Tried**: What we attempted
-**Why failed**: Reasons it didn't work
-**Learned**: Key insights
-**Revisit**: Conditions to reconsider
+## Summary
 
-## Decisions Made
+### Key Insights
+1. Cross-cutting learning from the discussion
+2. Something that applies broadly
 
-### Decision: {What}
-
-**Date**: YYYY-MM-DD
-**What chosen**: Clear statement
-**Rationale**: Why, deciding factor, trade-offs accepted
-**Alternatives**: What else considered, why rejected
-**Implications**: System impact, constraints, what enabled
-**Confidence**: High | Medium | Low (why?)
-
-## Key Insights
-
-1. Insight 1
-2. Insight 2
-
-## Impact
-
-**Who affected**: Users, teams
-**Problem solved**: What this fixes
-**Enabled**: New capabilities
-**Risk mitigated**: What safer now
-
-## Current State
-
-- What's clear now
+### Current State
+- What's resolved
 - What's still uncertain
-- Assumptions we're making
-- Needs more exploration
 
-## Next Steps
-
-What happens next (NOT implementation - just discussion/exploration):
+### Next Steps
 - [ ] Research X
 - [ ] Validate Y
-- [ ] Decide Z
-
-## Evolution Log
-
-Track how discussion evolved:
-
-### YYYY-MM-DD - Initial
-Started exploring {topic}
-
-### YYYY-MM-DD - {Milestone}
-Made decision on X, ruled out Y
 ```
 
 ## Usage Notes
 
 **When creating**:
 1. Create directory: `docs/specs/discussions/<topic-name>/`
-2. Create initial file: `discussion.md` (or `part-1.md`, `main-discussion.md`)
-3. Fill header: date, status, participants
+2. Create file: `discussion.md`
+3. Fill header: date, status
 4. Start with context: why discussing?
 5. List questions: what needs deciding?
 
 **During discussion**:
-- Update open questions as answered
-- Add options as explored
-- Document false paths immediately
-- Record decisions with full rationale
-- Update current state
-- Create additional files as needed:
-  - Long discussions: `part-2.md`, `part-3.md`
-  - Supporting material: `research-notes.md`, `analysis.md`
-  - Forks/branches: Topic-specific files
-  - Artifacts: Code examples, diagrams, etc.
+- Work through questions one at a time
+- Document options, journey, and decision for each
+- Check off questions as concluded
+- Keep journey contextual - false paths, debates, and "aha" moments belong with the question they relate to
 
-**Optional sections**: Skip what doesn't apply. Always include Context, Decisions, Impact.
+**Per-question structure**:
+- **Context**: Why this specific question matters
+- **Options Considered**: Approaches explored and their trade-offs
+- **Journey**: The exploration - what we thought, what changed, false paths, insights
+- **Decision**: What we chose, why, the deciding factor
+
+**Optional sections**: Not every question needs all four sub-sections. Context and Decision are most important. Options and Journey depend on complexity.
 
 **Anti-patterns**:
-- ❌ Don't turn into plan (no implementation steps)
-- ❌ Don't write code
-- ❌ Don't make it formal spec
+- Don't pull false paths into a separate top-level section - keep them with the question they relate to
+- Don't turn into plan (no implementation steps)
+- Don't write code
+- Don't summarise the journey - document it
 
 **Complete when**:
-- Major decisions made with rationale
-- Questions answered (or parked)
+- Major questions concluded with rationale
 - Trade-offs understood
 - Path forward clear


### PR DESCRIPTION
- Replace flat top-level sections with per-question structure
- Each question gets its own section: Context → Options → Journey → Decision
- False paths now documented contextually within each question's journey
- Remove participants field and evolution log
- Simplify to single file per discussion
- Update SKILL.md to reflect per-question approach