### PR TITLE
Add draft planning workflow and immediate capture rules to planning skill

### DIFF
--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -37,6 +37,54 @@ The planning *approach* is the same regardless of destination. Only the output f
 
 You're at step 2. Don't implement.
 
+## Draft Planning for Complex Features
+
+For complex or deeply technical work, planning itself requires discussion. Figuring out phases and tasks IS a conversation that needs capturing.
+
+**Two-phase planning**:
+1. **Draft Planning**: Back-and-forth about structure, captured in `draft-plan.md`
+2. **Formal Planning**: Convert draft to structured `plan.md` (or Linear/Backlog.md)
+
+See **[planning-conversations.md](references/planning-conversations.md)** for the draft planning workflow.
+
+**When to use draft planning**:
+- Complex features with unclear phase boundaries
+- Deeply technical work requiring back-and-forth
+- Multiple valid ways to structure the work
+
+**Skip to formal planning when**:
+- Structure is obvious from discussion doc
+- Small feature with clear phases
+
+## Capture Planning Conversations Immediately
+
+> **After each user response, IMMEDIATELY update the planning document before asking your next question. Capture the user's exact words and reasoning, not summaries.**
+
+Context windows refresh without warning. Hours of planning discussion can vanish.
+
+**Capture frequency**:
+- Update after every natural break in discussion
+- Never let more than 2-3 exchanges pass without writing
+- When in doubt, write it down NOW
+
+**What to capture**:
+- What the user said AND why, not just conclusions
+- Trade-offs considered and rejected
+- Scope decisions with reasoning
+- The journey, not just the destination
+
+## Commit Frequently
+
+**Commit planning docs often** to `docs/specs/plans/{topic-name}/`:
+
+- After each significant exchange
+- At natural breaks in planning discussion
+- When phases/tasks become clearer
+- **Before any context refresh**
+- When creating new files
+
+**Why**: You lose memory on context refresh. Commits prevent losing hours of planning work. This is non-negotiable.
+
 ## You Create Plans, NOT Code
 
 **Your job**: Write plan document with phases, tasks, and acceptance criteria
@@ -97,6 +145,7 @@ Implementation will:
 ## Reference Files
 
 **Planning approach**:
+- **[planning-conversations.md](references/planning-conversations.md)** - Draft planning for complex features
 - **[planning-approach.md](references/planning-approach.md)** - Workflow, step-by-step
 - **[guidelines.md](references/guidelines.md)** - Best practices, task sizing
 - **[template.md](references/template.md)** - Plan document template (for local markdown)

--- a/skills/technical-planning/references/guidelines.md
+++ b/skills/technical-planning/references/guidelines.md
@@ -24,6 +24,24 @@ If you don't know something, don't guess. If the discussion is missing informati
 
 Planning is iterative. You don't need complete information on pass one. Create structure, flag gaps, refine.
 
+### After Context Refresh
+
+You have summaries, not nuance. The planning documents ARE the nuance.
+
+**If draft/plan documents exist**: Read them. Trust them. They have reasoning you've lost.
+
+**If no documents exist**: You've lost the planning conversation. Be honest. Don't pretend you remember details you don't have.
+
+**Never invent reasoning** that wasn't captured. If it's not in the document, ask again.
+
+### Immediate Capture
+
+> After each user response, IMMEDIATELY update the planning document before asking your next question.
+
+- Capture the user's exact words and reasoning, not summaries
+- Never let more than 2-3 exchanges pass without writing
+- Record what was said AND why, not just conclusions
+
 ### Task Design
 
 - **One task = One TDD cycle**: write test → implement → pass → commit

--- a/skills/technical-planning/references/planning-approach.md
+++ b/skills/technical-planning/references/planning-approach.md
@@ -13,6 +13,22 @@ Bridge between discussion and implementation. Convert decisions into executable 
 
 ## Workflow
 
+### 0. Draft Planning (For Complex Features)
+
+For complex or deeply technical work, the planning conversation itself needs capturing.
+
+**Before jumping to formal phases and tasks**:
+1. Create `draft-plan.md` in the plans directory
+2. Discuss structure with the user
+3. Capture the conversation in real-time (see below)
+4. Once structure is agreed, proceed to formal planning
+
+**Immediate capture rule**: After each user response, update the draft document BEFORE your next question. Never let 2-3 exchanges pass without writing.
+
+See **[planning-conversations.md](planning-conversations.md)** for full draft planning workflow.
+
+**Skip draft planning when**: Structure is obvious, small feature, user knows exactly what they want.
+
 ### 1. Read Discussion Document
 
 From `docs/specs/discussions/{topic}/` extract:
@@ -61,3 +77,13 @@ Verify:
 Create `docs/specs/plans/{topic-name}/plan.md` using [template.md](template.md).
 
 Implementation can execute via strict TDD without going back to discussion.
+
+## Commit Frequently
+
+Commit planning docs at:
+- After each significant exchange during draft planning
+- At natural breaks in discussion
+- When phases/tasks become clearer
+- **Before any context refresh**
+
+Context refresh = memory loss. Uncommitted work = lost work.

--- a/skills/technical-planning/references/planning-conversations.md
+++ b/skills/technical-planning/references/planning-conversations.md
@@ -1,0 +1,188 @@
+# Planning Conversations
+
+*Reference for **[technical-planning](../SKILL.md)***
+
+---
+
+## The Problem
+
+Planning complex features requires discussion. Figuring out what phases and tasks should exist IS a conversation - and that conversation can be lost to context window refresh just like any other.
+
+**Lost context = lost nuance**. A summary after refresh contains conclusions, not the reasoning. The "why we structured it this way" is gone.
+
+## Two-Phase Planning
+
+For complex or deeply technical work, planning happens in two phases:
+
+### Phase A: Draft Planning (Capture)
+
+A back-and-forth conversation about structure:
+- What phases make sense?
+- How should we break this down?
+- What order? What dependencies?
+- What's the scope of each task?
+
+**Output**: `draft-plan.md` - running log of the planning conversation
+
+### Phase B: Formal Planning (Organize)
+
+Convert draft into structured format:
+- Phases with acceptance criteria
+- Tasks with micro acceptance
+- Ready for implementation
+
+**Output**: `plan.md` (or Linear/Backlog.md depending on destination)
+
+## When to Use Draft Planning
+
+**Use draft planning when**:
+- Complex feature with unclear phase boundaries
+- Deeply technical work requiring back-and-forth
+- Multiple valid ways to structure the work
+- User wants to think through the approach together
+
+**Skip to formal planning when**:
+- Structure is obvious from discussion doc
+- Small feature with clear phases
+- User already knows exactly how they want it structured
+
+## Critical Rule: Immediate Capture
+
+> **After each user response, IMMEDIATELY update the draft document before asking your next question.**
+
+This is non-negotiable. Context windows refresh without warning. Three hours of planning discussion can vanish.
+
+### Capture Frequency
+
+- Update after **every natural break** in discussion
+- **Never let more than 2-3 exchanges pass** without writing
+- When in doubt, write it down NOW
+
+### What to Capture
+
+Record **what the user said AND why**, not just conclusions:
+
+**Bad**: "Phase 1 will handle authentication"
+
+**Good**: "User wants auth first because: (1) everything depends on knowing who the user is, (2) can't test other features without login working, (3) existing auth is partially broken and blocking current work"
+
+### Capture the Reasoning Journey
+
+- Why this phase before that one
+- Trade-offs considered
+- Alternative structures rejected and why
+- Concerns raised and how addressed
+- Scope decisions (what's in, what's out, why)
+
+## Draft Document Format
+
+Use a running log format. Raw capture first, organize later.
+
+```markdown
+# Draft Plan: [Topic Name]
+
+**Status**: Draft - capturing planning discussion
+**Created**: [date]
+**Last Updated**: [timestamp]
+
+---
+
+## Planning Log
+
+### [timestamp] Initial Structure Discussion
+
+User wants to start with [X] because [reasoning].
+
+Considered starting with [Y] instead, but [why rejected].
+
+Key constraint: [what limits our options].
+
+### [timestamp] Phase Breakdown
+
+Discussing how to split the work:
+
+**Option A**: [description]
+- Pro: [benefit]
+- Con: [drawback]
+
+**Option B**: [description]
+- Pro: [benefit]
+- Con: [drawback]
+
+User leaning toward Option A because [specific reasoning].
+
+### [timestamp] Task Granularity
+
+For Phase 1, user wants tasks like:
+- [task idea] - reasoning: [why this granularity]
+- [task idea] - concern: [what might be tricky]
+
+Discussed whether [X] should be one task or two. Decision: [outcome] because [why].
+
+### [timestamp] Dependencies and Order
+
+[Y] must come before [Z] because [specific dependency].
+
+User noted that [A] and [B] could be parallel since [reasoning].
+
+---
+
+## Emerging Structure
+
+(Update this as structure becomes clear)
+
+### Phase 1: [Name]
+- Goal: [what this accomplishes]
+- Tasks identified so far:
+  - [ ] [task]
+  - [ ] [task]
+
+### Phase 2: [Name]
+- Goal: [what this accomplishes]
+- Depends on: Phase 1 because [why]
+- Tasks identified so far:
+  - [ ] [task]
+
+---
+
+## Open Questions
+
+- [ ] [question still being discussed]
+- [ ] [decision not yet made]
+
+## Decisions Made
+
+- [decision]: [reasoning captured]
+```
+
+## Commit Frequently
+
+**Commit the draft document**:
+- After each significant exchange
+- At natural breaks in discussion
+- When structure becomes clearer
+- **Before any context refresh**
+- When creating the initial file
+
+Commits are your safety net. A context refresh with uncommitted work = lost work.
+
+## Transitioning to Formal Plan
+
+When draft planning is complete:
+
+1. Review the draft document together
+2. User confirms the emerging structure
+3. Create formal `plan.md` using the [template](template.md)
+4. Keep `draft-plan.md` for reference (the "why we structured it this way")
+
+The draft captures the journey. The formal plan captures the destination.
+
+## Anti-Hallucination
+
+After context refresh, you have summaries, not nuance. The draft document IS the nuance.
+
+**If the draft exists**: Read it. Trust it. It has the reasoning you've lost.
+
+**If no draft exists**: You've lost the planning conversation. Be honest about this. Don't pretend you remember details you don't have.
+
+**Never invent reasoning** that wasn't captured. If it's not in the document, ask again.


### PR DESCRIPTION
- Create planning-conversations.md reference for complex features requiring
  back-and-forth discussion about structure before formal planning
- Add "Capture Planning Conversations Immediately" section to SKILL.md with
  strict frequency mandate (update after every exchange, never 2-3 without writing)
- Add step 0 "Draft Planning" to planning-approach.md workflow
- Add anti-hallucination and immediate capture guidelines to guidelines.md
- Add commit frequency rules throughout (context refresh = lost work)

Addresses the problem of losing planning discussion context when context
window refreshes. The draft document captures the journey (why we structured
it this way) while the formal plan captures the destination.