### PR TITLE
Add technical-specification skill for five-phase workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,28 +6,31 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Claude Code skills package for structured technical discussion and planning workflows. Distributed via Composer as `leeovery/claude-technical-workflows`.
 
-## Four-Phase Workflow
+## Five-Phase Workflow
 
 1. **Discussion** (`technical-discussion` skill): Capture WHAT and WHY - decisions, architecture, edge cases, debates
-2. **Planning** (`technical-planning` skill): Define HOW - phases, tasks, acceptance criteria
-3. **Implementation** (`technical-implementation` skill): Execute plan via strict TDD
-4. **Review** (`technical-review` skill): Validate work against discussion and plan
+2. **Specification** (`technical-specification` skill): Validate and refine into standalone spec
+3. **Planning** (`technical-planning` skill): Define HOW - phases, tasks, acceptance criteria
+4. **Implementation** (`technical-implementation` skill): Execute plan via strict TDD
+5. **Review** (`technical-review` skill): Validate work against discussion, specification, and plan
 
 ## Structure
 
 ```
 skills/
-  technical-discussion/    # Phase 1: Document discussions
-  technical-planning/      # Phase 2: Create implementation plans
-  technical-implementation/ # Phase 3: Execute via TDD
-  technical-review/        # Phase 4: Validate against artifacts
+  technical-discussion/      # Phase 1: Document discussions
+  technical-specification/   # Phase 2: Build validated specifications
+  technical-planning/        # Phase 3: Create implementation plans
+  technical-implementation/  # Phase 4: Execute via TDD
+  technical-review/          # Phase 5: Validate against artifacts
 commands/
-  start-discussion.md      # Slash command to begin discussions
+  start-discussion.md        # Slash command to begin discussions
 ```
 
 ## Key Conventions
 
 - Discussion docs: `docs/specs/discussions/<topic-name>/discussion.md`
+- Specification docs: `docs/specs/specifications/<topic-name>/specification.md`
 - Plan docs: `docs/specs/plans/<topic-name>/`
-- Commit discussion docs frequently (natural breaks, before context refresh)
+- Commit docs frequently (natural breaks, before context refresh)
 - Skills capture context, don't implement

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="#installation">Installation</a> •
-  <a href="#the-four-phase-workflow">Workflow</a> •
+  <a href="#the-five-phase-workflow">Workflow</a> •
   <a href="#skills">Skills</a> •
   <a href="#commands">Commands</a> •
   <a href="#how-it-works">How It Works</a> •
@@ -17,7 +17,7 @@
 
 ## About
 
-A structured approach to technical discussions and implementation planning with Claude Code. These skills enforce a deliberate **discuss-then-plan-then-implement-then-review** workflow that captures context, decisions, and rationale before any code is written—then validates the work against those artifacts.
+A structured approach to technical discussions and implementation planning with Claude Code. These skills enforce a deliberate **discuss-then-specify-then-plan-then-implement-then-review** workflow that captures context, decisions, and rationale before any code is written—then validates the work against those artifacts.
 
 **Why this matters:** Complex features benefit from thorough discussion before implementation. These skills help you document the *what* and *why* before diving into the *how*—preserving architectural decisions, edge cases, and the reasoning behind choices that would otherwise be lost.
 
@@ -31,35 +31,37 @@ composer require --dev leeovery/claude-technical-workflows
 
 That's it. The [Claude Manager](https://github.com/leeovery/claude-manager) handles everything else automatically.
 
-## The Four-Phase Workflow
+## The Five-Phase Workflow
 
-This package enforces a deliberate progression through four distinct phases:
+This package enforces a deliberate progression through five distinct phases:
 
 ```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│   Discussion    │ ──▶ │    Planning     │ ──▶ │ Implementation  │ ──▶ │     Review      │
-│   (Phase 1)     │     │    (Phase 2)    │     │    (Phase 3)    │     │    (Phase 4)    │
-├─────────────────┤     ├─────────────────┤     ├─────────────────┤     ├─────────────────┤
-│ WHAT and WHY    │     │ HOW             │     │ DOING           │     │ VALIDATING      │
-│                 │     │                 │     │                 │     │                 │
-│ • Architecture  │     │ • Phases        │     │ • Tests first   │     │ • Plan check    │
-│ • Decisions     │     │ • Tasks         │     │ • Then code     │     │ • Decision check│
-│ • Edge cases    │     │ • Acceptance    │     │ • Commit often  │     │ • Test quality  │
-│ • Debates       │     │   criteria      │     │ • Phase gates   │     │ • Code quality  │
-│ • Rationale     │     │ • Output format │     │                 │     │                 │
-└─────────────────┘     └─────────────────┘     └─────────────────┘     └─────────────────┘
-         ▲                       ▲                       ▲                       ▲
-         │                       │                       │                       │
-  technical-discussion    technical-planning    technical-implementation  technical-review
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   Discussion    │ ──▶ │  Specification  │ ──▶ │    Planning     │ ──▶ │ Implementation  │ ──▶ │     Review      │
+│   (Phase 1)     │     │    (Phase 2)    │     │    (Phase 3)    │     │    (Phase 4)    │     │    (Phase 5)    │
+├─────────────────┤     ├─────────────────┤     ├─────────────────┤     ├─────────────────┤     ├─────────────────┤
+│ WHAT and WHY    │     │ REFINING        │     │ HOW             │     │ DOING           │     │ VALIDATING      │
+│                 │     │                 │     │                 │     │                 │     │                 │
+│ • Architecture  │     │ • Validate      │     │ • Phases        │     │ • Tests first   │     │ • Plan check    │
+│ • Decisions     │     │ • Filter        │     │ • Tasks         │     │ • Then code     │     │ • Decision check│
+│ • Edge cases    │     │ • Enrich        │     │ • Acceptance    │     │ • Commit often  │     │ • Test quality  │
+│ • Debates       │     │ • Standalone    │     │   criteria      │     │ • Phase gates   │     │ • Code quality  │
+│ • Rationale     │     │   spec          │     │ • Output format │     │                 │     │                 │
+└─────────────────┘     └─────────────────┘     └─────────────────┘     └─────────────────┘     └─────────────────┘
+         ▲                       ▲                       ▲                       ▲                       ▲
+         │                       │                       │                       │                       │
+  technical-discussion   technical-specification  technical-planning   technical-implementation  technical-review
 ```
 
 **Phase 1 - Discussion:** Captures the back-and-forth exploration of a problem. Documents competing solutions, why certain approaches won or lost, edge cases discovered, and the journey to decisions—not just the decisions themselves.
 
-**Phase 2 - Planning:** Transforms discussion documentation into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (local markdown, Linear, Backlog.md).
+**Phase 2 - Specification:** Transforms discussion documentation into a validated, standalone specification. Filters hallucinations and inaccuracies, enriches gaps through discussion, and builds a document that planning can execute against without referencing other sources.
 
-**Phase 3 - Implementation:** Executes the plan using strict TDD. Writes tests first, implements to pass, commits frequently, and stops for user approval between phases.
+**Phase 3 - Planning:** Converts specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (local markdown, Linear, Backlog.md).
 
-**Phase 4 - Review:** Validates completed work against discussion decisions and plan acceptance criteria. Provides structured feedback without fixing code directly.
+**Phase 4 - Implementation:** Executes the plan using strict TDD. Writes tests first, implements to pass, commits frequently, and stops for user approval between phases.
+
+**Phase 5 - Review:** Validates completed work against discussion decisions, specification requirements, and plan acceptance criteria. Provides structured feedback without fixing code directly.
 
 ## How It Works
 
@@ -74,16 +76,19 @@ You don't need to configure anything—just install and start discussing.
 
 ### Output Structure
 
-Discussion and planning documents are stored in your project:
+Discussion, specification, and planning documents are stored in your project:
 
 ```
 docs/specs/
 ├── discussions/
 │   └── <topic-name>/
 │       └── discussion.md      # Phase 1 output
+├── specifications/
+│   └── <topic-name>/
+│       └── specification.md   # Phase 2 output
 └── plans/
     └── <topic-name>/
-        └── plan.md            # Phase 2 output
+        └── plan.md            # Phase 3 output
 ```
 
 ## Skills
@@ -91,9 +96,10 @@ docs/specs/
 | Skill | Phase | Description |
 |-------|-------|-------------|
 | [**technical-discussion**](skills/technical-discussion/) | 1 | Document technical discussions as expert architect and meeting assistant. Captures context, decisions, edge cases, competing solutions, debates, and rationale. |
-| [**technical-planning**](skills/technical-planning/) | 2 | Transform discussion documents into actionable implementation plans with phases, tasks, and acceptance criteria. Supports draft and formal planning paths. |
-| [**technical-implementation**](skills/technical-implementation/) | 3 | Execute implementation plans using strict TDD workflow. Writes tests first, implements to pass, commits frequently, and gates phases on user approval. |
-| [**technical-review**](skills/technical-review/) | 4 | Review completed implementation against discussion decisions and plan acceptance criteria. Produces structured feedback without fixing code. |
+| [**technical-specification**](skills/technical-specification/) | 2 | Build validated specifications from discussion documents through collaborative refinement. Filters hallucinations, enriches gaps, produces standalone spec. |
+| [**technical-planning**](skills/technical-planning/) | 3 | Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats. |
+| [**technical-implementation**](skills/technical-implementation/) | 4 | Execute implementation plans using strict TDD workflow. Writes tests first, implements to pass, commits frequently, and gates phases on user approval. |
+| [**technical-review**](skills/technical-review/) | 5 | Review completed implementation against discussion decisions, specification, and plan acceptance criteria. Produces structured feedback without fixing code. |
 
 ### technical-discussion
 
@@ -101,7 +107,7 @@ Acts as both **expert software architect** (participating in discussions) and **
 
 **Use when:**
 - Discussing or exploring architecture and design decisions
-- Working through edge cases before planning
+- Working through edge cases before specification
 - Documenting technical decisions and their rationale
 - Capturing competing solutions and why certain choices were made
 
@@ -111,14 +117,30 @@ Acts as both **expert software architect** (participating in discussions) and **
 - Competing solutions and why some won over others
 - The journey—false paths, "aha" moments, course corrections
 
-### technical-planning
+### technical-specification
 
-Converts discussion documentation into structured implementation plans. Offers two paths: draft planning (collaborative specification building) or formal planning (direct to phases and tasks).
+Acts as **expert technical architect** and **specification builder**. Transforms discussion documents into validated, standalone specifications.
 
 **Use when:**
-- Ready to plan implementation after discussions
+- Ready to validate and refine discussion content
+- Need to filter potential hallucinations or inaccuracies from source material
+- Building a standalone document that planning can execute against
+- Converting discussions into verified requirements
+
+**What it produces:**
+- Validated, standalone specification document
+- Filtered content (hallucinations and inaccuracies removed)
+- Enriched content (gaps filled through discussion)
+- Clear bridge document for formal planning
+
+### technical-planning
+
+Converts specifications into structured implementation plans.
+
+**Use when:**
+- Ready to plan implementation after specification is complete
 - Need to structure how to build something with phases and concrete steps
-- Converting discussion insights into actionable developer guidance
+- Converting specification into actionable developer guidance
 
 **What it produces:**
 - Phased implementation plans with specific tasks
@@ -151,6 +173,7 @@ Reviews completed work with fresh perspective. Validates implementation against 
 
 **What it checks:**
 - Were discussion decisions followed?
+- Were specification requirements implemented?
 - Were all plan acceptance criteria met?
 - Do tests actually verify requirements?
 - Does code follow project conventions?
@@ -176,7 +199,7 @@ Contributions are welcome! Whether it's:
 - **Bug fixes** in the documentation or skill definitions
 - **Improvements** to the workflow or templates
 - **Discussion** about approaches and trade-offs
-- **New skills** that complement the discuss-plan-implement workflow
+- **New skills** that complement the discuss-specify-plan-implement workflow
 
 Please open an issue first to discuss significant changes.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ Slash commands to quickly invoke the workflow.
 | Command | Description |
 |---------|-------------|
 | [**/start-discussion**](commands/start-discussion.md) | Begin a new technical discussion. Gathers topic, context, background information, and relevant codebase areas before starting documentation. |
-| [**/start-planning**](commands/start-planning.md) | Start a planning session from an existing discussion. Discovers available discussions, offers draft vs formal planning paths, and supports multiple output formats (markdown, Linear, Backlog.md). |
+| [**/start-specification**](commands/start-specification.md) | Start a specification session from an existing discussion. Validates and refines discussion content into a standalone specification. |
+| [**/start-planning**](commands/start-planning.md) | Start a planning session from an existing specification. Creates implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (markdown, Linear, Backlog.md). |
 
 ## Requirements
 

--- a/commands/start-planning.md
+++ b/commands/start-planning.md
@@ -54,6 +54,8 @@ Show what you found using a list like below:
 Which specification would you like to create a plan for?
 ```
 
+**Important:** Only completed specifications should proceed to planning. If a specification is still being built, advise the user to complete the specification phase first.
+
 Ask: **Which specification would you like to plan?**
 
 ## Step 4: Choose Output Destination

--- a/commands/start-planning.md
+++ b/commands/start-planning.md
@@ -47,14 +47,14 @@ Show what you found using a list like below:
 
 ```
 📂 Specifications found:
-  ⏳ {topic-1} - Building specification - not ready for planning
+  ⚠️ {topic-1} - Building specification - not ready for planning
   ✅ {topic-2} - Complete - ready for planning
   ✅ {topic-3} - Complete - plan exists
 
 Which specification would you like to create a plan for?
 ```
 
-**Note:** You can pick any option—extend an existing plan, or create a new plan for a completed specification.
+**Important:** Only completed specifications should proceed to planning. If a specification is still being built, advise the user to complete the specification phase first.
 
 Ask: **Which specification would you like to plan?**
 

--- a/commands/start-planning.md
+++ b/commands/start-planning.md
@@ -54,8 +54,6 @@ Show what you found using a list like below:
 Which specification would you like to create a plan for?
 ```
 
-**Important:** Only completed specifications should proceed to planning. If a specification is still being built, advise the user to complete the specification phase first.
-
 Ask: **Which specification would you like to plan?**
 
 ## Step 4: Choose Output Destination

--- a/commands/start-planning.md
+++ b/commands/start-planning.md
@@ -1,5 +1,5 @@
 ---
-description: Start a planning session from an existing discussion. Discovers available discussions, asks where to store the plan, and invokes the technical-planning skill.
+description: Start a planning session from an existing specification. Discovers available specifications, asks where to store the plan, and invokes the technical-planning skill.
 ---
 
 Invoke the **technical-planning** skill for this conversation.
@@ -16,55 +16,49 @@ Use simple, individual commands. Never combine multiple operations into bash loo
 
 ## Step 1: Discover Existing Work
 
-Scan the codebase for discussions and plans:
+Scan the codebase for specifications and plans:
 
-1. **Find discussions**: Look in `docs/specs/discussions/*/discussion.md`
-   - First, run `ls docs/specs/discussions/` to list topic directories
-   - Then, for each topic, run `head -20 docs/specs/discussions/{topic}/discussion.md` to read the frontmatter and extract the `status:` field
+1. **Find specifications**: Look in `docs/specs/specifications/*/specification.md`
+   - First, run `ls docs/specs/specifications/` to list topic directories
+   - Then, for each topic, run `head -20 docs/specs/specifications/{topic}/specification.md` to read the frontmatter and extract the `status:` field
    - Do NOT use bash loops - run separate `head` commands for each topic
 
 2. **Find existing plans**: Look in `docs/specs/plans/*/`
    - Run `ls docs/specs/plans/` to list existing plans
    - For each plan, run `ls docs/specs/plans/{topic}/` to see what files exist
 
-3. **Identify gaps**: Discussions without corresponding plans
+3. **Identify gaps**: Specifications without corresponding plans
 
-## Step 2: Present Options to User
+## Step 2: Check Prerequisites
+
+**If no specifications exist:**
+
+```
+⚠️ No specifications found in docs/specs/specifications/
+
+The planning phase requires a completed specification. Please run /start-specification first to validate and refine the discussion content into a standalone specification before creating a plan.
+```
+
+Stop here and wait for the user to acknowledge.
+
+## Step 3: Present Options to User
 
 Show what you found using a list like below:
 
 ```
-📂 Discussions found:
-  ⏳ {topic-1} - Concluded - ready for planning
-  ⚠️ {topic-2} - Exploring - not ready for planning
-  ✅ {topic-3} - Concluded - plan exists
+📂 Specifications found:
+  ⏳ {topic-1} - Building specification - not ready for planning
+  ✅ {topic-2} - Complete - ready for planning
+  ✅ {topic-3} - Complete - plan exists
 
-Which discussion would you like to create a plan for?
+Which specification would you like to create a plan for?
 ```
 
-**Note:** You can pick any option—continue an exploring discussion, extend an existing plan, or even start a plan without a prior discussion.
+**Note:** You can pick any option—extend an existing plan, or create a new plan for a completed specification.
 
-Ask: **Which discussion would you like to plan?**
-
-## Step 3: Choose Planning Path
-
-Ask: **Do you want to create a draft plan first, or proceed directly to formal planning?**
-
-**Path A: Draft Planning**
-- Use when: Source materials need enrichment or filtering
-- Creates `draft-plan.md` to build the specification collaboratively
-- After draft is signed off, proceed to formal planning
-
-**Path B: Formal Planning**
-- Use when: Source materials already contain complete specification
-- Go straight to creating phases and tasks
-
-If user chooses Path A, skip to Step 5 (invoke skill with draft planning).
-If user chooses Path B, continue to Step 4.
+Ask: **Which specification would you like to plan?**
 
 ## Step 4: Choose Output Destination
-
-*Skip this step if doing draft planning (Path A).*
 
 Ask: **Where should this plan live?**
 
@@ -92,31 +86,30 @@ Ask: **Where should this plan live?**
 
 **For all destinations**:
 - Any additional context or priorities to consider?
-- Any constraints since the discussion concluded?
+- Any constraints since the specification was completed?
 
 ## Step 6: Invoke Planning Skill
 
 Pass to the technical-planning skill:
-- Discussion path: `docs/specs/discussions/{topic-name}/`
-- Planning path: (draft | formal)
-- Output destination: (local-markdown | linear | backlog-md) - only if formal
+- Specification path: `docs/specs/specifications/{topic-name}/specification.md`
+- Output destination: (local-markdown | linear | backlog-md)
 - Additional context gathered
 
-**Example handoff for Path A (Draft)**:
+**Example handoff:**
 ```
 Planning session for: {topic-name}
-Discussion: docs/specs/discussions/{topic-name}/discussion.md
-Path: Draft planning
+Specification: docs/specs/specifications/{topic-name}/specification.md
+Output destination: Local Markdown
+Output path: docs/specs/plans/{topic-name}/plan.md
 
 Begin planning using the technical-planning skill.
-Reference: draft-planning.md
+Reference: formal-planning.md, then output-local-markdown.md
 ```
 
-**Example handoff for Path B (Formal)**:
+**Example handoff for Linear:**
 ```
 Planning session for: {topic-name}
-Discussion: docs/specs/discussions/{topic-name}/discussion.md
-Path: Formal planning
+Specification: docs/specs/specifications/{topic-name}/specification.md
 Output destination: Linear
 Team: Engineering
 
@@ -127,5 +120,5 @@ Reference: formal-planning.md, then output-linear.md
 ## Notes
 
 - Ask questions clearly and wait for responses before proceeding
-- If the user wants to plan something without a discussion doc, that's okay - just note there's no prior discussion to reference
+- The specification is the sole source of truth for planning - do not reference discussions
 - Commit the plan files when complete

--- a/commands/start-specification.md
+++ b/commands/start-specification.md
@@ -54,6 +54,8 @@ Show what you found using a list like below:
 Which discussion would you like to create a specification for?
 ```
 
+**Important:** Only concluded discussions should proceed to specification. If a discussion is still exploring, advise the user to complete the discussion phase first.
+
 Ask: **Which discussion would you like to specify?**
 
 ## Step 4: Gather Additional Context

--- a/commands/start-specification.md
+++ b/commands/start-specification.md
@@ -47,14 +47,14 @@ Show what you found using a list like below:
 
 ```
 📂 Discussions found:
-  ⏳ {topic-1} - Concluded - ready for specification
+  ✅ {topic-1} - Concluded - ready for specification
   ⚠️ {topic-2} - Exploring - not ready for specification
   ✅ {topic-3} - Concluded - specification exists
 
 Which discussion would you like to create a specification for?
 ```
 
-**Note:** You can pick any option—continue an exploring discussion, extend an existing specification, or create a new specification for a concluded discussion.
+**Important:** Only concluded discussions should proceed to specification. If a discussion is still exploring, advise the user to complete the discussion phase first.
 
 Ask: **Which discussion would you like to specify?**
 

--- a/commands/start-specification.md
+++ b/commands/start-specification.md
@@ -54,8 +54,6 @@ Show what you found using a list like below:
 Which discussion would you like to create a specification for?
 ```
 
-**Important:** Only concluded discussions should proceed to specification. If a discussion is still exploring, advise the user to complete the discussion phase first.
-
 Ask: **Which discussion would you like to specify?**
 
 ## Step 4: Gather Additional Context

--- a/commands/start-specification.md
+++ b/commands/start-specification.md
@@ -1,0 +1,89 @@
+---
+description: Start a specification session from an existing discussion. Discovers available discussions, checks for existing specifications, and invokes the technical-specification skill.
+---
+
+Invoke the **technical-specification** skill for this conversation.
+
+## Instructions
+
+Follow these steps EXACTLY as written. Do not skip steps or combine them. Present output using the EXACT format shown in examples - do not simplify or alter the formatting.
+
+Before beginning, discover existing work and gather necessary information.
+
+## Important
+
+Use simple, individual commands. Never combine multiple operations into bash loops or one-liners. Execute commands one at a time.
+
+## Step 1: Discover Existing Work
+
+Scan the codebase for discussions and specifications:
+
+1. **Find discussions**: Look in `docs/specs/discussions/*/discussion.md`
+   - First, run `ls docs/specs/discussions/` to list topic directories
+   - Then, for each topic, run `head -20 docs/specs/discussions/{topic}/discussion.md` to read the frontmatter and extract the `status:` field
+   - Do NOT use bash loops - run separate `head` commands for each topic
+
+2. **Find existing specifications**: Look in `docs/specs/specifications/*/`
+   - Run `ls docs/specs/specifications/` to list existing specifications
+   - For each specification, run `ls docs/specs/specifications/{topic}/` to see what files exist
+
+3. **Identify gaps**: Discussions without corresponding specifications
+
+## Step 2: Check Prerequisites
+
+**If no discussions exist:**
+
+```
+⚠️ No discussions found in docs/specs/discussions/
+
+The specification phase requires a completed discussion. Please run /start-discussion first to document the technical decisions, edge cases, and rationale before creating a specification.
+```
+
+Stop here and wait for the user to acknowledge.
+
+## Step 3: Present Options to User
+
+Show what you found using a list like below:
+
+```
+📂 Discussions found:
+  ⏳ {topic-1} - Concluded - ready for specification
+  ⚠️ {topic-2} - Exploring - not ready for specification
+  ✅ {topic-3} - Concluded - specification exists
+
+Which discussion would you like to create a specification for?
+```
+
+**Note:** You can pick any option—continue an exploring discussion, extend an existing specification, or create a new specification for a concluded discussion.
+
+Ask: **Which discussion would you like to specify?**
+
+## Step 4: Gather Additional Context
+
+Ask:
+- Any additional context or priorities to consider?
+- Any constraints or changes since the discussion concluded?
+- Are there any existing partial plans or related documentation I should review?
+
+## Step 5: Invoke Specification Skill
+
+Pass to the technical-specification skill:
+- Discussion path: `docs/specs/discussions/{topic-name}/`
+- Specification path: `docs/specs/specifications/{topic-name}/`
+- Additional context gathered
+
+**Example handoff:**
+```
+Specification session for: {topic-name}
+Discussion: docs/specs/discussions/{topic-name}/discussion.md
+Output: docs/specs/specifications/{topic-name}/specification.md
+
+Begin specification using the technical-specification skill.
+Reference: specification-guide.md
+```
+
+## Notes
+
+- Ask questions clearly and wait for responses before proceeding
+- The specification phase validates and refines discussion content into a standalone document
+- Commit the specification files frequently during the session

--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: technical-discussion
-description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to planning or implementation. First phase of discussion-plan-implement-review workflow. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before planning, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/specs/discussions/ that technical-planning uses to build implementation plans."
+description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. First phase of discussion-specification-plan-implement-review workflow. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/specs/discussions/ that technical-specification uses to build validated specifications."
 ---
 
 # Technical Discussion
 
 Act as **expert software architect** participating in discussions AND **documentation assistant** capturing them. Do both simultaneously. Engage deeply while documenting for planning teams.
 
-## Four-Phase Workflow
+## Five-Phase Workflow
 
 1. **Discussion** (YOU): WHAT and WHY - decisions, architecture, edge cases
-2. **Planning** (next): HOW - phases, structure, implementation steps
-3. **Implementation** (after): DOING - actual coding
-4. **Review** (final): VALIDATING - check work against decisions and plan
+2. **Specification** (next): REFINE - validate and build standalone spec
+3. **Planning** (after): HOW - phases, tasks, acceptance criteria
+4. **Implementation** (after): DOING - tests first, then code
+5. **Review** (final): VALIDATING - check work against artifacts
 
-You stop at step 1. Capture context. Don't jump to plans or code.
+You stop at step 1. Capture context. Don't jump to specs, plans, or code.
 
 ## What to Capture
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-implementation
-description: "Execute implementation plans using strict TDD workflow with quality gates. Third phase of discussion-plan-implement-review workflow. Use when: (1) Implementing a plan from docs/specs/plans/, (2) User says 'implement', 'build', or 'code this' after planning, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Writes tests first, implements to pass, commits frequently, stops for user approval between phases."
+description: "Execute implementation plans using strict TDD workflow with quality gates. Fourth phase of discussion-specification-plan-implement-review workflow. Use when: (1) Implementing a plan from docs/specs/plans/, (2) User says 'implement', 'build', or 'code this' after planning, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Writes tests first, implements to pass, commits frequently, stops for user approval between phases."
 ---
 
 # Technical Implementation
@@ -9,14 +9,15 @@ Act as **expert senior developer** who builds quality software through disciplin
 
 Execute plans through strict TDD. Write tests first, then code to pass them.
 
-## Four-Phase Workflow
+## Five-Phase Workflow
 
 1. **Discussion** (previous): WHAT and WHY - decisions, architecture, rationale
-2. **Planning** (previous): HOW - phases, tasks, acceptance criteria
-3. **Implementation** (YOU): DOING - tests first, then code
-4. **Review** (next): VALIDATING - check work against decisions and plan
+2. **Specification** (previous): REFINE - validated, standalone specification
+3. **Planning** (previous): HOW - phases, tasks, acceptance criteria
+4. **Implementation** (YOU): DOING - tests first, then code
+5. **Review** (next): VALIDATING - check work against artifacts
 
-You're at step 3. Execute the plan. Don't re-debate decisions.
+You're at step 4. Execute the plan. Don't re-debate decisions.
 
 ## Hard Rules
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -1,38 +1,32 @@
 ---
 name: technical-planning
-description: "Transform technical discussion documents into actionable implementation plans with phases, tasks, and acceptance criteria. Second phase of discussion-plan-implement-review workflow. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation of discussed features, (3) Converting discussion documents from docs/specs/discussions/ into implementation plans, (4) User says 'plan this' or 'create a plan' after discussions, (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/specs/plans/{topic-name}/ that implementation phase executes via strict TDD."
+description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Third phase of discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation after specification is complete, (3) Converting specifications from docs/specs/specifications/ into implementation plans, (4) User says 'plan this' or 'create a plan' after specification, (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/specs/plans/{topic-name}/ that implementation phase executes via strict TDD."
 ---
 
 # Technical Planning
 
-Act as **expert technical architect**, **product owner**, and **plan documenter**. Collaborate with the user to translate discussion decisions into actionable implementation plans.
+Act as **expert technical architect**, **product owner**, and **plan documenter**. Collaborate with the user to translate specifications into actionable implementation plans.
 
 Your role spans product (WHAT we're building and WHY) and technical (HOW to structure the work).
 
-## You Must Ask Before Proceeding
+## Five-Phase Workflow
 
-**If you don't know which path to take, ask the user.**
+1. **Discussion** (previous): WHAT and WHY - decisions, architecture, edge cases
+2. **Specification** (previous): REFINE - validated, standalone specification
+3. **Planning** (YOU): HOW - phases, tasks, acceptance criteria
+4. **Implementation** (next): DOING - tests first, then code
+5. **Review** (final): VALIDATING - check work against artifacts
 
-There are two paths:
-- **Path A**: Draft planning first, then formal planning
-- **Path B**: Formal planning directly
+You're at step 3. Create the plan. Don't jump to implementation.
 
-The user decides. If they haven't told you, ask:
-> "Should we create a draft plan first to work through the details, or proceed directly to formal planning?"
+## Source Material
 
-## Path A: Draft Planning
+Plans are built **exclusively** from the specification:
+- **Specification** (`docs/specs/specifications/{topic-name}/specification.md`)
 
-User wants to build the specification collaboratively before creating the formal plan.
+The specification is the **sole source of truth**. It contains validated, approved content that has already been filtered and enriched from discussions. Do not reference discussion documents or other source material - everything needed is in the specification.
 
-**Load**: [draft-planning.md](references/draft-planning.md)
-
-**Output**: `draft-plan.md` - standalone specification
-
-**When complete**: User signs off, then proceed to Path B.
-
-## Path B: Formal Planning
-
-User wants to create the formal implementation plan (directly, or after draft).
+## The Process
 
 **Load**: [formal-planning.md](references/formal-planning.md)
 
@@ -41,12 +35,14 @@ User wants to create the formal implementation plan (directly, or after draft).
 - [output-linear.md](references/output-linear.md) - Linear project
 - [output-backlog-md.md](references/output-backlog-md.md) - Backlog.md tasks
 
+**Output**: Implementation plan in chosen format
+
 ## Critical Rules
 
 **Capture immediately**: After each user response, update the planning document BEFORE your next question. Never let more than 2-3 exchanges pass without writing.
 
 **Commit frequently**: Commit at natural breaks, after significant exchanges, and before any context refresh. Context refresh = lost work.
 
-**Never invent reasoning**: If it's not in the document, ask again.
+**Never invent reasoning**: If it's not in the specification, ask again.
 
 **Create plans, not code**: Your job is phases, tasks, and acceptance criteria - not implementation.

--- a/skills/technical-planning/references/formal-planning.md
+++ b/skills/technical-planning/references/formal-planning.md
@@ -1,12 +1,10 @@
 # Formal Planning
 
-*Reference for **[technical-planning](../SKILL.md)** - Path B*
+*Reference for **[technical-planning](../SKILL.md)***
 
 ---
 
-You are creating the formal implementation plan. This is either:
-- Direct from source materials (discussion docs), OR
-- After completing draft planning (from `draft-plan.md`)
+You are creating the formal implementation plan from the specification.
 
 ## Before You Begin
 
@@ -19,13 +17,15 @@ If you don't know which format, ask.
 
 ## The Planning Process
 
-### 1. Read Source Material
+### 1. Read Specification
 
-From discussion docs or draft plan, extract:
+From the specification (`docs/specs/specifications/{topic-name}/specification.md`), extract:
 - Key decisions and rationale
 - Architectural choices
 - Edge cases identified
 - Constraints and requirements
+
+**The specification is your sole input.** Discussion documents and other source materials have already been validated, filtered, and enriched during the specification phase. Everything you need is in the specification - do not reference other documents.
 
 ### 2. Define Phases
 
@@ -52,7 +52,7 @@ Extract each edge case, create a task with micro acceptance.
 
 Only for novel patterns not obvious to implement.
 
-### 7. Review Against Source
+### 7. Review Against Specification
 
 Verify:
 - All decisions referenced

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-review
-description: "Review completed implementation against discussion decisions and plan acceptance criteria. Fourth phase of discussion-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User asks to review code against the plan, (3) User wants validation before merging/shipping, (4) Quality gate check needed after implementation. Produces structured feedback (approve, request changes, or comments) - does NOT fix code. Fresh perspective catches plan deviations, missed edge cases, and test quality issues."
+description: "Review completed implementation against discussion decisions, specification, and plan acceptance criteria. Fifth phase of discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User asks to review code against the plan, (3) User wants validation before merging/shipping, (4) Quality gate check needed after implementation. Produces structured feedback (approve, request changes, or comments) - does NOT fix code. Fresh perspective catches plan deviations, missed edge cases, and test quality issues."
 ---
 
 # Technical Review
@@ -9,14 +9,15 @@ Act as **expert code reviewer** with fresh perspective. You haven't seen this co
 
 Review completed work. Produce feedback. Don't fix code.
 
-## Four-Phase Workflow
+## Five-Phase Workflow
 
 1. **Discussion** (artifact): WHAT and WHY - decisions, architecture, rationale
-2. **Planning** (artifact): HOW - phases, tasks, acceptance criteria
-3. **Implementation** (completed): DOING - tests and code
-4. **Review** (YOU): VALIDATING - check work against artifacts
+2. **Specification** (artifact): REFINE - validated, standalone specification
+3. **Planning** (artifact): HOW - phases, tasks, acceptance criteria
+4. **Implementation** (completed): DOING - tests and code
+5. **Review** (YOU): VALIDATING - check work against artifacts
 
-You're at step 4. The code exists. Your job is validation.
+You're at step 5. The code exists. Your job is validation.
 
 ## What You Review Against
 
@@ -25,18 +26,22 @@ You're at step 4. The code exists. Your job is validation.
    - Were edge cases handled as discussed?
    - Any deviations from agreed approach?
 
-2. **Plan** (`docs/specs/plans/{topic}/plan.md`)
+2. **Specification** (`docs/specs/specifications/{topic}/specification.md`)
+   - Were validated requirements implemented?
+   - Any gaps between specification and implementation?
+
+3. **Plan** (`docs/specs/plans/{topic}/plan.md`)
    - Check `format` frontmatter to determine source (local-markdown, linear, backlog-md)
    - Were all phase acceptance criteria actually met?
    - Were all tasks completed?
    - Any scope creep or missing scope?
 
-3. **Code quality** (via project skills)
+4. **Code quality** (via project skills)
    - Does code follow project conventions?
    - Are patterns appropriate for the framework?
    - Any obvious issues?
 
-4. **Test quality**
+5. **Test quality**
    - Do tests actually verify the requirements?
    - Are tests meaningful or just passing?
    - Edge cases from discussion covered?
@@ -44,13 +49,14 @@ You're at step 4. The code exists. Your job is validation.
 ## Review Process
 
 1. **Read the discussion doc** - Understand what was decided and why
-2. **Read the plan** (`plan.md`) - Check `format` frontmatter:
+2. **Read the specification** - The validated requirements that were approved
+3. **Read the plan** (`plan.md`) - Check `format` frontmatter:
    - `local-markdown` → content is in this file
    - `linear` → query Linear via MCP for project issues
    - `backlog-md` → query Backlog.md via MCP or read `backlog/`
-3. **Read the implementation** - Code changes and tests
-4. **Check project skills** - Framework/language conventions
-5. **Produce review** - Structured feedback
+4. **Read the implementation** - Code changes and tests
+5. **Check project skills** - Framework/language conventions
+6. **Produce review** - Structured feedback
 
 See **[review-checklist.md](references/review-checklist.md)** for detailed checklist.
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: technical-review
-description: "Review completed implementation against discussion decisions, specification, and plan acceptance criteria. Fifth phase of discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User asks to review code against the plan, (3) User wants validation before merging/shipping, (4) Quality gate check needed after implementation. Produces structured feedback (approve, request changes, or comments) - does NOT fix code. Fresh perspective catches plan deviations, missed edge cases, and test quality issues."
+description: "Validate completed implementation against the entire workflow chain: discussion decisions, specification requirements, and plan acceptance criteria. Fifth phase of discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. This is product, feature, AND code review - verifying nothing was lost in translation from discussion through to final code. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
 ---
 
 # Technical Review
 
-Act as **expert code reviewer** with fresh perspective. You haven't seen this code before. Validate implementation against prior workflow artifacts: discussion decisions and plan acceptance criteria.
+Act as **expert reviewer** with fresh perspective. You haven't seen this code before. Your job is to validate the **entire workflow chain** - ensuring nothing was lost as context flowed from discussion through to implementation.
 
-Review completed work. Produce feedback. Don't fix code.
+This is **product review**, **feature review**, **edge case review**, AND **code review**. Not just "does the code work?" but "did we build what we discussed?"
 
 ## Five-Phase Workflow
 
@@ -15,48 +15,86 @@ Review completed work. Produce feedback. Don't fix code.
 2. **Specification** (artifact): REFINE - validated, standalone specification
 3. **Planning** (artifact): HOW - phases, tasks, acceptance criteria
 4. **Implementation** (completed): DOING - tests and code
-5. **Review** (YOU): VALIDATING - check work against artifacts
+5. **Review** (YOU): VALIDATING - verify the entire chain
 
-You're at step 5. The code exists. Your job is validation.
+You're at step 5. The code exists. Your job is chain verification.
 
-## What You Review Against
+## Chain Verification
 
-1. **Discussion doc** (`docs/specs/discussions/{topic}/`)
-   - Were decisions followed?
-   - Were edge cases handled as discussed?
-   - Any deviations from agreed approach?
+Your primary role is verifying nothing was lost in translation:
 
-2. **Specification** (`docs/specs/specifications/{topic}/specification.md`)
-   - Were validated requirements implemented?
-   - Any gaps between specification and implementation?
+```
+Discussion → Specification → Plan → Implementation
+    ↑_____________________________________________|
+              You validate every link in this chain
+```
 
-3. **Plan** (`docs/specs/plans/{topic}/plan.md`)
-   - Check `format` frontmatter to determine source (local-markdown, linear, backlog-md)
-   - Were all phase acceptance criteria actually met?
-   - Were all tasks completed?
-   - Any scope creep or missing scope?
+**Discussion → Specification**: Did the spec capture all discussed decisions, edge cases, and rationale? Or did things get lost or changed?
 
-4. **Code quality** (via project skills)
-   - Does code follow project conventions?
-   - Are patterns appropriate for the framework?
-   - Any obvious issues?
+**Specification → Plan**: Did the plan cover all specification requirements? Were any spec items not planned?
 
-5. **Test quality**
-   - Do tests actually verify the requirements?
-   - Are tests meaningful or just passing?
-   - Edge cases from discussion covered?
+**Plan → Implementation**: Did the code implement all planned tasks? Were acceptance criteria actually met?
+
+**Full loop**: Does the final implementation achieve what was originally discussed? Would the user recognize this as what they asked for?
+
+## What You Review
+
+### 1. Chain Integrity
+
+Trace each discussion decision through to code:
+- Find decision in discussion doc
+- Verify it appears in specification
+- Verify it has plan task(s)
+- Verify it's implemented and tested
+
+Flag anything that:
+- Was discussed but didn't make it to spec
+- Was in spec but wasn't planned
+- Was planned but wasn't implemented
+- Drifted from the original intent
+
+### 2. Discussion Compliance (`docs/specs/discussions/{topic}/`)
+
+- Were decisions followed?
+- Were edge cases handled as discussed?
+- Any deviations from agreed approach?
+- Were rejected alternatives accidentally implemented?
+
+### 3. Specification Coverage (`docs/specs/specifications/{topic}/specification.md`)
+
+- Were all validated requirements implemented?
+- Any gaps between specification and implementation?
+- Did anything in the spec get missed?
+
+### 4. Plan Completion (`docs/specs/plans/{topic}/plan.md`)
+
+- Check `format` frontmatter to determine source (local-markdown, linear, backlog-md)
+- Were all phase acceptance criteria actually met?
+- Were all tasks completed?
+- Any scope creep or missing scope?
+
+### 5. Code Quality (via project skills)
+
+- Does code follow project conventions?
+- Are patterns appropriate for the framework?
+- Any obvious issues?
+
+### 6. Test Quality
+
+- Do tests actually verify the requirements?
+- Are tests meaningful or just passing?
+- Edge cases from discussion covered?
 
 ## Review Process
 
 1. **Read the discussion doc** - Understand what was decided and why
 2. **Read the specification** - The validated requirements that were approved
-3. **Read the plan** (`plan.md`) - Check `format` frontmatter:
-   - `local-markdown` → content is in this file
-   - `linear` → query Linear via MCP for project issues
-   - `backlog-md` → query Backlog.md via MCP or read `backlog/`
-4. **Read the implementation** - Code changes and tests
-5. **Check project skills** - Framework/language conventions
-6. **Produce review** - Structured feedback
+3. **Read the plan** - The tasks and acceptance criteria
+4. **Map the chain** - Trace key decisions through each document
+5. **Read the implementation** - Code changes and tests
+6. **Verify chain integrity** - Did everything flow through correctly?
+7. **Check project skills** - Framework/language conventions
+8. **Produce review** - Structured feedback with chain verification findings
 
 See **[review-checklist.md](references/review-checklist.md)** for detailed checklist.
 
@@ -65,8 +103,9 @@ See **[review-checklist.md](references/review-checklist.md)** for detailed check
 1. **Don't fix code** - Identify problems, don't solve them
 2. **Don't re-implement** - You're reviewing, not building
 3. **Be specific** - "Test doesn't cover X" not "tests need work"
-4. **Reference artifacts** - Link findings to discussion/plan
+4. **Reference artifacts** - Link findings to discussion/spec/plan
 5. **Fresh perspective** - You haven't seen this code before; question everything
+6. **Verify the chain** - Don't just check code quality; verify intent was preserved
 
 ## What Happens After Review
 

--- a/skills/technical-review/references/review-checklist.md
+++ b/skills/technical-review/references/review-checklist.md
@@ -7,9 +7,50 @@
 ## Before Starting
 
 1. Locate discussion doc: `docs/specs/discussions/{topic}/`
-2. Locate plan doc: `docs/specs/plans/{topic}/`
-3. Identify what code/files were changed
-4. Check for project-specific skills in `.claude/skills/`
+2. Locate specification: `docs/specs/specifications/{topic}/specification.md`
+3. Locate plan doc: `docs/specs/plans/{topic}/`
+4. Identify what code/files were changed
+5. Check for project-specific skills in `.claude/skills/`
+
+## Chain Verification
+
+This is the primary review task - verifying nothing was lost in translation.
+
+### Discussion → Specification
+
+For each key decision in the discussion:
+- Does it appear in the specification?
+- Was it accurately captured or did meaning change?
+- Were any decisions dropped without justification?
+
+For each edge case discussed:
+- Is it documented in the specification?
+- Was any nuance lost?
+
+### Specification → Plan
+
+For each requirement in the specification:
+- Is there a corresponding plan task?
+- Does the task fully address the requirement?
+- Were any spec items not planned?
+
+### Plan → Implementation
+
+For each planned task:
+- Was it implemented?
+- Does the implementation match the task description?
+- Were acceptance criteria actually met?
+
+### Full Chain Trace
+
+Pick 3-5 key decisions from the discussion and trace each one:
+1. Find it in the discussion doc
+2. Verify it's in the specification
+3. Verify it has plan task(s)
+4. Verify it's implemented
+5. Verify it's tested
+
+Flag any breaks in the chain.
 
 ## Discussion Compliance
 
@@ -29,6 +70,19 @@ For competing solutions that were rejected:
 
 - Did implementation accidentally use a rejected approach?
 - Are there traces of discarded ideas?
+
+## Specification Coverage
+
+For each validated requirement:
+
+- Is it implemented?
+- Is it tested?
+- Does the implementation match the spec exactly?
+
+Look for gaps:
+
+- Requirements in spec but not in code
+- Code that doesn't trace back to a spec requirement
 
 ## Plan Completion
 
@@ -82,6 +136,8 @@ General checks:
 
 ## Common Issues
 
+**Chain breaks**: Decision discussed but never made it to code
+
 **Partial implementation**: Task marked done but only happy path implemented
 
 **Test theater**: Tests pass but don't actually verify requirements
@@ -94,6 +150,8 @@ General checks:
 
 **Orphaned code**: Code added but not used or tested
 
+**Lost nuance**: Requirement simplified in a way that loses important detail
+
 ## Writing Feedback
 
 Be specific and actionable:
@@ -101,12 +159,12 @@ Be specific and actionable:
 - **Bad**: "Tests need improvement"
 - **Good**: "Test `test_cache_expiry` doesn't verify TTL, only that value is returned"
 
-Reference the artifact:
+Reference the artifact and chain position:
 
 - **Bad**: "This wasn't the agreed approach"
-- **Good**: "Discussion doc section 'Caching Strategy' decided on Redis, but implementation uses file cache"
+- **Good**: "Discussion doc section 'Caching Strategy' decided on Redis → Spec requirement 3.2 confirms Redis → Plan task 2.1 says 'implement Redis cache' → but implementation uses file cache. Chain broke at implementation."
 
 Distinguish blocking vs non-blocking:
 
-- Blocking: Required changes before shipping
-- Non-blocking: Recommendations for improvement
+- Blocking: Required changes before shipping (chain breaks, missing requirements)
+- Non-blocking: Recommendations for improvement (code style, minor optimizations)

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: technical-specification
+description: "Build validated specifications from discussion documents through collaborative refinement. Second phase of discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/build a specification from discussions, (2) User wants to validate and refine discussion content before planning, (3) Converting discussion documents into standalone specifications, (4) User says 'specify this' or 'create a spec' after discussions, (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in docs/specs/specifications/{topic-name}/ that technical-planning uses to build implementation plans."
+---
+
+# Technical Specification
+
+Act as **expert technical architect** and **specification builder**. Collaborate with the user to transform discussion documents into validated, standalone specifications.
+
+Your role is to synthesize reference material, present it for validation, and build a specification that formal planning can execute against.
+
+## Five-Phase Workflow
+
+1. **Discussion** (previous): WHAT and WHY - decisions, architecture, edge cases
+2. **Specification** (YOU): REFINE - validate, filter, enrich into standalone spec
+3. **Planning** (next): HOW - phases, tasks, acceptance criteria
+4. **Implementation** (after): DOING - tests first, then code
+5. **Review** (final): VALIDATING - check work against artifacts
+
+You're at step 2. Build the specification. Don't jump to phases, tasks, or code.
+
+## The Process
+
+**Load**: [specification-guide.md](references/specification-guide.md)
+
+**Output**: `specification.md` in `docs/specs/specifications/{topic-name}/`
+
+**When complete**: User signs off, then proceed to technical-planning.
+
+## What You Do
+
+1. **Filter**: Reference material may contain hallucinations, inaccuracies, or outdated concepts. Validate before including.
+
+2. **Enrich**: Reference material may have gaps. Fill them through discussion.
+
+3. **Present**: Synthesize and present content to the user in the format it would appear in the specification.
+
+4. **Log**: Only when approved, write content verbatim to the specification.
+
+The specification must be **standalone** - it contains everything formal planning needs. No references back to discussions or other source material.
+
+## Critical Rules
+
+**Present before logging**: Never write content to the specification until the user has seen and approved it.
+
+**Log verbatim**: When approved, write exactly what was presented - no silent modifications.
+
+**Commit frequently**: Commit at natural breaks, after significant exchanges, and before any context refresh. Context refresh = lost work.
+
+**Trust nothing without validation**: Synthesize and present, but never assume source material is correct.

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -22,6 +22,7 @@ The specification is the **bridge document** - a workspace for collecting valida
 
 Before starting any topic, review ALL available reference material:
 - Discussion documents (from technical-discussion phase)
+- Any existing partial plans
 - Any existing partial specifications
 - Related documentation
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -1,28 +1,28 @@
-# Draft Planning
+# Specification Guide
 
-*Reference for **[technical-planning](../SKILL.md)** - Path A*
+*Reference for **[technical-specification](../SKILL.md)***
 
 ---
 
-You are creating a draft plan - a collaborative workspace where you and the user refine reference material into a validated specification.
+You are building a specification - a collaborative workspace where you and the user refine reference material into a validated, standalone document.
 
 ## Purpose
 
-Draft planning is a **two-way process**:
+Specification building is a **two-way process**:
 
 1. **Filter**: Reference material may contain hallucinations, inaccuracies, or outdated concepts. Validate before including.
 
 2. **Enrich**: Reference material may have gaps. Fill them through discussion.
 
-The draft plan is an **interim document** - a workspace for collecting validated, refined content that will feed formal planning.
+The specification is the **bridge document** - a workspace for collecting validated, refined content that will feed formal planning.
 
-**The draft plan must be standalone.** It should contain everything formal planning needs - no references back to discussions or other source material. When complete, it draws a line: formal planning uses only this document.
+**The specification must be standalone.** It should contain everything formal planning needs - no references back to discussions or other source material. When complete, it draws a line: formal planning uses only this document.
 
 ## Source Materials
 
 Before starting any topic, review ALL available reference material:
 - Discussion documents (from technical-discussion phase)
-- Any existing partial plans
+- Any existing partial specifications
 - Related documentation
 
 **Treat all source material as untrusted input.** Even discussion documents that went through a collaborative process may contain issues. Your job is to synthesize and present - the user validates.
@@ -35,7 +35,7 @@ Work through the specification **topic by topic**:
 Read all reference material for the current topic. Understand what exists.
 
 ### 2. Synthesize and Present
-Present your understanding to the user **in the format it would appear in the plan**:
+Present your understanding to the user **in the format it would appear in the specification**:
 
 > "Here's what I understand about [topic] based on the reference material. This is how I'd write it into the specification:
 >
@@ -54,7 +54,7 @@ Work through the content together:
 This is a **human-level conversation**, not form-filling. The user brings context from across the project that may not be in the reference material - decisions from other topics, implications from later work, or knowledge that can't all fit in context.
 
 ### 4. Log When Approved
-Only when the user approves ("yes, log it", "that's good", etc.) do you write it to the draft plan - **verbatim** as presented and approved.
+Only when the user approves ("yes, log it", "that's good", etc.) do you write it to the specification - **verbatim** as presented and approved.
 
 ### 5. Repeat
 Move to the next topic.
@@ -63,22 +63,22 @@ Move to the next topic.
 
 When you discover information that affects **already-logged topics**, resurface them. Even mid-discussion - interrupt, flag what you found, and discuss whether it changes anything.
 
-If it does: summarize what's changing in the chat, then re-present the full updated topic. The summary is for discussion only - the draft plan just gets the clean replacement. Standard workflow applies: user approves before you update.
+If it does: summarize what's changing in the chat, then re-present the full updated topic. The summary is for discussion only - the specification just gets the clean replacement. Standard workflow applies: user approves before you update.
 
 This is encouraged. Better to resurface and confirm "already covered" than let something slip past.
 
-## The Draft Document
+## The Specification Document
 
-Create `draft-plan.md` in `docs/specs/plans/{topic-name}/`
+Create `specification.md` in `docs/specs/specifications/{topic-name}/`
 
 Structure is **flexible** - organize around phases and subject matter, not rigid sections. This is a working document.
 
 Suggested skeleton:
 
 ```markdown
-# Draft Plan: [Topic Name]
+# Specification: [Topic Name]
 
-**Status**: Draft - building specification
+**Status**: Building specification
 **Last Updated**: [timestamp]
 
 ---
@@ -96,7 +96,7 @@ Suggested skeleton:
 
 ## Critical Rules
 
-**Present before logging**: Never write content to the draft until the user has seen and approved it.
+**Present before logging**: Never write content to the specification until the user has seen and approved it.
 
 **Log verbatim**: When approved, write exactly what was presented - no silent modifications.
 
@@ -106,15 +106,15 @@ Suggested skeleton:
 
 ## After Context Refresh
 
-Read the draft plan. It contains validated, approved content. Trust it - you built it together with the user.
+Read the specification. It contains validated, approved content. Trust it - you built it together with the user.
 
 If working notes exist, they show where you left off.
 
 ## Transitioning to Formal Planning
 
-Draft is complete when:
+Specification is complete when:
 - All topics/phases have validated content
 - User confirms the specification is complete
 - No blocking gaps remain
 
-Then proceed to formal planning → Load [formal-planning.md](formal-planning.md)
+Then proceed to formal planning with the **technical-planning** skill.


### PR DESCRIPTION
- Create new technical-specification skill (Phase 2) to build validated
  specifications from discussion documents
- Extract draft planning content into specification-guide.md reference
- Update technical-planning to use specification as sole input source
- Remove optional draft planning path - specification is now mandatory
- Update all skills with five-phase workflow documentation
- Update README.md with new workflow diagram and skill descriptions
- Update CLAUDE.md with new structure

The workflow now progresses through five mandatory phases:
1. Discussion → 2. Specification → 3. Planning → 4. Implementation → 5. Review

Specifications serve as the validated bridge between discussions and
formal planning, filtering hallucinations and enriching gaps.