### PR TITLE
feat: add technical-research skill as preliminary workflow phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,10 @@ commands/
 
 ## Key Conventions
 
-- Topic directory: `docs/workflow/{topic}/`
-- Research: `docs/workflow/{topic}/research.md`
-- Discussion: `docs/workflow/{topic}/discussion.md`
-- Specification: `docs/workflow/{topic}/specification.md`
-- Plan: `docs/workflow/{topic}/plan.md`
-- Commit docs frequently (natural breaks, before context refresh)
-- Skills capture context, don't implement
+Phase-first directory structure:
+- Research: `docs/workflow/research/` (flat, semantically named files)
+- Discussion: `docs/workflow/discussion/{topic}.md`
+- Specification: `docs/workflow/specification/{topic}.md`
+- Planning: `docs/workflow/planning/{topic}.md`
+
+Commit docs frequently (natural breaks, before context refresh). Skills capture context, don't implement.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,5 @@ commands/
 - Discussion: `docs/workflow/{topic}/discussion.md`
 - Specification: `docs/workflow/{topic}/specification.md`
 - Plan: `docs/workflow/{topic}/plan.md`
-- Multiple files: Use pluralized subdirectory (e.g., `research/`, `discussions/`, `specifications/`, `plans/`)
 - Commit docs frequently (natural breaks, before context refresh)
 - Skills capture context, don't implement

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,33 +6,39 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Claude Code skills package for structured technical discussion and planning workflows. Distributed via Composer as `leeovery/claude-technical-workflows`.
 
-## Five-Phase Workflow
+## Six-Phase Workflow
 
-1. **Discussion** (`technical-discussion` skill): Capture WHAT and WHY - decisions, architecture, edge cases, debates
-2. **Specification** (`technical-specification` skill): Validate and refine into standalone spec
-3. **Planning** (`technical-planning` skill): Define HOW - phases, tasks, acceptance criteria
-4. **Implementation** (`technical-implementation` skill): Execute plan via strict TDD
-5. **Review** (`technical-review` skill): Validate work against discussion, specification, and plan
+1. **Research** (`technical-research` skill): EXPLORE - feasibility, market, viability, early ideas
+2. **Discussion** (`technical-discussion` skill): Capture WHAT and WHY - decisions, architecture, edge cases, debates
+3. **Specification** (`technical-specification` skill): Validate and refine into standalone spec
+4. **Planning** (`technical-planning` skill): Define HOW - phases, tasks, acceptance criteria
+5. **Implementation** (`technical-implementation` skill): Execute plan via strict TDD
+6. **Review** (`technical-review` skill): Validate work against discussion, specification, and plan
 
 ## Structure
 
 ```
 skills/
-  technical-discussion/      # Phase 1: Document discussions
-  technical-specification/   # Phase 2: Build validated specifications
-  technical-planning/        # Phase 3: Create implementation plans
-  technical-implementation/  # Phase 4: Execute via TDD
-  technical-review/          # Phase 5: Validate against artifacts
+  technical-research/        # Phase 1: Explore and validate ideas
+  technical-discussion/      # Phase 2: Document discussions
+  technical-specification/   # Phase 3: Build validated specifications
+  technical-planning/        # Phase 4: Create implementation plans
+  technical-implementation/  # Phase 5: Execute via TDD
+  technical-review/          # Phase 6: Validate against artifacts
 commands/
+  start-research.md          # Slash command to begin research
   start-discussion.md        # Slash command to begin discussions
+  start-specification.md     # Slash command to begin specifications
+  start-planning.md          # Slash command to begin planning
 ```
 
 ## Key Conventions
 
 - Topic directory: `docs/workflow/{topic}/`
+- Research: `docs/workflow/{topic}/research.md`
 - Discussion: `docs/workflow/{topic}/discussion.md`
 - Specification: `docs/workflow/{topic}/specification.md`
 - Plan: `docs/workflow/{topic}/plan.md`
-- Multiple files: Use pluralized subdirectory (e.g., `discussions/`, `specifications/`, `plans/`)
+- Multiple files: Use pluralized subdirectory (e.g., `research/`, `discussions/`, `specifications/`, `plans/`)
 - Commit docs frequently (natural breaks, before context refresh)
 - Skills capture context, don't implement

--- a/README.md
+++ b/README.md
@@ -77,18 +77,22 @@ You don't need to configure anything—just install and start discussing.
 
 ### Output Structure
 
-Research, discussion, specification, and planning documents are stored in your project using a **topic-first** organization:
+Documents are stored using a **phase-first** organization:
 
 ```
 docs/workflow/
-└── {topic}/
-    ├── research.md        # Phase 1 output
-    ├── discussion.md      # Phase 2 output
-    ├── specification.md   # Phase 3 output
-    └── plan.md            # Phase 4 output
+├── research/              # Phase 1 - flat, semantically named files
+│   ├── competitor-analysis.md
+│   └── pricing-models.md
+├── discussion/            # Phase 2 - one file per topic
+│   └── {topic}.md
+├── specification/         # Phase 3 - one file per topic
+│   └── {topic}.md
+└── planning/              # Phase 4 - one file per topic
+    └── {topic}.md
 ```
 
-Each topic gets a single directory containing all its workflow artifacts. This keeps related documents together and makes it easy to see the complete picture for any feature.
+Research is a flat directory of semantically named files (topics emerge later). From discussion onwards, each topic gets its own file per phase.
 
 ## Skills
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Converts specifications into structured implementation plans.
 Executes plans through strict TDD. Acts as an expert senior developer who builds quality software through disciplined test-driven development.
 
 **Use when:**
-- Implementing a plan from `docs/workflow/{topic}/plan.md`
+- Implementing a plan from `docs/workflow/planning/{topic}.md`
 - Ad hoc coding that should follow TDD and quality standards
 - Bug fixes or features benefiting from structured implementation
 

--- a/README.md
+++ b/README.md
@@ -90,17 +90,6 @@ docs/workflow/
 
 Each topic gets a single directory containing all its workflow artifacts. This keeps related documents together and makes it easy to see the complete picture for any feature.
 
-**Multiple files:** If any phase needs multiple files (e.g., multiple research threads), they move to a pluralized subdirectory:
-```
-docs/workflow/{topic}/
-├── research/              # plural = directory with multiple files
-│   ├── competitor-analysis.md
-│   └── pricing-models.md
-├── discussion.md
-├── specification.md
-└── plan.md
-```
-
 ## Skills
 
 | Skill | Phase | Description |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="#installation">Installation</a> •
-  <a href="#the-five-phase-workflow">Workflow</a> •
+  <a href="#the-six-phase-workflow">Workflow</a> •
   <a href="#skills">Skills</a> •
   <a href="#commands">Commands</a> •
   <a href="#how-it-works">How It Works</a> •
@@ -17,7 +17,7 @@
 
 ## About
 
-A structured approach to technical discussions and implementation planning with Claude Code. These skills enforce a deliberate **discuss-then-specify-then-plan-then-implement-then-review** workflow that captures context, decisions, and rationale before any code is written—then validates the work against those artifacts.
+A structured approach to technical discussions and implementation planning with Claude Code. These skills enforce a deliberate **research-then-discuss-then-specify-then-plan-then-implement-then-review** workflow that captures context, decisions, and rationale before any code is written—then validates the work against those artifacts.
 
 **Why this matters:** Complex features benefit from thorough discussion before implementation. These skills help you document the *what* and *why* before diving into the *how*—preserving architectural decisions, edge cases, and the reasoning behind choices that would otherwise be lost.
 
@@ -31,37 +31,38 @@ composer require --dev leeovery/claude-technical-workflows
 
 That's it. The [Claude Manager](https://github.com/leeovery/claude-manager) handles everything else automatically.
 
-## The Five-Phase Workflow
+## The Six-Phase Workflow
 
-This package enforces a deliberate progression through five distinct phases:
+This package enforces a deliberate progression through six distinct phases:
 
 ```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│   Discussion    │ ──▶ │  Specification  │ ──▶ │    Planning     │ ──▶ │ Implementation  │ ──▶ │     Review      │
-│   (Phase 1)     │     │    (Phase 2)    │     │    (Phase 3)    │     │    (Phase 4)    │     │    (Phase 5)    │
-├─────────────────┤     ├─────────────────┤     ├─────────────────┤     ├─────────────────┤     ├─────────────────┤
-│ WHAT and WHY    │     │ REFINING        │     │ HOW             │     │ DOING           │     │ VALIDATING      │
-│                 │     │                 │     │                 │     │                 │     │                 │
-│ • Architecture  │     │ • Validate      │     │ • Phases        │     │ • Tests first   │     │ • Plan check    │
-│ • Decisions     │     │ • Filter        │     │ • Tasks         │     │ • Then code     │     │ • Decision check│
-│ • Edge cases    │     │ • Enrich        │     │ • Acceptance    │     │ • Commit often  │     │ • Test quality  │
-│ • Debates       │     │ • Standalone    │     │   criteria      │     │ • Phase gates   │     │ • Code quality  │
-│ • Rationale     │     │   spec          │     │ • Output format │     │                 │     │                 │
-└─────────────────┘     └─────────────────┘     └─────────────────┘     └─────────────────┘     └─────────────────┘
-         ▲                       ▲                       ▲                       ▲                       ▲
-         │                       │                       │                       │                       │
-  technical-discussion   technical-specification  technical-planning   technical-implementation  technical-review
+┌───────────────┐   ┌───────────────┐   ┌───────────────┐   ┌───────────────┐   ┌───────────────┐   ┌───────────────┐
+│   Research    │──▶│  Discussion   │──▶│ Specification │──▶│   Planning    │──▶│Implementation │──▶│    Review     │
+│   (Phase 1)   │   │   (Phase 2)   │   │   (Phase 3)   │   │   (Phase 4)   │   │   (Phase 5)   │   │   (Phase 6)   │
+├───────────────┤   ├───────────────┤   ├───────────────┤   ├───────────────┤   ├───────────────┤   ├───────────────┤
+│ EXPLORING     │   │ WHAT & WHY    │   │ REFINING      │   │ HOW           │   │ DOING         │   │ VALIDATING    │
+│               │   │               │   │               │   │               │   │               │   │               │
+│ • Ideas       │   │ • Architecture│   │ • Validate    │   │ • Phases      │   │ • Tests first │   │ • Plan check  │
+│ • Market      │   │ • Decisions   │   │ • Filter      │   │ • Tasks       │   │ • Then code   │   │ • Specs check │
+│ • Viability   │   │ • Edge cases  │   │ • Enrich      │   │ • Criteria    │   │ • Commit often│   │ • Test quality│
+│               │   │ • Rationale   │   │ • Standalone  │   │ • Outputs     │   │ • Phase gates │   │ • Code quality│
+└───────────────┘   └───────────────┘   └───────────────┘   └───────────────┘   └───────────────┘   └───────────────┘
+        ▲                   ▲                   ▲                   ▲                   ▲                   ▲
+        │                   │                   │                   │                   │                   │
+ technical-research  technical-discussion  technical-spec  technical-planning  technical-impl  technical-review
 ```
 
-**Phase 1 - Discussion:** Captures the back-and-forth exploration of a problem. Documents competing solutions, why certain approaches won or lost, edge cases discovered, and the journey to decisions—not just the decisions themselves.
+**Phase 1 - Research:** Explore ideas from their earliest seed. Investigate market fit, technical feasibility, business viability. Free-flowing exploration that may or may not lead to building something.
 
-**Phase 2 - Specification:** Transforms discussion documentation into a validated, standalone specification. Filters hallucinations and inaccuracies, enriches gaps through discussion, and builds a document that planning can execute against without referencing other sources.
+**Phase 2 - Discussion:** Captures the back-and-forth exploration of a problem. Documents competing solutions, why certain approaches won or lost, edge cases discovered, and the journey to decisions—not just the decisions themselves.
 
-**Phase 3 - Planning:** Converts specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (local markdown, Linear, Backlog.md).
+**Phase 3 - Specification:** Transforms discussion documentation into a validated, standalone specification. Filters hallucinations and inaccuracies, enriches gaps through discussion, and builds a document that planning can execute against without referencing other sources.
 
-**Phase 4 - Implementation:** Executes the plan using strict TDD. Writes tests first, implements to pass, commits frequently, and stops for user approval between phases.
+**Phase 4 - Planning:** Converts specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (local markdown, Linear, Backlog.md).
 
-**Phase 5 - Review:** Validates completed work against discussion decisions, specification requirements, and plan acceptance criteria. Provides structured feedback without fixing code directly.
+**Phase 5 - Implementation:** Executes the plan using strict TDD. Writes tests first, implements to pass, commits frequently, and stops for user approval between phases.
+
+**Phase 6 - Review:** Validates completed work against discussion decisions, specification requirements, and plan acceptance criteria. Provides structured feedback without fixing code directly.
 
 ## How It Works
 
@@ -76,24 +77,26 @@ You don't need to configure anything—just install and start discussing.
 
 ### Output Structure
 
-Discussion, specification, and planning documents are stored in your project using a **topic-first** organization:
+Research, discussion, specification, and planning documents are stored in your project using a **topic-first** organization:
 
 ```
 docs/workflow/
 └── {topic}/
-    ├── discussion.md      # Phase 1 output
-    ├── specification.md   # Phase 2 output
-    └── plan.md            # Phase 3 output
+    ├── research.md        # Phase 1 output
+    ├── discussion.md      # Phase 2 output
+    ├── specification.md   # Phase 3 output
+    └── plan.md            # Phase 4 output
 ```
 
 Each topic gets a single directory containing all its workflow artifacts. This keeps related documents together and makes it easy to see the complete picture for any feature.
 
-**Multiple files:** If any phase needs multiple files (e.g., multiple discussion threads), they move to a pluralized subdirectory:
+**Multiple files:** If any phase needs multiple files (e.g., multiple research threads), they move to a pluralized subdirectory:
 ```
 docs/workflow/{topic}/
-├── discussions/           # plural = directory with multiple files
-│   ├── api-design.md
-│   └── data-model.md
+├── research/              # plural = directory with multiple files
+│   ├── competitor-analysis.md
+│   └── pricing-models.md
+├── discussion.md
 ├── specification.md
 └── plan.md
 ```
@@ -102,11 +105,29 @@ docs/workflow/{topic}/
 
 | Skill | Phase | Description |
 |-------|-------|-------------|
-| [**technical-discussion**](skills/technical-discussion/) | 1 | Document technical discussions as expert architect and meeting assistant. Captures context, decisions, edge cases, competing solutions, debates, and rationale. |
-| [**technical-specification**](skills/technical-specification/) | 2 | Build validated specifications from discussion documents through collaborative refinement. Filters hallucinations, enriches gaps, produces standalone spec. |
-| [**technical-planning**](skills/technical-planning/) | 3 | Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats. |
-| [**technical-implementation**](skills/technical-implementation/) | 4 | Execute implementation plans using strict TDD workflow. Writes tests first, implements to pass, commits frequently, and gates phases on user approval. |
-| [**technical-review**](skills/technical-review/) | 5 | Review completed implementation against discussion decisions, specification, and plan acceptance criteria. Produces structured feedback without fixing code. |
+| [**technical-research**](skills/technical-research/) | 1 | Explore ideas from their earliest seed. Investigate market fit, technical feasibility, business viability. Free-flowing exploration across technical, business, and market domains. |
+| [**technical-discussion**](skills/technical-discussion/) | 2 | Document technical discussions as expert architect and meeting assistant. Captures context, decisions, edge cases, competing solutions, debates, and rationale. |
+| [**technical-specification**](skills/technical-specification/) | 3 | Build validated specifications from discussion documents through collaborative refinement. Filters hallucinations, enriches gaps, produces standalone spec. |
+| [**technical-planning**](skills/technical-planning/) | 4 | Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats. |
+| [**technical-implementation**](skills/technical-implementation/) | 5 | Execute implementation plans using strict TDD workflow. Writes tests first, implements to pass, commits frequently, and gates phases on user approval. |
+| [**technical-review**](skills/technical-review/) | 6 | Review completed implementation against discussion decisions, specification, and plan acceptance criteria. Produces structured feedback without fixing code. |
+
+### technical-research
+
+Acts as **research partner** with broad expertise spanning technical, product, business, and market domains.
+
+**Use when:**
+- Exploring a new idea from its earliest seed
+- Investigating market fit, competitors, or positioning
+- Validating technical feasibility before committing to build
+- Learning and exploration without necessarily building anything
+- Brain dumping early thoughts before formal discussion
+
+**What it does:**
+- Explores ideas freely across technical, business, and market domains
+- Prompts before documenting: "Shall I capture that?"
+- Creates research documents that may seed the discussion phase
+- Follows tangents and goes broad when useful
 
 ### technical-discussion
 
@@ -191,6 +212,7 @@ Slash commands to quickly invoke the workflow.
 
 | Command | Description |
 |---------|-------------|
+| [**/start-research**](commands/start-research.md) | Begin research exploration. For early-stage ideas, feasibility checks, and broad exploration before formal discussion. |
 | [**/start-discussion**](commands/start-discussion.md) | Begin a new technical discussion. Gathers topic, context, background information, and relevant codebase areas before starting documentation. |
 | [**/start-specification**](commands/start-specification.md) | Start a specification session from an existing discussion. Validates and refines discussion content into a standalone specification. |
 | [**/start-planning**](commands/start-planning.md) | Start a planning session from an existing specification. Creates implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (markdown, Linear, Backlog.md). |

--- a/commands/start-discussion.md
+++ b/commands/start-discussion.md
@@ -1,5 +1,5 @@
 ---
-description: Start a technical discussion using the technical-discussion skill. Gathers information about the topic and creates discussion documentation in docs/workflow/{topic}/
+description: Start a technical discussion using the technical-discussion skill. Gathers information about the topic and creates discussion documentation in docs/workflow/discussion/
 ---
 
 Invoke the **technical-discussion** skill for this conversation.
@@ -8,7 +8,7 @@ Before beginning, ask the user these questions to properly set up the discussion
 
 ## Essential Information
 
-1. **Discussion Topic**: What are we discussing? (This will be used to create the topic directory in `docs/workflow/{topic}/`)
+1. **Discussion Topic**: What are we discussing? (This will be used as the filename in `docs/workflow/discussion/{topic}.md`)
 
 2. **Context & Background**:
    - What sparked this discussion?
@@ -28,10 +28,9 @@ Before beginning, ask the user these questions to properly set up the discussion
 ## After Gathering Information
 
 Once I have this information:
-- Ensure topic directory exists: `docs/workflow/{topic}/`
+- Ensure discussion directory exists: `docs/workflow/discussion/`
 - Start documenting the discussion following the technical-discussion skill structure
-- Create initial file: `docs/workflow/{topic}/discussion.md`
-- If multiple discussion files needed, move to `docs/workflow/{topic}/discussions/` with semantic names
+- Create file: `docs/workflow/discussion/{topic}.md`
 - Commit frequently at natural discussion breaks
 
 Ask these questions clearly and wait for responses before proceeding with the discussion.

--- a/commands/start-planning.md
+++ b/commands/start-planning.md
@@ -18,22 +18,23 @@ Use simple, individual commands. Never combine multiple operations into bash loo
 
 Scan the codebase for specifications and plans:
 
-1. **Find topic directories**: Look in `docs/workflow/*/`
-   - First, run `ls docs/workflow/` to list topic directories
-   - Then, for each topic, check for `specification.md` and `plan.md`
+1. **Find specifications**: Look in `docs/workflow/specification/`
+   - Run `ls docs/workflow/specification/` to list specification files
+   - Each file is named `{topic}.md`
 
-2. **Check specification status**: For each topic with a specification
-   - Run `head -20 docs/workflow/{topic}/specification.md` to read the frontmatter and extract the `status:` field
+2. **Check specification status**: For each specification file
+   - Run `head -20 docs/workflow/specification/{topic}.md` to read the frontmatter and extract the `status:` field
    - Do NOT use bash loops - run separate `head` commands for each topic
 
-3. **Identify gaps**: Topics with specifications but no plans
+3. **Check for existing plans**: Look in `docs/workflow/planning/`
+   - Identify specifications that don't have corresponding plans
 
 ## Step 2: Check Prerequisites
 
 **If no specifications exist:**
 
 ```
-⚠️ No specifications found in docs/workflow/
+⚠️ No specifications found in docs/workflow/specification/
 
 The planning phase requires a completed specification. Please run /start-specification first to validate and refine the discussion content into a standalone specification before creating a plan.
 ```
@@ -61,7 +62,7 @@ Ask: **Which specification would you like to plan?**
 
 Ask: **Where should this plan live?**
 
-1. **Local Markdown** - Simple `plan.md` file in `docs/workflow/{topic}/`
+1. **Local Markdown** - Simple `{topic}.md` file in `docs/workflow/planning/`
    - Best for: Small features, solo work, quick iterations
    - Everything in one version-controlled file
 
@@ -90,19 +91,17 @@ Ask: **Where should this plan live?**
 ## Step 6: Invoke Planning Skill
 
 Pass to the technical-planning skill:
-- Topic directory: `docs/workflow/{topic}/`
-- Specification: `docs/workflow/{topic}/specification.md`
-- Output: `docs/workflow/{topic}/plan.md`
+- Specification: `docs/workflow/specification/{topic}.md`
+- Output: `docs/workflow/planning/{topic}.md`
 - Output destination: (local-markdown | linear | backlog-md)
 - Additional context gathered
 
 **Example handoff:**
 ```
 Planning session for: {topic}
-Topic directory: docs/workflow/{topic}/
-Specification: docs/workflow/{topic}/specification.md
+Specification: docs/workflow/specification/{topic}.md
 Output destination: Local Markdown
-Output path: docs/workflow/{topic}/plan.md
+Output path: docs/workflow/planning/{topic}.md
 
 Begin planning using the technical-planning skill.
 Reference: formal-planning.md, then output-local-markdown.md
@@ -111,8 +110,7 @@ Reference: formal-planning.md, then output-local-markdown.md
 **Example handoff for Linear:**
 ```
 Planning session for: {topic}
-Topic directory: docs/workflow/{topic}/
-Specification: docs/workflow/{topic}/specification.md
+Specification: docs/workflow/specification/{topic}.md
 Output destination: Linear
 Team: Engineering
 

--- a/commands/start-research.md
+++ b/commands/start-research.md
@@ -23,10 +23,10 @@ Before beginning, ask the user these questions to get the exploration started:
 ## After Gathering Information
 
 Once I have this information:
-- Ensure topic directory exists: `docs/workflow/{topic}/`
+- Ensure research directory exists: `docs/workflow/research/`
 - Start exploring using the technical-research skill
 - Prompt before documenting: "Shall I capture that?"
-- Create `docs/workflow/{topic}/research.md` when ready to document
+- Create semantically named files in `docs/workflow/research/` when ready to document
 - Commit frequently at natural breaks
 
 This is early-stage exploration. It may lead to building something, or it may not. Both outcomes are valid.

--- a/commands/start-research.md
+++ b/commands/start-research.md
@@ -1,0 +1,34 @@
+---
+description: Start a research exploration using the technical-research skill. For early-stage ideas, feasibility checks, and broad exploration before formal discussion.
+---
+
+Invoke the **technical-research** skill for this conversation.
+
+Before beginning, ask the user these questions to get the exploration started:
+
+## Essential Information
+
+1. **What's on your mind?**
+   - What idea or topic do you want to explore?
+   - What prompted this - a problem, opportunity, curiosity?
+
+2. **What do you already know?**
+   - Any initial thoughts or research you've done?
+   - Constraints or context I should be aware of?
+
+3. **Where should we start?**
+   - Technical feasibility? Market landscape? Business model?
+   - Or just talk it through and see where it goes?
+
+## After Gathering Information
+
+Once I have this information:
+- Ensure topic directory exists: `docs/workflow/{topic}/`
+- Start exploring using the technical-research skill
+- Prompt before documenting: "Shall I capture that?"
+- Create `docs/workflow/{topic}/research.md` when ready to document
+- Commit frequently at natural breaks
+
+This is early-stage exploration. It may lead to building something, or it may not. Both outcomes are valid.
+
+Ask these questions clearly and wait for responses before proceeding.

--- a/commands/start-specification.md
+++ b/commands/start-specification.md
@@ -18,22 +18,23 @@ Use simple, individual commands. Never combine multiple operations into bash loo
 
 Scan the codebase for discussions and specifications:
 
-1. **Find topic directories**: Look in `docs/workflow/*/`
-   - First, run `ls docs/workflow/` to list topic directories
-   - Then, for each topic, check for `discussion.md` and `specification.md`
+1. **Find discussions**: Look in `docs/workflow/discussion/`
+   - Run `ls docs/workflow/discussion/` to list discussion files
+   - Each file is named `{topic}.md`
 
-2. **Check discussion status**: For each topic with a discussion
-   - Run `head -20 docs/workflow/{topic}/discussion.md` to read the frontmatter and extract the `status:` field
+2. **Check discussion status**: For each discussion file
+   - Run `head -20 docs/workflow/discussion/{topic}.md` to read the frontmatter and extract the `status:` field
    - Do NOT use bash loops - run separate `head` commands for each topic
 
-3. **Identify gaps**: Topics with discussions but no specifications
+3. **Check for existing specifications**: Look in `docs/workflow/specification/`
+   - Identify discussions that don't have corresponding specifications
 
 ## Step 2: Check Prerequisites
 
 **If no discussions exist:**
 
 ```
-⚠️ No discussions found in docs/workflow/
+⚠️ No discussions found in docs/workflow/discussion/
 
 The specification phase requires a completed discussion. Please run /start-discussion first to document the technical decisions, edge cases, and rationale before creating a specification.
 ```
@@ -67,17 +68,15 @@ Ask:
 ## Step 5: Invoke Specification Skill
 
 Pass to the technical-specification skill:
-- Topic directory: `docs/workflow/{topic}/`
-- Discussion: `docs/workflow/{topic}/discussion.md`
-- Output: `docs/workflow/{topic}/specification.md`
+- Discussion: `docs/workflow/discussion/{topic}.md`
+- Output: `docs/workflow/specification/{topic}.md`
 - Additional context gathered
 
 **Example handoff:**
 ```
 Specification session for: {topic}
-Topic directory: docs/workflow/{topic}/
-Discussion: docs/workflow/{topic}/discussion.md
-Output: docs/workflow/{topic}/specification.md
+Discussion: docs/workflow/discussion/{topic}.md
+Output: docs/workflow/specification/{topic}.md
 
 Begin specification using the technical-specification skill.
 Reference: specification-guide.md

--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-discussion
-description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. Second phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/workflow/{topic}/ that technical-specification uses to build validated specifications."
+description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. Second phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/workflow/discussion/{topic}.md that technical-specification uses to build validated specifications."
 ---
 
 # Technical Discussion
@@ -32,7 +32,7 @@ See **[meeting-assistant.md](references/meeting-assistant.md)** for detailed app
 
 ## Structure
 
-**Output**: `docs/workflow/{topic}/discussion.md`
+**Output**: `docs/workflow/discussion/{topic}.md`
 
 Use **[template.md](references/template.md)** for structure:
 

--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -32,11 +32,7 @@ See **[meeting-assistant.md](references/meeting-assistant.md)** for detailed app
 
 ## Structure
 
-Discussions are stored in `docs/workflow/{topic}/discussion.md`. Each topic gets its own directory containing all workflow artifacts (discussion, specification, plan).
-
-**Single file (default):** `docs/workflow/{topic}/discussion.md`
-
-**Multiple files (when needed):** If a discussion needs to be split across multiple files, move them to a pluralized subdirectory: `docs/workflow/{topic}/discussions/` with semantically named files (e.g., `api-design.md`, `data-model.md`).
+**Output**: `docs/workflow/{topic}/discussion.md`
 
 Use **[template.md](references/template.md)** for structure:
 
@@ -56,13 +52,12 @@ See **[guidelines.md](references/guidelines.md)** for best practices and anti-ha
 
 ## Commit Frequently
 
-**Commit discussion docs often** to `docs/workflow/{topic}/`:
+**Commit discussion docs often**:
 
 - At natural breaks in discussion
 - When solutions to problems are identified
 - When discussion branches/forks to new topics
 - Before context refresh (prevents hallucination/memory loss)
-- When creating new files in the discussion directory
 
 **Why**: You lose memory on context refresh. Commits help you track, backtrack, and fill gaps. Critical for avoiding hallucination.
 

--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -1,21 +1,22 @@
 ---
 name: technical-discussion
-description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. First phase of discussion-specification-plan-implement-review workflow. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/workflow/{topic}/ that technical-specification uses to build validated specifications."
+description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. Second phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/workflow/{topic}/ that technical-specification uses to build validated specifications."
 ---
 
 # Technical Discussion
 
 Act as **expert software architect** participating in discussions AND **documentation assistant** capturing them. Do both simultaneously. Engage deeply while documenting for planning teams.
 
-## Five-Phase Workflow
+## Six-Phase Workflow
 
-1. **Discussion** (YOU): WHAT and WHY - decisions, architecture, edge cases
-2. **Specification** (next): REFINE - validate and build standalone spec
-3. **Planning** (after): HOW - phases, tasks, acceptance criteria
-4. **Implementation** (after): DOING - tests first, then code
-5. **Review** (final): VALIDATING - check work against artifacts
+1. **Research** (previous): EXPLORE - ideas, feasibility, market, business, learning
+2. **Discussion** (YOU): WHAT and WHY - decisions, architecture, edge cases
+3. **Specification** (next): REFINE - validate and build standalone spec
+4. **Planning** (after): HOW - phases, tasks, acceptance criteria
+5. **Implementation** (after): DOING - tests first, then code
+6. **Review** (final): VALIDATING - check work against artifacts
 
-You stop at step 1. Capture context. Don't jump to specs, plans, or code.
+You're at step 2. Capture context. Don't jump to specs, plans, or code.
 
 ## What to Capture
 

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -4,11 +4,9 @@
 
 ---
 
-Standard structure for `docs/workflow/{topic}/discussion.md`. Each topic gets its own directory containing all workflow artifacts. DOCUMENT only - no plans or code.
+Standard structure for `docs/workflow/discussion/{topic}.md`. DOCUMENT only - no plans or code.
 
-**Single file (default):** `docs/workflow/{topic}/discussion.md`
-
-**Multiple files (when needed):** Move to `docs/workflow/{topic}/discussions/` with semantically named files.
+This is a single file per topic.
 
 **This is a guide, not a form.** Use the structure to capture what naturally emerges from discussion. Don't force sections that didn't come up. The goal is to document the reasoning journey, not fill in every field.
 
@@ -97,8 +95,8 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 ## Usage Notes
 
 **When creating**:
-1. Ensure topic directory exists: `docs/workflow/{topic}/`
-2. Create file: `discussion.md`
+1. Ensure discussion directory exists: `docs/workflow/discussion/`
+2. Create file: `{topic}.md`
 3. Fill header: date, status
 4. Start with context: why discussing?
 5. List questions: what needs deciding?

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-implementation
-description: "Execute implementation plans using strict TDD workflow with quality gates. Fifth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementing a plan from docs/workflow/{topic}/, (2) User says 'implement', 'build', or 'code this' after planning, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Writes tests first, implements to pass, commits frequently, stops for user approval between phases."
+description: "Execute implementation plans using strict TDD workflow with quality gates. Fifth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementing a plan from docs/workflow/planning/{topic}.md, (2) User says 'implement', 'build', or 'code this' after planning, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Writes tests first, implements to pass, commits frequently, stops for user approval between phases."
 ---
 
 # Technical Implementation
@@ -32,7 +32,7 @@ You're at step 5. Execute the plan. Don't re-debate decisions.
 
 ### With a Plan
 
-1. **Read the plan** from `docs/workflow/{topic}/plan.md`
+1. **Read the plan** from `docs/workflow/planning/{topic}.md`
    - Check the `format` field in frontmatter:
      - `local-markdown` → content is in this file
      - `linear` → query Linear via MCP using frontmatter project_id
@@ -81,7 +81,7 @@ Keep user informed of progress:
 
 ## When to Reference Discussion
 
-Check the discussion doc (`docs/workflow/{topic}/discussion.md`) when:
+Check the discussion doc (`docs/workflow/discussion/{topic}.md`) when:
 
 - Task rationale is unclear
 - Multiple valid approaches exist

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-implementation
-description: "Execute implementation plans using strict TDD workflow with quality gates. Fourth phase of discussion-specification-plan-implement-review workflow. Use when: (1) Implementing a plan from docs/workflow/{topic}/, (2) User says 'implement', 'build', or 'code this' after planning, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Writes tests first, implements to pass, commits frequently, stops for user approval between phases."
+description: "Execute implementation plans using strict TDD workflow with quality gates. Fifth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementing a plan from docs/workflow/{topic}/, (2) User says 'implement', 'build', or 'code this' after planning, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Writes tests first, implements to pass, commits frequently, stops for user approval between phases."
 ---
 
 # Technical Implementation
@@ -9,15 +9,16 @@ Act as **expert senior developer** who builds quality software through disciplin
 
 Execute plans through strict TDD. Write tests first, then code to pass them.
 
-## Five-Phase Workflow
+## Six-Phase Workflow
 
-1. **Discussion** (previous): WHAT and WHY - decisions, architecture, rationale
-2. **Specification** (previous): REFINE - validated, standalone specification
-3. **Planning** (previous): HOW - phases, tasks, acceptance criteria
-4. **Implementation** (YOU): DOING - tests first, then code
-5. **Review** (next): VALIDATING - check work against artifacts
+1. **Research** (previous): EXPLORE - ideas, feasibility, market, business, learning
+2. **Discussion** (previous): WHAT and WHY - decisions, architecture, rationale
+3. **Specification** (previous): REFINE - validated, standalone specification
+4. **Planning** (previous): HOW - phases, tasks, acceptance criteria
+5. **Implementation** (YOU): DOING - tests first, then code
+6. **Review** (next): VALIDATING - check work against artifacts
 
-You're at step 4. Execute the plan. Don't re-debate decisions.
+You're at step 5. Execute the plan. Don't re-debate decisions.
 
 ## Hard Rules
 

--- a/skills/technical-implementation/references/plan-execution.md
+++ b/skills/technical-implementation/references/plan-execution.md
@@ -6,7 +6,7 @@
 
 ## Plan Structure
 
-Plans live in `docs/workflow/{topic}/plan.md` with phases and tasks.
+Plans live in `docs/workflow/planning/{topic}.md` with phases and tasks.
 
 **Phase** = grouping with acceptance criteria
 **Task** = single TDD cycle = one commit
@@ -27,7 +27,7 @@ For each phase:
 
 ## Referencing Discussion
 
-Check `docs/workflow/{topic}/discussion.md` when:
+Check `docs/workflow/discussion/{topic}.md` when:
 - Task rationale unclear
 - Multiple valid approaches
 - Edge case handling not specified

--- a/skills/technical-implementation/references/plan-sources.md
+++ b/skills/technical-implementation/references/plan-sources.md
@@ -4,7 +4,7 @@
 
 ---
 
-Plans are always stored in `docs/workflow/{topic}/plan.md`. The file's frontmatter declares the format.
+Plans are always stored in `docs/workflow/planning/{topic}.md`. The file's frontmatter declares the format.
 
 ## Detecting Plan Format
 

--- a/skills/technical-implementation/references/plan-sources.md
+++ b/skills/technical-implementation/references/plan-sources.md
@@ -8,7 +8,7 @@ Plans are always stored in `docs/workflow/planning/{topic}.md`. The file's front
 
 ## Detecting Plan Format
 
-Always read `plan.md` first and check the `format` field in frontmatter:
+Always read the plan file first and check the `format` field in frontmatter:
 
 | Format | Meaning | How to Proceed |
 |--------|---------|----------------|
@@ -25,7 +25,7 @@ For full format details, see the planning skill's output adapters:
 
 ### Local Markdown
 
-1. Read `plan.md` - all content is inline
+1. Read the plan file - all content is inline
 2. Phases and tasks are in the document
 3. Follow phase order as written
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-planning
-description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Fourth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation after specification is complete, (3) Converting specifications from docs/workflow/{topic}/ into implementation plans, (4) User says 'plan this' or 'create a plan' after specification, (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/workflow/{topic}/ that implementation phase executes via strict TDD."
+description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Fourth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation after specification is complete, (3) Converting specifications from docs/workflow/specification/{topic}.md into implementation plans, (4) User says 'plan this' or 'create a plan' after specification, (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/workflow/planning/{topic}.md that implementation phase executes via strict TDD."
 ---
 
 # Technical Planning
@@ -23,7 +23,7 @@ You're at step 4. Create the plan. Don't jump to implementation.
 ## Source Material
 
 Plans are built **exclusively** from the specification:
-- **Specification** (`docs/workflow/{topic}/specification.md`)
+- **Specification** (`docs/workflow/specification/{topic}.md`)
 
 The specification is the **sole source of truth**. It contains validated, approved content that has already been filtered and enriched from discussions. Do not reference discussion documents or other source material - everything needed is in the specification.
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -32,7 +32,7 @@ The specification is the **sole source of truth**. It contains validated, approv
 **Load**: [formal-planning.md](references/formal-planning.md)
 
 **Then load output adapter** (ask user which format):
-- [output-local-markdown.md](references/output-local-markdown.md) - Single `plan.md` file (default)
+- [output-local-markdown.md](references/output-local-markdown.md) - Single `{topic}.md` file (default)
 - [output-linear.md](references/output-linear.md) - Linear project
 - [output-backlog-md.md](references/output-backlog-md.md) - Backlog.md tasks
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-planning
-description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Third phase of discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation after specification is complete, (3) Converting specifications from docs/workflow/{topic}/ into implementation plans, (4) User says 'plan this' or 'create a plan' after specification, (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/workflow/{topic}/ that implementation phase executes via strict TDD."
+description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Fourth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation after specification is complete, (3) Converting specifications from docs/workflow/{topic}/ into implementation plans, (4) User says 'plan this' or 'create a plan' after specification, (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/workflow/{topic}/ that implementation phase executes via strict TDD."
 ---
 
 # Technical Planning
@@ -9,15 +9,16 @@ Act as **expert technical architect**, **product owner**, and **plan documenter*
 
 Your role spans product (WHAT we're building and WHY) and technical (HOW to structure the work).
 
-## Five-Phase Workflow
+## Six-Phase Workflow
 
-1. **Discussion** (previous): WHAT and WHY - decisions, architecture, edge cases
-2. **Specification** (previous): REFINE - validated, standalone specification
-3. **Planning** (YOU): HOW - phases, tasks, acceptance criteria
-4. **Implementation** (next): DOING - tests first, then code
-5. **Review** (final): VALIDATING - check work against artifacts
+1. **Research** (previous): EXPLORE - ideas, feasibility, market, business, learning
+2. **Discussion** (previous): WHAT and WHY - decisions, architecture, edge cases
+3. **Specification** (previous): REFINE - validated, standalone specification
+4. **Planning** (YOU): HOW - phases, tasks, acceptance criteria
+5. **Implementation** (next): DOING - tests first, then code
+6. **Review** (final): VALIDATING - check work against artifacts
 
-You're at step 3. Create the plan. Don't jump to implementation.
+You're at step 4. Create the plan. Don't jump to implementation.
 
 ## Source Material
 

--- a/skills/technical-planning/references/formal-planning.md
+++ b/skills/technical-planning/references/formal-planning.md
@@ -19,7 +19,7 @@ If you don't know which format, ask.
 
 ### 1. Read Specification
 
-From the specification (`docs/workflow/{topic}/specification.md`), extract:
+From the specification (`docs/workflow/specification/{topic}.md`), extract:
 - Key decisions and rationale
 - Architectural choices
 - Edge cases identified

--- a/skills/technical-planning/references/formal-planning.md
+++ b/skills/technical-planning/references/formal-planning.md
@@ -121,6 +121,6 @@ Context refresh = memory loss. Uncommitted work = lost work.
 ## Output
 
 Load the appropriate output adapter for format-specific structure:
-- [output-local-markdown.md](output-local-markdown.md) - Single plan.md file
+- [output-local-markdown.md](output-local-markdown.md) - Single `{topic}.md` file
 - [output-linear.md](output-linear.md) - Linear project
 - [output-backlog-md.md](output-backlog-md.md) - Backlog.md tasks

--- a/skills/technical-planning/references/output-backlog-md.md
+++ b/skills/technical-planning/references/output-backlog-md.md
@@ -25,13 +25,10 @@ For Backlog.md integration, use the project's `backlog/` directory:
 backlog/
 ├── task-1 - Phase 1 Setup.md
 ├── task-2 - Implement login endpoint.md
-├── task-3 - Add session management.md
-└── docs/
-    └── {topic}/
-        └── plan-reference.md     # Links back to topic
+└── task-3 - Add session management.md
 ```
 
-The plan file in `docs/workflow/planning/{topic}.md` serves as the reference pointer.
+The plan file in `docs/workflow/planning/{topic}.md` serves as the reference pointer to backlog tasks.
 
 ## File Structure
 

--- a/skills/technical-planning/references/output-backlog-md.md
+++ b/skills/technical-planning/references/output-backlog-md.md
@@ -31,11 +31,11 @@ backlog/
         └── plan-reference.md     # Links back to topic
 ```
 
-The `plan.md` file in `docs/workflow/{topic}/` serves as the reference pointer.
+The plan file in `docs/workflow/planning/{topic}.md` serves as the reference pointer.
 
 ## File Structure
 
-### Plan Reference File (`docs/workflow/{topic}/plan.md`)
+### Plan Reference File (`docs/workflow/planning/{topic}.md`)
 
 ```markdown
 ---
@@ -45,7 +45,7 @@ project: {TOPIC_NAME}
 
 # Plan Reference: {Topic Name}
 
-**Topic**: `docs/workflow/{topic}/`
+**Specification**: `docs/workflow/specification/{topic}.md`
 **Created**: {DATE}
 
 ## About This Plan
@@ -104,7 +104,7 @@ labels: [phase-1, api]
 
 ## Notes
 
-- Topic: `docs/workflow/{topic}/`
+- Specification: `docs/workflow/specification/{topic}.md`
 - Related decisions: [link if applicable]
 ```
 
@@ -166,15 +166,11 @@ project/
 ├── backlog/
 │   ├── task-1 - [P1] Configure auth.md
 │   ├── task-2 - [P1] Add login endpoint.md
-│   ├── task-3 - [P2] Session management.md
-│   └── docs/
-│       └── {topic}/
-│           └── reference.md
+│   └── task-3 - [P2] Session management.md
 ├── docs/workflow/
-│   └── {topic}/
-│       ├── discussion.md      # Phase 1 output
-│       ├── specification.md   # Phase 2 output
-│       └── plan.md            # Phase 3 output (format: backlog-md - pointer)
+│   ├── discussion/{topic}.md      # Phase 2 output
+│   ├── specification/{topic}.md   # Phase 3 output
+│   └── planning/{topic}.md        # Phase 4 output (format: backlog-md - pointer)
 ```
 
 ## Implementation Reading

--- a/skills/technical-planning/references/output-backlog-md.md
+++ b/skills/technical-planning/references/output-backlog-md.md
@@ -173,7 +173,7 @@ project/
 ## Implementation Reading
 
 Implementation will:
-1. Read `plan.md`, see `format: backlog-md`
+1. Read `planning/{topic}.md`, see `format: backlog-md`
 2. Query backlog via MCP or read `backlog/` directory
 3. Filter tasks by label (e.g., `phase-1`)
 4. Process in priority order (high → medium → low)

--- a/skills/technical-planning/references/output-linear.md
+++ b/skills/technical-planning/references/output-linear.md
@@ -157,7 +157,7 @@ Issues should be **self-contained for execution**:
 - Any code examples for complex patterns
 
 **Link to (don't copy)**:
-- Discussion document in same topic directory (for "why" context)
+- Discussion document at `docs/workflow/discussion/{topic}.md` (for "why" context)
 - Specific decision sections if particularly relevant
 
 The goal: anyone (Claude or human) could pick up the issue and execute it.

--- a/skills/technical-planning/references/output-linear.md
+++ b/skills/technical-planning/references/output-linear.md
@@ -72,7 +72,7 @@ For each task, create an issue and apply the appropriate phase label:
 - [Specific edge cases for this task]
 
 ## Context
-Topic: `docs/workflow/{topic}/`
+Specification: `docs/workflow/specification/{topic}.md`
 [Optional: link to specific decision if relevant]
 ```
 
@@ -97,7 +97,7 @@ This allows iterative refinement. Create all issues, identify gaps, circle back 
 
 ### 4. Create Local Plan File
 
-Create `docs/workflow/{topic}/plan.md`:
+Create `docs/workflow/planning/{topic}.md`:
 
 ```markdown
 ---
@@ -109,7 +109,7 @@ team: {TEAM_NAME}
 
 # Plan Reference: {Topic Name}
 
-**Topic**: `docs/workflow/{topic}/`
+**Specification**: `docs/workflow/specification/{topic}.md`
 **Created**: {DATE}
 
 ## About This Plan
@@ -175,10 +175,9 @@ After planning:
 
 ```
 docs/workflow/
-└── {topic}/
-    ├── discussion.md      # Phase 1 output
-    ├── specification.md   # Phase 2 output
-    └── plan.md            # Phase 3 output (format: linear - pointer)
+├── discussion/{topic}.md      # Phase 2 output
+├── specification/{topic}.md   # Phase 3 output
+└── planning/{topic}.md        # Phase 4 output (format: linear - pointer)
 
 Linear:
 └── Project: {topic}
@@ -187,7 +186,7 @@ Linear:
     └── Issue: Task 3 [label: phase-2]
 ```
 
-Implementation will read `plan.md`, see `format: linear`, and query Linear via MCP.
+Implementation will read `planning/{topic}.md`, see `format: linear`, and query Linear via MCP.
 
 ## Fallback Handling
 

--- a/skills/technical-planning/references/output-local-markdown.md
+++ b/skills/technical-planning/references/output-local-markdown.md
@@ -9,15 +9,11 @@ Use this format for simple features or when you want everything in a single vers
 ## Output Location
 
 ```
-docs/workflow/{topic}/
-└── plan.md
+docs/workflow/planning/
+└── {topic}.md
 ```
 
-The topic directory contains all workflow artifacts (discussion, specification, plan).
-
-**Single file (default):** `docs/workflow/{topic}/plan.md`
-
-**Multiple files (when needed):** Move to `docs/workflow/{topic}/plans/` with semantically named files.
+This is a single file per topic in the planning directory.
 
 ## Template
 
@@ -32,7 +28,7 @@ format: local-markdown
 
 **Date**: YYYY-MM-DD
 **Status**: Draft | Ready | In Progress | Completed
-**Topic**: `docs/workflow/{topic}/`
+**Specification**: `docs/workflow/specification/{topic}.md`
 
 ## Overview
 
@@ -158,10 +154,9 @@ After planning:
 
 ```
 docs/workflow/
-└── {topic}/
-    ├── discussion.md      # Phase 1 output
-    ├── specification.md   # Phase 2 output
-    └── plan.md            # Phase 3 output (format: local-markdown)
+├── discussion/{topic}.md      # Phase 2 output
+├── specification/{topic}.md   # Phase 3 output
+└── planning/{topic}.md        # Phase 4 output (format: local-markdown)
 ```
 
-Implementation reads `plan.md`, sees `format: local-markdown`, and executes directly from file content.
+Implementation reads `planning/{topic}.md`, sees `format: local-markdown`, and executes directly from file content.

--- a/skills/technical-planning/references/output-local-markdown.md
+++ b/skills/technical-planning/references/output-local-markdown.md
@@ -17,7 +17,7 @@ This is a single file per topic in the planning directory.
 
 ## Template
 
-Create `plan.md` with this structure:
+Create `{topic}.md` with this structure:
 
 ```markdown
 ---

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-research
-description: "Explore ideas, validate concepts, and research broadly across technical, business, and market domains. Preliminary phase before discussion-specification-plan-implement-review workflow. Use when: (1) User has a new idea to explore, (2) Need to research a topic deeply, (3) Validating feasibility - technical, business, or market, (4) Learning and exploration without necessarily building anything, (5) User says 'research this' or 'explore this idea', (6) Brain dumping early thoughts before formal discussion. Creates research documents in docs/workflow/{topic}/ that may seed the technical-discussion phase."
+description: "Explore ideas, validate concepts, and research broadly across technical, business, and market domains. Preliminary phase before discussion-specification-plan-implement-review workflow. Use when: (1) User has a new idea to explore, (2) Need to research a topic deeply, (3) Validating feasibility - technical, business, or market, (4) Learning and exploration without necessarily building anything, (5) User says 'research this' or 'explore this idea', (6) Brain dumping early thoughts before formal discussion. Creates research documents in docs/workflow/research/ that may seed the technical-discussion phase."
 ---
 
 # Technical Research
@@ -22,7 +22,7 @@ You're at step 1. Explore freely.
 
 **Load**: [research-guide.md](references/research-guide.md) for detailed approach.
 
-**Output**: `docs/workflow/{topic}/research.md`
+**Output**: `docs/workflow/research/` (flat directory, semantically named files)
 
 ## Critical Rules
 

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: technical-research
+description: "Explore ideas, validate concepts, and research broadly across technical, business, and market domains. Preliminary phase before discussion-specification-plan-implement-review workflow. Use when: (1) User has a new idea to explore, (2) Need to research a topic deeply, (3) Validating feasibility - technical, business, or market, (4) Learning and exploration without necessarily building anything, (5) User says 'research this' or 'explore this idea', (6) Brain dumping early thoughts before formal discussion. Creates research documents in docs/workflow/{topic}/ that may seed the technical-discussion phase."
+---
+
+# Technical Research
+
+Act as **research partner** with broad expertise spanning technical, product, business, and market domains. Your role is learning, exploration, and discovery.
+
+## Six-Phase Workflow
+
+1. **Research** (YOU): EXPLORE - ideas, feasibility, market, business, learning
+2. **Discussion** (next): WHAT and WHY - decisions, architecture, edge cases
+3. **Specification** (after): REFINE - validate and build standalone spec
+4. **Planning** (after): HOW - phases, tasks, acceptance criteria
+5. **Implementation** (after): DOING - tests first, then code
+6. **Review** (final): VALIDATING - check work against artifacts
+
+You're at step 1. Explore freely.
+
+## The Process
+
+**Load**: [research-guide.md](references/research-guide.md) for detailed approach.
+
+**Output**: `docs/workflow/{topic}/research.md`
+
+**Single file (default):** `docs/workflow/{topic}/research.md`
+
+**Multiple files (when needed):** Move to `docs/workflow/{topic}/research/` with semantically named files.
+
+## Critical Rules
+
+**Don't hallucinate**: Only document what was actually discussed.
+
+**Don't expand**: Capture what was said, don't embellish.
+
+**Ask before documenting**: Prompt the user about whether and where to capture.
+
+**Commit frequently**: At natural breaks and before context refresh.

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -24,10 +24,6 @@ You're at step 1. Explore freely.
 
 **Output**: `docs/workflow/{topic}/research.md`
 
-**Single file (default):** `docs/workflow/{topic}/research.md`
-
-**Multiple files (when needed):** Move to `docs/workflow/{topic}/research/` with semantically named files.
-
 ## Critical Rules
 
 **Don't hallucinate**: Only document what was actually discussed.

--- a/skills/technical-research/references/research-guide.md
+++ b/skills/technical-research/references/research-guide.md
@@ -34,7 +34,7 @@ When something worth capturing comes up, prompt the user:
 
 ## Output
 
-Research documents live in `docs/workflow/{topic}/research.md`.
+Research documents live in `docs/workflow/research/` as semantically named files.
 
 ## Why Commit Frequently
 

--- a/skills/technical-research/references/research-guide.md
+++ b/skills/technical-research/references/research-guide.md
@@ -30,16 +30,11 @@ Don't constrain yourself. Research goes wherever it needs to go.
 When something worth capturing comes up, prompt the user:
 
 - "Shall I document that?"
-- "Would you like me to add that to [existing file]?"
-- "Should I create a new file for this - maybe [suggested name].md?"
+- "Would you like me to add that to the research doc?"
 
-Check where findings should go. Could be an existing file, could be a new one.
-
-## Output Structure
+## Output
 
 Research documents live in `docs/workflow/{topic}/research.md`.
-
-If multiple research files are needed, move to `docs/workflow/{topic}/research/` with semantically named files (e.g., `competitor-analysis.md`, `pricing-models.md`).
 
 ## Why Commit Frequently
 

--- a/skills/technical-research/references/research-guide.md
+++ b/skills/technical-research/references/research-guide.md
@@ -1,0 +1,48 @@
+# Research Exploration Guide
+
+*Part of **[technical-research](../SKILL.md)***
+
+---
+
+## Your Expertise
+
+You bring knowledge across the full landscape:
+
+- **Technical**: Feasibility, architecture approaches, time to market, complexity
+- **Business**: Pricing models, profitability, business models, unit economics
+- **Market**: Competitors, market fit, timing, gaps, positioning
+- **Product**: User needs, value proposition, differentiation
+
+Don't constrain yourself. Research goes wherever it needs to go.
+
+## Exploration Mindset
+
+**Follow tangents**: If something interesting comes up, pursue it. Even mid-conversation.
+
+**Go broad**: Technical feasibility, pricing, competitors, timing, market fit, profitability - explore whatever's relevant.
+
+**Learning is valid**: Not everything leads to building something. Understanding and exploration have value on their own.
+
+**Be honest**: If something seems flawed or risky, say so. Challenge assumptions.
+
+## Documentation Behaviour
+
+When something worth capturing comes up, prompt the user:
+
+- "Shall I document that?"
+- "Would you like me to add that to [existing file]?"
+- "Should I create a new file for this - maybe [suggested name].md?"
+
+Check where findings should go. Could be an existing file, could be a new one.
+
+## Output Structure
+
+Research documents live in `docs/workflow/{topic}/research.md`.
+
+If multiple research files are needed, move to `docs/workflow/{topic}/research/` with semantically named files (e.g., `competitor-analysis.md`, `pricing-models.md`).
+
+## Why Commit Frequently
+
+Memory loss on context refresh causes gaps. Commits preserve exploration.
+
+Commit after capturing something significant, at natural pauses, and before context refresh.

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -54,20 +54,20 @@ Flag anything that:
 - Was planned but wasn't implemented
 - Drifted from the original intent
 
-### 2. Discussion Compliance (`docs/workflow/{topic}/discussion.md`)
+### 2. Discussion Compliance (`docs/workflow/discussion/{topic}.md`)
 
 - Were decisions followed?
 - Were edge cases handled as discussed?
 - Any deviations from agreed approach?
 - Were rejected alternatives accidentally implemented?
 
-### 3. Specification Coverage (`docs/workflow/{topic}/specification.md`)
+### 3. Specification Coverage (`docs/workflow/specification/{topic}.md`)
 
 - Were all validated requirements implemented?
 - Any gaps between specification and implementation?
 - Did anything in the spec get missed?
 
-### 4. Plan Completion (`docs/workflow/{topic}/plan.md`)
+### 4. Plan Completion (`docs/workflow/planning/{topic}.md`)
 
 - Check `format` frontmatter to determine source (local-markdown, linear, backlog-md)
 - Were all phase acceptance criteria actually met?

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-review
-description: "Validate completed implementation against the entire workflow chain: discussion decisions, specification requirements, and plan acceptance criteria. Fifth phase of discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. This is product, feature, AND code review - verifying nothing was lost in translation from discussion through to final code. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
+description: "Validate completed implementation against the entire workflow chain: discussion decisions, specification requirements, and plan acceptance criteria. Sixth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. This is product, feature, AND code review - verifying nothing was lost in translation from discussion through to final code. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
 ---
 
 # Technical Review
@@ -9,15 +9,16 @@ Act as **expert reviewer** with fresh perspective. You haven't seen this code be
 
 This is **product review**, **feature review**, **edge case review**, AND **code review**. Not just "does the code work?" but "did we build what we discussed?"
 
-## Five-Phase Workflow
+## Six-Phase Workflow
 
-1. **Discussion** (artifact): WHAT and WHY - decisions, architecture, rationale
-2. **Specification** (artifact): REFINE - validated, standalone specification
-3. **Planning** (artifact): HOW - phases, tasks, acceptance criteria
-4. **Implementation** (completed): DOING - tests and code
-5. **Review** (YOU): VALIDATING - verify the entire chain
+1. **Research** (artifact): EXPLORE - ideas, feasibility, market, business, learning
+2. **Discussion** (artifact): WHAT and WHY - decisions, architecture, rationale
+3. **Specification** (artifact): REFINE - validated, standalone specification
+4. **Planning** (artifact): HOW - phases, tasks, acceptance criteria
+5. **Implementation** (completed): DOING - tests and code
+6. **Review** (YOU): VALIDATING - verify the entire chain
 
-You're at step 5. The code exists. Your job is chain verification.
+You're at step 6. The code exists. Your job is chain verification.
 
 ## Chain Verification
 

--- a/skills/technical-review/references/review-checklist.md
+++ b/skills/technical-review/references/review-checklist.md
@@ -6,12 +6,11 @@
 
 ## Before Starting
 
-1. Locate topic directory: `docs/workflow/{topic}/`
-2. Read discussion: `docs/workflow/{topic}/discussion.md`
-3. Read specification: `docs/workflow/{topic}/specification.md`
-4. Read plan: `docs/workflow/{topic}/plan.md`
-5. Identify what code/files were changed
-6. Check for project-specific skills in `.claude/skills/`
+1. Read discussion: `docs/workflow/discussion/{topic}.md`
+2. Read specification: `docs/workflow/specification/{topic}.md`
+3. Read plan: `docs/workflow/planning/{topic}.md`
+4. Identify what code/files were changed
+5. Check for project-specific skills in `.claude/skills/`
 
 ## Chain Verification
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-specification
-description: "Build validated specifications from discussion documents through collaborative refinement. Third phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/build a specification from discussions, (2) User wants to validate and refine discussion content before planning, (3) Converting discussion documents into standalone specifications, (4) User says 'specify this' or 'create a spec' after discussions, (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in docs/workflow/{topic}/ that technical-planning uses to build implementation plans."
+description: "Build validated specifications from discussion documents through collaborative refinement. Third phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/build a specification from discussions, (2) User wants to validate and refine discussion content before planning, (3) Converting discussion documents into standalone specifications, (4) User says 'specify this' or 'create a spec' after discussions, (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in docs/workflow/specification/{topic}.md that technical-planning uses to build implementation plans."
 ---
 
 # Technical Specification
@@ -24,7 +24,7 @@ You're at step 3. Build the specification. Don't jump to phases, tasks, or code.
 
 **Load**: [specification-guide.md](references/specification-guide.md)
 
-**Output**: `docs/workflow/{topic}/specification.md`
+**Output**: `docs/workflow/specification/{topic}.md`
 
 **When complete**: User signs off, then proceed to technical-planning.
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-specification
-description: "Build validated specifications from discussion documents through collaborative refinement. Second phase of discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/build a specification from discussions, (2) User wants to validate and refine discussion content before planning, (3) Converting discussion documents into standalone specifications, (4) User says 'specify this' or 'create a spec' after discussions, (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in docs/workflow/{topic}/ that technical-planning uses to build implementation plans."
+description: "Build validated specifications from discussion documents through collaborative refinement. Third phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/build a specification from discussions, (2) User wants to validate and refine discussion content before planning, (3) Converting discussion documents into standalone specifications, (4) User says 'specify this' or 'create a spec' after discussions, (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in docs/workflow/{topic}/ that technical-planning uses to build implementation plans."
 ---
 
 # Technical Specification
@@ -9,15 +9,16 @@ Act as **expert technical architect** and **specification builder**. Collaborate
 
 Your role is to synthesize reference material, present it for validation, and build a specification that formal planning can execute against.
 
-## Five-Phase Workflow
+## Six-Phase Workflow
 
-1. **Discussion** (previous): WHAT and WHY - decisions, architecture, edge cases
-2. **Specification** (YOU): REFINE - validate, filter, enrich into standalone spec
-3. **Planning** (next): HOW - phases, tasks, acceptance criteria
-4. **Implementation** (after): DOING - tests first, then code
-5. **Review** (final): VALIDATING - check work against artifacts
+1. **Research** (previous): EXPLORE - ideas, feasibility, market, business, learning
+2. **Discussion** (previous): WHAT and WHY - decisions, architecture, edge cases
+3. **Specification** (YOU): REFINE - validate, filter, enrich into standalone spec
+4. **Planning** (next): HOW - phases, tasks, acceptance criteria
+5. **Implementation** (after): DOING - tests first, then code
+6. **Review** (final): VALIDATING - check work against artifacts
 
-You're at step 2. Build the specification. Don't jump to phases, tasks, or code.
+You're at step 3. Build the specification. Don't jump to phases, tasks, or code.
 
 ## The Process
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -26,10 +26,6 @@ You're at step 3. Build the specification. Don't jump to phases, tasks, or code.
 
 **Output**: `docs/workflow/{topic}/specification.md`
 
-**Single file (default):** `docs/workflow/{topic}/specification.md`
-
-**Multiple files (when needed):** Move to `docs/workflow/{topic}/specifications/` with semantically named files.
-
 **When complete**: User signs off, then proceed to technical-planning.
 
 ## What You Do

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -70,13 +70,9 @@ This is encouraged. Better to resurface and confirm "already covered" than let s
 
 ## The Specification Document
 
-Create `docs/workflow/{topic}/specification.md`
+Create `docs/workflow/specification/{topic}.md`
 
-**Single file (default):** `docs/workflow/{topic}/specification.md`
-
-**Multiple files (when needed):** Move to `docs/workflow/{topic}/specifications/` with semantically named files.
-
-Structure is **flexible** - organize around phases and subject matter, not rigid sections. This is a working document.
+This is a single file per topic. Structure is **flexible** - organize around phases and subject matter, not rigid sections. This is a working document.
 
 Suggested skeleton:
 


### PR DESCRIPTION
Introduce research phase as the first step in the workflow, before
discussion. The research skill helps explore new ideas from their
earliest seed - testing feasibility, market fit, and technical
viability before committing to build.

- Add technical-research skill with SKILL.md and reference docs
- Update CLAUDE.md to reflect six-phase workflow
- Research documents seed the discussion phase