### PR TITLE
✨ Add chain-verifier subagent for parallel review verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ commands/
   start-discussion.md        # Slash command to begin discussions
   start-specification.md     # Slash command to begin specifications
   start-planning.md          # Slash command to begin planning
+agents/
+  chain-verifier.md          # Parallel chain verification for review phase
 ```
 
 ## Key Conventions

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ This package depends on [`leeovery/claude-manager`](https://github.com/leeovery/
 
 1. **Symlinks skills** into your project's `.claude/skills/` directory
 2. **Symlinks commands** into your project's `.claude/commands/` directory
-3. **Manages your `.gitignore`** with a deterministic list of linked skills and commands
-4. **Handles installation/removal** automatically via Composer hooks
+3. **Symlinks agents** into your project's `.claude/agents/` directory
+4. **Manages your `.gitignore`** with a deterministic list of linked skills, commands, and agents
+5. **Handles installation/removal** automatically via Composer hooks
 
 You don't need to configure anything—just install and start discussing.
 
@@ -209,6 +210,14 @@ Slash commands to quickly invoke the workflow.
 | [**/start-discussion**](commands/start-discussion.md) | Begin a new technical discussion. Gathers topic, context, background information, and relevant codebase areas before starting documentation. |
 | [**/start-specification**](commands/start-specification.md) | Start a specification session from an existing discussion. Validates and refines discussion content into a standalone specification. |
 | [**/start-planning**](commands/start-planning.md) | Start a planning session from an existing specification. Creates implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (markdown, Linear, Backlog.md). |
+
+## Agents
+
+Subagents that skills can spawn for parallel task execution.
+
+| Agent | Used By | Description |
+|-------|---------|-------------|
+| [**chain-verifier**](agents/chain-verifier.md) | technical-review | Traces a single decision through the discussion → specification → plan → implementation chain. Multiple chain-verifiers run in parallel to verify chain integrity efficiently. |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This package enforces a deliberate progression through six distinct phases:
 
 **Phase 5 - Implementation:** Executes the plan using strict TDD. Writes tests first, implements to pass, commits frequently, and stops for user approval between phases.
 
-**Phase 6 - Review:** Validates completed work against discussion decisions, specification requirements, and plan acceptance criteria. Provides structured feedback without fixing code directly.
+**Phase 6 - Review:** Validates completed work against specification requirements and plan acceptance criteria. The specification is the validated source of truth—earlier phases may contain rejected ideas that were intentionally filtered out. Provides structured feedback without fixing code directly.
 
 ## How It Works
 
@@ -104,7 +104,7 @@ Research is a flat directory of semantically named files (topics emerge later). 
 | [**technical-specification**](skills/technical-specification/) | 3 | Build validated specifications from discussion documents through collaborative refinement. Filters hallucinations, enriches gaps, produces standalone spec. |
 | [**technical-planning**](skills/technical-planning/) | 4 | Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats. |
 | [**technical-implementation**](skills/technical-implementation/) | 5 | Execute implementation plans using strict TDD workflow. Writes tests first, implements to pass, commits frequently, and gates phases on user approval. |
-| [**technical-review**](skills/technical-review/) | 6 | Review completed implementation against discussion decisions, specification, and plan acceptance criteria. Produces structured feedback without fixing code. |
+| [**technical-review**](skills/technical-review/) | 6 | Review completed implementation against specification requirements and plan acceptance criteria. Uses parallel subagents for efficient chain verification. Produces structured feedback without fixing code. |
 
 ### technical-research
 
@@ -194,7 +194,6 @@ Reviews completed work with fresh perspective. Validates implementation against 
 - Quality gate check needed after implementation
 
 **What it checks:**
-- Were discussion decisions followed?
 - Were specification requirements implemented?
 - Were all plan acceptance criteria met?
 - Do tests actually verify requirements?
@@ -217,7 +216,7 @@ Subagents that skills can spawn for parallel task execution.
 
 | Agent | Used By | Description |
 |-------|---------|-------------|
-| [**chain-verifier**](agents/chain-verifier.md) | technical-review | Traces a single decision through the discussion → specification → plan → implementation chain. Multiple chain-verifiers run in parallel to verify chain integrity efficiently. |
+| [**chain-verifier**](agents/chain-verifier.md) | technical-review | Traces a single requirement through the specification → plan → implementation → tests chain. Multiple chain-verifiers run in parallel to verify chain integrity efficiently. |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Subagents that skills can spawn for parallel task execution.
 
 | Agent | Used By | Description |
 |-------|---------|-------------|
-| [**chain-verifier**](agents/chain-verifier.md) | technical-review | Traces a single requirement through the specification → plan → implementation → tests chain. Multiple chain-verifiers run in parallel to verify chain integrity efficiently. |
+| [**chain-verifier**](agents/chain-verifier.md) | technical-review | Verifies a single plan task was implemented correctly. Checks implementation, tests (not under/over-tested), and code quality. Multiple chain-verifiers run in parallel to verify ALL tasks efficiently. |
 
 ## Requirements
 

--- a/agents/chain-verifier.md
+++ b/agents/chain-verifier.md
@@ -1,76 +1,77 @@
 ---
 name: chain-verifier
-description: Traces a single decision through the discussion → specification → plan → implementation chain. Invoked by technical-review to verify chain integrity. Returns structured findings for one decision. Use multiple chain-verifiers in PARALLEL to verify multiple decisions simultaneously.
+description: Traces a single requirement through the specification → plan → implementation chain. Invoked by technical-review to verify chain integrity. Returns structured findings for one requirement. Use multiple chain-verifiers in PARALLEL to verify multiple requirements simultaneously.
 tools: Read, Glob, Grep
 model: haiku
 ---
 
 # Chain Verifier
 
-You verify that ONE specific decision flowed correctly through the entire workflow chain.
+You verify that ONE specific requirement flowed correctly from specification through to implementation.
+
+## Why Specification is the Starting Point
+
+The specification is the **validated source of truth**. It has already been filtered, enriched, and approved from earlier research and discussion phases. Earlier phases may contain:
+- Rejected ideas
+- Rough thoughts that were refined
+- Outdated concepts that were filtered out
+
+Do NOT trace back to discussion or research documents. The specification contains everything that was validated and approved for implementation.
 
 ## Your Input
 
 You receive:
-1. **Decision to trace**: A specific decision, requirement, or edge case
-2. **Artifact paths**: Discussion, specification, and plan file paths
+1. **Requirement to trace**: A specific requirement, decision, or edge case from the specification
+2. **Artifact paths**: Specification and plan file paths
 3. **Implementation scope**: Files or directories to check
 
 ## Your Task
 
-Trace the decision through each link in the chain:
+Trace the requirement through each link in the chain:
 
 ```
-Discussion → Specification → Plan → Implementation → Tests
+Specification → Plan → Implementation → Tests
 ```
 
-### Step 1: Find in Discussion
+### Step 1: Verify in Specification
 
-Search the discussion document for the decision:
-- What was decided?
-- What was the rationale?
-- Were there alternatives considered?
-- Any edge cases mentioned?
+Confirm the requirement in the specification:
+- What exactly does it specify?
+- Are there constraints or edge cases mentioned?
+- What is the expected behavior?
 
-### Step 2: Verify in Specification
-
-Search the specification for this decision:
-- Is it present?
-- Is it accurately captured (meaning preserved)?
-- Any nuance lost?
-
-### Step 3: Verify in Plan
+### Step 2: Verify in Plan
 
 Search the plan for corresponding tasks:
-- Is there a task that addresses this decision?
+- Is there a task that addresses this requirement?
 - Does the task fully cover the requirement?
-- Is there acceptance criteria?
+- Is there acceptance criteria that matches?
+- Were any aspects of the requirement not planned?
 
-### Step 4: Verify in Implementation
+### Step 3: Verify in Implementation
 
 Search the codebase for the implementation:
 - Is it implemented?
-- Does the implementation match the decision?
-- Any drift from original intent?
+- Does the implementation match the specification?
+- Any drift from the specified behavior?
 
-### Step 5: Verify in Tests
+### Step 4: Verify in Tests
 
 Search for test coverage:
-- Is there a test for this decision?
-- Does the test actually verify the requirement?
-- Edge cases covered?
+- Is there a test for this requirement?
+- Does the test actually verify the specified behavior?
+- Edge cases from specification covered?
 
 ## Your Output
 
 Return a structured finding:
 
 ```
-DECISION: [The decision you traced]
+REQUIREMENT: [The requirement you traced]
 
 CHAIN STATUS: Complete | Broken at [stage]
 
-DISCUSSION: [Found/Not Found] - [Brief note]
-SPECIFICATION: [Found/Not Found/Drifted] - [Brief note]
+SPECIFICATION: [Confirmed] - [Brief summary of what it specifies]
 PLAN: [Found/Not Found/Partial] - [Brief note]
 IMPLEMENTATION: [Found/Not Found/Drifted] - [Brief note]
 TESTS: [Found/Not Found/Inadequate] - [Brief note]
@@ -83,7 +84,8 @@ SEVERITY: Blocking | Non-blocking | None
 
 ## Rules
 
-1. **One decision only** - You trace exactly one decision per invocation
-2. **Be specific** - Include file paths and line numbers
-3. **Report findings** - Don't fix anything, just report what you find
-4. **Fast and focused** - You're one of several running in parallel
+1. **One requirement only** - You trace exactly one requirement per invocation
+2. **Start from specification** - The spec is your source of truth, not earlier phases
+3. **Be specific** - Include file paths and line numbers
+4. **Report findings** - Don't fix anything, just report what you find
+5. **Fast and focused** - You're one of several running in parallel

--- a/agents/chain-verifier.md
+++ b/agents/chain-verifier.md
@@ -1,91 +1,129 @@
 ---
 name: chain-verifier
-description: Traces a single requirement through the specification → plan → implementation chain. Invoked by technical-review to verify chain integrity. Returns structured findings for one requirement. Use multiple chain-verifiers in PARALLEL to verify multiple requirements simultaneously.
+description: Verifies a single plan task was implemented correctly. Checks implementation, tests, and code quality against the task's acceptance criteria and spec context. Invoked by technical-review to verify ALL plan tasks in PARALLEL.
 tools: Read, Glob, Grep
 model: haiku
 ---
 
 # Chain Verifier
 
-You verify that ONE specific requirement flowed correctly from specification through to implementation.
-
-## Why Specification is the Starting Point
-
-The specification is the **validated source of truth**. It has already been filtered, enriched, and approved from earlier research and discussion phases. Earlier phases may contain:
-- Rejected ideas
-- Rough thoughts that were refined
-- Outdated concepts that were filtered out
-
-Do NOT trace back to discussion or research documents. The specification contains everything that was validated and approved for implementation.
+Act as a **senior software architect** with deep experience in code review. You verify that ONE plan task was implemented correctly, tested adequately, and meets professional quality standards.
 
 ## Your Input
 
 You receive:
-1. **Requirement to trace**: A specific requirement, decision, or edge case from the specification
-2. **Artifact paths**: Specification and plan file paths
-3. **Implementation scope**: Files or directories to check
+1. **Plan task**: A specific task with its acceptance criteria
+2. **Specification path**: For loading context about this task's feature/requirement
+3. **Plan path**: The full plan for additional context
+4. **Implementation scope**: Files or directories to check
 
 ## Your Task
 
-Trace the requirement through each link in the chain:
+For the given plan task:
 
 ```
-Specification → Plan → Implementation → Tests
+Plan Task (acceptance criteria)
+    ↓
+    Load Spec Context (deeper understanding)
+    ↓
+    Verify Implementation (code exists, correct)
+    ↓
+    Verify Tests (adequate, not over/under tested)
+    ↓
+    Check Code Quality (readable, conventions)
 ```
 
-### Step 1: Verify in Specification
+### Step 1: Understand the Task
 
-Confirm the requirement in the specification:
-- What exactly does it specify?
-- Are there constraints or edge cases mentioned?
-- What is the expected behavior?
+From the plan task:
+- What should be built?
+- What are the acceptance criteria?
+- What tests should exist (micro acceptance)?
 
-### Step 2: Verify in Plan
+### Step 2: Load Spec Context
 
-Search the plan for corresponding tasks:
-- Is there a task that addresses this requirement?
-- Does the task fully cover the requirement?
-- Is there acceptance criteria that matches?
-- Were any aspects of the requirement not planned?
+Search the specification for relevant context:
+- What is the broader requirement this task fulfills?
+- Are there edge cases or constraints mentioned?
+- What behavior is expected?
 
-### Step 3: Verify in Implementation
+### Step 3: Verify Implementation
 
-Search the codebase for the implementation:
-- Is it implemented?
-- Does the implementation match the specification?
-- Any drift from the specified behavior?
+Search the codebase:
+- Is the task implemented?
+- Does the implementation match the acceptance criteria?
+- Does it align with the spec's expected behavior?
+- Any drift from what was planned?
 
-### Step 4: Verify in Tests
+### Step 4: Verify Tests
 
-Search for test coverage:
-- Is there a test for this requirement?
-- Does the test actually verify the specified behavior?
-- Edge cases from specification covered?
+Evaluate test coverage critically:
+- Is there a test for this task?
+- Does the test actually verify the acceptance criteria?
+- **Not under-tested**: Are edge cases from the spec covered?
+- **Not over-tested**: Are tests focused and necessary, or bloated with redundant checks?
+- Would the test fail if the feature broke?
+
+### Step 5: Check Code Quality
+
+Review the implementation as a senior architect would:
+
+**Project conventions** (if `.claude/skills/` contains project-specific guidance):
+- Check for project-specific code quality skills
+- Follow any framework or architecture guidelines defined there
+
+**General principles** (always apply):
+- **SOLID**: Single responsibility, open/closed, Liskov substitution, interface segregation, dependency inversion
+- **DRY**: No unnecessary duplication (but don't over-abstract prematurely)
+- **Low complexity**: Cyclomatic complexity is reasonable, code paths are clear
+- **Modern idioms**: Uses current language features appropriately
+- **Readability**: Code is self-documenting, intent is clear
+- **Security**: No obvious vulnerabilities (injection, exposure, etc.)
+- **Performance**: No obvious inefficiencies (N+1 queries, unnecessary loops, etc.)
 
 ## Your Output
 
 Return a structured finding:
 
 ```
-REQUIREMENT: [The requirement you traced]
+TASK: [Task name/description]
 
-CHAIN STATUS: Complete | Broken at [stage]
+ACCEPTANCE CRITERIA: [List from plan]
 
-SPECIFICATION: [Confirmed] - [Brief summary of what it specifies]
-PLAN: [Found/Not Found/Partial] - [Brief note]
-IMPLEMENTATION: [Found/Not Found/Drifted] - [Brief note]
-TESTS: [Found/Not Found/Inadequate] - [Brief note]
+STATUS: Complete | Incomplete | Issues Found
 
-ISSUES:
-- [Specific issue if any, with file:line references]
+SPEC CONTEXT: [Brief summary of relevant spec context]
 
-SEVERITY: Blocking | Non-blocking | None
+IMPLEMENTATION:
+- Status: [Implemented/Missing/Partial/Drifted]
+- Location: [file:line references]
+- Notes: [Any concerns]
+
+TESTS:
+- Status: [Adequate/Under-tested/Over-tested/Missing]
+- Coverage: [What is/isn't tested]
+- Notes: [Specific issues]
+
+CODE QUALITY:
+- Project conventions: [Followed/Violations/N/A]
+- SOLID principles: [Good/Concerns]
+- Complexity: [Low/Acceptable/High]
+- Modern idioms: [Yes/Opportunities]
+- Readability: [Good/Concerns]
+- Issues: [Specific problems if any]
+
+BLOCKING ISSUES:
+- [List any issues that must be fixed]
+
+NON-BLOCKING NOTES:
+- [Suggestions for improvement]
 ```
 
 ## Rules
 
-1. **One requirement only** - You trace exactly one requirement per invocation
-2. **Start from specification** - The spec is your source of truth, not earlier phases
+1. **One task only** - You verify exactly one plan task per invocation
+2. **Be thorough** - Check implementation, tests, AND quality
 3. **Be specific** - Include file paths and line numbers
-4. **Report findings** - Don't fix anything, just report what you find
-5. **Fast and focused** - You're one of several running in parallel
+4. **Balanced test review** - Flag both under-testing AND over-testing
+5. **Report findings** - Don't fix anything, just report what you find
+6. **Fast and focused** - You're one of many running in parallel

--- a/agents/chain-verifier.md
+++ b/agents/chain-verifier.md
@@ -1,0 +1,89 @@
+---
+name: chain-verifier
+description: Traces a single decision through the discussion → specification → plan → implementation chain. Invoked by technical-review to verify chain integrity. Returns structured findings for one decision. Use multiple chain-verifiers in PARALLEL to verify multiple decisions simultaneously.
+tools: Read, Glob, Grep
+model: haiku
+---
+
+# Chain Verifier
+
+You verify that ONE specific decision flowed correctly through the entire workflow chain.
+
+## Your Input
+
+You receive:
+1. **Decision to trace**: A specific decision, requirement, or edge case
+2. **Artifact paths**: Discussion, specification, and plan file paths
+3. **Implementation scope**: Files or directories to check
+
+## Your Task
+
+Trace the decision through each link in the chain:
+
+```
+Discussion → Specification → Plan → Implementation → Tests
+```
+
+### Step 1: Find in Discussion
+
+Search the discussion document for the decision:
+- What was decided?
+- What was the rationale?
+- Were there alternatives considered?
+- Any edge cases mentioned?
+
+### Step 2: Verify in Specification
+
+Search the specification for this decision:
+- Is it present?
+- Is it accurately captured (meaning preserved)?
+- Any nuance lost?
+
+### Step 3: Verify in Plan
+
+Search the plan for corresponding tasks:
+- Is there a task that addresses this decision?
+- Does the task fully cover the requirement?
+- Is there acceptance criteria?
+
+### Step 4: Verify in Implementation
+
+Search the codebase for the implementation:
+- Is it implemented?
+- Does the implementation match the decision?
+- Any drift from original intent?
+
+### Step 5: Verify in Tests
+
+Search for test coverage:
+- Is there a test for this decision?
+- Does the test actually verify the requirement?
+- Edge cases covered?
+
+## Your Output
+
+Return a structured finding:
+
+```
+DECISION: [The decision you traced]
+
+CHAIN STATUS: Complete | Broken at [stage]
+
+DISCUSSION: [Found/Not Found] - [Brief note]
+SPECIFICATION: [Found/Not Found/Drifted] - [Brief note]
+PLAN: [Found/Not Found/Partial] - [Brief note]
+IMPLEMENTATION: [Found/Not Found/Drifted] - [Brief note]
+TESTS: [Found/Not Found/Inadequate] - [Brief note]
+
+ISSUES:
+- [Specific issue if any, with file:line references]
+
+SEVERITY: Blocking | Non-blocking | None
+```
+
+## Rules
+
+1. **One decision only** - You trace exactly one decision per invocation
+2. **Be specific** - Include file paths and line numbers
+3. **Report findings** - Don't fix anything, just report what you find
+4. **Fast and focused** - You're one of several running in parallel

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: technical-review
-description: "Validate completed implementation against the entire workflow chain: discussion decisions, specification requirements, and plan acceptance criteria. Sixth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. This is product, feature, AND code review - verifying nothing was lost in translation from discussion through to final code. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
+description: "Validate completed implementation against specification requirements and plan acceptance criteria. Sixth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. This is product, feature, AND code review - verifying nothing was lost in translation from specification through to final code. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
 ---
 
 # Technical Review
 
-Act as **expert reviewer** with fresh perspective. You haven't seen this code before. Your job is to validate the **entire workflow chain** - ensuring nothing was lost as context flowed from discussion through to implementation.
+Act as **expert reviewer** with fresh perspective. You haven't seen this code before. Your job is to validate the **workflow chain** - ensuring nothing was lost as context flowed from specification through to implementation.
 
-This is **product review**, **feature review**, **edge case review**, AND **code review**. Not just "does the code work?" but "did we build what we discussed?"
+This is **product review**, **feature review**, **edge case review**, AND **code review**. Not just "does the code work?" but "did we build what was specified?"
 
 ## Six-Phase Workflow
 
@@ -22,48 +22,40 @@ You're at step 6. The code exists. Your job is chain verification.
 
 ## Chain Verification
 
-Your primary role is verifying nothing was lost in translation:
+Your primary role is verifying nothing was lost in translation from **specification** through to **implementation**:
 
 ```
-Discussion → Specification → Plan → Implementation
-    ↑_____________________________________________|
-              You validate every link in this chain
+Specification → Plan → Implementation → Tests
+       ↑___________________________________|
+         You validate every link in this chain
 ```
 
-**Use parallel `chain-verifier` subagents** to trace multiple decisions simultaneously. Each verifier traces one decision through the entire chain and reports findings. This dramatically speeds up verification while maintaining thoroughness.
+**Why start from specification?** The specification is the **validated source of truth**. It has already filtered, enriched, and validated content from research and discussion phases. Earlier phases may contain rejected ideas or rough thoughts that were intentionally filtered out.
 
-**Discussion → Specification**: Did the spec capture all discussed decisions, edge cases, and rationale? Or did things get lost or changed?
+**Use parallel `chain-verifier` subagents** to trace multiple requirements simultaneously. Each verifier traces one requirement through the chain and reports findings. This dramatically speeds up verification while maintaining thoroughness.
 
 **Specification → Plan**: Did the plan cover all specification requirements? Were any spec items not planned?
 
 **Plan → Implementation**: Did the code implement all planned tasks? Were acceptance criteria actually met?
 
-**Full loop**: Does the final implementation achieve what was originally discussed? Would the user recognize this as what they asked for?
+**Implementation → Tests**: Do tests verify the specified requirements? Are edge cases covered?
 
 ## What You Review
 
 ### 1. Chain Integrity
 
-Trace each discussion decision through to code:
-- Find decision in discussion doc
-- Verify it appears in specification
+Trace each specification requirement through to code:
+- Find requirement in specification
 - Verify it has plan task(s)
-- Verify it's implemented and tested
+- Verify it's implemented
+- Verify it's tested
 
 Flag anything that:
-- Was discussed but didn't make it to spec
 - Was in spec but wasn't planned
 - Was planned but wasn't implemented
-- Drifted from the original intent
+- Drifted from the specified behavior
 
-### 2. Discussion Compliance (`docs/workflow/discussion/{topic}.md`)
-
-- Were decisions followed?
-- Were edge cases handled as discussed?
-- Any deviations from agreed approach?
-- Were rejected alternatives accidentally implemented?
-
-### 3. Specification Coverage (`docs/workflow/specification/{topic}.md`)
+### 2. Specification Coverage (`docs/workflow/specification/{topic}.md`)
 
 - Were all validated requirements implemented?
 - Any gaps between specification and implementation?
@@ -82,23 +74,22 @@ Flag anything that:
 - Are patterns appropriate for the framework?
 - Any obvious issues?
 
-### 6. Test Quality
+### 5. Test Quality
 
 - Do tests actually verify the requirements?
 - Are tests meaningful or just passing?
-- Edge cases from discussion covered?
+- Edge cases from specification covered?
 
 ## Review Process
 
-1. **Read the discussion doc** - Understand what was decided and why
-2. **Read the specification** - The validated requirements that were approved
-3. **Read the plan** - The tasks and acceptance criteria
-4. **Identify key decisions** - Pick 3-5 critical decisions to trace
-5. **Spawn chain-verifiers in parallel** - One subagent per decision, all running simultaneously
-6. **Read the implementation** - Code changes and tests (while verifiers run)
-7. **Aggregate verifier findings** - Collect and synthesize reports from all chain-verifiers
-8. **Check project skills** - Framework/language conventions
-9. **Produce review** - Structured feedback incorporating chain verification findings
+1. **Read the specification** - The validated source of truth (what was approved)
+2. **Read the plan** - The tasks and acceptance criteria
+3. **Identify key requirements** - Pick 3-5 critical requirements from the specification
+4. **Spawn chain-verifiers in parallel** - One subagent per requirement, all running simultaneously
+5. **Read the implementation** - Code changes and tests (while verifiers run)
+6. **Aggregate verifier findings** - Collect and synthesize reports from all chain-verifiers
+7. **Check project skills** - Framework/language conventions
+8. **Produce review** - Structured feedback incorporating chain verification findings
 
 See **[review-checklist.md](references/review-checklist.md)** for detailed checklist.
 
@@ -107,9 +98,9 @@ See **[review-checklist.md](references/review-checklist.md)** for detailed check
 1. **Don't fix code** - Identify problems, don't solve them
 2. **Don't re-implement** - You're reviewing, not building
 3. **Be specific** - "Test doesn't cover X" not "tests need work"
-4. **Reference artifacts** - Link findings to discussion/spec/plan
+4. **Reference artifacts** - Link findings to spec/plan with file:line references
 5. **Fresh perspective** - You haven't seen this code before; question everything
-6. **Verify the chain** - Don't just check code quality; verify intent was preserved
+6. **Verify the chain** - Don't just check code quality; verify requirements were implemented
 
 ## What Happens After Review
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -30,6 +30,8 @@ Discussion → Specification → Plan → Implementation
               You validate every link in this chain
 ```
 
+**Use parallel `chain-verifier` subagents** to trace multiple decisions simultaneously. Each verifier traces one decision through the entire chain and reports findings. This dramatically speeds up verification while maintaining thoroughness.
+
 **Discussion → Specification**: Did the spec capture all discussed decisions, edge cases, and rationale? Or did things get lost or changed?
 
 **Specification → Plan**: Did the plan cover all specification requirements? Were any spec items not planned?
@@ -91,11 +93,12 @@ Flag anything that:
 1. **Read the discussion doc** - Understand what was decided and why
 2. **Read the specification** - The validated requirements that were approved
 3. **Read the plan** - The tasks and acceptance criteria
-4. **Map the chain** - Trace key decisions through each document
-5. **Read the implementation** - Code changes and tests
-6. **Verify chain integrity** - Did everything flow through correctly?
-7. **Check project skills** - Framework/language conventions
-8. **Produce review** - Structured feedback with chain verification findings
+4. **Identify key decisions** - Pick 3-5 critical decisions to trace
+5. **Spawn chain-verifiers in parallel** - One subagent per decision, all running simultaneously
+6. **Read the implementation** - Code changes and tests (while verifiers run)
+7. **Aggregate verifier findings** - Collect and synthesize reports from all chain-verifiers
+8. **Check project skills** - Framework/language conventions
+9. **Produce review** - Structured feedback incorporating chain verification findings
 
 See **[review-checklist.md](references/review-checklist.md)** for detailed checklist.
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: technical-review
-description: "Validate completed implementation against specification requirements and plan acceptance criteria. Sixth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. This is product, feature, AND code review - verifying nothing was lost in translation from specification through to final code. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
+description: "Validate completed implementation against plan tasks and acceptance criteria. Sixth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. Reviews ALL plan tasks for implementation correctness, test adequacy, and code quality. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
 ---
 
 # Technical Review
 
-Act as **expert reviewer** with fresh perspective. You haven't seen this code before. Your job is to validate the **workflow chain** - ensuring nothing was lost as context flowed from specification through to implementation.
+Act as a **senior software architect** with deep experience in code review. You haven't seen this code before. Your job is to verify that **every plan task** was implemented correctly, tested adequately, and meets professional quality standards.
 
-This is **product review**, **feature review**, **edge case review**, AND **code review**. Not just "does the code work?" but "did we build what was specified?"
+This is **product review**, **feature review**, **test review**, AND **code review**. Not just "does the code work?" but "was every task done correctly, tested properly, and built to professional standards?"
 
 ## Six-Phase Workflow
 
@@ -16,91 +16,81 @@ This is **product review**, **feature review**, **edge case review**, AND **code
 3. **Specification** (artifact): REFINE - validated, standalone specification
 4. **Planning** (artifact): HOW - phases, tasks, acceptance criteria
 5. **Implementation** (completed): DOING - tests and code
-6. **Review** (YOU): VALIDATING - verify the entire chain
+6. **Review** (YOU): VALIDATING - verify every task
 
-You're at step 6. The code exists. Your job is chain verification.
+You're at step 6. The code exists. Your job is comprehensive verification.
 
-## Chain Verification
+## Review Approach
 
-Your primary role is verifying nothing was lost in translation from **specification** through to **implementation**:
+Start from the **plan** - it contains the granular tasks and acceptance criteria. Use the **specification** for context. Verify **all** tasks, not a sample.
 
 ```
-Specification → Plan → Implementation → Tests
-       ↑___________________________________|
-         You validate every link in this chain
+Plan (tasks + acceptance criteria)
+    ↓
+    For EACH task:
+        → Load Spec Context (deeper understanding)
+        → Verify Implementation (code exists, correct)
+        → Verify Tests (adequate, not over/under tested)
+        → Check Code Quality (readable, conventions)
 ```
 
-**Why start from specification?** The specification is the **validated source of truth**. It has already filtered, enriched, and validated content from research and discussion phases. Earlier phases may contain rejected ideas or rough thoughts that were intentionally filtered out.
+**Use parallel `chain-verifier` subagents** to verify ALL plan tasks simultaneously. Each verifier checks one task for implementation, tests, and quality. This enables comprehensive review without sequential bottlenecks.
 
-**Use parallel `chain-verifier` subagents** to trace multiple requirements simultaneously. Each verifier traces one requirement through the chain and reports findings. This dramatically speeds up verification while maintaining thoroughness.
+## What You Verify (Per Task)
 
-**Specification → Plan**: Did the plan cover all specification requirements? Were any spec items not planned?
+### Implementation
 
-**Plan → Implementation**: Did the code implement all planned tasks? Were acceptance criteria actually met?
+- Is the task implemented?
+- Does it match the acceptance criteria?
+- Does it align with spec context?
+- Any drift from what was planned?
 
-**Implementation → Tests**: Do tests verify the specified requirements? Are edge cases covered?
+### Tests
 
-## What You Review
+Evaluate test coverage critically - both directions:
 
-### 1. Chain Integrity
+- **Not under-tested**: Does a test exist? Does it verify acceptance criteria? Are edge cases covered?
+- **Not over-tested**: Are tests focused and necessary? No redundant or bloated checks?
+- Would the test fail if the feature broke?
 
-Trace each specification requirement through to code:
-- Find requirement in specification
-- Verify it has plan task(s)
-- Verify it's implemented
-- Verify it's tested
+### Code Quality
 
-Flag anything that:
-- Was in spec but wasn't planned
-- Was planned but wasn't implemented
-- Drifted from the specified behavior
+Review as a senior architect would:
 
-### 2. Specification Coverage (`docs/workflow/specification/{topic}.md`)
+**Project conventions** (check `.claude/skills/` for project-specific guidance):
+- Framework and architecture guidelines
+- Code style and patterns specific to the project
 
-- Were all validated requirements implemented?
-- Any gaps between specification and implementation?
-- Did anything in the spec get missed?
-
-### 4. Plan Completion (`docs/workflow/planning/{topic}.md`)
-
-- Check `format` frontmatter to determine source (local-markdown, linear, backlog-md)
-- Were all phase acceptance criteria actually met?
-- Were all tasks completed?
-- Any scope creep or missing scope?
-
-### 5. Code Quality (via project skills)
-
-- Does code follow project conventions?
-- Are patterns appropriate for the framework?
-- Any obvious issues?
-
-### 5. Test Quality
-
-- Do tests actually verify the requirements?
-- Are tests meaningful or just passing?
-- Edge cases from specification covered?
+**General principles** (always apply):
+- **SOLID**: Single responsibility, open/closed, Liskov substitution, interface segregation, dependency inversion
+- **DRY**: No unnecessary duplication (without premature abstraction)
+- **Low complexity**: Reasonable cyclomatic complexity, clear code paths
+- **Modern idioms**: Uses current language features appropriately
+- **Readability**: Self-documenting code, clear intent
+- **Security**: No obvious vulnerabilities
+- **Performance**: No obvious inefficiencies
 
 ## Review Process
 
-1. **Read the specification** - The validated source of truth (what was approved)
-2. **Read the plan** - The tasks and acceptance criteria
-3. **Identify key requirements** - Pick 3-5 critical requirements from the specification
-4. **Spawn chain-verifiers in parallel** - One subagent per requirement, all running simultaneously
-5. **Read the implementation** - Code changes and tests (while verifiers run)
-6. **Aggregate verifier findings** - Collect and synthesize reports from all chain-verifiers
-7. **Check project skills** - Framework/language conventions
-8. **Produce review** - Structured feedback incorporating chain verification findings
+1. **Read the plan** - Understand all phases, tasks, and acceptance criteria
+2. **Read the specification** - Load context for the feature being reviewed
+3. **Extract all tasks** - List every task from every phase
+4. **Spawn chain-verifiers in parallel** - One subagent per task, all running simultaneously
+5. **Aggregate findings** - Collect reports from all chain-verifiers
+6. **Check project skills** - Framework/language conventions
+7. **Produce review** - Structured feedback covering all tasks
 
 See **[review-checklist.md](references/review-checklist.md)** for detailed checklist.
 
 ## Hard Rules
 
-1. **Don't fix code** - Identify problems, don't solve them
-2. **Don't re-implement** - You're reviewing, not building
-3. **Be specific** - "Test doesn't cover X" not "tests need work"
-4. **Reference artifacts** - Link findings to spec/plan with file:line references
-5. **Fresh perspective** - You haven't seen this code before; question everything
-6. **Verify the chain** - Don't just check code quality; verify requirements were implemented
+1. **Review ALL tasks** - Don't sample; verify every planned task
+2. **Don't fix code** - Identify problems, don't solve them
+3. **Don't re-implement** - You're reviewing, not building
+4. **Be specific** - "Test doesn't cover X" not "tests need work"
+5. **Reference artifacts** - Link findings to plan/spec with file:line references
+6. **Balanced test review** - Flag both under-testing AND over-testing
+7. **Fresh perspective** - You haven't seen this code before; question everything
 
 ## What Happens After Review
 

--- a/skills/technical-review/references/review-checklist.md
+++ b/skills/technical-review/references/review-checklist.md
@@ -43,23 +43,27 @@ For each planned task:
 
 ### Full Chain Trace (Parallel Verification)
 
-Pick 3-5 key decisions from the discussion, then spawn `chain-verifier` subagents **in parallel** to trace each one simultaneously:
+Pick 3-5 key requirements from the **specification**, then spawn `chain-verifier` subagents **in parallel** to trace each one simultaneously:
 
 ```
-Decision 1 ──▶ [chain-verifier] ──▶ Findings
-Decision 2 ──▶ [chain-verifier] ──▶ Findings  (all running in parallel)
-Decision 3 ──▶ [chain-verifier] ──▶ Findings
+Requirement 1 ──▶ [chain-verifier] ──▶ Findings
+Requirement 2 ──▶ [chain-verifier] ──▶ Findings  (all running in parallel)
+Requirement 3 ──▶ [chain-verifier] ──▶ Findings
 ```
+
+**Why start from specification?**
+
+The specification is the **validated source of truth**. It has already filtered, enriched, and validated content from research and discussion phases. Earlier phases may contain rejected ideas or rough thoughts that were intentionally filtered out. Starting from spec avoids false positives.
 
 **How to invoke:**
 
-For each decision, spawn a chain-verifier with:
-- The specific decision to trace
-- Paths to discussion, specification, and plan documents
+For each requirement, spawn a chain-verifier with:
+- The specific requirement to trace (from specification)
+- Paths to specification and plan documents
 - The implementation scope (files/directories changed)
 
-Each chain-verifier traces one decision through:
-1. Discussion doc → 2. Specification → 3. Plan → 4. Implementation → 5. Tests
+Each chain-verifier traces one requirement through:
+1. Specification → 2. Plan → 3. Implementation → 4. Tests
 
 **Aggregate the findings:**
 
@@ -131,7 +135,7 @@ Tests exist vs tests are meaningful:
 Coverage of requirements:
 
 - Each plan task should have corresponding test(s)
-- Edge cases from discussion should have tests
+- Edge cases from specification should have tests
 
 Test isolation:
 
@@ -154,15 +158,15 @@ General checks:
 
 ## Common Issues
 
-**Chain breaks**: Decision discussed but never made it to code
+**Chain breaks**: Requirement in spec but never made it to code
 
 **Partial implementation**: Task marked done but only happy path implemented
 
 **Test theater**: Tests pass but don't actually verify requirements
 
-**Decision drift**: Started with agreed approach, drifted to something else
+**Requirement drift**: Started with specified approach, drifted to something else
 
-**Missing edge cases**: Discussed but not implemented or tested
+**Missing edge cases**: In specification but not implemented or tested
 
 **Scope creep**: Extra features not in plan
 
@@ -180,7 +184,7 @@ Be specific and actionable:
 Reference the artifact and chain position:
 
 - **Bad**: "This wasn't the agreed approach"
-- **Good**: "Discussion doc section 'Caching Strategy' decided on Redis → Spec requirement 3.2 confirms Redis → Plan task 2.1 says 'implement Redis cache' → but implementation uses file cache. Chain broke at implementation."
+- **Good**: "Spec requirement 3.2 specifies Redis cache → Plan task 2.1 says 'implement Redis cache' → but implementation uses file cache. Chain broke at implementation."
 
 Distinguish blocking vs non-blocking:
 

--- a/skills/technical-review/references/review-checklist.md
+++ b/skills/technical-review/references/review-checklist.md
@@ -6,173 +6,131 @@
 
 ## Before Starting
 
-1. Read discussion: `docs/workflow/discussion/{topic}.md`
-2. Read specification: `docs/workflow/specification/{topic}.md`
-3. Read plan: `docs/workflow/planning/{topic}.md`
-4. Identify what code/files were changed
-5. Check for project-specific skills in `.claude/skills/`
+1. Read plan: `docs/workflow/planning/{topic}.md`
+2. Read specification: `docs/workflow/specification/{topic}.md` (for context)
+3. Identify what code/files were changed
+4. Check for project-specific skills in `.claude/skills/`
 
-## Chain Verification
+## Task-Based Review (Primary Approach)
 
-This is the primary review task - verifying nothing was lost in translation.
+Review **every task** in the plan. Don't sample - verify all of them.
 
-### Discussion → Specification
+### Extract All Tasks
 
-For each key decision in the discussion:
-- Does it appear in the specification?
-- Was it accurately captured or did meaning change?
-- Were any decisions dropped without justification?
+From the plan, list every task across all phases:
+- Note each task's description
+- Note each task's acceptance criteria
+- Note expected micro acceptance (test name)
 
-For each edge case discussed:
-- Is it documented in the specification?
-- Was any nuance lost?
+### Parallel Verification
 
-### Specification → Plan
-
-For each requirement in the specification:
-- Is there a corresponding plan task?
-- Does the task fully address the requirement?
-- Were any spec items not planned?
-
-### Plan → Implementation
-
-For each planned task:
-- Was it implemented?
-- Does the implementation match the task description?
-- Were acceptance criteria actually met?
-
-### Full Chain Trace (Parallel Verification)
-
-Pick 3-5 key requirements from the **specification**, then spawn `chain-verifier` subagents **in parallel** to trace each one simultaneously:
+Spawn `chain-verifier` subagents **in parallel** for ALL tasks:
 
 ```
-Requirement 1 ──▶ [chain-verifier] ──▶ Findings
-Requirement 2 ──▶ [chain-verifier] ──▶ Findings  (all running in parallel)
-Requirement 3 ──▶ [chain-verifier] ──▶ Findings
+Task 1 ──▶ [chain-verifier] ──▶ Findings
+Task 2 ──▶ [chain-verifier] ──▶ Findings
+Task 3 ──▶ [chain-verifier] ──▶ Findings  (all running in parallel)
+Task 4 ──▶ [chain-verifier] ──▶ Findings
+  ...
+Task N ──▶ [chain-verifier] ──▶ Findings
 ```
 
-**Why start from specification?**
+**How to invoke each chain-verifier:**
 
-The specification is the **validated source of truth**. It has already filtered, enriched, and validated content from research and discussion phases. Earlier phases may contain rejected ideas or rough thoughts that were intentionally filtered out. Starting from spec avoids false positives.
+Provide:
+- The specific task (with acceptance criteria)
+- Path to specification (for context)
+- Path to plan (for phase context)
+- Implementation scope (files/directories changed)
 
-**How to invoke:**
-
-For each requirement, spawn a chain-verifier with:
-- The specific requirement to trace (from specification)
-- Paths to specification and plan documents
-- The implementation scope (files/directories changed)
-
-Each chain-verifier traces one requirement through:
-1. Specification → 2. Plan → 3. Implementation → 4. Tests
+**Each chain-verifier checks:**
+1. Implementation exists and matches acceptance criteria
+2. Tests are adequate (not under-tested, not over-tested)
+3. Code quality is acceptable
 
 **Aggregate the findings:**
 
 Once all chain-verifiers complete, synthesize their reports:
-- Collect all "Broken" chains as blocking issues
-- Collect all "Drifted" items for review
-- Include specific file:line references in your review output
+- Collect all incomplete/failed tasks as blocking issues
+- Collect all test issues (under/over-tested)
+- Collect all code quality concerns
+- Include specific file:line references
 
-Flag any breaks in the chain.
+## Per-Task Verification Details
 
-## Discussion Compliance
+For each task, the chain-verifier checks:
 
-For each decision documented in the discussion:
+### Implementation
 
-- Was it followed in implementation?
-- If deviated, was there documented justification?
-- Were the "why" reasons preserved in the approach?
+- Is the task implemented?
+- Does the implementation match the acceptance criteria?
+- Does it align with spec context (load relevant spec section)?
+- Any drift from what was planned?
 
-For each edge case discussed:
+### Test Adequacy
 
-- Is it handled in the code?
-- Is it tested?
-- Does the handling match what was agreed?
+**Not under-tested:**
+- Does a test exist for this task?
+- Does the test verify the acceptance criteria?
+- Are edge cases from the spec covered?
+- Would the test fail if the feature broke?
 
-For competing solutions that were rejected:
+**Not over-tested:**
+- Are tests focused on what matters?
+- No redundant assertions testing the same thing?
+- No unnecessary mocking or setup?
+- Tests aren't testing implementation details instead of behavior?
 
-- Did implementation accidentally use a rejected approach?
-- Are there traces of discarded ideas?
+### Code Quality
 
-## Specification Coverage
+Review as a senior architect would:
 
-For each validated requirement:
+**Project conventions** (check `.claude/skills/` for project-specific guidance):
+- Framework and architecture guidelines defined for the project
+- Code style and patterns specific to the codebase
 
-- Is it implemented?
-- Is it tested?
-- Does the implementation match the spec exactly?
+**General principles** (always apply):
+- **SOLID**: Single responsibility, open/closed, Liskov substitution, interface segregation, dependency inversion
+- **DRY**: No unnecessary duplication (without premature abstraction)
+- **Low complexity**: Reasonable cyclomatic complexity, clear code paths
+- **Modern idioms**: Uses current language features appropriately
+- **Readability**: Self-documenting code, clear intent
+- **Security**: No obvious vulnerabilities (injection, exposure, etc.)
+- **Performance**: No obvious inefficiencies (N+1 queries, unnecessary loops, etc.)
 
-Look for gaps:
+## Plan Completion Check
 
-- Requirements in spec but not in code
-- Code that doesn't trace back to a spec requirement
+After task-level verification, check overall plan completion:
 
-## Plan Completion
+### Phase Acceptance Criteria
 
 For each phase:
+- Are all phase-level acceptance criteria met?
+- Were all tasks in the phase completed?
 
-- Are all acceptance criteria actually met (not just claimed)?
-- Verify each criterion independently
-
-For each task:
-
-- Was a test written for the micro acceptance?
-- Does the test actually verify the requirement?
-- Is there a commit for the task?
-
-Scope check:
+### Scope
 
 - Was anything built that wasn't in the plan? (scope creep)
 - Was anything in the plan not built? (missing scope)
-
-## Test Quality
-
-Tests exist vs tests are meaningful:
-
-- Does the test name match what it actually tests?
-- Would the test fail if the feature broke?
-- Are assertions specific or overly broad?
-
-Coverage of requirements:
-
-- Each plan task should have corresponding test(s)
-- Edge cases from specification should have tests
-
-Test isolation:
-
-- Do tests depend on each other?
-- Are tests repeatable?
-
-## Code Quality
-
-Check against project-specific skills for:
-
-- Framework patterns and conventions
-- Code style requirements
-- Architecture guidelines
-
-General checks:
-
-- Obvious bugs or logic errors
-- Error handling present where needed
-- No hardcoded values that should be configurable
+- Any unplanned files or features added?
 
 ## Common Issues
 
-**Chain breaks**: Requirement in spec but never made it to code
+**Incomplete task**: Task marked done but not fully implemented
 
-**Partial implementation**: Task marked done but only happy path implemented
+**Under-tested**: Missing tests, or tests don't verify acceptance criteria
 
-**Test theater**: Tests pass but don't actually verify requirements
+**Over-tested**: Redundant tests, testing implementation details, excessive mocking
 
-**Requirement drift**: Started with specified approach, drifted to something else
+**Requirement drift**: Implementation doesn't match what was planned
 
-**Missing edge cases**: In specification but not implemented or tested
+**Missing edge cases**: Spec mentions edge cases not implemented or tested
 
 **Scope creep**: Extra features not in plan
 
 **Orphaned code**: Code added but not used or tested
 
-**Lost nuance**: Requirement simplified in a way that loses important detail
+**Poor readability**: Code works but is hard to understand
 
 ## Writing Feedback
 
@@ -181,12 +139,17 @@ Be specific and actionable:
 - **Bad**: "Tests need improvement"
 - **Good**: "Test `test_cache_expiry` doesn't verify TTL, only that value is returned"
 
-Reference the artifact and chain position:
+Reference the plan task:
 
-- **Bad**: "This wasn't the agreed approach"
-- **Good**: "Spec requirement 3.2 specifies Redis cache → Plan task 2.1 says 'implement Redis cache' → but implementation uses file cache. Chain broke at implementation."
+- **Bad**: "This wasn't done correctly"
+- **Good**: "Plan Phase 2, Task 3 says 'implement Redis cache' with acceptance 'cache stores values for configured TTL' → implementation uses file cache with no TTL. Task incomplete."
+
+Flag test balance issues:
+
+- **Under-tested**: "Task 2.1 has no test for the error case mentioned in spec section 3.2"
+- **Over-tested**: "Task 2.1 has 5 tests that all verify the same happy path with slight variations"
 
 Distinguish blocking vs non-blocking:
 
-- Blocking: Required changes before shipping (chain breaks, missing requirements)
-- Non-blocking: Recommendations for improvement (code style, minor optimizations)
+- **Blocking**: Incomplete tasks, missing tests, broken functionality
+- **Non-blocking**: Code style suggestions, minor readability improvements

--- a/skills/technical-review/references/review-checklist.md
+++ b/skills/technical-review/references/review-checklist.md
@@ -41,14 +41,32 @@ For each planned task:
 - Does the implementation match the task description?
 - Were acceptance criteria actually met?
 
-### Full Chain Trace
+### Full Chain Trace (Parallel Verification)
 
-Pick 3-5 key decisions from the discussion and trace each one:
-1. Find it in the discussion doc
-2. Verify it's in the specification
-3. Verify it has plan task(s)
-4. Verify it's implemented
-5. Verify it's tested
+Pick 3-5 key decisions from the discussion, then spawn `chain-verifier` subagents **in parallel** to trace each one simultaneously:
+
+```
+Decision 1 ──▶ [chain-verifier] ──▶ Findings
+Decision 2 ──▶ [chain-verifier] ──▶ Findings  (all running in parallel)
+Decision 3 ──▶ [chain-verifier] ──▶ Findings
+```
+
+**How to invoke:**
+
+For each decision, spawn a chain-verifier with:
+- The specific decision to trace
+- Paths to discussion, specification, and plan documents
+- The implementation scope (files/directories changed)
+
+Each chain-verifier traces one decision through:
+1. Discussion doc → 2. Specification → 3. Plan → 4. Implementation → 5. Tests
+
+**Aggregate the findings:**
+
+Once all chain-verifiers complete, synthesize their reports:
+- Collect all "Broken" chains as blocking issues
+- Collect all "Drifted" items for review
+- Include specific file:line references in your review output
 
 Flag any breaks in the chain.
 


### PR DESCRIPTION
Integrate subagent support into the technical-review phase:
- Add agents/chain-verifier.md for tracing decisions through artifact chain
- Update review skill to spawn parallel chain-verifiers for efficiency
- Update review checklist with parallel verification guidance
- Document agents in README and CLAUDE.md