### PR TITLE
feat: add beads output adapter for planning skill

### DIFF
--- a/skills/technical-implementation/references/plan-sources.md
+++ b/skills/technical-implementation/references/plan-sources.md
@@ -15,11 +15,13 @@ Always read the plan file first and check the `format` field in frontmatter:
 | `local-markdown` | Full plan is in this file | Read content directly |
 | `linear` | Plan managed in Linear | Query Linear via MCP |
 | `backlog-md` | Tasks in Backlog.md | Query via MCP or read `backlog/` |
+| `beads` | Graph tracker for agents | Use `bd` CLI commands |
 
 For full format details, see the planning skill's output adapters:
 - [output-local-markdown.md](../../technical-planning/references/output-local-markdown.md)
 - [output-linear.md](../../technical-planning/references/output-linear.md)
 - [output-backlog-md.md](../../technical-planning/references/output-backlog-md.md)
+- [output-beads.md](../../technical-planning/references/output-beads.md)
 
 ## Reading Plans
 
@@ -47,6 +49,16 @@ For full format details, see the planning skill's output adapters:
 
 **Fallback**: Can read `backlog/` files directly if MCP unavailable.
 
+### Beads
+
+1. Extract `epic` ID from frontmatter
+2. Run `bd ready` to get unblocked tasks
+3. View task details with `bd show bd-{id}`
+4. Process by priority (P0 → P1 → P2 → P3)
+5. Respect dependency graph - only work on ready tasks
+
+**Fallback**: If `bd` CLI unavailable, inform user to install beads.
+
 ## Updating Progress
 
 ### Local Markdown
@@ -62,6 +74,12 @@ For full format details, see the planning skill's output adapters:
 - Check off acceptance criteria items in task file
 - Update status to "Done" when complete
 - Backlog.md CLI auto-moves to completed folder
+
+### Beads
+- Close tasks with `bd close bd-{id} "reason"` when complete
+- Include task ID in commit messages: `git commit -m "message (bd-{id})"`
+- **Critical**: Run `bd sync` at session end to persist changes
+- Use `bd ready` to identify next unblocked task
 
 ## Execution Workflow
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -35,6 +35,7 @@ The specification is the **sole source of truth**. It contains validated, approv
 - [output-local-markdown.md](references/output-local-markdown.md) - Single `{topic}.md` file (default)
 - [output-linear.md](references/output-linear.md) - Linear project
 - [output-backlog-md.md](references/output-backlog-md.md) - Backlog.md tasks
+- [output-beads.md](references/output-beads.md) - Beads graph tracker (agent-optimized)
 
 **Output**: Implementation plan in chosen format
 

--- a/skills/technical-planning/references/output-beads.md
+++ b/skills/technical-planning/references/output-beads.md
@@ -1,0 +1,255 @@
+# Output: Beads
+
+*Output adapter for **[technical-planning](../SKILL.md)***
+
+---
+
+Use this output format when you need **dependency-aware task tracking designed for AI agents**. Beads is a git-backed graph issue tracker that excels at complex, multi-phase implementations with real dependency management.
+
+## About Beads
+
+Beads (`bd`) is an issue tracker built specifically for AI agents:
+- Git-backed storage in `.beads/` directory (JSONL format)
+- Hash-based IDs (`bd-a1b2`) prevent merge conflicts
+- Native dependency graph with blocking relationships
+- Hierarchical tasks: epics → tasks → subtasks
+- `bd ready` command identifies unblocked work
+- Semantic summarization preserves context windows
+- Multi-agent coordination via sync protocol
+
+See: https://github.com/steveyegge/beads
+
+## Prerequisites
+
+- Beads CLI installed (`npm install -g @anthropic-ai/beads` or via Homebrew/Go)
+- Repository initialized with `bd init` (human setup step)
+
+## When to Use
+
+Choose beads when:
+- Complex dependency graphs between tasks
+- Multi-session implementations needing context preservation
+- Multiple agents may work on the project
+- You need `bd ready` to identify actionable work
+- Long-horizon task management
+
+Avoid beads when:
+- Simple linear features (use local markdown)
+- Team collaboration with non-AI members (use Linear)
+- Human readability is paramount (JSONL is less readable)
+- Single-session implementations
+
+## Beads Structure Mapping
+
+| Planning Concept | Beads Entity |
+|------------------|--------------|
+| Plan | Epic issue |
+| Phase | Sub-issue under epic |
+| Task | Sub-task under phase |
+| Dependency | `bd dep add` relationship |
+
+Example hierarchy:
+```
+bd-a3f8        (Epic: User Authentication)
+├── bd-a3f8.1  (Phase 1: Core Auth)
+│   ├── bd-a3f8.1.1  (Task: Login endpoint)
+│   └── bd-a3f8.1.2  (Task: Session management)
+└── bd-a3f8.2  (Phase 2: OAuth)
+    └── bd-a3f8.2.1  (Task: Google provider)
+```
+
+## Output Process
+
+### 1. Create Epic for Plan
+
+```bash
+bd create "Plan: {Topic Name}" -p 1
+```
+
+Note the returned ID (e.g., `bd-a3f8`). This is the plan epic.
+
+### 2. Create Phase Issues
+
+For each phase, create a sub-issue under the epic:
+
+```bash
+bd create "Phase 1: {Phase Name}" -p 1 --parent bd-a3f8
+bd create "Phase 2: {Phase Name}" -p 2 --parent bd-a3f8
+```
+
+Add phase acceptance criteria in the issue body.
+
+### 3. Create Task Issues
+
+For each task, create under the appropriate phase:
+
+```bash
+bd create "{Task Name}" -p 1 --parent bd-a3f8.1
+```
+
+Task body should include:
+```
+## Goal
+{What this task accomplishes}
+
+## Implementation
+{Specific files, methods, approach}
+
+## Tests
+- `it does expected behavior`
+- `it handles edge case`
+
+## Specification
+docs/workflow/specification/{topic}.md
+```
+
+### 4. Add Dependencies
+
+When tasks depend on each other:
+
+```bash
+bd dep add bd-a3f8.1.2 bd-a3f8.1.1  # 1.2 blocked by 1.1
+```
+
+### 5. Create Local Plan File
+
+Create `docs/workflow/planning/{topic}.md`:
+
+```markdown
+---
+format: beads
+epic: bd-{EPIC_ID}
+---
+
+# Plan Reference: {Topic Name}
+
+**Specification**: `docs/workflow/specification/{topic}.md`
+**Created**: {DATE}
+
+## About This Plan
+
+This plan is managed via Beads. Tasks are stored in `.beads/` and tracked as a dependency graph.
+
+## How to Use
+
+**View ready tasks**: Run `bd ready`
+**View all tasks**: Run `bd list --tree`
+**View specific task**: Run `bd show bd-{id}`
+
+**Implementation will**:
+1. Read this file to identify the epic
+2. Query `bd ready` for unblocked tasks
+3. Work through tasks respecting dependencies
+4. Close tasks with `bd close bd-{id} "reason"`
+5. Sync with `bd sync` at session end
+
+## Key Decisions
+
+[Summary of key decisions from specification]
+
+## Phase Overview
+
+| Phase | Goal | Epic ID |
+|-------|------|---------|
+| Phase 1 | {Goal} | bd-{id}.1 |
+| Phase 2 | {Goal} | bd-{id}.2 |
+```
+
+## Frontmatter
+
+The `format: beads` frontmatter tells implementation to use beads CLI:
+
+```yaml
+---
+format: beads
+epic: bd-a3f8
+---
+```
+
+## Flagging Incomplete Tasks
+
+When information is missing, note it in the task body:
+
+```bash
+bd create "Configure rate limiting [needs-info]" -p 2 --parent bd-a3f8.1
+```
+
+In the task body:
+```
+## Needs Clarification
+- What's the rate limit threshold?
+- Per-user or per-IP?
+```
+
+## Implementation Reading
+
+Implementation will:
+1. Read `planning/{topic}.md`, see `format: beads`
+2. Run `bd ready` to get unblocked tasks
+3. Pick highest priority ready task
+4. Execute task (TDD cycle)
+5. Close task: `bd close bd-{id} "Implemented with tests"`
+6. Repeat until `bd ready` returns empty
+7. **Critical**: Run `bd sync` before session end
+
+## Beads Workflow Commands
+
+| Command | Purpose |
+|---------|---------|
+| `bd ready` | List tasks with no open blockers |
+| `bd list --tree` | Show full task hierarchy |
+| `bd show bd-{id}` | View task details |
+| `bd close bd-{id} "reason"` | Complete a task |
+| `bd dep add child parent` | Add dependency |
+| `bd sync` | Commit and push changes |
+
+## Sync Protocol
+
+**Critical**: Implementation must run `bd sync` at session end to:
+- Export pending changes to JSONL
+- Commit to git
+- Push to remote
+
+Without sync, changes stay in a 30-second debounce window and may not persist.
+
+## Commit Message Convention
+
+Include issue IDs in commits:
+
+```bash
+git commit -m "Add login endpoint (bd-a3f8.1.1)"
+```
+
+This enables `bd doctor` to identify orphaned issues.
+
+## Resulting Structure
+
+After planning:
+
+```
+project/
+├── .beads/
+│   └── issues.jsonl          # Beads database
+├── docs/workflow/
+│   ├── discussion/{topic}.md      # Phase 2 output
+│   ├── specification/{topic}.md   # Phase 3 output
+│   └── planning/{topic}.md        # Phase 4 output (format: beads)
+```
+
+## Fallback Handling
+
+If beads CLI is unavailable during implementation:
+- Check if `bd` command exists
+- If not, inform user to install beads
+- Suggest switching to local markdown format as alternative
+
+## Priority Mapping
+
+| Planning Priority | Beads Priority |
+|-------------------|----------------|
+| Foundation/Setup | P0 |
+| Core functionality | P1 |
+| Enhancement | P2 |
+| Nice-to-have | P3 |
+
+Use `-p {0-3}` flag when creating issues.


### PR DESCRIPTION
Add support for beads (steveyegge/beads) as a fourth output format
option for the planning skill. Beads is a git-backed graph issue
tracker designed for AI agents with dependency tracking, hierarchical
tasks, and context window management.

- Add output-beads.md adapter with full workflow documentation
- Update planning SKILL.md to include beads option
- Update implementation plan-sources.md to handle beads format