### PR TITLE
feat: add beads output format option to start-planning command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ This package depends on [`leeovery/claude-manager`](https://github.com/leeovery/
 1. **Symlinks skills** into your project's `.claude/skills/` directory
 2. **Symlinks commands** into your project's `.claude/commands/` directory
 3. **Symlinks agents** into your project's `.claude/agents/` directory
-4. **Manages your `.gitignore`** with a deterministic list of linked skills, commands, and agents
-5. **Handles installation/removal** automatically via Composer hooks
+4. **Provides hooks** that can be copied to `.claude/hooks/` for session setup
+5. **Manages your `.gitignore`** with a deterministic list of linked skills, commands, and agents
+6. **Handles installation/removal** automatically via Composer hooks
 
 You don't need to configure anything—just install and start discussing.
 
@@ -94,6 +95,33 @@ docs/workflow/
 ```
 
 Research is a flat directory of semantically named files (topics emerge later). From discussion onwards, each topic gets its own file per phase.
+
+### Package Structure
+
+This package provides:
+
+```
+skills/
+├── technical-research/        # Phase 1: Explore and validate ideas
+├── technical-discussion/      # Phase 2: Document discussions
+├── technical-specification/   # Phase 3: Build validated specifications
+├── technical-planning/        # Phase 4: Create implementation plans
+├── technical-implementation/  # Phase 5: Execute via TDD
+└── technical-review/          # Phase 6: Validate against artifacts
+
+commands/
+├── start-research.md          # Begin research exploration
+├── start-discussion.md        # Begin technical discussions
+├── start-specification.md     # Begin specification building
+├── start-planning.md          # Begin implementation planning
+└── interview.md               # Focused questioning mode
+
+agents/
+└── chain-verifier.md          # Parallel task verification for review
+
+hooks/
+└── install-beads.sh           # Auto-install Beads CLI for web sessions
+```
 
 ## Skills
 
@@ -167,7 +195,7 @@ Converts specifications into structured implementation plans.
 **What it produces:**
 - Phased implementation plans with specific tasks
 - Acceptance criteria at phase and task levels
-- Multiple output formats: local markdown, Linear, or Backlog.md
+- Multiple output formats: local markdown, Linear, Backlog.md, or Beads
 
 ### technical-implementation
 
@@ -208,7 +236,7 @@ Slash commands to quickly invoke the workflow.
 | [**/start-research**](commands/start-research.md) | Begin research exploration. For early-stage ideas, feasibility checks, and broad exploration before formal discussion. |
 | [**/start-discussion**](commands/start-discussion.md) | Begin a new technical discussion. Gathers topic, context, background information, and relevant codebase areas before starting documentation. |
 | [**/start-specification**](commands/start-specification.md) | Start a specification session from an existing discussion. Validates and refines discussion content into a standalone specification. |
-| [**/start-planning**](commands/start-planning.md) | Start a planning session from an existing specification. Creates implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (markdown, Linear, Backlog.md). |
+| [**/start-planning**](commands/start-planning.md) | Start a planning session from an existing specification. Creates implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (markdown, Linear, Backlog.md, Beads). |
 | [**/interview**](commands/interview.md) | Shift into focused questioning mode during research or discussion. Probes ideas with non-obvious questions, challenges assumptions, and surfaces concerns. |
 
 ## Agents
@@ -218,6 +246,37 @@ Subagents that skills can spawn for parallel task execution.
 | Agent | Used By | Description |
 |-------|---------|-------------|
 | [**chain-verifier**](agents/chain-verifier.md) | technical-review | Verifies a single plan task was implemented correctly. Checks implementation, tests (not under/over-tested), and code quality. Multiple chain-verifiers run in parallel to verify ALL tasks efficiently. |
+
+## Hooks
+
+Session start hooks for environment setup, particularly useful for Claude Code on the web.
+
+| Hook | Description |
+|------|-------------|
+| [**install-beads.sh**](hooks/install-beads.sh) | Auto-installs the Beads CLI (`bd`) if not present. Detects platform (linux/darwin, amd64/arm64) and downloads the correct binary from GitHub releases. Essential for Claude Code on the web where `bd` isn't pre-installed. |
+
+### Using Hooks
+
+To use a hook in your project, copy it to `.claude/hooks/` and configure in `.claude/settings.json`:
+
+```bash
+mkdir -p .claude/hooks
+cp vendor/leeovery/claude-technical-workflows/hooks/install-beads.sh .claude/hooks/
+chmod +x .claude/hooks/install-beads.sh
+```
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": ".claude/hooks/install-beads.sh"
+      }
+    ]
+  }
+}
+```
 
 ## Requirements
 

--- a/commands/start-planning.md
+++ b/commands/start-planning.md
@@ -85,7 +85,40 @@ Ask: **Where should this plan live?**
 
 **If Linear or Backlog.md selected**: Check if MCP is available. If not, inform the user and suggest alternatives.
 
-**If Beads selected**: Check if `bd` command is available. If not, inform the user to install it (`npm install -g @anthropic-ai/beads`).
+**If Beads selected**: Check if `bd` command is available. If not:
+- For local Claude Code: Inform the user to install it (`npm install -g @beads/bd`)
+- For Claude Code on the web: Offer to set up a session start hook that auto-installs beads
+
+### Setting Up Beads for Claude Code on the Web
+
+If the user is on Claude Code for the web and `bd` is not available, offer to install a session start hook:
+
+1. Create the hooks directory if it doesn't exist:
+   ```bash
+   mkdir -p .claude/hooks
+   ```
+
+2. Copy the install script:
+   ```bash
+   cp hooks/install-beads.sh .claude/hooks/install-beads.sh
+   chmod +x .claude/hooks/install-beads.sh
+   ```
+
+3. Add the hook to `.claude/settings.json`:
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [
+         {
+           "type": "command",
+           "command": ".claude/hooks/install-beads.sh"
+         }
+       ]
+     }
+   }
+   ```
+
+This ensures `bd` is available at the start of each Claude Code session.
 
 ## Step 5: Gather Additional Context
 

--- a/commands/start-planning.md
+++ b/commands/start-planning.md
@@ -77,7 +77,15 @@ Ask: **Where should this plan live?**
    - Terminal and web Kanban views
    - Git-native with auto-commit support
 
+4. **Beads** - Git-backed graph issue tracker for AI agents
+   - Best for: Complex dependency graphs, multi-session implementations
+   - Native dependency tracking with `bd ready` for unblocked work
+   - Hierarchical: epics → phases → tasks
+   - Requires: Beads CLI installed (`bd`)
+
 **If Linear or Backlog.md selected**: Check if MCP is available. If not, inform the user and suggest alternatives.
+
+**If Beads selected**: Check if `bd` command is available. If not, inform the user to install it (`npm install -g @anthropic-ai/beads`).
 
 ## Step 5: Gather Additional Context
 
@@ -93,7 +101,7 @@ Ask: **Where should this plan live?**
 Pass to the technical-planning skill:
 - Specification: `docs/workflow/specification/{topic}.md`
 - Output: `docs/workflow/planning/{topic}.md`
-- Output destination: (local-markdown | linear | backlog-md)
+- Output destination: (local-markdown | linear | backlog-md | beads)
 - Additional context gathered
 
 **Example handoff:**
@@ -116,6 +124,17 @@ Team: Engineering
 
 Begin planning using the technical-planning skill.
 Reference: formal-planning.md, then output-linear.md
+```
+
+**Example handoff for Beads:**
+```
+Planning session for: {topic}
+Specification: docs/workflow/specification/{topic}.md
+Output destination: Beads
+Output path: docs/workflow/planning/{topic}.md
+
+Begin planning using the technical-planning skill.
+Reference: formal-planning.md, then output-beads.md
 ```
 
 ## Notes

--- a/hooks/install-beads.sh
+++ b/hooks/install-beads.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Session Start Hook: Install Beads (bd) if not present
+# This hook is for Claude Code on the web where bd isn't pre-installed.
+# Local Claude Code users should install bd via: npm install -g @beads/bd
+#
+
+set -e
+
+BEADS_VERSION="0.41.0"
+
+# Check if bd is already installed
+if command -v bd &> /dev/null; then
+    exit 0
+fi
+
+# Detect platform
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+case "$ARCH" in
+    x86_64) ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# Download and install
+DOWNLOAD_URL="https://github.com/steveyegge/beads/releases/download/v${BEADS_VERSION}/beads_${BEADS_VERSION}_${OS}_${ARCH}.tar.gz"
+TMP_DIR=$(mktemp -d)
+
+curl -fsSL -o "$TMP_DIR/beads.tar.gz" "$DOWNLOAD_URL"
+tar -xzf "$TMP_DIR/beads.tar.gz" -C "$TMP_DIR"
+
+# Install to /usr/local/bin (requires sudo in some environments)
+if [[ -w /usr/local/bin ]]; then
+    mv "$TMP_DIR/bd" /usr/local/bin/bd
+else
+    sudo mv "$TMP_DIR/bd" /usr/local/bin/bd
+fi
+chmod +x /usr/local/bin/bd
+
+rm -rf "$TMP_DIR"
+
+echo "Installed beads v${BEADS_VERSION}"

--- a/skills/technical-planning/references/output-beads.md
+++ b/skills/technical-planning/references/output-beads.md
@@ -21,8 +21,39 @@ See: https://github.com/steveyegge/beads
 
 ## Prerequisites
 
-- Beads CLI installed (`npm install -g @anthropic-ai/beads` or via Homebrew/Go)
+- Beads CLI installed (`npm install -g @beads/bd` or via Homebrew/Go)
 - Repository initialized with `bd init` (human setup step)
+
+### Claude Code on the Web
+
+For Claude Code on the web where `bd` isn't pre-installed, set up a session start hook:
+
+1. Create the hooks directory:
+   ```bash
+   mkdir -p .claude/hooks
+   ```
+
+2. Copy the install script from this package:
+   ```bash
+   cp hooks/install-beads.sh .claude/hooks/install-beads.sh
+   chmod +x .claude/hooks/install-beads.sh
+   ```
+
+3. Add to `.claude/settings.json`:
+   ```json
+   {
+     "hooks": {
+       "SessionStart": [
+         {
+           "type": "command",
+           "command": ".claude/hooks/install-beads.sh"
+         }
+       ]
+     }
+   }
+   ```
+
+The hook script is available at `hooks/install-beads.sh` in this package. It automatically downloads and installs the correct beads binary for the platform.
 
 ## When to Use
 


### PR DESCRIPTION
Add Beads as fourth output destination option alongside Local Markdown,
Linear, and Backlog.md. Beads is a git-backed graph issue tracker
designed for AI agents with dependency-aware task tracking.