### PR TITLE
docs: add installation modes section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ composer require --dev leeovery/claude-technical-workflows
 
 That's it. The [Claude Manager](https://github.com/leeovery/claude-manager) handles everything else automatically.
 
+### Installation Modes
+
+On first install, you'll be prompted to choose an installation mode. This choice applies to all plugins managed by Claude Manager:
+
+| Mode | Description |
+|------|-------------|
+| **Symlink** (default) | Assets stay in vendor/ with symlinks to `.claude/`. Gitignore is managed automatically. |
+| **Copy** | Assets are copied to `.claude/` and become part of your repository. Ideal for Claude Code on the web where skills need to be available before `composer install` runs. |
+
+See the [Claude Manager README](https://github.com/leeovery/claude-manager) for full details on switching modes and CLI commands.
+
 ## The Six-Phase Workflow
 
 This package enforces a deliberate progression through six distinct phases:


### PR DESCRIPTION
Document symlink and copy installation modes matching the
Claude Manager's new mode selection feature.