### PR TITLE
Add strict instructions to prevent skipping steps in start-implementation

### DIFF
--- a/commands/start-implementation.md
+++ b/commands/start-implementation.md
@@ -4,6 +4,14 @@ description: Start an implementation session from an existing plan. Discovers av
 
 Invoke the **technical-implementation** skill for this conversation.
 
+## IMPORTANT: Follow these steps EXACTLY. Do not skip steps.
+
+- Ask each question and WAIT for a response before proceeding
+- Do NOT install anything or invoke tools until Step 6
+- Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
+- Do NOT make assumptions about what the user wants
+- Complete each step fully before moving to the next
+
 ## Instructions
 
 Follow these steps EXACTLY as written. Do not skip steps or combine them.

--- a/commands/start-implementation.md
+++ b/commands/start-implementation.md
@@ -2,8 +2,6 @@
 description: Start an implementation session from an existing plan. Discovers available plans, checks environment setup, and invokes the technical-implementation skill.
 ---
 
-Invoke the **technical-implementation** skill for this conversation.
-
 ## IMPORTANT: Follow these steps EXACTLY. Do not skip steps.
 
 - Ask each question and WAIT for a response before proceeding
@@ -84,6 +82,8 @@ Which approach?
 If they choose a specific phase or task, ask them to specify which one.
 
 ## Step 6: Invoke Implementation Skill
+
+Invoke the **technical-implementation** skill for this conversation.
 
 Pass to the technical-implementation skill:
 - Plan: `docs/workflow/planning/{topic}.md`


### PR DESCRIPTION
Adds explicit warnings at the top of the command to ensure Claude:
- Waits for user responses before proceeding
- Does not invoke tools until the appropriate step
- Confirms with users even if initial prompt seems to answer questions
- Does not make assumptions about user intent