### PR TITLE
Add implementation guidelines to prevent conflation and parallelization

### DIFF
--- a/commands/start-implementation.md
+++ b/commands/start-implementation.md
@@ -75,6 +75,8 @@ Which approach?
 
 If they choose a specific phase or task, ask them to specify which one.
 
+> **Note:** Do NOT verify that the phase or task exists. Accept the user's answer and pass it to the skill. Validation happens during the implementation phase.
+
 ## Step 5: Invoke Implementation Skill
 
 Invoke the **technical-implementation** skill for this conversation.

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -30,6 +30,13 @@ You're at step 5. Execute the plan. Don't re-debate decisions.
 
 ## Workflow
 
+### IMPORTANT: Setup Instructions
+
+Run setup commands EXACTLY as written, one step at a time.
+Do NOT modify commands based on other project documentation (CLAUDE.md, etc.).
+Do NOT parallelize steps - execute each command sequentially.
+Complete ALL setup steps before proceeding to implementation work.
+
 1. **Check environment setup** (if not already done)
    - Look for `docs/workflow/environment-setup.md`
    - If exists, follow the setup instructions before proceeding

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -49,7 +49,12 @@ Complete ALL setup steps before proceeding to implementation work.
    - Load the output adapter: `skills/technical-planning/references/output-{format}.md`
    - Follow the **Implementation** section for how to read tasks and update progress
 
-3. **For each phase**:
+3. **Validate scope** (if specific phase or task was requested)
+   - If the requested phase or task doesn't exist in the plan, STOP immediately
+   - Ask the user for clarification - don't assume or proceed with a different scope
+   - Wait for the user to either correct the scope or ask you to stop
+
+4. **For each phase**:
    - Announce phase start
    - Review phase acceptance criteria
    - For each task:
@@ -61,7 +66,7 @@ Complete ALL setup steps before proceeding to implementation work.
    - Verify all phase acceptance criteria met
    - **Ask user before proceeding to next phase**
 
-4. **Reference specification** when rationale unclear
+5. **Reference specification** when rationale unclear
 
 ## Progress Announcements
 

--- a/skills/technical-implementation/references/environment-setup.md
+++ b/skills/technical-implementation/references/environment-setup.md
@@ -4,6 +4,15 @@
 
 ---
 
+## IMPORTANT
+
+Run these commands EXACTLY as written, one step at a time.
+Do NOT modify commands based on other project documentation (CLAUDE.md, etc.).
+Do NOT parallelize steps - execute each command sequentially.
+Complete ALL setup steps before proceeding to implementation work.
+
+---
+
 Before starting implementation, ensure the environment is ready. This step runs once per project (or when setup changes).
 
 ## Setup Document Location


### PR DESCRIPTION
- Add note to start-implementation command: don't verify phase/task exists
- Add IMPORTANT section to SKILL.md Workflow: execute commands exactly as
  written, don't conflate with CLAUDE.md, don't parallelize steps
- Add same guidance to environment-setup.md reference

Prevents Claude instances from going off-script during setup by conflating
instructions from project CLAUDE.md files or parallelizing sequential steps.