### PR TITLE
Tighten TDD enforcement in technical-implementation skill

### DIFF
--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -24,21 +24,15 @@ You're at step 5. Execute the plan. Don't re-debate decisions.
 
 **MANDATORY. No exceptions. Violating these rules invalidates the work.**
 
-1. **No code before tests** - Write the failing test first. Always. If you catch yourself writing implementation code without a failing test, STOP immediately, delete the code, and write the test first.
-2. **No test changes to pass** - If code doesn't pass, fix the code. Tests can only be fixed if genuinely broken or poorly designed, never to accommodate broken code.
+1. **No code before tests** - Write the failing test first. Always.
+2. **No test changes to pass** - Fix the code, not the test.
 3. **No scope expansion** - If it's not in the plan, don't build it.
 4. **No assumptions** - Uncertain? Check specification. Still uncertain? Stop and ask.
 5. **Commit after green** - Every passing test = commit point.
 
-### Before Writing ANY Implementation Code
+**Pragmatic TDD**: The discipline is test-first sequencing, not artificial minimalism. Write complete, functional implementations - don't fake it with hardcoded returns. "Minimal" means no gold-plating beyond what the test requires.
 
-Ask yourself these questions. If any answer is "no", STOP.
-
-- [ ] Do I have a failing test for this behavior?
-- [ ] Did I run the test and confirm it fails?
-- [ ] Does it fail for the RIGHT reason (not a syntax error or missing import)?
-
-Only after all three: write the minimum code to pass.
+See **[tdd-workflow.md](references/tdd-workflow.md)** for the full TDD cycle, violation recovery, and guidance on when tests can change.
 
 ## Workflow
 
@@ -68,20 +62,10 @@ Complete ALL setup steps before proceeding to implementation work.
    - Wait for the user to either correct the scope or ask you to stop
 
 4. **For each phase**:
-   - Announce phase start
-   - Review phase acceptance criteria
-   - For each task:
-     - Derive test from task's micro acceptance criteria
-     - Write the test (**no implementation code yet**)
-     - Run test - confirm it **fails** (for the right reason)
-     - Write minimal code to pass
-     - Run test - confirm it **passes**
-     - Refactor if needed (only when green)
-     - Commit immediately
+   - Announce phase start and review acceptance criteria
+   - For each task: follow the TDD cycle in **[tdd-workflow.md](references/tdd-workflow.md)**
    - Verify all phase acceptance criteria met
    - **Ask user before proceeding to next phase**
-
-   **If you write implementation before a failing test: STOP, delete the code, write the test first.**
 
 5. **Reference specification** when rationale unclear
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -22,11 +22,23 @@ You're at step 5. Execute the plan. Don't re-debate decisions.
 
 ## Hard Rules
 
-1. **No code before tests** - Write the failing test first. Always.
+**MANDATORY. No exceptions. Violating these rules invalidates the work.**
+
+1. **No code before tests** - Write the failing test first. Always. If you catch yourself writing implementation code without a failing test, STOP immediately, delete the code, and write the test first.
 2. **No test changes to pass** - If code doesn't pass, fix the code. Tests can only be fixed if genuinely broken or poorly designed, never to accommodate broken code.
 3. **No scope expansion** - If it's not in the plan, don't build it.
 4. **No assumptions** - Uncertain? Check specification. Still uncertain? Stop and ask.
 5. **Commit after green** - Every passing test = commit point.
+
+### Before Writing ANY Implementation Code
+
+Ask yourself these questions. If any answer is "no", STOP.
+
+- [ ] Do I have a failing test for this behavior?
+- [ ] Did I run the test and confirm it fails?
+- [ ] Does it fail for the RIGHT reason (not a syntax error or missing import)?
+
+Only after all three: write the minimum code to pass.
 
 ## Workflow
 
@@ -60,12 +72,16 @@ Complete ALL setup steps before proceeding to implementation work.
    - Review phase acceptance criteria
    - For each task:
      - Derive test from task's micro acceptance criteria
-     - Write failing test
-     - Implement minimal code to pass
+     - Write the test (**no implementation code yet**)
+     - Run test - confirm it **fails** (for the right reason)
+     - Write minimal code to pass
+     - Run test - confirm it **passes**
      - Refactor if needed (only when green)
-     - Commit
+     - Commit immediately
    - Verify all phase acceptance criteria met
    - **Ask user before proceeding to next phase**
+
+   **If you write implementation before a failing test: STOP, delete the code, write the test first.**
 
 5. **Reference specification** when rationale unclear
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -56,18 +56,20 @@ Complete ALL setup steps before proceeding to implementation work.
    - Load the output adapter: `skills/technical-planning/references/output-{format}.md`
    - Follow the **Implementation** section for how to read tasks and update progress
 
-3. **Validate scope** (if specific phase or task was requested)
+3. **Read the TDD workflow** - Load **[tdd-workflow.md](references/tdd-workflow.md)** before writing any code. This is mandatory.
+
+4. **Validate scope** (if specific phase or task was requested)
    - If the requested phase or task doesn't exist in the plan, STOP immediately
    - Ask the user for clarification - don't assume or proceed with a different scope
    - Wait for the user to either correct the scope or ask you to stop
 
-4. **For each phase**:
+5. **For each phase**:
    - Announce phase start and review acceptance criteria
-   - For each task: follow the TDD cycle in **[tdd-workflow.md](references/tdd-workflow.md)**
+   - For each task: follow the TDD cycle loaded in step 3
    - Verify all phase acceptance criteria met
    - **Ask user before proceeding to next phase**
 
-5. **Reference specification** when rationale unclear
+6. **Reference specification** when rationale unclear
 
 ## Progress Announcements
 

--- a/skills/technical-implementation/references/environment-setup.md
+++ b/skills/technical-implementation/references/environment-setup.md
@@ -62,7 +62,7 @@ Each output adapter contains prerequisites and installation instructions for tha
 
 ## Example Setup Document
 
-```markdown
+````markdown
 # Environment Setup
 
 Instructions for setting up the implementation environment.
@@ -100,4 +100,4 @@ Run tests to verify setup:
 ```bash
 php artisan test
 ```
-```
+````

--- a/skills/technical-implementation/references/plan-execution.md
+++ b/skills/technical-implementation/references/plan-execution.md
@@ -21,17 +21,9 @@ Plans live in `docs/workflow/planning/{topic}.md` with phases and tasks.
 
 For each phase:
 1. Announce phase start with acceptance criteria
-2. For each task:
-   - Derive test from micro acceptance criteria
-   - Write the test (no implementation code yet)
-   - Run test - confirm it FAILS
-   - Write minimal code to pass
-   - Run test - confirm it PASSES
-   - Commit immediately
+2. For each task: follow the TDD cycle in **[tdd-workflow.md](tdd-workflow.md)**
 3. Verify all acceptance criteria met
 4. **Wait for user confirmation before next phase**
-
-**The test-first sequence is mandatory.** If you find yourself writing implementation before a failing test exists, STOP, delete the code, and start over with the test.
 
 ## Referencing Specification
 

--- a/skills/technical-implementation/references/plan-execution.md
+++ b/skills/technical-implementation/references/plan-execution.md
@@ -21,9 +21,17 @@ Plans live in `docs/workflow/planning/{topic}.md` with phases and tasks.
 
 For each phase:
 1. Announce phase start with acceptance criteria
-2. For each task: derive test → write failing test → implement → commit
+2. For each task:
+   - Derive test from micro acceptance criteria
+   - Write the test (no implementation code yet)
+   - Run test - confirm it FAILS
+   - Write minimal code to pass
+   - Run test - confirm it PASSES
+   - Commit immediately
 3. Verify all acceptance criteria met
 4. **Wait for user confirmation before next phase**
+
+**The test-first sequence is mandatory.** If you find yourself writing implementation before a failing test exists, STOP, delete the code, and start over with the test.
 
 ## Referencing Specification
 

--- a/skills/technical-implementation/references/tdd-workflow.md
+++ b/skills/technical-implementation/references/tdd-workflow.md
@@ -10,6 +10,15 @@ RED → GREEN → REFACTOR → COMMIT
 
 Repeat for each task. **Never skip steps. Never reorder.**
 
+### Pragmatic TDD
+
+This is pragmatic TDD, not purist. The mandatory discipline is **test-first sequencing**:
+- You MUST write a failing test before implementation
+- You MUST see it fail for the right reason
+- You MUST NOT change tests to make broken code pass
+
+But write **complete, functional implementations** - don't artificially minimize with hardcoded returns or fake values that you'll "fix later". "Minimal" means no gold-plating beyond what the test requires, not "return 42 and triangulate".
+
 ## TDD Violation Recovery
 
 **If you catch yourself violating TDD, stop immediately and recover:**
@@ -37,10 +46,10 @@ Repeat for each task. **Never skip steps. Never reorder.**
 
 **No implementation code exists yet.** If you're tempted to "just sketch out the class first" - don't. The test comes first. Always.
 
-## GREEN: Minimal Implementation
+## GREEN: Implementation
 
-Write the simplest code that passes:
-- No extra features
+Write complete, functional code that passes:
+- No extra features beyond what the test requires
 - No "while I'm here" improvements
 - No edge cases not yet tested
 

--- a/skills/technical-implementation/references/tdd-workflow.md
+++ b/skills/technical-implementation/references/tdd-workflow.md
@@ -8,18 +8,34 @@
 
 RED → GREEN → REFACTOR → COMMIT
 
-Repeat for each task.
+Repeat for each task. **Never skip steps. Never reorder.**
+
+## TDD Violation Recovery
+
+**If you catch yourself violating TDD, stop immediately and recover:**
+
+| Violation | Recovery |
+|-----------|----------|
+| Wrote code before test | DELETE the code. Write the failing test. Then rewrite the code. |
+| Multiple failing tests | Comment out all but one. Fix that one. Uncomment next. |
+| Test passes immediately | Suspicious. Verify the test actually exercises your code. Check for false positives. |
+| Changed test to make code pass | REVERT the test change. Fix the implementation instead. |
+| "While I'm here" improvement | STOP. Is it in the plan? No? Don't do it. |
+
+**These are not suggestions. Skipping recovery corrupts the entire TDD discipline.**
 
 ## RED: Write Failing Test
 
 1. Read task's micro acceptance criteria
 2. Write test asserting that behavior
-3. Run test - must fail
-4. Verify it fails for the right reason
+3. Run test - **MUST fail**
+4. Verify it fails for the **right reason** (not syntax error, not missing import)
 
 **Derive tests from plan**: Task's micro acceptance becomes your first test. Edge cases become additional tests.
 
 **Write test names first**: List all test names before writing bodies. Confirm coverage matches acceptance criteria.
+
+**No implementation code exists yet.** If you're tempted to "just sketch out the class first" - don't. The test comes first. Always.
 
 ## GREEN: Minimal Implementation
 
@@ -28,36 +44,31 @@ Write the simplest code that passes:
 - No "while I'm here" improvements
 - No edge cases not yet tested
 
-If you think "I should also handle X" - stop. Write a test for X first.
+If you think "I should also handle X" - STOP. Write a test for X first.
 
-**One test at a time**: Write → Pass → Commit → Next
+**One test at a time**: Write test → Run (fails) → Implement → Run (passes) → Commit → Next
 
 ## REFACTOR: Only When Green
 
 **Do**: Remove duplication, improve naming, extract methods
 **Don't**: Touch code outside current task, optimize prematurely
 
-Run tests after. If they fail, undo.
+Run tests after. If they fail, undo the refactor.
 
 ## COMMIT: After Every Green
 
-Commit with descriptive message referencing the task.
+Commit with descriptive message referencing the task. This is non-negotiable - it creates recovery points.
 
 ## When Tests CAN Change
 
-- Genuine bug in test
-- Tests implementation not behavior
+- Genuine bug in test logic
+- Test asserts implementation details, not behavior
 - Missing setup/fixtures
 
 ## When Tests CANNOT Change
 
-- To make broken code pass (fix the code)
-- To avoid difficult work (the test is the requirement)
-- To skip temporarily (fix or escalate)
+- To make broken code pass → **fix the code**
+- To avoid difficult implementation → **the test IS the requirement**
+- To skip temporarily → **fix it now or escalate**
 
-## Red Flags
-
-- Wrote code before test → delete code, write test first
-- Multiple failing tests → work on one at a time
-- Test passes immediately → investigate
-- Changing tests frequently → design unclear, review plan
+Changing a test to pass is admitting the implementation is wrong and hiding it. Don't.


### PR DESCRIPTION
- Add explicit "MANDATORY" header to Hard Rules section
- Add pre-implementation checklist to catch violations before they happen
- Create TDD Violation Recovery table with specific recovery actions
- Strengthen language throughout (should → MUST, stop → STOP)
- Add explicit "delete code, write test first" recovery instruction
- Expand task execution steps to separate test writing from running
- Move red flags content into actionable violation recovery section