### PR TITLE
claude/cache-discussion-analysis-6qCxd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 *$py.class
 *.so
 .Python
+
+# Workflow cache
+docs/workflow/.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@ __pycache__/
 *$py.class
 *.so
 .Python
-
-# Workflow cache
-docs/workflow/.cache/


### PR DESCRIPTION
- Cache research analysis results using md5 checksum of research files
- Skip re-analysis when research documents haven't changed
- Allow users to force refresh with 'refresh' command
- Store cache in docs/workflow/.cache/research-analysis.md
- Add .cache directory to .gitignore