### PR TITLE
Add exhaustive extraction requirements to specification skill

### DIFF
--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -37,15 +37,17 @@ Either way: Transform unvalidated reference material into a specification that's
 
 ## What You Do
 
-1. **Filter**: Reference material may contain hallucinations, inaccuracies, or outdated concepts. Validate before including.
+1. **Extract exhaustively**: For each topic, re-scan ALL source material. Search for keywords and related terms. Information is often scattered - collect it all before synthesizing. Include only what we're building (not discarded alternatives).
 
-2. **Enrich**: Reference material may have gaps. Fill them through discussion.
+2. **Filter**: Reference material may contain hallucinations, inaccuracies, or outdated concepts. Validate before including.
 
-3. **Present**: Synthesize and present content to the user in the format it would appear in the specification.
+3. **Enrich**: Reference material may have gaps. Fill them through discussion.
 
-4. **Log**: Only when approved, write content verbatim to the specification.
+4. **Present**: Synthesize and present content to the user in the format it would appear in the specification.
 
-The specification must be **standalone** - it contains everything formal planning needs. No references back to discussions or other source material.
+5. **Log**: Only when approved, write content verbatim to the specification.
+
+The specification is the **golden document** - planning uses only this. If information doesn't make it into the specification, it won't be built. No references back to discussions or other source material.
 
 ## Critical Rules
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -33,8 +33,31 @@ Before starting any topic, identify ALL available reference material:
 
 Work through the specification **topic by topic**:
 
-### 1. Review
-Read all reference material for the current topic. Understand what exists.
+### 1. Review (Exhaustive Extraction)
+
+**This step is critical. The specification is the golden document - if information doesn't make it here, it won't be built.**
+
+For each topic or subtopic, perform exhaustive extraction:
+
+1. **Re-scan ALL source material** - Don't rely on memory. Go back to the documents and systematically review them for the current topic.
+
+2. **Search for keywords** - Topics are rarely contained in one section. Search for:
+   - The topic name and synonyms
+   - Related concepts and terms
+   - Names of systems, fields, or behaviors mentioned in context
+
+3. **Collect scattered information** - Research and discussion documents are non-linear. Information about a single topic may be scattered across:
+   - Multiple sections of the same document
+   - Different documents entirely
+   - Tangential discussions that revealed important details
+
+4. **Filter for what we're building** - Include only validated decisions:
+   - Exclude discarded alternatives
+   - Exclude ideas that were explored but rejected
+   - Exclude "maybes" that weren't confirmed
+   - Include only what the user has decided to build
+
+**Why this matters:** The specification is the single source of truth for planning. Planning will not reference discussions or research - only this document. Missing a detail here means that detail doesn't get implemented.
 
 ### 2. Synthesize and Present
 Present your understanding to the user **in the format it would appear in the specification**:
@@ -97,6 +120,8 @@ Suggested skeleton:
 ```
 
 ## Critical Rules
+
+**Exhaustive extraction is non-negotiable**: Before presenting any topic, re-scan source material. Search for keywords. Collect scattered information. The specification is the golden document - planning uses only this. If you miss something, it doesn't get built.
 
 **Present before logging**: Never write content to the specification until the user has seen and approved it.
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -46,7 +46,7 @@ For each topic or subtopic, perform exhaustive extraction:
    - Related concepts and terms
    - Names of systems, fields, or behaviors mentioned in context
 
-3. **Collect scattered information** - Research and discussion documents are non-linear. Information about a single topic may be scattered across:
+3. **Collect scattered information** - Source material (research, discussions, requirements) is often non-linear. Information about a single topic may be scattered across:
    - Multiple sections of the same document
    - Different documents entirely
    - Tangential discussions that revealed important details

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -39,7 +39,7 @@ Work through the specification **topic by topic**:
 
 For each topic or subtopic, perform exhaustive extraction:
 
-1. **Re-scan ALL source material** - Don't rely on memory. Go back to the documents and systematically review them for the current topic.
+1. **Re-scan ALL source material** - Don't rely on memory. Go back to the source material and systematically review it for the current topic.
 
 2. **Search for keywords** - Topics are rarely contained in one section. Search for:
    - The topic name and synonyms


### PR DESCRIPTION
The specification is the golden document - if information is missing, it
won't be built. This change strengthens the extraction process:

- Add "Extract exhaustively" as explicit first step in SKILL.md
- Expand Review step in guide with detailed extraction methodology
- Emphasize re-scanning source material and keyword searching
- Add guidance on collecting scattered information from non-linear docs
- Filter for what we're building (exclude discarded alternatives)
- Add exhaustive extraction to Critical Rules for reinforcement