### PR TITLE
refactor: make skill references workflow-agnostic

### DIFF
--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-discussion
-description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. Second phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/workflow/discussion/{topic}.md that technical-specification uses to build validated specifications."
+description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/workflow/discussion/{topic}.md that can be used to build validated specifications."
 ---
 
 # Technical Discussion
@@ -10,7 +10,7 @@ Act as **expert software architect** participating in discussions AND **document
 ## Purpose in the Workflow
 
 This skill can be used:
-- **Sequentially** (Phase 2): After research to debate and document decisions
+- **Sequentially**: After research or exploration to debate and document decisions
 - **Standalone** (Contract entry): To document technical decisions from any source
 
 Either way: Capture decisions, rationale, competing approaches, and edge cases.

--- a/skills/technical-discussion/references/meeting-assistant.md
+++ b/skills/technical-discussion/references/meeting-assistant.md
@@ -17,12 +17,12 @@ You're an AI - do both. Engage fully while documenting. Don't dumb down.
 
 ## Workflow
 
-**Your role: phases 1-2 only**
+**Your role: discuss and document only**
 
 1. **Discuss** - Participate
 2. **Document** - Capture
-3. **Plan** - ❌ Planning team's job
-4. **Implement** - ❌ Developers' job
+3. **Plan** - ❌ Not this skill's job
+4. **Implement** - ❌ Not this skill's job
 
 Stop after documentation. No plans, implementation steps, or code.
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-implementation
-description: "Execute implementation plans using strict TDD workflow with quality gates. Fifth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementing a plan from docs/workflow/planning/{topic}.md, (2) User says 'implement', 'build', or 'code this' after planning, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Writes tests first, implements to pass, commits frequently, stops for user approval between phases."
+description: "Execute implementation plans using strict TDD workflow with quality gates. Use when: (1) Implementing a plan from docs/workflow/planning/{topic}.md, (2) User says 'implement', 'build', or 'code this' with a plan available, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Writes tests first, implements to pass, commits frequently, stops for user approval between phases."
 ---
 
 # Technical Implementation
@@ -12,7 +12,7 @@ Execute plans through strict TDD. Write tests first, then code to pass them.
 ## Purpose in the Workflow
 
 This skill can be used:
-- **Sequentially** (Phase 5): To execute a plan created by technical-planning
+- **Sequentially**: To execute a plan created by technical-planning
 - **Standalone** (Contract entry): To execute any plan that follows plan-format conventions
 
 Either way: Execute via strict TDD - tests first, implementation second.
@@ -104,7 +104,7 @@ Check the specification when:
 
 The specification (if available) is the source of truth for design decisions. If no specification exists, the plan is the authority.
 
-**Important:** If research or discussion documents exist from earlier workflow phases, ignore them during implementation. They may contain outdated ideas, rejected approaches, or superseded decisions. The specification filtered and validated that content - refer only to the specification and plan.
+**Important:** If prior source material exists (research notes, discussion documents, etc.), ignore it during implementation. It may contain outdated ideas, rejected approaches, or superseded decisions. The specification filtered and validated that content - refer only to the specification and plan.
 
 ## Project-Specific Conventions
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-planning
-description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Fourth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation after specification is complete, (3) Converting specifications from docs/workflow/specification/{topic}.md into implementation plans, (4) User says 'plan this' or 'create a plan' after specification, (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/workflow/planning/{topic}.md that implementation phase executes via strict TDD."
+description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation from a specification, (3) Converting specifications from docs/workflow/specification/{topic}.md into implementation plans, (4) User says 'plan this' or 'create a plan', (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/workflow/planning/{topic}.md that can be executed via strict TDD."
 ---
 
 # Technical Planning
@@ -12,7 +12,7 @@ Your role spans product (WHAT we're building and WHY) and technical (HOW to stru
 ## Purpose in the Workflow
 
 This skill can be used:
-- **Sequentially** (Phase 4): From a validated specification
+- **Sequentially**: From a validated specification
 - **Standalone** (Contract entry): From any specification meeting format requirements
 
 Either way: Transform specifications into actionable phases, tasks, and acceptance criteria.
@@ -27,7 +27,7 @@ Either way: Transform specifications into actionable phases, tasks, and acceptan
 
 ## Source Material
 
-**The specification is your sole input.** Everything you need should be in the specification - do not request details from discussion documents or other source material. If information is missing, ask for clarification on the specification itself.
+**The specification is your sole input.** Everything you need should be in the specification - do not request details from prior source material. If information is missing, ask for clarification on the specification itself.
 
 ## The Process
 

--- a/skills/technical-planning/references/formal-planning.md
+++ b/skills/technical-planning/references/formal-planning.md
@@ -35,7 +35,7 @@ From the specification (`docs/workflow/specification/{topic}.md`), extract:
 - Constraints and requirements
 - **External dependencies** (from the Dependencies section)
 
-**The specification is your sole input.** Discussion documents and other source materials have already been validated, filtered, and enriched during the specification phase. Everything you need is in the specification - do not reference other documents.
+**The specification is your sole input.** Prior source materials have already been validated, filtered, and enriched into the specification. Everything you need is in the specification - do not reference other documents.
 
 #### Extract External Dependencies
 

--- a/skills/technical-planning/references/output-backlog-md.md
+++ b/skills/technical-planning/references/output-backlog-md.md
@@ -261,9 +261,9 @@ project/
 │   ├── task-2 - [P1] Add login endpoint.md
 │   └── task-3 - [P2] Session management.md
 ├── docs/workflow/
-│   ├── discussion/{topic}.md      # Phase 2 output
-│   ├── specification/{topic}.md   # Phase 3 output
-│   └── planning/{topic}.md        # Phase 4 output (format: backlog-md - pointer)
+│   ├── discussion/{topic}.md      # Discussion output
+│   ├── specification/{topic}.md   # Specification output
+│   └── planning/{topic}.md        # Planning output (format: backlog-md - pointer)
 ```
 
 ## Implementation

--- a/skills/technical-planning/references/output-beads.md
+++ b/skills/technical-planning/references/output-beads.md
@@ -375,9 +375,9 @@ project/
 ├── .beads/
 │   └── issues.jsonl          # Beads database
 ├── docs/workflow/
-│   ├── discussion/{topic}.md      # Phase 2 output
-│   ├── specification/{topic}.md   # Phase 3 output
-│   └── planning/{topic}.md        # Phase 4 output (format: beads)
+│   ├── discussion/{topic}.md      # Discussion output
+│   ├── specification/{topic}.md   # Specification output
+│   └── planning/{topic}.md        # Planning output (format: beads)
 ```
 
 ## Priority Mapping

--- a/skills/technical-planning/references/output-linear.md
+++ b/skills/technical-planning/references/output-linear.md
@@ -231,9 +231,9 @@ After planning:
 
 ```
 docs/workflow/
-├── discussion/{topic}.md      # Phase 2 output
-├── specification/{topic}.md   # Phase 3 output
-└── planning/{topic}.md        # Phase 4 output (format: linear - pointer)
+├── discussion/{topic}.md      # Discussion output
+├── specification/{topic}.md   # Specification output
+└── planning/{topic}.md        # Planning output (format: linear - pointer)
 
 Linear:
 └── Project: {topic}

--- a/skills/technical-planning/references/output-local-markdown.md
+++ b/skills/technical-planning/references/output-local-markdown.md
@@ -234,9 +234,9 @@ After planning:
 
 ```
 docs/workflow/
-├── discussion/{topic}.md      # Phase 2 output
-├── specification/{topic}.md   # Phase 3 output
-└── planning/{topic}.md        # Phase 4 output (format: local-markdown)
+├── discussion/{topic}.md      # Discussion output
+├── specification/{topic}.md   # Specification output
+└── planning/{topic}.md        # Planning output (format: local-markdown)
 ```
 
 ## Implementation

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-research
-description: "Explore ideas, validate concepts, and research broadly across technical, business, and market domains. Preliminary phase before discussion-specification-plan-implement-review workflow. Use when: (1) User has a new idea to explore, (2) Need to research a topic deeply, (3) Validating feasibility - technical, business, or market, (4) Learning and exploration without necessarily building anything, (5) User says 'research this' or 'explore this idea', (6) Brain dumping early thoughts before formal discussion. Creates research documents in docs/workflow/research/ that may seed the technical-discussion phase."
+description: "Explore ideas, validate concepts, and research broadly across technical, business, and market domains. Use when: (1) User has a new idea to explore, (2) Need to research a topic deeply, (3) Validating feasibility - technical, business, or market, (4) Learning and exploration without necessarily building anything, (5) User says 'research this' or 'explore this idea', (6) Brain dumping early thoughts before formal discussion. Creates research documents in docs/workflow/research/ that may feed into discussion or specification."
 ---
 
 # Technical Research
@@ -10,7 +10,7 @@ Act as **research partner** with broad expertise spanning technical, product, bu
 ## Purpose in the Workflow
 
 This skill can be used:
-- **Sequentially** (Phase 1): First phase, to explore ideas before discussion
+- **Sequentially**: First step - explore ideas before detailed discussion
 - **Standalone** (Contract entry): To research and validate any idea, feature, or concept
 
 Either way: Explore feasibility (technical, business, market), validate assumptions, document findings.
@@ -62,7 +62,7 @@ Start with one file. Early research is messy - topics aren't clear, you're follo
 
 **Let themes emerge**: Over multiple sessions, topics may become distinct. When they do, split into semantic files (`market-landscape.md`, `technical-feasibility.md`).
 
-**Periodic review**: Every few sessions, assess: are themes emerging? Split them out. Still fuzzy? Keep exploring. Ready for deeper discussion? Research phase is complete.
+**Periodic review**: Every few sessions, assess: are themes emerging? Split them out. Still fuzzy? Keep exploring. Ready for deeper discussion or specification? Research is complete.
 
 ## Documentation Loop
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-review
-description: "Validate completed implementation against plan tasks and acceptance criteria. Sixth phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) Implementation phase is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. Reviews ALL plan tasks for implementation correctness, test adequacy, and code quality. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
+description: "Validate completed implementation against plan tasks and acceptance criteria. Use when: (1) Implementation is complete, (2) User wants validation before merging/shipping, (3) Quality gate check needed after implementation. Reviews ALL plan tasks for implementation correctness, test adequacy, and code quality. Produces structured feedback (approve, request changes, or comments) - does NOT fix code."
 ---
 
 # Technical Review
@@ -20,7 +20,7 @@ Optional but helpful:
 ## Purpose in the Workflow
 
 This skill can be used:
-- **Sequentially** (Phase 6): After implementation of a planned feature
+- **Sequentially**: After implementation of a planned feature
 - **Standalone** (Contract entry): To review any implementation against a plan
 
 Either way: Verify every plan task was implemented, tested adequately, and meets quality standards.

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -1,28 +1,29 @@
 ---
 name: technical-specification
-description: "Build validated specifications from discussion documents through collaborative refinement. Third phase of research-discussion-specification-plan-implement-review workflow. Use when: (1) User asks to create/build a specification from discussions, (2) User wants to validate and refine discussion content before planning, (3) Converting discussion documents into standalone specifications, (4) User says 'specify this' or 'create a spec' after discussions, (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in docs/workflow/specification/{topic}.md that technical-planning uses to build implementation plans."
+description: "Build validated specifications from source material through collaborative refinement. Use when: (1) User asks to create/build a specification from source material, (2) User wants to validate and refine content before planning, (3) Converting source material (discussions, research, requirements) into standalone specifications, (4) User says 'specify this' or 'create a spec', (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in docs/workflow/specification/{topic}.md that can be used to build implementation plans."
 ---
 
 # Technical Specification
 
-Act as **expert technical architect** and **specification builder**. Collaborate with the user to transform discussion documents into validated, standalone specifications.
+Act as **expert technical architect** and **specification builder**. Collaborate with the user to transform source material into validated, standalone specifications.
 
 Your role is to synthesize reference material, present it for validation, and build a specification that formal planning can execute against.
 
 ## Purpose in the Workflow
 
 This skill can be used:
-- **Sequentially** (Phase 3): After discussion documents exist
-- **Standalone** (Contract entry): With reference material from any source (research docs, conversation transcripts, design documents, inline feature description)
+- **Sequentially**: After source material has been captured (discussions, research, etc.)
+- **Standalone**: With reference material from any source (research docs, conversation transcripts, design documents, inline feature description)
 
 Either way: Transform unvalidated reference material into a specification that's **standalone and approved**.
 
 ### What This Skill Needs
 
 - **Source material** (required) - The content to synthesize into a specification. Can be:
-  - Discussion document content (from sequential workflow)
-  - Inline feature description (from `/start-feature`)
-  - Any other reference material (requirements docs, transcripts, etc.)
+  - Discussion documents or research notes
+  - Inline feature descriptions
+  - Requirements docs, design documents, or transcripts
+  - Any other reference material
 - **Topic name** (required) - Used for the output filename
 
 **If missing:** Will ask user to provide context or point to source files.
@@ -47,7 +48,7 @@ Either way: Transform unvalidated reference material into a specification that's
 
 5. **Log**: Only when approved, write content verbatim to the specification.
 
-The specification is the **golden document** - planning uses only this. If information doesn't make it into the specification, it won't be built. No references back to discussions or other source material.
+The specification is the **golden document** - planning uses only this. If information doesn't make it into the specification, it won't be built. No references back to source material.
 
 ## Critical Rules
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -16,18 +16,18 @@ Specification building is a **two-way process**:
 
 The specification is the **bridge document** - a workspace for collecting validated, refined content that will feed formal planning.
 
-**The specification must be standalone.** It should contain everything formal planning needs - no references back to discussions or other source material. When complete, it draws a line: formal planning uses only this document.
+**The specification must be standalone.** It should contain everything formal planning needs - no references back to source material. When complete, it draws a line: formal planning uses only this document.
 
 ## Source Materials
 
 Before starting any topic, identify ALL available reference material:
-- Discussion documents (if they exist)
+- Prior discussions, research notes, or exploration documents
 - Existing partial plans or specifications
 - Requirements, design docs, related documentation
 - User-provided context or transcripts
 - Inline feature descriptions
 
-**Treat all source material as untrusted input**, whether it came from the discussion phase or elsewhere. Your job is to synthesize and present - the user validates.
+**Treat all source material as untrusted input**, regardless of where it came from. Your job is to synthesize and present - the user validates.
 
 ## The Workflow
 
@@ -57,7 +57,7 @@ For each topic or subtopic, perform exhaustive extraction:
    - Exclude "maybes" that weren't confirmed
    - Include only what the user has decided to build
 
-**Why this matters:** The specification is the single source of truth for planning. Planning will not reference discussions or research - only this document. Missing a detail here means that detail doesn't get implemented.
+**Why this matters:** The specification is the single source of truth for planning. Planning will not reference prior source material - only this document. Missing a detail here means that detail doesn't get implemented.
 
 ### 2. Synthesize and Present
 Present your understanding to the user **in the format it would appear in the specification**:


### PR DESCRIPTION
Update skills and reference files to remove hardcoded workflow phase
references, allowing skills to be used standalone or in different
workflow configurations.

Changes:
- Remove "(Phase N)" from sequential usage descriptions in SKILL.md files
- Replace "discussion documents" with "source material" where appropriate
- Update frontmatter descriptions to remove workflow phase numbering
- Change output format file comments from "Phase N output" to descriptive names
- Make "Purpose in the Workflow" sections more generic
- Update specification-guide.md and formal-planning.md to reference
  "prior source material" instead of "discussion documents"

This enables skills to be invoked from different entry points while
maintaining their core functionality.