### PR TITLE
feat: add final specification review step

### DIFF
--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -48,6 +48,8 @@ Either way: Transform unvalidated reference material into a specification that's
 
 5. **Log**: Only when approved, write content verbatim to the specification.
 
+6. **Final review**: After all topics and dependencies are documented, perform a comprehensive review of ALL source material against the specification. Flag any potentially missed content to the user - but only from the sources, never fabricated. User confirms before any additions.
+
 The specification is the **golden document** - planning uses only this. If information doesn't make it into the specification, it won't be built. No references back to source material.
 
 ## Critical Rules

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -264,9 +264,17 @@ After documenting dependencies, perform a **final comprehensive review** of the 
    - Integration points that seem implicit but aren't specified
    - Behaviors that are ambiguous without clarification
 
-   Frame these as questions, not requirements:
+   Present these as a batch for the user to triage:
 
-   > "The specification doesn't address [scenario], and I didn't find it in the source material either. Is this something we need to specify, or is it intentionally out of scope?"
+   > "I've identified some potential gaps that aren't covered in the source material:
+   >
+   > 1. **[Gap A]** - [brief description of what's unclear/missing]
+   > 2. **[Gap B]** - [brief description]
+   > 3. **[Gap C]** - [brief description]
+   >
+   > Are any of these areas you'd like to discuss, or are they intentionally out of scope?"
+
+   The user can then pick which gaps (if any) need addressing. For those they want to discuss, work through them and add to the specification with standard approval workflow.
 
    This should be infrequent - most gaps will be caught from source material. But occasionally the sources themselves have blind spots worth surfacing.
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -209,6 +209,56 @@ This section feeds into the planning phase, where dependencies become blocking r
 
 **Key distinction**: This is about sequencing what must come first, not mapping out what works together. A feature may integrate with many systems - only list the ones that block you from starting.
 
+## Final Specification Review
+
+After documenting dependencies, perform a **final comprehensive review** of the entire specification against all source material. This is your last chance to catch anything that was missed.
+
+**Why this matters**: The specification is the golden document. Plans are built from it. If a detail isn't in the specification, it won't be built - regardless of whether it was in the source material.
+
+### The Review Process
+
+1. **Re-read ALL source material** - Go back to every source document, discussion, research note, and reference. Don't rely on memory.
+
+2. **Compare systematically** - For each piece of source material:
+   - What topics does it cover?
+   - Are those topics fully captured in the specification?
+   - Are there details, edge cases, or decisions that didn't make it?
+
+3. **Search for the forgotten** - Look specifically for:
+   - Edge cases mentioned in passing
+   - Constraints or requirements buried in tangential discussions
+   - Technical details that seemed minor at the time
+   - Decisions made early that may have been overshadowed
+   - Error handling, validation rules, or boundary conditions
+   - Integration points or data flows mentioned but not elaborated
+
+4. **Flag what you find** - When you discover potentially missed content, present it to the user:
+
+   > "During my final review of the source material, I found [X] that doesn't appear to be captured in the specification. From [source], I see:
+   >
+   > [quote or summary from source material]
+   >
+   > Should this be added to the specification? If so, which section?"
+
+5. **Never fabricate** - Every item you flag must trace back to specific source material. If you can't point to where it came from, don't suggest it. The goal is to catch missed content, not invent new requirements.
+
+6. **User confirms before inclusion** - Standard workflow applies: present proposed additions, get approval, then log verbatim.
+
+### What You're NOT Doing
+
+- **Not generating new ideas** - Only surfacing what's already in the source material
+- **Not assuming gaps** - If something isn't in the sources, it may have been intentionally omitted
+- **Not padding the spec** - Only add what's genuinely missing and relevant
+- **Not re-litigating decisions** - If something was discussed and rejected, it stays rejected
+
+### Completing the Review
+
+When you've systematically reviewed all source material and either:
+- Found nothing missing, or
+- Addressed all discovered gaps with the user
+
+...then inform the user the final review is complete and proceed to getting sign-off on the specification.
+
 ## Completion
 
 Specification is complete when:

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -258,18 +258,31 @@ After documenting dependencies, perform a **final comprehensive review** of the 
 
 6. **User confirms before inclusion** - Standard workflow applies: present proposed additions, get approval, then log verbatim.
 
+7. **Surface potential gaps** - After reviewing source material, consider whether the specification has gaps that the sources simply didn't address. These might be:
+   - Edge cases that weren't discussed
+   - Error scenarios not covered
+   - Integration points that seem implicit but aren't specified
+   - Behaviors that are ambiguous without clarification
+
+   Frame these as questions, not requirements:
+
+   > "The specification doesn't address [scenario], and I didn't find it in the source material either. Is this something we need to specify, or is it intentionally out of scope?"
+
+   This should be infrequent - most gaps will be caught from source material. But occasionally the sources themselves have blind spots worth surfacing.
+
 ### What You're NOT Doing
 
-- **Not generating new ideas** - Only surfacing what's already in the source material
-- **Not assuming gaps** - If something isn't in the sources, it may have been intentionally omitted
+- **Not inventing requirements** - When surfacing gaps not in sources, you're asking questions, not proposing answers
+- **Not assuming gaps need filling** - If something isn't in the sources, it may have been intentionally omitted
 - **Not padding the spec** - Only add what's genuinely missing and relevant
 - **Not re-litigating decisions** - If something was discussed and rejected, it stays rejected
 
 ### Completing the Review
 
-When you've systematically reviewed all source material and either:
-- Found nothing missing, or
-- Addressed all discovered gaps with the user
+When you've:
+- Systematically reviewed all source material for missed content
+- Addressed any discovered gaps with the user
+- Surfaced any potential gaps not covered by sources (and resolved them)
 
 ...then inform the user the final review is complete and proceed to getting sign-off on the specification.
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -240,7 +240,9 @@ After documenting dependencies, perform a **final comprehensive review** of the 
    >
    > [quote or summary from source material]
    >
-   > I'd add this to the [section name] section. Should I include it?"
+   > I'd add this to the [section name] section. Would you like me to include it, or show you the full section with this addition first?"
+
+   If the user wants to see context, present the entire section with the new content clearly marked (e.g., with a comment like `<!-- NEW -->` or by calling it out before the block).
 
    **An entirely missed topic** - Something that warrants its own section but was glossed over:
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -232,13 +232,25 @@ After documenting dependencies, perform a **final comprehensive review** of the 
    - Error handling, validation rules, or boundary conditions
    - Integration points or data flows mentioned but not elaborated
 
-4. **Flag what you find** - When you discover potentially missed content, present it to the user:
+4. **Flag what you find** - When you discover potentially missed content, present it to the user. There are two cases:
 
-   > "During my final review of the source material, I found [X] that doesn't appear to be captured in the specification. From [source], I see:
+   **Enhancing an existing topic** - Details that belong in an already-documented section:
+
+   > "During my final review, I found additional detail about [existing topic] that isn't captured. From [source]:
    >
    > [quote or summary from source material]
    >
-   > Should this be added to the specification? If so, which section?"
+   > I'd add this to the [section name] section. Should I include it?"
+
+   **An entirely missed topic** - Something that warrants its own section but was glossed over:
+
+   > "During my final review, I found [topic] discussed in [source] that doesn't have coverage in the specification:
+   >
+   > [quote or summary from source material]
+   >
+   > This would be a new section. Should I add it?"
+
+   In both cases, you know where the content belongs - existing topics get enhanced in place, new topics get added at the end.
 
 5. **Never fabricate** - Every item you flag must trace back to specific source material. If you can't point to where it came from, don't suggest it. The goal is to catch missed content, not invent new requirements.
 


### PR DESCRIPTION
After documenting dependencies, the specification skill now performs
a comprehensive final review of ALL source material against the spec.
This catches any missed details before the spec becomes the "golden
document" that planning works from.

Key principles:
- All flagged content must trace back to source material
- No fabrication or hallucination - only surfacing what exists
- User confirms before any additions
- Not re-litigating decisions already made