### PR TITLE
fix: add explicit instruction to use today's actual date in document templates

### DIFF
--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -15,7 +15,7 @@ This is a single file per topic.
 ```markdown
 # Discussion: {Topic}
 
-**Date**: YYYY-MM-DD
+**Date**: YYYY-MM-DD *(use today's actual date)*
 **Status**: Exploring | Deciding | Concluded
 
 ## Context

--- a/skills/technical-planning/references/output-backlog-md.md
+++ b/skills/technical-planning/references/output-backlog-md.md
@@ -59,7 +59,7 @@ project: {TOPIC_NAME}
 # Plan Reference: {Topic Name}
 
 **Specification**: `docs/workflow/specification/{topic}.md`
-**Created**: {DATE}
+**Created**: YYYY-MM-DD *(use today's actual date)*
 
 ## About This Plan
 

--- a/skills/technical-planning/references/output-beads.md
+++ b/skills/technical-planning/references/output-beads.md
@@ -246,7 +246,7 @@ epic: bd-{EPIC_ID}
 # Plan Reference: {Topic Name}
 
 **Specification**: `docs/workflow/specification/{topic}.md`
-**Created**: {DATE}
+**Created**: YYYY-MM-DD *(use today's actual date)*
 
 ## About This Plan
 

--- a/skills/technical-planning/references/output-linear.md
+++ b/skills/technical-planning/references/output-linear.md
@@ -156,7 +156,7 @@ team: {TEAM_NAME}
 # Plan Reference: {Topic Name}
 
 **Specification**: `docs/workflow/specification/{topic}.md`
-**Created**: {DATE}
+**Created**: YYYY-MM-DD *(use today's actual date)*
 
 ## About This Plan
 

--- a/skills/technical-planning/references/output-local-markdown.md
+++ b/skills/technical-planning/references/output-local-markdown.md
@@ -38,7 +38,7 @@ format: local-markdown
 
 # Implementation Plan: {Feature/Project Name}
 
-**Date**: YYYY-MM-DD
+**Date**: YYYY-MM-DD *(use today's actual date)*
 **Status**: Draft | Ready | In Progress | Completed
 **Specification**: `docs/workflow/specification/{topic}.md`
 
@@ -145,7 +145,7 @@ Triggers and steps
 
 | Date | Change |
 |------|--------|
-| YYYY-MM-DD | Created from specification |
+| YYYY-MM-DD *(use today's actual date)* | Created from specification |
 ```
 
 ## Cross-Topic Dependencies

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -104,7 +104,7 @@ Suggested skeleton:
 # Specification: [Topic Name]
 
 **Status**: Building specification
-**Last Updated**: [timestamp]
+**Last Updated**: YYYY-MM-DD *(use today's actual date)*
 
 ---
 


### PR DESCRIPTION
Date placeholders in workflow documents were missing guidance to use the
current date, causing incorrect dates (often years off) due to AI knowledge
cutoff issues. Added "(use today's actual date)" instruction to all date
fields across discussion, specification, and planning templates.