### PR TITLE
fix: enforce explicit user approval before spec writes

### DIFF
--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -36,6 +36,30 @@ Either way: Transform unvalidated reference material into a specification that's
 
 **When complete**: User signs off on the specification.
 
+## CRITICAL: You Do NOT Create or Update the Specification Autonomously
+
+**This is a collaborative, interactive process. You MUST wait for explicit user approval before writing ANYTHING to the specification file.**
+
+❌ **NEVER:**
+- Create the specification document and then ask the user to review it
+- Write multiple sections and present them for review afterward
+- Assume silence or moving on means approval
+- Make "minor" amendments without explicit approval
+- Batch up content and log it all at once
+
+✅ **ALWAYS:**
+- Present ONE topic at a time
+- **STOP and WAIT** for the user to explicitly approve before writing
+- Treat each write operation as requiring its own explicit approval
+
+**What counts as approval:** "Yes", "Log it", "That's good", "Approved", "Add it", or similar explicit confirmation.
+
+**What does NOT count as approval:** Silence, you asking "Does this capture it?", the user asking a follow-up question, the user saying "What's next?", or any response that isn't explicit confirmation.
+
+If you are uncertain whether the user approved, **ASK**: "Would you like me to log this to the specification now, or do you have changes?"
+
+---
+
 ## What You Do
 
 1. **Extract exhaustively**: For each topic, re-scan ALL source material. Search for keywords and related terms. Information is often scattered - collect it all before synthesizing. Include only what we're building (not discarded alternatives).
@@ -46,18 +70,32 @@ Either way: Transform unvalidated reference material into a specification that's
 
 4. **Present**: Synthesize and present content to the user in the format it would appear in the specification.
 
-5. **Log**: Only when approved, write content verbatim to the specification.
+5. ⛔ **STOP AND WAIT**: Do not proceed until the user explicitly approves. This is not optional.
 
-6. **Final review**: After all topics and dependencies are documented, perform a comprehensive review of ALL source material against the specification. Flag any potentially missed content to the user - but only from the sources, never fabricated. User confirms before any additions.
+6. **Log**: Only after explicit approval, write content verbatim to the specification.
+
+7. **Final review**: After all topics and dependencies are documented, perform a comprehensive review of ALL source material against the specification. Flag any potentially missed content to the user - but only from the sources, never fabricated. User confirms before any additions.
 
 The specification is the **golden document** - planning uses only this. If information doesn't make it into the specification, it won't be built. No references back to source material.
 
 ## Critical Rules
 
-**Present before logging**: Never write content to the specification until the user has seen and approved it.
+**⛔ STOP AND WAIT FOR APPROVAL**: You MUST NOT write to the specification until the user has explicitly approved. Presenting content is NOT approval. Asking "Does this capture it?" is NOT approval. You must receive explicit confirmation ("yes", "log it", "approved", etc.) before ANY write operation. If uncertain, ASK.
 
 **Log verbatim**: When approved, write exactly what was presented - no silent modifications.
 
 **Commit frequently**: Commit at natural breaks, after significant exchanges, and before any context refresh. Context refresh = lost work.
 
 **Trust nothing without validation**: Synthesize and present, but never assume source material is correct.
+
+---
+
+## Self-Check: Are You Following the Rules?
+
+Before ANY write operation to the specification, ask yourself:
+
+1. **Did I present this specific content to the user?** If no → STOP. Present it first.
+2. **Did the user explicitly approve it?** (Not "did I ask if it's good" - did THEY say yes?) If no → STOP. Wait for approval.
+3. **Am I writing exactly what was approved?** If adding/changing anything → STOP. Present the changes first.
+
+> ⛔ **If you have written to the specification file without going through steps 1-2-3 above, you have violated the workflow.** The user must approve every piece of content before it's logged. There are no exceptions.

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -29,6 +29,16 @@ Before starting any topic, identify ALL available reference material:
 
 **Treat all source material as untrusted input**, regardless of where it came from. Your job is to synthesize and present - the user validates.
 
+## CRITICAL: This is an Interactive Process
+
+**You MUST NOT create or update the specification without explicit user approval for each piece of content.**
+
+This is a collaborative dialogue, not an autonomous task. The user validates every piece before it's logged.
+
+> ⛔ **CHECKPOINT**: If you are about to write to the specification file and haven't received explicit approval (e.g., "yes", "log it", "approved") for this specific content, **STOP**. You are violating the workflow. Go back and ask for approval first.
+
+---
+
 ## The Workflow
 
 Work through the specification **topic by topic**:
@@ -68,6 +78,8 @@ Present your understanding to the user **in the format it would appear in the sp
 >
 > Does this capture it? Anything to adjust, remove, or add?"
 
+> ⛔ **CHECKPOINT**: After presenting, you MUST STOP and wait for the user's response. Do NOT proceed to logging. Do NOT present the next topic. WAIT.
+
 ### 3. Discuss and Refine
 Work through the content together:
 - Validate what's accurate
@@ -78,21 +90,49 @@ Work through the content together:
 
 This is a **human-level conversation**, not form-filling. The user brings context from across the project that may not be in the reference material - decisions from other topics, implications from later work, or knowledge that can't all fit in context.
 
-### 4. Log When Approved
-Only when the user approves ("yes, log it", "that's good", etc.) do you write it to the specification - **verbatim** as presented and approved.
+### 4. ⛔ STOP - Wait for Explicit Approval
 
-### 5. Repeat
+**DO NOT PROCEED TO LOGGING WITHOUT EXPLICIT USER APPROVAL.**
+
+**What counts as approval:**
+- "Yes"
+- "Log it"
+- "That's good"
+- "Approved"
+- "Add it to the spec"
+- Other explicit confirmation
+
+**What does NOT count as approval:**
+- Silence
+- You asking "Does this capture it?" (that's you asking, not them approving)
+- The user asking a follow-up question
+- The user saying "What's next?" or "Continue"
+- The user making a minor comment without explicit approval
+- ANY response that isn't explicit confirmation
+
+**If you are uncertain, ASK:** "Would you like me to log this to the specification now?"
+
+> ⛔ **CHECKPOINT**: If you are about to write to the specification and the user's last message was not explicit approval, **STOP**. You are violating the workflow. Ask for approval first.
+
+### 5. Log When Approved
+Only after receiving explicit approval do you write to the specification - **verbatim** as presented and approved. No silent modifications.
+
+### 6. Repeat
 Move to the next topic.
 
 ## Context Resurfacing
 
 When you discover information that affects **already-logged topics**, resurface them. Even mid-discussion - interrupt, flag what you found, and discuss whether it changes anything.
 
-If it does: summarize what's changing in the chat, then re-present the full updated topic. The summary is for discussion only - the specification just gets the clean replacement. Standard workflow applies: user approves before you update.
+If it does: summarize what's changing in the chat, then re-present the full updated topic. The summary is for discussion only - the specification just gets the clean replacement. **Standard workflow applies: user approves before you update.**
+
+> ⛔ **CHECKPOINT**: Even when resurfacing content, you MUST NOT update the specification until the user explicitly approves the change. Present the updated version, wait for approval, then update.
 
 This is encouraged. Better to resurface and confirm "already covered" than let something slip past.
 
 ## The Specification Document
+
+> ⛔ **CHECKPOINT**: You should NOT be creating or writing to this file unless you have explicit user approval for specific content. If you're about to create this file with content you haven't presented and had approved, **STOP**. That violates the workflow.
 
 Create `docs/workflow/specification/{topic}.md`
 
@@ -121,9 +161,11 @@ Suggested skeleton:
 
 ## Critical Rules
 
-**Exhaustive extraction is non-negotiable**: Before presenting any topic, re-scan source material. Search for keywords. Collect scattered information. The specification is the golden document - planning uses only this. If you miss something, it doesn't get built.
+**⛔ EXPLICIT APPROVAL REQUIRED FOR EVERY WRITE**: You MUST NOT write to the specification until the user has explicitly approved. "Presenting" is not approval. "Asking a question" is not approval. You need explicit confirmation. If uncertain, ASK. This rule is non-negotiable.
 
-**Present before logging**: Never write content to the specification until the user has seen and approved it.
+> ⛔ **CHECKPOINT**: Before ANY write operation, ask yourself: "Did the user explicitly approve this specific content?" If the answer is no or uncertain, STOP and ask.
+
+**Exhaustive extraction is non-negotiable**: Before presenting any topic, re-scan source material. Search for keywords. Collect scattered information. The specification is the golden document - planning uses only this. If you miss something, it doesn't get built.
 
 **Log verbatim**: When approved, write exactly what was presented - no silent modifications.
 
@@ -232,7 +274,11 @@ After documenting dependencies, perform a **final comprehensive review** of the 
    - Error handling, validation rules, or boundary conditions
    - Integration points or data flows mentioned but not elaborated
 
-4. **Flag what you find** - When you discover potentially missed content, present it to the user. There are two cases:
+4. **Flag what you find** - When you discover potentially missed content, present it to the user. **Do NOT add it to the specification without explicit approval.**
+
+   > ⛔ **CHECKPOINT**: If you found missed content and are about to add it to the specification without presenting it first and receiving explicit approval, **STOP**. Every addition requires the present → approve → log cycle, even during final review.
+
+   There are two cases:
 
    **Enhancing an existing topic** - Details that belong in an already-documented section:
 
@@ -300,3 +346,17 @@ Specification is complete when:
 - All topics/phases have validated content
 - User confirms the specification is complete
 - No blocking gaps remain
+
+---
+
+## Self-Check: Have You Followed the Rules?
+
+Before ANY write operation to the specification file, verify:
+
+| Question | If No... |
+|----------|----------|
+| Did I present this specific content to the user? | ⛔ STOP. Present it first. |
+| Did the user explicitly approve? (e.g., "yes", "log it") | ⛔ STOP. Wait for approval or ask. |
+| Am I writing exactly what was approved, with no additions? | ⛔ STOP. Present any changes first. |
+
+> ⛔ **FINAL CHECK**: If you have written to the specification file and cannot answer "yes" to all three questions above for that content, you have violated the workflow. Every piece of content requires explicit user approval before logging.


### PR DESCRIPTION
Add multiple safeguards to prevent autonomous spec creation/updates:

- Add prominent "CRITICAL" section with explicit NEVER/ALWAYS rules
- Add checkpoint markers throughout workflow steps
- Define what counts vs doesn't count as approval
- Add self-check sections at end of both documents
- Insert STOP markers between present and log steps
- Add tripwire language: "if you got here without approval, STOP"

Addresses issue where Claude was creating full specs or making
bulk amendments without waiting for explicit user confirmation.