### PR TITLE
feat: formalize spec confirmation with explicit Log it/Adjust choices

### DIFF
--- a/commands/start-feature.md
+++ b/commands/start-feature.md
@@ -74,7 +74,7 @@ Work from the inline context provided above.
 
 ## Notes
 
-- The specification skill will synthesize the inline context, present it for validation, and build the specification
+- The specification skill contains instructions for synthesizing the inline context, presenting it for validation, and building the specification
 - Output is a standard specification file at `docs/workflow/specification/{topic}.md`
 - From there, the user can proceed to `/workflow:start-planning` as normal
 - This path skips formal discussion documentation - use the full workflow for complex features that need debate captured

--- a/commands/workflow:start-discussion.md
+++ b/commands/workflow:start-discussion.md
@@ -315,7 +315,7 @@ Research reference:
 Source: docs/workflow/research/{filename}.md (lines {start}-{end})
 Summary: {the 1-2 sentence summary from Step 3A}
 
-Begin using the technical-discussion skill.
+Invoke the technical-discussion skill.
 ```
 
 **Example handoff (continuing or fresh):**
@@ -324,7 +324,7 @@ Discussion session for: {topic}
 Source: {existing discussion | fresh}
 Output: docs/workflow/discussion/{topic}.md
 
-Begin using the technical-discussion skill.
+Invoke the technical-discussion skill.
 ```
 
 ## Notes

--- a/commands/workflow:start-discussion.md
+++ b/commands/workflow:start-discussion.md
@@ -300,40 +300,36 @@ What would you like to focus on in this session?
 
 Wait for response before proceeding.
 
-## Step 5: Invoke Discussion Skill
+## Step 5: Invoke the Skill
 
-Begin the discussion session with appropriate context based on the path taken.
+**Your work at this stage is complete.** You have gathered the inputs needed.
 
-**If from research:**
+Now invoke the [technical-discussion](../skills/technical-discussion/SKILL.md) skill. The skill will provide the instructions for what to do next.
+
+**Example handoff (from research):**
 ```
 Discussion session for: {topic}
 Output: docs/workflow/discussion/{topic}.md
 
-## Research Reference
+Research reference:
 Source: docs/workflow/research/{filename}.md (lines {start}-{end})
 Summary: {the 1-2 sentence summary from Step 3A}
 
-Begin discussion using the technical-discussion skill.
+Begin using the technical-discussion skill.
 ```
 
-**If continuing or fresh:**
+**Example handoff (continuing or fresh):**
 ```
 Discussion session for: {topic}
 Source: {existing discussion | fresh}
 Output: docs/workflow/discussion/{topic}.md
 
-Begin discussion using the technical-discussion skill.
+Begin using the technical-discussion skill.
 ```
 
-**Setup:**
-- Ensure discussion directory exists: `docs/workflow/discussion/`
-- If new: Create file using the template structure
-- If continuing: Work with existing file
-- Commit frequently at natural discussion breaks
+⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 
 - Ask questions clearly and wait for responses before proceeding
 - Discussion captures WHAT and WHY - don't jump to specifications or implementation
-- The goal is to work through edge cases, debates, and decisions before planning
-- Commit the discussion document frequently during the session

--- a/commands/workflow:start-discussion.md
+++ b/commands/workflow:start-discussion.md
@@ -327,7 +327,7 @@ Output: docs/workflow/discussion/{topic}.md
 Begin using the technical-discussion skill.
 ```
 
-⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
+**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-discussion.md
+++ b/commands/workflow:start-discussion.md
@@ -304,7 +304,7 @@ Wait for response before proceeding.
 
 **Your work at this stage is complete.** You have gathered the inputs needed.
 
-Now invoke the [technical-discussion](../skills/technical-discussion/SKILL.md) skill. The skill will provide the instructions for what to do next.
+Now invoke the [technical-discussion](../skills/technical-discussion/SKILL.md) skill. The skill contains the instructions for what to do next.
 
 **Example handoff (from research):**
 ```

--- a/commands/workflow:start-discussion.md
+++ b/commands/workflow:start-discussion.md
@@ -302,9 +302,9 @@ Wait for response before proceeding.
 
 ## Step 5: Invoke the Skill
 
-**Your work at this stage is complete.** You have gathered the inputs needed.
+After completing the steps above, this command's purpose is fulfilled.
 
-Now invoke the [technical-discussion](../skills/technical-discussion/SKILL.md) skill. The skill contains the instructions for what to do next.
+Invoke the [technical-discussion](../skills/technical-discussion/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
 
 **Example handoff (from research):**
 ```
@@ -326,8 +326,6 @@ Output: docs/workflow/discussion/{topic}.md
 
 Begin using the technical-discussion skill.
 ```
-
-**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-implementation.md
+++ b/commands/workflow:start-implementation.md
@@ -157,31 +157,27 @@ If they choose a specific phase or task, ask them to specify which one.
 
 > **Note:** Do NOT verify that the phase or task exists. Accept the user's answer and pass it to the skill. Validation happens during the implementation phase.
 
-## Step 6: Invoke Implementation Skill
+## Step 6: Invoke the Skill
 
-Invoke the **technical-implementation** skill for this conversation.
+**Your work at this stage is complete.** You have gathered the inputs needed.
 
-Pass to the technical-implementation skill:
-- Plan: `docs/workflow/planning/{topic}.md`
-- Format: (from frontmatter)
-- Scope: (all phases | specific phase | specific task | next-available)
-- Dependencies: (all satisfied - verified in Step 3)
-- Environment setup: (completed | not needed)
+Now invoke the [technical-implementation](../skills/technical-implementation/SKILL.md) skill. The skill will provide the instructions for what to do next.
 
 **Example handoff:**
 ```
 Implementation session for: {topic}
 Plan: docs/workflow/planning/{topic}.md
 Format: {format}
-Scope: All phases
+Scope: {all phases | specific phase | specific task | next-available}
 
 Dependencies: All satisfied ✓
-Environment setup: Completed (or: Not needed)
+Environment setup: {completed | not needed}
 
-Begin implementation using the technical-implementation skill.
+Begin using the technical-implementation skill.
 ```
+
+⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 
 - Ask questions clearly and wait for responses before proceeding
-- Execute environment setup before starting implementation

--- a/commands/workflow:start-implementation.md
+++ b/commands/workflow:start-implementation.md
@@ -173,7 +173,7 @@ Scope: {all phases | specific phase | specific task | next-available}
 Dependencies: All satisfied ✓
 Environment setup: {completed | not needed}
 
-Begin using the technical-implementation skill.
+Invoke the technical-implementation skill.
 ```
 
 ## Notes

--- a/commands/workflow:start-implementation.md
+++ b/commands/workflow:start-implementation.md
@@ -159,9 +159,9 @@ If they choose a specific phase or task, ask them to specify which one.
 
 ## Step 6: Invoke the Skill
 
-**Your work at this stage is complete.** You have gathered the inputs needed.
+After completing the steps above, this command's purpose is fulfilled.
 
-Now invoke the [technical-implementation](../skills/technical-implementation/SKILL.md) skill. The skill contains the instructions for what to do next.
+Invoke the [technical-implementation](../skills/technical-implementation/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
 
 **Example handoff:**
 ```
@@ -175,8 +175,6 @@ Environment setup: {completed | not needed}
 
 Begin using the technical-implementation skill.
 ```
-
-**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-implementation.md
+++ b/commands/workflow:start-implementation.md
@@ -176,7 +176,7 @@ Environment setup: {completed | not needed}
 Begin using the technical-implementation skill.
 ```
 
-⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
+**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-implementation.md
+++ b/commands/workflow:start-implementation.md
@@ -127,7 +127,7 @@ Proceeding with environment setup...
 
 ## Step 4: Check Environment Setup
 
-> **IMPORTANT**: This step is for **information gathering only**. Do NOT execute any setup commands at this stage. The technical-implementation skill will handle execution when invoked.
+> **IMPORTANT**: This step is for **information gathering only**. Do NOT execute any setup commands at this stage. Execution instructions are in the technical-implementation skill.
 
 After the user selects a plan:
 
@@ -161,7 +161,7 @@ If they choose a specific phase or task, ask them to specify which one.
 
 **Your work at this stage is complete.** You have gathered the inputs needed.
 
-Now invoke the [technical-implementation](../skills/technical-implementation/SKILL.md) skill. The skill will provide the instructions for what to do next.
+Now invoke the [technical-implementation](../skills/technical-implementation/SKILL.md) skill. The skill contains the instructions for what to do next.
 
 **Example handoff:**
 ```

--- a/commands/workflow:start-planning.md
+++ b/commands/workflow:start-planning.md
@@ -92,7 +92,7 @@ Load **[output-formats.md](../skills/technical-planning/references/output-format
 
 **Your work at this stage is complete.** You have gathered the inputs needed.
 
-Now invoke the [technical-planning](../skills/technical-planning/SKILL.md) skill. The skill will provide the instructions for what to do next.
+Now invoke the [technical-planning](../skills/technical-planning/SKILL.md) skill. The skill contains the instructions for what to do next.
 
 **Example handoff:**
 ```

--- a/commands/workflow:start-planning.md
+++ b/commands/workflow:start-planning.md
@@ -90,9 +90,9 @@ Load **[output-formats.md](../skills/technical-planning/references/output-format
 
 ## Step 6: Invoke the Skill
 
-**Your work at this stage is complete.** You have gathered the inputs needed.
+After completing the steps above, this command's purpose is fulfilled.
 
-Now invoke the [technical-planning](../skills/technical-planning/SKILL.md) skill. The skill contains the instructions for what to do next.
+Invoke the [technical-planning](../skills/technical-planning/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
 
 **Example handoff:**
 ```
@@ -103,8 +103,6 @@ Additional context: {summary of user's answers from Step 5}
 
 Begin using the technical-planning skill.
 ```
-
-**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-planning.md
+++ b/commands/workflow:start-planning.md
@@ -101,7 +101,7 @@ Specification: docs/workflow/specification/{topic}.md
 Output format: {format}
 Additional context: {summary of user's answers from Step 5}
 
-Begin using the technical-planning skill.
+Invoke the technical-planning skill.
 ```
 
 ## Notes

--- a/commands/workflow:start-planning.md
+++ b/commands/workflow:start-planning.md
@@ -88,24 +88,25 @@ Load **[output-formats.md](../skills/technical-planning/references/output-format
 - Any additional context or priorities to consider?
 - Any constraints since the specification was completed?
 
-## Step 6: Invoke Planning Skill
+## Step 6: Invoke the Skill
 
-Pass to the technical-planning skill with:
-- Specification path
-- Output format chosen
-- Additional context gathered
+**Your work at this stage is complete.** You have gathered the inputs needed.
+
+Now invoke the [technical-planning](../skills/technical-planning/SKILL.md) skill. The skill will provide the instructions for what to do next.
 
 **Example handoff:**
 ```
 Planning session for: {topic}
 Specification: docs/workflow/specification/{topic}.md
 Output format: {format}
+Additional context: {summary of user's answers from Step 5}
 
-Begin planning using the technical-planning skill.
+Begin using the technical-planning skill.
 ```
+
+⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 
 - Ask questions clearly and wait for responses before proceeding
 - The specification is the sole source of truth for planning - do not reference discussions
-- Commit the plan files when complete

--- a/commands/workflow:start-planning.md
+++ b/commands/workflow:start-planning.md
@@ -104,7 +104,7 @@ Additional context: {summary of user's answers from Step 5}
 Begin using the technical-planning skill.
 ```
 
-⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
+**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-research.md
+++ b/commands/workflow:start-research.md
@@ -45,4 +45,4 @@ Ask these questions clearly and wait for responses before proceeding.
 
 Now invoke the [technical-research](../skills/technical-research/SKILL.md) skill. The skill will provide the instructions for what to do next.
 
-⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
+**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.

--- a/commands/workflow:start-research.md
+++ b/commands/workflow:start-research.md
@@ -41,8 +41,6 @@ Ask these questions clearly and wait for responses before proceeding.
 
 ## Invoke the Skill
 
-**Your work at this stage is complete.** You have gathered the inputs needed.
+After completing the steps above, this command's purpose is fulfilled.
 
-Now invoke the [technical-research](../skills/technical-research/SKILL.md) skill. The skill contains the instructions for what to do next.
-
-**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
+Invoke the [technical-research](../skills/technical-research/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.

--- a/commands/workflow:start-research.md
+++ b/commands/workflow:start-research.md
@@ -43,6 +43,6 @@ Ask these questions clearly and wait for responses before proceeding.
 
 **Your work at this stage is complete.** You have gathered the inputs needed.
 
-Now invoke the [technical-research](../skills/technical-research/SKILL.md) skill. The skill will provide the instructions for what to do next.
+Now invoke the [technical-research](../skills/technical-research/SKILL.md) skill. The skill contains the instructions for what to do next.
 
 **STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.

--- a/commands/workflow:start-research.md
+++ b/commands/workflow:start-research.md
@@ -21,7 +21,9 @@ This is **Phase 1** of the six-phase workflow:
 
 ---
 
-Then ask these questions to kickstart the exploration:
+## Instructions
+
+Ask these questions to gather context:
 
 1. **What's on your mind?**
    - What idea or topic do you want to explore?
@@ -35,4 +37,12 @@ Then ask these questions to kickstart the exploration:
    - Technical feasibility? Market landscape? Business model?
    - Or just talk it through and see where it goes?
 
-Ask these questions clearly and wait for responses before proceeding. The skill handles everything else.
+Ask these questions clearly and wait for responses before proceeding.
+
+## Invoke the Skill
+
+**Your work at this stage is complete.** You have gathered the inputs needed.
+
+Now invoke the [technical-research](../skills/technical-research/SKILL.md) skill. The skill will provide the instructions for what to do next.
+
+⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.

--- a/commands/workflow:start-review.md
+++ b/commands/workflow:start-review.md
@@ -86,13 +86,11 @@ Check if a specification exists:
 2. **If exists**: Note the path for context
 3. **If missing**: Proceed without - the plan is the primary review artifact
 
-## Step 6: Invoke Review Skill
+## Step 6: Invoke the Skill
 
-Pass to the technical-review skill:
-- Plan: `docs/workflow/planning/{topic}.md`
-- Format: (from frontmatter)
-- Specification: `docs/workflow/specification/{topic}.md` (if exists)
-- Implementation scope: (files/directories to review)
+**Your work at this stage is complete.** You have gathered the inputs needed.
+
+Now invoke the [technical-review](../skills/technical-review/SKILL.md) skill. The skill will provide the instructions for what to do next.
 
 **Example handoff:**
 ```
@@ -102,11 +100,12 @@ Format: {format}
 Specification: docs/workflow/specification/{topic}.md (or: Not available)
 Scope: {implementation scope}
 
-Begin review using the technical-review skill.
+Begin using the technical-review skill.
 ```
+
+⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 
 - Ask questions clearly and wait for responses before proceeding
 - Review produces feedback (approve, request changes, or comments) - it does NOT fix code
-- Verify ALL plan tasks, don't sample

--- a/commands/workflow:start-review.md
+++ b/commands/workflow:start-review.md
@@ -88,9 +88,9 @@ Check if a specification exists:
 
 ## Step 6: Invoke the Skill
 
-**Your work at this stage is complete.** You have gathered the inputs needed.
+After completing the steps above, this command's purpose is fulfilled.
 
-Now invoke the [technical-review](../skills/technical-review/SKILL.md) skill. The skill contains the instructions for what to do next.
+Invoke the [technical-review](../skills/technical-review/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
 
 **Example handoff:**
 ```
@@ -102,8 +102,6 @@ Scope: {implementation scope}
 
 Begin using the technical-review skill.
 ```
-
-**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-review.md
+++ b/commands/workflow:start-review.md
@@ -100,7 +100,7 @@ Format: {format}
 Specification: docs/workflow/specification/{topic}.md (or: Not available)
 Scope: {implementation scope}
 
-Begin using the technical-review skill.
+Invoke the technical-review skill.
 ```
 
 ## Notes

--- a/commands/workflow:start-review.md
+++ b/commands/workflow:start-review.md
@@ -103,7 +103,7 @@ Scope: {implementation scope}
 Begin using the technical-review skill.
 ```
 
-⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
+**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-review.md
+++ b/commands/workflow:start-review.md
@@ -90,7 +90,7 @@ Check if a specification exists:
 
 **Your work at this stage is complete.** You have gathered the inputs needed.
 
-Now invoke the [technical-review](../skills/technical-review/SKILL.md) skill. The skill will provide the instructions for what to do next.
+Now invoke the [technical-review](../skills/technical-review/SKILL.md) skill. The skill contains the instructions for what to do next.
 
 **Example handoff:**
 ```

--- a/commands/workflow:start-specification.md
+++ b/commands/workflow:start-specification.md
@@ -21,6 +21,21 @@ This is **Phase 3** of the six-phase workflow:
 
 ---
 
+## Stage Boundaries
+
+These instructions cover **input gathering only** (Steps 1-4).
+
+The specification workflow rules - how to present content, obtain approval, and log to the document - are contained in the **technical-specification skill**. You must invoke that skill to load those instructions.
+
+**At this stage:**
+- Discover existing discussions
+- Help the user choose which to specify
+- Gather additional context
+
+**Do not proceed to specification work** (creating/updating the specification document) until you have invoked the skill. The skill contains essential rules that are not available here.
+
+---
+
 ## Instructions
 
 Follow these steps EXACTLY as written. Do not skip steps or combine them. Present output using the EXACT format shown in examples - do not simplify or alter the formatting.
@@ -82,25 +97,23 @@ Ask:
 - Any constraints or changes since the discussion concluded?
 - Are there any existing partial plans or related documentation I should review?
 
-## Step 5: Invoke Specification Skill
+## Step 5: Invoke the Skill
 
-Pass to the technical-specification skill:
+**Your work at this stage is complete.** You have gathered the inputs needed. Now invoke the technical-specification skill to load the instructions for the next phase.
+
+The skill will provide:
+- How to present content for user approval
+- The approval workflow (explicit confirmation required before logging)
+- Rules for writing content verbatim when approved
+
+**Invoke the skill with:**
 - Source: `docs/workflow/discussion/{topic}.md`
 - Output: `docs/workflow/specification/{topic}.md`
-- Additional context gathered
+- Additional context gathered from the user
 
-**Example handoff:**
-```
-Specification session for: {topic}
-Source: docs/workflow/discussion/{topic}.md
-Output: docs/workflow/specification/{topic}.md
-
-Begin specification using the technical-specification skill.
-Reference: specification-guide.md
-```
+⛔ **Do not proceed to create or update the specification document yourself.** The skill contains the workflow rules. Invoke it now.
 
 ## Notes
 
 - Ask questions clearly and wait for responses before proceeding
 - The specification phase validates and refines discussion content into a standalone document
-- Commit the specification files frequently during the session

--- a/commands/workflow:start-specification.md
+++ b/commands/workflow:start-specification.md
@@ -95,7 +95,7 @@ Source: docs/workflow/discussion/{topic}.md
 Output: docs/workflow/specification/{topic}.md
 Additional context: {summary of user's answers from Step 4}
 
-Begin using the technical-specification skill.
+Invoke the technical-specification skill.
 ```
 
 ## Notes

--- a/commands/workflow:start-specification.md
+++ b/commands/workflow:start-specification.md
@@ -21,21 +21,6 @@ This is **Phase 3** of the six-phase workflow:
 
 ---
 
-## Stage Boundaries
-
-These instructions cover **input gathering only** (Steps 1-4).
-
-The specification workflow rules - how to present content, obtain approval, and log to the document - are contained in the **technical-specification skill**. You must invoke that skill to load those instructions.
-
-**At this stage:**
-- Discover existing discussions
-- Help the user choose which to specify
-- Gather additional context
-
-**Do not proceed to specification work** (creating/updating the specification document) until you have invoked the skill. The skill contains essential rules that are not available here.
-
----
-
 ## Instructions
 
 Follow these steps EXACTLY as written. Do not skip steps or combine them. Present output using the EXACT format shown in examples - do not simplify or alter the formatting.

--- a/commands/workflow:start-specification.md
+++ b/commands/workflow:start-specification.md
@@ -98,7 +98,7 @@ Additional context: {summary of user's answers from Step 4}
 Begin using the technical-specification skill.
 ```
 
-⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
+**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-specification.md
+++ b/commands/workflow:start-specification.md
@@ -84,9 +84,9 @@ Ask:
 
 ## Step 5: Invoke the Skill
 
-**Your work at this stage is complete.** You have gathered the inputs needed.
+After completing the steps above, this command's purpose is fulfilled.
 
-Now invoke the [technical-specification](../skills/technical-specification/SKILL.md) skill. The skill contains the instructions for what to do next.
+Invoke the [technical-specification](../skills/technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
 
 **Example handoff:**
 ```
@@ -97,8 +97,6 @@ Additional context: {summary of user's answers from Step 4}
 
 Begin using the technical-specification skill.
 ```
-
-**STOP: Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-specification.md
+++ b/commands/workflow:start-specification.md
@@ -84,19 +84,21 @@ Ask:
 
 ## Step 5: Invoke the Skill
 
-**Your work at this stage is complete.** You have gathered the inputs needed. Now invoke the technical-specification skill to load the instructions for the next phase.
+**Your work at this stage is complete.** You have gathered the inputs needed.
 
-The skill will provide:
-- How to present content for user approval
-- The approval workflow (explicit confirmation required before logging)
-- Rules for writing content verbatim when approved
+Now invoke the [technical-specification](../skills/technical-specification/SKILL.md) skill. The skill will provide the instructions for what to do next.
 
-**Invoke the skill with:**
-- Source: `docs/workflow/discussion/{topic}.md`
-- Output: `docs/workflow/specification/{topic}.md`
-- Additional context gathered from the user
+**Example handoff:**
+```
+Specification session for: {topic}
+Source: docs/workflow/discussion/{topic}.md
+Output: docs/workflow/specification/{topic}.md
+Additional context: {summary of user's answers from Step 4}
 
-⛔ **Do not proceed to create or update the specification document yourself.** The skill contains the workflow rules. Invoke it now.
+Begin using the technical-specification skill.
+```
+
+⛔ **Do not proceed without invoking the skill.** The skill contains the workflow rules for this phase.
 
 ## Notes
 

--- a/commands/workflow:start-specification.md
+++ b/commands/workflow:start-specification.md
@@ -86,7 +86,7 @@ Ask:
 
 **Your work at this stage is complete.** You have gathered the inputs needed.
 
-Now invoke the [technical-specification](../skills/technical-specification/SKILL.md) skill. The skill will provide the instructions for what to do next.
+Now invoke the [technical-specification](../skills/technical-specification/SKILL.md) skill. The skill contains the instructions for what to do next.
 
 **Example handoff:**
 ```

--- a/skills/technical-discussion/references/meeting-assistant.md
+++ b/skills/technical-discussion/references/meeting-assistant.md
@@ -21,8 +21,8 @@ You're an AI - do both. Engage fully while documenting. Don't dumb down.
 
 1. **Discuss** - Participate
 2. **Document** - Capture
-3. **Plan** - ❌ Not this skill's job
-4. **Implement** - ❌ Not this skill's job
+3. **Plan** - ❌ Not covered here
+4. **Implement** - ❌ Not covered here
 
 Stop after documentation. No plans, implementation steps, or code.
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -115,7 +115,7 @@ Follow project-specific coding skills in `.claude/skills/` for:
 - Architecture conventions
 - Testing conventions
 
-This skill provides the implementation **process**. Project skills provide the **style**.
+This skill contains the implementation **process**. Project skills contain the **style**.
 
 ## Handling Problems
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -52,11 +52,11 @@ Either way: Transform unvalidated reference material into a specification that's
 - **STOP and WAIT** for the user to explicitly approve before writing
 - Treat each write operation as requiring its own explicit approval
 
-**What counts as approval:** "Yes", "Log it", "That's good", "Approved", "Add it", or similar explicit confirmation.
+**What counts as approval:** "Log it" (the standard choice you present) or equivalent: "Yes", "Approved", "Add it", "That's good".
 
-**What does NOT count as approval:** Silence, you asking "Does this capture it?", the user asking a follow-up question, the user saying "What's next?", or any response that isn't explicit confirmation.
+**What does NOT count as approval:** Silence, you presenting choices, the user asking a follow-up question, the user saying "What's next?", or any response that isn't explicit confirmation.
 
-If you are uncertain whether the user approved, **ASK**: "Would you like me to log this to the specification now, or do you have changes?"
+If you are uncertain whether the user approved, **ASK**: "Would you like me to log it, or do you want to adjust something?"
 
 ---
 
@@ -80,7 +80,7 @@ The specification is the **golden document** - planning uses only this. If infor
 
 ## Critical Rules
 
-**⛔ STOP AND WAIT FOR APPROVAL**: You MUST NOT write to the specification until the user has explicitly approved. Presenting content is NOT approval. Asking "Does this capture it?" is NOT approval. You must receive explicit confirmation ("yes", "log it", "approved", etc.) before ANY write operation. If uncertain, ASK.
+**⛔ STOP AND WAIT FOR APPROVAL**: You MUST NOT write to the specification until the user has explicitly approved. Presenting content is NOT approval. Presenting choices is NOT approval. You must receive explicit confirmation (e.g., "Log it") before ANY write operation. If uncertain, ASK.
 
 **Log verbatim**: When approved, write exactly what was presented - no silent modifications.
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -70,7 +70,7 @@ If you are uncertain whether the user approved, **ASK**: "Would you like me to l
 
 4. **Present**: Synthesize and present content to the user in the format it would appear in the specification.
 
-5. ⛔ **STOP AND WAIT**: Do not proceed until the user explicitly approves. This is not optional.
+5. **STOP AND WAIT**: Do not proceed until the user explicitly approves. This is not optional.
 
 6. **Log**: Only after explicit approval, write content verbatim to the specification.
 
@@ -80,7 +80,7 @@ The specification is the **golden document** - planning uses only this. If infor
 
 ## Critical Rules
 
-**⛔ STOP AND WAIT FOR APPROVAL**: You MUST NOT write to the specification until the user has explicitly approved. Presenting content is NOT approval. Presenting choices is NOT approval. You must receive explicit confirmation (e.g., "Log it") before ANY write operation. If uncertain, ASK.
+**STOP AND WAIT FOR APPROVAL**: You MUST NOT write to the specification until the user has explicitly approved. Presenting content is NOT approval. Presenting choices is NOT approval. You must receive explicit confirmation (e.g., "Log it") before ANY write operation. If uncertain, ASK.
 
 **Log verbatim**: When approved, write exactly what was presented - no silent modifications.
 
@@ -98,4 +98,4 @@ Before ANY write operation to the specification, ask yourself:
 2. **Did the user explicitly approve it?** (Not "did I ask if it's good" - did THEY say yes?) If no → STOP. Wait for approval.
 3. **Am I writing exactly what was approved?** If adding/changing anything → STOP. Present the changes first.
 
-> ⛔ **If you have written to the specification file without going through steps 1-2-3 above, you have violated the workflow.** The user must approve every piece of content before it's logged. There are no exceptions.
+> **If you have written to the specification file without going through steps 1-2-3 above, you have violated the workflow.** The user must approve every piece of content before it's logged. There are no exceptions.

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -35,7 +35,7 @@ Before starting any topic, identify ALL available reference material:
 
 This is a collaborative dialogue, not an autonomous task. The user validates every piece before it's logged.
 
-> ⛔ **CHECKPOINT**: If you are about to write to the specification file and haven't received explicit approval (e.g., "yes", "log it", "approved") for this specific content, **STOP**. You are violating the workflow. Go back and ask for approval first.
+> ⛔ **CHECKPOINT**: If you are about to write to the specification file and haven't received explicit approval (e.g., "Log it") for this specific content, **STOP**. You are violating the workflow. Go back and present the choices first.
 
 ---
 
@@ -72,11 +72,17 @@ For each topic or subtopic, perform exhaustive extraction:
 ### 2. Synthesize and Present
 Present your understanding to the user **in the format it would appear in the specification**:
 
-> "Here's what I understand about [topic] based on the reference material. This is how I'd write it into the specification:
+> "Here's what I understand about [topic] based on the reference material. This is exactly what I'll write into the specification:
 >
 > [content as it would appear]
->
-> Does this capture it? Anything to adjust, remove, or add?"
+
+Then present two explicit choices:
+
+> **To proceed, choose one:**
+> - **"Log it"** - I'll add the above to the specification **verbatim** (exactly as shown, no modifications)
+> - **"Adjust"** - Tell me which part to change and what you want it to say instead
+
+**Do not paraphrase these choices.** Present them exactly as written so users always know what to expect.
 
 > ⛔ **CHECKPOINT**: After presenting, you MUST STOP and wait for the user's response. Do NOT proceed to logging. Do NOT present the next topic. WAIT.
 
@@ -95,24 +101,20 @@ This is a **human-level conversation**, not form-filling. The user brings contex
 **DO NOT PROCEED TO LOGGING WITHOUT EXPLICIT USER APPROVAL.**
 
 **What counts as approval:**
-- "Yes"
-- "Log it"
-- "That's good"
-- "Approved"
-- "Add it to the spec"
-- Other explicit confirmation
+- **"Log it"** - the standard confirmation you present as a choice
+- Or equivalent explicit confirmation: "Yes", "Approved", "Add it", "That's good"
 
 **What does NOT count as approval:**
 - Silence
-- You asking "Does this capture it?" (that's you asking, not them approving)
+- You presenting choices (that's you asking, not them approving)
 - The user asking a follow-up question
 - The user saying "What's next?" or "Continue"
 - The user making a minor comment without explicit approval
 - ANY response that isn't explicit confirmation
 
-**If you are uncertain, ASK:** "Would you like me to log this to the specification now?"
+**If you are uncertain, ASK:** "Would you like me to log it, or do you want to adjust something?"
 
-> ⛔ **CHECKPOINT**: If you are about to write to the specification and the user's last message was not explicit approval, **STOP**. You are violating the workflow. Ask for approval first.
+> ⛔ **CHECKPOINT**: If you are about to write to the specification and the user's last message was not explicit approval, **STOP**. You are violating the workflow. Present the choices again.
 
 ### 5. Log When Approved
 Only after receiving explicit approval do you write to the specification - **verbatim** as presented and approved. No silent modifications.
@@ -356,7 +358,7 @@ Before ANY write operation to the specification file, verify:
 | Question | If No... |
 |----------|----------|
 | Did I present this specific content to the user? | ⛔ STOP. Present it first. |
-| Did the user explicitly approve? (e.g., "yes", "log it") | ⛔ STOP. Wait for approval or ask. |
+| Did the user explicitly approve? (e.g., "Log it") | ⛔ STOP. Wait for approval or ask. |
 | Am I writing exactly what was approved, with no additions? | ⛔ STOP. Present any changes first. |
 
 > ⛔ **FINAL CHECK**: If you have written to the specification file and cannot answer "yes" to all three questions above for that content, you have violated the workflow. Every piece of content requires explicit user approval before logging.

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -35,7 +35,7 @@ Before starting any topic, identify ALL available reference material:
 
 This is a collaborative dialogue, not an autonomous task. The user validates every piece before it's logged.
 
-> ⛔ **CHECKPOINT**: If you are about to write to the specification file and haven't received explicit approval (e.g., "Log it") for this specific content, **STOP**. You are violating the workflow. Go back and present the choices first.
+> **CHECKPOINT**: If you are about to write to the specification file and haven't received explicit approval (e.g., "Log it") for this specific content, **STOP**. You are violating the workflow. Go back and present the choices first.
 
 ---
 
@@ -84,7 +84,7 @@ Then present two explicit choices:
 
 **Do not paraphrase these choices.** Present them exactly as written so users always know what to expect.
 
-> ⛔ **CHECKPOINT**: After presenting, you MUST STOP and wait for the user's response. Do NOT proceed to logging. Do NOT present the next topic. WAIT.
+> **CHECKPOINT**: After presenting, you MUST STOP and wait for the user's response. Do NOT proceed to logging. Do NOT present the next topic. WAIT.
 
 ### 3. Discuss and Refine
 Work through the content together:
@@ -96,7 +96,7 @@ Work through the content together:
 
 This is a **human-level conversation**, not form-filling. The user brings context from across the project that may not be in the reference material - decisions from other topics, implications from later work, or knowledge that can't all fit in context.
 
-### 4. ⛔ STOP - Wait for Explicit Approval
+### 4. STOP - Wait for Explicit Approval
 
 **DO NOT PROCEED TO LOGGING WITHOUT EXPLICIT USER APPROVAL.**
 
@@ -114,7 +114,7 @@ This is a **human-level conversation**, not form-filling. The user brings contex
 
 **If you are uncertain, ASK:** "Would you like me to log it, or do you want to adjust something?"
 
-> ⛔ **CHECKPOINT**: If you are about to write to the specification and the user's last message was not explicit approval, **STOP**. You are violating the workflow. Present the choices again.
+> **CHECKPOINT**: If you are about to write to the specification and the user's last message was not explicit approval, **STOP**. You are violating the workflow. Present the choices again.
 
 ### 5. Log When Approved
 Only after receiving explicit approval do you write to the specification - **verbatim** as presented and approved. No silent modifications.
@@ -128,13 +128,13 @@ When you discover information that affects **already-logged topics**, resurface 
 
 If it does: summarize what's changing in the chat, then re-present the full updated topic. The summary is for discussion only - the specification just gets the clean replacement. **Standard workflow applies: user approves before you update.**
 
-> ⛔ **CHECKPOINT**: Even when resurfacing content, you MUST NOT update the specification until the user explicitly approves the change. Present the updated version, wait for approval, then update.
+> **CHECKPOINT**: Even when resurfacing content, you MUST NOT update the specification until the user explicitly approves the change. Present the updated version, wait for approval, then update.
 
 This is encouraged. Better to resurface and confirm "already covered" than let something slip past.
 
 ## The Specification Document
 
-> ⛔ **CHECKPOINT**: You should NOT be creating or writing to this file unless you have explicit user approval for specific content. If you're about to create this file with content you haven't presented and had approved, **STOP**. That violates the workflow.
+> **CHECKPOINT**: You should NOT be creating or writing to this file unless you have explicit user approval for specific content. If you're about to create this file with content you haven't presented and had approved, **STOP**. That violates the workflow.
 
 Create `docs/workflow/specification/{topic}.md`
 
@@ -163,9 +163,9 @@ Suggested skeleton:
 
 ## Critical Rules
 
-**⛔ EXPLICIT APPROVAL REQUIRED FOR EVERY WRITE**: You MUST NOT write to the specification until the user has explicitly approved. "Presenting" is not approval. "Asking a question" is not approval. You need explicit confirmation. If uncertain, ASK. This rule is non-negotiable.
+**EXPLICIT APPROVAL REQUIRED FOR EVERY WRITE**: You MUST NOT write to the specification until the user has explicitly approved. "Presenting" is not approval. "Asking a question" is not approval. You need explicit confirmation. If uncertain, ASK. This rule is non-negotiable.
 
-> ⛔ **CHECKPOINT**: Before ANY write operation, ask yourself: "Did the user explicitly approve this specific content?" If the answer is no or uncertain, STOP and ask.
+> **CHECKPOINT**: Before ANY write operation, ask yourself: "Did the user explicitly approve this specific content?" If the answer is no or uncertain, STOP and ask.
 
 **Exhaustive extraction is non-negotiable**: Before presenting any topic, re-scan source material. Search for keywords. Collect scattered information. The specification is the golden document - planning uses only this. If you miss something, it doesn't get built.
 
@@ -278,7 +278,7 @@ After documenting dependencies, perform a **final comprehensive review** of the 
 
 4. **Flag what you find** - When you discover potentially missed content, present it to the user. **Do NOT add it to the specification without explicit approval.**
 
-   > ⛔ **CHECKPOINT**: If you found missed content and are about to add it to the specification without presenting it first and receiving explicit approval, **STOP**. Every addition requires the present → approve → log cycle, even during final review.
+   > **CHECKPOINT**: If you found missed content and are about to add it to the specification without presenting it first and receiving explicit approval, **STOP**. Every addition requires the present → approve → log cycle, even during final review.
 
    There are two cases:
 
@@ -357,8 +357,8 @@ Before ANY write operation to the specification file, verify:
 
 | Question | If No... |
 |----------|----------|
-| Did I present this specific content to the user? | ⛔ STOP. Present it first. |
-| Did the user explicitly approve? (e.g., "Log it") | ⛔ STOP. Wait for approval or ask. |
-| Am I writing exactly what was approved, with no additions? | ⛔ STOP. Present any changes first. |
+| Did I present this specific content to the user? | **STOP**. Present it first. |
+| Did the user explicitly approve? (e.g., "Log it") | **STOP**. Wait for approval or ask. |
+| Am I writing exactly what was approved, with no additions? | **STOP**. Present any changes first. |
 
-> ⛔ **FINAL CHECK**: If you have written to the specification file and cannot answer "yes" to all three questions above for that content, you have violated the workflow. Every piece of content requires explicit user approval before logging.
+> **FINAL CHECK**: If you have written to the specification file and cannot answer "yes" to all three questions above for that content, you have violated the workflow. Every piece of content requires explicit user approval before logging.


### PR DESCRIPTION
- Replace open-ended question with two formal choices after each topic
- "Log it" explicitly states content is logged verbatim (exactly as shown)
- "Adjust" prompts user to specify what to change
- Consolidate scattered approval language to use "Log it" as standard phrase
- Update checkpoints to reference presenting choices instead of asking questions