### PR TITLE
docs: clarify research documents have no status field

### DIFF
--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -87,7 +87,7 @@ Research without documentation is wasted. Follow this loop:
 
 ## Critical Rules
 
-**No status field**: Research documents do NOT have a `status` field in their frontmatter. Only `topic` and `date`. Research is open-ended by nature — it doesn't "conclude." Even when a research exploration feels complete, do not add `status: concluded` or any similar field. The concept of document status is introduced in later phases (discussion onwards), not here. When research naturally leads to deeper work, you simply move on to the next phase — the research document stays as-is.
+**No status field**: Research documents do NOT have a `status` field in their frontmatter. Only `topic` and `date`. Research is open-ended by nature — it doesn't "conclude." Even when a research exploration feels complete, do not add `status: concluded` or any similar field. The document stays as-is.
 
 **Don't hallucinate**: Only document what was actually discussed.
 

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -87,6 +87,8 @@ Research without documentation is wasted. Follow this loop:
 
 ## Critical Rules
 
+**No status field**: Research documents do NOT have a `status` field in their frontmatter. Only `topic` and `date`. Research is open-ended by nature — it doesn't "conclude." Even when a research exploration feels complete, do not add `status: concluded` or any similar field. The concept of document status is introduced in later phases (discussion onwards), not here. When research naturally leads to deeper work, you simply move on to the next phase — the research document stays as-is.
+
 **Don't hallucinate**: Only document what was actually discussed.
 
 **Don't expand**: Capture what was said, don't embellish.

--- a/skills/technical-research/references/template.md
+++ b/skills/technical-research/references/template.md
@@ -30,6 +30,7 @@ What we know so far:
 
 - `topic`: Use `exploration` for the initial exploration file. Use semantic names (`market-landscape`, `technical-feasibility`) when splitting into focused files.
 - `date`: Today's date when creating the document.
+- **No `status` field**: Research documents intentionally have no status. Do not add `status`, `state`, or any lifecycle field. Research is open-ended — it never "concludes." Status tracking begins in later phases.
 
 ## Notes
 

--- a/skills/technical-research/references/template.md
+++ b/skills/technical-research/references/template.md
@@ -30,7 +30,7 @@ What we know so far:
 
 - `topic`: Use `exploration` for the initial exploration file. Use semantic names (`market-landscape`, `technical-feasibility`) when splitting into focused files.
 - `date`: Today's date when creating the document.
-- **No `status` field**: Research documents intentionally have no status. Do not add `status`, `state`, or any lifecycle field. Research is open-ended — it never "concludes." Status tracking begins in later phases.
+- **No `status` field**: Research documents intentionally have no status. Do not add `status`, `state`, or any lifecycle field. Research is open-ended — it never "concludes."
 
 ## Notes
 


### PR DESCRIPTION
Research is open-ended by nature and should never be marked as
concluded. Status tracking is introduced in the discussion phase
onwards. Added explicit guidance to both the research skill and
template to prevent Claude from adding status fields to research
document frontmatter.

https://claude.ai/code/session_013zE8xTT2n41kC4jSyJ8adV