### PR TITLE
Align start-planning command with skill resume/continue/review modes

### DIFF
--- a/commands/workflow/start-planning.md
+++ b/commands/workflow/start-planning.md
@@ -125,9 +125,9 @@ Available:
   3. ✔ {topic-4} - review plan
 
 Not plannable:
-  · {topic-1} - spec in-progress
-  · {caching-strategy} - cross-cutting (concluded)
-  · {rate-limiting} - cross-cutting (in-progress)
+  · {topic-1} [spec in-progress]
+  · {caching-strategy} [cross-cutting, concluded]
+  · {rate-limiting} [cross-cutting, in-progress]
 ```
 
 **Formatting rules:**
@@ -137,10 +137,10 @@ Available (numbered, selectable):
 - **`▶`** — has a plan with `plan_status: planning`
 - **`✔`** — has a plan with `plan_status: concluded`
 
-Not plannable (no number, not selectable):
+Not plannable (no number, not selectable — square brackets for all metadata):
 - **`·`** — feature specs still in-progress, or cross-cutting specifications
-- Feature specs: label with `spec in-progress`
-- Cross-cutting specs: label with `cross-cutting ({status})` showing their concluded/in-progress status
+- Feature specs: `[spec in-progress]`
+- Cross-cutting specs: `[cross-cutting, {status}]`
 
 Omit either section entirely if it has no entries.
 

--- a/commands/workflow/start-planning.md
+++ b/commands/workflow/start-planning.md
@@ -121,8 +121,8 @@ Planning Phase
 
 Available:
   1. ✓ {topic-2} - create new plan
-  2. ▶ {topic-3} - continue planning
-  3. ✔ {topic-4} - review plan
+  2. ▶ {topic-3} - continue in-progress plan
+  3. ✔ {topic-4} - review concluded plan
 
 Not plannable specifications:
   · {topic-1} [feature, in-progress]

--- a/commands/workflow/start-planning.md
+++ b/commands/workflow/start-planning.md
@@ -112,31 +112,36 @@ At least one specification is ready for planning, or an existing plan can be con
 
 ## Step 3: Present Workflow State and Options
 
-Present everything discovered to help the user make an informed choice. Each feature specification falls into one of four visual states:
+Present everything discovered to help the user make an informed choice.
 
 **Present the full state:**
 
 ```
 Planning Phase
 
-Feature specifications:
-  · {topic-1} (spec in-progress) — not ready
-  1. ✓ {topic-2} (concluded) — start new plan
-  2. ▶ {topic-3} → plan in-progress — continue planning
-  3. ✔ {topic-4} → plan concluded — review/revise
+Available:
+  1. ✓ {topic-2} - create new plan
+  2. ▶ {topic-3} - continue planning
+  3. ✔ {topic-4} - review plan
 
-Cross-cutting specifications (reference context):
-  - {caching-strategy} (concluded)
-  - {rate-limiting} (concluded)
+Not plannable:
+  · {topic-1} - spec in-progress
+  · {caching-strategy} - cross-cutting
+  · {rate-limiting} - cross-cutting
 ```
 
 **Formatting rules:**
-- **`·` not ready** — spec still in-progress; no number, not selectable
-- **`✓` start new plan** — concluded spec with no plan yet; numbered
-- **`▶` continue planning** — has a plan with `plan_status: planning`; numbered
-- **`✔` review/revise** — has a plan with `plan_status: concluded`; numbered
-- Only show cross-cutting section if cross-cutting specs exist
-- Only show states that have entries (e.g., omit the `·` group if all specs are concluded)
+
+Available (numbered, selectable):
+- **`✓`** — concluded spec with no plan yet
+- **`▶`** — has a plan with `plan_status: planning`
+- **`✔`** — has a plan with `plan_status: concluded`
+
+Not plannable (no number, not selectable):
+- **`·`** — feature specs still in-progress, or cross-cutting specifications
+- Label each with the reason: `spec in-progress` or `cross-cutting`
+
+Omit either section entirely if it has no entries.
 
 **Then prompt based on what's actionable:**
 
@@ -156,7 +161,7 @@ Auto-selecting: {topic} (only actionable specification)
 
 **If nothing actionable:**
 ```
-No actionable specifications.
+No plannable specifications.
 
 To proceed:
 - Complete any in-progress specifications with /start-specification

--- a/commands/workflow/start-planning.md
+++ b/commands/workflow/start-planning.md
@@ -120,9 +120,9 @@ Present everything discovered to help the user make an informed choice.
 Planning Phase
 
 Available:
-  1. ✓ {topic-2} - create new plan
+  1. + {topic-2} - create new plan
   2. ▶ {topic-3} - continue in-progress plan
-  3. ✔ {topic-4} - review concluded plan
+  3. > {topic-4} - review concluded plan
 
 Not plannable specifications:
   · {topic-1} [feature, in-progress]
@@ -133,9 +133,9 @@ Not plannable specifications:
 **Formatting rules:**
 
 Available (numbered, selectable):
-- **`✓`** — concluded spec with no plan yet
+- **`+`** — concluded spec with no plan yet
 - **`▶`** — has a plan with `plan_status: planning`
-- **`✔`** — has a plan with `plan_status: concluded`
+- **`>`** — has a plan with `plan_status: concluded`
 
 Not plannable specifications (no number, not selectable — `[type, status]` format):
 - **`·`** — feature specs still in-progress, or cross-cutting specifications

--- a/commands/workflow/start-planning.md
+++ b/commands/workflow/start-planning.md
@@ -126,8 +126,8 @@ Available:
 
 Not plannable:
   · {topic-1} - spec in-progress
-  · {caching-strategy} - cross-cutting
-  · {rate-limiting} - cross-cutting
+  · {caching-strategy} - cross-cutting (concluded)
+  · {rate-limiting} - cross-cutting (in-progress)
 ```
 
 **Formatting rules:**
@@ -139,7 +139,8 @@ Available (numbered, selectable):
 
 Not plannable (no number, not selectable):
 - **`·`** — feature specs still in-progress, or cross-cutting specifications
-- Label each with the reason: `spec in-progress` or `cross-cutting`
+- Feature specs: label with `spec in-progress`
+- Cross-cutting specs: label with `cross-cutting ({status})` showing their concluded/in-progress status
 
 Omit either section entirely if it has no entries.
 
@@ -204,23 +205,39 @@ Ask:
 
 ## Step 6: Surface Cross-Cutting Context
 
-If any **concluded cross-cutting specifications** exist (from `specifications.crosscutting` in discovery), surface them as reference context for planning:
+**If no cross-cutting specifications exist**: Skip this step. → Proceed to **Step 7**.
 
-1. **List applicable cross-cutting specs**:
-   - Read each cross-cutting specification
-   - Identify which ones are relevant to the feature being planned
-   - Relevance is determined by topic overlap (e.g., caching strategy applies if the feature involves data retrieval or API calls)
+Read each cross-cutting specification from `specifications.crosscutting` in the discovery output.
 
-2. **Summarize for handoff**:
-   ```
-   Cross-cutting specifications to reference:
-   - caching-strategy.md: [brief summary of key decisions]
-   - rate-limiting.md: [brief summary of key decisions]
-   ```
+### 6a: Warn about in-progress cross-cutting specs
+
+If any **in-progress** cross-cutting specifications exist, check whether they could be relevant to the feature being planned (by topic overlap — e.g., a caching strategy is relevant if the feature involves data retrieval or API calls).
+
+If any are relevant:
+
+```
+Note: The following cross-cutting specifications are still in-progress:
+  · {rate-limiting} - in-progress
+
+These may contain architectural decisions relevant to this plan. You can:
+- Continue planning without them
+- Stop and complete them first (/start-specification)
+```
+
+**STOP.** Wait for user response.
+
+If the user chooses to stop, end here. If they choose to continue, proceed.
+
+### 6b: Summarize concluded cross-cutting specs
+
+If any **concluded** cross-cutting specifications exist, identify which are relevant to the feature being planned and summarize for handoff:
+
+```
+Cross-cutting specifications to reference:
+- caching-strategy.md: [brief summary of key decisions]
+```
 
 These specifications contain validated architectural decisions that should inform the plan. The planning skill will incorporate these as a "Cross-Cutting References" section in the plan.
-
-**If no cross-cutting specifications exist**: Skip this step.
 
 → Proceed to **Step 7**.
 

--- a/commands/workflow/start-planning.md
+++ b/commands/workflow/start-planning.md
@@ -124,8 +124,8 @@ Available:
   2. ▶ {topic-3} - continue planning
   3. ✔ {topic-4} - review plan
 
-Not plannable:
-  · {topic-1} [spec in-progress]
+Not plannable specifications:
+  · {topic-1} [feature, in-progress]
   · {caching-strategy} [cross-cutting, concluded]
   · {rate-limiting} [cross-cutting, in-progress]
 ```
@@ -137,9 +137,9 @@ Available (numbered, selectable):
 - **`▶`** — has a plan with `plan_status: planning`
 - **`✔`** — has a plan with `plan_status: concluded`
 
-Not plannable (no number, not selectable — square brackets for all metadata):
+Not plannable specifications (no number, not selectable — `[type, status]` format):
 - **`·`** — feature specs still in-progress, or cross-cutting specifications
-- Feature specs: `[spec in-progress]`
+- Feature specs: `[feature, in-progress]`
 - Cross-cutting specs: `[cross-cutting, {status}]`
 
 Omit either section entirely if it has no entries.

--- a/commands/workflow/start-specification.md
+++ b/commands/workflow/start-specification.md
@@ -120,25 +120,29 @@ At least one concluded discussion exists.
 Show the current state clearly. Use this EXACT format:
 
 ```
-Workflow Status: Specification Phase
+Specification Phase
 
-Discussions:
-  ✓ {topic-1} - concluded - ready
-  ✓ {topic-2} - concluded - ready
-  ○ {topic-3} - concluded - spec: {spec_status}
-  · {topic-4} - in-progress - not ready
+Available discussions:
+  ✓ {topic-1} - ready to specify
+  ✓ {topic-2} - ready to specify
+  ○ {topic-3} - spec exists [{status}]
 
-Specifications:
-  • {spec-1} (active) - sources: {topic-1}
-  • {spec-2} (superseded → {other-spec}) - sources: {topic-x}
+Not specifiable discussions:
+  · {topic-4} [in-progress]
+
+Existing specifications:
+  • {spec-1} [active] - sources: {topic-1}
+  • {spec-2} [superseded → {other-spec}] - sources: {topic-x}
 
 {N} concluded discussions available.
 ```
 
 **Legend:**
 - `✓` = concluded, no spec yet (ready to specify)
-- `○` = concluded, has individual spec (shows spec status: in-progress or concluded)
-- `·` = in-progress (not ready)
+- `○` = concluded, has individual spec (shows spec status in brackets)
+- `·` = in-progress (not specifiable)
+
+Omit either discussions section if it has no entries.
 
 #### Routing Based on State
 

--- a/commands/workflow/start-specification.md
+++ b/commands/workflow/start-specification.md
@@ -123,12 +123,13 @@ Show the current state clearly. Use this EXACT format:
 Specification Phase
 
 Available discussions:
-  ✓ {topic-1} - ready to specify
-  ✓ {topic-2} - ready to specify
-  ○ {topic-3} - spec exists [{status}]
+  + {topic-1} - create new spec
+  + {topic-2} - create new spec
+  ▶ {topic-3} - continue in-progress spec
+  > {topic-4} - review concluded spec
 
 Not specifiable discussions:
-  · {topic-4} [in-progress]
+  · {topic-5} [in-progress]
 
 Existing specifications:
   • {spec-1} [active] - sources: {topic-1}
@@ -138,8 +139,9 @@ Existing specifications:
 ```
 
 **Legend:**
-- `✓` = concluded, no spec yet (ready to specify)
-- `○` = concluded, has individual spec (shows spec status in brackets)
+- `+` = concluded, no spec yet (create new)
+- `▶` = concluded, has in-progress spec (continue)
+- `>` = concluded, has concluded spec (review)
 - `·` = in-progress (not specifiable)
 
 Omit either discussions section if it has no entries.

--- a/skills/technical-planning/references/steps/plan-construction.md
+++ b/skills/technical-planning/references/steps/plan-construction.md
@@ -88,6 +88,17 @@ Present the task list to the user for review.
 
 Work through each task in the phase's task table, in order.
 
+### Parallel authoring (optional optimization)
+
+After the first `pending` task in a phase is approved, you may invoke multiple Step B agents concurrently for tasks you judge to be independent — where the authored detail of one would not inform the other. This is an invocation optimization only; the approval flow is unchanged:
+
+- Present tasks one at a time, in order
+- Each task still requires explicit user approval before logging
+- If user feedback on a presented task changes context that could affect any already-authored task waiting to be presented, discard those results and re-invoke Step B
+- When uncertain about independence, default to sequential — it is always safe
+
+Never parallelize the first `pending` task in a phase. Never parallelize across phases.
+
 #### If the task status is `authored`
 
 Already written. Present a brief summary:


### PR DESCRIPTION
## Summary

- **Discovery script**: Exposes `plan_status` and `feature_with_plan` count for feature specs with existing plans. Replaces old scenario values (`no_ready_specs`, `single_ready_spec`, `multiple_ready_specs`) with `nothing_actionable` and `has_options`.
- **Start-planning command**: Rewrites presentation with four visual states (`·` not ready, `✓` start new plan, `▶` continue planning, `✔` review/revise). Adds Step 4 routing to skip context gathering for existing plans. Provides separate handoff examples for fresh vs continue/review paths.
- **Plan construction**: Adds parallel authoring optimization for independent tasks within a phase.
- **Tests**: Updates all scenario assertions and adds 3 new tests (concluded plan actionable, mixed ready+plans, all in-progress nothing actionable). All 63 tests pass.

## Test plan

- [x] Run `tests/scripts/test-discovery-for-planning.sh` — 63/63 pass
- [ ] Manual: Run `/start-planning` with a concluded spec and no plan → should show `✓` and route to fresh flow
- [ ] Manual: Run `/start-planning` with an in-progress plan → should show `▶` and skip context gathering
- [ ] Manual: Run `/start-planning` with a concluded plan → should show `✔` and skip context gathering

🤖 Generated with [Claude Code](https://claude.com/claude-code)