### PR TITLE
Add visual separators and command shortcuts to stopgates

### DIFF
--- a/.claude/skills/update-workflow-explorer/SKILL.md
+++ b/.claude/skills/update-workflow-explorer/SKILL.md
@@ -13,7 +13,7 @@ Audit `workflow-explorer.html` and sync its flowchart data with the actual comma
 Check `$ARGUMENTS` for user-provided context about what changed.
 
 - **Context given** (e.g. "I just updated the implementation skill") → narrow to affected flowchart keys using the source mapping below
-- **No context** → full audit of all 17 flowchart keys
+- **No context** → full audit of all 24 flowchart keys
 - **Ambiguous** → ASK user to confirm scope before proceeding
 
 ## Step 1: Read Source Files
@@ -41,6 +41,13 @@ For each in-scope flowchart key, read its source file(s) and extract the logical
 | `status` | `commands/workflow/status.md` |
 | `view-plan` | `commands/workflow/view-plan.md` |
 | `migrate` | `commands/migrate.md` |
+| `planning-phase-designer` | `agents/planning-phase-designer.md` |
+| `planning-task-designer` | `agents/planning-task-designer.md` |
+| `planning-task-author` | `agents/planning-task-author.md` |
+| `planning-dependency-grapher` | `agents/planning-dependency-grapher.md` |
+| `implementation-task-executor` | `agents/implementation-task-executor.md` |
+| `implementation-task-reviewer` | `agents/implementation-task-reviewer.md` |
+| `review-task-verifier` | `agents/review-task-verifier.md` |
 
 Use parallel reads (Task tool with Explore agents or multiple Read calls) to gather sources efficiently.
 
@@ -91,7 +98,8 @@ Follow the conventions documented in the file header (lines 1-41):
 - `backloop` — gray dashed (retry/loop-back flows)
 
 **Color conventions (type-based, NOT phase-based — use CSS vars):**
-- `var(--action)` sky blue — primary work steps (validate, extract, invoke agents, etc.)
+- `var(--action)` sky blue — primary work steps (validate, extract, etc.)
+- `var(--agent)` cyan — agent invocation nodes (with optional `skillLink` to agent flowchart)
 - `var(--text-dim)` gray — utility/support steps (read existing, load format, etc.)
 - `var(--ask)` purple — user-interaction nodes
 - `var(--routing)` amber — decision diamonds (all diamonds use this)
@@ -103,7 +111,7 @@ Follow the conventions documented in the file header (lines 1-41):
 - `var(--{phase})` phase color — END output artifacts only (keeps phase identity)
 
 **Node properties:**
-- `skillLink` — on nodes that should navigate to a skill flowchart on click
+- `skillLink` — on nodes that should navigate to a skill or agent flowchart on click
 - `desc` — tooltip text describing what the node does
 
 **Next-phase nodes (skill flowcharts only):**

--- a/.claude/skills/update-workflow-explorer/SKILL.md
+++ b/.claude/skills/update-workflow-explorer/SKILL.md
@@ -46,12 +46,14 @@ Use parallel reads (Task tool with Explore agents or multiple Read calls) to gat
 
 ## Step 2: Read Current Flowchart Data
 
-Read `workflow-explorer.html` and extract the 4 data structures for each in-scope key:
+Read `workflow-explorer.html` and extract the 6 data structures for each in-scope key:
 
 1. **`phases[key]`** — metadata (steps, desc, scenarios, detailHTML)
 2. **`FLOWCHARTS[key]`** — nodes + connections
 3. **`FLOWCHART_DESCS[key]`** — summary, body, meta
 4. **`OVERVIEW_*`** — only if phases were added/removed/renamed
+5. **`SOURCE_MAP[key]`** — repo-relative path to source file (update when files are renamed)
+6. **`SKILL_NEXT_PHASE[key]`** — next-phase navigation for skill flowcharts
 
 ## Step 3: Compare and Report
 
@@ -78,7 +80,8 @@ Follow the conventions documented in the file header (lines 1-41):
 
 **Node shapes:**
 - `pill` — start/end nodes (w:150, h:40)
-- `diamond` — decision/gate nodes (w:110-130, h:110-130)
+- `diamond` — decision/routing nodes (w:110-130, h:110-130)
+- `stop` — hard-cornered terminal nodes for STOP/BLOCK (w:150-180, h:40, rx:3)
 - rect (default) — action step nodes (w:180-200, h:44)
 
 **Connection types:**
@@ -87,18 +90,32 @@ Follow the conventions documented in the file header (lines 1-41):
 - `transition` — orange dashed (phase/context transitions)
 - `backloop` — gray dashed (retry/loop-back flows)
 
-**Color conventions:**
-- Phase color for primary nodes
-- `var(--accent)` for start/migrate nodes
-- `var(--text-dim)` for secondary/utility nodes
-- `#a78bfa` for ASK/user-interaction nodes
-- `#f43f5e` for gates/blocks
-- `#fbbf24` for routing diamonds
-- `#34d399` for discovery nodes
+**Color conventions (type-based, NOT phase-based — use CSS vars):**
+- `var(--action)` sky blue — primary work steps (validate, extract, invoke agents, etc.)
+- `var(--text-dim)` gray — utility/support steps (read existing, load format, etc.)
+- `var(--ask)` purple — user-interaction nodes
+- `var(--routing)` amber — decision diamonds (all diamonds use this)
+- `var(--gate)` red — STOP/BLOCK terminal nodes (hard-cornered `stop` shape), cache refresh
+- `var(--discovery)` green — discovery script execution
+- `var(--skill)` orange — skill invocation pills (with `skillLink`)
+- `var(--next)` green — next-phase navigation pills
+- `var(--accent)` blue — entry points, migrations, git commits
+- `var(--{phase})` phase color — END output artifacts only (keeps phase identity)
 
 **Node properties:**
 - `skillLink` — on nodes that should navigate to a skill flowchart on click
 - `desc` — tooltip text describing what the node does
+
+**Next-phase nodes (skill flowcharts only):**
+- Every skill flowchart except `skill-review` has a `next` pill node at the end
+- Node: `{ id: 'next', label: 'Next: /start-{phase}', shape: 'pill', w: 180, h: 40, color: '#34d399', bg: 'rgba(52,211,153,0.15)', skillLink: NEXT_PHASE_KEY }`
+- Connection: `{ from: 'end', to: 'next', type: 'transition' }`
+- All next nodes use consistent green (`#34d399`) regardless of target phase
+- `SKILL_NEXT_PHASE` mapping must stay in sync
+
+**SOURCE_MAP maintenance:**
+- When source files are renamed or new flowchart keys are added, update `SOURCE_MAP` accordingly
+- `SOURCE_MAP` maps flowchart keys to repo-relative file paths for the markdown viewer
 
 ## Step 5: Validate and Verify
 

--- a/commands/link-dependencies.md
+++ b/commands/link-dependencies.md
@@ -159,7 +159,9 @@ UPDATED FILES:
 If any files were updated:
 
 ```
-Shall I commit these dependency updates? (y/n)
+· · ·
+
+Shall I commit these dependency updates? (**`y`/`yes`** or **`n`/`no`**)
 ```
 
 If yes, commit with message:

--- a/commands/link-dependencies.md
+++ b/commands/link-dependencies.md
@@ -161,7 +161,9 @@ If any files were updated:
 ```
 · · ·
 
-Shall I commit these dependency updates? (**`y`/`yes`** or **`n`/`no`**)
+Shall I commit these dependency updates?
+- **`y`/`yes`** — Commit the changes
+- **`n`/`no`** — Skip
 ```
 
 If yes, commit with message:

--- a/commands/workflow/start-discussion.md
+++ b/commands/workflow/start-discussion.md
@@ -222,25 +222,31 @@ Discussions:
 
 **If research AND discussions exist:**
 ```
+· · ·
+
 How would you like to proceed?
 
   • **From research** - Pick a topic number above (e.g., "research 1" or "1")
   • **Continue discussion** - Name one above (e.g., "continue {topic}")
   • **Fresh topic** - Describe what you want to discuss
-  • **refresh** - Force fresh research analysis
+  • **`r`/`refresh`** - Force fresh research analysis
 ```
 
 **If ONLY research exists:**
 ```
+· · ·
+
 How would you like to proceed?
 
   • **From research** - Pick a topic number above (e.g., "research 1" or "1")
   • **Fresh topic** - Describe what you want to discuss
-  • **refresh** - Force fresh research analysis
+  • **`r`/`refresh`** - Force fresh research analysis
 ```
 
 **If ONLY discussions exist:**
 ```
+· · ·
+
 How would you like to proceed?
 
   • **Continue discussion** - Name one above (e.g., "continue {topic}")

--- a/commands/workflow/start-implementation.md
+++ b/commands/workflow/start-implementation.md
@@ -193,6 +193,8 @@ Show Not implementable section only (with unblock hint above).
 ```
 No implementable plans.
 
+· · ·
+
 To proceed:
 - Complete blocking dependencies first
 - Or finish plans still in progress with /start-planning
@@ -202,6 +204,8 @@ To proceed:
 
 **Otherwise (multiple selectable plans, or implemented plans exist):**
 ```
+· · ·
+
 Select a plan (enter number):
 ```
 
@@ -249,6 +253,8 @@ UNRESOLVED (not yet planned):
 INCOMPLETE (planned but not implemented):
 - {topic}: task {task_id} not yet completed
   -> This task must be completed first.
+
+· · ·
 
 OPTIONS:
 1. Implement the blocking dependencies first

--- a/commands/workflow/start-implementation.md
+++ b/commands/workflow/start-implementation.md
@@ -193,14 +193,14 @@ Show Not implementable section only (with unblock hint above).
 ```
 No implementable plans.
 
-· · ·
+Before you can start implementation:
+- Complete blocking dependencies first, or
+- Finish plans still in progress with /start-planning
 
-To proceed:
-- Complete blocking dependencies first
-- Or finish plans still in progress with /start-planning
+Then re-run /start-implementation.
 ```
 
-**STOP.** Wait for user response.
+**STOP.** This workflow cannot continue — do not proceed.
 
 **Otherwise (multiple selectable plans, or implemented plans exist):**
 ```

--- a/commands/workflow/start-planning.md
+++ b/commands/workflow/start-planning.md
@@ -149,6 +149,8 @@ Omit either section entirely if it has no entries.
 
 **If multiple actionable items:**
 ```
+· · ·
+
 Select a specification (enter number):
 ```
 
@@ -164,6 +166,8 @@ Auto-selecting: {topic} (only actionable specification)
 **If nothing actionable:**
 ```
 No plannable specifications.
+
+· · ·
 
 To proceed:
 - Complete any in-progress specifications with /start-specification

--- a/commands/workflow/start-planning.md
+++ b/commands/workflow/start-planning.md
@@ -167,14 +167,14 @@ Auto-selecting: {topic} (only actionable specification)
 ```
 No plannable specifications.
 
-· · ·
+Before you can start planning:
+- Complete any in-progress specifications with /start-specification, or
+- Create a new specification first
 
-To proceed:
-- Complete any in-progress specifications with /start-specification
-- Or create a new specification first
+Then re-run /start-planning.
 ```
 
-**STOP.** Wait for user response before ending.
+**STOP.** This workflow cannot continue — do not proceed.
 
 → Based on user choice, proceed to **Step 4**.
 

--- a/commands/workflow/start-review.md
+++ b/commands/workflow/start-review.md
@@ -108,6 +108,8 @@ Available Plans:
   1. {topic-1} ({status}) - format: {format}, spec: {exists|missing}
   2. {topic-2} ({status}) - format: {format}, spec: {exists|missing}
 
+· · ·
+
 Which plan would you like to review the implementation for? (Enter a number or name)
 ```
 
@@ -130,6 +132,8 @@ Auto-selecting: {topic} (only available plan)
 Ask the user what code to review:
 
 ```
+· · ·
+
 What code should I review?
 
 1. All changes since the plan was created

--- a/commands/workflow/start-specification.md
+++ b/commands/workflow/start-specification.md
@@ -204,6 +204,8 @@ Check `cache.status` from discovery to determine which options to present.
 ##### If `cache.status: "valid"`
 
 ```
+· · ·
+
 What would you like to do?
 
 1. **Continue an existing specification** - Resume work on a spec in progress
@@ -218,6 +220,8 @@ Which approach?
 ##### If `cache.status: "stale"`
 
 ```
+· · ·
+
 What would you like to do?
 
 Note: A previous grouping analysis exists but is now outdated - discussion documents have changed since it was created. Re-analysis is required, but existing specification names will be preserved where groupings overlap.
@@ -233,6 +237,8 @@ Which approach?
 ##### If `cache.status: "none"`
 
 ```
+· · ·
+
 What would you like to do?
 
 1. **Continue an existing specification** - Resume work on a spec in progress
@@ -468,6 +474,8 @@ Coupling: {explanation}
 
 ---
 
+· · ·
+
 How would you like to proceed?
 
 1. **Proceed as recommended** - I'll ask which to start with
@@ -475,7 +483,7 @@ How would you like to proceed?
 3. **Single specification** - Consolidate ALL into one unified spec
 4. **Individual specifications** - Create 1:1 specs (I'll ask which to start)
 
-(Enter 'refresh' to re-analyze)
+(Enter **`r`/`refresh`** to re-analyze)
 ```
 
 **Status Legend:**
@@ -556,6 +564,8 @@ This reorganization affects multiple existing specifications:
 - {spec-2} (sources: {topics})
 
 Moving discussions between established specifications requires deleting the affected specs and re-processing. The source material in your discussions is preserved.
+
+· · ·
 
 Options:
 1. **Delete affected specs and proceed** - Remove {spec-1}, {spec-2} and create fresh specs for your new groupings

--- a/commands/workflow/start-specification.md
+++ b/commands/workflow/start-specification.md
@@ -483,7 +483,7 @@ How would you like to proceed?
 3. **Single specification** - Consolidate ALL into one unified spec
 4. **Individual specifications** - Create 1:1 specs (I'll ask which to start)
 
-(Enter **`r`/`refresh`** to re-analyze)
+- **`r`/`refresh`** — Re-analyze discussions
 ```
 
 **Status Legend:**
@@ -612,7 +612,11 @@ Check if `docs/workflow/specification/unified.md` already exists.
 
 This will consolidate ALL {N} concluded discussions into a single specification.
 
-Proceed with unified specification? (y/n)
+· · ·
+
+Proceed with unified specification?
+- **`y`/`yes`** — Proceed
+- **`n`/`no`** — Cancel
 ```
 
 **STOP.** Wait for user to confirm, then proceed to **Step 9** with all discussions as sources.
@@ -665,7 +669,11 @@ Output: docs/workflow/specification/{grouping-name}.md
 After completion:
 - specification/{topic-c}.md will be marked as superseded
 
-Proceed? (y/n)
+· · ·
+
+Proceed?
+- **`y`/`yes`** — Proceed
+- **`n`/`no`** — Go back
 ```
 
 #### If creating a NEW grouped specification (no existing specs)
@@ -680,7 +688,11 @@ Sources:
 
 Output: docs/workflow/specification/{grouping-name}.md
 
-Proceed? (y/n)
+· · ·
+
+Proceed?
+- **`y`/`yes`** — Proceed
+- **`n`/`no`** — Go back
 ```
 
 #### If CONTINUING an existing grouped specification
@@ -694,7 +706,11 @@ Sources:
 - docs/workflow/discussion/{topic-a}.md
 - docs/workflow/discussion/{topic-b}.md
 
-Proceed? (y/n)
+· · ·
+
+Proceed?
+- **`y`/`yes`** — Proceed
+- **`n`/`no`** — Go back
 ```
 
 #### If creating/continuing an INDIVIDUAL specification
@@ -707,7 +723,11 @@ Sources:
 
 Output: docs/workflow/specification/{topic}.md
 
-Proceed? (y/n)
+· · ·
+
+Proceed?
+- **`y`/`yes`** — Proceed
+- **`n`/`no`** — Go back
 ```
 
 **STOP.** Wait for user confirmation.

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -151,8 +151,10 @@ If `project_skills` is populated in the tracking file, present for confirmation:
 > - `{skill-name}` — {path}
 > - ...
 >
+> · · ·
+>
 > - **`y`/`yes`** — Keep these, proceed
-> - **`change`** — Add or remove skills"
+> - **`c`/`change`** — Add or remove skills"
 
 **STOP.** Wait for user choice.
 

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -45,9 +45,11 @@ Present the executor's ISSUES to the user:
 >
 > {executor's ISSUES content}
 >
-> - **`retry`** — Re-invoke the executor with your comments (provide below)
-> - **`skip`** — Skip this task and move to the next
-> - **`stop`** — Stop implementation entirely
+> · · ·
+>
+> - **`r`/`retry`** — Re-invoke the executor with your comments (provide below)
+> - **`s`/`skip`** — Skip this task and move to the next
+> - **`t`/`stop`** — Stop implementation entirely
 
 **STOP.** Wait for user choice.
 
@@ -84,8 +86,10 @@ Present the reviewer's findings to the user:
 > Notes (non-blocking):
 > {NOTES from reviewer}
 >
+> · · ·
+>
 > - **`y`/`yes`** — Accept these notes and pass them to the executor to fix
-> - **`skip`** — Override the reviewer and proceed as-is
+> - **`s`/`skip`** — Override the reviewer and proceed as-is
 > - **Comment** — Modify or add to the notes before passing to the executor
 
 **STOP.** Wait for user choice.
@@ -109,9 +113,11 @@ Present a summary and wait for user input:
 > Phase: {phase number} — {phase name}
 > {executor's SUMMARY — brief commentary, decisions, implementation notes}
 >
+> · · ·
+>
 > **Options:**
 > - **`y`/`yes`** — Approve, commit, continue to next task
-> - **`auto`** — Approve this and all future reviewer-approved tasks automatically
+> - **`a`/`auto`** — Approve this and all future reviewer-approved tasks automatically
 > - **Comment** — Feedback the reviewer missed (triggers a fix round)
 
 **STOP.** Wait for user input.

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -79,8 +79,10 @@ Load **[spec-change-detection.md](references/spec-change-detection.md)** to chec
 >
 > {spec change summary from spec-change-detection.md}
 >
-> - **`continue`** — Walk through the plan from the start. You can review, amend, or navigate at any point — including straight to the leading edge.
-> - **`restart`** — Erase all planning work for this topic and start fresh. This deletes the Plan Index File and any Authored Tasks. Other topics are unaffected."
+> · · ·
+>
+> - **`c`/`continue`** — Walk through the plan from the start. You can review, amend, or navigate at any point — including straight to the leading edge.
+> - **`r`/`restart`** — Erase all planning work for this topic and start fresh. This deletes the Plan Index File and any Authored Tasks. Other topics are unaffected."
 
 **STOP.** Wait for user response.
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -120,8 +120,11 @@ First, choose the Output Format.
 Present the recommendation:
 
 > "Existing plans use **{format}**. Use the same format for consistency?
-> - **yes** — use {format}
-> - **no** — see all available formats"
+>
+> · · ·
+>
+> - **`y`/`yes`** — Use {format}
+> - **`n`/`no`** — See all available formats"
 
 **STOP.** Wait for user choice. If declined, fall through to the full list below.
 

--- a/skills/technical-planning/references/steps/analyze-task-graph.md
+++ b/skills/technical-planning/references/steps/analyze-task-graph.md
@@ -38,6 +38,8 @@ The natural task order is already correct. Present this to the user:
 >
 > {notes from agent output}"
 
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Confirmed.
 > - **Or tell me what to change.**
@@ -70,6 +72,8 @@ Dependencies and priorities have already been written to the task files. Present
 >
 > {any notes from agent output}"
 
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Approved.
 > - **Or tell me what to change.**

--- a/skills/technical-planning/references/steps/author-tasks.md
+++ b/skills/technical-planning/references/steps/author-tasks.md
@@ -31,6 +31,8 @@ After presenting, ask:
 
 > **Task {M} of {total}: {Task Name}**
 >
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Approved. I'll log it to the plan.
 > - **Or tell me what to change.**

--- a/skills/technical-planning/references/steps/define-phases.md
+++ b/skills/technical-planning/references/steps/define-phases.md
@@ -59,6 +59,8 @@ Present the phase structure to the user.
 
 > **Phase Structure**
 >
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Approved. I'll proceed to task breakdown.
 > - **Or tell me what to change** — reorder, split, merge, add, edit, or remove phases.

--- a/skills/technical-planning/references/steps/define-tasks.md
+++ b/skills/technical-planning/references/steps/define-tasks.md
@@ -42,6 +42,8 @@ Present the task overview to the user.
 
 **STOP.** Ask:
 
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Approved.
 > - **Or tell me what to change** — reorder, split, merge, add, edit, or remove tasks.

--- a/skills/technical-planning/references/steps/plan-construction.md
+++ b/skills/technical-planning/references/steps/plan-construction.md
@@ -71,6 +71,8 @@ Present the task list to the user for review.
 
 > **Phase {N}: {Phase Name}** — {M} tasks.
 >
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Confirmed.
 > - **Or tell me what to change.**

--- a/skills/technical-planning/references/steps/resolve-dependencies.md
+++ b/skills/technical-planning/references/steps/resolve-dependencies.md
@@ -43,6 +43,8 @@ Skip the resolution and reverse check — there is nothing to resolve against. D
 
 **STOP.** Present a summary of the dependency state: what was documented, what was resolved, what remains unresolved, and any reverse resolutions made.
 
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Approved. I'll proceed to plan review.
 > - **Or tell me what to change.**

--- a/skills/technical-planning/references/steps/review-integrity.md
+++ b/skills/technical-planning/references/steps/review-integrity.md
@@ -171,9 +171,11 @@ After presenting the finding and proposed fix, ask:
 
 > **Finding {N} of {total}: {Brief Title}**
 >
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Approved. I'll apply it to the plan verbatim.
-> - **`skip`** — Leave this as-is and move to the next finding.
+> - **`s`/`skip`** — Leave this as-is and move to the next finding.
 > - **Or tell me what to change.**
 
 **STOP.** Wait for the user's response.

--- a/skills/technical-planning/references/steps/review-traceability.md
+++ b/skills/technical-planning/references/steps/review-traceability.md
@@ -149,9 +149,11 @@ After presenting the finding and proposed fix, ask:
 
 > **Finding {N} of {total}: {Brief Title}**
 >
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Approved. I'll apply it to the plan verbatim.
-> - **`skip`** — Leave this as-is and move to the next finding.
+> - **`s`/`skip`** — Leave this as-is and move to the next finding.
 > - **Or tell me what to change.**
 
 **STOP.** Wait for the user's response.

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -78,6 +78,8 @@ Present your understanding to the user **in the format it would appear in the sp
 
 Then present two explicit choices:
 
+> · · ·
+>
 > **To proceed:**
 > - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim** (exactly as shown, no modifications).
 > - **Or tell me what to change.**
@@ -516,6 +518,8 @@ For each item, follow the **same workflow as the main specification process**:
    >
    > [content exactly as it would appear]
    >
+   > · · ·
+   >
    > **To proceed:**
    > - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim**.
    > - **Or tell me what to change.**
@@ -645,6 +649,8 @@ For each item:
    > "Here's what I'll add to the specification:
    >
    > [content exactly as it would appear]
+   >
+   > · · ·
    >
    > **To proceed:**
    > - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim**.

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -45,7 +45,8 @@
     Connection types map to colors + arrow markers (yes=green, no=red, transition=orange dashed, backloop=gray dashed).
 
   Node color system (type-based, not phase-based — CSS vars in :root):
-    - var(--action)    sky blue    — primary work steps (validate, extract, invoke agents, etc.)
+    - var(--action)    sky blue    — primary work steps (validate, extract, etc.)
+    - var(--agent)     cyan        — agent invocation nodes (with optional skillLink to agent flowchart)
     - var(--text-dim)  gray        — utility/support steps (read existing, load format, etc.)
     - var(--ask)       purple      — user interaction nodes
     - var(--routing)   amber       — non-blocking decision diamonds
@@ -57,7 +58,7 @@
     - var(--{phase})   phase color — output artifact pills only (keeps phase identity)
 
   Conventions:
-    - Clicking flowchart nodes with `desc` shows a tooltip; nodes with `skillLink` navigate to that skill's flowchart.
+    - Clicking flowchart nodes with `desc` shows a tooltip; nodes with `skillLink` navigate to that skill/agent's flowchart.
     - Overview nodes with `phase` are clickable and route to selectPhase().
     - The info panel (ⓘ button) shows contextual info for the current flowchart.
     - Skill flowcharts (except skill-review) have a `next` pill node at the end, always green (#34d399),
@@ -113,6 +114,8 @@
     --skill-bg: rgba(249,115,22,0.15);
     --next: #34d399;
     --next-bg: rgba(52,211,153,0.15);
+    --agent: #22d3ee;
+    --agent-bg: rgba(34,211,238,0.15);
   }
   * { margin:0; padding:0; box-sizing:border-box; }
   body {
@@ -797,15 +800,15 @@
     <div class="section-label collapsible" onclick="toggleSidebarSection(this)"><span class="chevron">▼</span> Agents</div>
     <div class="collapsible-content" style="max-height:400px">
       <div class="dropdown-subheading">Planning</div>
-      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">planning-phase-designer</span></button>
-      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">planning-task-designer</span></button>
-      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">planning-task-author</span></button>
-      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">planning-dependency-grapher</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('planning-phase-designer',this)" id="btn-planning-phase-designer"><span class="badge badge-agt">agt</span><span class="btn-label">planning-phase-designer</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('planning-task-designer',this)" id="btn-planning-task-designer"><span class="badge badge-agt">agt</span><span class="btn-label">planning-task-designer</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('planning-task-author',this)" id="btn-planning-task-author"><span class="badge badge-agt">agt</span><span class="btn-label">planning-task-author</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('planning-dependency-grapher',this)" id="btn-planning-dependency-grapher"><span class="badge badge-agt">agt</span><span class="btn-label">planning-dependency-grapher</span></button>
       <div class="dropdown-subheading">Implementation</div>
-      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">implementation-task-executor</span></button>
-      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">implementation-task-reviewer</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('implementation-task-executor',this)" id="btn-implementation-task-executor"><span class="badge badge-agt">agt</span><span class="btn-label">implementation-task-executor</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('implementation-task-reviewer',this)" id="btn-implementation-task-reviewer"><span class="badge badge-agt">agt</span><span class="btn-label">implementation-task-reviewer</span></button>
       <div class="dropdown-subheading">Review</div>
-      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">review-task-verifier</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('review-task-verifier',this)" id="btn-review-task-verifier"><span class="badge badge-agt">agt</span><span class="btn-label">review-task-verifier</span></button>
     </div>
 
     <div class="section-label collapsible" onclick="toggleSidebarSection(this)"><span class="chevron">▼</span> Legend</div>
@@ -824,6 +827,7 @@
         <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--ask-bg);border-color:var(--ask)"></div></div> User interaction</div>
         <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--discovery-bg);border-color:var(--discovery)"></div></div> Discovery script</div>
         <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:var(--skill-bg);border-color:var(--skill)"></div></div> Skill handoff</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--agent-bg);border-color:var(--agent)"></div></div> Agent invocation</div>
         <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:var(--next-bg);border-color:var(--next)"></div></div> Next phase</div>
         <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:#34d399"></div></div> Yes branch</div>
         <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:#f43f5e"></div></div> No branch</div>
@@ -1080,6 +1084,41 @@ const phases = {
   'skill-review': {
     color: '#f472b6', bg: 'rgba(244,114,182,0.12)',
     label: 'Review Skill', cmd: 'technical-review',
+  },
+  'planning-phase-designer': {
+    color: '#fbbf24', bg: 'rgba(251,191,36,0.12)',
+    label: 'Phase Designer',
+    desc: 'Subagent that designs implementation phases from a specification. Invoked during plan construction.',
+  },
+  'planning-task-designer': {
+    color: '#fbbf24', bg: 'rgba(251,191,36,0.12)',
+    label: 'Task Designer',
+    desc: 'Subagent that breaks phases into task lists with edge cases. Invoked during plan construction.',
+  },
+  'planning-task-author': {
+    color: '#fbbf24', bg: 'rgba(251,191,36,0.12)',
+    label: 'Task Author',
+    desc: 'Subagent that writes full task detail in the chosen output format. Invoked during plan construction.',
+  },
+  'planning-dependency-grapher': {
+    color: '#fbbf24', bg: 'rgba(251,191,36,0.12)',
+    label: 'Dependency Grapher',
+    desc: 'Subagent that analyzes task dependencies, detects cycles, and assigns priorities.',
+  },
+  'implementation-task-executor': {
+    color: '#f97316', bg: 'rgba(249,115,22,0.12)',
+    label: 'Task Executor',
+    desc: 'Subagent that implements a single task via strict TDD. Returns structured completion report.',
+  },
+  'implementation-task-reviewer': {
+    color: '#f97316', bg: 'rgba(249,115,22,0.12)',
+    label: 'Task Reviewer',
+    desc: 'Subagent that independently reviews a task for spec conformance and code quality.',
+  },
+  'review-task-verifier': {
+    color: '#f472b6', bg: 'rgba(244,114,182,0.12)',
+    label: 'Task Verifier',
+    desc: 'Subagent that verifies a single task implementation against plan and spec. Spawned in parallel.',
   },
 };
 
@@ -1518,8 +1557,8 @@ const FLOWCHARTS = {
       { id: 'load-existing', label: 'Load existing plan', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Continue: load existing plan and output format adapter.' },
       { id: 'principles', label: 'Load principles', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 2: Load planning-principles.md. Internalize constraints.' },
       { id: 'verify', label: 'Verify source material', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 3: Verify specification is complete. Check cross-cutting references.' },
-      { id: 'plan-construction', label: 'Plan construction', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Nested loop — define phases, define tasks per phase, author each task. Commits after each phase completes.' },
-      { id: 'analyze-graph', label: 'Analyze task graph', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 5: Invoke planning-dependency-grapher agent. Analyze task dependencies, detect cycles, assign priorities. User approves changes.' },
+      { id: 'plan-construction', label: 'Plan construction', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', desc: 'Step 4: Nested loop — invoke phase-designer, task-designer, and task-author agents. Commits after each phase completes.' },
+      { id: 'analyze-graph', label: 'Analyze task graph', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', skillLink: 'planning-dependency-grapher', desc: 'Step 5: Invoke planning-dependency-grapher agent. Analyze task dependencies, detect cycles, assign priorities. User approves changes.' },
       { id: 'deps', label: 'Resolve ext deps', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 6: Identify external dependencies. Match to tasks in other plans if possible. Mark unresolved for /link-dependencies.' },
       { id: 'review', label: 'Plan review', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 7: Two-part review — traceability (spec ↔ plan) and integrity (structure, quality, dependencies). User resolves findings.' },
       { id: 'conclude', label: 'Conclude plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 8: Set status: concluded. All tasks must be authored.' },
@@ -1557,11 +1596,11 @@ const FLOWCHARTS = {
       { id: 'retrieve', label: 'A. Retrieve next task', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Stage A: Use plan adapter to get next available task. Normalise task content for agent invocation.' },
       { id: 'done-check', label: 'Tasks remain?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if any tasks remain. If none, proceed to completion.' },
       // Task loop — Stage B
-      { id: 'executor', label: 'B. Invoke executor', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Stage B: Dispatch executor agent with TDD workflow, code quality refs, spec, project skills, and normalised task. Agent implements via strict TDD and returns STATUS report.' },
+      { id: 'executor', label: 'B. Invoke executor', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', skillLink: 'implementation-task-executor', desc: 'Stage B: Dispatch executor agent with TDD workflow, code quality refs, spec, project skills, and normalised task. Agent implements via strict TDD and returns STATUS report.' },
       { id: 'exec-result', label: 'Executor result?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Route on executor STATUS: complete → review, blocked/failed → present to user.' },
       { id: 'exec-blocked', label: 'Executor blocked', shape: 'stop', w: 180, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Present executor ISSUES to user. Options: retry (with comments), skip task, or stop implementation entirely.' },
       // Task loop — Stage C
-      { id: 'reviewer', label: 'C. Invoke reviewer', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Stage C: Dispatch reviewer agent (opus) with spec, task content, project skills. Independent verification — no access to executor context.' },
+      { id: 'reviewer', label: 'C. Invoke reviewer', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', skillLink: 'implementation-task-reviewer', desc: 'Stage C: Dispatch reviewer agent (opus) with spec, task content, project skills. Independent verification — no access to executor context.' },
       { id: 'review-result', label: 'Reviewer verdict?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Route on VERDICT: approved → task gate, needs-changes → present findings to user.' },
       { id: 'review-changes', label: 'Review: needs changes', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Present reviewer ISSUES and NOTES. Options: accept notes (re-invoke executor), skip reviewer (proceed as-is), or add own comments.' },
       // Task loop — Stage D
@@ -1615,7 +1654,7 @@ const FLOWCHARTS = {
       { id: 'read-plan', label: 'Read plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Read the plan — all phases, tasks, and acceptance criteria.' },
       { id: 'read-spec', label: 'Read specification', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'If available, read specification for design context.' },
       { id: 'extract', label: 'Extract ALL tasks', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'List every task from every phase. Verify all, not a sample.' },
-      { id: 'spawn', label: 'Spawn task verifiers', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Launch parallel review-task-verifier subagents (haiku). One per task.' },
+      { id: 'spawn', label: 'Spawn task verifiers', w: 180, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', skillLink: 'review-task-verifier', desc: 'Launch parallel review-task-verifier subagents (haiku). One per task.' },
       { id: 'v1', label: 'Verify task 1', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'Check: implementation, acceptance criteria, tests, code quality.' },
       { id: 'v2', label: 'Verify task 2', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'Same checks, different task. Runs in parallel.' },
       { id: 'vn', label: 'Verify task N', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'One per task. All run simultaneously.' },
@@ -1706,6 +1745,164 @@ const FLOWCHARTS = {
       { from: 'updated', to: 'end-clean', type: 'no', label: 'no' },
       { from: 'updated', to: 'show-changes', type: 'yes', label: 'yes' },
       { from: 'show-changes', to: 'end-updated' },
+    ]
+  },
+  // ── Agent Flowcharts ──
+  'planning-phase-designer': {
+    nodes: [
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning skill during plan construction.' },
+      { id: 'read-refs', label: 'Read spec ingestion', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification ingestion protocol and full spec. Also reads cross-cutting specs if referenced.' },
+      { id: 'read-principles', label: 'Read design principles', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read phase design principles and task design principles reference files.' },
+      { id: 'design', label: 'Design phases', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Design implementation phase structure. Define goals, acceptance criteria, and sequencing.' },
+      { id: 'amend', label: 'Amendment?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if prior output + feedback exists (amendment round). If so, revise instead of starting fresh.' },
+      { id: 'revise', label: 'Revise phases', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Read prior output and feedback, then revise the phase design accordingly.' },
+      { id: 'end', label: 'Phase structure', shape: 'pill', w: 180, h: 40, color: 'var(--planning)', bg: 'var(--planning-bg)', desc: 'Output: human-readable phase summary with goals and acceptance criteria.' },
+    ],
+    connections: [
+      { from: 'start', to: 'read-refs' },
+      { from: 'read-refs', to: 'read-principles' },
+      { from: 'read-principles', to: 'amend' },
+      { from: 'amend', to: 'revise', type: 'yes', label: 'yes' },
+      { from: 'amend', to: 'design', type: 'no', label: 'no', weight: 2 },
+      { from: 'revise', to: 'end' },
+      { from: 'design', to: 'end' },
+    ]
+  },
+  'planning-task-designer': {
+    nodes: [
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning skill during plan construction.' },
+      { id: 'read-refs', label: 'Read spec ingestion', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification ingestion protocol, full spec, cross-cutting specs, and approved phases.' },
+      { id: 'read-principles', label: 'Read task principles', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read task design principles reference file.' },
+      { id: 'design', label: 'Design task list', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Break target phase into individual tasks with edge cases for each.' },
+      { id: 'amend', label: 'Amendment?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if prior output + feedback exists (amendment round). If so, revise instead of starting fresh.' },
+      { id: 'revise', label: 'Revise tasks', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Read prior output and feedback, then revise the task list accordingly.' },
+      { id: 'end', label: 'Task list', shape: 'pill', w: 180, h: 40, color: 'var(--planning)', bg: 'var(--planning-bg)', desc: 'Output: task table with IDs, names, edge cases, and status.' },
+    ],
+    connections: [
+      { from: 'start', to: 'read-refs' },
+      { from: 'read-refs', to: 'read-principles' },
+      { from: 'read-principles', to: 'amend' },
+      { from: 'amend', to: 'revise', type: 'yes', label: 'yes' },
+      { from: 'amend', to: 'design', type: 'no', label: 'no', weight: 2 },
+      { from: 'revise', to: 'end' },
+      { from: 'design', to: 'end' },
+    ]
+  },
+  'planning-task-author': {
+    nodes: [
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning skill during plan construction.' },
+      { id: 'read-refs', label: 'Read spec ingestion', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification ingestion protocol, full spec, and cross-cutting specs.' },
+      { id: 'read-template', label: 'Read task template', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read task design template, phases, and task list for context.' },
+      { id: 'read-format', label: 'Read format adapter', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Load the output format adapter (authoring.md) for the plan\'s chosen format.' },
+      { id: 'author', label: 'Author task detail', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Write complete task in output format structure: problem, solution, outcome, acceptance criteria, tests, context.' },
+      { id: 'amend', label: 'Amendment?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if prior output + feedback exists (amendment round). If so, revise instead of starting fresh.' },
+      { id: 'revise', label: 'Revise task', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Read prior output and feedback, then revise the authored task accordingly.' },
+      { id: 'end', label: 'Authored task', shape: 'pill', w: 180, h: 40, color: 'var(--planning)', bg: 'var(--planning-bg)', desc: 'Output: complete task detail in exact output format adapter structure.' },
+    ],
+    connections: [
+      { from: 'start', to: 'read-refs' },
+      { from: 'read-refs', to: 'read-template' },
+      { from: 'read-template', to: 'read-format' },
+      { from: 'read-format', to: 'amend' },
+      { from: 'amend', to: 'revise', type: 'yes', label: 'yes' },
+      { from: 'amend', to: 'author', type: 'no', label: 'no', weight: 2 },
+      { from: 'revise', to: 'end' },
+      { from: 'author', to: 'end' },
+    ]
+  },
+  'planning-dependency-grapher': {
+    nodes: [
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning skill after plan construction.' },
+      { id: 'read-format', label: 'Read format refs', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read reading.md and graph.md format adapter references.' },
+      { id: 'read-index', label: 'Read plan index', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the plan index file to understand plan structure.' },
+      { id: 'list-tasks', label: 'List authored tasks', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Enumerate all authored task files from the plan.' },
+      { id: 'clear', label: 'Clear existing graph', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Clear any existing dependency graph data before re-analysis.' },
+      { id: 'analyze', label: 'Analyze dependencies', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Read every task. Extract produces/requires. Match produces→requires across all tasks. Identify data, capability, and infrastructure dependencies.' },
+      { id: 'priorities', label: 'Assign priorities', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Classify tasks as bottleneck, foundation, or leaf based on dependency analysis.' },
+      { id: 'cycles', label: 'Cycles detected?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if the dependency graph contains circular dependencies.' },
+      { id: 'stop-cycles', label: 'STOP: Report cycles', shape: 'stop', w: 180, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Cycles found — report cycle chains and do NOT apply changes.' },
+      { id: 'apply', label: 'Apply graph changes', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Write dependency and priority data back to tasks using the graph format adapter.' },
+      { id: 'end', label: 'Dependency graph', shape: 'pill', w: 180, h: 40, color: 'var(--planning)', bg: 'var(--planning-bg)', desc: 'Output: structured summary with dependencies, priorities, and status.' },
+    ],
+    connections: [
+      { from: 'start', to: 'read-format' },
+      { from: 'read-format', to: 'read-index' },
+      { from: 'read-index', to: 'list-tasks' },
+      { from: 'list-tasks', to: 'clear' },
+      { from: 'clear', to: 'analyze' },
+      { from: 'analyze', to: 'priorities' },
+      { from: 'priorities', to: 'cycles' },
+      { from: 'cycles', to: 'stop-cycles', type: 'yes', label: 'yes' },
+      { from: 'cycles', to: 'apply', type: 'no', label: 'no', weight: 2 },
+      { from: 'apply', to: 'end' },
+    ]
+  },
+  'implementation-task-executor': {
+    nodes: [
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-implementation skill for a single task.' },
+      { id: 'read-refs', label: 'Read TDD + quality refs', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read TDD workflow reference and code quality standards. Read project skills and specification.' },
+      { id: 'explore', label: 'Explore codebase', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Explore the codebase to understand existing patterns, conventions, and relevant code.' },
+      { id: 'write-test', label: 'Write failing test', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'TDD red phase: write a test for the next acceptance criterion. Test must fail.' },
+      { id: 'implement', label: 'Implement to pass', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'TDD green phase: write minimal implementation to make the test pass.' },
+      { id: 'verify', label: 'Verify tests pass', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Run tests to confirm everything passes. Refactor if needed (TDD refactor phase).' },
+      { id: 'more', label: 'More criteria?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if there are more acceptance criteria / test cases to implement.' },
+      { id: 'report', label: 'Build report', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Compile structured completion report: status, files changed, tests written, test results.' },
+      { id: 'end', label: 'STATUS report', shape: 'pill', w: 180, h: 40, color: 'var(--implementation)', bg: 'var(--implementation-bg)', desc: 'Output: structured report (complete/blocked/failed) with files, tests, and issues.' },
+    ],
+    connections: [
+      { from: 'start', to: 'read-refs' },
+      { from: 'read-refs', to: 'explore' },
+      { from: 'explore', to: 'write-test' },
+      { from: 'write-test', to: 'implement' },
+      { from: 'implement', to: 'verify' },
+      { from: 'verify', to: 'more' },
+      { from: 'more', to: 'write-test', type: 'backloop', label: 'yes', port: 'right' },
+      { from: 'more', to: 'report', type: 'no', label: 'no', weight: 2 },
+      { from: 'report', to: 'end' },
+    ]
+  },
+  'implementation-task-reviewer': {
+    nodes: [
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-implementation skill after each task.' },
+      { id: 'read-spec', label: 'Read specification', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the specification to understand the broader requirement and constraints.' },
+      { id: 'read-skills', label: 'Read project skills', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Load project skills to understand conventions and patterns.' },
+      { id: 'check-diff', label: 'Check unstaged changes', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Run git diff/status to identify all changed files from the executor.' },
+      { id: 'read-files', label: 'Read changed files', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the full content of all changed files for review.' },
+      { id: 'evaluate', label: 'Evaluate 5 dimensions', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Evaluate: spec conformance, acceptance criteria, test adequacy, convention adherence, architectural quality.' },
+      { id: 'verdict', label: 'Verdict?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Determine verdict: approved or needs-changes based on evaluation.' },
+      { id: 'report', label: 'Build review report', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Compile structured review with file:line references for any issues found.' },
+      { id: 'end', label: 'VERDICT report', shape: 'pill', w: 180, h: 40, color: 'var(--implementation)', bg: 'var(--implementation-bg)', desc: 'Output: structured verdict (approved/needs-changes) with issues and notes.' },
+    ],
+    connections: [
+      { from: 'start', to: 'read-spec' },
+      { from: 'read-spec', to: 'read-skills' },
+      { from: 'read-skills', to: 'check-diff' },
+      { from: 'check-diff', to: 'read-files' },
+      { from: 'read-files', to: 'evaluate' },
+      { from: 'evaluate', to: 'verdict' },
+      { from: 'verdict', to: 'report' },
+      { from: 'report', to: 'end' },
+    ]
+  },
+  'review-task-verifier': {
+    nodes: [
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Spawned in parallel by technical-review skill (one per task).' },
+      { id: 'read-task', label: 'Understand task', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the task: what it does, acceptance criteria, and expected tests.' },
+      { id: 'load-spec', label: 'Load spec context', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Load the broader specification context: requirements, constraints, edge cases.' },
+      { id: 'verify-impl', label: 'Verify implementation', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Check: implementation exists, matches acceptance criteria, aligns with spec.' },
+      { id: 'verify-tests', label: 'Verify tests', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Check: tests are adequate (not over/under), edge cases covered, tests pass.' },
+      { id: 'check-quality', label: 'Check code quality', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Check conventions, SOLID, DRY, complexity, idioms, readability, security, performance.' },
+      { id: 'compile', label: 'Compile findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Aggregate results into structured finding with blocking issues and non-blocking notes.' },
+      { id: 'end', label: 'Task finding', shape: 'pill', w: 180, h: 40, color: 'var(--review)', bg: 'var(--review-bg)', desc: 'Output: structured finding (complete/incomplete/issues) with implementation, tests, and quality assessment.' },
+    ],
+    connections: [
+      { from: 'start', to: 'read-task' },
+      { from: 'read-task', to: 'load-spec' },
+      { from: 'load-spec', to: 'verify-impl' },
+      { from: 'verify-impl', to: 'verify-tests' },
+      { from: 'verify-tests', to: 'check-quality' },
+      { from: 'check-quality', to: 'compile' },
+      { from: 'compile', to: 'end' },
     ]
   }
 };
@@ -1823,6 +2020,49 @@ const FLOWCHART_DESCS = {
 <p>Runs automatically as <strong>Step 0 of every workflow command</strong>. If files were updated, shows changes and waits for user review via git diff. Delete the log file to force re-running all migrations.</p>`,
     meta: { complexity: 'System' }
   },
+  'planning-phase-designer': {
+    summary: 'Design implementation phases from a specification — goals, sequencing, and acceptance criteria.',
+    body: `<p>Reads the specification via ingestion protocol, then loads phase and task design principles. Designs a phased implementation structure with clear goals and acceptance criteria for each phase.</p>
+<p>Supports <strong>amendment rounds</strong> — if prior output and feedback are provided, the agent revises its design rather than starting fresh. Output is a human-readable phase summary.</p>`,
+    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Subagent' }
+  },
+  'planning-task-designer': {
+    summary: 'Break a single phase into concrete tasks with edge cases and dependencies.',
+    body: `<p>Reads the specification, approved phases, and task design principles. For the target phase, produces a detailed task list with edge cases identified per task.</p>
+<p>Supports <strong>amendment rounds</strong> — revises task list based on feedback when prior output exists. Output is a task table with IDs, names, edge cases, and status.</p>`,
+    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Subagent' }
+  },
+  'planning-task-author': {
+    summary: 'Author full task detail in the plan\'s output format — problem, solution, acceptance criteria, tests.',
+    body: `<p>Reads specification, task template, phases, task list, and the <strong>output format adapter</strong> (authoring.md). Writes complete task detail in the exact format structure: problem, solution, outcome, do/don\'t, acceptance criteria, tests, and context.</p>
+<p>Supports <strong>amendment rounds</strong>. Format-aware — adapts to whichever output format the plan uses.</p>`,
+    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Subagent' }
+  },
+  'planning-dependency-grapher': {
+    summary: 'Analyze task dependencies, detect circular references, and assign priority classifications.',
+    body: `<p>Reads format adapters (reading.md + graph.md), then the plan index and all authored task files. <strong>Clears existing graph data</strong> before re-analysis to ensure a clean state.</p>
+<p>For each task, extracts what it produces and requires, then matches across all tasks to build a dependency graph. Classifies tasks as <strong>bottleneck</strong>, <strong>foundation</strong>, or <strong>leaf</strong>. If <strong>cycles are detected</strong>, reports the cycle chain and does NOT apply changes — a hard stop. Otherwise, writes dependency and priority data back to tasks.</p>`,
+    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Subagent' }
+  },
+  'implementation-task-executor': {
+    summary: 'Implement a single task via strict TDD — red/green/refactor cycle per acceptance criterion.',
+    body: `<p>Reads TDD workflow, code quality standards, project skills, and specification. Explores the codebase first to understand existing patterns.</p>
+<p>Executes a <strong>strict TDD loop</strong> per acceptance criterion: <strong>write failing test → implement to pass → verify → repeat</strong>. Has hard stops for scope expansion, uncertainty, and untenable spec decisions — reports back rather than making autonomous choices.</p>
+<p>Returns a structured <strong>STATUS report</strong> (complete/blocked/failed) with files changed, tests written, and results.</p>`,
+    meta: { model: 'Opus', invokedBy: 'technical-implementation', complexity: 'Subagent' }
+  },
+  'implementation-task-reviewer': {
+    summary: 'Independently review a task across 5 dimensions — no access to executor context.',
+    body: `<p>Reads the specification, project skills, then checks unstaged changes via git diff/status and reads all changed files. <strong>Independent from the executor</strong> — no shared context.</p>
+<p>Evaluates across <strong>5 dimensions</strong>: spec conformance, acceptance criteria coverage, test adequacy, convention adherence, and architectural quality. Produces a structured verdict (<strong>approved</strong> or <strong>needs-changes</strong>) with file:line references for any issues.</p>`,
+    meta: { model: 'Opus', invokedBy: 'technical-implementation', complexity: 'Subagent' }
+  },
+  'review-task-verifier': {
+    summary: 'Verify a single task\'s implementation, tests, and code quality against the plan and spec.',
+    body: `<p>Spawned <strong>in parallel</strong> (one per task) by the technical-review skill. Reads the task details, then loads the broader specification context.</p>
+<p>Three verification stages: <strong>implementation</strong> (exists, matches criteria, aligns with spec), <strong>tests</strong> (adequate coverage, edge cases, not over/under-tested), and <strong>code quality</strong> (conventions, SOLID, DRY, complexity, security, performance). Compiles a structured finding with blocking issues and non-blocking notes.</p>`,
+    meta: { model: 'Opus', invokedBy: 'technical-review', complexity: 'Subagent' }
+  },
 };
 
 // ── Source File Mapping (flowchart key → repo-relative path) ──
@@ -1846,6 +2086,13 @@ const SOURCE_MAP = {
   'status':               'commands/workflow/status.md',
   'view-plan':            'commands/workflow/view-plan.md',
   'migrate':              'commands/migrate.md',
+  'planning-phase-designer':      'agents/planning-phase-designer.md',
+  'planning-task-designer':       'agents/planning-task-designer.md',
+  'planning-task-author':         'agents/planning-task-author.md',
+  'planning-dependency-grapher':  'agents/planning-dependency-grapher.md',
+  'implementation-task-executor': 'agents/implementation-task-executor.md',
+  'implementation-task-reviewer': 'agents/implementation-task-reviewer.md',
+  'review-task-verifier':         'agents/review-task-verifier.md',
 };
 
 // ── Markdown Viewer ──

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -3,21 +3,30 @@
   WORKFLOW EXPLORER — Single-file interactive explorer for the 6-phase technical workflow system.
 
   Architecture:
-    Inline CSS + JS. dagre.js CDN for auto-layout. SVG canvas rendering.
-    No build step, no framework — open directly in a browser.
+    Inline CSS + JS. dagre.js CDN for auto-layout. marked.js CDN for markdown rendering.
+    SVG canvas rendering. No build step, no framework — open directly in a browser.
 
   Data structures:
-    FLOWCHARTS       — node/connection definitions per phase/skill/command (dagre-compatible: w/h, no x/y)
-    OVERVIEW_NODES   — hand-positioned nodes for the top-level pipeline view
+    FLOWCHARTS           — node/connection definitions per phase/skill/command (dagre-compatible: w/h, no x/y)
+    OVERVIEW_NODES       — hand-positioned nodes for the top-level pipeline view
     OVERVIEW_CONNECTIONS — connections between overview nodes
-    phases           — metadata per phase (color, cmd, label, complexity, detailHTML, etc.)
-    FLOWCHART_DESCS  — one-line summaries shown in the prompt bar
+    phases               — metadata per phase (color, cmd, label, complexity, detailHTML, etc.)
+    FLOWCHART_DESCS      — rich descriptions shown in the info bar
+    SKILL_NEXT_PHASE     — maps skill flowchart keys to their next workflow phase (label, target, color)
+    SOURCE_MAP           — maps flowchart keys to repo-relative source file paths for markdown viewer
 
   Navigation model:
-    Sidebar-driven. Three view functions:
+    Sidebar-driven. Three view functions + markdown viewer:
       showOverview()        — pipeline view (OVERVIEW_NODES)
       selectPhase(phase)    — flowchart view (FLOWCHARTS[phase]) or detail panel (utility commands)
       closeDetail()         — dismiss the slide-over detail panel
+      openMdViewer(key)     — open markdown viewer for a flowchart's source file
+
+  Markdown viewer:
+    Slide-over panel (65% width, 100% on mobile, z-index 30). Fetches .md files from GitHub raw URL,
+    strips YAML frontmatter, renders via marked.parse(). Relative .md links are intercepted and
+    navigated within the viewer. Breadcrumb trail with scroll position memory for back navigation.
+    In-memory _mdCache for fetched content. Opened via "Source" button in info bar or </> in tooltip.
 
   Layout:
     CSS grid: 300px sidebar + flexible canvas area. Detail panel slides over canvas (absolute positioned).
@@ -26,18 +35,40 @@
   Rendering:
     renderSVG() draws all views into <svg id="svg-canvas">.
     computeFlowchartLayout(key) runs dagre and caches results in _layoutCache.
-    Zoom/pan via viewBox manipulation (wheel + drag).
+    Symmetric viewBox calculation: computes minX/minY/maxX/maxY from all nodes, applies equal padding.
+    Zoom/pan via viewBox manipulation (wheel + drag + touch).
 
   Flowchart data:
     Manual JS objects — not generated. dagre handles positioning only.
     To modify a flowchart, update FLOWCHARTS[key].nodes and .connections.
-    Node shapes: pill = start/end, diamond = decision/gate, rect = action step.
+    Node shapes: pill = start/end, diamond = decision, stop = hard-cornered terminal (STOP/BLOCK), rect = action step.
     Connection types map to colors + arrow markers (yes=green, no=red, transition=orange dashed, backloop=gray dashed).
+
+  Node color system (type-based, not phase-based — CSS vars in :root):
+    - var(--action)    sky blue    — primary work steps (validate, extract, invoke agents, etc.)
+    - var(--text-dim)  gray        — utility/support steps (read existing, load format, etc.)
+    - var(--ask)       purple      — user interaction nodes
+    - var(--routing)   amber       — non-blocking decision diamonds
+    - var(--gate)      red         — STOP/BLOCK nodes (hard-cornered rects), refresh-cache
+    - var(--discovery) green       — discovery script execution
+    - var(--skill)     orange      — skill invocation pills (with skillLink)
+    - var(--next)      green       — next-phase navigation pills
+    - var(--accent)    blue        — entry points, migrations, git commits
+    - var(--{phase})   phase color — output artifact pills only (keeps phase identity)
 
   Conventions:
     - Clicking flowchart nodes with `desc` shows a tooltip; nodes with `skillLink` navigate to that skill's flowchart.
     - Overview nodes with `phase` are clickable and route to selectPhase().
     - The prompt bar shows contextual info and is copy-able.
+    - Skill flowcharts (except skill-review) have a `next` pill node at the end, always green (#34d399),
+      connected from `end` via `type: 'transition'`, using `skillLink` for navigation.
+    - SOURCE_MAP must be updated when source files are renamed or added.
+
+  Key sections (search terms):
+    CSS:         "/* Info bar */"  "/* Markdown viewer */"  "/* View Source */"
+    Data:        "const FLOWCHARTS"  "const SOURCE_MAP"  "const SKILL_NEXT_PHASE"  "const FLOWCHART_DESCS"
+    Rendering:   "function renderSVG"  "function computeFlowchartLayout"
+    Interaction: "function showFcTooltip"  "function updatePrompt"  "function openMdViewer"
 -->
 <html lang="en">
 <head>
@@ -59,14 +90,29 @@
     --specification: #34d399;
     --planning: #fbbf24;
     --implementation: #f97316;
-    --review: #f43f5e;
+    --review: #f472b6;
     /* Softer fills */
     --research-bg: rgba(167,139,250,0.12);
     --discussion-bg: rgba(96,165,250,0.12);
     --specification-bg: rgba(52,211,153,0.12);
     --planning-bg: rgba(251,191,36,0.12);
     --implementation-bg: rgba(249,115,22,0.12);
-    --review-bg: rgba(244,63,94,0.12);
+    --review-bg: rgba(244,114,182,0.12);
+    /* Node type colors */
+    --action: #38bdf8;
+    --action-bg: rgba(56,189,248,0.12);
+    --ask: #a78bfa;
+    --ask-bg: rgba(167,139,250,0.15);
+    --routing: #fbbf24;
+    --routing-bg: rgba(251,191,36,0.15);
+    --gate: #f43f5e;
+    --gate-bg: rgba(244,63,94,0.15);
+    --discovery: #34d399;
+    --discovery-bg: rgba(52,211,153,0.15);
+    --skill: #f97316;
+    --skill-bg: rgba(249,115,22,0.15);
+    --next: #34d399;
+    --next-bg: rgba(52,211,153,0.15);
   }
   * { margin:0; padding:0; box-sizing:border-box; }
   body {
@@ -87,10 +133,13 @@
     position: fixed;
     top: 0; left: 0; bottom: 0;
     width: 300px;
-    z-index: 20;
+    z-index: 40;
     background: var(--surface);
     border-right: 1px solid var(--border);
     overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
     padding: 16px;
     transform: translateX(0);
     transition: transform 0.2s ease;
@@ -233,7 +282,7 @@
     position: fixed;
     inset: 0;
     background: rgba(0,0,0,0.5);
-    z-index: 18;
+    z-index: 38;
   }
   .sidebar-backdrop.visible {
     display: block;
@@ -264,11 +313,13 @@
     grid-column: 1;
     background: var(--surface);
     border-top: 1px solid var(--border);
-    padding: 16px 20px;
+    padding: 16px 20px 40px;
     height: 180px;
     overflow-y: auto;
   }
   .prompt-bar .info-title {
+    display: flex;
+    align-items: center;
     font-size: 14px;
     font-weight: 700;
     color: var(--text);
@@ -527,6 +578,7 @@
   @media (max-width: 768px) {
     .zoom-btn { width: 44px; height: 44px; font-size: 20px; }
     .zoom-controls { gap: 6px; }
+    .sidebar-toggle { width: 44px; height: 44px; }
   }
 
   /* Overview nav button */
@@ -589,8 +641,179 @@
     line-height: 1.5;
     color: var(--text-dim);
   }
+
+  /* Markdown viewer slide-over */
+  .md-viewer-backdrop {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.3);
+    z-index: 34;
+  }
+  .md-viewer-backdrop.visible { display: block; }
+  .md-viewer {
+    position: fixed;
+    top: 0; right: 0;
+    width: 65%;
+    height: 100vh;
+    background: var(--surface);
+    border-left: 1px solid var(--border);
+    transform: translateX(100%);
+    transition: transform 0.2s ease;
+    z-index: 35;
+    display: flex;
+    flex-direction: column;
+    touch-action: pan-y;
+    overscroll-behavior: contain;
+  }
+  .md-viewer.open { transform: translateX(0); }
+  .md-viewer-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .md-viewer-back {
+    background: none; border: none;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 16px;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+  .md-viewer-back:hover { color: var(--text); background: var(--surface2); }
+  .md-viewer-back:disabled { opacity: 0.3; pointer-events: none; }
+  .md-viewer-breadcrumb {
+    flex: 1;
+    font-size: 12px;
+    color: var(--text-dim);
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .md-viewer-breadcrumb span {
+    cursor: pointer;
+    color: var(--accent);
+  }
+  .md-viewer-breadcrumb span:hover { text-decoration: underline; }
+  .md-viewer-breadcrumb span.current {
+    color: var(--text);
+    cursor: default;
+  }
+  .md-viewer-breadcrumb span.current:hover { text-decoration: none; }
+  .md-viewer-github {
+    flex-shrink: 0;
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 11px;
+    padding: 3px 8px;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    transition: color 0.15s, border-color 0.15s;
+  }
+  .md-viewer-github:hover { color: var(--text); border-color: var(--text-dim); }
+  .md-viewer-close {
+    background: none; border: none;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 18px;
+    padding: 4px 8px;
+    flex-shrink: 0;
+  }
+  .md-viewer-close:hover { color: var(--text); }
+  .md-viewer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px 40px;
+  }
+  .md-viewer-body > :first-child { margin-top: 0; }
+  .md-viewer-body h1 { font-size: 20px; font-weight: 700; color: var(--text); margin: 24px 0 12px; }
+  .md-viewer-body h2 { font-size: 16px; font-weight: 700; color: var(--text); margin: 20px 0 10px; }
+  .md-viewer-body h3 { font-size: 14px; font-weight: 600; color: var(--text); margin: 16px 0 8px; }
+  .md-viewer-body h4 { font-size: 13px; font-weight: 600; color: var(--text-dim); margin: 12px 0 6px; }
+  .md-viewer-body p { font-size: 13px; line-height: 1.7; color: var(--text-dim); margin-bottom: 10px; }
+  .md-viewer-body ul, .md-viewer-body ol { font-size: 13px; line-height: 1.7; color: var(--text-dim); padding-left: 20px; margin-bottom: 10px; }
+  .md-viewer-body li { margin-bottom: 4px; }
+  .md-viewer-body code {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 12px;
+    background: var(--surface2);
+    padding: 1px 5px;
+    border-radius: 3px;
+    color: var(--accent);
+  }
+  .md-viewer-body pre {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px 16px;
+    overflow-x: auto;
+    margin-bottom: 12px;
+  }
+  .md-viewer-body pre code { background: none; padding: 0; color: var(--text); }
+  .md-viewer-body blockquote {
+    border-left: 3px solid var(--accent);
+    padding-left: 12px;
+    margin: 10px 0;
+    color: var(--text-dim);
+    font-style: italic;
+  }
+  .md-viewer-body a { color: var(--accent); text-decoration: none; }
+  .md-viewer-body a:hover { text-decoration: underline; }
+  .md-viewer-body table { border-collapse: collapse; width: 100%; margin-bottom: 12px; font-size: 12px; }
+  .md-viewer-body th { text-align: left; padding: 6px 8px; background: var(--surface2); color: var(--text-dim); border-bottom: 1px solid var(--border); }
+  .md-viewer-body td { padding: 6px 8px; border-bottom: 1px solid var(--border); color: var(--text); }
+  .md-viewer-body hr { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
+  .md-viewer-body strong { color: var(--text); }
+  .md-viewer-loading { text-align: center; padding: 40px; color: var(--text-dim); font-size: 13px; }
+  .md-viewer-error { text-align: center; padding: 40px; color: #f43f5e; font-size: 13px; }
+  @media (max-width: 768px) {
+    .md-viewer { width: 100%; }
+  }
+
+  /* View Source button in info bar */
+  .view-source-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--surface2);
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 11px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    margin-left: auto;
+    flex-shrink: 0;
+  }
+  .view-source-btn:hover { border-color: var(--accent); color: var(--text); }
+
+  /* Source button in tooltip */
+  .fc-tooltip-source {
+    position: absolute;
+    top: 8px; right: 8px;
+    background: none; border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 10px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    padding: 2px 6px;
+    display: none;
+  }
+  .fc-tooltip-source:hover { border-color: var(--accent); color: var(--text); }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/@dagrejs/dagre@1.1.4/dist/dagre.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.6/marked.min.js"></script>
 </head>
 <body>
 
@@ -671,12 +894,14 @@
     </div>
     <div class="legend legend-flowchart" id="legend-flowchart" style="display:none">
       <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:rgba(108,138,255,0.15);border-color:var(--accent)"></div></div> Start / End</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--surface2);border-color:var(--text-dim)"></div></div> Action step</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-diamond" style="background:rgba(251,191,36,0.15);border-color:#fbbf24"></div></div> Decision branch</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-diamond" style="background:rgba(244,63,94,0.15);border-color:#f43f5e"></div></div> Gate (can STOP)</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:rgba(167,139,250,0.15);border-color:#a78bfa"></div></div> User interaction</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:rgba(52,211,153,0.15);border-color:#34d399"></div></div> Discovery script</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:rgba(249,115,22,0.15);border-color:#f97316"></div></div> Skill handoff</div>
+      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--action-bg);border-color:var(--action)"></div></div> Action step</div>
+      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--surface2);border-color:var(--text-dim)"></div></div> Support / utility</div>
+      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-diamond" style="background:var(--routing-bg);border-color:var(--routing)"></div></div> Decision branch</div>
+      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--gate-bg);border-color:var(--gate);border-radius:3px"></div></div> STOP / BLOCK</div>
+      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--ask-bg);border-color:var(--ask)"></div></div> User interaction</div>
+      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--discovery-bg);border-color:var(--discovery)"></div></div> Discovery script</div>
+      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:var(--skill-bg);border-color:var(--skill)"></div></div> Skill handoff</div>
+      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:var(--next-bg);border-color:var(--next)"></div></div> Next phase</div>
       <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:#34d399"></div></div> Yes branch</div>
       <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:#f43f5e"></div></div> No branch</div>
       <div class="legend-item"><div class="legend-icon"><div class="legend-line dashed" style="background:repeating-linear-gradient(90deg, #f97316 0 6px, transparent 6px 10px)"></div></div> Skill transition</div>
@@ -702,8 +927,19 @@
     </div>
     <div class="tooltip" id="tooltip"></div>
     <div id="fc-tooltip">
+      <button class="fc-tooltip-source" id="fc-tooltip-source" onclick="openMdViewerFromTooltip()" title="View source">&lt;/&gt;</button>
       <div id="fc-tooltip-title"></div>
       <div id="fc-tooltip-desc"></div>
+    </div>
+    <div class="md-viewer-backdrop" id="md-viewer-backdrop"></div>
+    <div class="md-viewer" id="md-viewer">
+      <div class="md-viewer-header">
+        <button class="md-viewer-back" id="md-viewer-back" onclick="mdViewerBack()" title="Back">&larr;</button>
+        <div class="md-viewer-breadcrumb" id="md-viewer-breadcrumb"></div>
+        <a class="md-viewer-github" id="md-viewer-github" href="#" target="_blank" rel="noopener" title="Open on GitHub"><svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> GitHub</a>
+        <button class="md-viewer-close" onclick="closeMdViewer()" title="Close">&times;</button>
+      </div>
+      <div class="md-viewer-body" id="md-viewer-body"></div>
     </div>
   </div>
 
@@ -779,7 +1015,7 @@ window.addEventListener('resize', () => {
 // ── Phase Data ──
 const phases = {
   research: {
-    color: '#a78bfa', bg: 'rgba(167,139,250,0.12)',
+    color: 'var(--ask)', bg: 'var(--ask-bg)',
     label: 'Research', cmd: '/start-research',
     complexity: 'Simple', steps: 6,
     output: 'docs/workflow/research/',
@@ -1123,7 +1359,7 @@ const phases = {
     `
   },
   review: {
-    color: '#f43f5e', bg: 'rgba(244,63,94,0.12)',
+    color: '#f472b6', bg: 'rgba(244,114,182,0.12)',
     label: 'Review', cmd: '/start-review',
     complexity: 'Moderate', steps: 5,
     output: 'Review feedback (approve/changes/comments)',
@@ -1267,7 +1503,7 @@ const phases = {
     desc: 'Runs as Step 0 of every workflow command. Keeps workflow files in sync with system design.',
   },
   'skill-research': {
-    color: '#a78bfa', bg: 'rgba(167,139,250,0.12)',
+    color: 'var(--ask)', bg: 'var(--ask-bg)',
     label: 'Research Skill', cmd: 'technical-research',
   },
   'skill-discussion': {
@@ -1287,7 +1523,7 @@ const phases = {
     label: 'Implementation Skill', cmd: 'technical-implementation',
   },
   'skill-review': {
-    color: '#f43f5e', bg: 'rgba(244,63,94,0.12)',
+    color: '#f472b6', bg: 'rgba(244,114,182,0.12)',
     label: 'Review Skill', cmd: 'technical-review',
   },
 };
@@ -1361,12 +1597,11 @@ const FLOWCHARTS = {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for the /start-research command.' },
       { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations to keep workflow files in sync. Mandatory before proceeding.' },
-      { id: 'ask1', label: "ASK: What's on your mind?", w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 1: Ask user for their seed idea - what topic they want to explore and what prompted it.' },
-      { id: 'ask2', label: 'ASK: What do you know?', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 2: Understand current knowledge - any initial thoughts, research, or constraints.' },
-      { id: 'ask3', label: 'ASK: Where to start?', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 3: Determine starting point - technical feasibility, market, business, or open exploration.' },
-      { id: 'ask4', label: 'ASK: Constraints?', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 4: Gather final context - any constraints or context to know upfront.' },
-      { id: 'skill', label: 'technical-research', shape: 'pill', w: 150, h: 40, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Step 5: Invoke the technical-research skill with all gathered context.', skillLink: 'skill-research' },
-      { id: 'end', label: 'research/ output', shape: 'pill', w: 150, h: 40, color: 'var(--research)', bg: 'var(--research-bg)', desc: 'Output: docs/workflow/research/exploration.md. Starts as one file, splits as themes emerge.' },
+      { id: 'ask1', label: "ASK: What's on your mind?", w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 1: Ask user for their seed idea - what topic they want to explore and what prompted it.' },
+      { id: 'ask2', label: 'ASK: What do you know?', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 2: Understand current knowledge - any initial thoughts, research, or constraints.' },
+      { id: 'ask3', label: 'ASK: Where to start?', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 3: Determine starting point - technical feasibility, market, business, or open exploration.' },
+      { id: 'ask4', label: 'ASK: Constraints?', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 4: Gather final context - any constraints or context to know upfront.' },
+      { id: 'skill', label: 'Invoke research skill', shape: 'pill', w: 170, h: 40, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 5: Invoke the technical-research skill with all gathered context.', skillLink: 'skill-research' },
     ],
     connections: [
       { from: 'start', to: 'migrate' },
@@ -1375,28 +1610,26 @@ const FLOWCHARTS = {
       { from: 'ask2', to: 'ask3' },
       { from: 'ask3', to: 'ask4' },
       { from: 'ask4', to: 'skill', type: 'transition' },
-      { from: 'skill', to: 'end' },
     ]
   },
   discussion: {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /start-discussion.' },
       { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations.' },
-      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Step 1: Run discovery-for-discussion.sh. Scans research files, existing discussions, and cache. Outputs YAML with scenario classification.' },
-      { id: 'scenario', label: 'Scenario?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 2: Route based on scenario from discovery: fresh, research_only, discussions_only, or research_and_discussions.' },
-      { id: 'fresh', label: 'ASK: Topic name', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Fresh scenario: No research or discussions exist. Ask user for topic, skip to gather context.' },
-      { id: 'has-research', label: 'Cache valid?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 3: Check research analysis cache status (valid/stale/none) before presenting options.' },
+      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Run discovery-for-discussion.sh. Scans research files, existing discussions, and cache. Outputs YAML with scenario classification.' },
+      { id: 'scenario', label: 'Scenario?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2: Route based on scenario from discovery: fresh, research_only, discussions_only, or research_and_discussions.' },
+      { id: 'fresh', label: 'ASK: Topic name', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Fresh scenario: No research or discussions exist. Ask user for topic, skip to gather context.' },
+      { id: 'has-research', label: 'Cache valid?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 3: Check research analysis cache status (valid/stale/none) before presenting options.' },
       { id: 'disc-only', label: 'Discussions only', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Discussions-only scenario: No research exists, skip research analysis.' },
-      { id: 'load-cache', label: 'Load cached analysis', w: 180, h: 44, color: '#fbbf24', bg: 'rgba(251,191,36,0.12)', desc: 'Cache valid: Load cached research-analysis.md and present topics.' },
+      { id: 'load-cache', label: 'Load cached analysis', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Cache valid: Load cached research-analysis.md and present topics.' },
       { id: 'analyze', label: 'Analyze research', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Cache stale/none: Read each research file, extract themes, save to cache with checksums.' },
-      { id: 'present', label: 'Present options menu', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 4: Show workflow state and present options. Menu varies by scenario (2-4 options).' },
-      { id: 'choice', label: 'User choice?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 5: Route based on user selection from options menu.' },
+      { id: 'present', label: 'Present options menu', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 4: Show workflow state and present options. Menu varies by scenario (2-4 options).' },
+      { id: 'choice', label: 'User choice?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 5: Route based on user selection from options menu.' },
       { id: 'from-res', label: 'From research', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'User chose to start from a research topic. Identify which topic was selected.' },
       { id: 'continue', label: 'Continue discussion', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'User chose to continue an existing discussion. Read existing doc first.' },
-      { id: 'refresh', label: 'Refresh cache', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.12)', desc: 'User chose refresh: Delete cache file, return to Step 3 to re-analyze research.' },
-      { id: 'gather', label: 'ASK: Context & constraints', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 6: Gather context - core problem/decision, constraints, codebase files to review.' },
-      { id: 'skill', label: 'technical-discussion', shape: 'pill', w: 150, h: 40, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Step 7: Invoke technical-discussion skill with gathered context.', skillLink: 'skill-discussion' },
-      { id: 'end', label: 'discussion/{topic}.md', shape: 'pill', w: 150, h: 40, color: 'var(--discussion)', bg: 'var(--discussion-bg)', desc: 'Output: docs/workflow/discussion/{topic}.md with frontmatter status tracking.' },
+      { id: 'refresh', label: 'Refresh cache', w: 180, h: 44, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'User chose refresh: Delete cache file, return to Step 3 to re-analyze research.' },
+      { id: 'gather', label: 'ASK: Context & constraints', w: 205, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 6: Gather context - core problem/decision, constraints, codebase files to review.' },
+      { id: 'skill', label: 'Invoke discussion skill', shape: 'pill', w: 180, h: 40, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 7: Invoke technical-discussion skill with gathered context.', skillLink: 'skill-discussion' },
     ],
     connections: [
       { from: 'start', to: 'migrate' },
@@ -1419,36 +1652,34 @@ const FLOWCHARTS = {
       { from: 'continue', to: 'gather' },
       { from: 'refresh', to: 'analyze', type: 'backloop' },
       { from: 'gather', to: 'skill', type: 'transition' },
-      { from: 'skill', to: 'end' },
     ]
   },
   specification: {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /start-specification.' },
       { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations.' },
-      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Step 1: Run discovery-for-specification.sh. Scans discussions (with has_individual_spec check), specifications, and cache.' },
-      { id: 'gate-disc', label: 'Discussions?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Step 2 Gate: Do any discussions exist? If not, STOP.' },
-      { id: 'stop-no-disc', label: 'STOP: No discussions', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Terminal: No discussions found. User must run /start-discussion first.' },
-      { id: 'gate-concluded', label: 'Concluded?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Step 2 Gate: Are any discussions concluded? If not, STOP.' },
-      { id: 'stop-no-conc', label: 'STOP: None concluded', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Terminal: Discussions exist but none concluded. Complete discussion phase first.' },
-      { id: 'count', label: 'How many?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 3: Route based on concluded discussion count. 1 = auto-select, multiple = check specs/cache.' },
+      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Run discovery-for-specification.sh. Scans discussions (with has_individual_spec check), specifications, and cache.' },
+      { id: 'gate-disc', label: 'Discussions?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2 Gate: Do any discussions exist? If not, STOP.' },
+      { id: 'stop-no-disc', label: 'STOP: No discussions', shape: 'stop', w: 170, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No discussions found. User must run /start-discussion first.' },
+      { id: 'gate-concluded', label: 'Concluded?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2 Gate: Are any discussions concluded? If not, STOP.' },
+      { id: 'stop-no-conc', label: 'STOP: None concluded', shape: 'stop', w: 170, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: Discussions exist but none concluded. Complete discussion phase first.' },
+      { id: 'count', label: 'How many?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 3: Route based on concluded discussion count. 1 = auto-select, multiple = check specs/cache.' },
       { id: 'auto-select', label: 'Auto-select single', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Only one concluded discussion. Auto-select it, skip to confirm.' },
-      { id: 'multi-route', label: 'Specs exist?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Multiple concluded: Do existing specifications exist? Routes to different options.' },
-      { id: 'no-specs-cache', label: 'Cache valid?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'No specs + multiple discussions: Check consolidation cache. Valid = show groupings, stale/none = gather context first.' },
-      { id: 'specs-options', label: 'ASK: Continue / Regroup', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Specs exist: Offer continue existing spec, select from groupings (if cache valid), or re-analyze.' },
-      { id: 'gather-ctx', label: 'Gather analysis context', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 4: Ask about project structure and topic relationships before analysis.' },
+      { id: 'multi-route', label: 'Specs exist?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Multiple concluded: Do existing specifications exist? Routes to different options.' },
+      { id: 'no-specs-cache', label: 'Cache valid?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'No specs + multiple discussions: Check consolidation cache. Valid = show groupings, stale/none = gather context first.' },
+      { id: 'specs-options', label: 'ASK: Continue / Regroup', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Specs exist: Offer continue existing spec, select from groupings (if cache valid), or re-analyze.' },
+      { id: 'gather-ctx', label: 'Gather analysis context', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 4: Ask about project structure and topic relationships before analysis.' },
       { id: 'analyze', label: 'Analyze discussions', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 6: Read ALL concluded discussions. Analyze coupling (data, behavioral, conceptual). Group into specs. Save to cache.' },
-      { id: 'show-groups', label: 'Present groupings', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 7: Present recommended groupings with full status info and 5 options.' },
-      { id: 'group-choice', label: 'Grouping choice?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 8: Route based on user grouping choice: proceed, combine, single, individual, or refresh.' },
-      { id: 'refresh', label: 'Refresh cache', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.12)', desc: 'Delete cache, return to Step 6 (analyze discussions) for fresh analysis.' },
-      { id: 'proceed', label: 'ASK: Which grouping?', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Proceed as recommended: Ask which grouping to start with.' },
-      { id: 'combine', label: 'ASK: Custom groupings', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Combine differently: User describes groupings. Impact analysis if 2+ specs affected.' },
+      { id: 'show-groups', label: 'Present groupings', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 7: Present recommended groupings with full status info and 5 options.' },
+      { id: 'group-choice', label: 'Grouping choice?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 8: Route based on user grouping choice: proceed, combine, single, individual, or refresh.' },
+      { id: 'refresh', label: 'Refresh cache', w: 180, h: 44, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Delete cache, return to Step 6 (analyze discussions) for fresh analysis.' },
+      { id: 'proceed', label: 'ASK: Which grouping?', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Proceed as recommended: Ask which grouping to start with.' },
+      { id: 'combine', label: 'ASK: Custom groupings', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Combine differently: User describes groupings. Impact analysis if 2+ specs affected.' },
       { id: 'single', label: 'Use "unified" name', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Single specification: Consolidate ALL discussions into one "unified" spec.' },
-      { id: 'individual', label: 'ASK: Which discussion?', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Individual specifications: 1:1 mapping. Ask which discussion to specify.' },
-      { id: 'confirm', label: 'ASK: Confirm selection', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 9: Confirm selection - show sources, output path, supersede info. Wait for y/n.' },
-      { id: 'add-ctx', label: 'ASK: Additional context', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 10: Gather additional context, priorities, constraints since discussion concluded.' },
-      { id: 'skill', label: 'technical-specification', shape: 'pill', w: 150, h: 40, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Step 11: Invoke technical-specification skill with all gathered context.', skillLink: 'skill-specification' },
-      { id: 'end', label: 'specification/{topic}.md', shape: 'pill', w: 150, h: 40, color: 'var(--specification)', bg: 'var(--specification-bg)', desc: 'Output: docs/workflow/specification/{topic}.md with frontmatter and source attribution.' },
+      { id: 'individual', label: 'ASK: Which discussion?', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Individual specifications: 1:1 mapping. Ask which discussion to specify.' },
+      { id: 'confirm', label: 'ASK: Confirm selection', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 9: Confirm selection - show sources, output path, supersede info. Wait for y/n.' },
+      { id: 'add-ctx', label: 'ASK: Additional context', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 10: Gather additional context, priorities, constraints since discussion concluded.' },
+      { id: 'skill', label: 'Invoke specification skill', shape: 'pill', w: 205, h: 40, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 11: Invoke technical-specification skill with all gathered context.', skillLink: 'skill-specification' },
     ],
     connections: [
       { from: 'start', to: 'migrate' },
@@ -1481,23 +1712,21 @@ const FLOWCHARTS = {
       { from: 'auto-select', to: 'confirm' },
       { from: 'confirm', to: 'add-ctx' },
       { from: 'add-ctx', to: 'skill', type: 'transition' },
-      { from: 'skill', to: 'end' },
     ]
   },
   planning: {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /start-planning.' },
       { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations.' },
-      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Step 1: Run discovery-for-planning.sh. Scans specs (feature vs cross-cutting), counts ready specs, checks existing plans.' },
-      { id: 'scenario', label: 'Scenario?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 2: Route based on scenario: no_specs, nothing_actionable, or has_options.' },
-      { id: 'stop-no-spec', label: 'STOP: No specs', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Terminal: No specifications found. Run /start-specification first.' },
-      { id: 'stop-none-ready', label: 'STOP: None actionable', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'nothing_actionable: Specs exist but none actionable. Show state and suggest completing in-progress specs.' },
-      { id: 'present', label: 'Present options', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 3: Present available specs (+new, ▶continue, >review) and not plannable specs. Single auto-selects, multiple asks.' },
-      { id: 'plan-state', label: 'Existing plan?', shape: 'diamond', w: 120, h: 120, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 4: Route by plan state. New plan gathers context first; existing plan skips straight to skill invocation.' },
-      { id: 'gather', label: 'ASK: Additional context', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 5: Gather additional context, priorities, or constraint changes. Only for new plans.' },
-      { id: 'cross-cut', label: 'Surface cross-cutting specs', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 6: Read concluded cross-cutting specs and surface relevant ones as reference context for planning. Only for new plans.' },
-      { id: 'skill', label: 'technical-planning', shape: 'pill', w: 150, h: 40, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Step 7: Invoke technical-planning skill. Handles format selection, phases, tasks, dependencies.', skillLink: 'skill-planning' },
-      { id: 'end', label: 'planning/{topic}.md', shape: 'pill', w: 150, h: 40, color: 'var(--planning)', bg: 'var(--planning-bg)', desc: 'Output: docs/workflow/planning/{topic}.md with phases, tasks, and acceptance criteria.' },
+      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Run discovery-for-planning.sh. Scans specs (feature vs cross-cutting), counts ready specs, checks existing plans.' },
+      { id: 'scenario', label: 'Scenario?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2: Route based on scenario: no_specs, nothing_actionable, or has_options.' },
+      { id: 'stop-no-spec', label: 'STOP: No specs', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No specifications found. Run /start-specification first.' },
+      { id: 'stop-none-ready', label: 'STOP: None actionable', shape: 'stop', w: 175, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'nothing_actionable: Specs exist but none actionable. Show state and suggest completing in-progress specs.' },
+      { id: 'present', label: 'Present options', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 3: Present available specs (+new, ▶continue, >review) and not plannable specs. Single auto-selects, multiple asks.' },
+      { id: 'plan-state', label: 'Existing plan?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 4: Route by plan state. New plan gathers context first; existing plan skips straight to skill invocation.' },
+      { id: 'gather', label: 'ASK: Additional context', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 5: Gather additional context, priorities, or constraint changes. Only for new plans.' },
+      { id: 'cross-cut', label: 'Surface cross-cutting specs', w: 215, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 6: Read concluded cross-cutting specs and surface relevant ones as reference context for planning. Only for new plans.' },
+      { id: 'skill', label: 'Invoke planning skill', shape: 'pill', w: 170, h: 40, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 7: Invoke technical-planning skill. Handles format selection, phases, tasks, dependencies.', skillLink: 'skill-planning' },
     ],
     connections: [
       { from: 'start', to: 'migrate' },
@@ -1511,27 +1740,25 @@ const FLOWCHARTS = {
       { from: 'plan-state', to: 'skill', type: 'yes', label: 'exists' },
       { from: 'gather', to: 'cross-cut' },
       { from: 'cross-cut', to: 'skill', type: 'transition' },
-      { from: 'skill', to: 'end' },
     ]
   },
   implementation: {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /start-implementation.' },
       { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations.' },
-      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Step 1: Run discovery-for-implementation-and-review.sh. Scans plans, implementation tracking, dependencies, and environment setup.' },
-      { id: 'scenario', label: 'Plans?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Step 2: Route on scenario — no_plans, single_plan, or multiple_plans.' },
-      { id: 'stop-no-plan', label: 'STOP: No plans', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Terminal: No plans found. Run /start-planning first.' },
-      { id: 'present', label: 'Present plans', w: 200, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 3: Classify plans into Implementable (▶ in-progress, + new), Implemented (> completed), and Not implementable (· blocked/not concluded). Number selectable entries. Includes unblock escape hatch for externally satisfied deps.' },
-      { id: 'select', label: 'Select plan', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Single implementable = auto-select, otherwise ask user. Implemented plans can be re-selected.' },
-      { id: 'unblock', label: 'ASK: Unblock dep', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'User requests unblock: identify plan and dep, confirm, mark satisfied_externally in frontmatter, commit, re-present.' },
-      { id: 'gate-deps', label: 'Ext deps OK?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Step 4: Confirm external dependencies satisfied. Pre-analyzed by discovery script. Escape hatch: mark as satisfied externally.' },
-      { id: 'block-deps', label: 'BLOCK: Deps missing', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Dependencies blocking. Show unresolved and incomplete. Offer: implement first, mark satisfied externally, or run /link-dependencies.' },
-      { id: 'escape', label: 'Mark satisfied externally', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Escape hatch: User says dep was implemented outside workflow. Update plan frontmatter, re-check.' },
-      { id: 'gate-env', label: 'Env setup?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 5: Check environment setup. Info gathering only — does not execute setup.' },
-      { id: 'create-env', label: 'ASK: Setup instructions', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Setup file missing: Ask user for setup instructions, save to environment-setup.md and commit.' },
+      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Run discovery-for-implementation-and-review.sh. Scans plans, implementation tracking, dependencies, and environment setup.' },
+      { id: 'scenario', label: 'Plans?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2: Route on scenario — no_plans, single_plan, or multiple_plans.' },
+      { id: 'stop-no-plan', label: 'STOP: No plans', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No plans found. Run /start-planning first.' },
+      { id: 'present', label: 'Present plans', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 3: Classify plans into Implementable (▶ in-progress, + new), Implemented (> completed), and Not implementable (· blocked/not concluded). Number selectable entries. Includes unblock escape hatch for externally satisfied deps.' },
+      { id: 'select', label: 'Select plan', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Single implementable = auto-select, otherwise ask user. Implemented plans can be re-selected.' },
+      { id: 'unblock', label: 'ASK: Unblock dep', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'User requests unblock: identify plan and dep, confirm, mark satisfied_externally in frontmatter, commit, re-present.' },
+      { id: 'gate-deps', label: 'Ext deps OK?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 4: Confirm external dependencies satisfied. Pre-analyzed by discovery script. Escape hatch: mark as satisfied externally.' },
+      { id: 'block-deps', label: 'BLOCK: Deps missing', shape: 'stop', w: 180, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Dependencies blocking. Show unresolved and incomplete. Offer: implement first, mark satisfied externally, or run /link-dependencies.' },
+      { id: 'escape', label: 'Mark satisfied externally', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Escape hatch: User says dep was implemented outside workflow. Update plan frontmatter, re-check.' },
+      { id: 'gate-env', label: 'Env setup?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 5: Check environment setup. Info gathering only — does not execute setup.' },
+      { id: 'create-env', label: 'ASK: Setup instructions', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Setup file missing: Ask user for setup instructions, save to environment-setup.md and commit.' },
       { id: 'env-ok', label: 'Environment noted', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Setup exists (no special setup or has instructions). Note for skill handoff.' },
-      { id: 'skill', label: 'technical-implementation', shape: 'pill', w: 150, h: 40, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Step 6: Invoke technical-implementation skill with plan, format, spec, tracking state, deps, and env info.', skillLink: 'skill-implementation' },
-      { id: 'end', label: 'Code changes (tracked)', shape: 'pill', w: 150, h: 40, color: 'var(--implementation)', bg: 'var(--implementation-bg)', desc: 'Output: Code changes tracked in plan and implementation tracking file.' },
+      { id: 'skill', label: 'Invoke implementation skill', shape: 'pill', w: 215, h: 40, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 6: Invoke technical-implementation skill with plan, format, spec, tracking state, deps, and env info.', skillLink: 'skill-implementation' },
     ],
     connections: [
       { from: 'start', to: 'migrate' },
@@ -1551,27 +1778,20 @@ const FLOWCHARTS = {
       { from: 'gate-env', to: 'env-ok', label: 'exists' },
       { from: 'create-env', to: 'skill', type: 'transition' },
       { from: 'env-ok', to: 'skill', type: 'transition' },
-      { from: 'skill', to: 'end' },
     ]
   },
   review: {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /start-review.' },
       { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations.' },
-      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Step 1: Run shared discovery-for-implementation-and-review.sh. Scans plans.' },
-      { id: 'scenario', label: 'Plans?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Step 2: Do any plans exist? Gate check.' },
-      { id: 'stop', label: 'STOP: No plans', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Terminal: No plans found. Run /start-planning first.' },
-      { id: 'select', label: 'Select plan', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 3: Single plan = auto-select, multiple = ask user.' },
+      { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Run shared discovery-for-implementation-and-review.sh. Scans plans.' },
+      { id: 'scenario', label: 'Plans?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2: Do any plans exist? Gate check.' },
+      { id: 'stop', label: 'STOP: No plans', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No plans found. Run /start-planning first.' },
+      { id: 'select', label: 'Select plan', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 3: Single plan = auto-select, multiple = ask user.' },
       { id: 'auto', label: 'Auto-select single', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Only one plan. Auto-select it.' },
-      { id: 'ask', label: 'ASK: Which plan?', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Multiple plans. Ask user which to review.' },
-      { id: 'scope', label: 'ASK: Review scope', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 4: Choose scope - all changes since plan, specific dirs/files, or from git status.' },
-      { id: 'skill', label: 'technical-review', shape: 'pill', w: 150, h: 40, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Step 5: Invoke technical-review skill. Reads plan, spec, extracts ALL tasks.', skillLink: 'skill-review' },
-      { id: 'fanout', label: 'Spawn review-task-verifiers', w: 180, h: 44, color: '#f97316', bg: 'rgba(249,115,22,0.08)', desc: 'Spawn parallel review-task-verifier subagents (Haiku model). One per task, all run simultaneously.' },
-      { id: 'v1', label: 'Verify task 1', w: 140, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.08)', desc: 'Review-task-verifier: Check implementation exists, acceptance criteria met, test coverage, code quality.' },
-      { id: 'v2', label: 'Verify task 2', w: 140, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.08)', desc: 'Review-task-verifier: Same checks, different task. Runs in parallel with others.' },
-      { id: 'vn', label: 'Verify task N', w: 140, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.08)', desc: 'Review-task-verifier: One per task in the plan. All run simultaneously.' },
-      { id: 'aggregate', label: 'Aggregate findings', w: 180, h: 44, color: '#f97316', bg: 'rgba(249,115,22,0.08)', desc: 'Collect all verifier results. Aggregate into structured review feedback.' },
-      { id: 'end', label: 'approve / changes / comments', shape: 'pill', w: 150, h: 40, color: 'var(--review)', bg: 'var(--review-bg)', desc: 'Output: Structured review - approve, request changes, or comments. Does NOT fix code.' },
+      { id: 'ask', label: 'ASK: Which plan?', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Multiple plans. Ask user which to review.' },
+      { id: 'scope', label: 'ASK: Review scope', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 4: Choose scope - all changes since plan, specific dirs/files, or from git status.' },
+      { id: 'skill', label: 'Invoke review skill', shape: 'pill', w: 170, h: 40, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 5: Invoke technical-review skill. Reads plan, spec, extracts ALL tasks.', skillLink: 'skill-review' },
     ],
     connections: [
       { from: 'start', to: 'migrate' },
@@ -1584,25 +1804,16 @@ const FLOWCHARTS = {
       { from: 'auto', to: 'scope' },
       { from: 'ask', to: 'scope' },
       { from: 'scope', to: 'skill', type: 'transition' },
-      { from: 'skill', to: 'fanout' },
-      { from: 'fanout', to: 'v1' },
-      { from: 'fanout', to: 'v2' },
-      { from: 'fanout', to: 'vn' },
-      { from: 'v1', to: 'aggregate' },
-      { from: 'v2', to: 'aggregate' },
-      { from: 'vn', to: 'aggregate' },
-      { from: 'aggregate', to: 'end' },
     ]
   },
   'start-feature': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /start-feature. No migration step (standalone command).' },
-      { id: 'gather', label: 'ASK: Feature context', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 1: Gather feature context - what, scope, constraints. Can skip if already provided inline.' },
-      { id: 'name', label: 'ASK: Suggest topic name', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 2: Suggest a topic name for the specification file based on feature description.' },
-      { id: 'check', label: 'Name conflict?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 3: Check docs/workflow/specification/ for naming conflicts.' },
-      { id: 'conflict', label: 'ASK: Append / rename / replace', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Conflict found: Ask user to append to existing, choose different name, or replace.' },
-      { id: 'skill', label: 'technical-specification', shape: 'pill', w: 150, h: 40, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Step 4: Invoke technical-specification skill with inline feature context (no discussion doc).', skillLink: 'skill-specification' },
-      { id: 'end', label: 'specification/{topic}.md', shape: 'pill', w: 150, h: 40, color: 'var(--specification)', bg: 'var(--specification-bg)', desc: 'Output: Standard specification file. Continues to /start-planning normally.' },
+      { id: 'gather', label: 'ASK: Feature context', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 1: Gather feature context - what, scope, constraints. Can skip if already provided inline.' },
+      { id: 'name', label: 'ASK: Suggest topic name', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 2: Suggest a topic name for the specification file based on feature description.' },
+      { id: 'check', label: 'Name conflict?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 3: Check docs/workflow/specification/ for naming conflicts.' },
+      { id: 'conflict', label: 'ASK: Append / rename / replace', w: 230, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Conflict found: Ask user to append to existing, choose different name, or replace.' },
+      { id: 'skill', label: 'Invoke specification skill', shape: 'pill', w: 205, h: 40, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Invoke technical-specification skill with inline feature context (no discussion doc).', skillLink: 'skill-specification' },
     ],
     connections: [
       { from: 'start', to: 'gather' },
@@ -1611,23 +1822,22 @@ const FLOWCHARTS = {
       { from: 'check', to: 'conflict', type: 'yes', label: 'conflict' },
       { from: 'check', to: 'skill', type: 'no', label: 'ok' },
       { from: 'conflict', to: 'skill' },
-      { from: 'skill', to: 'end' },
     ]
   },
   'link-deps': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /link-dependencies. No migration step.' },
-      { id: 'discover', label: 'Discover all plans', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Step 1: Scan docs/workflow/planning/ for all plan files. Extract format metadata.' },
-      { id: 'gate-count', label: 'Plans >= 2?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Gate: Need at least 2 plans for cross-topic linking. 0-1 = STOP.' },
-      { id: 'stop-count', label: 'STOP: Need 2+ plans', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Terminal: Fewer than 2 plans. Cannot link across topics.' },
-      { id: 'gate-format', label: 'Same format?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Gate: All plans must use the same output format. Mixed formats = STOP.' },
-      { id: 'stop-format', label: 'STOP: Mixed formats', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Terminal: Plans use different formats. Consolidate first.' },
+      { id: 'discover', label: 'Discover all plans', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Scan docs/workflow/planning/ for all plan files. Extract format metadata.' },
+      { id: 'gate-count', label: 'Plans >= 2?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Gate: Need at least 2 plans for cross-topic linking. 0-1 = STOP.' },
+      { id: 'stop-count', label: 'STOP: Need 2+ plans', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: Fewer than 2 plans. Cannot link across topics.' },
+      { id: 'gate-format', label: 'Same format?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Gate: All plans must use the same output format. Mixed formats = STOP.' },
+      { id: 'stop-format', label: 'STOP: Mixed formats', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: Plans use different formats. Consolidate first.' },
       { id: 'extract', label: 'Extract ext dependencies', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 3: Read External Dependencies section from each plan. Categorize as unresolved/resolved/satisfied.' },
       { id: 'match', label: 'Match deps to tasks', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 4: For each unresolved dep, search other plans for matching tasks using output format querying.' },
       { id: 'wire', label: 'Wire up dependencies', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 5: Update plan index files with resolved task IDs. Create blocking relationships.' },
       { id: 'bidir', label: 'Bidirectional check', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 6: Check reverse dependencies. If plan X depends on Y, does Y know about it?' },
       { id: 'report', label: 'Report results', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 7: Summary of resolved, already-resolved, satisfied, and still-unresolved deps.' },
-      { id: 'commit', label: 'ASK: Commit changes?', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Step 8: Ask user to commit dependency updates.' },
+      { id: 'commit', label: 'ASK: Commit changes?', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 8: Ask user to commit dependency updates.' },
       { id: 'end', label: 'Plans updated', shape: 'pill', w: 150, h: 40, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Output: Updated plan files with wired-up cross-topic dependencies.' },
     ],
     connections: [
@@ -1648,16 +1858,17 @@ const FLOWCHARTS = {
   'skill-research': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-research skill receives gathered context from command.' },
-      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.12)', desc: 'Verify topic/idea is provided. If missing or vague, stop and ask.' },
-      { id: 'init', label: 'Initialize doc', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.12)', desc: 'Create exploration.md with YAML frontmatter (topic + date). No status field.' },
-      { id: 'ask', label: 'ASK question', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Ask one research question at a time. Probe feasibility, hidden complexity, assumptions.' },
+      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Verify topic/idea is provided. If missing or vague, stop and ask.' },
+      { id: 'init', label: 'Initialize doc', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Create exploration.md with YAML frontmatter (topic + date). No status field.' },
+      { id: 'ask', label: 'ASK question', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Ask one research question at a time. Probe feasibility, hidden complexity, assumptions.' },
       { id: 'discuss', label: 'Discuss answer', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Engage with the answer. Follow tangents. Challenge assumptions. Be honest about risks.' },
       { id: 'document', label: 'Document insight', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Capture the insight in the research file. Only what was discussed, no embellishment.' },
       { id: 'commit', label: 'Commit & push', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Commit immediately. Every insight pushed before the next question. Unpushed work is lost.' },
-      { id: 'more', label: 'More to explore?', shape: 'diamond', w: 120, h: 120, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Periodic review: more questions? Themes emerging? Ready for discussion/spec?' },
-      { id: 'split', label: 'Themes emerging?', shape: 'diamond', w: 120, h: 120, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Over multiple sessions, topics may become distinct. Split if so.' },
-      { id: 'split-files', label: 'Split into files', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.12)', desc: 'Split exploration.md into semantic files (market-landscape.md, technical-feasibility.md, etc).' },
+      { id: 'more', label: 'More to explore?', shape: 'diamond', w: 120, h: 120, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Periodic review: more questions? Themes emerging? Ready for discussion/spec?' },
+      { id: 'split', label: 'Themes emerging?', shape: 'diamond', w: 120, h: 120, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Over multiple sessions, topics may become distinct. Split if so.' },
+      { id: 'split-files', label: 'Split into files', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Split exploration.md into semantic files (market-landscape.md, technical-feasibility.md, etc).' },
       { id: 'end', label: 'research/ output', shape: 'pill', w: 150, h: 40, color: 'var(--research)', bg: 'var(--research-bg)', desc: 'Output: docs/workflow/research/ files. Research never "concludes" — always open-ended.' },
+      { id: 'next', label: 'Next: /start-discussion', shape: 'pill', w: 180, h: 40, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'discussion' },
     ],
     connections: [
       { from: 'start', to: 'validate' },
@@ -1672,20 +1883,22 @@ const FLOWCHARTS = {
       { from: 'split', to: 'split-files', type: 'yes', label: 'yes' },
       { from: 'split', to: 'end', type: 'no', label: 'no' },
       { from: 'split-files', to: 'end' },
+      { from: 'end', to: 'next', type: 'transition' },
     ]
   },
   'skill-discussion': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-discussion skill receives context from command.' },
-      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: '#60a5fa', bg: 'rgba(96,165,250,0.12)', desc: 'Verify source material and topic name. Stop if missing.' },
-      { id: 'init', label: 'Initialize document', w: 180, h: 44, color: '#60a5fa', bg: 'rgba(96,165,250,0.12)', desc: 'Create discussion/{topic}.md with YAML frontmatter. Set status: active.' },
-      { id: 'engage', label: 'Engage on topic', w: 180, h: 44, color: '#60a5fa', bg: 'rgba(96,165,250,0.15)', desc: 'Present topic for discussion. Ask probing questions one at a time.' },
+      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Verify source material and topic name. Stop if missing.' },
+      { id: 'init', label: 'Initialize document', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Create discussion/{topic}.md with YAML frontmatter. Set status: active.' },
+      { id: 'engage', label: 'Engage on topic', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Present topic for discussion. Ask probing questions one at a time.' },
       { id: 'capture', label: 'Capture decisions', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Record options considered, journey of exploration, final decision, and rationale.' },
       { id: 'document', label: 'Document to file', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Log decisions to the discussion document. Verbatim — no embellishment.' },
       { id: 'commit', label: 'Commit & push', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Commit at natural breaks. Never batch — context refresh loses unpushed work.' },
-      { id: 'more', label: 'More topics?', shape: 'diamond', w: 110, h: 110, color: '#60a5fa', bg: 'rgba(96,165,250,0.15)', desc: 'Are there more topics to discuss?' },
-      { id: 'conclude', label: 'Conclude discussion', w: 180, h: 44, color: '#60a5fa', bg: 'rgba(96,165,250,0.12)', desc: 'Set status: concluded. All decisions documented. Ready for specification.' },
-      { id: 'end', label: 'discussion/{topic}.md', shape: 'pill', w: 150, h: 40, color: 'var(--discussion)', bg: 'var(--discussion-bg)', desc: 'Output: Concluded discussion document ready for specification phase.' },
+      { id: 'more', label: 'More topics?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Are there more topics to discuss?' },
+      { id: 'conclude', label: 'Conclude discussion', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Set status: concluded. All decisions documented. Ready for specification.' },
+      { id: 'end', label: 'discussion/{topic}.md', shape: 'pill', w: 175, h: 40, color: 'var(--discussion)', bg: 'var(--discussion-bg)', desc: 'Output: Concluded discussion document ready for specification phase.' },
+      { id: 'next', label: 'Next: /start-specification', shape: 'pill', w: 205, h: 40, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'specification' },
     ],
     connections: [
       { from: 'start', to: 'validate' },
@@ -1698,24 +1911,26 @@ const FLOWCHARTS = {
       { from: 'more', to: 'engage', type: 'backloop', label: 'yes' },
       { from: 'more', to: 'conclude', type: 'no', label: 'done' },
       { from: 'conclude', to: 'end' },
+      { from: 'end', to: 'next', type: 'transition' },
     ]
   },
   'skill-specification': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-specification skill receives source material and topic.' },
-      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.12)', desc: 'Verify source material and topic name. Multiple sources OK — extract from ALL.' },
-      { id: 'load-guide', label: 'Load spec guide', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.12)', desc: 'Load specification-guide.md for structure and section requirements.' },
-      { id: 'extract', label: 'Extract from sources', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Re-scan ALL source materials for current topic. Search keywords. Collect everything.' },
+      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Verify source material and topic name. Multiple sources OK — extract from ALL.' },
+      { id: 'load-guide', label: 'Load spec guide', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Load specification-guide.md for structure and section requirements.' },
+      { id: 'extract', label: 'Extract from sources', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Re-scan ALL source materials for current topic. Search keywords. Collect everything.' },
       { id: 'filter', label: 'Filter & validate', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Source material may contain hallucinations or inaccuracies. Validate before including.' },
       { id: 'enrich', label: 'Enrich gaps', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Identify gaps in source material. Fill through discussion with user.' },
-      { id: 'present', label: 'Present to user', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Present synthesized content in spec format. ONE topic at a time.' },
-      { id: 'wait', label: 'Approved?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'CRITICAL: STOP and WAIT for explicit user approval. Never write without approval.' },
-      { id: 'log', label: 'Log to specification', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.12)', desc: 'Write approved content verbatim to specification file. No silent modifications.' },
-      { id: 'more-topics', label: 'More topics?', shape: 'diamond', w: 110, h: 110, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Are there more specification topics to cover from the sources?' },
-      { id: 'final-review', label: 'Final review', w: 180, h: 44, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Review ALL sources against spec. Flag potentially missed content.' },
+      { id: 'present', label: 'Present to user', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Present synthesized content in spec format. ONE topic at a time.' },
+      { id: 'wait', label: 'Approved?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'CRITICAL: STOP and WAIT for explicit user approval. Never write without approval.' },
+      { id: 'log', label: 'Log to specification', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Write approved content verbatim to specification file. No silent modifications.' },
+      { id: 'more-topics', label: 'More topics?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Are there more specification topics to cover from the sources?' },
+      { id: 'final-review', label: 'Final review', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Review ALL sources against spec. Flag potentially missed content.' },
       { id: 'supersede', label: 'Supersede source specs', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'If sources included existing specs, mark them superseded_by new spec.' },
-      { id: 'signoff', label: 'User sign-off', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Final user approval of the complete specification.' },
-      { id: 'end', label: 'specification/{topic}.md', shape: 'pill', w: 150, h: 40, color: 'var(--specification)', bg: 'var(--specification-bg)', desc: 'Output: Validated, standalone specification — the golden document.' },
+      { id: 'signoff', label: 'User sign-off', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Final user approval of the complete specification.' },
+      { id: 'end', label: 'specification/{topic}.md', shape: 'pill', w: 190, h: 40, color: 'var(--specification)', bg: 'var(--specification-bg)', desc: 'Output: Validated, standalone specification — the golden document.' },
+      { id: 'next', label: 'Next: /start-planning', shape: 'pill', w: 180, h: 40, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'planning' },
     ],
     connections: [
       { from: 'start', to: 'validate' },
@@ -1733,23 +1948,25 @@ const FLOWCHARTS = {
       { from: 'final-review', to: 'supersede' },
       { from: 'supersede', to: 'signoff' },
       { from: 'signoff', to: 'end' },
+      { from: 'end', to: 'next', type: 'transition' },
     ]
   },
   'skill-planning': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-planning skill receives specification and context.' },
-      { id: 'resume', label: 'Existing plan?', shape: 'diamond', w: 110, h: 110, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 0: Check if plan index file exists at docs/workflow/planning/{topic}.md.' },
-      { id: 'resume-choice', label: 'Continue / Restart?', shape: 'diamond', w: 120, h: 120, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'User chooses: continue from previous position or restart (deletes existing plan).' },
-      { id: 'init', label: 'Initialize plan', w: 180, h: 44, color: '#fbbf24', bg: 'rgba(251,191,36,0.12)', desc: 'Step 1: Create plan index file. Choose output format.' },
+      { id: 'resume', label: 'Existing plan?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if plan index file exists at docs/workflow/planning/{topic}.md.' },
+      { id: 'resume-choice', label: 'Continue / Restart?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'User chooses: continue from previous position or restart (deletes existing plan).' },
+      { id: 'init', label: 'Initialize plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Create plan index file. Choose output format.' },
       { id: 'load-existing', label: 'Load existing plan', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Continue: load existing plan and output format adapter.' },
       { id: 'principles', label: 'Load principles', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 2: Load planning-principles.md. Internalize constraints.' },
       { id: 'verify', label: 'Verify source material', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 3: Verify specification is complete. Check cross-cutting references.' },
-      { id: 'plan-construction', label: 'Plan construction', w: 200, h: 44, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 4: Nested loop — define phases, define tasks per phase, author each task. Commits after each phase completes.' },
-      { id: 'analyze-graph', label: 'Analyze task graph', w: 200, h: 44, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 5: Invoke planning-dependency-grapher agent. Analyze task dependencies, detect cycles, assign priorities. User approves changes.' },
+      { id: 'plan-construction', label: 'Plan construction', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Nested loop — define phases, define tasks per phase, author each task. Commits after each phase completes.' },
+      { id: 'analyze-graph', label: 'Analyze task graph', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 5: Invoke planning-dependency-grapher agent. Analyze task dependencies, detect cycles, assign priorities. User approves changes.' },
       { id: 'deps', label: 'Resolve ext deps', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 6: Identify external dependencies. Match to tasks in other plans if possible. Mark unresolved for /link-dependencies.' },
-      { id: 'review', label: 'Plan review', w: 180, h: 44, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Step 7: Two-part review — traceability (spec ↔ plan) and integrity (structure, quality, dependencies). User resolves findings.' },
-      { id: 'conclude', label: 'Conclude plan', w: 180, h: 44, color: '#fbbf24', bg: 'rgba(251,191,36,0.12)', desc: 'Step 8: Set status: concluded. All tasks must be authored.' },
+      { id: 'review', label: 'Plan review', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 7: Two-part review — traceability (spec ↔ plan) and integrity (structure, quality, dependencies). User resolves findings.' },
+      { id: 'conclude', label: 'Conclude plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 8: Set status: concluded. All tasks must be authored.' },
       { id: 'end', label: 'planning/{topic}.md', shape: 'pill', w: 150, h: 40, color: 'var(--planning)', bg: 'var(--planning-bg)', desc: 'Output: Plan index + authored tasks in chosen output format.' },
+      { id: 'next', label: 'Next: /start-implementation', shape: 'pill', w: 210, h: 40, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'implementation' },
     ],
     connections: [
       { from: 'start', to: 'resume' },
@@ -1766,35 +1983,37 @@ const FLOWCHARTS = {
       { from: 'deps', to: 'review' },
       { from: 'review', to: 'conclude' },
       { from: 'conclude', to: 'end' },
+      { from: 'end', to: 'next', type: 'transition' },
     ]
   },
   'skill-implementation': {
     nodes: [
       // Orchestrator setup (Steps 1-4)
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-implementation skill receives plan, env info, and tracking state.' },
-      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: '#f97316', bg: 'rgba(249,115,22,0.12)', desc: 'Step 1: Verify plan content and output format field in frontmatter.' },
-      { id: 'env-setup', label: 'Environment setup', w: 180, h: 44, color: '#f97316', bg: 'rgba(249,115,22,0.12)', desc: 'Step 1: Run setup commands from environment-setup.md. Sequential, exactly as written.' },
-      { id: 'read-plan', label: 'Read plan + adapter', w: 180, h: 44, color: '#f97316', bg: 'rgba(249,115,22,0.12)', desc: 'Step 2: Load plan, read format field, load output format adapter for reading/writing tasks.' },
-      { id: 'skills-disc', label: 'Project skills discovery', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 3: Scan .claude/skills/ for project-specific conventions. ASK user which to pass to agents.' },
-      { id: 'init-track', label: 'Init tracking file', w: 180, h: 44, color: '#f97316', bg: 'rgba(249,115,22,0.12)', desc: 'Step 4: Create/resume docs/workflow/implementation/{topic}.md. Reset gate mode to gated on fresh session.' },
+      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Verify plan content and output format field in frontmatter.' },
+      { id: 'env-setup', label: 'Environment setup', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Run setup commands from environment-setup.md. Sequential, exactly as written.' },
+      { id: 'read-plan', label: 'Read plan + adapter', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 2: Load plan, read format field, load output format adapter for reading/writing tasks.' },
+      { id: 'skills-disc', label: 'Project skills discovery', w: 195, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 3: Scan .claude/skills/ for project-specific conventions. ASK user which to pass to agents.' },
+      { id: 'init-track', label: 'Init tracking file', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Create/resume docs/workflow/implementation/{topic}.md. Reset gate mode to gated on fresh session.' },
       // Task loop — Stage A
-      { id: 'retrieve', label: 'A. Retrieve next task', w: 200, h: 44, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Stage A: Use plan adapter to get next available task. Normalise task content for agent invocation.' },
-      { id: 'done-check', label: 'Tasks remain?', shape: 'diamond', w: 120, h: 120, color: '#f97316', bg: 'rgba(249,115,22,0.15)', desc: 'Check if any tasks remain. If none, proceed to completion.' },
+      { id: 'retrieve', label: 'A. Retrieve next task', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Stage A: Use plan adapter to get next available task. Normalise task content for agent invocation.' },
+      { id: 'done-check', label: 'Tasks remain?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if any tasks remain. If none, proceed to completion.' },
       // Task loop — Stage B
-      { id: 'executor', label: 'B. Invoke executor', w: 200, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.12)', desc: 'Stage B: Dispatch executor agent with TDD workflow, code quality refs, spec, project skills, and normalised task. Agent implements via strict TDD and returns STATUS report.' },
-      { id: 'exec-result', label: 'Executor result?', shape: 'diamond', w: 130, h: 130, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Route on executor STATUS: complete → review, blocked/failed → present to user.' },
-      { id: 'exec-blocked', label: 'Executor blocked', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Present executor ISSUES to user. Options: retry (with comments), skip task, or stop implementation entirely.' },
+      { id: 'executor', label: 'B. Invoke executor', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Stage B: Dispatch executor agent with TDD workflow, code quality refs, spec, project skills, and normalised task. Agent implements via strict TDD and returns STATUS report.' },
+      { id: 'exec-result', label: 'Executor result?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Route on executor STATUS: complete → review, blocked/failed → present to user.' },
+      { id: 'exec-blocked', label: 'Executor blocked', shape: 'stop', w: 180, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Present executor ISSUES to user. Options: retry (with comments), skip task, or stop implementation entirely.' },
       // Task loop — Stage C
-      { id: 'reviewer', label: 'C. Invoke reviewer', w: 200, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.12)', desc: 'Stage C: Dispatch reviewer agent (opus) with spec, task content, project skills. Independent verification — no access to executor context.' },
-      { id: 'review-result', label: 'Reviewer verdict?', shape: 'diamond', w: 130, h: 130, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Route on VERDICT: approved → task gate, needs-changes → present findings to user.' },
-      { id: 'review-changes', label: 'Review: needs changes', w: 200, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Present reviewer ISSUES and NOTES. Options: accept notes (re-invoke executor), skip reviewer (proceed as-is), or add own comments.' },
+      { id: 'reviewer', label: 'C. Invoke reviewer', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Stage C: Dispatch reviewer agent (opus) with spec, task content, project skills. Independent verification — no access to executor context.' },
+      { id: 'review-result', label: 'Reviewer verdict?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Route on VERDICT: approved → task gate, needs-changes → present findings to user.' },
+      { id: 'review-changes', label: 'Review: needs changes', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Present reviewer ISSUES and NOTES. Options: accept notes (re-invoke executor), skip reviewer (proceed as-is), or add own comments.' },
       // Task loop — Stage D
-      { id: 'gate', label: 'D. Task gate', shape: 'diamond', w: 130, h: 130, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Stage D: Check task_gate_mode. Gated = present summary, wait for user (y/auto/comment). Auto = announce and proceed.' },
-      { id: 'gate-prompt', label: 'ASK: Approve task?', w: 200, h: 44, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Gated mode: Present task summary. Options: approve (y), switch to auto mode, or comment (triggers executor fix round).' },
+      { id: 'gate', label: 'D. Task gate', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Stage D: Check task_gate_mode. Gated = present summary, wait for user (y/auto/comment). Auto = announce and proceed.' },
+      { id: 'gate-prompt', label: 'ASK: Approve task?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Gated mode: Present task summary. Options: approve (y), switch to auto mode, or comment (triggers executor fix round).' },
       // Task loop — Stage E
       { id: 'commit', label: 'E. Update + commit', w: 200, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Stage E: Update task in plan (via adapter), mirror to tracking file, commit all changes in one commit: code, tests, plan progress, tracking.' },
       // Completion
-      { id: 'end', label: 'Implementation complete', shape: 'pill', w: 170, h: 40, color: 'var(--implementation)', bg: 'var(--implementation-bg)', desc: 'All tasks complete. Set tracking status: completed. Final commit.' },
+      { id: 'end', label: 'Implementation complete', shape: 'pill', w: 190, h: 40, color: 'var(--implementation)', bg: 'var(--implementation-bg)', desc: 'All tasks complete. Set tracking status: completed. Final commit.' },
+      { id: 'next', label: 'Next: /start-review', shape: 'pill', w: 180, h: 40, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'review' },
     ],
     connections: [
       // Setup flow
@@ -1827,22 +2046,24 @@ const FLOWCHARTS = {
       { from: 'gate-prompt', to: 'executor', type: 'backloop', label: 'comment' },
       // E: Commit and loop
       { from: 'commit', to: 'retrieve', type: 'backloop', label: 'next task' },
+      // Next phase
+      { from: 'end', to: 'next', type: 'transition' },
     ]
   },
   'skill-review': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-review skill receives plan, optional spec, and scope.' },
-      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.12)', desc: 'Verify plan is available. Specification is optional but helpful.' },
-      { id: 'read-plan', label: 'Read plan', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.12)', desc: 'Read the plan — all phases, tasks, and acceptance criteria.' },
+      { id: 'validate', label: 'Validate inputs', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Verify plan is available. Specification is optional but helpful.' },
+      { id: 'read-plan', label: 'Read plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Read the plan — all phases, tasks, and acceptance criteria.' },
       { id: 'read-spec', label: 'Read specification', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'If available, read specification for design context.' },
-      { id: 'extract', label: 'Extract ALL tasks', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'List every task from every phase. Verify all, not a sample.' },
-      { id: 'spawn', label: 'Spawn review-task-verifiers', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Launch parallel review-task-verifier subagents (haiku). One per task.' },
-      { id: 'v1', label: 'Verify task 1', w: 140, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.08)', desc: 'Check: implementation, acceptance criteria, tests, code quality.' },
-      { id: 'v2', label: 'Verify task 2', w: 140, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.08)', desc: 'Same checks, different task. Runs in parallel.' },
-      { id: 'vn', label: 'Verify task N', w: 140, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.08)', desc: 'One per task. All run simultaneously.' },
-      { id: 'aggregate', label: 'Aggregate findings', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.12)', desc: 'Collect verifier results. Merge into structured review.' },
+      { id: 'extract', label: 'Extract ALL tasks', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'List every task from every phase. Verify all, not a sample.' },
+      { id: 'spawn', label: 'Spawn task verifiers', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Launch parallel review-task-verifier subagents (haiku). One per task.' },
+      { id: 'v1', label: 'Verify task 1', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'Check: implementation, acceptance criteria, tests, code quality.' },
+      { id: 'v2', label: 'Verify task 2', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'Same checks, different task. Runs in parallel.' },
+      { id: 'vn', label: 'Verify task N', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'One per task. All run simultaneously.' },
+      { id: 'aggregate', label: 'Aggregate findings', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Collect verifier results. Merge into structured review.' },
       { id: 'conventions', label: 'Check conventions', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Check project skills for conventions. Apply SOLID, DRY, etc.' },
-      { id: 'produce', label: 'Produce review', w: 180, h: 44, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Generate structured review: per-task verdicts, overall verdict.' },
+      { id: 'produce', label: 'Produce review', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Generate structured review: per-task verdicts, overall verdict.' },
       { id: 'end', label: 'approve / changes', shape: 'pill', w: 150, h: 40, color: 'var(--review)', bg: 'var(--review-bg)', desc: 'Output: Approve, request changes, or comments. Does NOT fix code.' },
     ],
     connections: [
@@ -1866,9 +2087,9 @@ const FLOWCHARTS = {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /status.' },
       { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations to keep workflow files in sync.' },
-      { id: 'gate-migrate', label: 'Files updated?', shape: 'diamond', w: 120, h: 120, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Check if migration scripts modified any workflow files.' },
-      { id: 'wait-review', label: 'STOP: Review changes', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Migration updated files. Pause for user to review changes before continuing.' },
-      { id: 'scan', label: 'Scan workflow directories', w: 180, h: 44, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Scan docs/workflow/ subdirectories for research, discussion, specification, planning files.' },
+      { id: 'gate-migrate', label: 'Files updated?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if migration scripts modified any workflow files.' },
+      { id: 'wait-review', label: 'STOP: Review changes', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Migration updated files. Pause for user to review changes before continuing.' },
+      { id: 'scan', label: 'Scan workflow directories', w: 200, h: 44, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Scan docs/workflow/ subdirectories for research, discussion, specification, planning files.' },
       { id: 'present', label: 'Present status table', w: 180, h: 44, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Display a table organized by topic showing progress across all 6 phases.' },
       { id: 'suggest', label: 'Suggest next steps', w: 180, h: 44, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Recommend which workflow command to run next based on current state.' },
       { id: 'end', label: 'Status output', shape: 'pill', w: 150, h: 40, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Final status overview presented to the user.' },
@@ -1887,11 +2108,11 @@ const FLOWCHARTS = {
   'view-plan': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /view-plan.' },
-      { id: 'gate-plans', label: 'Plans exist?', shape: 'diamond', w: 120, h: 120, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Check if any plan files exist in docs/workflow/planning/.' },
-      { id: 'stop', label: 'STOP: No plans', shape: 'pill', w: 150, h: 40, color: '#f43f5e', bg: 'rgba(244,63,94,0.15)', desc: 'Terminal: No plans found. Run /start-planning first.' },
-      { id: 'count', label: 'Single plan?', shape: 'diamond', w: 120, h: 120, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Check if there is exactly one plan or multiple.' },
+      { id: 'gate-plans', label: 'Plans exist?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if any plan files exist in docs/workflow/planning/.' },
+      { id: 'stop', label: 'STOP: No plans', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No plans found. Run /start-planning first.' },
+      { id: 'count', label: 'Single plan?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if there is exactly one plan or multiple.' },
       { id: 'auto', label: 'Auto-select single', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Only one plan exists. Auto-select it.' },
-      { id: 'ask', label: 'ASK: Which plan?', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Multiple plans found. Ask user which plan to view.' },
+      { id: 'ask', label: 'ASK: Which plan?', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Multiple plans found. Ask user which plan to view.' },
       { id: 'read-index', label: 'Read plan index', w: 180, h: 44, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Read the plan frontmatter and index to understand structure and format.' },
       { id: 'load-format', label: 'Load format reference', w: 180, h: 44, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Load the output format reference file based on the plan format field.' },
       { id: 'read-content', label: 'Read plan content', w: 180, h: 44, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Follow format reading instructions to read plan phases, tasks, and status.' },
@@ -1916,9 +2137,9 @@ const FLOWCHARTS = {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /migrate.' },
       { id: 'run', label: 'Run migrate.sh', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Execute scripts/migrate.sh — runs all numbered migration scripts in order. Idempotent.' },
-      { id: 'updated', label: 'Files updated?', shape: 'diamond', w: 120, h: 120, color: '#fbbf24', bg: 'rgba(251,191,36,0.15)', desc: 'Check if any migration scripts modified workflow files.' },
-      { id: 'show-changes', label: 'Show changes + review', w: 180, h: 44, color: '#a78bfa', bg: 'rgba(167,139,250,0.15)', desc: 'Display changed files and wait for user to review via git diff.' },
-      { id: 'end-updated', label: 'Changes applied', shape: 'pill', w: 150, h: 40, color: '#34d399', bg: 'rgba(52,211,153,0.15)', desc: 'Migration complete — files were updated.' },
+      { id: 'updated', label: 'Files updated?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if any migration scripts modified workflow files.' },
+      { id: 'show-changes', label: 'Show changes + review', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Display changed files and wait for user to review via git diff.' },
+      { id: 'end-updated', label: 'Changes applied', shape: 'pill', w: 150, h: 40, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Migration complete — files were updated.' },
       { id: 'end-clean', label: 'All up to date', shape: 'pill', w: 150, h: 40, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'No changes needed — all workflow files already in sync.' },
     ],
     connections: [
@@ -1929,6 +2150,15 @@ const FLOWCHARTS = {
       { from: 'show-changes', to: 'end-updated' },
     ]
   }
+};
+
+// ── Next-phase navigation mapping for skill flowcharts ──
+const SKILL_NEXT_PHASE = {
+  'skill-research':       { label: 'Next: /start-discussion',       target: 'discussion',      color: 'var(--next)', bg: 'var(--next-bg)' },
+  'skill-discussion':     { label: 'Next: /start-specification',    target: 'specification',   color: 'var(--next)', bg: 'var(--next-bg)' },
+  'skill-specification':  { label: 'Next: /start-planning',         target: 'planning',        color: 'var(--next)', bg: 'var(--next-bg)' },
+  'skill-planning':       { label: 'Next: /start-implementation',   target: 'implementation',  color: 'var(--next)', bg: 'var(--next-bg)' },
+  'skill-implementation': { label: 'Next: /start-review',           target: 'review',          color: 'var(--next)', bg: 'var(--next-bg)' },
 };
 
 // Info bar descriptions — richer content per flowchart
@@ -2037,6 +2267,241 @@ const FLOWCHART_DESCS = {
   },
 };
 
+// ── Source File Mapping (flowchart key → repo-relative path) ──
+const GITHUB_RAW_BASE = 'https://raw.githubusercontent.com/leeovery/claude-technical-workflows/main/';
+
+const SOURCE_MAP = {
+  'research':             'commands/workflow/start-research.md',
+  'discussion':           'commands/workflow/start-discussion.md',
+  'specification':        'commands/workflow/start-specification.md',
+  'planning':             'commands/workflow/start-planning.md',
+  'implementation':       'commands/workflow/start-implementation.md',
+  'review':               'commands/workflow/start-review.md',
+  'skill-research':       'skills/technical-research/SKILL.md',
+  'skill-discussion':     'skills/technical-discussion/SKILL.md',
+  'skill-specification':  'skills/technical-specification/SKILL.md',
+  'skill-planning':       'skills/technical-planning/SKILL.md',
+  'skill-implementation': 'skills/technical-implementation/SKILL.md',
+  'skill-review':         'skills/technical-review/SKILL.md',
+  'start-feature':        'commands/start-feature.md',
+  'link-deps':            'commands/link-dependencies.md',
+  'status':               'commands/workflow/status.md',
+  'view-plan':            'commands/workflow/view-plan.md',
+  'migrate':              'commands/migrate.md',
+};
+
+// ── Markdown Viewer ──
+const _mdCache = {};
+let _mdHistory = []; // [{path, scrollTop, anchor}]
+
+function openMdViewer(key, scrollAnchor) {
+  const path = SOURCE_MAP[key];
+  if (!path) return;
+  _mdHistory = [];
+  loadMdFile(path, scrollAnchor, false);
+  document.getElementById('md-viewer').classList.add('open');
+  document.getElementById('md-viewer-backdrop').classList.add('visible');
+}
+
+function closeMdViewer() {
+  document.getElementById('md-viewer').classList.remove('open');
+  document.getElementById('md-viewer-backdrop').classList.remove('visible');
+  _mdHistory = [];
+}
+
+function loadMdFile(path, anchor, isBack) {
+  const body = document.getElementById('md-viewer-body');
+  body.innerHTML = '<div class="md-viewer-loading">Loading...</div>';
+
+  if (!isBack && _mdHistory.length > 0) {
+    // Save scroll position of current page before navigating
+    const last = _mdHistory[_mdHistory.length - 1];
+    last.scrollTop = body.scrollTop;
+  }
+
+  if (!isBack) {
+    _mdHistory.push({ path, scrollTop: 0, anchor });
+  }
+
+  updateMdBreadcrumb();
+  updateMdBackButton();
+  document.getElementById('md-viewer-github').href = 'https://github.com/leeovery/claude-technical-workflows/blob/main/' + path;
+
+  const url = GITHUB_RAW_BASE + path;
+
+  if (_mdCache[path]) {
+    renderMdContent(_mdCache[path], anchor);
+    return;
+  }
+
+  fetch(url)
+    .then(r => {
+      if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+      return r.text();
+    })
+    .then(text => {
+      _mdCache[path] = text;
+      // Only render if still on this path
+      if (_mdHistory.length > 0 && _mdHistory[_mdHistory.length - 1].path === path) {
+        renderMdContent(text, anchor);
+      }
+    })
+    .catch(err => {
+      body.innerHTML = `<div class="md-viewer-error">Failed to load: ${path}<br><small>${err.message}</small></div>`;
+    });
+}
+
+function renderMdContent(raw, anchor) {
+  const body = document.getElementById('md-viewer-body');
+  // Strip YAML frontmatter
+  let content = raw;
+  if (content.startsWith('---')) {
+    const end = content.indexOf('---', 3);
+    if (end !== -1) content = content.slice(end + 3).trim();
+  }
+  body.innerHTML = marked.parse(content);
+  interceptMdLinks(body, _mdHistory[_mdHistory.length - 1].path);
+  if (anchor) {
+    setTimeout(() => scrollToMdAnchor(anchor), 50);
+  } else {
+    body.scrollTop = 0;
+  }
+}
+
+function interceptMdLinks(container, currentPath) {
+  const links = container.querySelectorAll('a');
+  const currentDir = currentPath.substring(0, currentPath.lastIndexOf('/') + 1);
+  links.forEach(a => {
+    const href = a.getAttribute('href');
+    if (!href) return;
+    // External or absolute links open in new tab
+    if (href.startsWith('http://') || href.startsWith('https://') || href.startsWith('//')) {
+      a.target = '_blank';
+      a.rel = 'noopener';
+      return;
+    }
+    // Relative .md links navigate within viewer
+    if (href.endsWith('.md') || href.includes('.md#')) {
+      a.addEventListener('click', (e) => {
+        e.preventDefault();
+        let [filePart, anchorPart] = href.split('#');
+        // Resolve relative path
+        let resolved = currentDir + filePart;
+        // Normalize ../
+        const parts = resolved.split('/');
+        const normalized = [];
+        for (const p of parts) {
+          if (p === '..') normalized.pop();
+          else if (p !== '.') normalized.push(p);
+        }
+        loadMdFile(normalized.join('/'), anchorPart || null, false);
+      });
+      a.style.cursor = 'pointer';
+    }
+  });
+}
+
+function updateMdBreadcrumb() {
+  const bc = document.getElementById('md-viewer-breadcrumb');
+  bc.innerHTML = _mdHistory.map((entry, i) => {
+    const filename = entry.path.split('/').pop();
+    if (i === _mdHistory.length - 1) {
+      return `<span class="current">${filename}</span>`;
+    }
+    return `<span onclick="mdViewerNavigateTo(${i})">${filename}</span>`;
+  }).join(' &rsaquo; ');
+}
+
+function updateMdBackButton() {
+  document.getElementById('md-viewer-back').disabled = _mdHistory.length <= 1;
+}
+
+function mdViewerBack() {
+  if (_mdHistory.length <= 1) return;
+  _mdHistory.pop();
+  const prev = _mdHistory[_mdHistory.length - 1];
+  // Re-render from cache (already visited)
+  const body = document.getElementById('md-viewer-body');
+  if (_mdCache[prev.path]) {
+    renderMdContent(_mdCache[prev.path], null);
+    setTimeout(() => { body.scrollTop = prev.scrollTop || 0; }, 50);
+  } else {
+    _mdHistory.pop(); // Remove so loadMdFile re-adds it
+    loadMdFile(prev.path, prev.anchor, false);
+  }
+  updateMdBreadcrumb();
+  updateMdBackButton();
+}
+
+function mdViewerNavigateTo(index) {
+  if (index < 0 || index >= _mdHistory.length - 1) return;
+  // Save current scroll before navigating
+  const body = document.getElementById('md-viewer-body');
+  const cur = _mdHistory[_mdHistory.length - 1];
+  cur.scrollTop = body.scrollTop;
+
+  // Trim history to target
+  _mdHistory = _mdHistory.slice(0, index + 1);
+  const target = _mdHistory[_mdHistory.length - 1];
+  if (_mdCache[target.path]) {
+    renderMdContent(_mdCache[target.path], null);
+    setTimeout(() => { body.scrollTop = target.scrollTop || 0; }, 50);
+  } else {
+    _mdHistory.pop();
+    loadMdFile(target.path, target.anchor, false);
+  }
+  updateMdBreadcrumb();
+  updateMdBackButton();
+}
+
+function scrollToMdAnchor(anchor) {
+  const body = document.getElementById('md-viewer-body');
+  // Try heading ID match first (marked.js generates slug IDs)
+  const slug = anchor.toLowerCase().replace(/[^\w]+/g, '-').replace(/^-|-$/g, '');
+  let el = body.querySelector('#' + CSS.escape(slug));
+  if (!el) el = body.querySelector('[id="' + slug + '"]');
+  // Fallback: search heading text
+  if (!el) {
+    const headings = body.querySelectorAll('h1, h2, h3, h4, h5, h6');
+    for (const h of headings) {
+      if (h.textContent.toLowerCase().includes(anchor.toLowerCase())) {
+        el = h; break;
+      }
+    }
+  }
+  // Fallback: search any text
+  if (!el) {
+    const all = body.querySelectorAll('p, li, td');
+    for (const p of all) {
+      if (p.textContent.toLowerCase().includes(anchor.toLowerCase())) {
+        el = p; break;
+      }
+    }
+  }
+  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function openMdViewerFromTooltip() {
+  const tooltip = document.getElementById('fc-tooltip');
+  const key = state.selectedFlowchart;
+  if (!key || !SOURCE_MAP[key]) return;
+  const nodeId = tooltip.dataset.nodeId;
+  const nodes = getNodes();
+  const node = nodes.find(n => n.id === nodeId);
+  let anchor = null;
+  if (node && node.desc) {
+    // Extract step number: "Step 5:" → "Step 5"
+    const stepMatch = node.desc.match(/Step\s+(\d+)/i);
+    if (stepMatch) {
+      anchor = 'step ' + stepMatch[1];
+    } else {
+      anchor = node.label;
+    }
+  }
+  hideFcTooltip();
+  openMdViewer(key, anchor);
+}
+
 // ── Rendering ──
 const svg = document.getElementById('svg-canvas');
 const canvasArea = document.getElementById('canvas-area');
@@ -2077,17 +2542,23 @@ function renderSVG() {
     fcEdgePoints = computeFlowchartLayout(state.selectedFlowchart).edgePoints;
   }
 
-  // Calculate bounds
-  let maxX = 0, maxY = 0;
+  // Calculate bounds — symmetric padding using actual min/max of all nodes
+  if (nodes.length === 0) {
+    svg.setAttribute('viewBox', '0 0 100 100');
+    svg.style.width = '100%';
+    svg.style.height = '100%';
+    svg.innerHTML = '';
+    return;
+  }
+  let minX = Infinity, minY = Infinity, maxX = 0, maxY = 0;
   nodes.forEach(n => {
-    maxX = Math.max(maxX, n.x + n.w + 40);
-    maxY = Math.max(maxY, n.y + n.h + 40);
+    minX = Math.min(minX, n.x);
+    minY = Math.min(minY, n.y);
+    maxX = Math.max(maxX, n.x + n.w);
+    maxY = Math.max(maxY, n.y + n.h);
   });
-
-  const vw = maxX + 60;
-  const vh = maxY + 60;
-
-  svg.setAttribute('viewBox', `0 0 ${vw} ${vh}`);
+  const pad = 40;
+  svg.setAttribute('viewBox', `${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`);
   svg.style.width = '100%';
   svg.style.height = '100%';
 
@@ -2219,8 +2690,16 @@ function renderSVG() {
           html += `<path d="${d}" stroke="${strokeColor}" stroke-width="1.5" fill="none" stroke-dasharray="${dashArray}" marker-end="${marker}" opacity="0.6"/>`;
         }
 
-        // Label position: use actual path midpoint instead of start/end midpoint
-        if (allPts.length % 2 === 1) {
+        // Label position along dagre path
+        if (c.label && from.shape === 'diamond') {
+          // Position label near source diamond (~30% along path)
+          const totalLen = allPts.length - 1;
+          const fracIdx = totalLen * 0.3;
+          const lo = Math.floor(fracIdx), hi = Math.min(lo + 1, allPts.length - 1);
+          const t = fracIdx - lo;
+          sx = allPts[lo].x + (allPts[hi].x - allPts[lo].x) * t;
+          sy = allPts[lo].y + (allPts[hi].y - allPts[lo].y) * t;
+        } else if (allPts.length % 2 === 1) {
           const mi = Math.floor(allPts.length / 2);
           sx = allPts[mi].x; sy = allPts[mi].y;
         } else {
@@ -2309,7 +2788,7 @@ function renderSVG() {
     const cy = n.y + n.h / 2;
     const hasDesc = isFlowchart && n.desc;
 
-    html += `<g class="svg-node" data-id="${n.id}" data-phase="${n.phase || ''}" style="cursor:${(n.phase || hasDesc) ? 'pointer' : 'default'}">`;
+    html += `<g class="svg-node" data-id="${n.id}" data-phase="${n.phase || ''}" style="cursor:${(n.phase || hasDesc || n.skillLink) ? 'pointer' : 'default'}">`;
 
     if (n.shape === 'diamond') {
       const hw = n.w / 2, hh = n.h / 2;
@@ -2330,6 +2809,9 @@ function renderSVG() {
     } else if (n.shape === 'pill') {
       const pillR = n.h / 2;
       html += `<rect x="${n.x}" y="${n.y}" width="${n.w}" height="${n.h}" rx="${pillR}" fill="${n.bg}" stroke="${n.color}" stroke-width="${strokeW}" stroke-opacity="${strokeOpacity}"/>`;
+      html += `<text x="${cx}" y="${cy + 4}" fill="${n.color}" font-size="11" font-weight="600" text-anchor="middle" font-family="-apple-system,system-ui,sans-serif">${n.label}</text>`;
+    } else if (n.shape === 'stop') {
+      html += `<rect x="${n.x}" y="${n.y}" width="${n.w}" height="${n.h}" rx="3" fill="${n.bg}" stroke="${n.color}" stroke-width="${strokeW}" stroke-opacity="${strokeOpacity}"/>`;
       html += `<text x="${cx}" y="${cy + 4}" fill="${n.color}" font-size="11" font-weight="600" text-anchor="middle" font-family="-apple-system,system-ui,sans-serif">${n.label}</text>`;
     } else {
       html += `<rect x="${n.x}" y="${n.y}" width="${n.w}" height="${n.h}" rx="${radius}" fill="${n.bg}" stroke="${n.color}" stroke-width="${strokeW}" stroke-opacity="${strokeOpacity}"/>`;
@@ -2385,6 +2867,10 @@ function showFcTooltip(nodeId, gEl) {
   tooltip.style.borderColor = node.color;
   tooltip.dataset.nodeId = nodeId;
 
+  // Show/hide source button based on whether flowchart has a source file
+  const sourceBtn = document.getElementById('fc-tooltip-source');
+  sourceBtn.style.display = (state.selectedFlowchart && SOURCE_MAP[state.selectedFlowchart]) ? 'inline-block' : 'none';
+
   // Position tooltip close to the clicked node (prefer above, fallback below/side)
   const svgRect = svg.getBoundingClientRect();
   const vb = svg.getAttribute('viewBox').split(' ').map(Number);
@@ -2433,6 +2919,9 @@ canvasArea.addEventListener('click', (e) => {
   }
 });
 
+// Close md-viewer via backdrop click
+document.getElementById('md-viewer-backdrop').addEventListener('click', closeMdViewer);
+
 // ── Interaction ──
 function showOverview() {
   state.view = 'overview';
@@ -2444,6 +2933,7 @@ function showOverview() {
 
   document.getElementById('detail-panel').classList.remove('open');
   hideFcTooltip();
+  closeMdViewer();
   _layoutCache = {};
 
   document.getElementById('legend-default').style.display = '';
@@ -2459,6 +2949,7 @@ function showOverview() {
 
 function selectPhase(phase) {
   if (isMobile()) closeSidebar();
+  closeMdViewer();
   if (!_navigatingFromHash) location.hash = phase;
 
   // If it has a flowchart, show it
@@ -2534,7 +3025,7 @@ function resetZoom() {
 
 // Mouse wheel zoom
 canvasArea.addEventListener('wheel', (e) => {
-  if (e.target.closest('.detail-panel')) return;
+  if (e.target.closest('.detail-panel') || e.target.closest('.md-viewer')) return;
   e.preventDefault();
   const factor = e.deltaY < 0 ? 1.03 : 1/1.03;
   zoom(factor);
@@ -2543,7 +3034,7 @@ canvasArea.addEventListener('wheel', (e) => {
 // Pan
 let isPanning = false, panStart = { x: 0, y: 0 }, vbStart = [0,0,0,0];
 canvasArea.addEventListener('mousedown', (e) => {
-  if (e.target.closest('.svg-node') || e.target.closest('.detail-panel')) return;
+  if (e.target.closest('.svg-node') || e.target.closest('.detail-panel') || e.target.closest('.md-viewer')) return;
   isPanning = true;
   panStart = { x: e.clientX, y: e.clientY };
   vbStart = svg.getAttribute('viewBox').split(' ').map(Number);
@@ -2575,7 +3066,7 @@ function touchMidpoint(t) {
 }
 
 canvasArea.addEventListener('touchstart', (e) => {
-  if (e.target.closest('.detail-panel') || e.target.closest('.zoom-controls')) return;
+  if (e.target.closest('.detail-panel') || e.target.closest('.zoom-controls') || e.target.closest('.md-viewer')) return;
   const t = e.touches;
   if (t.length === 2) {
     // Start pinch
@@ -2593,7 +3084,7 @@ canvasArea.addEventListener('touchstart', (e) => {
 }, { passive: true });
 
 canvasArea.addEventListener('touchmove', (e) => {
-  if (e.target.closest('.detail-panel') || e.target.closest('.zoom-controls')) return;
+  if (e.target.closest('.detail-panel') || e.target.closest('.zoom-controls') || e.target.closest('.md-viewer')) return;
   e.preventDefault();
   const t = e.touches;
   if (pinching && t.length === 2) {
@@ -2632,8 +3123,11 @@ function updatePrompt() {
     const name = p ? p.label : state.selectedFlowchart;
     const cmd = p ? p.cmd : '/' + state.selectedFlowchart;
 
+    const hasSource = !!SOURCE_MAP[state.selectedFlowchart];
+    const sourceBtn = hasSource ? ` <button class="view-source-btn" onclick="openMdViewer('${state.selectedFlowchart}')">&lt;/&gt; Source</button>` : '';
+
     if (desc && typeof desc === 'object') {
-      let html = `<div class="info-title">${name}</div>`;
+      let html = `<div class="info-title">${name}${sourceBtn}</div>`;
       html += `<div class="info-subtitle">${cmd}</div>`;
       html += `<div class="info-body">${desc.summary ? `<p><strong>${desc.summary}</strong></p>` : ''}${desc.body || ''}</div>`;
       if (desc.meta) {
@@ -2647,7 +3141,7 @@ function updatePrompt() {
       }
       bar.innerHTML = html;
     } else {
-      bar.innerHTML = `<div class="info-title">${name}</div><div class="info-subtitle">${cmd}</div><div class="info-body">${desc || ''}</div>`;
+      bar.innerHTML = `<div class="info-title">${name}${sourceBtn}</div><div class="info-subtitle">${cmd}</div><div class="info-body">${desc || ''}</div>`;
     }
     bar.scrollTop = 0;
     return;

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -10,16 +10,16 @@
     FLOWCHARTS           — node/connection definitions per phase/skill/command (dagre-compatible: w/h, no x/y)
     OVERVIEW_NODES       — hand-positioned nodes for the top-level pipeline view
     OVERVIEW_CONNECTIONS — connections between overview nodes
-    phases               — metadata per phase (color, cmd, label, complexity, detailHTML, etc.)
+    phases               — metadata per phase (color, cmd, label, complexity, etc.)
     FLOWCHART_DESCS      — rich descriptions shown in the info bar
     SKILL_NEXT_PHASE     — maps skill flowchart keys to their next workflow phase (label, target, color)
     SOURCE_MAP           — maps flowchart keys to repo-relative source file paths for markdown viewer
 
   Navigation model:
-    Sidebar-driven. Three view functions + markdown viewer:
+    Sidebar-driven. Two view functions + markdown viewer + info panel:
       showOverview()        — pipeline view (OVERVIEW_NODES)
-      selectPhase(phase)    — flowchart view (FLOWCHARTS[phase]) or detail panel (utility commands)
-      closeDetail()         — dismiss the slide-over detail panel
+      selectPhase(phase)    — flowchart view (FLOWCHARTS[phase])
+      openInfoPanel()       — open info slide-over for current flowchart
       openMdViewer(key)     — open markdown viewer for a flowchart's source file
 
   Markdown viewer:
@@ -29,8 +29,8 @@
     In-memory _mdCache for fetched content. Opened via "Source" button in info bar or </> in tooltip.
 
   Layout:
-    CSS grid: 300px sidebar + flexible canvas area. Detail panel slides over canvas (absolute positioned).
-    Prompt bar spans below the canvas. Sidebar spans both rows.
+    CSS grid: 300px sidebar + flexible canvas area. Info panel slides over canvas (fixed positioned).
+    Canvas takes full height. Sidebar fixed overlay with margin push.
 
   Rendering:
     renderSVG() draws all views into <svg id="svg-canvas">.
@@ -59,16 +59,16 @@
   Conventions:
     - Clicking flowchart nodes with `desc` shows a tooltip; nodes with `skillLink` navigate to that skill's flowchart.
     - Overview nodes with `phase` are clickable and route to selectPhase().
-    - The prompt bar shows contextual info and is copy-able.
+    - The info panel (ⓘ button) shows contextual info for the current flowchart.
     - Skill flowcharts (except skill-review) have a `next` pill node at the end, always green (#34d399),
       connected from `end` via `type: 'transition'`, using `skillLink` for navigation.
     - SOURCE_MAP must be updated when source files are renamed or added.
 
   Key sections (search terms):
-    CSS:         "/* Info bar */"  "/* Markdown viewer */"  "/* View Source */"
+    CSS:         "/* Info panel */"  "/* Markdown viewer */"
     Data:        "const FLOWCHARTS"  "const SOURCE_MAP"  "const SKILL_NEXT_PHASE"  "const FLOWCHART_DESCS"
     Rendering:   "function renderSVG"  "function computeFlowchartLayout"
-    Interaction: "function showFcTooltip"  "function updatePrompt"  "function openMdViewer"
+    Interaction: "function showFcTooltip"  "function openInfoPanel"  "function openMdViewer"
 -->
 <html lang="en">
 <head>
@@ -125,7 +125,7 @@
   .layout {
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr auto;
+    grid-template-rows: 1fr;
     height: 100vh;
   }
   /* Sidebar — fixed overlay, pushes content via margin */
@@ -155,6 +155,8 @@
     color: var(--text-dim);
     margin-bottom: 16px;
   }
+  .sidebar { scrollbar-width: none; }
+  .sidebar::-webkit-scrollbar { display: none; }
   .section-label {
     font-size: 10px;
     text-transform: uppercase;
@@ -162,50 +164,101 @@
     color: var(--text-dim);
     margin: 16px 0 8px;
     font-weight: 600;
-  }
-  /* Phase buttons in sidebar */
-  .phase-btn {
     display: flex;
     align-items: center;
-    gap: 10px;
-    width: 100%;
-    padding: 10px 12px;
-    border: 1px solid var(--border);
-    border-radius: 8px;
-    background: var(--surface2);
-    color: var(--text);
-    cursor: pointer;
-    font-size: 13px;
-    margin-bottom: 6px;
-    transition: all 0.15s;
-    text-align: left;
+    gap: 6px;
   }
-  .phase-btn:hover { border-color: var(--accent); }
-  .phase-btn.active { border-color: var(--accent); background: rgba(108,138,255,0.1); }
-  .phase-btn .dot {
-    width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
-  }
-  .phase-btn .phase-name { font-weight: 600; }
-  .phase-btn .phase-cmd { font-size: 11px; color: var(--text-dim); font-family: monospace; }
+  .section-label.collapsible { cursor: pointer; user-select: none; }
+  .section-label.collapsible:hover { color: var(--text); }
+  .section-label .chevron { font-size: 8px; transition: transform 0.15s; display: inline-block; }
+  .section-label.collapsed .chevron { transform: rotate(-90deg); }
+  .collapsible-content { overflow: hidden; transition: max-height 0.25s ease; }
+  .collapsible-content.collapsed { max-height: 0 !important; }
 
-  /* Standalone/Utility buttons */
-  .cmd-btn {
-    display: block;
-    width: 100%;
-    padding: 8px 12px;
-    border: 1px solid var(--border);
-    border-radius: 6px;
-    background: var(--surface2);
-    color: var(--text);
-    cursor: pointer;
-    font-size: 12px;
-    margin-bottom: 4px;
-    text-align: left;
-    transition: all 0.15s;
-    font-family: monospace;
+  /* Timeline pipeline */
+  .tl-wrapper { position: relative; padding-left: 24px; }
+  .tl-group { position: relative; margin-bottom: 2px; }
+  .tl-group:not(:last-child)::after {
+    content: ''; position: absolute; left: -16px; top: 14px; bottom: -3px;
+    width: 2px; background: var(--border); z-index: 0;
   }
-  .cmd-btn:hover { border-color: var(--accent); }
-  .cmd-btn.active { border-color: var(--accent); background: rgba(108,138,255,0.1); }
+  .tl-group:not(:first-child)::before {
+    content: ''; position: absolute; left: -16px; top: -1px; height: 17px;
+    width: 2px; background: var(--border); z-index: 0;
+  }
+  .tl-dot {
+    position: absolute; left: -21px; top: 9px;
+    width: 12px; height: 12px; border-radius: 50%;
+    border: 2px solid var(--surface); z-index: 1;
+  }
+  .tl-cmd {
+    display: flex; align-items: center; gap: 10px; width: 100%;
+    padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px;
+    background: var(--surface2); color: var(--text); cursor: pointer;
+    font-size: 13px; transition: all 0.15s; text-align: left; margin-bottom: 2px;
+  }
+  .tl-cmd:hover { border-color: var(--accent); }
+  .tl-cmd.active { border-color: var(--accent); background: rgba(108,138,255,0.1); }
+  .tl-cmd .name { font-weight: 600; font-size: 12px; flex: 1; }
+  .tl-skill {
+    display: flex; align-items: center; gap: 6px;
+    width: calc(100% - 16px); margin-left: 16px;
+    padding: 5px 8px; border: 1px solid var(--border); border-radius: 5px;
+    background: transparent; color: var(--text-dim); cursor: pointer;
+    font-size: 11px; font-family: monospace; margin-bottom: 4px; margin-top: 1px;
+    transition: all 0.15s; text-align: left; position: relative;
+  }
+  .tl-skill:hover { border-color: var(--accent); color: var(--text); background: var(--surface2); }
+  .tl-skill.active { border-color: var(--accent); color: var(--text); background: rgba(108,138,255,0.1); }
+  .tl-skill::before {
+    content: ''; position: absolute; left: -10px; top: 50%;
+    width: 7px; height: 1px; background: var(--border);
+  }
+  .tl-skill::after {
+    content: ''; position: absolute; left: -10px; top: -3px;
+    width: 1px; height: calc(50% + 3px); background: var(--border);
+  }
+  .tl-skill .skill-label { flex: 1; }
+
+  /* Badges */
+  .badge {
+    font-size: 8px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.5px; padding: 2px 5px; border-radius: 3px; flex-shrink: 0;
+    font-family: -apple-system, system-ui, sans-serif;
+  }
+  .badge-cmd { background: rgba(108,138,255,0.15); color: var(--accent); }
+  .badge-skl { background: rgba(249,115,22,0.15); color: #f97316; }
+  .badge-agt { background: rgba(34,211,238,0.15); color: #22d3ee; }
+
+  /* Dropdown items */
+  .dropdown-btn {
+    display: flex; align-items: center; gap: 8px; width: 100%;
+    padding: 7px 10px; border: 1px solid var(--border); border-radius: 6px;
+    background: var(--surface2); color: var(--text); cursor: pointer;
+    font-size: 12px; margin-bottom: 4px; text-align: left;
+    transition: all 0.15s; font-family: monospace;
+  }
+  .dropdown-btn:hover { border-color: var(--accent); }
+  .dropdown-btn.active { border-color: var(--accent); background: rgba(108,138,255,0.1); }
+  .dropdown-btn .btn-label { flex: 1; }
+  .dropdown-subheading {
+    font-size: 9px; text-transform: uppercase; letter-spacing: 1px;
+    color: var(--text-dim); margin: 10px 0 6px; font-weight: 600; opacity: 0.7;
+  }
+  .dropdown-subheading:first-child { margin-top: 4px; }
+
+  /* Sidebar footer */
+  .sidebar-footer {
+    position: sticky; bottom: -16px;
+    margin: 20px -16px -16px; padding: 10px 16px 14px;
+    border-top: 1px solid var(--border); background: var(--surface);
+    text-align: center; font-size: 11px; color: var(--text-dim);
+    line-height: 1.6; z-index: 2;
+  }
+  .sidebar-footer a { color: var(--text-dim); text-decoration: none; transition: color 0.15s; }
+  .sidebar-footer a:hover { color: var(--accent); }
+  .sidebar-footer .repo-link { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; margin-bottom: 4px; }
+  .sidebar-footer .credit { font-size: 10px; opacity: 0.7; }
 
   /* Legend */
   .legend { margin-top: 16px; }
@@ -238,7 +291,7 @@
   .legend-shape-pill {
     width: 24px; height: 12px; border-radius: 6px; border: 1px solid;
   }
-  .cmd-btn.dimmed, .phase-btn.dimmed {
+  .nav-btn.dimmed {
     opacity: 0.35;
     pointer-events: none;
   }
@@ -263,16 +316,14 @@
   .sidebar-toggle:hover { border-color: var(--accent); }
 
   /* Sidebar collapse — fixed sidebar + margin push on content */
-  .layout .canvas-area,
-  .layout .prompt-bar {
+  .layout .canvas-area {
     margin-left: 300px;
     transition: margin-left 0.2s ease;
   }
   .layout.sidebar-collapsed .sidebar {
     transform: translateX(-300px);
   }
-  .layout.sidebar-collapsed .canvas-area,
-  .layout.sidebar-collapsed .prompt-bar {
+  .layout.sidebar-collapsed .canvas-area {
     margin-left: 0;
   }
 
@@ -290,8 +341,7 @@
 
   /* Mobile — pure overlay, no margin push */
   @media (max-width: 768px) {
-    .layout .canvas-area,
-    .layout .prompt-bar {
+    .layout .canvas-area {
       margin-left: 0;
     }
   }
@@ -308,256 +358,13 @@
     height: 100%;
   }
 
-  /* Info bar */
-  .prompt-bar {
-    grid-column: 1;
-    background: var(--surface);
-    border-top: 1px solid var(--border);
-    padding: 16px 20px 40px;
-    height: 180px;
-    overflow-y: auto;
-  }
-  .prompt-bar .info-title {
-    display: flex;
-    align-items: center;
-    font-size: 14px;
-    font-weight: 700;
-    color: var(--text);
-    margin-bottom: 4px;
-  }
-  .prompt-bar .info-subtitle {
-    font-size: 11px;
-    color: var(--text-dim);
-    font-family: 'SF Mono', 'Fira Code', monospace;
-    margin-bottom: 10px;
-  }
-  .prompt-bar .info-body {
-    font-size: 12.5px;
-    color: var(--text-dim);
-    line-height: 1.6;
-  }
-  .prompt-bar .info-body p {
-    margin-bottom: 6px;
-  }
-  .prompt-bar .info-body strong {
-    color: var(--text);
-    font-weight: 600;
-  }
-  .prompt-bar .info-body code {
-    font-family: 'SF Mono', 'Fira Code', monospace;
-    font-size: 11px;
-    background: var(--surface2);
-    padding: 1px 5px;
-    border-radius: 3px;
-    color: var(--accent);
-  }
-  .prompt-bar .info-meta {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-    margin-top: 8px;
-    padding-top: 8px;
-    border-top: 1px solid var(--border);
-    font-size: 11px;
-    color: var(--text-dim);
-  }
-  .prompt-bar .info-meta span {
-    white-space: nowrap;
-  }
-  .prompt-bar .info-meta strong {
-    color: var(--text);
-    font-weight: 600;
-  }
 
-  /* Detail panel (overlays canvas) */
-  .detail-panel {
-    position: absolute;
-    top: 0; right: 0;
-    width: 420px;
-    height: 100%;
-    background: var(--surface);
-    border-left: 1px solid var(--border);
-    overflow-y: auto;
-    padding: 20px;
-    transform: translateX(100%);
-    transition: transform 0.2s ease;
-    z-index: 10;
-  }
-  .detail-panel.open { transform: translateX(0); }
-  .detail-close {
-    position: absolute;
-    top: 12px; right: 12px;
-    background: none; border: none;
-    color: var(--text-dim);
-    cursor: pointer;
-    font-size: 18px;
-  }
-  .detail-close:hover { color: var(--text); }
-  .detail-panel h2 {
-    font-size: 16px;
-    margin-bottom: 4px;
-  }
-  .detail-panel .detail-subtitle {
-    font-size: 12px;
-    color: var(--text-dim);
-    margin-bottom: 16px;
-    font-family: monospace;
-  }
-  .detail-section {
-    margin-bottom: 16px;
-  }
-  .detail-section h3 {
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--text-dim);
-    margin-bottom: 8px;
-    font-weight: 600;
-  }
-  .detail-section p, .detail-section li {
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--text);
-  }
-  .detail-section ul {
-    list-style: none;
-    padding: 0;
-  }
-  .detail-section li {
-    padding: 4px 0;
-    padding-left: 16px;
-    position: relative;
-  }
-  .detail-section li::before {
-    content: ''; position: absolute; left: 0; top: 11px;
-    width: 6px; height: 6px; border-radius: 50%;
-    background: var(--accent);
-  }
 
-  /* Flow diagram elements */
-  .flow-box {
-    padding: 6px 10px;
-    border-radius: 4px;
-    font-size: 11px;
-    font-weight: 600;
-    display: inline-block;
-    margin: 2px 0;
-  }
-
-  /* Routing table in detail panel */
-  .routing-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 12px;
-    margin-top: 8px;
-  }
-  .routing-table th {
-    text-align: left;
-    padding: 6px 8px;
-    background: var(--surface2);
-    color: var(--text-dim);
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    border-bottom: 1px solid var(--border);
-  }
-  .routing-table td {
-    padding: 6px 8px;
-    border-bottom: 1px solid var(--border);
-    color: var(--text);
-    vertical-align: top;
-  }
-  .routing-table tr:last-child td { border-bottom: none; }
-  .scenario-tag {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-size: 11px;
-    font-family: monospace;
-    font-weight: 600;
-  }
-  .tag-stop { background: rgba(244,63,94,0.2); color: #f87171; }
-  .tag-auto { background: rgba(52,211,153,0.2); color: #34d399; }
-  .tag-ask { background: rgba(251,191,36,0.2); color: #fbbf24; }
-  .tag-route { background: rgba(96,165,250,0.2); color: #60a5fa; }
-  .tag-gate { background: rgba(249,115,22,0.2); color: #f97316; }
-
-  /* Gate indicator */
-  .gate-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 3px 8px;
-    border-radius: 4px;
-    font-size: 11px;
-    font-weight: 600;
-    background: rgba(244,63,94,0.15);
-    color: #f87171;
-    margin: 2px 0;
-  }
-  .gate-badge::before {
-    content: ''; width:8px; height:8px; border-radius:50%;
-    background: #f43f5e; display: inline-block;
-  }
-
-  /* Step flow in detail */
-  .step-flow {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    margin-top: 8px;
-  }
-  .step-item {
-    display: flex;
-    align-items: flex-start;
-    gap: 10px;
-    padding: 6px 0;
-    font-size: 12px;
-  }
-  .step-num {
-    width: 22px; height: 22px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 10px;
-    font-weight: 700;
-    flex-shrink: 0;
-    border: 1px solid var(--border);
-    color: var(--text-dim);
-  }
-  .step-num.migration { background: rgba(108,138,255,0.2); color: var(--accent); border-color: var(--accent); }
-  .step-num.discovery { background: rgba(52,211,153,0.2); color: #34d399; border-color: #34d399; }
-  .step-num.gate { background: rgba(244,63,94,0.2); color: #f87171; border-color: #f43f5e; }
-  .step-num.route { background: rgba(251,191,36,0.2); color: #fbbf24; border-color: #fbbf24; }
-  .step-num.gather { background: rgba(167,139,250,0.2); color: #a78bfa; border-color: #a78bfa; }
-  .step-num.skill { background: rgba(249,115,22,0.2); color: #f97316; border-color: #f97316; }
-  .step-text { line-height: 1.5; color: var(--text); }
-  .step-text code {
-    font-family: 'SF Mono', monospace;
-    font-size: 11px;
-    background: var(--surface2);
-    padding: 1px 5px;
-    border-radius: 3px;
-    color: var(--accent);
-  }
-
-  /* File path display */
-  .file-path {
-    font-family: 'SF Mono', monospace;
-    font-size: 11px;
-    color: var(--accent);
-    background: var(--surface2);
-    padding: 4px 8px;
-    border-radius: 4px;
-    display: inline-block;
-    margin: 2px 0;
-  }
 
   /* Zoom controls */
   .zoom-controls {
     position: absolute;
-    bottom: 16px; left: 16px;
+    bottom: 12px; left: 12px;
     display: flex;
     gap: 4px;
     z-index: 5;
@@ -575,6 +382,8 @@
     font-size: 16px;
   }
   .zoom-btn:hover { border-color: var(--accent); }
+  .zoom-btn-context { margin-left: 4px; }
+  .zoom-btn-context.disabled { opacity: 0.3; pointer-events: none; }
   @media (max-width: 768px) {
     .zoom-btn { width: 44px; height: 44px; font-size: 20px; }
     .zoom-controls { gap: 6px; }
@@ -640,6 +449,129 @@
     font-size: 12px;
     line-height: 1.5;
     color: var(--text-dim);
+  }
+
+  /* Info panel slide-over */
+  .info-panel-backdrop {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.2);
+    z-index: 29;
+  }
+  .info-panel-backdrop.visible { display: block; }
+  .info-panel {
+    position: fixed;
+    top: 0; right: 0;
+    width: 420px;
+    height: 100vh;
+    background: var(--surface);
+    border-left: 1px solid var(--border);
+    transform: translateX(100%);
+    transition: transform 0.2s ease;
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    touch-action: pan-y;
+    overscroll-behavior: contain;
+  }
+  .info-panel.open { transform: translateX(0); }
+  .info-panel-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+  }
+  .info-panel-title {
+    flex: 1;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text);
+  }
+  .info-panel-close {
+    background: none; border: none;
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 18px;
+    padding: 4px 8px;
+    flex-shrink: 0;
+  }
+  .info-panel-close:hover { color: var(--text); }
+  .info-panel-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px 40px;
+  }
+  .info-panel-body .info-subtitle {
+    font-size: 11px;
+    color: var(--text-dim);
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    margin-bottom: 14px;
+  }
+  .info-panel-body .info-summary {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1.6;
+    margin-bottom: 12px;
+  }
+  .info-panel-body .info-desc {
+    font-size: 12.5px;
+    color: var(--text-dim);
+    line-height: 1.6;
+  }
+  .info-panel-body .info-desc p {
+    margin-bottom: 8px;
+  }
+  .info-panel-body .info-desc strong {
+    color: var(--text);
+    font-weight: 600;
+  }
+  .info-panel-body .info-desc code {
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    background: var(--surface2);
+    padding: 1px 5px;
+    border-radius: 3px;
+    color: var(--accent);
+  }
+  .info-panel-body .info-meta {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px solid var(--border);
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+  .info-panel-body .info-meta span {
+    white-space: nowrap;
+  }
+  .info-panel-body .info-meta strong {
+    color: var(--text);
+    font-weight: 600;
+  }
+  .info-panel-source-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 16px;
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface2);
+    color: var(--text-dim);
+    cursor: pointer;
+    font-size: 12px;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    transition: all 0.15s;
+  }
+  .info-panel-source-btn:hover { border-color: var(--accent); color: var(--text); }
+  @media (max-width: 768px) {
+    .info-panel { width: 100%; }
   }
 
   /* Markdown viewer slide-over */
@@ -779,24 +711,6 @@
     .md-viewer { width: 100%; }
   }
 
-  /* View Source button in info bar */
-  .view-source-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 2px 8px;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--surface2);
-    color: var(--text-dim);
-    cursor: pointer;
-    font-size: 11px;
-    font-family: 'SF Mono', 'Fira Code', monospace;
-    margin-left: auto;
-    flex-shrink: 0;
-  }
-  .view-source-btn:hover { border-color: var(--accent); color: var(--text); }
-
   /* Source button in tooltip */
   .fc-tooltip-source {
     position: absolute;
@@ -823,89 +737,107 @@
     <h1>Technical Workflows</h1>
     <div class="subtitle">Interactive architecture explorer</div>
 
-    <button class="nav-overview active" onclick="showOverview()" id="btn-overview">Overview</button>
+    <button class="nav-overview active nav-btn" onclick="showOverview()" id="btn-overview">Overview</button>
 
-    <div class="section-label">Workflow Phases</div>
-    <button class="phase-btn" onclick="selectPhase('research')" id="btn-research">
-      <div class="dot" style="background:var(--research)"></div>
-      <div><div class="phase-name">1. Research</div><div class="phase-cmd">/start-research</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('discussion')" id="btn-discussion">
-      <div class="dot" style="background:var(--discussion)"></div>
-      <div><div class="phase-name">2. Discussion</div><div class="phase-cmd">/start-discussion</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('specification')" id="btn-specification">
-      <div class="dot" style="background:var(--specification)"></div>
-      <div><div class="phase-name">3. Specification</div><div class="phase-cmd">/start-specification</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('planning')" id="btn-planning">
-      <div class="dot" style="background:var(--planning)"></div>
-      <div><div class="phase-name">4. Planning</div><div class="phase-cmd">/start-planning</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('implementation')" id="btn-implementation">
-      <div class="dot" style="background:var(--implementation)"></div>
-      <div><div class="phase-name">5. Implementation</div><div class="phase-cmd">/start-implementation</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('review')" id="btn-review">
-      <div class="dot" style="background:var(--review)"></div>
-      <div><div class="phase-name">6. Review</div><div class="phase-cmd">/start-review</div></div>
-    </button>
-
-    <div class="section-label">Skills</div>
-    <button class="phase-btn" onclick="selectPhase('skill-research')" id="btn-skill-research">
-      <div class="dot" style="background:var(--research)"></div>
-      <div><div class="phase-name">Research</div><div class="phase-cmd">technical-research</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('skill-discussion')" id="btn-skill-discussion">
-      <div class="dot" style="background:var(--discussion)"></div>
-      <div><div class="phase-name">Discussion</div><div class="phase-cmd">technical-discussion</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('skill-specification')" id="btn-skill-specification">
-      <div class="dot" style="background:var(--specification)"></div>
-      <div><div class="phase-name">Specification</div><div class="phase-cmd">technical-specification</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('skill-planning')" id="btn-skill-planning">
-      <div class="dot" style="background:var(--planning)"></div>
-      <div><div class="phase-name">Planning</div><div class="phase-cmd">technical-planning</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('skill-implementation')" id="btn-skill-implementation">
-      <div class="dot" style="background:var(--implementation)"></div>
-      <div><div class="phase-name">Implementation</div><div class="phase-cmd">technical-implementation</div></div>
-    </button>
-    <button class="phase-btn" onclick="selectPhase('skill-review')" id="btn-skill-review">
-      <div class="dot" style="background:var(--review)"></div>
-      <div><div class="phase-name">Review</div><div class="phase-cmd">technical-review</div></div>
-    </button>
-
-    <div class="section-label">Standalone Commands</div>
-    <button class="cmd-btn" onclick="selectPhase('start-feature')" id="btn-start-feature">/start-feature</button>
-    <button class="cmd-btn" onclick="selectPhase('link-deps')" id="btn-link-deps">/link-dependencies</button>
-
-    <div class="section-label">Utility</div>
-    <button class="cmd-btn" onclick="selectPhase('status')" id="btn-status">/status</button>
-    <button class="cmd-btn" onclick="selectPhase('view-plan')" id="btn-view-plan">/view-plan</button>
-    <button class="cmd-btn" onclick="selectPhase('migrate')" id="btn-migrate">/migrate</button>
-
-    <div class="section-label">Legend</div>
-    <div class="legend legend-default" id="legend-default">
-      <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:var(--accent)"></div></div> Phase flow</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-line dashed" style="background:#818cf8"></div></div> Shortcut entry</div>
-      <div class="legend-item" style="font-size:10px;color:var(--text-dim);margin-top:6px">Click any phase to view its flowchart</div>
+    <div class="section-label collapsible" onclick="toggleSidebarSection(this)"><span class="chevron">▼</span> Workflow Pipeline</div>
+    <div class="collapsible-content" style="max-height:800px">
+      <div class="tl-wrapper">
+        <div class="tl-group"><div class="tl-dot" style="background:var(--research)"></div>
+          <button class="nav-btn tl-cmd" onclick="selectPhase('research',this)" id="btn-research"><span class="name">1. Research</span><span class="badge badge-cmd">cmd</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-research',this)" id="btn-skill-research"><span class="skill-label">technical-research</span><span class="badge badge-skl">skl</span></button>
+        </div>
+        <div class="tl-group"><div class="tl-dot" style="background:var(--discussion)"></div>
+          <button class="nav-btn tl-cmd" onclick="selectPhase('discussion',this)" id="btn-discussion"><span class="name">2. Discussion</span><span class="badge badge-cmd">cmd</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-discussion',this)" id="btn-skill-discussion"><span class="skill-label">technical-discussion</span><span class="badge badge-skl">skl</span></button>
+        </div>
+        <div class="tl-group"><div class="tl-dot" style="background:var(--specification)"></div>
+          <button class="nav-btn tl-cmd" onclick="selectPhase('specification',this)" id="btn-specification"><span class="name">3. Specification</span><span class="badge badge-cmd">cmd</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-specification',this)" id="btn-skill-specification"><span class="skill-label">technical-specification</span><span class="badge badge-skl">skl</span></button>
+        </div>
+        <div class="tl-group"><div class="tl-dot" style="background:var(--planning)"></div>
+          <button class="nav-btn tl-cmd" onclick="selectPhase('planning',this)" id="btn-planning"><span class="name">4. Planning</span><span class="badge badge-cmd">cmd</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-planning',this)" id="btn-skill-planning"><span class="skill-label">technical-planning</span><span class="badge badge-skl">skl</span></button>
+        </div>
+        <div class="tl-group"><div class="tl-dot" style="background:var(--implementation)"></div>
+          <button class="nav-btn tl-cmd" onclick="selectPhase('implementation',this)" id="btn-implementation"><span class="name">5. Implementation</span><span class="badge badge-cmd">cmd</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-implementation',this)" id="btn-skill-implementation"><span class="skill-label">technical-implementation</span><span class="badge badge-skl">skl</span></button>
+        </div>
+        <div class="tl-group"><div class="tl-dot" style="background:var(--review)"></div>
+          <button class="nav-btn tl-cmd" onclick="selectPhase('review',this)" id="btn-review"><span class="name">6. Review</span><span class="badge badge-cmd">cmd</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-review',this)" id="btn-skill-review"><span class="skill-label">technical-review</span><span class="badge badge-skl">skl</span></button>
+        </div>
+      </div>
     </div>
-    <div class="legend legend-flowchart" id="legend-flowchart" style="display:none">
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:rgba(108,138,255,0.15);border-color:var(--accent)"></div></div> Start / End</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--action-bg);border-color:var(--action)"></div></div> Action step</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--surface2);border-color:var(--text-dim)"></div></div> Support / utility</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-diamond" style="background:var(--routing-bg);border-color:var(--routing)"></div></div> Decision branch</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--gate-bg);border-color:var(--gate);border-radius:3px"></div></div> STOP / BLOCK</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--ask-bg);border-color:var(--ask)"></div></div> User interaction</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--discovery-bg);border-color:var(--discovery)"></div></div> Discovery script</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:var(--skill-bg);border-color:var(--skill)"></div></div> Skill handoff</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:var(--next-bg);border-color:var(--next)"></div></div> Next phase</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:#34d399"></div></div> Yes branch</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:#f43f5e"></div></div> No branch</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-line dashed" style="background:repeating-linear-gradient(90deg, #f97316 0 6px, transparent 6px 10px)"></div></div> Skill transition</div>
-      <div class="legend-item"><div class="legend-icon"><div class="legend-line dashed" style="background:repeating-linear-gradient(90deg, #6b7280 0 6px, transparent 6px 10px)"></div></div> Back-loop</div>
+
+    <div class="section-label collapsible" onclick="toggleSidebarSection(this)"><span class="chevron">▼</span> Skills</div>
+    <div class="collapsible-content" style="max-height:1200px">
+      <div class="dropdown-subheading">Workflow Orchestrators</div>
+      <button class="nav-btn dropdown-btn" data-phase="research" onclick="selectPhase('research',this)"><span class="badge badge-skl">skl</span><span class="btn-label">start-research</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="discussion" onclick="selectPhase('discussion',this)"><span class="badge badge-skl">skl</span><span class="btn-label">start-discussion</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="specification" onclick="selectPhase('specification',this)"><span class="badge badge-skl">skl</span><span class="btn-label">start-specification</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="planning" onclick="selectPhase('planning',this)"><span class="badge badge-skl">skl</span><span class="btn-label">start-planning</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="implementation" onclick="selectPhase('implementation',this)"><span class="badge badge-skl">skl</span><span class="btn-label">start-implementation</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="review" onclick="selectPhase('review',this)"><span class="badge badge-skl">skl</span><span class="btn-label">start-review</span></button>
+      <div class="dropdown-subheading">Workflow Skills</div>
+      <button class="nav-btn dropdown-btn" data-phase="skill-research" onclick="selectPhase('skill-research',this)"><span class="badge badge-skl">skl</span><span class="btn-label">technical-research</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="skill-discussion" onclick="selectPhase('skill-discussion',this)"><span class="badge badge-skl">skl</span><span class="btn-label">technical-discussion</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="skill-specification" onclick="selectPhase('skill-specification',this)"><span class="badge badge-skl">skl</span><span class="btn-label">technical-specification</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="skill-planning" onclick="selectPhase('skill-planning',this)"><span class="badge badge-skl">skl</span><span class="btn-label">technical-planning</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="skill-implementation" onclick="selectPhase('skill-implementation',this)"><span class="badge badge-skl">skl</span><span class="btn-label">technical-implementation</span></button>
+      <button class="nav-btn dropdown-btn" data-phase="skill-review" onclick="selectPhase('skill-review',this)"><span class="badge badge-skl">skl</span><span class="btn-label">technical-review</span></button>
+      <div class="dropdown-subheading">Standalone</div>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('start-feature',this)" id="btn-start-feature"><span class="badge badge-skl">skl</span><span class="btn-label">start-feature</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('link-deps',this)" id="btn-link-deps"><span class="badge badge-skl">skl</span><span class="btn-label">link-dependencies</span></button>
+      <div class="dropdown-subheading">Utility</div>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('status',this)" id="btn-status"><span class="badge badge-skl">skl</span><span class="btn-label">status</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('view-plan',this)" id="btn-view-plan"><span class="badge badge-skl">skl</span><span class="btn-label">view-plan</span></button>
+      <button class="nav-btn dropdown-btn" onclick="selectPhase('migrate',this)" id="btn-migrate"><span class="badge badge-skl">skl</span><span class="btn-label">migrate</span></button>
+    </div>
+
+    <div class="section-label collapsible" onclick="toggleSidebarSection(this)"><span class="chevron">▼</span> Agents</div>
+    <div class="collapsible-content" style="max-height:400px">
+      <div class="dropdown-subheading">Planning</div>
+      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">planning-phase-designer</span></button>
+      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">planning-task-designer</span></button>
+      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">planning-task-author</span></button>
+      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">planning-dependency-grapher</span></button>
+      <div class="dropdown-subheading">Implementation</div>
+      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">implementation-task-executor</span></button>
+      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">implementation-task-reviewer</span></button>
+      <div class="dropdown-subheading">Review</div>
+      <button class="nav-btn dropdown-btn dimmed"><span class="badge badge-agt">agt</span><span class="btn-label">review-task-verifier</span></button>
+    </div>
+
+    <div class="section-label collapsible" onclick="toggleSidebarSection(this)"><span class="chevron">▼</span> Legend</div>
+    <div class="collapsible-content" style="max-height:400px">
+      <div class="legend legend-default" id="legend-default">
+        <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:var(--accent)"></div></div> Phase flow</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-line dashed" style="background:#818cf8"></div></div> Shortcut entry</div>
+        <div class="legend-item" style="font-size:10px;color:var(--text-dim);margin-top:6px">Click any phase to view its flowchart</div>
+      </div>
+      <div class="legend legend-flowchart" id="legend-flowchart" style="display:none">
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:rgba(108,138,255,0.15);border-color:var(--accent)"></div></div> Start / End</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--action-bg);border-color:var(--action)"></div></div> Action step</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--surface2);border-color:var(--text-dim)"></div></div> Support / utility</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape-diamond" style="background:var(--routing-bg);border-color:var(--routing)"></div></div> Decision branch</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--gate-bg);border-color:var(--gate);border-radius:3px"></div></div> STOP / BLOCK</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--ask-bg);border-color:var(--ask)"></div></div> User interaction</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape" style="background:var(--discovery-bg);border-color:var(--discovery)"></div></div> Discovery script</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:var(--skill-bg);border-color:var(--skill)"></div></div> Skill handoff</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-shape-pill" style="background:var(--next-bg);border-color:var(--next)"></div></div> Next phase</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:#34d399"></div></div> Yes branch</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-line" style="background:#f43f5e"></div></div> No branch</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-line dashed" style="background:repeating-linear-gradient(90deg, #f97316 0 6px, transparent 6px 10px)"></div></div> Skill transition</div>
+        <div class="legend-item"><div class="legend-icon"><div class="legend-line dashed" style="background:repeating-linear-gradient(90deg, #6b7280 0 6px, transparent 6px 10px)"></div></div> Back-loop</div>
+      </div>
+    </div>
+
+    <div class="sidebar-footer">
+      <a href="https://github.com/leeovery/claude-technical-workflows" target="_blank" rel="noopener" class="repo-link">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        claude-technical-workflows
+      </a>
+      <div class="credit">Created with ❤️ by <a href="https://github.com/leeovery" target="_blank" rel="noopener">Lee Overy</a></div>
     </div>
   </div>
 
@@ -916,20 +848,26 @@
   <div class="canvas-area" id="canvas-area">
     <button class="sidebar-toggle" id="sidebar-toggle" onclick="toggleSidebar()" title="Toggle sidebar"><svg style="width:12px;height:10px;flex-shrink:0" viewBox="0 0 12 10" fill="none"><rect y="0" width="12" height="1.5" rx="0.75" fill="currentColor"/><rect y="4.25" width="12" height="1.5" rx="0.75" fill="currentColor"/><rect y="8.5" width="12" height="1.5" rx="0.75" fill="currentColor"/></svg></button>
     <svg id="svg-canvas" xmlns="http://www.w3.org/2000/svg"></svg>
-    <div class="detail-panel" id="detail-panel">
-      <button class="detail-close" onclick="closeDetail()">&times;</button>
-      <div id="detail-content"></div>
-    </div>
     <div class="zoom-controls">
       <button class="zoom-btn" onclick="zoom(1.15)">+</button>
       <button class="zoom-btn" onclick="zoom(1/1.15)">&minus;</button>
       <button class="zoom-btn" onclick="resetZoom()" style="font-size:11px">Fit</button>
+      <button class="zoom-btn zoom-btn-context" id="btn-info" onclick="openInfoPanel()" title="Info" style="font-size:14px">&#9432;</button>
+      <button class="zoom-btn zoom-btn-context" id="btn-source" onclick="openMdViewerFromZoom()" title="View source" style="font-size:11px;font-family:'SF Mono','Fira Code',monospace">&lt;/&gt;</button>
     </div>
     <div class="tooltip" id="tooltip"></div>
     <div id="fc-tooltip">
       <button class="fc-tooltip-source" id="fc-tooltip-source" onclick="openMdViewerFromTooltip()" title="View source">&lt;/&gt;</button>
       <div id="fc-tooltip-title"></div>
       <div id="fc-tooltip-desc"></div>
+    </div>
+    <div class="info-panel-backdrop" id="info-panel-backdrop"></div>
+    <div class="info-panel" id="info-panel">
+      <div class="info-panel-header">
+        <div class="info-panel-title" id="info-panel-title"></div>
+        <button class="info-panel-close" onclick="closeInfoPanel()">&times;</button>
+      </div>
+      <div class="info-panel-body" id="info-panel-body"></div>
     </div>
     <div class="md-viewer-backdrop" id="md-viewer-backdrop"></div>
     <div class="md-viewer" id="md-viewer">
@@ -943,10 +881,6 @@
     </div>
   </div>
 
-  <!-- Info bar -->
-  <div class="prompt-bar" id="info-bar">
-    <div class="info-body">Click a phase or command to explore its logic paths, inputs, outputs, and routing.</div>
-  </div>
 </div>
 
 <script>
@@ -992,6 +926,13 @@ function openSidebar() {
 // Backdrop click closes sidebar
 document.getElementById('sidebar-backdrop').addEventListener('click', closeSidebar);
 
+// Collapsible sidebar sections
+function toggleSidebarSection(label) {
+  label.classList.toggle('collapsed');
+  const content = label.nextElementSibling;
+  content.classList.toggle('collapsed');
+}
+
 // Auto-collapse on mobile at load
 if (isMobile()) {
   document.querySelector('.layout').classList.add('sidebar-collapsed');
@@ -1025,38 +966,6 @@ const phases = {
     prerequisites: 'None',
     scenarios: null,
     desc: 'Explore ideas, feasibility, market and technical validation. No prerequisites, no discovery.',
-    detailHTML: () => `
-      <h2 style="color:var(--research)">Phase 1: Research</h2>
-      <div class="detail-subtitle">/start-research &rarr; technical-research skill</div>
-      <div class="detail-section">
-        <h3>Overview</h3>
-        <p>The simplest command. No discovery script, no prerequisites, no cache. Just gathers context through questions and invokes the skill.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Command Steps</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num migration">0</div><div class="step-text">Run <code>/migrate</code> (mandatory for all commands)</div></div>
-          <div class="step-item"><div class="step-num gather">1</div><div class="step-text">Ask: <strong>"What's on your mind?"</strong> &mdash; seed idea</div></div>
-          <div class="step-item"><div class="step-num gather">2</div><div class="step-text">Ask: <strong>"What do you already know?"</strong></div></div>
-          <div class="step-item"><div class="step-num gather">3</div><div class="step-text">Ask: <strong>"Where should we start?"</strong><br>Options: technical / market / business / open exploration</div></div>
-          <div class="step-item"><div class="step-num gather">4</div><div class="step-text">Ask: <strong>"Any constraints or context?"</strong></div></div>
-          <div class="step-item"><div class="step-num skill">5</div><div class="step-text">Invoke <code>technical-research</code> skill with gathered context</div></div>
-        </div>
-      </div>
-      <div class="detail-section">
-        <h3>Output</h3>
-        <div class="file-path">docs/workflow/research/exploration.md</div>
-        <p style="margin-top:6px;font-size:12px;color:var(--text-dim)">Starts as one file, splits as themes emerge. No frontmatter status &mdash; research never "concludes".</p>
-      </div>
-      <div class="detail-section">
-        <h3>Skill Behaviour</h3>
-        <ul>
-          <li>Acts as research partner across technical, product, business, market domains</li>
-          <li>Loop: Ask &rarr; Discuss &rarr; Document &rarr; Commit/push &rarr; Repeat</li>
-          <li>Uses <code>references/interview.md</code> for structured questioning</li>
-        </ul>
-      </div>
-    `
   },
   discussion: {
     color: '#60a5fa', bg: 'rgba(96,165,250,0.12)',
@@ -1069,61 +978,6 @@ const phases = {
     prerequisites: 'None (but can consume research)',
     scenarios: ['fresh','research_only','discussions_only','research_and_discussions'],
     desc: 'Capture architecture decisions, debates, and edge cases. Cache-aware research analysis.',
-    detailHTML: () => `
-      <h2 style="color:var(--discussion)">Phase 2: Discussion</h2>
-      <div class="detail-subtitle">/start-discussion &rarr; technical-discussion skill</div>
-      <div class="detail-section">
-        <h3>Overview</h3>
-        <p>Moderate complexity. Discovery script scans research files, existing discussions, and cache. Routes based on what exists.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Discovery Script</h3>
-        <div class="file-path">scripts/discovery-for-discussion.sh</div>
-        <p style="margin-top:6px;font-size:12px">Scans <code>docs/workflow/research/</code> and <code>docs/workflow/discussion/</code>. Checks cache checksums. Outputs YAML with scenario classification.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Scenario Routing</h3>
-        <table class="routing-table">
-          <tr><th>Scenario</th><th>Action</th></tr>
-          <tr><td><span class="scenario-tag tag-auto">fresh</span></td><td>Ask topic, skip to gather context</td></tr>
-          <tr><td><span class="scenario-tag tag-route">discussions_only</span></td><td>Present options: Continue / Fresh topic</td></tr>
-          <tr><td><span class="scenario-tag tag-route">research_only</span></td><td>Handle research analysis (cache-aware)</td></tr>
-          <tr><td><span class="scenario-tag tag-route">research_and_discussions</span></td><td>Handle research analysis (cache-aware)</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Cache System</h3>
-        <div class="file-path">.cache/research-analysis.md</div>
-        <p style="margin-top:6px;font-size:12px">Checksums research files via md5. States: <code>valid</code> (use cached) / <code>stale</code> (re-analyze) / <code>none</code> (first run)</p>
-      </div>
-      <div class="detail-section">
-        <h3>Options Presented (varies)</h3>
-        <table class="routing-table">
-          <tr><th>Context</th><th>Menu Options</th></tr>
-          <tr><td>Research + Discussions</td><td>"From research" / "Continue discussion" / "Fresh topic" / "Refresh"</td></tr>
-          <tr><td>Only Research</td><td>"From research" / "Fresh topic" / "Refresh"</td></tr>
-          <tr><td>Only Discussions</td><td>"Continue discussion" / "Fresh topic"</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Command Steps</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num migration">0</div><div class="step-text">Run <code>/migrate</code></div></div>
-          <div class="step-item"><div class="step-num discovery">1</div><div class="step-text">Run discovery script &rarr; YAML output</div></div>
-          <div class="step-item"><div class="step-num route">2</div><div class="step-text">Route based on scenario</div></div>
-          <div class="step-item"><div class="step-num route">3</div><div class="step-text">Research analysis (if needed, cache-aware)</div></div>
-          <div class="step-item"><div class="step-num gather">4</div><div class="step-text">Present options menu</div></div>
-          <div class="step-item"><div class="step-num gather">5</div><div class="step-text">Handle user selection</div></div>
-          <div class="step-item"><div class="step-num gather">6</div><div class="step-text">Gather context (problem, constraints, codebase files)</div></div>
-          <div class="step-item"><div class="step-num skill">7</div><div class="step-text">Invoke <code>technical-discussion</code> skill</div></div>
-        </div>
-      </div>
-      <div class="detail-section">
-        <h3>Output</h3>
-        <div class="file-path">docs/workflow/discussion/{topic}.md</div>
-        <p style="margin-top:6px;font-size:12px;color:var(--text-dim)">Frontmatter status: in-progress &rarr; concluded. Per-question structure: Options &rarr; Journey &rarr; Decision.</p>
-      </div>
-    `
   },
   specification: {
     color: '#34d399', bg: 'rgba(52,211,153,0.12)',
@@ -1136,82 +990,6 @@ const phases = {
     prerequisites: 'Concluded discussions required',
     scenarios: ['1 concluded','multi+no specs+cache valid','multi+no specs+stale','multi+specs+cache valid','multi+specs+stale','multi+specs+no cache'],
     desc: 'The most complex command (820 lines, 11 steps). Analyzes discussion coupling, groups into features, builds validated specs.',
-    detailHTML: () => `
-      <h2 style="color:var(--specification)">Phase 3: Specification</h2>
-      <div class="detail-subtitle">/start-specification &rarr; technical-specification skill</div>
-      <div class="detail-section">
-        <h3>Overview</h3>
-        <p>The most complex command at 820 lines and 11 steps. Analyzes coupling between concluded discussions, groups them into coherent features, and builds validated specifications.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Prerequisites Gate</h3>
-        <div class="gate-badge">No discussions &rarr; STOP</div><br>
-        <div class="gate-badge">No concluded discussions &rarr; STOP</div>
-      </div>
-      <div class="detail-section">
-        <h3>Discovery Script</h3>
-        <div class="file-path">scripts/discovery-for-specification.sh</div>
-        <p style="margin-top:6px;font-size:12px">Scans discussions (with <code>has_individual_spec</code> check), specifications (with sources as objects), cache with anchored names.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Routing Matrix (Step 3)</h3>
-        <table class="routing-table">
-          <tr><th>Condition</th><th>Path</th></tr>
-          <tr><td><span class="scenario-tag tag-auto">1 concluded</span></td><td>Auto-select, skip to Step 9</td></tr>
-          <tr><td><span class="scenario-tag tag-route">Multi + no specs + cache valid</span></td><td>Show groupings from cache &rarr; Step 7</td></tr>
-          <tr><td><span class="scenario-tag tag-ask">Multi + no specs + stale/none</span></td><td>Gather context &rarr; Analyze &rarr; Steps 4-6</td></tr>
-          <tr><td><span class="scenario-tag tag-route">Multi + specs + cache valid</span></td><td>Offer: continue / groupings / re-analyze</td></tr>
-          <tr><td><span class="scenario-tag tag-ask">Multi + specs + stale</span></td><td>Offer: continue / assess</td></tr>
-          <tr><td><span class="scenario-tag tag-ask">Multi + specs + none</span></td><td>Offer: continue / assess</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Analysis Engine (Step 6)</h3>
-        <ul>
-          <li>Reads ALL concluded discussions thoroughly</li>
-          <li>Analyzes coupling: data, behavioral, conceptual</li>
-          <li>Groups into coherent features/capabilities</li>
-          <li>Preserves anchored names (existing spec groupings must be reused)</li>
-          <li>Saves to cache with checksums</li>
-        </ul>
-      </div>
-      <div class="detail-section">
-        <h3>Grouping Options (Step 7)</h3>
-        <table class="routing-table">
-          <tr><th>Choice</th><th>Action</th></tr>
-          <tr><td>"Proceed as recommended"</td><td>Ask which grouping to spec</td></tr>
-          <tr><td>"Combine differently"</td><td>User describes groupings, handle impact on existing specs</td></tr>
-          <tr><td>"Single specification"</td><td>Use "unified" name</td></tr>
-          <tr><td>"Individual specifications"</td><td>Ask which discussion</td></tr>
-          <tr><td>"Refresh"</td><td>Delete cache, re-analyze</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Command Steps</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num migration">0</div><div class="step-text">Run <code>/migrate</code></div></div>
-          <div class="step-item"><div class="step-num discovery">1</div><div class="step-text">Run discovery script</div></div>
-          <div class="step-item"><div class="step-num gate">2</div><div class="step-text"><strong>Prerequisites gate</strong> (concluded discussions required)</div></div>
-          <div class="step-item"><div class="step-num route">3</div><div class="step-text">Route based on 6-condition matrix</div></div>
-          <div class="step-item"><div class="step-num gather">4</div><div class="step-text">Gather analysis context (project structure, relationships)</div></div>
-          <div class="step-item"><div class="step-num route">5</div><div class="step-text">Check cache status (valid / stale / none)</div></div>
-          <div class="step-item"><div class="step-num">6</div><div class="step-text">Analyze discussions (coupling engine)</div></div>
-          <div class="step-item"><div class="step-num gather">7</div><div class="step-text">Present grouping options</div></div>
-          <div class="step-item"><div class="step-num gather">8</div><div class="step-text">Handle selection (with existing spec impact analysis)</div></div>
-          <div class="step-item"><div class="step-num gather">9</div><div class="step-text">Confirm selection (sources, path, supersede info)</div></div>
-          <div class="step-item"><div class="step-num gather">10</div><div class="step-text">Gather additional context</div></div>
-          <div class="step-item"><div class="step-num skill">11</div><div class="step-text">Invoke <code>technical-specification</code> skill</div></div>
-        </div>
-      </div>
-      <div class="detail-section">
-        <h3>Skill Behaviour</h3>
-        <ul>
-          <li><strong>Collaborative, NOT autonomous</strong> &mdash; must wait for explicit user approval before writing</li>
-          <li>Process: Extract &rarr; Filter (validate) &rarr; Enrich (fill gaps) &rarr; Present &rarr; STOP &amp; WAIT &rarr; Log</li>
-          <li>Self-check before every write: Was this presented? Was it approved?</li>
-        </ul>
-      </div>
-    `
   },
   planning: {
     color: '#fbbf24', bg: 'rgba(251,191,36,0.12)',
@@ -1224,63 +1002,6 @@ const phases = {
     prerequisites: 'Concluded specifications required',
     scenarios: ['no_specs','nothing_actionable','has_options'],
     desc: 'Transform specs into phased implementation plans. Routes by plan state (new vs existing). Surfaces cross-cutting specs.',
-    detailHTML: () => `
-      <h2 style="color:var(--planning)">Phase 4: Planning</h2>
-      <div class="detail-subtitle">/start-planning &rarr; technical-planning skill</div>
-      <div class="detail-section">
-        <h3>Overview</h3>
-        <p>Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Routes by plan state &mdash; new plans gather context first, existing plans skip straight to the skill. Surfaces cross-cutting specifications as context.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Discovery Script</h3>
-        <div class="file-path">scripts/discovery-for-planning.sh</div>
-        <p style="margin-top:6px;font-size:12px">Scans specs (separates feature vs cross-cutting by <code>type:</code> field). Counts ready specs (concluded + no existing plan). Tracks plan status for existing plans.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Scenario Routing</h3>
-        <table class="routing-table">
-          <tr><th>Scenario</th><th>Action</th></tr>
-          <tr><td><span class="scenario-tag tag-stop">no_specs</span></td><td>STOP &mdash; run <code>/start-specification</code></td></tr>
-          <tr><td><span class="scenario-tag tag-gate">nothing_actionable</span></td><td>Show state, nothing ready to plan</td></tr>
-          <tr><td><span class="scenario-tag tag-route">has_options</span></td><td>Present options (single auto-selects, multiple asks)</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Plan State Routing (Step 4)</h3>
-        <table class="routing-table">
-          <tr><th>State</th><th>Action</th></tr>
-          <tr><td>No existing plan</td><td>Gather context (Step 5) &rarr; cross-cutting (Step 6) &rarr; invoke skill</td></tr>
-          <tr><td>Existing plan</td><td>Skip context &rarr; invoke skill directly (Step 7)</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Command Steps</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num migration">0</div><div class="step-text">Run <code>/migrate</code></div></div>
-          <div class="step-item"><div class="step-num discovery">1</div><div class="step-text">Run discovery script</div></div>
-          <div class="step-item"><div class="step-num route">2</div><div class="step-text">Route based on scenario</div></div>
-          <div class="step-item"><div class="step-num gather">3</div><div class="step-text">Present state &amp; select spec (auto or ask)</div></div>
-          <div class="step-item"><div class="step-num route">4</div><div class="step-text">Route by plan state (new vs existing)</div></div>
-          <div class="step-item"><div class="step-num gather">5</div><div class="step-text">Gather additional context (new plans only)</div></div>
-          <div class="step-item"><div class="step-num">6</div><div class="step-text">Surface cross-cutting specs as context (new plans only)</div></div>
-          <div class="step-item"><div class="step-num skill">7</div><div class="step-text">Invoke <code>technical-planning</code> skill</div></div>
-        </div>
-      </div>
-      <div class="detail-section">
-        <h3>Skill: 9-Step Planning Process</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num">0</div><div class="step-text">Resume detection (existing plan? spec changes?)</div></div>
-          <div class="step-item"><div class="step-num">1</div><div class="step-text">Initialize plan (choose output format, create Plan Index File)</div></div>
-          <div class="step-item"><div class="step-num">2</div><div class="step-text">Load planning principles</div></div>
-          <div class="step-item"><div class="step-num">3</div><div class="step-text">Verify source material</div></div>
-          <div class="step-item"><div class="step-num">4</div><div class="step-text">Plan construction (phases &rarr; tasks &rarr; author, nested loop)</div></div>
-          <div class="step-item"><div class="step-num">5</div><div class="step-text">Analyze task graph (dependency-grapher agent)</div></div>
-          <div class="step-item"><div class="step-num">6</div><div class="step-text">Resolve external dependencies</div></div>
-          <div class="step-item"><div class="step-num">7</div><div class="step-text">Plan review (traceability + integrity)</div></div>
-          <div class="step-item"><div class="step-num">8</div><div class="step-text">Conclude plan (<code>status: concluded</code>)</div></div>
-        </div>
-      </div>
-    `
   },
   implementation: {
     color: '#f97316', bg: 'rgba(249,115,22,0.12)',
@@ -1293,70 +1014,6 @@ const phases = {
     prerequisites: 'Concluded plan required',
     scenarios: ['no_plans','single_plan','multiple_plans'],
     desc: 'Execute plans via strict TDD. Three-section plan classification with unblock escape hatch. Gates: external deps, environment setup.',
-    detailHTML: () => `
-      <h2 style="color:var(--implementation)">Phase 5: Implementation</h2>
-      <div class="detail-subtitle">/start-implementation &rarr; technical-implementation skill</div>
-      <div class="detail-section">
-        <h3>Overview</h3>
-        <p>Execute implementation plans using strict TDD workflow with quality gates. Two blocking gates before work begins.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Discovery Script (shared with Review)</h3>
-        <div class="file-path">scripts/discovery-for-implementation-and-review.sh</div>
-        <p style="margin-top:6px;font-size:12px">Scans plans, checks <code>environment-setup.md</code>. Outputs plan metadata + environment state.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Scenario Routing</h3>
-        <table class="routing-table">
-          <tr><th>Scenario</th><th>Action</th></tr>
-          <tr><td><span class="scenario-tag tag-stop">no_plans</span></td><td>STOP &mdash; run <code>/start-planning</code></td></tr>
-          <tr><td><span class="scenario-tag tag-auto">single_plan</span></td><td>Auto-select</td></tr>
-          <tr><td><span class="scenario-tag tag-ask">multiple_plans</span></td><td>Ask which plan</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Gate 1: External Dependencies</h3>
-        <div class="gate-badge">Blocks if unresolved dependencies exist</div>
-        <table class="routing-table" style="margin-top:8px">
-          <tr><th>Dependency State</th><th>Result</th></tr>
-          <tr><td>Unresolved</td><td><strong>BLOCK</strong> &mdash; offer: implement blocking deps / mark satisfied / run <code>/link-dependencies</code></td></tr>
-          <tr><td>Resolved</td><td>Check task completion in other plan</td></tr>
-          <tr><td>Satisfied externally</td><td>OK &mdash; proceed</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Gate 2: Environment Setup</h3>
-        <div class="gate-badge">Checks environment-setup.md</div>
-        <table class="routing-table" style="margin-top:8px">
-          <tr><th>State</th><th>Result</th></tr>
-          <tr><td>Exists, "no special setup"</td><td>Skip</td></tr>
-          <tr><td>Exists with instructions</td><td>Note for handoff</td></tr>
-          <tr><td>Missing</td><td>Ask user, save to file</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Command Steps</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num migration">0</div><div class="step-text">Run <code>/migrate</code></div></div>
-          <div class="step-item"><div class="step-num discovery">1</div><div class="step-text">Run discovery script</div></div>
-          <div class="step-item"><div class="step-num route">2</div><div class="step-text">Route based on scenario</div></div>
-          <div class="step-item"><div class="step-num gather">3</div><div class="step-text">Present plans &amp; select (with unblock escape hatch)</div></div>
-          <div class="step-item"><div class="step-num gate">4</div><div class="step-text"><strong>External dependencies gate</strong></div></div>
-          <div class="step-item"><div class="step-num gate">5</div><div class="step-text"><strong>Environment setup gate</strong> (info gathering only)</div></div>
-          <div class="step-item"><div class="step-num skill">6</div><div class="step-text">Invoke <code>technical-implementation</code> skill (strict TDD)</div></div>
-        </div>
-      </div>
-      <div class="detail-section">
-        <h3>Skill: Strict TDD Rules</h3>
-        <ul>
-          <li>No code before tests</li>
-          <li>No test changes to make tests pass</li>
-          <li>No scope expansion beyond plan</li>
-          <li>Commit after every green</li>
-          <li>Ask user before moving to next phase</li>
-        </ul>
-      </div>
-    `
   },
   review: {
     color: '#f472b6', bg: 'rgba(244,114,182,0.12)',
@@ -1369,120 +1026,18 @@ const phases = {
     prerequisites: 'Implementation of a plan',
     scenarios: ['no_plans','single_plan','multiple_plans'],
     desc: 'Validate implementation against plan. Uses parallel review-task-verifier subagents (one per task).',
-    detailHTML: () => `
-      <h2 style="color:var(--review)">Phase 6: Review</h2>
-      <div class="detail-subtitle">/start-review &rarr; technical-review skill</div>
-      <div class="detail-section">
-        <h3>Overview</h3>
-        <p>Validate completed implementation against plan tasks and acceptance criteria. Uses parallel review-task-verifier subagents for efficiency. Does NOT fix code &mdash; only reviews.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Discovery Script (shared with Implementation)</h3>
-        <div class="file-path">scripts/discovery-for-implementation-and-review.sh</div>
-      </div>
-      <div class="detail-section">
-        <h3>Scenario Routing</h3>
-        <table class="routing-table">
-          <tr><th>Scenario</th><th>Action</th></tr>
-          <tr><td><span class="scenario-tag tag-stop">no_plans</span></td><td>STOP &mdash; run <code>/start-planning</code></td></tr>
-          <tr><td><span class="scenario-tag tag-auto">single_plan</span></td><td>Auto-select</td></tr>
-          <tr><td><span class="scenario-tag tag-ask">multiple_plans</span></td><td>Ask which plan</td></tr>
-        </table>
-      </div>
-      <div class="detail-section">
-        <h3>Scope Selection</h3>
-        <ul>
-          <li>All changes since plan created</li>
-          <li>Specific directories / files</li>
-          <li>From git status</li>
-        </ul>
-      </div>
-      <div class="detail-section">
-        <h3>Command Steps</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num migration">0</div><div class="step-text">Run <code>/migrate</code></div></div>
-          <div class="step-item"><div class="step-num discovery">1</div><div class="step-text">Run discovery script</div></div>
-          <div class="step-item"><div class="step-num route">2</div><div class="step-text">Route based on scenario</div></div>
-          <div class="step-item"><div class="step-num gather">3</div><div class="step-text">Select plan</div></div>
-          <div class="step-item"><div class="step-num gather">4</div><div class="step-text">Identify implementation scope</div></div>
-          <div class="step-item"><div class="step-num skill">5</div><div class="step-text">Invoke <code>technical-review</code> skill</div></div>
-        </div>
-      </div>
-      <div class="detail-section">
-        <h3>Skill: Parallel Chain Verification</h3>
-        <ul>
-          <li>Read plan &rarr; Read spec &rarr; Extract ALL tasks</li>
-          <li>Spawn <strong>parallel review-task-verifier subagents</strong> (Haiku model)</li>
-          <li>One verifier per task &mdash; all run simultaneously</li>
-          <li>Each checks: implementation exists, acceptance criteria met, test coverage, code quality</li>
-          <li>Aggregate findings into structured review</li>
-          <li>Output: approve / request changes / comments</li>
-        </ul>
-      </div>
-    `
   },
   'start-feature': {
     color: '#818cf8', bg: 'rgba(129,140,248,0.12)',
     label: 'Start Feature', cmd: '/start-feature',
     complexity: 'Shortcut',
     desc: 'Bypass phases 1-2. Gather feature context inline, invoke specification skill directly.',
-    detailHTML: () => `
-      <h2 style="color:#818cf8">Standalone: /start-feature</h2>
-      <div class="detail-subtitle">Shortcut &rarr; technical-specification skill</div>
-      <div class="detail-section">
-        <h3>Overview</h3>
-        <p>Bypasses Research and Discussion phases entirely. For adding features to existing projects where you already know what you're building.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Flow</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num gather">1</div><div class="step-text">Gather feature context (what, scope, constraints) &mdash; can skip if already provided</div></div>
-          <div class="step-item"><div class="step-num gather">2</div><div class="step-text">Suggest topic name for output file</div></div>
-          <div class="step-item"><div class="step-num gate">3</div><div class="step-text">Check naming conflicts in <code>docs/workflow/specification/</code></div></div>
-          <div class="step-item"><div class="step-num skill">4</div><div class="step-text">Invoke <code>technical-specification</code> skill with inline context</div></div>
-        </div>
-      </div>
-      <div class="detail-section">
-        <h3>Key Difference</h3>
-        <p>No discovery script. No migration step. No discussion document to reference. Context is provided inline instead of from previous phase files.</p>
-        <p style="margin-top:8px">Output is a standard specification file &mdash; continues to <code>/start-planning</code> normally.</p>
-      </div>
-    `
   },
   'link-deps': {
     color: '#94a3b8', bg: 'rgba(148,163,184,0.12)',
     label: 'Link Dependencies', cmd: '/link-dependencies',
     complexity: 'Cross-plan',
     desc: 'Wire up cross-topic dependencies across all plans.',
-    detailHTML: () => `
-      <h2 style="color:#94a3b8">Standalone: /link-dependencies</h2>
-      <div class="detail-subtitle">Cross-plan dependency wiring</div>
-      <div class="detail-section">
-        <h3>Overview</h3>
-        <p>Works across ALL plans. Requires 2+ plans with the same output format. Extracts external dependencies, matches unresolved deps to tasks in other plans, wires up bidirectional links.</p>
-      </div>
-      <div class="detail-section">
-        <h3>Flow</h3>
-        <div class="step-flow">
-          <div class="step-item"><div class="step-num discovery">1</div><div class="step-text">Discover all plans, extract metadata</div></div>
-          <div class="step-item"><div class="step-num gate">2</div><div class="step-text">Check output format consistency (must all match)</div></div>
-          <div class="step-item"><div class="step-num">3</div><div class="step-text">Extract External Dependencies from all plans</div></div>
-          <div class="step-item"><div class="step-num">4</div><div class="step-text">Match unresolved deps to tasks in other plans</div></div>
-          <div class="step-item"><div class="step-num">5</div><div class="step-text">Wire up matches (update plan index + output format)</div></div>
-          <div class="step-item"><div class="step-num">6</div><div class="step-text">Bidirectional check (reverse dependencies)</div></div>
-          <div class="step-item"><div class="step-num">7</div><div class="step-text">Report results &amp; commit</div></div>
-        </div>
-      </div>
-      <div class="detail-section">
-        <h3>Dependency States</h3>
-        <table class="routing-table">
-          <tr><th>State</th><th>Meaning</th></tr>
-          <tr><td><code>unresolved</code></td><td>Not yet matched to a task</td></tr>
-          <tr><td><code>resolved</code></td><td>Matched to task ID in another plan</td></tr>
-          <tr><td><code>satisfied externally</code></td><td>Manually marked as met</td></tr>
-        </table>
-      </div>
-    `
   },
   'status': {
     color: '#94a3b8', bg: 'rgba(148,163,184,0.12)',
@@ -1562,7 +1117,7 @@ function computeFlowchartLayout(key) {
 
   const fc = FLOWCHARTS[key];
   const g = new dagre.graphlib.Graph();
-  g.setGraph({ rankdir: 'TB', nodesep: 40, ranksep: 55, marginx: 30, marginy: 30 });
+  g.setGraph({ rankdir: 'TB', nodesep: 50, ranksep: 60, edgesep: 25, marginx: 30, marginy: 30 });
   g.setDefaultEdgeLabel(() => ({}));
 
   fc.nodes.forEach(n => {
@@ -1570,7 +1125,10 @@ function computeFlowchartLayout(key) {
   });
 
   fc.connections.forEach(c => {
-    g.setEdge(c.from, c.to, { label: c.label || '' });
+    const opts = { label: c.label || '' };
+    if (c.weight) opts.weight = c.weight;
+    if (c.minlen) opts.minlen = c.minlen;
+    g.setEdge(c.from, c.to, opts);
   });
 
   dagre.layout(g);
@@ -1685,11 +1243,11 @@ const FLOWCHARTS = {
       { from: 'start', to: 'migrate' },
       { from: 'migrate', to: 'discovery' },
       { from: 'discovery', to: 'gate-disc' },
+      { from: 'gate-disc', to: 'gate-concluded', type: 'yes', label: 'exist', weight: 2 },
       { from: 'gate-disc', to: 'stop-no-disc', type: 'no', label: 'none' },
-      { from: 'gate-disc', to: 'gate-concluded', type: 'yes', label: 'exist' },
+      { from: 'gate-concluded', to: 'count', type: 'yes', label: 'yes', weight: 2 },
       { from: 'gate-concluded', to: 'stop-no-conc', type: 'no', label: 'none' },
-      { from: 'gate-concluded', to: 'count', type: 'yes', label: 'yes' },
-      { from: 'count', to: 'auto-select', label: '1' },
+      { from: 'count', to: 'auto-select', label: 'one' },
       { from: 'count', to: 'multi-route', label: 'multi' },
       { from: 'multi-route', to: 'no-specs-cache', type: 'no', label: 'no specs' },
       { from: 'multi-route', to: 'specs-options', type: 'yes', label: 'specs exist' },
@@ -1732,9 +1290,9 @@ const FLOWCHARTS = {
       { from: 'start', to: 'migrate' },
       { from: 'migrate', to: 'discovery' },
       { from: 'discovery', to: 'scenario' },
+      { from: 'scenario', to: 'present', type: 'yes', label: 'has options', weight: 2 },
       { from: 'scenario', to: 'stop-no-spec', type: 'no', label: 'no specs' },
       { from: 'scenario', to: 'stop-none-ready', label: 'none actionable' },
-      { from: 'scenario', to: 'present', type: 'yes', label: 'has options' },
       { from: 'present', to: 'plan-state' },
       { from: 'plan-state', to: 'gather', type: 'no', label: 'new' },
       { from: 'plan-state', to: 'skill', type: 'yes', label: 'exists' },
@@ -1765,15 +1323,15 @@ const FLOWCHARTS = {
       { from: 'migrate', to: 'discovery' },
       { from: 'discovery', to: 'scenario' },
       { from: 'scenario', to: 'stop-no-plan', type: 'no', label: 'no plans' },
-      { from: 'scenario', to: 'present', type: 'yes', label: 'exist' },
-      { from: 'present', to: 'select' },
-      { from: 'select', to: 'unblock', label: 'unblock' },
+      { from: 'scenario', to: 'present', type: 'yes', label: 'exist', weight: 2 },
+      { from: 'present', to: 'select', weight: 2 },
+      { from: 'select', to: 'unblock', label: 'unblock', port: 'left' },
       { from: 'unblock', to: 'present', type: 'backloop' },
-      { from: 'select', to: 'gate-deps' },
-      { from: 'gate-deps', to: 'block-deps', type: 'no', label: 'blocked' },
+      { from: 'select', to: 'gate-deps', label: 'proceed', weight: 2, port: 'bottom' },
+      { from: 'gate-deps', to: 'block-deps', type: 'no', label: 'blocked', port: 'lower-left' },
       { from: 'block-deps', to: 'escape' },
       { from: 'escape', to: 'gate-deps', type: 'backloop' },
-      { from: 'gate-deps', to: 'gate-env', type: 'yes', label: 'ok' },
+      { from: 'gate-deps', to: 'gate-env', type: 'yes', label: 'ok', weight: 2, port: 'lower-right' },
       { from: 'gate-env', to: 'create-env', label: 'missing' },
       { from: 'gate-env', to: 'env-ok', label: 'exists' },
       { from: 'create-env', to: 'skill', type: 'transition' },
@@ -1797,8 +1355,8 @@ const FLOWCHARTS = {
       { from: 'start', to: 'migrate' },
       { from: 'migrate', to: 'discovery' },
       { from: 'discovery', to: 'scenario' },
+      { from: 'scenario', to: 'select', type: 'yes', label: 'exist', weight: 2 },
       { from: 'scenario', to: 'stop', type: 'no', label: 'none' },
-      { from: 'scenario', to: 'select', type: 'yes', label: 'exist' },
       { from: 'select', to: 'auto', label: 'single' },
       { from: 'select', to: 'ask', label: 'multiple' },
       { from: 'auto', to: 'scope' },
@@ -1843,10 +1401,10 @@ const FLOWCHARTS = {
     connections: [
       { from: 'start', to: 'discover' },
       { from: 'discover', to: 'gate-count' },
+      { from: 'gate-count', to: 'gate-format', type: 'yes', label: '>= 2', weight: 2 },
       { from: 'gate-count', to: 'stop-count', type: 'no', label: '< 2' },
-      { from: 'gate-count', to: 'gate-format', type: 'yes', label: '>= 2' },
+      { from: 'gate-format', to: 'extract', type: 'yes', label: 'match', weight: 2 },
       { from: 'gate-format', to: 'stop-format', type: 'no', label: 'mixed' },
-      { from: 'gate-format', to: 'extract', type: 'yes', label: 'match' },
       { from: 'extract', to: 'match' },
       { from: 'match', to: 'wire' },
       { from: 'wire', to: 'bidir' },
@@ -1908,7 +1466,7 @@ const FLOWCHARTS = {
       { from: 'capture', to: 'document' },
       { from: 'document', to: 'commit' },
       { from: 'commit', to: 'more' },
-      { from: 'more', to: 'engage', type: 'backloop', label: 'yes' },
+      { from: 'more', to: 'engage', type: 'backloop', label: 'yes', port: 'right' },
       { from: 'more', to: 'conclude', type: 'no', label: 'done' },
       { from: 'conclude', to: 'end' },
       { from: 'end', to: 'next', type: 'transition' },
@@ -1941,7 +1499,7 @@ const FLOWCHARTS = {
       { from: 'enrich', to: 'present' },
       { from: 'present', to: 'wait' },
       { from: 'wait', to: 'present', type: 'backloop', label: 'revise' },
-      { from: 'wait', to: 'log', type: 'yes', label: 'approved' },
+      { from: 'wait', to: 'log', type: 'yes', label: 'approved', weight: 2 },
       { from: 'log', to: 'more-topics' },
       { from: 'more-topics', to: 'extract', type: 'backloop', label: 'yes' },
       { from: 'more-topics', to: 'final-review', type: 'no', label: 'all done' },
@@ -2025,17 +1583,17 @@ const FLOWCHARTS = {
       // Enter task loop
       { from: 'init-track', to: 'retrieve', type: 'transition' },
       { from: 'retrieve', to: 'done-check' },
+      { from: 'done-check', to: 'executor', type: 'yes', label: 'has task', weight: 2 },
       { from: 'done-check', to: 'end', type: 'no', label: 'none left' },
-      { from: 'done-check', to: 'executor', type: 'yes', label: 'has task' },
       // B: Executor
       { from: 'executor', to: 'exec-result' },
-      { from: 'exec-result', to: 'reviewer', type: 'yes', label: 'complete' },
+      { from: 'exec-result', to: 'reviewer', type: 'yes', label: 'complete', weight: 2 },
       { from: 'exec-result', to: 'exec-blocked', type: 'no', label: 'blocked' },
       { from: 'exec-blocked', to: 'executor', type: 'backloop', label: 'retry' },
       { from: 'exec-blocked', to: 'commit', label: 'skip' },
       // C: Reviewer
       { from: 'reviewer', to: 'review-result' },
-      { from: 'review-result', to: 'gate', type: 'yes', label: 'approved' },
+      { from: 'review-result', to: 'gate', type: 'yes', label: 'approved', weight: 2 },
       { from: 'review-result', to: 'review-changes', type: 'no', label: 'needs changes' },
       { from: 'review-changes', to: 'executor', type: 'backloop', label: 'fix' },
       { from: 'review-changes', to: 'gate', label: 'skip' },
@@ -2097,8 +1655,8 @@ const FLOWCHARTS = {
     connections: [
       { from: 'start', to: 'migrate' },
       { from: 'migrate', to: 'gate-migrate' },
-      { from: 'gate-migrate', to: 'wait-review', type: 'yes', label: 'yes' },
       { from: 'gate-migrate', to: 'scan', type: 'no', label: 'no' },
+      { from: 'gate-migrate', to: 'wait-review', type: 'yes', label: 'yes' },
       { from: 'wait-review', to: 'scan' },
       { from: 'scan', to: 'present' },
       { from: 'present', to: 'suggest' },
@@ -2121,9 +1679,9 @@ const FLOWCHARTS = {
     ],
     connections: [
       { from: 'start', to: 'gate-plans' },
+      { from: 'gate-plans', to: 'count', type: 'yes', label: 'exist', weight: 2 },
       { from: 'gate-plans', to: 'stop', type: 'no', label: 'none' },
-      { from: 'gate-plans', to: 'count', type: 'yes', label: 'exist' },
-      { from: 'count', to: 'auto', label: '1' },
+      { from: 'count', to: 'auto', label: 'one' },
       { from: 'count', to: 'ask', label: 'multi' },
       { from: 'auto', to: 'read-index' },
       { from: 'ask', to: 'read-index' },
@@ -2145,8 +1703,8 @@ const FLOWCHARTS = {
     connections: [
       { from: 'start', to: 'run' },
       { from: 'run', to: 'updated' },
-      { from: 'updated', to: 'show-changes', type: 'yes', label: 'yes' },
       { from: 'updated', to: 'end-clean', type: 'no', label: 'no' },
+      { from: 'updated', to: 'show-changes', type: 'yes', label: 'yes' },
       { from: 'show-changes', to: 'end-updated' },
     ]
   }
@@ -2531,6 +2089,103 @@ function clipToDiamond(cx, cy, hw, hh, px, py) {
   return { x: cx + dx / sum, y: cy + dy / sum };
 }
 
+// Simple direction-based snap for incoming edges to diamonds.
+// Uses dominant axis: vertical → top/bottom vertex, horizontal → left/right vertex.
+function snapToDiamondPort(cx, cy, hw, hh, pt) {
+  const dx = pt.x - cx, dy = pt.y - cy;
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx >= 0 ? { x: cx + hw, y: cy } : { x: cx - hw, y: cy };
+  } else {
+    return dy >= 0 ? { x: cx, y: cy + hh } : { x: cx, y: cy - hh };
+  }
+}
+
+// Context-aware outgoing port assignment for diamond nodes.
+// Distributes outgoing edges across diamond ports based on count:
+//   1 down → bottom vertex
+//   2 down → lower-left midpoint + lower-right midpoint
+//   3 down → lower-left midpoint + bottom vertex + lower-right midpoint
+//   4 down → left vertex + lower-left + lower-right + right vertex
+//   5 down → left + lower-left + bottom + lower-right + right
+// Side edges (same rank, far horizontal) → left/right vertex.
+// Upward edges (backloop) → top vertex.
+function computeDiamondPorts(nodes, connections) {
+  const ports = {};
+  // Group outgoing edges by source diamond
+  const diamondOut = {};
+  connections.forEach(c => {
+    const from = nodes.find(n => n.id === c.from);
+    if (!from || from.shape !== 'diamond') return;
+    if (!diamondOut[c.from]) diamondOut[c.from] = [];
+    diamondOut[c.from].push(c);
+  });
+
+  for (const [nodeId, edges] of Object.entries(diamondOut)) {
+    const node = nodes.find(n => n.id === nodeId);
+    if (!node) continue;
+    const cx = node.x + node.w / 2, cy = node.y + node.h / 2;
+    const hw = node.w / 2, hh = node.h / 2;
+
+    // Classify by target position relative to diamond
+    // Edges can specify explicit port hints: 'left', 'right', 'top', 'bottom',
+    // 'lower-left', 'lower-right', 'upper-left', 'upper-right'
+    const portMap = {
+      'left': { x: cx - hw, y: cy }, 'right': { x: cx + hw, y: cy },
+      'top': { x: cx, y: cy - hh }, 'bottom': { x: cx, y: cy + hh },
+      'lower-left': { x: cx - hw / 2, y: cy + hh / 2 },
+      'lower-right': { x: cx + hw / 2, y: cy + hh / 2 },
+      'upper-left': { x: cx - hw / 2, y: cy - hh / 2 },
+      'upper-right': { x: cx + hw / 2, y: cy - hh / 2 },
+    };
+    const downEdges = [], upEdges = [];
+    edges.forEach(e => {
+      // Honor explicit port hint
+      if (e.port && portMap[e.port]) {
+        ports[e.from + '->' + e.to] = portMap[e.port];
+        return;
+      }
+      const to = nodes.find(n => n.id === e.to);
+      if (!to) return;
+      const toCx = to.x + to.w / 2, toCy = to.y + to.h / 2;
+      const dx = toCx - cx, dy = toCy - cy;
+      if (dy < -10) {
+        upEdges.push({ edge: e, dx, dy });
+      } else {
+        // Everything at same level or below → treat as downward.
+        // Sorting by dx distributes them across lower ports (left-to-right).
+        downEdges.push({ edge: e, dx, dy });
+      }
+    });
+
+    // Up edges → top vertex
+    upEdges.forEach(({ edge }) => {
+      ports[edge.from + '->' + edge.to] = { x: cx, y: cy - hh };
+    });
+
+    // Down edges → distribute across lower ports based on count
+    downEdges.sort((a, b) => a.dx - b.dx); // sort left-to-right
+    const ll = { x: cx - hw / 2, y: cy + hh / 2 }; // lower-left midpoint
+    const bb = { x: cx, y: cy + hh };                // bottom vertex
+    const lr = { x: cx + hw / 2, y: cy + hh / 2 };  // lower-right midpoint
+    const lv = { x: cx - hw, y: cy };                // left vertex
+    const rv = { x: cx + hw, y: cy };                // right vertex
+    let downPorts;
+    switch (downEdges.length) {
+      case 0: downPorts = []; break;
+      case 1: downPorts = [bb]; break;
+      case 2: downPorts = [ll, lr]; break;
+      case 3: downPorts = [ll, bb, lr]; break;
+      case 4: downPorts = [lv, ll, lr, rv]; break;
+      case 5: downPorts = [lv, ll, bb, lr, rv]; break;
+      default: downPorts = [lv, ll, bb, lr, rv]; break;
+    }
+    downEdges.forEach(({ edge }, i) => {
+      ports[edge.from + '->' + edge.to] = downPorts[Math.min(i, downPorts.length - 1)];
+    });
+  }
+  return ports;
+}
+
 function renderSVG() {
   const nodes = getNodes();
   const conns = getConnections();
@@ -2538,8 +2193,10 @@ function renderSVG() {
 
   // Get dagre edge points for flowchart view
   let fcEdgePoints = null;
+  let diamondPorts = null;
   if (isFlowchart && state.selectedFlowchart) {
     fcEdgePoints = computeFlowchartLayout(state.selectedFlowchart).edgePoints;
+    diamondPorts = computeDiamondPorts(nodes, conns);
   }
 
   // Calculate bounds — symmetric padding using actual min/max of all nodes
@@ -2557,8 +2214,27 @@ function renderSVG() {
     maxX = Math.max(maxX, n.x + n.w);
     maxY = Math.max(maxY, n.y + n.h);
   });
-  const pad = 40;
-  svg.setAttribute('viewBox', `${minX - pad} ${minY - pad} ${maxX - minX + pad * 2} ${maxY - minY + pad * 2}`);
+  const pad = 40; // base padding in SVG units (all sides)
+  // Scale-aware top/bottom clearance for UI overlays (burger menu, zoom controls).
+  // When height constrains the fit, we solve for the viewBox height that guarantees
+  // the desired screen-pixel clearance at the FINAL scale, not the pre-padding scale.
+  const rawW = maxX - minX + pad * 2;
+  const rawH = maxY - minY + pad * 2;
+  const canvasW = svg.clientWidth || 800;
+  const canvasH = svg.clientHeight || 600;
+  let extraTop = 0, extraBottom = 0;
+  if (rawH / canvasH > rawW / canvasW) {
+    // Height-constrained: viewBox height maps exactly to canvas height
+    const topClearPx = 48;
+    const bottomClearPx = 52;
+    const usableFrac = 1 - (topClearPx + bottomClearPx) / canvasH;
+    const finalH = rawH / usableFrac;
+    extraTop = Math.max(0, finalH * (topClearPx / canvasH) - pad);
+    extraBottom = Math.max(0, finalH * (bottomClearPx / canvasH) - pad);
+  }
+  const contentW = rawW;
+  const contentH = rawH + extraTop + extraBottom;
+  svg.setAttribute('viewBox', `${minX - pad} ${minY - pad - extraTop} ${contentW} ${contentH}`);
   svg.style.width = '100%';
   svg.style.height = '100%';
 
@@ -2661,15 +2337,29 @@ function renderSVG() {
         let endPt = pts[pts.length - 1];
 
         if (fromIsDiamond) {
-          startPt = clipToDiamond(fromCx, fromCy, from.w / 2, from.h / 2, pts[1] ? pts[1].x : endPt.x, pts[1] ? pts[1].y : endPt.y);
+          // Use pre-computed context-aware port for outgoing edges
+          const portKey = c.from + '->' + c.to;
+          if (diamondPorts && diamondPorts[portKey]) {
+            startPt = diamondPorts[portKey];
+          } else {
+            startPt = clipToDiamond(fromCx, fromCy, from.w / 2, from.h / 2, pts[1] ? pts[1].x : endPt.x, pts[1] ? pts[1].y : endPt.y);
+          }
         }
         if (toIsDiamond) {
+          // Use simple direction-based snap for incoming edges
           const prevPt = pts.length > 2 ? pts[pts.length - 2] : startPt;
           endPt = clipToDiamond(toCx, toCy, to.w / 2, to.h / 2, prevPt.x, prevPt.y);
+          endPt = snapToDiamondPort(toCx, toCy, to.w / 2, to.h / 2, endPt);
         }
 
-        // Build rounded polyline through dagre waypoints
-        const allPts = [startPt, ...pts.slice(1, -1), endPt];
+        // When an explicit port hint overrides dagre's exit point, discard
+        // dagre's intermediate waypoints — they were computed for a different
+        // exit direction and create kinks.  Draw a direct line instead.
+        // Skip dagre waypoints for port-hinted edges (they create kinks),
+        // but keep them for backloops which need waypoints to route around nodes.
+        const hasPortHint = c.port && c.type !== 'backloop' && diamondPorts && diamondPorts[c.from + '->' + c.to];
+        const midPts = hasPortHint ? [] : pts.slice(1, -1);
+        const allPts = [startPt, ...midPts, endPt];
         if (allPts.length === 2) {
           html += `<path d="M${allPts[0].x},${allPts[0].y} L${allPts[1].x},${allPts[1].y}" stroke="${strokeColor}" stroke-width="1.5" fill="none" stroke-dasharray="${dashArray}" marker-end="${marker}" opacity="0.6"/>`;
         } else {
@@ -2692,13 +2382,25 @@ function renderSVG() {
 
         // Label position along dagre path
         if (c.label && from.shape === 'diamond') {
-          // Position label near source diamond (~30% along path)
-          const totalLen = allPts.length - 1;
-          const fracIdx = totalLen * 0.3;
-          const lo = Math.floor(fracIdx), hi = Math.min(lo + 1, allPts.length - 1);
-          const t = fracIdx - lo;
-          sx = allPts[lo].x + (allPts[hi].x - allPts[lo].x) * t;
-          sy = allPts[lo].y + (allPts[hi].y - allPts[lo].y) * t;
+          // Position label near source diamond — dynamic distance based on
+          // edge direction and label width to prevent overlap
+          const segDx = allPts[1].x - allPts[0].x;
+          const segDy = allPts[1].y - allPts[0].y;
+          const segLen = Math.sqrt(segDx * segDx + segDy * segDy);
+          if (segLen > 1) {
+            const tw = c.label.length * 5.5 + 10; // label pill width
+            const horizBias = Math.abs(segDx) / segLen; // 0=vertical, 1=horizontal
+            const vertBias = Math.abs(segDy) / segLen;
+            // Horizontal edges need more distance for wide labels (tw/2 + gap)
+            // Vertical edges need less (just pill half-height + gap)
+            const minDist = horizBias * (tw / 2 + 8) + vertBias * 22;
+            const dist = Math.max(minDist, segLen * 0.3);
+            sx = allPts[0].x + (segDx / segLen) * dist;
+            sy = allPts[0].y + (segDy / segLen) * dist;
+          } else {
+            sx = allPts[0].x;
+            sy = allPts[0].y;
+          }
         } else if (allPts.length % 2 === 1) {
           const mi = Math.floor(allPts.length / 2);
           sx = allPts[mi].x; sy = allPts[mi].y;
@@ -2793,12 +2495,22 @@ function renderSVG() {
     if (n.shape === 'diamond') {
       const hw = n.w / 2, hh = n.h / 2;
       html += `<polygon points="${cx},${cy - hh} ${cx + hw},${cy} ${cx},${cy + hh} ${cx - hw},${cy}" fill="${n.bg}" stroke="${n.color}" stroke-width="${strokeW}" stroke-opacity="${strokeOpacity}"/>`;
-      // Text wrapping for diamonds: split long labels
+      // Text wrapping for diamonds: split long labels at nearest space to midpoint
       const label = n.label;
       if (label.length > 12) {
         const mid = Math.ceil(label.length / 2);
-        const spaceIdx = label.lastIndexOf(' ', mid);
-        const breakAt = spaceIdx > 3 ? spaceIdx : mid;
+        const spaceBefore = label.lastIndexOf(' ', mid);
+        const spaceAfter = label.indexOf(' ', mid);
+        let breakAt;
+        if (spaceBefore <= 0 && (spaceAfter < 0 || spaceAfter >= label.length - 1)) {
+          breakAt = mid;
+        } else if (spaceBefore <= 0) {
+          breakAt = spaceAfter;
+        } else if (spaceAfter < 0 || spaceAfter >= label.length - 1) {
+          breakAt = spaceBefore;
+        } else {
+          breakAt = (mid - spaceBefore <= spaceAfter - mid) ? spaceBefore : spaceAfter;
+        }
         const line1 = label.substring(0, breakAt);
         const line2 = label.substring(breakAt).trim();
         html += `<text x="${cx}" y="${cy - 4}" fill="${n.color}" font-size="11" font-weight="600" text-anchor="middle" font-family="-apple-system,system-ui,sans-serif">${line1}</text>`;
@@ -2922,17 +2634,94 @@ canvasArea.addEventListener('click', (e) => {
 // Close md-viewer via backdrop click
 document.getElementById('md-viewer-backdrop').addEventListener('click', closeMdViewer);
 
+// ── Info Panel ──
+document.getElementById('info-panel-backdrop').addEventListener('click', closeInfoPanel);
+
+function openInfoPanel() {
+  if (!state.selectedFlowchart) return;
+  const p = phases[state.selectedFlowchart];
+  const desc = FLOWCHART_DESCS[state.selectedFlowchart];
+  const name = p ? p.label : state.selectedFlowchart;
+  const cmd = p ? p.cmd : '/' + state.selectedFlowchart;
+
+  document.getElementById('info-panel-title').textContent = name;
+
+  let html = `<div class="info-subtitle">${cmd}</div>`;
+
+  if (desc && typeof desc === 'object') {
+    if (desc.summary) html += `<div class="info-summary">${desc.summary}</div>`;
+    if (desc.body) html += `<div class="info-desc">${desc.body}</div>`;
+    if (desc.meta) {
+      html += '<div class="info-meta">';
+      if (desc.meta.complexity) html += `<span><strong>Complexity:</strong> ${desc.meta.complexity}</span>`;
+      if (desc.meta.output) html += `<span><strong>Output:</strong> <code>${desc.meta.output}</code></span>`;
+      if (desc.meta.skill) html += `<span><strong>Skill:</strong> ${desc.meta.skill}</span>`;
+      if (desc.meta.discovery) html += `<span><strong>Discovery:</strong> ${desc.meta.discovery}</span>`;
+      if (desc.meta.cache) html += `<span><strong>Cache:</strong> ${desc.meta.cache}</span>`;
+      html += '</div>';
+    }
+  } else if (desc) {
+    html += `<div class="info-desc">${desc}</div>`;
+  } else if (p && p.desc) {
+    html += `<div class="info-desc">${p.desc}</div>`;
+  }
+
+  if (SOURCE_MAP[state.selectedFlowchart]) {
+    html += `<button class="info-panel-source-btn" onclick="openMdViewer('${state.selectedFlowchart}')">&lt;/&gt; View Source</button>`;
+  }
+
+  document.getElementById('info-panel-body').innerHTML = html;
+  document.getElementById('info-panel').classList.add('open');
+  document.getElementById('info-panel-backdrop').classList.add('visible');
+}
+
+function closeInfoPanel() {
+  document.getElementById('info-panel').classList.remove('open');
+  document.getElementById('info-panel-backdrop').classList.remove('visible');
+}
+
+function openMdViewerFromZoom() {
+  if (!state.selectedFlowchart || !SOURCE_MAP[state.selectedFlowchart]) return;
+  openMdViewer(state.selectedFlowchart);
+}
+
+function updateContextButtons() {
+  const hasFlowchart = !!state.selectedFlowchart;
+  const hasSource = hasFlowchart && !!SOURCE_MAP[state.selectedFlowchart];
+  const infoBtn = document.getElementById('btn-info');
+  const sourceBtn = document.getElementById('btn-source');
+  if (infoBtn) {
+    infoBtn.classList.toggle('disabled', !hasFlowchart);
+  }
+  if (sourceBtn) {
+    sourceBtn.classList.toggle('disabled', !hasSource);
+  }
+}
+
 // ── Interaction ──
+function highlightNavButtons(phase, clickedBtn) {
+  document.querySelectorAll('.nav-btn').forEach(b => b.classList.remove('active'));
+  if (!phase) return;
+  if (clickedBtn) {
+    // Highlight only the specific button that was clicked
+    clickedBtn.classList.add('active');
+  } else {
+    // Fallback: highlight by ID (for hash navigation, programmatic calls)
+    const byId = document.getElementById('btn-' + phase);
+    if (byId) byId.classList.add('active');
+  }
+}
+
 function showOverview() {
   state.view = 'overview';
   state.selectedPhase = null;
   state.selectedFlowchart = null;
 
-  document.querySelectorAll('.phase-btn, .cmd-btn, .nav-overview').forEach(b => b.classList.remove('active'));
+  highlightNavButtons(null);
   document.getElementById('btn-overview').classList.add('active');
 
-  document.getElementById('detail-panel').classList.remove('open');
   hideFcTooltip();
+  closeInfoPanel();
   closeMdViewer();
   _layoutCache = {};
 
@@ -2942,13 +2731,14 @@ function showOverview() {
   if (isMobile()) closeSidebar();
 
   if (!_navigatingFromHash) location.hash = 'overview';
-  updatePrompt();
+  updateContextButtons();
   resetZoom();
   renderSVG();
 }
 
-function selectPhase(phase) {
+function selectPhase(phase, clickedBtn) {
   if (isMobile()) closeSidebar();
+  closeInfoPanel();
   closeMdViewer();
   if (!_navigatingFromHash) location.hash = phase;
 
@@ -2958,46 +2748,26 @@ function selectPhase(phase) {
     state.selectedFlowchart = phase;
     state.selectedPhase = phase;
 
-    document.querySelectorAll('.phase-btn, .cmd-btn, .nav-overview').forEach(b => b.classList.remove('active'));
-    const btn = document.getElementById('btn-' + phase);
-    if (btn) btn.classList.add('active');
+    highlightNavButtons(phase, clickedBtn);
 
-    document.getElementById('detail-panel').classList.remove('open');
     hideFcTooltip();
     _layoutCache = {};
 
     document.getElementById('legend-default').style.display = 'none';
     document.getElementById('legend-flowchart').style.display = '';
 
-    updatePrompt();
+    updateContextButtons();
     resetZoom();
     renderSVG();
     return;
   }
 
-  // No flowchart — show detail panel (utility commands)
+  // No flowchart — just highlight sidebar
   state.selectedPhase = phase;
-  document.querySelectorAll('.phase-btn, .cmd-btn, .nav-overview').forEach(b => b.classList.remove('active'));
-  const btn = document.getElementById('btn-' + phase);
-  if (btn) btn.classList.add('active');
+  state.selectedFlowchart = null;
+  highlightNavButtons(phase, clickedBtn);
 
-  const data = phases[phase];
-  if (data && data.detailHTML) {
-    document.getElementById('detail-content').innerHTML = data.detailHTML();
-    document.getElementById('detail-panel').classList.add('open');
-  }
-  updatePrompt();
-  renderSVG();
-}
-
-function closeDetail() {
-  document.getElementById('detail-panel').classList.remove('open');
-  state.selectedPhase = null;
-  document.querySelectorAll('.phase-btn, .cmd-btn').forEach(b => b.classList.remove('active'));
-  if (state.view === 'overview') {
-    document.getElementById('btn-overview').classList.add('active');
-  }
-  updatePrompt();
+  updateContextButtons();
   renderSVG();
 }
 
@@ -3025,7 +2795,7 @@ function resetZoom() {
 
 // Mouse wheel zoom
 canvasArea.addEventListener('wheel', (e) => {
-  if (e.target.closest('.detail-panel') || e.target.closest('.md-viewer')) return;
+  if (e.target.closest('.md-viewer') || e.target.closest('.info-panel')) return;
   e.preventDefault();
   const factor = e.deltaY < 0 ? 1.03 : 1/1.03;
   zoom(factor);
@@ -3034,7 +2804,7 @@ canvasArea.addEventListener('wheel', (e) => {
 // Pan
 let isPanning = false, panStart = { x: 0, y: 0 }, vbStart = [0,0,0,0];
 canvasArea.addEventListener('mousedown', (e) => {
-  if (e.target.closest('.svg-node') || e.target.closest('.detail-panel') || e.target.closest('.md-viewer')) return;
+  if (e.target.closest('.svg-node') || e.target.closest('.md-viewer') || e.target.closest('.info-panel')) return;
   isPanning = true;
   panStart = { x: e.clientX, y: e.clientY };
   vbStart = svg.getAttribute('viewBox').split(' ').map(Number);
@@ -3066,7 +2836,7 @@ function touchMidpoint(t) {
 }
 
 canvasArea.addEventListener('touchstart', (e) => {
-  if (e.target.closest('.detail-panel') || e.target.closest('.zoom-controls') || e.target.closest('.md-viewer')) return;
+  if (e.target.closest('.zoom-controls') || e.target.closest('.md-viewer') || e.target.closest('.info-panel')) return;
   const t = e.touches;
   if (t.length === 2) {
     // Start pinch
@@ -3084,7 +2854,7 @@ canvasArea.addEventListener('touchstart', (e) => {
 }, { passive: true });
 
 canvasArea.addEventListener('touchmove', (e) => {
-  if (e.target.closest('.detail-panel') || e.target.closest('.zoom-controls') || e.target.closest('.md-viewer')) return;
+  if (e.target.closest('.zoom-controls') || e.target.closest('.md-viewer') || e.target.closest('.info-panel')) return;
   e.preventDefault();
   const t = e.touches;
   if (pinching && t.length === 2) {
@@ -3113,59 +2883,15 @@ canvasArea.addEventListener('touchend', (e) => {
   if (e.touches.length < 1) touchPanning = false;
 }, { passive: true });
 
-// ── Info Bar ──
-function updatePrompt() {
-  const bar = document.getElementById('info-bar');
-
-  if (state.view === 'flowchart' && state.selectedFlowchart) {
-    const p = phases[state.selectedFlowchart];
-    const desc = FLOWCHART_DESCS[state.selectedFlowchart];
-    const name = p ? p.label : state.selectedFlowchart;
-    const cmd = p ? p.cmd : '/' + state.selectedFlowchart;
-
-    const hasSource = !!SOURCE_MAP[state.selectedFlowchart];
-    const sourceBtn = hasSource ? ` <button class="view-source-btn" onclick="openMdViewer('${state.selectedFlowchart}')">&lt;/&gt; Source</button>` : '';
-
-    if (desc && typeof desc === 'object') {
-      let html = `<div class="info-title">${name}${sourceBtn}</div>`;
-      html += `<div class="info-subtitle">${cmd}</div>`;
-      html += `<div class="info-body">${desc.summary ? `<p><strong>${desc.summary}</strong></p>` : ''}${desc.body || ''}</div>`;
-      if (desc.meta) {
-        html += '<div class="info-meta">';
-        if (desc.meta.complexity) html += `<span><strong>Complexity:</strong> ${desc.meta.complexity}</span>`;
-        if (desc.meta.output) html += `<span><strong>Output:</strong> <code>${desc.meta.output}</code></span>`;
-        if (desc.meta.skill) html += `<span><strong>Skill:</strong> ${desc.meta.skill}</span>`;
-        if (desc.meta.discovery) html += `<span><strong>Discovery:</strong> ${desc.meta.discovery}</span>`;
-        if (desc.meta.cache) html += `<span><strong>Cache:</strong> ${desc.meta.cache}</span>`;
-        html += '</div>';
-      }
-      bar.innerHTML = html;
-    } else {
-      bar.innerHTML = `<div class="info-title">${name}${sourceBtn}</div><div class="info-subtitle">${cmd}</div><div class="info-body">${desc || ''}</div>`;
-    }
-    bar.scrollTop = 0;
-    return;
-  }
-
-  if (!state.selectedPhase) {
-    const msg = state.view === 'overview'
-      ? 'The 6-phase workflow pipeline. Click any phase to view its command flowchart.'
-      : 'Select a command or skill to view its flowchart, or click Overview to return.';
-    bar.innerHTML = `<div class="info-body">${msg}</div>`;
-    return;
-  }
-
-  const p = phases[state.selectedPhase];
-  if (!p) return;
-  bar.innerHTML = `<div class="info-title">${p.label}</div><div class="info-subtitle">${p.cmd}</div><div class="info-body">${p.desc || ''}</div>`;
-  bar.scrollTop = 0;
-}
-
 // ── Hash Navigation ──
 let _navigatingFromHash = false;
 
 function navigateFromHash() {
   const hash = location.hash.replace('#', '');
+  // Skip if we're already viewing this phase (avoids re-highlighting from programmatic hash changes)
+  const currentKey = state.selectedFlowchart || state.selectedPhase;
+  if (hash && hash === currentKey) return;
+  if ((!hash || hash === 'overview') && state.view === 'overview') return;
   _navigatingFromHash = true;
   if (!hash || hash === 'overview') {
     showOverview();
@@ -3184,8 +2910,8 @@ if (location.hash && location.hash !== '#' && location.hash !== '#overview') {
   navigateFromHash();
 } else {
   renderSVG();
-  updatePrompt();
   document.getElementById('btn-overview').classList.add('active');
+  updateContextButtons();
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary

- Added `· · ·` (middle-dot) separator lines before option/choice blocks across all ~30 stopgate points in 18 files
- Added single-letter shortcut prefixes to commands (e.g., `skip` → `s`/`skip`, `continue` → `c`/`continue`) for faster interaction
- Non-command instructions ("Or tell me what to change", "Comment") left as-is

## Why `· · ·`

- `---` is overloaded (frontmatter, section breaks)
- `· · ·` is lighter — signals "pause, options follow" without competing with structural separators
- Renders cleanly in Claude Code's terminal

## Files changed (18)

**Skills:**
- `specification-guide.md` — 3 stopgates
- `define-phases.md`, `define-tasks.md`, `plan-construction.md`, `author-tasks.md` — 1 each
- `analyze-task-graph.md` — 2 stopgates
- `resolve-dependencies.md` — 1 stopgate
- `review-traceability.md`, `review-integrity.md` — 1 each + `skip` → `s`/`skip`
- `technical-planning/SKILL.md` — `c`/`continue`, `r`/`restart`
- `task-loop.md` — 3 stopgates + `r`/`retry`, `s`/`skip`, `t`/`stop`, `a`/`auto`
- `technical-implementation/SKILL.md` — `c`/`change`

**Commands:**
- `start-discussion.md` — 3 stopgates + `r`/`refresh`
- `start-specification.md` — 5 stopgates + `r`/`refresh`
- `start-implementation.md` — 3 stopgates
- `start-planning.md` — 2 stopgates
- `start-review.md` — 2 stopgates
- `link-dependencies.md` — `y`/`yes`, `n`/`no`

## Test plan

- [x] Verify `grep -rn '· · ·' skills/ commands/` returns all 18 expected files (33 occurrences)
- [ ] Visual review of each file to confirm separator positioning
- [ ] Run a planning or implementation session to confirm terminal rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)