### PR TITLE
Fix executor re-attempt to include full task content

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(git checkout:*)",
-      "Bash(gh issue view:*)"
+      "Bash(gh issue view:*)",
+      "Bash(/usr/bin/diff:*)"
     ],
     "deny": [],
     "ask": []

--- a/agents/implementation-task-executor.md
+++ b/agents/implementation-task-executor.md
@@ -19,9 +19,11 @@ You receive file paths and context via the orchestrator's prompt:
 4. **Project skill paths** — Relevant `.claude/skills/` paths for framework conventions
 5. **Task content** — Task ID, phase, and all instructional content: goal, implementation steps, acceptance criteria, tests, edge cases, context, notes. This is your scope.
 
-On **re-invocation after review feedback**, you also receive:
-- **User-approved review notes** — may be the reviewer's original notes, modified by user, or user's own notes
-- **Specific issues to address**
+On **re-invocation after review feedback**, you receive all of the above, plus:
+6. **User-approved review notes** — may be the reviewer's original notes, modified by user, or user's own notes
+7. **Specific issues to address**
+
+You are stateless — each invocation starts fresh. The full task content is always provided so you can see what was asked, what was done, and what needs fixing.
 
 ## Your Process
 

--- a/skills/technical-implementation/references/steps/invoke-executor.md
+++ b/skills/technical-implementation/references/steps/invoke-executor.md
@@ -10,7 +10,7 @@ This step invokes the `implementation-task-executor` agent (`.claude/agents/impl
 
 ## Invoke the Agent
 
-Invoke `implementation-task-executor` with these file paths:
+**Every invocation** — initial or re-attempt — includes these file paths:
 
 1. **tdd-workflow.md**: `.claude/skills/technical-implementation/references/tdd-workflow.md`
 2. **code-quality.md**: `.claude/skills/technical-implementation/references/code-quality.md`
@@ -18,9 +18,11 @@ Invoke `implementation-task-executor` with these file paths:
 4. **Project skill paths**: from `project_skills` in the implementation tracking file
 5. **Task content**: normalised task content (see [task-normalisation.md](../task-normalisation.md))
 
-On **re-invocation after review feedback**, also include:
-- **User-approved review notes**: verbatim or as modified by the user
-- **Specific issues to address**: the ISSUES from the review
+**Re-attempts after review feedback** additionally include:
+6. **User-approved review notes**: verbatim or as modified by the user
+7. **Specific issues to address**: the ISSUES from the review
+
+The executor is stateless — each invocation starts fresh with no memory of previous attempts. Always pass the full task content so the executor can see what was asked, what was done, and what needs fixing.
 
 ---
 

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -55,7 +55,7 @@ Present the executor's ISSUES to the user:
 
 #### If `retry`
 
-→ Return to the top of **B. Execute Task** and re-invoke the executor with the user's comments added to the task context.
+→ Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the user's comments.
 
 #### If `skip`
 
@@ -94,9 +94,9 @@ Present the reviewer's findings to the user:
 
 **STOP.** Wait for user choice.
 
-- **`y`/`yes`**: → Return to the top of **B. Execute Task** and re-invoke the executor with the reviewer's notes added.
+- **`y`/`yes`**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes.
 - **`skip`**: → Proceed to **D. Task Gate**.
-- **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the user's notes.
+- **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the user's notes.
 
 ---
 
@@ -124,7 +124,7 @@ Present a summary and wait for user input:
 
 - **`y`/`yes`**: → Proceed to **E. Update Progress and Commit**.
 - **`auto`**: Note that `task_gate_mode` should be updated to `auto` during the commit step. → Proceed to **E. Update Progress and Commit**.
-- **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the user's notes added.
+- **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the user's notes.
 
 ### If `task_gate_mode: auto`
 


### PR DESCRIPTION
## Summary

- Executor re-attempts after review feedback were missing the original task details (goal, acceptance criteria, implementation steps, etc.) because the instructions relied on the word "also" to imply re-sending all original context
- Reframed `invoke-executor.md` with an "every invocation" heading and added a stateless reminder explaining why full context is always needed
- Updated all four re-invocation points in `task-loop.md` to explicitly say "full task content and the notes"
- Mirrored changes in the executor agent's "Your Input" section

## Test plan

- [ ] Run an implementation session where the reviewer returns `needs-changes`
- [ ] Accept the reviewer's notes and verify the executor's re-attempt prompt includes the full normalised task content alongside the review notes
- [ ] Verify the executor can reference original acceptance criteria when addressing reviewer feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)