### PR TITLE
Add fix analysis to reviewer and fix_gate_mode

### DIFF
--- a/.claude/skills/update-workflow-explorer/SKILL.md
+++ b/.claude/skills/update-workflow-explorer/SKILL.md
@@ -10,11 +10,36 @@ Audit `workflow-explorer.html` and sync its flowchart data with the actual comma
 
 ## Step 0: Determine Scope
 
+### 0a: Check for explicit context
+
 Check `$ARGUMENTS` for user-provided context about what changed.
 
 - **Context given** (e.g. "I just updated the implementation skill") → narrow to affected flowchart keys using the source mapping below
-- **No context** → full audit of all 24 flowchart keys
 - **Ambiguous** → ASK user to confirm scope before proceeding
+
+If explicit context was given, skip 0b and proceed to Step 1 with the narrowed scope.
+
+### 0b: Detect git context
+
+If no explicit context was given, check the git state:
+
+1. **Branch check** — run `git branch --show-current`. If not on `main`/`master`, note the feature branch name.
+2. **Changed files** — run `git diff main --name-only` (branch changes) and `git diff --name-only` + `git diff --cached --name-only` (uncommitted/staged changes). Combine into a single list of changed files.
+3. **Cross-reference** — match changed files against the source mapping below. Identify which flowchart keys are affected.
+
+If changed source files are detected, present findings to the user:
+
+> I'm on branch `{branch}` with changes to these source files:
+> - `{file}` → flowchart key(s): `{key}`
+> - ...
+>
+> **Options:**
+> 1. **Scope to these changes** — audit only the affected flowchart keys (recommended if this branch represents all recent work)
+> 2. **Full audit** — audit all flowchart keys regardless of git state
+
+Wait for user confirmation before proceeding.
+
+If no changed source files are detected (on main with clean tree), proceed with a full audit.
 
 ## Step 1: Read Source Files
 

--- a/agents/implementation-task-reviewer.md
+++ b/agents/implementation-task-reviewer.md
@@ -62,6 +62,22 @@ Is this a sound design decision? Will it compose well with future tasks?
 - Will this cause problems for subsequent tasks in the phase?
 - Are there structural concerns that should be raised now rather than compounding?
 
+## Fix Recommendations (needs-changes only)
+
+When your verdict is `needs-changes`, you must also recommend how to fix each issue. You have full context — the spec, the task, the conventions, and the code — so use it.
+
+For each issue, provide:
+- **FIX**: The recommended approach to resolve the issue
+- **ALTERNATIVE** (optional): If multiple valid approaches exist, state them with tradeoffs and indicate which you recommend
+- **CONFIDENCE**: `high` | `medium` | `low`
+  - `high` — single obvious approach, no ambiguity
+  - `medium` — recommended approach is sound but alternatives exist
+  - `low` — genuinely uncertain, multiple approaches with significant tradeoffs
+
+Be specific and actionable. "Fix the validation" is not useful. "Add a test case in `tests/UserTest.php` that asserts `ValidationException` is thrown when email is empty, following the existing test pattern at line 45" is useful.
+
+When alternatives exist, explain the tradeoff briefly — don't just list options. State which you recommend and why.
+
 ## Hard Rules
 
 **MANDATORY. No exceptions. Violating these rules invalidates the review.**
@@ -89,9 +105,14 @@ CONVENTIONS: {followed | violations — list}
 ARCHITECTURE: {sound | concerns — details}
 ISSUES:
 - {specific issue with file:line reference}
+  FIX: {recommended approach}
+  ALTERNATIVE: {other valid approach with tradeoff — optional, only when multiple valid approaches exist}
+  CONFIDENCE: {high | medium | low}
 NOTES:
 - {non-blocking observations}
 ```
 
-- If VERDICT is `needs-changes`, ISSUES must contain specific, actionable items with file:line references
+- If VERDICT is `approved`, omit ISSUES entirely (or leave empty)
+- If VERDICT is `needs-changes`, ISSUES must contain specific, actionable items with file:line references AND fix recommendations
+- Each issue must include FIX and CONFIDENCE. ALTERNATIVE is optional — include only when genuinely multiple valid approaches exist
 - NOTES are for non-blocking observations — things worth noting but not requiring changes

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -48,7 +48,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Check task progress in the plan** — use the plan adapter's instructions to read the plan's current state. Also read the implementation tracking file and any other working documents for additional context.
-3. **Check `task_gate_mode`** in the tracking file — if `auto`, the user previously opted out of per-task gates for this session.
+3. **Check `task_gate_mode` and `fix_gate_mode`** in the tracking file — if `auto`, the user previously opted out of per-task or per-fix gates for this session.
 4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 5. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 
@@ -143,7 +143,7 @@ Store the selected skill paths — they will be persisted to the tracking file i
 
 #### If `docs/workflow/implementation/{topic}.md` already exists
 
-Reset `task_gate_mode` to `gated` in the tracking file before proceeding (fresh session = fresh gate).
+Reset `task_gate_mode` and `fix_gate_mode` to `gated` in the tracking file before proceeding (fresh session = fresh gates).
 
 If `project_skills` is populated in the tracking file, present for confirmation:
 
@@ -174,6 +174,7 @@ plan: ../planning/{topic}.md
 format: {format from plan}
 status: in-progress
 task_gate_mode: gated
+fix_gate_mode: gated
 project_skills: []
 current_phase: 1
 current_task: ~

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -48,7 +48,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Check task progress in the plan** — use the plan adapter's instructions to read the plan's current state. Also read the implementation tracking file and any other working documents for additional context.
-3. **Check `task_gate_mode` and `fix_gate_mode`** in the tracking file — if `auto`, the user previously opted out of per-task or per-fix gates for this session.
+3. **Check `task_gate_mode`, `fix_gate_mode`, and `fix_attempts`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task.
 4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 5. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 
@@ -143,7 +143,7 @@ Store the selected skill paths — they will be persisted to the tracking file i
 
 #### If `docs/workflow/implementation/{topic}.md` already exists
 
-Reset `task_gate_mode` and `fix_gate_mode` to `gated` in the tracking file before proceeding (fresh session = fresh gates).
+Reset `task_gate_mode` and `fix_gate_mode` to `gated`, and `fix_attempts` to `0`, in the tracking file before proceeding (fresh session = fresh gates).
 
 If `project_skills` is populated in the tracking file, present for confirmation:
 
@@ -175,6 +175,7 @@ format: {format from plan}
 status: in-progress
 task_gate_mode: gated
 fix_gate_mode: gated
+fix_attempts: 0
 project_skills: []
 current_phase: 1
 current_task: ~

--- a/skills/technical-implementation/references/steps/invoke-reviewer.md
+++ b/skills/technical-implementation/references/steps/invoke-reviewer.md
@@ -32,9 +32,12 @@ CONVENTIONS: {followed | violations — list}
 ARCHITECTURE: {sound | concerns — details}
 ISSUES:
 - {specific issue with file:line reference}
+  FIX: {recommended approach}
+  ALTERNATIVE: {other valid approach with tradeoff — optional}
+  CONFIDENCE: {high | medium | low}
 NOTES:
 - {non-blocking observations}
 ```
 
 - `approved`: task passes all five review dimensions
-- `needs-changes`: ISSUES contains specific, actionable items
+- `needs-changes`: ISSUES contains specific, actionable items with fix recommendations and confidence levels

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -26,7 +26,7 @@ E. Update progress + commit
 1. Follow the format's **reading.md** instructions to determine the next available task.
 2. If no available tasks remain → skip to **When All Tasks Are Complete**.
 3. Normalise the task content following **[task-normalisation.md](../task-normalisation.md)**.
-4. Reset the **fix attempt counter** to `0` for this task.
+4. Reset `fix_attempts` to `0` in the implementation tracking file.
 
 ---
 
@@ -78,7 +78,7 @@ Present the executor's ISSUES to the user:
 
 ### Review Changes
 
-Increment the **fix attempt counter** for this task.
+Increment `fix_attempts` in the implementation tracking file.
 
 Check the `fix_gate_mode` field in the implementation tracking file.
 
@@ -109,7 +109,7 @@ Present the reviewer's findings and fix analysis to the user:
 
 #### If `fix_gate_mode: auto`
 
-**Tripwire check:** If the fix attempt counter has reached **3**, the executor and reviewer have failed to converge. Override `fix_gate_mode` and escalate to the user:
+**Tripwire check:** If `fix_attempts` has reached **3**, the executor and reviewer have failed to converge. Override `fix_gate_mode` and escalate to the user:
 
 > **Review for Task {id}: {Task Name} — needs changes (attempt {N}, escalated)**
 >

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -80,23 +80,21 @@ Present the executor's ISSUES to the user:
 
 Increment `fix_attempts` in the implementation tracking file.
 
-#### Auto-proceed (no user interaction)
+#### If `fix_gate_mode: auto` and `fix_attempts < 3`
 
-If `fix_gate_mode: auto` **and** `fix_attempts < 3`:
+Announce the fix round (one line, no stop):
 
 > **Review for Task {id}: {Task Name} — needs changes** (attempt {N}/{max 3}, fix analysis included). Re-invoking executor.
 
 → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 
-#### Present to user (all other cases)
+#### If `fix_gate_mode: gated`, or `fix_attempts >= 3`
 
-This applies when `fix_gate_mode: gated`, **or** when `fix_attempts` has reached **3** (tripwire — the executor and reviewer have failed to converge, regardless of gate mode).
-
-If tripwire triggered, prepend:
+If `fix_attempts >= 3`, the executor and reviewer have failed to converge. Prepend:
 
 > The executor and reviewer have not converged after {N} attempts. Escalating for human review.
 
-Present the reviewer's findings and fix analysis:
+Present the reviewer's findings and fix analysis to the user:
 
 > **Review for Task {id}: {Task Name} — needs changes** (attempt {N})
 >

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -26,6 +26,7 @@ E. Update progress + commit
 1. Follow the format's **reading.md** instructions to determine the next available task.
 2. If no available tasks remain → skip to **When All Tasks Are Complete**.
 3. Normalise the task content following **[task-normalisation.md](../task-normalisation.md)**.
+4. Reset the **fix attempt counter** to `0` for this task.
 
 ---
 
@@ -77,13 +78,15 @@ Present the executor's ISSUES to the user:
 
 ### Review Changes
 
+Increment the **fix attempt counter** for this task.
+
 Check the `fix_gate_mode` field in the implementation tracking file.
 
-#### If `fix_gate_mode: gated`
+#### If `fix_gate_mode: gated` (or tripwire triggered — see below)
 
 Present the reviewer's findings and fix analysis to the user:
 
-> **Review for Task {id}: {Task Name} — needs changes**
+> **Review for Task {id}: {Task Name} — needs changes** (attempt {N})
 >
 > {ISSUES from reviewer, including FIX, ALTERNATIVE, and CONFIDENCE for each}
 >
@@ -106,9 +109,17 @@ Present the reviewer's findings and fix analysis to the user:
 
 #### If `fix_gate_mode: auto`
 
-Announce the fix round (one line, no stop):
+**Tripwire check:** If the fix attempt counter has reached **3**, the executor and reviewer have failed to converge. Override `fix_gate_mode` and escalate to the user:
 
-> **Review for Task {id}: {Task Name} — needs changes** ({N} issues, fix analysis included). Re-invoking executor.
+> **Review for Task {id}: {Task Name} — needs changes (attempt {N}, escalated)**
+>
+> The executor and reviewer have not converged after {N} attempts. Presenting for human review.
+
+→ Follow the **gated** path above.
+
+**Otherwise** (counter < 3), announce the fix round (one line, no stop):
+
+> **Review for Task {id}: {Task Name} — needs changes** (attempt {N}/{max 3}, fix analysis included). Re-invoking executor.
 
 → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -80,11 +80,23 @@ Present the executor's ISSUES to the user:
 
 Increment `fix_attempts` in the implementation tracking file.
 
-Check the `fix_gate_mode` field in the implementation tracking file.
+#### Auto-proceed (no user interaction)
 
-#### If `fix_gate_mode: gated` (or tripwire triggered — see below)
+If `fix_gate_mode: auto` **and** `fix_attempts < 3`:
 
-Present the reviewer's findings and fix analysis to the user:
+> **Review for Task {id}: {Task Name} — needs changes** (attempt {N}/{max 3}, fix analysis included). Re-invoking executor.
+
+→ Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
+
+#### Present to user (all other cases)
+
+This applies when `fix_gate_mode: gated`, **or** when `fix_attempts` has reached **3** (tripwire — the executor and reviewer have failed to converge, regardless of gate mode).
+
+If tripwire triggered, prepend:
+
+> The executor and reviewer have not converged after {N} attempts. Escalating for human review.
+
+Present the reviewer's findings and fix analysis:
 
 > **Review for Task {id}: {Task Name} — needs changes** (attempt {N})
 >
@@ -106,22 +118,6 @@ Present the reviewer's findings and fix analysis to the user:
 - **`auto`**: Note that `fix_gate_mode` should be updated to `auto` during the next commit step. → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 - **`skip`**: → Proceed to **D. Task Gate**.
 - **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content, the reviewer's notes, and the user's commentary.
-
-#### If `fix_gate_mode: auto`
-
-**Tripwire check:** If `fix_attempts` has reached **3**, the executor and reviewer have failed to converge. Override `fix_gate_mode` and escalate to the user:
-
-> **Review for Task {id}: {Task Name} — needs changes (attempt {N}, escalated)**
->
-> The executor and reviewer have not converged after {N} attempts. Presenting for human review.
-
-→ Follow the **gated** path above.
-
-**Otherwise** (counter < 3), announce the fix round (one line, no stop):
-
-> **Review for Task {id}: {Task Name} — needs changes** (attempt {N}/{max 3}, fix analysis included). Re-invoking executor.
-
-→ Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 
 ---
 

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -13,7 +13,7 @@ A. Retrieve next task
 B. Execute task → invoke-executor.md
    → Executor Blocked (conditional)
 C. Review task → invoke-reviewer.md
-   → Review Changes (conditional)
+   → Review Changes with fix analysis (conditional, fix_gate_mode)
 D. Task gate (gated → prompt user / auto → announce)
 E. Update progress + commit
 → loop back to A until done
@@ -77,26 +77,40 @@ Present the executor's ISSUES to the user:
 
 ### Review Changes
 
-Present the reviewer's findings to the user:
+Check the `fix_gate_mode` field in the implementation tracking file.
+
+#### If `fix_gate_mode: gated`
+
+Present the reviewer's findings and fix analysis to the user:
 
 > **Review for Task {id}: {Task Name} — needs changes**
 >
-> {ISSUES from reviewer}
+> {ISSUES from reviewer, including FIX, ALTERNATIVE, and CONFIDENCE for each}
 >
 > Notes (non-blocking):
 > {NOTES from reviewer}
 >
 > · · ·
 >
-> - **`y`/`yes`** — Accept these notes and pass them to the executor to fix
+> - **`y`/`yes`** — Accept the review and fix analysis, pass to executor
+> - **`a`/`auto`** — Accept and auto-approve future fix analyses
 > - **`s`/`skip`** — Override the reviewer and proceed as-is
-> - **Comment** — Modify or add to the notes before passing to the executor
+> - **Comment** — Any commentary, adjustments, alternative approaches, or questions before passing to executor
 
 **STOP.** Wait for user choice.
 
-- **`y`/`yes`**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes.
+- **`y`/`yes`**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
+- **`auto`**: Note that `fix_gate_mode` should be updated to `auto` during the next commit step. → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 - **`skip`**: → Proceed to **D. Task Gate**.
-- **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the user's notes.
+- **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content, the reviewer's notes, and the user's commentary.
+
+#### If `fix_gate_mode: auto`
+
+Announce the fix round (one line, no stop):
+
+> **Review for Task {id}: {Task Name} — needs changes** ({N} issues, fix analysis included). Re-invoking executor.
+
+→ Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 
 ---
 
@@ -145,9 +159,10 @@ Announce the result (one line, no stop):
 - Update `current_phase` if phase changed
 - Update `current_task` to the next task (or `~` if done)
 - Update `updated` to today's date
-- If user chose `auto` this turn: update `task_gate_mode: auto`
+- If user chose `auto` at the task gate this turn: update `task_gate_mode: auto`
+- If user chose `auto` at the fix gate this turn: update `fix_gate_mode: auto`
 
-The tracking file is a derived view for discovery scripts and cross-topic dependency resolution — not a decision-making input during implementation (except `task_gate_mode`).
+The tracking file is a derived view for discovery scripts and cross-topic dependency resolution — not a decision-making input during implementation (except `task_gate_mode` and `fix_gate_mode`).
 
 **Commit all changes** in a single commit:
 


### PR DESCRIPTION
## Summary

- **Reviewer now recommends fixes**: Each `needs-changes` issue includes `FIX` (recommended approach), `ALTERNATIVE` (optional, when multiple valid approaches exist), and `CONFIDENCE` (high/medium/low) — giving visibility into the system's fix strategy before the executor re-attempts
- **New `fix_gate_mode`**: Mirrors `task_gate_mode` (gated/auto) but controls the review-changes gate independently. Users can auto-approve fix analyses while keeping the task approval gate, or vice versa
- **Updated tracking file**: `fix_gate_mode: gated` added to template, reset on session resume, checked during context refresh recovery

### Files changed

| File | Change |
|------|--------|
| `agents/implementation-task-reviewer.md` | New "Fix Recommendations" section + updated output format |
| `skills/technical-implementation/references/steps/invoke-reviewer.md` | Updated expected result format |
| `skills/technical-implementation/references/steps/task-loop.md` | Review Changes now checks `fix_gate_mode`, auto option added |
| `skills/technical-implementation/SKILL.md` | Tracking file template, context refresh, session reset |

### Context

When the reviewer returns `needs-changes`, it currently says **what's wrong** but not **how to fix it**. The executor then independently decides the approach with no user visibility. This makes it hard to build confidence toward removing human-in-the-loop gates.

With fix analysis, the user can see the system's reasoning and planned approach before re-execution. Over time, consistently good fix recommendations build the trust needed to enable `fix_gate_mode: auto`.

## Test plan

- [ ] Run implementation with a task that triggers `needs-changes` — verify reviewer output includes FIX/CONFIDENCE per issue
- [ ] Verify fix analysis is presented in the Review Changes prompt
- [ ] Test `a`/`auto` at the fix gate — verify `fix_gate_mode` updates to `auto` in tracking file
- [ ] Test session resume resets `fix_gate_mode` to `gated`
- [ ] Test `fix_gate_mode: auto` skips the fix gate and re-invokes executor directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)