### PR TITLE
Add integration context and codebase cohesion to agent-based implementation

### DIFF
--- a/agents/implementation-task-executor.md
+++ b/agents/implementation-task-executor.md
@@ -82,7 +82,7 @@ TESTS_WRITTEN: {list of test files/methods}
 TEST_RESULTS: {all passing | failures — details}
 ISSUES: {any concerns, blockers, or deviations discovered}
 INTEGRATION_NOTES:
-- {3-5 concise bullet points anchored to concrete file paths — e.g., "Created `ValidationHelper` in `src/helpers/validation.ts` — use for all input validation". Reference what exists and where, not abstract descriptions}
+- {3-5 concise bullet points: key patterns, helpers, conventions, interface decisions established by this task. Anchor to concrete file paths where applicable (e.g., "Created `ValidationHelper` in `src/helpers/validation.ts` — use for all input validation"), but high-level observations without a specific file reference are also valuable}
 ```
 
 - If STATUS is `blocked` or `failed`, ISSUES **must** explain why and what decision is needed.

--- a/agents/implementation-task-executor.md
+++ b/agents/implementation-task-executor.md
@@ -34,7 +34,7 @@ You are stateless — each invocation starts fresh. The full task content is alw
 3. **Read project skills** — absorb framework conventions, testing patterns, architecture patterns
 4. **Read specification** (if provided) — understand broader context for this task
 5. **Explore codebase** — you are weaving into an existing canvas, not creating isolated patches:
-   - If an integration context file was provided, read it first to understand patterns, conventions, and helpers established by prior tasks
+   - If an integration context file was provided, read it first — identify helpers, patterns, and conventions you must reuse before writing anything new
    - Skim the plan file to understand the task landscape — what's been built, what's coming, where your task fits. Use this for awareness, not to build ahead (YAGNI still applies)
    - Read files and tests related to the task's domain
    - Search for existing helpers, utilities, and abstractions that solve similar problems — reuse, don't duplicate
@@ -82,7 +82,7 @@ TESTS_WRITTEN: {list of test files/methods}
 TEST_RESULTS: {all passing | failures — details}
 ISSUES: {any concerns, blockers, or deviations discovered}
 INTEGRATION_NOTES:
-- {3-5 concise bullet points: key patterns, helpers, conventions, interface decisions established by this task — factual, for future task context}
+- {3-5 concise bullet points anchored to concrete file paths — e.g., "Created `ValidationHelper` in `src/helpers/validation.ts` — use for all input validation". Reference what exists and where, not abstract descriptions}
 ```
 
 - If STATUS is `blocked` or `failed`, ISSUES **must** explain why and what decision is needed.

--- a/agents/implementation-task-executor.md
+++ b/agents/implementation-task-executor.md
@@ -76,7 +76,7 @@ Return a structured completion report:
 ```
 STATUS: complete | blocked | failed
 TASK: {task name}
-SUMMARY: {what was done, decisions made, and any judgment calls where the plan was ambiguous — e.g., observable behaviors you chose that weren't explicitly specified (logging, warnings, error messages for cases the plan didn't address)}
+SUMMARY: {what was done}
 FILES_CHANGED: {list of files created/modified}
 TESTS_WRITTEN: {list of test files/methods}
 TEST_RESULTS: {all passing | failures — details}

--- a/agents/implementation-task-executor.md
+++ b/agents/implementation-task-executor.md
@@ -76,7 +76,7 @@ Return a structured completion report:
 ```
 STATUS: complete | blocked | failed
 TASK: {task name}
-SUMMARY: {what was done}
+SUMMARY: {what was done, decisions made, and any judgment calls where the plan was ambiguous — e.g., observable behaviors you chose that weren't explicitly specified (logging, warnings, error messages for cases the plan didn't address)}
 FILES_CHANGED: {list of files created/modified}
 TESTS_WRITTEN: {list of test files/methods}
 TEST_RESULTS: {all passing | failures — details}

--- a/agents/implementation-task-executor.md
+++ b/agents/implementation-task-executor.md
@@ -18,10 +18,12 @@ You receive file paths and context via the orchestrator's prompt:
 3. **Specification path** — For context when rationale is unclear
 4. **Project skill paths** — Relevant `.claude/skills/` paths for framework conventions
 5. **Task content** — Task ID, phase, and all instructional content: goal, implementation steps, acceptance criteria, tests, edge cases, context, notes. This is your scope.
+6. **Plan file path** — The implementation plan, for understanding the overall task landscape and where this task fits
+7. **Integration context file path** (if exists) — Accumulated notes from prior tasks about established patterns, conventions, and decisions
 
 On **re-invocation after review feedback**, you receive all of the above, plus:
-6. **User-approved review notes** — may be the reviewer's original notes, modified by user, or user's own notes
-7. **Specific issues to address**
+8. **User-approved review notes** — may be the reviewer's original notes, modified by user, or user's own notes
+9. **Specific issues to address**
 
 You are stateless — each invocation starts fresh. The full task content is always provided so you can see what was asked, what was done, and what needs fixing.
 
@@ -31,10 +33,14 @@ You are stateless — each invocation starts fresh. The full task content is alw
 2. **Read code-quality.md** — absorb quality standards
 3. **Read project skills** — absorb framework conventions, testing patterns, architecture patterns
 4. **Read specification** (if provided) — understand broader context for this task
-5. **Explore codebase** — understand what exists before writing anything:
+5. **Explore codebase** — you are weaving into an existing canvas, not creating isolated patches:
+   - If an integration context file was provided, read it first to understand patterns, conventions, and helpers established by prior tasks
+   - Skim the plan file to understand the task landscape — what's been built, what's coming, where your task fits. Use this for awareness, not to build ahead (YAGNI still applies)
    - Read files and tests related to the task's domain
-   - Identify patterns, conventions, and structures you'll need to follow or extend
-   - Check for existing code that the task builds on or integrates with
+   - Search for existing helpers, utilities, and abstractions that solve similar problems — reuse, don't duplicate
+   - When creating an interface or API boundary, read BOTH sides: the code that will consume it AND the code that will implement it
+   - Match conventions established in the codebase: error message style, naming patterns, file organisation, type placement
+   - Your code should read as if the same developer wrote the entire codebase
 6. **Execute TDD cycle** — follow the process in tdd-workflow.md for each acceptance criterion and test case.
 7. **Verify all acceptance criteria met** — every criterion from the task must be satisfied
 8. **Return structured result**
@@ -75,7 +81,10 @@ FILES_CHANGED: {list of files created/modified}
 TESTS_WRITTEN: {list of test files/methods}
 TEST_RESULTS: {all passing | failures — details}
 ISSUES: {any concerns, blockers, or deviations discovered}
+INTEGRATION_NOTES:
+- {3-5 concise bullet points: key patterns, helpers, conventions, interface decisions established by this task — factual, for future task context}
 ```
 
 - If STATUS is `blocked` or `failed`, ISSUES **must** explain why and what decision is needed.
 - If STATUS is `complete`, all acceptance criteria must be met and all tests passing.
+- After completing the task, document what you created or established that future tasks should be aware of in INTEGRATION_NOTES. This is factual — what exists and why — not evaluative.

--- a/agents/implementation-task-reviewer.md
+++ b/agents/implementation-task-reviewer.md
@@ -62,7 +62,6 @@ Is this a sound design decision? Will it compose well with future tasks?
 - Are there coupling or abstraction concerns?
 - Will this cause problems for subsequent tasks in the phase?
 - Are there structural concerns that should be raised now rather than compounding?
-- Does the code produce any user-visible output (warnings, errors, log messages) that the plan doesn't explicitly require? Unspecified observable behavior is a common source of bugs when cases that should be silent share a code path with cases that should log.
 
 ### 6. Codebase Cohesion
 Does the new code integrate well with the existing codebase? If integration context exists from prior tasks, check against established patterns.

--- a/agents/implementation-task-reviewer.md
+++ b/agents/implementation-task-reviewer.md
@@ -18,6 +18,7 @@ You receive via the orchestrator's prompt:
 1. **Specification path** — The validated specification for design decision context
 2. **Task content** — Same task content the executor received: task ID, phase, and all instructional content
 3. **Project skill paths** — Relevant `.claude/skills/` paths for checking framework convention adherence
+4. **Integration context file path** (if exists) — Accumulated notes from prior tasks, for evaluating cohesion with established patterns
 
 ## Your Process
 
@@ -25,7 +26,7 @@ You receive via the orchestrator's prompt:
 2. **Check unstaged changes** — use `git diff` and `git status` to identify files changed by the executor
 3. **Read all changed files** — implementation code and test code
 4. **Read project skills** — understand framework conventions, testing patterns, architecture patterns
-5. **Evaluate all five review dimensions** (see below)
+5. **Evaluate all six review dimensions** (see below)
 
 ## Review Dimensions
 
@@ -62,6 +63,15 @@ Is this a sound design decision? Will it compose well with future tasks?
 - Will this cause problems for subsequent tasks in the phase?
 - Are there structural concerns that should be raised now rather than compounding?
 
+### 6. Codebase Cohesion
+Does the new code integrate well with the existing codebase? If integration context exists from prior tasks, check against established patterns.
+- Is there duplicated logic that should be extracted into a shared helper?
+- Are existing helpers and patterns being reused where applicable?
+- Are naming conventions consistent with existing code?
+- Are error message conventions consistent (casing, wrapping style, prefixes)?
+- Do interfaces use concrete types rather than generic/any types where possible?
+- Are related types co-located with the interfaces or functions they serve?
+
 ## Fix Recommendations (needs-changes only)
 
 When your verdict is `needs-changes`, you must also recommend how to fix each issue. You have full context — the spec, the task, the conventions, and the code — so use it.
@@ -86,7 +96,7 @@ When alternatives exist, explain the tradeoff briefly — don't just list option
 2. **No git writes** — Do not commit or stage. Reading git history and diffs is fine. The orchestrator handles all git writes.
 3. **One task only** — You review exactly one plan task per invocation.
 4. **Independent judgement** — Evaluate the code yourself. Do not trust the executor's self-assessment.
-5. **All five dimensions** — Evaluate spec conformance, acceptance criteria, test adequacy, convention adherence, and architectural quality.
+5. **All six dimensions** — Evaluate spec conformance, acceptance criteria, test adequacy, convention adherence, architectural quality, and codebase cohesion.
 6. **Be specific** — Include file paths and line numbers for every issue. Vague findings are not actionable.
 7. **Proportional** — Prioritize by impact. Don't nitpick style when the architecture is wrong.
 8. **Task scope only** — Only review what's in the task. Don't flag issues outside the task's scope.
@@ -103,6 +113,7 @@ ACCEPTANCE_CRITERIA: {all met | gaps — list}
 TEST_COVERAGE: {adequate | gaps — list}
 CONVENTIONS: {followed | violations — list}
 ARCHITECTURE: {sound | concerns — details}
+CODEBASE_COHESION: {cohesive | concerns — details}
 ISSUES:
 - {specific issue with file:line reference}
   FIX: {recommended approach}
@@ -110,9 +121,12 @@ ISSUES:
   CONFIDENCE: {high | medium | low}
 NOTES:
 - {non-blocking observations}
+COHESION_NOTES:
+- {2-4 concise bullet points: patterns to maintain, conventions confirmed, architectural integration observations}
 ```
 
 - If VERDICT is `approved`, omit ISSUES entirely (or leave empty)
 - If VERDICT is `needs-changes`, ISSUES must contain specific, actionable items with file:line references AND fix recommendations
 - Each issue must include FIX and CONFIDENCE. ALTERNATIVE is optional — include only when genuinely multiple valid approaches exist
 - NOTES are for non-blocking observations — things worth noting but not requiring changes
+- COHESION_NOTES are always included — they capture patterns and conventions observed for future task context

--- a/agents/implementation-task-reviewer.md
+++ b/agents/implementation-task-reviewer.md
@@ -62,6 +62,7 @@ Is this a sound design decision? Will it compose well with future tasks?
 - Are there coupling or abstraction concerns?
 - Will this cause problems for subsequent tasks in the phase?
 - Are there structural concerns that should be raised now rather than compounding?
+- Does the code produce any user-visible output (warnings, errors, log messages) that the plan doesn't explicitly require? Unspecified observable behavior is a common source of bugs when cases that should be silent share a code path with cases that should log.
 
 ### 6. Codebase Cohesion
 Does the new code integrate well with the existing codebase? If integration context exists from prior tasks, check against established patterns.

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -195,6 +195,8 @@ After creating the file, populate `project_skills` with the paths confirmed in S
 
 Commit: `impl({topic}): start implementation`
 
+Integration context will accumulate in `docs/workflow/implementation/{topic}-context.md` as tasks complete. This file is created automatically during the task loop — no initialisation needed here.
+
 → Proceed to **Step 5**.
 
 ---
@@ -227,3 +229,4 @@ Commit: `impl({topic}): complete implementation`
 - **[task-normalisation.md](references/task-normalisation.md)** — Normalised task shape for agent invocation
 - **[tdd-workflow.md](references/tdd-workflow.md)** — TDD cycle (passed to executor agent)
 - **[code-quality.md](references/code-quality.md)** — Quality standards (passed to executor agent)
+- **Integration context** — `docs/workflow/implementation/{topic}-context.md` — accumulated notes from completed tasks (created during task loop)

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -205,11 +205,29 @@ Integration context will accumulate in `docs/workflow/implementation/{topic}-con
 
 Load **[steps/task-loop.md](references/steps/task-loop.md)** and follow its instructions as written.
 
-→ After the loop completes, proceed to **Step 6**.
+→ After the loop completes (all tasks done), proceed to **Step 6**. If the task loop exits early (user chose `stop`), implementation is incomplete — do not run the smoke test or mark complete.
 
 ---
 
-## Step 6: Mark Implementation Complete
+## Step 6: Integration Smoke Test
+
+Before marking complete, verify the implemented features work together. This catches cross-task issues that individual task reviews cannot — bugs that only surface when multiple tasks interact.
+
+1. **Run the full test suite** — confirm all tests still pass after all tasks are complete
+2. **Exercise primary workflows** — run the main user-facing commands or entry points end-to-end (e.g., init → create → list → update). Use the specification to identify the key workflows
+3. **Check for unexpected output** — warnings, errors, or log messages that shouldn't appear during normal operation
+
+If issues are found:
+- Present findings to the user with specific details (command run, output observed, expected behavior)
+- **STOP.** Wait for user decision — this may require a fix, a plan amendment, or acceptance as-is
+
+If no issues are found:
+
+→ Proceed to **Step 7**.
+
+---
+
+## Step 7: Mark Implementation Complete
 
 Update the tracking file (`docs/workflow/implementation/{topic}.md`):
 - Set `status: completed`

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -205,29 +205,11 @@ Integration context will accumulate in `docs/workflow/implementation/{topic}-con
 
 Load **[steps/task-loop.md](references/steps/task-loop.md)** and follow its instructions as written.
 
-→ After the loop completes (all tasks done), proceed to **Step 6**. If the task loop exits early (user chose `stop`), implementation is incomplete — do not run the smoke test or mark complete.
+→ After the loop completes, proceed to **Step 6**.
 
 ---
 
-## Step 6: Integration Smoke Test
-
-Before marking complete, verify the implemented features work together. This catches cross-task issues that individual task reviews cannot — bugs that only surface when multiple tasks interact.
-
-1. **Run the full test suite** — confirm all tests still pass after all tasks are complete
-2. **Exercise primary workflows** — run the main user-facing commands or entry points end-to-end (e.g., init → create → list → update). Use the specification to identify the key workflows
-3. **Check for unexpected output** — warnings, errors, or log messages that shouldn't appear during normal operation
-
-If issues are found:
-- Present findings to the user with specific details (command run, output observed, expected behavior)
-- **STOP.** Wait for user decision — this may require a fix, a plan amendment, or acceptance as-is
-
-If no issues are found:
-
-→ Proceed to **Step 7**.
-
----
-
-## Step 7: Mark Implementation Complete
+## Step 6: Mark Implementation Complete
 
 Update the tracking file (`docs/workflow/implementation/{topic}.md`):
 - Set `status: completed`

--- a/skills/technical-implementation/references/code-quality.md
+++ b/skills/technical-implementation/references/code-quality.md
@@ -37,5 +37,15 @@ Only implement what's in the plan. Ask: "Is this in the plan?"
 - Long parameter lists (4+)
 - Boolean parameters
 
+## Convention Consistency
+
+When adding to an existing codebase, match what's already there:
+- **Error messages**: Match the casing, wrapping style, and prefix patterns in existing code
+- **Naming**: Follow the project's conventions for files, functions, types, and variables
+- **File organisation**: Follow the project's pattern for splitting concerns across files
+- **Helpers**: Search for existing helpers before creating new ones. After creating one, check if existing code could use it too
+- **Types**: Prefer concrete types over generic/any types when the set of possibilities is known. Use structured return types over multiple bare return values for extensibility
+- **Co-location**: Keep related types near the interfaces or functions they serve
+
 ## Project Standards
 Check `.claude/skills/` for project-specific patterns.

--- a/skills/technical-implementation/references/steps/invoke-executor.md
+++ b/skills/technical-implementation/references/steps/invoke-executor.md
@@ -39,7 +39,7 @@ SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
 TEST_RESULTS: {all passing | failures — details only if failures}
 ISSUES: {blockers or deviations — omit if none}
 INTEGRATION_NOTES:
-- {3-5 bullets anchored to file paths — what exists, where, and why}
+- {3-5 bullets: patterns, helpers, conventions established — anchor to file paths where applicable}
 ```
 
 - `complete`: all acceptance criteria met, tests passing

--- a/skills/technical-implementation/references/steps/invoke-executor.md
+++ b/skills/technical-implementation/references/steps/invoke-executor.md
@@ -39,7 +39,7 @@ SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
 TEST_RESULTS: {all passing | failures — details only if failures}
 ISSUES: {blockers or deviations — omit if none}
 INTEGRATION_NOTES:
-- {3-5 bullets: patterns, helpers, conventions established — for future task context}
+- {3-5 bullets anchored to file paths — what exists, where, and why}
 ```
 
 - `complete`: all acceptance criteria met, tests passing

--- a/skills/technical-implementation/references/steps/invoke-executor.md
+++ b/skills/technical-implementation/references/steps/invoke-executor.md
@@ -17,10 +17,12 @@ This step invokes the `implementation-task-executor` agent (`.claude/agents/impl
 3. **Specification path**: from the plan's frontmatter (if available)
 4. **Project skill paths**: from `project_skills` in the implementation tracking file
 5. **Task content**: normalised task content (see [task-normalisation.md](../task-normalisation.md))
+6. **Plan file path**: the implementation plan (same path used to read tasks)
+7. **Integration context file** (if exists): `docs/workflow/implementation/{topic}-context.md`
 
 **Re-attempts after review feedback** additionally include:
-6. **User-approved review notes**: verbatim or as modified by the user
-7. **Specific issues to address**: the ISSUES from the review
+8. **User-approved review notes**: verbatim or as modified by the user
+9. **Specific issues to address**: the ISSUES from the review
 
 The executor is stateless — each invocation starts fresh with no memory of previous attempts. Always pass the full task content so the executor can see what was asked, what was done, and what needs fixing.
 
@@ -36,6 +38,8 @@ TASK: {task name}
 SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
 TEST_RESULTS: {all passing | failures — details only if failures}
 ISSUES: {blockers or deviations — omit if none}
+INTEGRATION_NOTES:
+- {3-5 bullets: patterns, helpers, conventions established — for future task context}
 ```
 
 - `complete`: all acceptance criteria met, tests passing

--- a/skills/technical-implementation/references/steps/invoke-executor.md
+++ b/skills/technical-implementation/references/steps/invoke-executor.md
@@ -35,7 +35,7 @@ The agent returns a structured report:
 ```
 STATUS: complete | blocked | failed
 TASK: {task name}
-SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
+SUMMARY: {2-5 lines — commentary, decisions made, judgment calls where plan was ambiguous}
 TEST_RESULTS: {all passing | failures — details only if failures}
 ISSUES: {blockers or deviations — omit if none}
 INTEGRATION_NOTES:

--- a/skills/technical-implementation/references/steps/invoke-executor.md
+++ b/skills/technical-implementation/references/steps/invoke-executor.md
@@ -35,7 +35,7 @@ The agent returns a structured report:
 ```
 STATUS: complete | blocked | failed
 TASK: {task name}
-SUMMARY: {2-5 lines — commentary, decisions made, judgment calls where plan was ambiguous}
+SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
 TEST_RESULTS: {all passing | failures — details only if failures}
 ISSUES: {blockers or deviations — omit if none}
 INTEGRATION_NOTES:

--- a/skills/technical-implementation/references/steps/invoke-reviewer.md
+++ b/skills/technical-implementation/references/steps/invoke-reviewer.md
@@ -15,6 +15,7 @@ Invoke `implementation-task-reviewer` with:
 1. **Specification path**: same path given to the executor
 2. **Task content**: same normalised task content the executor received
 3. **Project skill paths**: from `project_skills` in the implementation tracking file
+4. **Integration context file** (if exists): `docs/workflow/implementation/{topic}-context.md` — for checking cohesion with established patterns
 
 ---
 
@@ -30,6 +31,7 @@ ACCEPTANCE_CRITERIA: {all met | gaps — list}
 TEST_COVERAGE: {adequate | gaps — list}
 CONVENTIONS: {followed | violations — list}
 ARCHITECTURE: {sound | concerns — details}
+CODEBASE_COHESION: {cohesive | concerns — details}
 ISSUES:
 - {specific issue with file:line reference}
   FIX: {recommended approach}
@@ -37,7 +39,9 @@ ISSUES:
   CONFIDENCE: {high | medium | low}
 NOTES:
 - {non-blocking observations}
+COHESION_NOTES:
+- {2-4 bullets: patterns to maintain, conventions confirmed, integration quality}
 ```
 
-- `approved`: task passes all five review dimensions
+- `approved`: task passes all six review dimensions
 - `needs-changes`: ISSUES contains specific, actionable items with fix recommendations and confidence levels

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -64,7 +64,7 @@ Present the executor's ISSUES to the user:
 
 #### If `stop`
 
-→ Return to the skill for **Step 6**.
+→ Return to the skill — implementation stopped early.
 
 ---
 

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -64,7 +64,7 @@ Present the executor's ISSUES to the user:
 
 #### If `stop`
 
-→ Return to the skill — implementation stopped early.
+→ Return to the skill for **Step 6**.
 
 ---
 

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -169,13 +169,27 @@ Announce the result (one line, no stop):
 
 The tracking file is a derived view for discovery scripts and cross-topic dependency resolution — not a decision-making input during implementation (except `task_gate_mode` and `fix_gate_mode`).
 
+**Append integration context** — extract INTEGRATION_NOTES from the executor's final output and COHESION_NOTES from the reviewer's output. Append both to `docs/workflow/implementation/{topic}-context.md`:
+
+```
+## T{task-id}: {task name}
+
+### Integration (executor)
+{INTEGRATION_NOTES content}
+
+### Cohesion (reviewer)
+{COHESION_NOTES content}
+```
+
+Create the file if it doesn't exist. This is mechanical text extraction and file append — the same as extracting STATUS to route on. Use outputs from the final approved iteration only.
+
 **Commit all changes** in a single commit:
 
 ```
 impl({topic}): T{task-id} — {brief description}
 ```
 
-Code, tests, plan progress, and tracking file — one commit per approved task.
+Code, tests, plan progress, tracking file, and integration context — one commit per approved task.
 
 This is the end of this iteration.
 


### PR DESCRIPTION
## Summary

- **Executor** now receives the plan file (forward-looking map) and an integration context file (backward-looking continuity) as inputs, with strengthened exploration guidance to reuse existing patterns and match conventions
- **Reviewer** gains a 6th review dimension (Codebase Cohesion) that checks for duplicated logic, naming consistency, type co-location, and helper reuse against established patterns
- **Orchestrator** mechanically appends INTEGRATION_NOTES (executor) and COHESION_NOTES (reviewer) to `{topic}-context.md` after each approved task, building an accumulating context file for future executors
- **Code quality reference** adds a Convention Consistency section covering error messages, naming, file organisation, helpers, types, and co-location

## Files changed

| File | Change |
|------|--------|
| `agents/implementation-task-executor.md` | Plan + context file inputs, stronger exploration, INTEGRATION_NOTES output |
| `agents/implementation-task-reviewer.md` | Context file input, 6th dimension (Codebase Cohesion), CODEBASE_COHESION + COHESION_NOTES output |
| `skills/technical-implementation/references/code-quality.md` | Convention Consistency section |
| `skills/technical-implementation/references/steps/invoke-executor.md` | Plan + context file inputs, INTEGRATION_NOTES in expected output |
| `skills/technical-implementation/references/steps/invoke-reviewer.md` | Context file input, CODEBASE_COHESION + COHESION_NOTES in expected output |
| `skills/technical-implementation/references/steps/task-loop.md` | Context file append in Stage E (before commit) |
| `skills/technical-implementation/SKILL.md` | Context file pattern note + references entry |

## Design principles maintained

- Orchestrator stays thin — passes file paths, extracts text sections, appends to file (all mechanical)
- Agents do all heavy lifting — reading, analysing, producing notes
- Language/framework agnostic throughout
- Output templates consistent between agent definitions and invoke-* contracts

## Test plan

- [ ] Trace full flow: executor reads plan + context → explores → implements → INTEGRATION_NOTES → reviewer reads context → checks cohesion → COHESION_NOTES → orchestrator appends after approval → next executor reads updated context
- [ ] Verify output templates match between agent definitions and invoke-* contracts
- [ ] Verify context file append happens before commit in Stage E
- [ ] Verify no orchestrator analysis introduced — only mechanical ops
- [ ] Verify executor input list has clear, non-overlapping purposes

🤖 Generated with [Claude Code](https://claude.com/claude-code)