### PR TITLE
Add convergence awareness to research phase

### DIFF
--- a/skills/start-research/SKILL.md
+++ b/skills/start-research/SKILL.md
@@ -19,7 +19,7 @@ This is **Phase 1** of the six-phase workflow:
 | 5. Implementation | DOING - tests first, then code | |
 | 6. Review | VALIDATING - check work against artifacts | |
 
-**Stay in your lane**: Explore freely. This is the time for broad thinking, feasibility checks, and learning. Don't jump to formal discussions or specifications yet.
+**Stay in your lane**: Explore freely. This is the time for broad thinking, feasibility checks, and learning. Surface options and tradeoffs — don't make decisions. When a topic converges toward a conclusion, that's a signal it's ready for discussion phase, not a cue to start deciding. Park it and move on.
 
 ---
 

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -65,6 +65,57 @@ Don't constrain yourself. Research goes wherever it needs to go.
 
 **Be honest**: If something seems flawed or risky, say so. Challenge assumptions.
 
+**Explore, don't decide**: Your job is to surface options, tradeoffs, and understanding — not to pick winners. Synthesis is welcome ("the tradeoffs are X, Y, Z"), conclusions are not ("therefore we should do Y"). Decisions belong in the discussion phase.
+
+## Convergence Awareness
+
+Research threads naturally converge. As you explore a topic, options narrow, tradeoffs clarify, and opinions start forming. This is healthy — but it's also a signal.
+
+### Recognizing convergence
+
+Watch for these signs that a thread is moving from exploration toward decision-making:
+
+- "We should..." or "The best approach is..." language (from you or the user)
+- Options narrowing to a clear frontrunner with well-understood tradeoffs
+- The same conclusion being reached from multiple angles
+- Discussion shifting from "what are the options?" to "which option?"
+- You or the user starting to advocate for a particular approach
+
+### What to do
+
+When you notice convergence, **flag it and give the user options**:
+
+> "This thread seems to be converging — we've explored {topic} enough that the tradeoffs are clear and it's approaching decision territory.
+>
+> - **`p`/`park`** — Mark as discussion-ready and move to another topic
+> - **`k`/`keep`** — Keep digging, there's more to understand
+> - **`s`/`something else`** — Your call"
+
+**Never decide for the user.** Even if the answer seems obvious, flag it and ask.
+
+### If the user parks it
+
+Document the convergence point in the research file using this marker:
+
+```markdown
+> **Discussion-ready**: {Brief summary of what was explored and why it's ready for decision-making. Key tradeoffs or options identified.}
+```
+
+Then continue with whatever's next — another topic, a different angle, or wrapping up the session.
+
+### If the user keeps digging
+
+Continue exploring. The convergence signal isn't a stop sign — it's an awareness check. The user might want to stress-test the emerging conclusion, explore edge cases, or understand the problem more deeply before moving on. That's valid research work.
+
+### Synthesis vs decision
+
+This distinction matters:
+
+- **Synthesis** (research): "There are three viable approaches. A is simplest but limited. B scales better but costs more. C is future-proof but complex."
+- **Decision** (discussion): "We should go with B because scaling matters more than simplicity for this project."
+
+Synthesis is your job. Decisions are not. Present the landscape, don't pick the destination.
+
 ## Questioning
 
 For structured questioning, use the interview reference (`references/interview.md`). Good research questions:


### PR DESCRIPTION
## Summary

- Adds convergence detection to `technical-research` skill — when a research thread starts drifting toward decisions, Claude flags it and offers the user options (`p`/park, `k`/keep, `s`/something else)
- Introduces `> **Discussion-ready**:` doc marker for parked topics, making them scannable when entering discussion phase
- Clarifies synthesis vs decision boundary ("present the landscape, don't pick the destination")
- Strengthens "stay in your lane" guidance in `start-research` entry point

## Test plan

- [ ] Run a research session and verify Claude flags convergence when discussion starts narrowing toward a decision
- [ ] Verify parked topics get the `> **Discussion-ready**:` marker in the research doc
- [ ] Verify the `p`/`k`/`s` shortcut format matches codebase conventions
- [ ] Confirm Claude still allows deep exploration when user chooses `k`/keep

🤖 Generated with [Claude Code](https://claude.com/claude-code)