### PR TITLE
Add dynamic content injection for discovery scripts

### DIFF
--- a/skills/start-discussion/SKILL.md
+++ b/skills/start-discussion/SKILL.md
@@ -2,7 +2,7 @@
 name: start-discussion
 description: "Start a technical discussion. Discovers research and existing discussions, offers multiple entry paths, and invokes the technical-discussion skill."
 disable-model-invocation: true
-allowed-tools: Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/research-analysis.md)
+allowed-tools: Bash(.claude/skills/start-discussion/scripts/discovery.sh), Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/research-analysis.md)
 ---
 
 Invoke the **technical-discussion** skill for this conversation.
@@ -50,15 +50,19 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Run Discovery Script
+## Step 1: Discovery State
 
-Run the discovery script to gather current state:
+!`.claude/skills/start-discussion/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-This outputs structured YAML. Parse it to understand:
+If YAML content is already displayed, it has been run on your behalf.
+
+Parse the discovery output to understand:
 
 **From `research` section:**
 - `exists` - whether research files exist

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -2,7 +2,7 @@
 name: start-implementation
 description: "Start an implementation session from an existing plan. Discovers available plans, checks environment setup, and invokes the technical-implementation skill."
 disable-model-invocation: true
-allowed-tools: Bash(./scripts/discovery.sh)
+allowed-tools: Bash(.claude/skills/start-implementation/scripts/discovery.sh), Bash(./scripts/discovery.sh)
 ---
 
 Invoke the **technical-implementation** skill for this conversation.
@@ -50,15 +50,19 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Run Discovery Script
+## Step 1: Discovery State
 
-Run the discovery script to gather current state:
+!`.claude/skills/start-implementation/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-This outputs structured YAML. Parse it to understand:
+If YAML content is already displayed, it has been run on your behalf.
+
+Parse the discovery output to understand:
 
 **From `plans` section:**
 - `exists` - whether any plans exist

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -2,7 +2,7 @@
 name: start-planning
 description: "Start a planning session from an existing specification. Discovers available specifications, gathers context, and invokes the technical-planning skill."
 disable-model-invocation: true
-allowed-tools: Bash(./scripts/discovery.sh)
+allowed-tools: Bash(.claude/skills/start-planning/scripts/discovery.sh), Bash(./scripts/discovery.sh)
 ---
 
 Invoke the **technical-planning** skill for this conversation.
@@ -50,15 +50,19 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Run Discovery Script
+## Step 1: Discovery State
 
-Run the discovery script to gather current state:
+!`.claude/skills/start-planning/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-This outputs structured YAML. Parse it to understand:
+If YAML content is already displayed, it has been run on your behalf.
+
+Parse the discovery output to understand:
 
 **From `specifications` section:**
 - `exists` - whether any specifications exist

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -2,7 +2,7 @@
 name: start-review
 description: "Start a review session from an existing plan and implementation. Discovers available plans, validates implementation exists, and invokes the technical-review skill."
 disable-model-invocation: true
-allowed-tools: Bash(./scripts/discovery.sh)
+allowed-tools: Bash(.claude/skills/start-review/scripts/discovery.sh), Bash(./scripts/discovery.sh)
 ---
 
 Invoke the **technical-review** skill for this conversation.
@@ -50,15 +50,19 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Run Discovery Script
+## Step 1: Discovery State
 
-Run the discovery script to gather current state:
+!`.claude/skills/start-review/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-This outputs structured YAML. Parse it to understand:
+If YAML content is already displayed, it has been run on your behalf.
+
+Parse the discovery output to understand:
 
 **From `plans` section:**
 - `exists` - whether any plans exist

--- a/skills/start-specification/SKILL.md
+++ b/skills/start-specification/SKILL.md
@@ -2,7 +2,7 @@
 name: start-specification
 description: "Start a specification session from existing discussions. Discovers available discussions, offers consolidation assessment for multiple discussions, and invokes the technical-specification skill."
 disable-model-invocation: true
-allowed-tools: Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/discussion-consolidation-analysis.md)
+allowed-tools: Bash(.claude/skills/start-specification/scripts/discovery.sh), Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/discussion-consolidation-analysis.md)
 ---
 
 Invoke the **technical-specification** skill for this conversation.
@@ -50,15 +50,19 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Run Discovery Script
+## Step 1: Discovery State
 
-Run the discovery script to gather current state:
+!`.claude/skills/start-specification/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-This outputs structured YAML. Parse it to understand:
+If YAML content is already displayed, it has been run on your behalf.
+
+Parse the discovery output to understand:
 
 **From `discussions` array:**
 - Each discussion's name, status, and whether it has an individual specification


### PR DESCRIPTION
## Summary

- Adds `!`command`` dynamic content syntax to all 5 entry-point skills with discovery scripts (start-discussion, start-specification, start-planning, start-implementation, start-review)
- Discovery script output is now injected inline before the prompt reaches the model, eliminating a tool call per skill invocation
- Includes fallback text and bash block so skills still work in environments without dynamic content support
- `allowed-tools` includes both project-root-relative path (for `!`command`` preprocessor) and skill-file-relative path (for Bash fallback)

## Changes per skill

1. Step 1 heading: "Run Discovery Script" → "Discovery State"
2. `!`.claude/skills/{name}/scripts/discovery.sh`` added for dynamic injection
3. Fallback: plain text explanation + `./scripts/discovery.sh` bash block
4. `allowed-tools` updated with both path entries
5. "This outputs structured YAML. Parse it to understand:" → "Parse the discovery output to understand:"

## Path resolution (tested)

- `!`command`` resolves from **project root** — needs `.claude/skills/{name}/scripts/discovery.sh`
- `allowed-tools` / Bash fallback resolves from **skill file directory** — uses `./scripts/discovery.sh`
- Both paths point to the same file in the installed context

## Test plan

- [ ] Install in a project with workflow data, run `/start-planning` — verify YAML appears inline without a Bash tool call
- [ ] Test fallback: verify skills still work in environments without `!`command`` support
- [ ] Verify all 5 skills: discussion, specification, planning, implementation, review

🤖 Generated with [Claude Code](https://claude.com/claude-code)