### PR TITLE
Revert dynamic content injection for discovery scripts

### DIFF
--- a/skills/start-discussion/SKILL.md
+++ b/skills/start-discussion/SKILL.md
@@ -2,7 +2,7 @@
 name: start-discussion
 description: "Start a technical discussion. Discovers research and existing discussions, offers multiple entry paths, and invokes the technical-discussion skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-discussion/scripts/discovery.sh), Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/research-analysis.md)
+allowed-tools: Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/research-analysis.md)
 ---
 
 Invoke the **technical-discussion** skill for this conversation.
@@ -50,19 +50,15 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Discovery State
+## Step 1: Run Discovery Script
 
-!`.claude/skills/start-discussion/scripts/discovery.sh`
-
-If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
+Run the discovery script to gather current state:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-If YAML content is already displayed, it has been run on your behalf.
-
-Parse the discovery output to understand:
+This outputs structured YAML. Parse it to understand:
 
 **From `research` section:**
 - `exists` - whether research files exist

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -2,7 +2,7 @@
 name: start-implementation
 description: "Start an implementation session from an existing plan. Discovers available plans, checks environment setup, and invokes the technical-implementation skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-implementation/scripts/discovery.sh), Bash(./scripts/discovery.sh)
+allowed-tools: Bash(./scripts/discovery.sh)
 ---
 
 Invoke the **technical-implementation** skill for this conversation.
@@ -50,19 +50,15 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Discovery State
+## Step 1: Run Discovery Script
 
-!`.claude/skills/start-implementation/scripts/discovery.sh`
-
-If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
+Run the discovery script to gather current state:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-If YAML content is already displayed, it has been run on your behalf.
-
-Parse the discovery output to understand:
+This outputs structured YAML. Parse it to understand:
 
 **From `plans` section:**
 - `exists` - whether any plans exist

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -2,7 +2,7 @@
 name: start-planning
 description: "Start a planning session from an existing specification. Discovers available specifications, gathers context, and invokes the technical-planning skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-planning/scripts/discovery.sh), Bash(./scripts/discovery.sh)
+allowed-tools: Bash(./scripts/discovery.sh)
 ---
 
 Invoke the **technical-planning** skill for this conversation.
@@ -50,19 +50,15 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Discovery State
+## Step 1: Run Discovery Script
 
-!`.claude/skills/start-planning/scripts/discovery.sh`
-
-If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
+Run the discovery script to gather current state:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-If YAML content is already displayed, it has been run on your behalf.
-
-Parse the discovery output to understand:
+This outputs structured YAML. Parse it to understand:
 
 **From `specifications` section:**
 - `exists` - whether any specifications exist

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -2,7 +2,7 @@
 name: start-review
 description: "Start a review session from an existing plan and implementation. Discovers available plans, validates implementation exists, and invokes the technical-review skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-review/scripts/discovery.sh), Bash(./scripts/discovery.sh)
+allowed-tools: Bash(./scripts/discovery.sh)
 ---
 
 Invoke the **technical-review** skill for this conversation.
@@ -50,19 +50,15 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Discovery State
+## Step 1: Run Discovery Script
 
-!`.claude/skills/start-review/scripts/discovery.sh`
-
-If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
+Run the discovery script to gather current state:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-If YAML content is already displayed, it has been run on your behalf.
-
-Parse the discovery output to understand:
+This outputs structured YAML. Parse it to understand:
 
 **From `plans` section:**
 - `exists` - whether any plans exist

--- a/skills/start-specification/SKILL.md
+++ b/skills/start-specification/SKILL.md
@@ -2,7 +2,7 @@
 name: start-specification
 description: "Start a specification session from existing discussions. Discovers available discussions, offers consolidation assessment for multiple discussions, and invokes the technical-specification skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-specification/scripts/discovery.sh), Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/discussion-consolidation-analysis.md)
+allowed-tools: Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/discussion-consolidation-analysis.md)
 ---
 
 Invoke the **technical-specification** skill for this conversation.
@@ -50,19 +50,15 @@ Invoke the `/migrate` skill and assess its output.
 
 ---
 
-## Step 1: Discovery State
+## Step 1: Run Discovery Script
 
-!`.claude/skills/start-specification/scripts/discovery.sh`
-
-If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
+Run the discovery script to gather current state:
 
 ```bash
 ./scripts/discovery.sh
 ```
 
-If YAML content is already displayed, it has been run on your behalf.
-
-Parse the discovery output to understand:
+This outputs structured YAML. Parse it to understand:
 
 **From `discussions` array:**
 - Each discussion's name, status, and whether it has an individual specification


### PR DESCRIPTION
## Summary

- Reverts PR #84 (`feat/dynamic-content-discovery`)
- The `!`command`` preprocessor runs from project CWD with no `$SKILL_DIR` environment variable, so marketplace-installed skills cannot locate their bundled scripts
- No reliable path resolution mechanism exists yet — tracked upstream in [anthropics/claude-code#12541](https://github.com/anthropics/claude-code/issues/12541)
- Reverts to Bash tool execution (`./scripts/discovery.sh`) which works for both project and marketplace installs

## Test plan

- [ ] Verify `/start-discussion` works via project install
- [ ] Verify `/start-discussion` works via marketplace install
- [ ] Confirm all five `start-*` skills execute discovery scripts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)