### PR TITLE
refactor: consolidate discussion conclusion guidance

### DIFF
--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -95,6 +95,36 @@ These are natural pauses, not every exchange. Document the reasoning and context
 
 **Create the file early.** After understanding the topic and initial questions, create the discussion file with frontmatter, context, and the questions list. Don't wait until you have answers.
 
+## Concluding a Discussion
+
+When the user is ready to conclude the discussion:
+
+1. Update frontmatter `status: concluded`
+2. Final commit
+3. Check for remaining in-progress discussions in `docs/workflow/discussion/`
+
+**If other in-progress discussions exist:**
+
+```
+Discussion concluded: {topic}
+
+Remaining in-progress discussions:
+- {topic-1}
+- {topic-2}
+
+To continue, clear your context and run `/start-discussion` to pick up the next topic.
+```
+
+**If no in-progress discussions remain:**
+
+```
+Discussion concluded: {topic}
+
+All discussions are now concluded.
+```
+
+**Do not offer to continue with another discussion in this session.** Each discussion benefits from a fresh context — continuing risks compaction-related information loss and reduced attention. Always advise the user to clear context first.
+
 ## Quick Reference
 
 - **Approach**: **[meeting-assistant.md](references/meeting-assistant.md)** - Dual role, workflow

--- a/skills/technical-discussion/references/guidelines.md
+++ b/skills/technical-discussion/references/guidelines.md
@@ -89,5 +89,3 @@ Before marking discussion complete:
 - ✅ Impact explained
 - ✅ Confidence stated
 - ✅ No hallucination
-
-**When complete**: Update frontmatter `status: concluded`.

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -128,5 +128,3 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 - Major questions concluded with rationale
 - Trade-offs understood
 - Path forward clear
-
-**When complete**: Update frontmatter `status: concluded` to signal ready for specification.


### PR DESCRIPTION
## Summary

- Add "Concluding a Discussion" section to `technical-discussion/SKILL.md` — checks for remaining in-progress discussions and advises clearing context instead of continuing in-session
- Remove redundant "when complete" one-liners from `template.md` and `guidelines.md` — conclusion behaviour now lives in one place
- Prevents Claude from suggesting to continue with next discussion in same session (compaction risk)

## Test plan

- [ ] Run a discussion to conclusion and verify Claude presents remaining topics and advises clearing context
- [ ] Verify Claude does not offer to continue with next discussion in-session

🤖 Generated with [Claude Code](https://claude.com/claude-code)