### PR TITLE
fix: analysis cycle suffixes and commit instructions

### DIFF
--- a/agents/implementation-analysis-architecture.md
+++ b/agents/implementation-analysis-architecture.md
@@ -35,7 +35,7 @@ You receive via the orchestrator's prompt:
 3. **Read specification** — understand design intent and boundaries
 4. **Read all implementation files** — understand the full picture
 5. **Analyze architecture** — evaluate how the pieces compose as a whole
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-architecture-c{cycle}.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-architecture-c{cycle-number}.md`
 
 ## Hard Rules
 
@@ -49,7 +49,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-architecture-c{cycle}.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-architecture-c{cycle-number}.md`:
 
 ```
 AGENT: architecture

--- a/agents/implementation-analysis-architecture.md
+++ b/agents/implementation-analysis-architecture.md
@@ -35,7 +35,7 @@ You receive via the orchestrator's prompt:
 3. **Read specification** — understand design intent and boundaries
 4. **Read all implementation files** — understand the full picture
 5. **Analyze architecture** — evaluate how the pieces compose as a whole
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-architecture-c{N}.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-architecture-c{cycle}.md`
 
 ## Hard Rules
 
@@ -49,7 +49,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-architecture-c{N}.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-architecture-c{cycle}.md`:
 
 ```
 AGENT: architecture

--- a/agents/implementation-analysis-architecture.md
+++ b/agents/implementation-analysis-architecture.md
@@ -18,6 +18,7 @@ You receive via the orchestrator's prompt:
 3. **Project skill paths** — relevant `.claude/skills/` paths for framework conventions
 4. **code-quality.md path** — quality standards
 5. **Topic name** — the implementation topic
+6. **Cycle number** — which analysis cycle this is (used in output file naming)
 
 ## Your Focus
 
@@ -34,7 +35,7 @@ You receive via the orchestrator's prompt:
 3. **Read specification** — understand design intent and boundaries
 4. **Read all implementation files** — understand the full picture
 5. **Analyze architecture** — evaluate how the pieces compose as a whole
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-architecture.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-architecture-c{N}.md`
 
 ## Hard Rules
 
@@ -48,7 +49,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-architecture.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-architecture-c{N}.md`:
 
 ```
 AGENT: architecture

--- a/agents/implementation-analysis-duplication.md
+++ b/agents/implementation-analysis-duplication.md
@@ -34,7 +34,7 @@ You receive via the orchestrator's prompt:
 3. **Read specification** — understand design intent
 4. **Read all implementation files** — build a mental map of the full codebase
 5. **Analyze for duplication** — compare patterns across files, identify extraction candidates
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-duplication-c{N}.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-duplication-c{cycle}.md`
 
 ## Hard Rules
 
@@ -48,7 +48,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-duplication-c{N}.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-duplication-c{cycle}.md`:
 
 ```
 AGENT: duplication

--- a/agents/implementation-analysis-duplication.md
+++ b/agents/implementation-analysis-duplication.md
@@ -34,7 +34,7 @@ You receive via the orchestrator's prompt:
 3. **Read specification** — understand design intent
 4. **Read all implementation files** — build a mental map of the full codebase
 5. **Analyze for duplication** — compare patterns across files, identify extraction candidates
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-duplication-c{cycle}.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-duplication-c{cycle-number}.md`
 
 ## Hard Rules
 
@@ -48,7 +48,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-duplication-c{cycle}.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-duplication-c{cycle-number}.md`:
 
 ```
 AGENT: duplication

--- a/agents/implementation-analysis-duplication.md
+++ b/agents/implementation-analysis-duplication.md
@@ -18,6 +18,7 @@ You receive via the orchestrator's prompt:
 3. **Project skill paths** — relevant `.claude/skills/` paths for framework conventions
 4. **code-quality.md path** — quality standards
 5. **Topic name** — the implementation topic
+6. **Cycle number** — which analysis cycle this is (used in output file naming)
 
 ## Your Focus
 
@@ -33,7 +34,7 @@ You receive via the orchestrator's prompt:
 3. **Read specification** — understand design intent
 4. **Read all implementation files** — build a mental map of the full codebase
 5. **Analyze for duplication** — compare patterns across files, identify extraction candidates
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-duplication.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-duplication-c{N}.md`
 
 ## Hard Rules
 
@@ -47,7 +48,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-duplication.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-duplication-c{N}.md`:
 
 ```
 AGENT: duplication

--- a/agents/implementation-analysis-standards.md
+++ b/agents/implementation-analysis-standards.md
@@ -18,6 +18,7 @@ You receive via the orchestrator's prompt:
 3. **Project skill paths** — relevant `.claude/skills/` paths for framework conventions
 4. **code-quality.md path** — quality standards
 5. **Topic name** — the implementation topic
+6. **Cycle number** — which analysis cycle this is (used in output file naming)
 
 ## Your Focus
 
@@ -33,7 +34,7 @@ You receive via the orchestrator's prompt:
 3. **Read code-quality.md** — understand quality standards
 4. **Read all implementation files** — map each file back to its spec requirements
 5. **Compare implementation against spec** — check every decision point
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-standards.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-standards-c{N}.md`
 
 ## Hard Rules
 
@@ -47,7 +48,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-standards.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-standards-c{N}.md`:
 
 ```
 AGENT: standards

--- a/agents/implementation-analysis-standards.md
+++ b/agents/implementation-analysis-standards.md
@@ -34,7 +34,7 @@ You receive via the orchestrator's prompt:
 3. **Read code-quality.md** — understand quality standards
 4. **Read all implementation files** — map each file back to its spec requirements
 5. **Compare implementation against spec** — check every decision point
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-standards-c{N}.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-standards-c{cycle}.md`
 
 ## Hard Rules
 
@@ -48,7 +48,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-standards-c{N}.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-standards-c{cycle}.md`:
 
 ```
 AGENT: standards

--- a/agents/implementation-analysis-standards.md
+++ b/agents/implementation-analysis-standards.md
@@ -34,7 +34,7 @@ You receive via the orchestrator's prompt:
 3. **Read code-quality.md** — understand quality standards
 4. **Read all implementation files** — map each file back to its spec requirements
 5. **Compare implementation against spec** — check every decision point
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-standards-c{cycle}.md`
+6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-standards-c{cycle-number}.md`
 
 ## Hard Rules
 
@@ -48,7 +48,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-standards-c{cycle}.md`:
+Write to `docs/workflow/implementation/{topic}/analysis-standards-c{cycle-number}.md`:
 
 ```
 AGENT: standards

--- a/agents/implementation-analysis-synthesizer.md
+++ b/agents/implementation-analysis-synthesizer.md
@@ -20,13 +20,13 @@ You receive via the orchestrator's prompt:
 
 ## Your Process
 
-1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication-c{N}.md`, `analysis-standards-c{N}.md`, and `analysis-architecture-c{N}.md` (where {N} is the cycle number)
+1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication-c{cycle}.md`, `analysis-standards-c{cycle}.md`, and `analysis-architecture-c{cycle}.md` (where {N} is the cycle number)
 2. **Deduplicate** — same issue found by multiple agents → one finding, note all sources
 3. **Group related findings** — multiple findings about the same pattern become one task (e.g., 3 duplication findings about the same helper pattern = 1 "extract helper" task)
 4. **Filter** — discard low-severity findings unless they cluster into a pattern. Never discard high-severity.
 5. **Normalize** — convert each group into a task using the canonical task template (Problem / Solution / Outcome / Do / Acceptance Criteria / Tests)
-6. **Write report** — output to `docs/workflow/implementation/{topic}/analysis-report-c{N}.md`
-7. **Write staging file** — if actionable tasks exist, write to `docs/workflow/implementation/{topic}/analysis-tasks-c{N}.md` with `status: pending` for each task
+6. **Write report** — output to `docs/workflow/implementation/{topic}/analysis-report-c{cycle}.md`
+7. **Write staging file** — if actionable tasks exist, write to `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle}.md` with `status: pending` for each task
 
 ## Report Format
 

--- a/agents/implementation-analysis-synthesizer.md
+++ b/agents/implementation-analysis-synthesizer.md
@@ -20,13 +20,13 @@ You receive via the orchestrator's prompt:
 
 ## Your Process
 
-1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication-c{cycle}.md`, `analysis-standards-c{cycle}.md`, and `analysis-architecture-c{cycle}.md` (where {N} is the cycle number)
+1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication-c{cycle-number}.md`, `analysis-standards-c{cycle-number}.md`, and `analysis-architecture-c{cycle-number}.md` (where {N} is the cycle number)
 2. **Deduplicate** — same issue found by multiple agents → one finding, note all sources
 3. **Group related findings** — multiple findings about the same pattern become one task (e.g., 3 duplication findings about the same helper pattern = 1 "extract helper" task)
 4. **Filter** — discard low-severity findings unless they cluster into a pattern. Never discard high-severity.
 5. **Normalize** — convert each group into a task using the canonical task template (Problem / Solution / Outcome / Do / Acceptance Criteria / Tests)
-6. **Write report** — output to `docs/workflow/implementation/{topic}/analysis-report-c{cycle}.md`
-7. **Write staging file** — if actionable tasks exist, write to `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle}.md` with `status: pending` for each task
+6. **Write report** — output to `docs/workflow/implementation/{topic}/analysis-report-c{cycle-number}.md`
+7. **Write staging file** — if actionable tasks exist, write to `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle-number}.md` with `status: pending` for each task
 
 ## Report Format
 

--- a/agents/implementation-analysis-synthesizer.md
+++ b/agents/implementation-analysis-synthesizer.md
@@ -20,13 +20,13 @@ You receive via the orchestrator's prompt:
 
 ## Your Process
 
-1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication.md`, `analysis-standards.md`, and `analysis-architecture.md`
+1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication-c{N}.md`, `analysis-standards-c{N}.md`, and `analysis-architecture-c{N}.md` (where {N} is the cycle number)
 2. **Deduplicate** — same issue found by multiple agents → one finding, note all sources
 3. **Group related findings** — multiple findings about the same pattern become one task (e.g., 3 duplication findings about the same helper pattern = 1 "extract helper" task)
 4. **Filter** — discard low-severity findings unless they cluster into a pattern. Never discard high-severity.
 5. **Normalize** — convert each group into a task using the canonical task template (Problem / Solution / Outcome / Do / Acceptance Criteria / Tests)
-6. **Write report** — output to `docs/workflow/implementation/{topic}/analysis-report.md`
-7. **Write staging file** — if actionable tasks exist, write to `docs/workflow/implementation/{topic}/analysis-tasks.md` with `status: pending` for each task
+6. **Write report** — output to `docs/workflow/implementation/{topic}/analysis-report-c{N}.md`
+7. **Write staging file** — if actionable tasks exist, write to `docs/workflow/implementation/{topic}/analysis-tasks-c{N}.md` with `status: pending` for each task
 
 ## Report Format
 

--- a/agents/implementation-analysis-synthesizer.md
+++ b/agents/implementation-analysis-synthesizer.md
@@ -20,7 +20,7 @@ You receive via the orchestrator's prompt:
 
 ## Your Process
 
-1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication-c{cycle-number}.md`, `analysis-standards-c{cycle-number}.md`, and `analysis-architecture-c{cycle-number}.md` (where {N} is the cycle number)
+1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication-c{cycle-number}.md`, `analysis-standards-c{cycle-number}.md`, and `analysis-architecture-c{cycle-number}.md`
 2. **Deduplicate** — same issue found by multiple agents → one finding, note all sources
 3. **Group related findings** — multiple findings about the same pattern become one task (e.g., 3 duplication findings about the same helper pattern = 1 "extract helper" task)
 4. **Filter** — discard low-severity findings unless they cluster into a pattern. Never discard high-severity.

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -49,7 +49,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Check task progress in the plan** — use the plan adapter's instructions to read the plan's current state. Also read the implementation tracking file and any other working documents for additional context.
-3. **Check `task_gate_mode`, `fix_gate_mode`, `fix_attempts`, and `analysis_cycle`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*-c*.md` in `{topic}/`) to determine mid-analysis state.
+3. **Check `task_gate_mode`, `fix_gate_mode`, `fix_attempts`, and `analysis_cycle`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*-c{cycle}.md` in `{topic}/`) to determine mid-analysis state.
 4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 5. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -49,7 +49,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Check task progress in the plan** — use the plan adapter's instructions to read the plan's current state. Also read the implementation tracking file and any other working documents for additional context.
-3. **Check `task_gate_mode`, `fix_gate_mode`, `fix_attempts`, and `analysis_cycle`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*-c{cycle}.md` in `{topic}/`) to determine mid-analysis state.
+3. **Check `task_gate_mode`, `fix_gate_mode`, `fix_attempts`, and `analysis_cycle`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*-c{cycle-number}.md` in `{topic}/`) to determine mid-analysis state.
 4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 5. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -49,7 +49,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Check task progress in the plan** — use the plan adapter's instructions to read the plan's current state. Also read the implementation tracking file and any other working documents for additional context.
-3. **Check `task_gate_mode`, `fix_gate_mode`, `fix_attempts`, and `analysis_cycle`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*.md` in `{topic}/`) to determine mid-analysis state.
+3. **Check `task_gate_mode`, `fix_gate_mode`, `fix_attempts`, and `analysis_cycle`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*-c*.md` in `{topic}/`) to determine mid-analysis state.
 4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 5. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 

--- a/skills/technical-implementation/references/steps/analysis-loop.md
+++ b/skills/technical-implementation/references/steps/analysis-loop.md
@@ -109,7 +109,7 @@ impl({topic}): analysis cycle {N} — synthesis
 
 ## E. Approval Gate
 
-Read the staging file from `docs/workflow/implementation/{topic}/analysis-tasks-c{N}.md`.
+Read the staging file from `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle}.md`.
 
 Present an overview:
 

--- a/skills/technical-implementation/references/steps/analysis-loop.md
+++ b/skills/technical-implementation/references/steps/analysis-loop.md
@@ -79,6 +79,12 @@ Load **[invoke-analysis.md](invoke-analysis.md)** and follow its instructions.
 
 **STOP.** Do not proceed until all agents have returned.
 
+Commit the analysis findings:
+
+```
+impl({topic}): analysis cycle {N} — findings
+```
+
 → Proceed to **D. Dispatch Synthesis Agent**.
 
 ---
@@ -89,6 +95,12 @@ Load **[invoke-synthesizer.md](invoke-synthesizer.md)** and follow its instructi
 
 **STOP.** Do not proceed until the synthesizer has returned.
 
+Commit the synthesis output:
+
+```
+impl({topic}): analysis cycle {N} — synthesis
+```
+
 → If `STATUS: clean`, return to the skill for **Step 8**.
 
 → If `STATUS: tasks_proposed`, proceed to **E. Approval Gate**.
@@ -97,7 +109,7 @@ Load **[invoke-synthesizer.md](invoke-synthesizer.md)** and follow its instructi
 
 ## E. Approval Gate
 
-Read the staging file from `docs/workflow/implementation/{topic}/analysis-tasks.md`.
+Read the staging file from `docs/workflow/implementation/{topic}/analysis-tasks-c{N}.md`.
 
 Present an overview:
 
@@ -155,7 +167,15 @@ After all tasks processed:
 
 → If any tasks have `status: approved`, proceed to **F. Create Tasks in Plan**.
 
-→ If all tasks were skipped, return to the skill for **Step 8**.
+→ If all tasks were skipped:
+
+Commit the staging file updates:
+
+```
+impl({topic}): analysis cycle {N} — tasks skipped
+```
+
+Return to the skill for **Step 8**.
 
 ---
 
@@ -165,7 +185,7 @@ Load **[invoke-task-writer.md](invoke-task-writer.md)** and follow its instructi
 
 **STOP.** Do not proceed until the task writer has returned.
 
-Commit:
+Commit all analysis and plan changes (staging file, plan tasks, Plan Index File):
 
 ```
 impl({topic}): add analysis phase {N} ({K} tasks)

--- a/skills/technical-implementation/references/steps/analysis-loop.md
+++ b/skills/technical-implementation/references/steps/analysis-loop.md
@@ -109,7 +109,7 @@ impl({topic}): analysis cycle {N} — synthesis
 
 ## E. Approval Gate
 
-Read the staging file from `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle}.md`.
+Read the staging file from `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle-number}.md`.
 
 Present an overview:
 

--- a/skills/technical-implementation/references/steps/invoke-analysis.md
+++ b/skills/technical-implementation/references/steps/invoke-analysis.md
@@ -29,6 +29,7 @@ Dispatch **all three in parallel** via the Task tool. Each agent receives the sa
 3. **Project skill paths** — from `project_skills` in the implementation tracking file
 4. **code-quality.md path** — `../code-quality.md`
 5. **Topic name** — the implementation topic
+6. **Cycle number** — the current analysis cycle number (from `analysis_cycle` in the tracking file)
 
 Each agent knows its own output path convention and writes findings independently.
 

--- a/skills/technical-implementation/references/steps/invoke-task-writer.md
+++ b/skills/technical-implementation/references/steps/invoke-task-writer.md
@@ -15,7 +15,7 @@ This step invokes the task writer agent to create plan tasks from approved analy
 Pass via the orchestrator's prompt:
 
 1. **Topic name** — the implementation topic
-2. **Staging file path** — `docs/workflow/implementation/{topic}/analysis-tasks-c{N}.md`
+2. **Staging file path** — `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle}.md`
 3. **Plan path** — the implementation plan path
 4. **Plan format reading adapter path** — `../../../technical-planning/references/output-formats/{format}/reading.md`
 5. **Plan format authoring adapter path** — `../../../technical-planning/references/output-formats/{format}/authoring.md`

--- a/skills/technical-implementation/references/steps/invoke-task-writer.md
+++ b/skills/technical-implementation/references/steps/invoke-task-writer.md
@@ -15,7 +15,7 @@ This step invokes the task writer agent to create plan tasks from approved analy
 Pass via the orchestrator's prompt:
 
 1. **Topic name** — the implementation topic
-2. **Staging file path** — `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle}.md`
+2. **Staging file path** — `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle-number}.md`
 3. **Plan path** — the implementation plan path
 4. **Plan format reading adapter path** — `../../../technical-planning/references/output-formats/{format}/reading.md`
 5. **Plan format authoring adapter path** — `../../../technical-planning/references/output-formats/{format}/authoring.md`

--- a/skills/technical-implementation/references/steps/invoke-task-writer.md
+++ b/skills/technical-implementation/references/steps/invoke-task-writer.md
@@ -15,7 +15,7 @@ This step invokes the task writer agent to create plan tasks from approved analy
 Pass via the orchestrator's prompt:
 
 1. **Topic name** — the implementation topic
-2. **Staging file path** — `docs/workflow/implementation/{topic}/analysis-tasks.md`
+2. **Staging file path** — `docs/workflow/implementation/{topic}/analysis-tasks-c{N}.md`
 3. **Plan path** — the implementation plan path
 4. **Plan format reading adapter path** — `../../../technical-planning/references/output-formats/{format}/reading.md`
 5. **Plan format authoring adapter path** — `../../../technical-planning/references/output-formats/{format}/authoring.md`


### PR DESCRIPTION
## Summary

- **Cycle suffixes**: All analysis file names now include `-c{N}` suffix (e.g., `analysis-architecture-c1.md`) so each cycle's files are preserved instead of overwritten
- **Commit at every stage**: Added commit instructions after findings (step C), synthesis (step D), and all-skipped path (step E) — previously files were only committed at task creation (step F)
- Updated all 8 affected files: 3 analysis agents, synthesizer, 3 orchestrator steps, and SKILL.md context refresh hint

## Test plan

- [ ] Trace `clean` path: C→commit findings→D→commit synthesis→Step 8 — all files committed with cycle suffix
- [ ] Trace `all skipped` path: C→commit→D→commit→E→commit staging→Step 8 — all committed
- [ ] Trace `some approved` path: C→commit→D→commit→E→F→commit plan+staging→Step 6 — all committed
- [ ] Verify cycle 2 creates `-c2` files while cycle 1 files remain untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)