### PR TITLE
feat: product assessment stage + architecture analysis enhancement

### DIFF
--- a/agents/implementation-analysis-architecture.md
+++ b/agents/implementation-analysis-architecture.md
@@ -29,6 +29,7 @@ You receive via the orchestrator's prompt:
 - Over/under-engineering — are abstractions justified by usage? Is raw code crying out for structure?
 - Missed composition opportunities — are new abstractions independently implemented when they could be derived from existing ones? If two queries are logical inverses, one should be defined in terms of the other.
 - Type safety at boundaries — are interfaces or function signatures using untyped parameters when the concrete types are known? Runtime type checks inside implementations signal the signature should be more specific.
+- Design decision soundness — are there foundational choices that introduce unnecessary complexity or latent risk? Look for: layers that mirror each other when the domain type could own the transformation; correctness that depends on caller discipline rather than being self-contained; struct tags, type annotations, or interface contracts that would produce wrong results if used outside their current narrow context. Only flag decisions that create latent bugs, unnecessary indirection, or fragile assumptions — not merely different-but-working approaches.
 
 ## Your Process
 

--- a/agents/review-product-assessor.md
+++ b/agents/review-product-assessor.md
@@ -1,0 +1,112 @@
+---
+name: review-product-assessor
+description: Evaluates implementation holistically as a product — robustness, gaps, cross-plan consistency, and forward-looking assessment. Invoked by technical-review skill during product assessment stage.
+tools: Read, Glob, Grep, Bash
+model: opus
+---
+
+# Review: Product Assessor
+
+You are evaluating an implementation as a product. Not task-by-task correctness (QA handles that) — you're assessing whether the product is robust, complete, and ready. You bring a holistic, forward-looking perspective.
+
+## Your Input
+
+You receive via the orchestrator's prompt:
+
+1. **Implementation files** — all files in scope
+2. **Specification path(s)** — validated specification(s) for design context
+3. **Plan path(s)** — implementation plan(s) for scope context
+4. **Project skill paths** — relevant `.claude/skills/` paths for framework conventions
+5. **Review scope** — one of: `single-plan`, `multi-plan`, `full-product`
+
+## Your Focus
+
+### For all scopes:
+
+- **Robustness** — Where would this break under real-world usage? Missing error handling, untested failure modes, fragile assumptions, edge cases the spec didn't cover
+- **Gaps** — What's obviously missing now the product exists? Things a real user would expect
+- **Strengthening** — Performance, security, scalability concerns visible only at the whole-product level
+- **What's next** — What does this enable? What should be built next?
+
+### Additional for multi-plan / full-product scope:
+
+- **Cross-plan consistency** — Are patterns consistent across independently-planned features? Same error handling, logging, configuration approaches?
+- **Integration seams** — Do the independently-built features connect cleanly? Shared types, compatible APIs, no conflicting assumptions?
+- **Missing shared concerns** — Are there utilities, middleware, or abstractions that should exist but don't because each plan was developed independently?
+- **Architectural coherence** — Does the product feel like one system or a collection of separate features?
+
+## Your Process
+
+1. **Read project skills** — understand framework conventions and architecture patterns
+2. **Read specification(s)** — understand design intent and boundaries
+3. **Read plan(s)** — understand what was built and the scope of each plan
+4. **Read all implementation files** — understand the full picture
+5. **Assess as a product** — evaluate holistically against focus areas
+6. **Write findings** to `docs/workflow/review/{topic-or-scope}/product-assessment.md`
+
+For multi-plan/full-product scope, use a descriptive scope name (e.g., `full-product` or a hyphenated list of topic names).
+
+## Hard Rules
+
+**MANDATORY. No exceptions.**
+
+1. **No git writes** — do not commit or stage. Writing the output file is your only file write.
+2. **No code edits** — read-only analysis. Do not modify implementation files.
+3. **Holistic perspective** — evaluate as a product, not task-by-task
+4. **Forward-looking** — assess the product as it stands. Do not re-litigate implementation decisions.
+5. **Proportional** — high-impact observations only. Not minor preferences.
+6. **Scope-aware** — cross-plan findings only for multi-plan/full-product scope. Don't fabricate cross-cutting issues for single-plan reviews.
+
+## Output File Format
+
+Write to `docs/workflow/review/{topic-or-scope}/product-assessment.md`:
+
+```
+SCOPE: {single-plan | multi-plan | full-product}
+PLANS_REVIEWED: {list}
+
+ROBUSTNESS:
+- {observation with file:line references}
+
+GAPS:
+- {what's missing with reasoning}
+
+INTEGRATION: (multi-plan/full-product only)
+- {cross-plan observations}
+
+CONSISTENCY: (multi-plan/full-product only)
+- {pattern inconsistencies across plans}
+
+STRENGTHENING:
+- {priority improvements}
+
+NEXT_STEPS:
+- {recommendations with priority}
+
+SUMMARY: {1-2 paragraph product readiness assessment}
+```
+
+If no significant findings:
+
+```
+SCOPE: {scope}
+PLANS_REVIEWED: {list}
+
+ROBUSTNESS: No significant concerns
+GAPS: No obvious gaps
+STRENGTHENING: No priority improvements identified
+NEXT_STEPS:
+- {recommendations}
+
+SUMMARY: {1-2 paragraph assessment}
+```
+
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+STATUS: findings | clean
+FINDINGS_COUNT: {N}
+SUMMARY: {1 sentence}
+```

--- a/agents/review-task-verifier.md
+++ b/agents/review-task-verifier.md
@@ -15,7 +15,8 @@ You receive:
 1. **Plan task**: A specific task with its acceptance criteria
 2. **Specification path**: For loading context about this task's feature/requirement
 3. **Plan path**: The full plan for additional context
-4. **Implementation scope**: Files or directories to check
+4. **Project skill paths**: Relevant `.claude/skills/` paths for framework conventions
+5. **Review checklist path**: Path to the review checklist (`skills/technical-review/references/review-checklist.md`) — read this for detailed verification criteria
 
 ## Your Task
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -208,40 +208,7 @@ Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
 
 ---
 
-## Step 5: Identify Implementation Scope
-
-**For single scope:** Ask what code to review:
-
-```
-· · · · · · · · · · · ·
-What code should I review?
-
-- **`a`/`all`** — All changes since the plan was created
-- **`g`/`git`** — Identify from git status
-- Specific directories or files — tell me which
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-If they choose specific directories/files, ask them to specify.
-
-**For multi/all scope:** Default to all changes. Briefly confirm:
-
-```
-· · · · · · · · · · · ·
-For multi-plan review, defaulting to all implementation changes.
-Override with specific paths? (Enter paths or press enter to continue)
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-→ Proceed to **Step 6**.
-
----
-
-## Step 6: Invoke the Skill
+## Step 5: Invoke the Skill
 
 After completing the steps above, this skill's purpose is fulfilled.
 
@@ -255,7 +222,6 @@ Plan: docs/workflow/planning/{topic}.md
 Format: {format}
 Plan ID: {plan_id} (if applicable)
 Specification: {specification} (exists: {true|false})
-Implementation scope: {all changes | specific paths | from git status}
 
 Invoke the technical-review skill.
 ```
@@ -267,7 +233,6 @@ Review scope: {multi | all}
 Plans:
   - docs/workflow/planning/{topic-1}.md (format: {format}, spec: {spec})
   - docs/workflow/planning/{topic-2}.md (format: {format}, spec: {spec})
-Implementation scope: {all changes | specific paths}
 
 Invoke the technical-review skill.
 ```

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -71,6 +71,8 @@ Parse the discovery output to understand:
 
 **From `state` section:**
 - `scenario` - one of: `"no_plans"`, `"single_plan"`, `"multiple_plans"`
+- `implemented_count` - plans with implementation_status != "none"
+- `completed_count` - plans with implementation_status == "completed"
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state - the script provides everything needed.
 
@@ -102,25 +104,53 @@ Plans exist.
 
 ---
 
-## Step 3: Present Plans and Select
+## Step 3a: Review Scope
 
-Present all discovered plans to help the user make an informed choice.
+Present the scope selection. If only one implemented plan exists, auto-select single scope and proceed to Step 3b.
 
-**Present the full state:**
+```
+· · · · · · · · · · · ·
+What scope would you like to review?
+
+- **`s`/`single`** — Review one plan's implementation
+- **`m`/`multi`** — Review selected plans together (cross-cutting)
+- **`a`/`all`** — Review all implemented plans (full product)
+· · · · · · · · · · · ·
+```
+
+**If only one implemented plan exists (auto-select):**
+```
+Auto-selecting single scope (only one implemented plan)
+```
+→ Proceed directly to **Step 3b**.
+
+**If multiple implemented plans exist:**
+
+**STOP.** Wait for user response.
+
+→ Based on user choice, proceed to **Step 3b**.
+
+---
+
+## Step 3b: Plan Selection
+
+**For single scope:** Present list of implemented plans, user picks one.
 
 ```
 Available Plans:
 
-  1. {topic-1} ({status}) - format: {format}, spec: {exists|missing}
-  2. {topic-2} ({status}) - format: {format}, spec: {exists|missing}
+  1. {topic-1} ({status}) - format: {format}, impl: {implementation_status}, spec: {exists|missing}
+  2. {topic-2} ({status}) - format: {format}, impl: {implementation_status}, spec: {exists|missing}
 
 · · · · · · · · · · · ·
-Which plan would you like to review the implementation for? (Enter a number or name)
+Which plan would you like to review? (Enter a number or name)
 ```
 
-**If single plan exists (auto-select):**
+Only show plans with implementation_status != "none".
+
+**If single plan auto-selected from Step 3a:**
 ```
-Auto-selecting: {topic} (only available plan)
+Auto-selecting: {topic} (only implemented plan)
 ```
 → Proceed directly to **Step 4**.
 
@@ -130,11 +160,34 @@ Auto-selecting: {topic} (only available plan)
 
 → Based on user choice, proceed to **Step 4**.
 
+**For multi scope:** Present list with multi-select.
+
+```
+Available Plans:
+
+  1. {topic-1} ({status}) - impl: {implementation_status}
+  2. {topic-2} ({status}) - impl: {implementation_status}
+  3. {topic-3} ({status}) - impl: {implementation_status}
+
+· · · · · · · · · · · ·
+Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
+```
+
+Only show plans with implementation_status != "none".
+
+**STOP.** Wait for user response.
+
+→ Based on user choice, proceed to **Step 4**.
+
+**For all scope:** No selection needed — include all plans with implementation_status != "none".
+
+→ Proceed directly to **Step 4**.
+
 ---
 
 ## Step 4: Identify Implementation Scope
 
-Ask the user what code to review:
+**For single scope:** Ask what code to review:
 
 ```
 · · · · · · · · · · · ·
@@ -150,6 +203,17 @@ What code should I review?
 
 If they choose specific directories/files, ask them to specify.
 
+**For multi/all scope:** Default to all changes. Briefly confirm:
+
+```
+· · · · · · · · · · · ·
+For multi-plan review, defaulting to all implementation changes.
+Override with specific paths? (Enter paths or press enter to continue)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
 → Proceed to **Step 5**.
 
 ---
@@ -160,14 +224,27 @@ After completing the steps above, this skill's purpose is fulfilled.
 
 Invoke the [technical-review](../technical-review/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
 
-**Example handoff:**
+**Example handoff (single):**
 ```
 Review session for: {topic}
+Review scope: single
 Plan: docs/workflow/planning/{topic}.md
 Format: {format}
 Plan ID: {plan_id} (if applicable)
 Specification: {specification} (exists: {true|false})
-Scope: {all changes | specific paths | from git status}
+Implementation scope: {all changes | specific paths | from git status}
+
+Invoke the technical-review skill.
+```
+
+**Example handoff (multi/all):**
+```
+Review session for: {scope description}
+Review scope: {multi | all}
+Plans:
+  - docs/workflow/planning/{topic-1}.md (format: {format}, spec: {spec})
+  - docs/workflow/planning/{topic-2}.md (format: {format}, spec: {spec})
+Implementation scope: {all changes | specific paths}
 
 Invoke the technical-review skill.
 ```

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -104,9 +104,57 @@ Plans exist.
 
 ---
 
-## Step 3: Review Scope
+## Step 3: Present Plans and Select Scope
 
-Present the scope selection. If only one implemented plan exists, auto-select single scope and proceed to Step 4.
+Present all discovered plans with implementation status to help the user understand what's reviewable.
+
+**Present the full state:**
+
+```
+Review Phase
+
+Reviewable:
+  1. ✓ {topic-1} (completed) - format: {format}, spec: {exists|missing}
+  2. ▶ {topic-2} (in-progress) - format: {format}, spec: {exists|missing}
+
+Not reviewable:
+  · {topic-3} [no implementation]
+```
+
+**Formatting rules:**
+
+Reviewable (numbered, selectable):
+- **`✓`** — implementation_status: completed
+- **`▶`** — implementation_status: in-progress
+
+Not reviewable (not numbered, not selectable):
+- **`·`** — implementation_status: none
+
+Omit either section entirely if it has no entries.
+
+**Then route based on what's reviewable:**
+
+#### If no reviewable plans
+
+```
+No implemented plans found.
+
+The review phase requires at least one plan with an implementation.
+Please run /start-implementation first.
+```
+
+**STOP.** Wait for user to acknowledge before ending.
+
+#### If single reviewable plan
+
+```
+Auto-selecting: {topic} (only reviewable plan)
+Scope: single
+```
+
+→ Proceed directly to **Step 5**.
+
+#### If multiple reviewable plans
 
 ```
 · · · · · · · · · · · ·
@@ -118,14 +166,6 @@ What scope would you like to review?
 · · · · · · · · · · · ·
 ```
 
-**If only one implemented plan exists (auto-select):**
-```
-Auto-selecting single scope (only one implemented plan)
-```
-→ Proceed directly to **Step 4**.
-
-**If multiple implemented plans exist:**
-
 **STOP.** Wait for user response.
 
 → Based on user choice, proceed to **Step 4**.
@@ -134,54 +174,37 @@ Auto-selecting single scope (only one implemented plan)
 
 ## Step 4: Plan Selection
 
-**For single scope:** Present list of implemented plans, user picks one.
+This step only applies for `single` or `multi` scope chosen in Step 3.
 
-```
-Available Plans:
+#### If scope is "all"
 
-  1. {topic-1} ({status}) - format: {format}, impl: {implementation_status}, spec: {exists|missing}
-  2. {topic-2} ({status}) - format: {format}, impl: {implementation_status}, spec: {exists|missing}
+All reviewable plans are included. No selection needed.
 
-· · · · · · · · · · · ·
-Which plan would you like to review? (Enter a number or name)
-```
-
-Only show plans with implementation_status != "none".
-
-**If single plan auto-selected from Step 3:**
-```
-Auto-selecting: {topic} (only implemented plan)
-```
 → Proceed directly to **Step 5**.
 
-**If multiple plans exist:**
+#### If scope is "single"
+
+```
+· · · · · · · · · · · ·
+Which plan would you like to review? (Enter a number from Step 3)
+· · · · · · · · · · · ·
+```
 
 **STOP.** Wait for user response.
 
-→ Based on user choice, proceed to **Step 5**.
+→ Proceed to **Step 5**.
 
-**For multi scope:** Present list with multi-select.
+#### If scope is "multi"
 
 ```
-Available Plans:
-
-  1. {topic-1} ({status}) - impl: {implementation_status}
-  2. {topic-2} ({status}) - impl: {implementation_status}
-  3. {topic-3} ({status}) - impl: {implementation_status}
-
 · · · · · · · · · · · ·
 Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
+· · · · · · · · · · · ·
 ```
-
-Only show plans with implementation_status != "none".
 
 **STOP.** Wait for user response.
 
-→ Based on user choice, proceed to **Step 5**.
-
-**For all scope:** No selection needed — include all plans with implementation_status != "none".
-
-→ Proceed directly to **Step 5**.
+→ Proceed to **Step 5**.
 
 ---
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -104,9 +104,9 @@ Plans exist.
 
 ---
 
-## Step 3a: Review Scope
+## Step 3: Review Scope
 
-Present the scope selection. If only one implemented plan exists, auto-select single scope and proceed to Step 3b.
+Present the scope selection. If only one implemented plan exists, auto-select single scope and proceed to Step 4.
 
 ```
 · · · · · · · · · · · ·
@@ -122,17 +122,17 @@ What scope would you like to review?
 ```
 Auto-selecting single scope (only one implemented plan)
 ```
-→ Proceed directly to **Step 3b**.
+→ Proceed directly to **Step 4**.
 
 **If multiple implemented plans exist:**
 
 **STOP.** Wait for user response.
 
-→ Based on user choice, proceed to **Step 3b**.
+→ Based on user choice, proceed to **Step 4**.
 
 ---
 
-## Step 3b: Plan Selection
+## Step 4: Plan Selection
 
 **For single scope:** Present list of implemented plans, user picks one.
 
@@ -148,17 +148,17 @@ Which plan would you like to review? (Enter a number or name)
 
 Only show plans with implementation_status != "none".
 
-**If single plan auto-selected from Step 3a:**
+**If single plan auto-selected from Step 3:**
 ```
 Auto-selecting: {topic} (only implemented plan)
 ```
-→ Proceed directly to **Step 4**.
+→ Proceed directly to **Step 5**.
 
 **If multiple plans exist:**
 
 **STOP.** Wait for user response.
 
-→ Based on user choice, proceed to **Step 4**.
+→ Based on user choice, proceed to **Step 5**.
 
 **For multi scope:** Present list with multi-select.
 
@@ -177,15 +177,15 @@ Only show plans with implementation_status != "none".
 
 **STOP.** Wait for user response.
 
-→ Based on user choice, proceed to **Step 4**.
+→ Based on user choice, proceed to **Step 5**.
 
 **For all scope:** No selection needed — include all plans with implementation_status != "none".
 
-→ Proceed directly to **Step 4**.
+→ Proceed directly to **Step 5**.
 
 ---
 
-## Step 4: Identify Implementation Scope
+## Step 5: Identify Implementation Scope
 
 **For single scope:** Ask what code to review:
 
@@ -214,11 +214,11 @@ Override with specific paths? (Enter paths or press enter to continue)
 
 **STOP.** Wait for user response.
 
-→ Proceed to **Step 5**.
+→ Proceed to **Step 6**.
 
 ---
 
-## Step 5: Invoke the Skill
+## Step 6: Invoke the Skill
 
 After completing the steps above, this skill's purpose is fulfilled.
 

--- a/skills/start-review/scripts/discovery.sh
+++ b/skills/start-review/scripts/discovery.sh
@@ -45,6 +45,8 @@ echo ""
 echo "plans:"
 
 plan_count=0
+implemented_count=0
+completed_count=0
 
 if [ -d "$PLAN_DIR" ] && [ -n "$(ls -A "$PLAN_DIR" 2>/dev/null)" ]; then
     echo "  exists: true"
@@ -73,6 +75,14 @@ if [ -d "$PLAN_DIR" ] && [ -n "$(ls -A "$PLAN_DIR" 2>/dev/null)" ]; then
             spec_exists="true"
         fi
 
+        # Check implementation status
+        impl_tracking="docs/workflow/implementation/${name}/tracking.md"
+        impl_status="none"
+        if [ -f "$impl_tracking" ]; then
+            impl_status_val=$(extract_field "$impl_tracking" "status")
+            impl_status=${impl_status_val:-"in-progress"}
+        fi
+
         echo "    - name: \"$name\""
         echo "      topic: \"$topic\""
         echo "      status: \"$status\""
@@ -83,8 +93,15 @@ if [ -d "$PLAN_DIR" ] && [ -n "$(ls -A "$PLAN_DIR" 2>/dev/null)" ]; then
         if [ -n "$plan_id" ]; then
             echo "      plan_id: \"$plan_id\""
         fi
+        echo "      implementation_status: \"$impl_status\""
 
         plan_count=$((plan_count + 1))
+        if [ "$impl_status" != "none" ]; then
+            implemented_count=$((implemented_count + 1))
+        fi
+        if [ "$impl_status" = "completed" ]; then
+            completed_count=$((completed_count + 1))
+        fi
     done
 
     echo "  count: $plan_count"
@@ -103,6 +120,8 @@ echo "state:"
 
 echo "  has_plans: $([ "$plan_count" -gt 0 ] && echo "true" || echo "false")"
 echo "  plan_count: $plan_count"
+echo "  implemented_count: $implemented_count"
+echo "  completed_count: $completed_count"
 
 # Determine workflow state for routing
 if [ "$plan_count" -eq 0 ]; then

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -100,6 +100,8 @@ Scan `.claude/skills/` for project-specific skill directories. Note which are re
 
 Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and follow its instructions as written.
 
+**STOP.** Do not proceed until ALL task verifiers have returned and findings are aggregated.
+
 → Proceed to **Step 4**.
 
 ---
@@ -107,6 +109,8 @@ Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and fol
 ## Step 4: Product Assessment
 
 Load **[invoke-product-assessor.md](references/invoke-product-assessor.md)** and follow its instructions as written.
+
+**STOP.** Do not proceed until the product assessor has returned.
 
 → Proceed to **Step 5**.
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -96,36 +96,7 @@ Scan `.claude/skills/` for project-specific skill directories. Note which are re
 
 ---
 
-## Step 3: Route by Review Scope
-
-#### If scope is "single"
-
-Single plan — full QA verification followed by product assessment.
-
-→ Proceed to **Step 4**.
-
-#### If scope is "multi" or "all"
-
-Multiple plans — per-task QA is optional since individual plans were presumably already reviewed during implementation.
-
-```
-· · · · · · · · · · · ·
-These plans were already reviewed during implementation.
-Run per-task QA verification anyway?
-
-- **`y`/`yes`** — Run QA across all selected plans
-- **`n`/`no`** — Skip to product assessment (default)
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-- **`yes`**: → Proceed to **Step 4**.
-- **`no`**: → Proceed to **Step 5**.
-
----
-
-## Step 4: QA Verification
+## Step 3: QA Verification
 
 Spawn `review-task-verifier` subagents **in parallel** for ALL tasks across the selected plan(s). Each verifier checks one task for implementation, tests, and quality.
 
@@ -143,11 +114,11 @@ See **[review-checklist.md](references/review-checklist.md)** for detailed per-t
 - Collect all code quality concerns
 - Include specific file:line references
 
-→ Proceed to **Step 5**.
+→ Proceed to **Step 4**.
 
 ---
 
-## Step 5: Product Assessment
+## Step 4: Product Assessment
 
 Spawn a single `review-product-assessor` agent with the full scope context. This is a holistic evaluation — not task-by-task.
 
@@ -162,22 +133,22 @@ The assessor evaluates robustness, gaps, strengthening opportunities, and what's
 
 Product Assessment findings are always **advisory** — they don't affect the QA Verdict.
 
-→ Proceed to **Step 6**.
+→ Proceed to **Step 5**.
 
 ---
 
-## Step 6: Produce Review
+## Step 5: Produce Review
 
 Aggregate findings from both stages into a review document using the **[template.md](references/template.md)**.
 
 Write the review to `docs/workflow/review/{topic}.md` (single) or `docs/workflow/review/{scope-description}.md` (multi/all).
 
-**QA Verdict** (from Step 4, or "Skipped" if QA was skipped):
+**QA Verdict** (from Step 3):
 - **Approve** — All acceptance criteria met, no blocking issues
 - **Request Changes** — Missing requirements, broken functionality, inadequate tests
 - **Comments Only** — Minor suggestions, non-blocking observations
 
-**Product Assessment** (from Step 5) — always advisory, presented alongside the verdict.
+**Product Assessment** (from Step 4) — always advisory, presented alongside the verdict.
 
 Commit: `review({topic}): complete review`
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -98,21 +98,7 @@ Scan `.claude/skills/` for project-specific skill directories. Note which are re
 
 ## Step 3: QA Verification
 
-Spawn `review-task-verifier` subagents **in parallel** for ALL tasks across the selected plan(s). Each verifier checks one task for implementation, tests, and quality.
-
-See **[review-checklist.md](references/review-checklist.md)** for detailed per-task verification criteria and invocation instructions.
-
-**Provide to each verifier:**
-- The specific task (with acceptance criteria)
-- Path to specification (for context)
-- Path to plan (for phase context)
-- Project skills (if discovered in Step 2)
-
-**Aggregate findings** once all verifiers complete:
-- Collect all incomplete/failed tasks as blocking issues
-- Collect all test issues (under/over-tested)
-- Collect all code quality concerns
-- Include specific file:line references
+Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
 
@@ -120,18 +106,7 @@ See **[review-checklist.md](references/review-checklist.md)** for detailed per-t
 
 ## Step 4: Product Assessment
 
-Spawn a single `review-product-assessor` agent with the full scope context. This is a holistic evaluation — not task-by-task.
-
-**Provide to the assessor:**
-- All implementation files in scope
-- All relevant specifications
-- All relevant plans
-- Project skills (`.claude/skills/`)
-- Review scope indicator (single-plan / multi-plan / full-product)
-
-The assessor evaluates robustness, gaps, strengthening opportunities, and what's next. For multi-plan/full-product scope, it additionally assesses cross-plan consistency and integration seams.
-
-Product Assessment findings are always **advisory** — they don't affect the QA Verdict.
+Load **[invoke-product-assessor.md](references/invoke-product-assessor.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
 
@@ -165,5 +140,7 @@ You produce feedback. User decides what to do with it.
 
 ## References
 
+- **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** — How to dispatch QA verifier agents
+- **[invoke-product-assessor.md](references/invoke-product-assessor.md)** — How to dispatch the product assessor agent
 - **[template.md](references/template.md)** — Review output structure and verdict guidelines
-- **[review-checklist.md](references/review-checklist.md)** — Detailed per-task verification criteria and invocation instructions
+- **[review-checklist.md](references/review-checklist.md)** — Per-task verification criteria (read by agents), plan completion checks, writing feedback guidance

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -41,7 +41,6 @@ Either way: Verify plan tasks were implemented, tested adequately, and meet qual
 - **Review scope** (required) - single, multi, or all
 - **Plan content** (required) - Tasks and acceptance criteria to verify against (one or more plans)
 - **Specification content** (optional) - Context for design decisions
-- **Implementation scope** (optional) - What code/files to review. Will identify from git if not specified.
 
 **Before proceeding**, verify the required input is available. If anything is missing, **STOP** — do not proceed until resolved.
 

--- a/skills/technical-review/references/invoke-product-assessor.md
+++ b/skills/technical-review/references/invoke-product-assessor.md
@@ -1,0 +1,57 @@
+# Invoke Product Assessor
+
+*Reference for **[technical-review](../SKILL.md)***
+
+---
+
+This step dispatches a single `review-product-assessor` agent to evaluate the implementation holistically as a product. This is not task-by-task — the assessor evaluates robustness, gaps, and product readiness.
+
+---
+
+## Identify Scope
+
+Determine the review scope indicator to pass to the assessor:
+
+- **single-plan** — one plan selected
+- **multi-plan** — multiple plans selected
+- **full-product** — all implemented plans
+
+Build the full list of implementation files across all plans in scope (same git history approach as QA verification).
+
+---
+
+## Dispatch Assessor
+
+Dispatch **one agent** via the Task tool.
+
+- **Agent path**: `../../../agents/review-product-assessor.md`
+
+The assessor receives:
+
+1. **Implementation files** — all files in scope (the full list, not summarized)
+2. **Specification path(s)** — from each plan's frontmatter
+3. **Plan path(s)** — all plans in scope
+4. **Project skill paths** — from Step 2 discovery
+5. **Review scope** — one of: `single-plan`, `multi-plan`, `full-product`
+
+---
+
+## Wait for Completion
+
+**STOP.** Do not proceed until the assessor has returned.
+
+The assessor writes its findings to `docs/workflow/review/{topic-or-scope}/product-assessment.md` and returns a brief status. If the agent fails (error, timeout), record the failure and continue to the review production step with QA findings only.
+
+---
+
+## Expected Result
+
+The assessor returns:
+
+```
+STATUS: findings | clean
+FINDINGS_COUNT: {N}
+SUMMARY: {1 sentence}
+```
+
+The full findings are in the output file. Read `docs/workflow/review/{topic-or-scope}/product-assessment.md` to incorporate into the review document.

--- a/skills/technical-review/references/invoke-task-verifiers.md
+++ b/skills/technical-review/references/invoke-task-verifiers.md
@@ -1,0 +1,104 @@
+# Invoke Task Verifiers
+
+*Reference for **[technical-review](../SKILL.md)***
+
+---
+
+This step dispatches `review-task-verifier` agents in parallel to verify ALL tasks across the selected plan(s). Each verifier independently checks one task for implementation, tests, and code quality.
+
+---
+
+## Identify Scope
+
+Build the list of implementation files using git history. For each plan in scope:
+
+```bash
+git log --oneline --name-only --pretty=format: --grep="impl({topic}):" | sort -u | grep -v '^$'
+```
+
+This captures all files touched by implementation commits for the topic.
+
+---
+
+## Extract All Tasks
+
+From each plan in scope, list every task across all phases:
+- Note each task's description
+- Note each task's acceptance criteria
+- Note expected micro acceptance (test name)
+
+---
+
+## Dispatch Verifiers
+
+Dispatch **one verifier per task, all in parallel** via the Task tool.
+
+- **Agent path**: `../../../agents/review-task-verifier.md`
+
+Each verifier receives:
+
+1. **Plan task** — the specific task with acceptance criteria
+2. **Specification path** — from the plan's frontmatter (if available)
+3. **Plan path** — the full plan for phase context
+4. **Project skill paths** — from Step 2 discovery
+5. **Review checklist path** — `skills/technical-review/references/review-checklist.md`
+
+---
+
+## Wait for Completion
+
+**STOP.** Do not proceed until all verifiers have returned.
+
+Each verifier returns a structured finding. If any verifier fails (error, timeout), record the failure and continue — aggregate what's available.
+
+---
+
+## Expected Result
+
+Each verifier returns:
+
+```
+TASK: [Task name/description]
+
+ACCEPTANCE CRITERIA: [List from plan]
+
+STATUS: Complete | Incomplete | Issues Found
+
+SPEC CONTEXT: [Brief summary of relevant spec context]
+
+IMPLEMENTATION:
+- Status: [Implemented/Missing/Partial/Drifted]
+- Location: [file:line references]
+- Notes: [Any concerns]
+
+TESTS:
+- Status: [Adequate/Under-tested/Over-tested/Missing]
+- Coverage: [What is/isn't tested]
+- Notes: [Specific issues]
+
+CODE QUALITY:
+- Project conventions: [Followed/Violations/N/A]
+- SOLID principles: [Good/Concerns]
+- Complexity: [Low/Acceptable/High]
+- Modern idioms: [Yes/Opportunities]
+- Readability: [Good/Concerns]
+- Issues: [Specific problems if any]
+
+BLOCKING ISSUES:
+- [List any issues that must be fixed]
+
+NON-BLOCKING NOTES:
+- [Suggestions for improvement]
+```
+
+---
+
+## Aggregate Findings
+
+Once all verifiers have returned, synthesize their reports:
+
+- Collect all tasks with `STATUS: Incomplete` or `STATUS: Issues Found` as blocking issues
+- Collect all test issues (under/over-tested)
+- Collect all code quality concerns
+- Include specific file:line references
+- Check overall plan completion (see [review-checklist.md](review-checklist.md) — Plan Completion Check)

--- a/skills/technical-review/references/review-checklist.md
+++ b/skills/technical-review/references/review-checklist.md
@@ -4,61 +4,7 @@
 
 ---
 
-## Before Starting
-
-1. Read plan (from the location provided)
-   - If not found at expected path, ask user where the plan is
-2. Read specification if available and linked in plan
-   - Not required, but helpful for context if it exists
-3. Identify what code/files were changed
-4. Check for project-specific skills in `.claude/skills/`
-
-## Task-Based Review (Primary Approach)
-
-Review **every task** in the plan. Don't sample - verify all of them.
-
-### Extract All Tasks
-
-From the plan, list every task across all phases:
-- Note each task's description
-- Note each task's acceptance criteria
-- Note expected micro acceptance (test name)
-
-### Parallel Verification
-
-Spawn `review-task-verifier` subagents **in parallel** for ALL tasks:
-
-```
-Task 1 ──▶ [review-task-verifier] ──▶ Findings
-Task 2 ──▶ [review-task-verifier] ──▶ Findings
-Task 3 ──▶ [review-task-verifier] ──▶ Findings  (all running in parallel)
-Task 4 ──▶ [review-task-verifier] ──▶ Findings
-  ...
-Task N ──▶ [review-task-verifier] ──▶ Findings
-```
-
-**How to invoke each review-task-verifier:**
-
-Provide:
-- The specific task (with acceptance criteria)
-- Path to specification (for context)
-- Path to plan (for phase context)
-- Implementation scope (files/directories changed)
-
-**Each review-task-verifier checks:**
-1. Implementation exists and matches acceptance criteria
-2. Tests are adequate (not under-tested, not over-tested)
-3. Code quality is acceptable
-
-**Aggregate the findings:**
-
-Once all review-task-verifiers complete, synthesize their reports:
-- Collect all incomplete/failed tasks as blocking issues
-- Collect all test issues (under/over-tested)
-- Collect all code quality concerns
-- Include specific file:line references
-
-## Per-Task Verification Details
+## Per-Task Verification Criteria
 
 For each task, the review-task-verifier checks:
 
@@ -115,17 +61,6 @@ For each phase:
 - Was anything built that wasn't in the plan? (scope creep)
 - Was anything in the plan not built? (missing scope)
 - Any unplanned files or features added?
-
-## Product Assessment
-
-After QA verification, run the product assessment stage:
-
-1. Spawn `review-product-assessor` with the full implementation scope
-2. Provide: all specs, all plans, project skills, and scope indicator
-3. For multi-plan/full-product scope, include ALL implementation files across
-   selected plans — the assessor needs the full picture for cross-cutting analysis
-4. Aggregate findings into the Product Assessment section of the review
-5. Product Assessment findings are always advisory — they don't affect QA Verdict
 
 ## Common Issues
 

--- a/skills/technical-review/references/review-checklist.md
+++ b/skills/technical-review/references/review-checklist.md
@@ -118,8 +118,7 @@ For each phase:
 
 ## Product Assessment
 
-After QA verification (or in place of it for multi/all scope), run the product
-assessment stage:
+After QA verification, run the product assessment stage:
 
 1. Spawn `review-product-assessor` with the full implementation scope
 2. Provide: all specs, all plans, project skills, and scope indicator

--- a/skills/technical-review/references/review-checklist.md
+++ b/skills/technical-review/references/review-checklist.md
@@ -116,6 +116,18 @@ For each phase:
 - Was anything in the plan not built? (missing scope)
 - Any unplanned files or features added?
 
+## Product Assessment
+
+After QA verification (or in place of it for multi/all scope), run the product
+assessment stage:
+
+1. Spawn `review-product-assessor` with the full implementation scope
+2. Provide: all specs, all plans, project skills, and scope indicator
+3. For multi-plan/full-product scope, include ALL implementation files across
+   selected plans — the assessor needs the full picture for cross-cutting analysis
+4. Aggregate findings into the Product Assessment section of the review
+5. Product Assessment findings are always advisory — they don't affect QA Verdict
+
 ## Common Issues
 
 **Incomplete task**: Task marked done but not fully implemented

--- a/skills/technical-review/references/template.md
+++ b/skills/technical-review/references/template.md
@@ -10,13 +10,12 @@
 # Implementation Review: {Topic / Product}
 
 **Scope**: Single Plan ({plan}) | Multi-Plan ({plans}) | Full Product
-**QA Verdict**: Approve | Request Changes | Comments Only | Skipped (multi/all)
+**QA Verdict**: Approve | Request Changes | Comments Only
 
 ## Summary
 [One paragraph overall assessment]
 
 ## QA Verification
-[Present if QA was run; omit or note "Skipped — individual plans already reviewed" for multi/all]
 
 ### Specification Compliance
 [Implementation aligns with specification / Note any deviations]
@@ -67,4 +66,3 @@
 
 **Comments Only**: Minor suggestions, style preferences, non-blocking observations
 
-**Skipped**: QA verification was skipped for multi/all scope (individual plans already reviewed)

--- a/skills/technical-review/references/template.md
+++ b/skills/technical-review/references/template.md
@@ -7,34 +7,56 @@
 ## Template
 
 ```markdown
-# Implementation Review: {Topic}
+# Implementation Review: {Topic / Product}
 
-**Verdict**: Approve | Request Changes | Comments Only
+**Scope**: Single Plan ({plan}) | Multi-Plan ({plans}) | Full Product
+**QA Verdict**: Approve | Request Changes | Comments Only | Skipped (multi/all)
 
 ## Summary
 [One paragraph overall assessment]
 
-## Specification Compliance
+## QA Verification
+[Present if QA was run; omit or note "Skipped — individual plans already reviewed" for multi/all]
+
+### Specification Compliance
 [Implementation aligns with specification / Note any deviations]
 
-## Plan Completion
-- [ ] Phase 1 acceptance criteria met
-- [ ] Phase 2 acceptance criteria met
+### Plan Completion
+- [ ] Phase N acceptance criteria met
 - [ ] All tasks completed
 - [ ] No scope creep
 
-## Code Quality
+### Code Quality
 [Issues or "No issues found"]
 
-## Test Quality
+### Test Quality
 [Issues or "Tests adequately verify requirements"]
 
-## Required Changes (if any)
+### Required Changes (if any)
 1. [Specific actionable change]
-2. [Specific actionable change]
 
-## Recommendations (optional)
-[Non-blocking suggestions]
+## Product Assessment
+
+### Robustness
+[Where would this break under real-world usage?]
+
+### Gaps
+[What's obviously missing now the product exists?]
+
+### Cross-Plan Consistency (multi/all only)
+[Are patterns consistent across features?]
+
+### Integration Seams (multi/all only)
+[Do independently-built features connect cleanly?]
+
+### Strengthening Opportunities
+[Priority improvements for production readiness]
+
+### What's Next
+[What does this enable? What should be built next?]
+
+## Recommendations
+[Combined non-blocking suggestions]
 ```
 
 ## Verdict Guidelines
@@ -44,3 +66,5 @@
 **Request Changes**: Missing requirements, deviations from decisions, broken functionality, inadequate tests
 
 **Comments Only**: Minor suggestions, style preferences, non-blocking observations
+
+**Skipped**: QA verification was skipped for multi/all scope (individual plans already reviewed)


### PR DESCRIPTION
## Summary

- **Architecture agent**: Added "design decision soundness" focus area — flags unnecessary complexity, caller-discipline dependencies, and fragile contracts (not just structural issues)
- **Review phase**: Reshaped into two stages — Stage 1 (QA verification via existing task verifiers) + Stage 2 (new product assessment via `review-product-assessor` agent)
- **Multi-plan scope**: Review now supports single/multi/all plan scopes with cross-cutting product evaluation, discovery script detects implementation status per plan

## Test plan

- [ ] Run discovery script on project with implemented plans — verify `implementation_status` appears in YAML output
- [ ] Run `/start-review` — verify scope selection menu (single/multi/all) appears
- [ ] Single plan review: confirm both task verifiers and product assessor run, review doc has both sections
- [ ] Multi/all review: confirm product assessor receives cross-plan scope and produces cross-cutting findings
- [ ] Next implementation run: verify architecture analysis produces design-decision findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)