### PR TITLE
fix: correct tree indentation and strengthen silent processing

### DIFF
--- a/skills/start-discussion/SKILL.md
+++ b/skills/start-discussion/SKILL.md
@@ -30,6 +30,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
+- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
@@ -87,8 +88,6 @@ Parse the discovery output to understand:
 - `scenario` - one of: `"fresh"`, `"research_only"`, `"discussions_only"`, `"research_and_discussions"`
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state - the script provides everything needed.
-
-**Silent processing**: Do NOT output your assessment of the discovery state. Parse it internally and proceed to the next step without narrating field values, routing decisions, or prerequisites. The first user-visible output should be the display content itself.
 
 → Proceed to **Step 2**.
 

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -30,6 +30,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
+- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
@@ -93,8 +94,6 @@ Parse the discovery output to understand:
 - `plans_completed_count` - implementations completed
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state - the script provides everything needed.
-
-**Silent processing**: Do NOT output your assessment of the discovery state. Parse it internally and proceed to the next step without narrating field values, routing decisions, or prerequisites. The first user-visible output should be the display content itself.
 
 → Proceed to **Step 2**.
 

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -30,6 +30,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
+- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
@@ -82,8 +83,6 @@ Parse the discovery output to understand:
 - `scenario` - one of: `"no_specs"`, `"nothing_actionable"`, `"has_options"`
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state - the script provides everything needed.
-
-**Silent processing**: Do NOT output your assessment of the discovery state. Parse it internally and proceed to the next step without narrating field values, routing decisions, or prerequisites. The first user-visible output should be the display content itself.
 
 → Proceed to **Step 2**.
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -30,6 +30,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
+- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
@@ -75,8 +76,6 @@ Parse the discovery output to understand:
 - `completed_count` - plans with implementation_status == "completed"
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state - the script provides everything needed.
-
-**Silent processing**: Do NOT output your assessment of the discovery state. Parse it internally and proceed to the next step without narrating field values, routing decisions, or prerequisites. The first user-visible output should be the display content itself.
 
 → Proceed to **Step 2**.
 

--- a/skills/start-specification/SKILL.md
+++ b/skills/start-specification/SKILL.md
@@ -30,6 +30,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
+- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
@@ -73,8 +74,6 @@ Parse the discovery output to understand:
 **From `current_state`:** `concluded_count`, `spec_count`, `has_discussions`, `has_concluded`, `has_specs`, and other counts/booleans for routing.
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state - the script provides everything needed.
-
-**Silent processing**: Do NOT output your assessment of the discovery state. Parse it internally and proceed to the next step without narrating field values, routing decisions, or prerequisites. The first user-visible output should be the display content itself.
 
 → Proceed to **Step 2**.
 

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -56,20 +56,18 @@ Specification Overview
 Recommended breakdown for specifications with their source discussions.
 
 1. {Grouping Name}
-    └─ Spec: {status} {(X of Y sources extracted) if applicable}
-    └─ Discussions:
-       ├─ {discussion-name} ({status})
-       └─ {discussion-name} ({status})
+   └─ Spec: {status} {(X of Y sources extracted) if applicable}
+   └─ Discussions:
+      ├─ {discussion-name} ({status})
+      └─ {discussion-name} ({status})
 
 2. {Grouping Name}
-    └─ Spec: none
-    └─ Discussions:
-       └─ {discussion-name} (ready)
+   └─ Spec: none
+   └─ Discussions:
+      └─ {discussion-name} (ready)
 ```
 
-Indentation: `└─` starts at column 4 (under the grouping name text, not the number). Discussion entries start at column 7.
-
-Use `├─` for all but the last discussion, `└─` for the last.
+**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces, blank lines between groupings, and `├─`/`└─` characters. Do not flatten or compress the spacing.
 
 ### If in-progress discussions exist
 
@@ -145,7 +143,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Menu descriptions are wrapped in backticks to visually distinguish them from the choice labels.
+**Formatting is exact**: Reproduce the menu exactly as shown above — descriptions are indented 3 spaces and wrapped in backticks.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/display-single-grouped.md
+++ b/skills/start-specification/references/display-single-grouped.md
@@ -21,13 +21,13 @@ Specification Overview
 Single concluded discussion found with existing multi-source specification.
 
 1. {Spec Title Case Name}
-    └─ Spec: {spec_status} ({X} of {Y} sources extracted)
-    └─ Discussions:
-       ├─ {source-name} (extracted)
-       └─ {source-name} (extracted, reopened)
+   └─ Spec: {spec_status} ({X} of {Y} sources extracted)
+   └─ Discussions:
+      ├─ {source-name} (extracted)
+      └─ {source-name} (extracted, reopened)
 ```
 
-Indentation: `└─` starts at column 4 (under the name text, not the number). Discussion entries start at column 7.
+**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces and `├─`/`└─` characters. Do not flatten or compress the spacing.
 
 ### If in-progress discussions exist
 

--- a/skills/start-specification/references/display-single-has-spec.md
+++ b/skills/start-specification/references/display-single-has-spec.md
@@ -16,12 +16,12 @@ Specification Overview
 Single concluded discussion found with existing specification.
 
 1. {Title Case Name}
-    └─ Spec: {spec_status} ({X} of {Y} sources extracted)
-    └─ Discussions:
-       └─ {discussion-name} (extracted)
+   └─ Spec: {spec_status} ({X} of {Y} sources extracted)
+   └─ Discussions:
+      └─ {discussion-name} (extracted)
 ```
 
-Indentation: `└─` starts at column 4 (under the name text, not the number). Discussion entries start at column 7.
+**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces and `├─`/`└─` characters. Do not flatten or compress the spacing.
 
 ### If in-progress discussions exist
 

--- a/skills/start-specification/references/display-single-no-spec.md
+++ b/skills/start-specification/references/display-single-no-spec.md
@@ -14,12 +14,12 @@ Specification Overview
 Single concluded discussion found.
 
 1. {Title Case Name}
-    └─ Spec: none
-    └─ Discussions:
-       └─ {discussion-name} (ready)
+   └─ Spec: none
+   └─ Discussions:
+      └─ {discussion-name} (ready)
 ```
 
-Indentation: `└─` starts at column 4 (under the name text, not the number). Discussion entries start at column 7.
+**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces and `├─`/`└─` characters. Do not flatten or compress the spacing.
 
 ### If in-progress discussions exist
 

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -20,13 +20,13 @@ For each non-superseded specification from discovery output, display as nested t
 
 ```
 1. {Spec Title Case Name}
-    └─ Spec: {status} ({X} of {Y} sources extracted)
-    └─ Discussions:
-       ├─ {source-name} (extracted)
-       └─ {source-name} (extracted)
+   └─ Spec: {status} ({X} of {Y} sources extracted)
+   └─ Discussions:
+      ├─ {source-name} (extracted)
+      └─ {source-name} (extracted)
 ```
 
-Indentation: `└─` starts at column 4 (under the name text, not the number). Discussion entries start at column 7.
+**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces and `├─`/`└─` characters. Do not flatten or compress the spacing.
 
 Determine discussion status from the spec's `sources` array:
 - `incorporated` + `discussion_status: concluded` or `not-found` → `extracted`


### PR DESCRIPTION
## Summary

- Reverts tree indentation from 4-space to 3-space so `└─` aligns under the first letter of the grouping name (not offset by one)
- Replaces abstract "column N" prose instructions with **"Formatting is exact: reproduce exactly as shown"** — Claude follows code block patterns better than positional rules
- Moves silent processing instruction from Step 1 (after discovery parsing) to the CRITICAL preamble (before any steps run) across all 5 start-* skills

## Test plan

- [ ] Run `/start-specification` on a project with multiple concluded discussions and verify tree indentation matches the template
- [ ] Verify Claude does not narrate discovery field values, routing decisions, or cache status before displaying content
- [ ] Spot-check `/start-discussion`, `/start-planning`, `/start-implementation`, `/start-review` for silent processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)