### PR TITLE
fix: enforce consistent display rendering across all skills

### DIFF
--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -168,6 +168,8 @@ Shall I commit these dependency updates?
 · · · · · · · · · · · ·
 ```
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 If yes, commit with message:
 ```
 Link cross-topic dependencies

--- a/skills/start-discussion/SKILL.md
+++ b/skills/start-discussion/SKILL.md
@@ -7,6 +7,8 @@ allowed-tools: Bash(.claude/skills/start-discussion/scripts/discovery.sh), Bash(
 
 Invoke the **technical-discussion** skill for this conversation.
 
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
 ## Workflow Context
 
 This is **Phase 2** of the six-phase workflow:
@@ -30,7 +32,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
-- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -30,11 +30,12 @@ Key:
   ✓ = already has a corresponding discussion
 ```
 
+**Output in a fenced code block exactly as shown above.**
+
 **Then present the options based on what exists:**
 
 #### If research and discussions exist
 
-```
 · · · · · · · · · · · ·
 How would you like to proceed?
 
@@ -43,11 +44,9 @@ How would you like to proceed?
 - Continue discussion — name one above (e.g., "continue {topic}")
 - Fresh topic — describe what you want to discuss
 · · · · · · · · · · · ·
-```
 
 #### If only research exists
 
-```
 · · · · · · · · · · · ·
 How would you like to proceed?
 
@@ -55,17 +54,14 @@ How would you like to proceed?
 - From research — pick a topic number above (e.g., "1" or "research 1")
 - Fresh topic — describe what you want to discuss
 · · · · · · · · · · · ·
-```
 
 #### If only discussions exist
 
-```
 · · · · · · · · · · · ·
 How would you like to proceed?
 
 - Continue discussion — name one above (e.g., "continue {topic}")
 - Fresh topic — describe what you want to discuss
 · · · · · · · · · · · ·
-```
 
 **STOP.** Wait for user response before proceeding.

--- a/skills/start-discussion/references/gather-context-research.md
+++ b/skills/start-discussion/references/gather-context-research.md
@@ -22,4 +22,6 @@ research you'd like to include — drop them in now.
 · · · · · · · · · · · ·
 ```
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 **STOP.** Wait for user response before proceeding.

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -7,6 +7,8 @@ allowed-tools: Bash(.claude/skills/start-implementation/scripts/discovery.sh)
 
 Invoke the **technical-implementation** skill for this conversation.
 
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
 ## Workflow Context
 
 This is **Phase 5** of the six-phase workflow:
@@ -30,7 +32,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
-- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
@@ -157,6 +158,8 @@ Not implementable:
   · advanced-features [blocked: core-features task core-2-3 not completed]
   · reporting [planning]
 ```
+
+**Output in a fenced code block exactly as shown above.**
 
 **Formatting rules:**
 

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -7,6 +7,8 @@ allowed-tools: Bash(.claude/skills/start-planning/scripts/discovery.sh)
 
 Invoke the **technical-planning** skill for this conversation.
 
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
 ## Workflow Context
 
 This is **Phase 4** of the six-phase workflow:
@@ -30,7 +32,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
-- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
@@ -137,6 +138,8 @@ Not plannable specifications:
   · {caching-strategy} [cross-cutting, concluded]
   · {rate-limiting} [cross-cutting, in-progress]
 ```
+
+**Output in a fenced code block exactly as shown above.**
 
 **Formatting rules:**
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -7,6 +7,8 @@ allowed-tools: Bash(.claude/skills/start-review/scripts/discovery.sh)
 
 Invoke the **technical-review** skill for this conversation.
 
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
 ## Workflow Context
 
 This is **Phase 6** of the six-phase workflow:
@@ -30,7 +32,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
-- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
@@ -121,6 +122,8 @@ Reviewable:
 Not reviewable:
   · {topic-3} [no implementation]
 ```
+
+**Output in a fenced code block exactly as shown above.**
 
 **Formatting rules:**
 

--- a/skills/start-specification/SKILL.md
+++ b/skills/start-specification/SKILL.md
@@ -7,6 +7,8 @@ allowed-tools: Bash(.claude/skills/start-specification/scripts/discovery.sh), Ba
 
 Invoke the **technical-specification** skill for this conversation.
 
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
 ## Workflow Context
 
 This is **Phase 3** of the six-phase workflow:
@@ -30,7 +32,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 **CRITICAL**: This guidance is mandatory.
 
-- **Silent processing**: Do NOT narrate your internal reasoning. Never output discovery field values, routing decisions, cache status, or prerequisite checks. The first user-visible output must be the display content itself.
 - After each user interaction, STOP and wait for their response before proceeding
 - Never assume or anticipate user choices
 - Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step

--- a/skills/start-specification/references/confirm-continue.md
+++ b/skills/start-specification/references/confirm-continue.md
@@ -16,13 +16,13 @@ Sources to extract:
 
 Previously extracted (for reference):
   • {discussion-name}
+```
 
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 #### If spec is in-progress with all sources extracted
 
@@ -34,13 +34,13 @@ Existing: docs/workflow/specification/{kebab-case-name}.md (in-progress)
 All sources extracted:
   • {discussion-name}
   • {discussion-name}
+```
 
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 #### If spec is concluded with pending sources
 
@@ -54,13 +54,13 @@ New sources to extract:
 
 Previously extracted (for reference):
   • {discussion-name}
+```
 
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/confirm-create.md
+++ b/skills/start-specification/references/confirm-create.md
@@ -14,13 +14,13 @@ Sources:
   • {discussion-name}
 
 Output: docs/workflow/specification/{kebab-case-name}.md
+```
 
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 #### If any source discussion has an individual spec
 
@@ -37,13 +37,13 @@ Output: docs/workflow/specification/{kebab-case-name}.md
 
 After completion:
   specification/{discussion-name}.md → marked as superseded
+```
 
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/confirm-refine.md
+++ b/skills/start-specification/references/confirm-refine.md
@@ -11,13 +11,13 @@ Existing: docs/workflow/specification/{kebab-case-name}.md (concluded)
 
 All sources extracted:
   • {discussion-name}
+```
 
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/confirm-unify.md
+++ b/skills/start-specification/references/confirm-unify.md
@@ -19,13 +19,13 @@ Existing specifications to incorporate:
   • {spec-name}.md → will be superseded
 
 Output: docs/workflow/specification/unified.md
+```
 
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 #### If no existing specifications
 
@@ -38,13 +38,13 @@ Sources:
   ...
 
 Output: docs/workflow/specification/unified.md
+```
 
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -40,13 +40,13 @@ No `---` separator before these messages.
 These discussions will be analyzed for natural groupings to determine
 how they should be organized into specifications. Results are cached
 and reused until discussions change.
+```
 
 · · · · · · · · · · · ·
 Proceed with analysis?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 #### If cache status is "stale"
 
@@ -56,13 +56,13 @@ have changed since it was created.
 
 These discussions will be re-analyzed for natural groupings. Results
 are cached and reused until discussions change.
+```
 
 · · · · · · · · · · · ·
 Proceed with analysis?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
-```
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -67,7 +67,7 @@ Recommended breakdown for specifications with their source discussions.
       └─ {discussion-name} (ready)
 ```
 
-**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces, blank lines between groupings, and `├─`/`└─` characters. Do not flatten or compress the spacing.
+**Output in a fenced code block exactly as shown above.**
 
 ### If in-progress discussions exist
 
@@ -143,7 +143,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-**Formatting is exact**: Reproduce the menu exactly as shown above — descriptions are indented 3 spaces and wrapped in backticks.
+**Output in a fenced code block exactly as shown above.** Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/display-single-grouped.md
+++ b/skills/start-specification/references/display-single-grouped.md
@@ -27,7 +27,7 @@ Single concluded discussion found with existing multi-source specification.
       └─ {source-name} (extracted, reopened)
 ```
 
-**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces and `├─`/`└─` characters. Do not flatten or compress the spacing.
+**Output in a fenced code block exactly as shown above.**
 
 ### If in-progress discussions exist
 

--- a/skills/start-specification/references/display-single-has-spec.md
+++ b/skills/start-specification/references/display-single-has-spec.md
@@ -21,7 +21,7 @@ Single concluded discussion found with existing specification.
       └─ {discussion-name} (extracted)
 ```
 
-**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces and `├─`/`└─` characters. Do not flatten or compress the spacing.
+**Output in a fenced code block exactly as shown above.**
 
 ### If in-progress discussions exist
 

--- a/skills/start-specification/references/display-single-no-spec.md
+++ b/skills/start-specification/references/display-single-no-spec.md
@@ -19,7 +19,7 @@ Single concluded discussion found.
       └─ {discussion-name} (ready)
 ```
 
-**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces and `├─`/`└─` characters. Do not flatten or compress the spacing.
+**Output in a fenced code block exactly as shown above.**
 
 ### If in-progress discussions exist
 

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -26,7 +26,7 @@ For each non-superseded specification from discovery output, display as nested t
       └─ {source-name} (extracted)
 ```
 
-**Formatting is exact**: Output the tree structure exactly as shown above — preserve all indentation spaces and `├─`/`└─` characters. Do not flatten or compress the spacing.
+**Output in a fenced code block exactly as shown above.**
 
 Determine discussion status from the spec's `sources` array:
 - `incorporated` + `discussion_status: concluded` or `not-found` → `extracted`
@@ -113,6 +113,8 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
+
+**Output in a fenced code block exactly as shown above.**
 
 Menu descriptions are wrapped in backticks to visually distinguish them from the choice labels.
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -175,6 +175,8 @@ Present the existing configuration for confirmation:
 > - **`c`/`change`** — Re-discover and choose skills
 > · · · · · · · · · · · ·
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 **STOP.** Wait for user choice.
 
 - **`yes`**: → Proceed to **Step 5**.
@@ -203,6 +205,8 @@ Scan `.claude/skills/` for project-specific skill directories. Present findings:
 > - **Or list the ones you want** — e.g. "golang-pro, react-patterns"
 > · · · · · · · · · · · ·
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 **STOP.** Wait for user to confirm which skills are relevant.
 
 Store the selected skill paths in the tracking file.
@@ -230,6 +234,8 @@ Otherwise, present discovery findings to the user:
 > - **`c`/`change`** — Modify the linter list
 > - **`s`/`skip`** — Skip linter setup (no linting during TDD)
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user choice.
 

--- a/skills/technical-implementation/references/steps/analysis-loop.md
+++ b/skills/technical-implementation/references/steps/analysis-loop.md
@@ -37,6 +37,8 @@ If `analysis_cycle > 3`:
 > - **`s`/`skip`** — Skip analysis, proceed to completion
 > · · · · · · · · · · · ·
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 **STOP.** Wait for user choice. You MUST NOT choose on the user's behalf.
 
 - **`proceed`**: → Continue to **B. Git Checkpoint**.
@@ -64,6 +66,8 @@ If there are unstaged changes or untracked files, categorize them:
 > - **`s`/`skip`** — Exclude unexpected files, commit only implementation files
 > - **Comment** — Specify which to include
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user choice.
 
@@ -146,6 +150,8 @@ Then present each task with `status: pending` individually:
 > - **`s`/`skip`** — Skip this task
 > - **Comment** — Revise based on feedback
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user input.
 

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -50,6 +50,8 @@ Present the executor's ISSUES to the user:
 > - **`t`/`stop`** — Stop implementation entirely
 > · · · · · · · · · · · ·
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 **STOP.** Wait for user choice.
 
 #### If `retry`
@@ -108,6 +110,8 @@ Present the reviewer's findings and fix analysis to the user:
 > - **Comment** — Any commentary, adjustments, alternative approaches, or questions before passing to executor
 > · · · · · · · · · · · ·
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 **STOP.** Wait for user choice.
 
 - **`y`/`yes`**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
@@ -136,6 +140,8 @@ Present a summary and wait for user input:
 > - **`a`/`auto`** — Approve this and all future reviewer-approved tasks automatically
 > - **Comment** — Feedback the reviewer missed (triggers a fix round)
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user input.
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -89,6 +89,8 @@ Load **[spec-change-detection.md](references/spec-change-detection.md)** to chec
 > - **`r`/`restart`** — Erase all planning work for this topic and start fresh. This deletes the Plan Index File and any Authored Tasks. Other topics are unaffected.
 > · · · · · · · · · · · ·
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 **STOP.** Wait for user response.
 
 #### If `continue`
@@ -130,6 +132,8 @@ Present the recommendation:
 > - **`y`/`yes`** — Use {format}
 > - **`n`/`no`** — See all available formats
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user choice. If declined, fall through to the full list below.
 

--- a/skills/technical-planning/references/steps/analyze-task-graph.md
+++ b/skills/technical-planning/references/steps/analyze-task-graph.md
@@ -32,7 +32,7 @@ The agent clears any existing dependencies/priorities, analyzes all tasks, and �
 
 #### If the agent reports no changes needed (`STATUS: no-changes`)
 
-The natural task order is already correct. Present this to the user:
+The natural task order is already correct. Present as rendered markdown (not in a code block):
 
 > "I've analyzed all {M} tasks and the natural execution order is already correct — no explicit dependencies or priorities are needed.
 >
@@ -43,6 +43,8 @@ The natural task order is already correct. Present this to the user:
 > - **`y`/`yes`** — Confirmed.
 > - **Or tell me what to change.**
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for the user's response.
 
@@ -60,7 +62,7 @@ No changes were applied. Present the cycle to the user:
 
 #### If the agent applied changes successfully (`STATUS: complete`)
 
-Dependencies and priorities have already been written to the task files. Present the summary:
+Dependencies and priorities have already been written to the task files. Present as rendered markdown (not in a code block):
 
 > "I've analyzed and applied dependencies and priorities across all {M} tasks:
 >
@@ -77,6 +79,8 @@ Dependencies and priorities have already been written to the task files. Present
 > - **`y`/`yes`** — Approved.
 > - **Or tell me what to change.**
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-planning/references/steps/author-tasks.md
+++ b/skills/technical-planning/references/steps/author-tasks.md
@@ -25,7 +25,7 @@ Invoke `planning-task-author` with these file paths:
 
 ### Present the Output
 
-The agent returns complete task detail following the task template from task-design.md. Present it to the user **exactly as it will be written** — what the user sees is what gets logged.
+The agent returns complete task detail following the task template from task-design.md. Present it to the user as rendered markdown (not in a code block) **exactly as it will be written** — what the user sees is what gets logged.
 
 After presenting, ask:
 
@@ -37,6 +37,8 @@ After presenting, ask:
 > - **Or tell me what to change.**
 > - **Or navigate** — a different phase or task, or the leading edge.
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-planning/references/steps/define-phases.md
+++ b/skills/technical-planning/references/steps/define-phases.md
@@ -53,7 +53,7 @@ Continue to **Review and Approve** below.
 
 ## Review and Approve
 
-Present the phase structure to the user.
+Present the phase structure to the user as rendered markdown (not in a code block). Then, separately, present the choices:
 
 **STOP.** Ask:
 
@@ -65,6 +65,8 @@ Present the phase structure to the user.
 > - **Or tell me what to change** — reorder, split, merge, add, edit, or remove phases.
 > - **Or navigate** — a different phase or task, or the leading edge.
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 #### If the user provides feedback
 

--- a/skills/technical-planning/references/steps/define-tasks.md
+++ b/skills/technical-planning/references/steps/define-tasks.md
@@ -38,7 +38,7 @@ planning:
 
 Commit: `planning({topic}): draft Phase {N} task list`
 
-Present the task overview to the user.
+Present the task overview to the user as rendered markdown (not in a code block). Then, separately, present the choices:
 
 **STOP.** Ask:
 
@@ -48,6 +48,8 @@ Present the task overview to the user.
 > - **Or tell me what to change** — reorder, split, merge, add, edit, or remove tasks.
 > - **Or navigate** — a different phase or task, or the leading edge.
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 #### If the user provides feedback
 

--- a/skills/technical-planning/references/steps/plan-construction.md
+++ b/skills/technical-planning/references/steps/plan-construction.md
@@ -67,7 +67,7 @@ After Step A returns with an approved task table, continue to **Author Tasks for
 
 #### If the phase has a task table
 
-Present the task list to the user for review.
+Present the task list to the user as rendered markdown (not in a code block).
 
 > **Phase {N}: {Phase Name}** — {M} tasks.
 >
@@ -77,6 +77,8 @@ Present the task list to the user for review.
 > - **Or tell me what to change.**
 > - **Or navigate** — a different phase or task, or the leading edge.
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-planning/references/steps/resolve-dependencies.md
+++ b/skills/technical-planning/references/steps/resolve-dependencies.md
@@ -49,6 +49,8 @@ Skip the resolution and reverse check — there is nothing to resolve against. D
 > - **Or tell me what to change.**
 > · · · · · · · · · · · ·
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 #### If the user provides feedback
 
 Incorporate feedback, re-present the updated dependency state, and ask again. Repeat until approved.

--- a/skills/technical-planning/references/steps/review-integrity.md
+++ b/skills/technical-planning/references/steps/review-integrity.md
@@ -117,7 +117,7 @@ Show the finding with full detail:
 
 ### Propose the Fix
 
-Present the proposed fix **in the format it will be written to the plan**. What the user sees is what gets applied — no changes between approval and writing.
+Present the proposed fix **in the format it will be written to the plan**, rendered as markdown (not in a code block). What the user sees is what gets applied — no changes between approval and writing.
 
 State the action type explicitly so the user knows what's changing structurally:
 
@@ -177,6 +177,8 @@ After presenting the finding and proposed fix, ask:
 > - **`s`/`skip`** — Leave this as-is and move to the next finding.
 > - **Or tell me what to change.**
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-planning/references/steps/review-traceability.md
+++ b/skills/technical-planning/references/steps/review-traceability.md
@@ -95,7 +95,7 @@ Show the finding with full detail:
 
 ### Propose the Fix
 
-Present the proposed fix **in the format it will be written to the plan**. What the user sees is what gets applied — no changes between approval and writing.
+Present the proposed fix **in the format it will be written to the plan**, rendered as markdown (not in a code block). What the user sees is what gets applied — no changes between approval and writing.
 
 State the action type explicitly so the user knows what's changing structurally:
 
@@ -155,6 +155,8 @@ After presenting the finding and proposed fix, ask:
 > - **`s`/`skip`** — Leave this as-is and move to the next finding.
 > - **Or tell me what to change.**
 > · · · · · · · · · · · ·
+
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -93,6 +93,8 @@ When you notice convergence, **flag it and give the user options**:
 > - Comment — your call
 > · · · · · · · · · · · ·
 
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+
 **Never decide for the user.** Even if the answer seems obvious, flag it and ask.
 
 ### If the user parks it

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -70,13 +70,13 @@ For each topic or subtopic, perform exhaustive extraction:
 **Why this matters:** The specification is the single source of truth for planning. Planning will not reference prior source material - only this document. Missing a detail here means that detail doesn't get implemented.
 
 ### 2. Synthesize and Present
-Present your understanding to the user **in the format it would appear in the specification**:
+Present your understanding to the user **in the format it would appear in the specification**. Output the content as rendered markdown (not in a code block) — the user needs to read it naturally, not inspect raw formatting:
 
 > "Here's what I understand about [topic] based on the reference material. This is exactly what I'll write into the specification:
 >
-> [content as it would appear]
+> [content as rendered markdown]
 
-Then present two explicit choices:
+Then, **separately from the content above** (clear visual break), present the choices as raw markdown:
 
 > · · · · · · · · · · · ·
 > **To proceed:**
@@ -84,7 +84,7 @@ Then present two explicit choices:
 > - **Or tell me what to change.**
 > · · · · · · · · · · · ·
 
-**Do not paraphrase these choices.** Present them exactly as written so users always know what to expect.
+**Do not wrap content or choices in a code block** — both must render as styled markdown. The content and choices must be visually distinct (not run together).
 
 > **CHECKPOINT**: After presenting, you MUST STOP and wait for the user's response. Do NOT proceed to logging. Do NOT present the next topic. WAIT.
 
@@ -512,17 +512,19 @@ For each item, follow the **same workflow as the main specification process**:
 
 1. **Present** the item in detail - what you found, where it came from (source reference), and what you propose to add
 2. **Discuss** if needed - clarify ambiguities, answer questions, refine the content
-3. **Present for approval** - show exactly what will be written to the specification:
+3. **Present for approval** - show as rendered markdown (not a code block) exactly what will be written to the specification. Then, separately, show the choices:
 
    > "Here's what I'll add to the specification:
    >
-   > [content exactly as it would appear]
+   > [content as rendered markdown]
    >
    > · · · · · · · · · · · ·
    > **To proceed:**
    > - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim**.
    > - **Or tell me what to change.**
    > · · · · · · · · · · · ·
+
+   **Do not wrap content or choices in a code block.** Content and choices must be visually distinct.
 
 4. **Wait for explicit approval** - same rules as always: `y`/`yes` or equivalent before writing
 5. **Log verbatim** when approved
@@ -644,17 +646,19 @@ For each item:
 
 1. **Present** the gap in detail - what's missing or unclear, what questions an implementer would have
 2. **Discuss** - work with the user to determine the correct specification content
-3. **Present for approval** - show exactly what will be written:
+3. **Present for approval** - show as rendered markdown (not a code block) exactly what will be written. Then, separately, show the choices:
 
    > "Here's what I'll add to the specification:
    >
-   > [content exactly as it would appear]
+   > [content as rendered markdown]
    >
    > · · · · · · · · · · · ·
    > **To proceed:**
    > - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim**.
    > - **Or tell me what to change.**
    > · · · · · · · · · · · ·
+
+   **Do not wrap content or choices in a code block.** Content and choices must be visually distinct.
 
 4. **Wait for explicit approval**
 5. **Log verbatim** when approved


### PR DESCRIPTION
## Summary

- **Structural content** (tree displays, keys, menus with special chars) now explicitly instructed to output in fenced code blocks — preserves indentation, `├─`/`└─` characters, and alignment
- **Styled choices** (bold y/n prompts) split out of code blocks into raw markdown — ensures `**bold**` renders as styled text instead of literal asterisks
- Applied consistently across all 6 workflow phases (32 files): entry-point skills, processing skills, confirm flows, and display references

## Test plan

- [ ] Run `/start-specification` with multiple discussions — verify tree display preserves indentation and choices render with bold styling
- [ ] Run `/start-discussion` — verify workflow status in code block, choice menu renders bold
- [ ] Run specification skill through a topic — verify "present for approval" content renders as styled markdown with choices visually separate
- [ ] Run `/start-planning` — verify tree display with `▶`/`+` chars preserved
- [ ] Spot-check planning approval gates (define-phases, author-tasks) — choices render bold

🤖 Generated with [Claude Code](https://claude.com/claude-code)