### PR TITLE
fix: discovery script looks in wrong path for implementation tracking

### DIFF
--- a/skills/start-implementation/scripts/discovery.sh
+++ b/skills/start-implementation/scripts/discovery.sh
@@ -262,10 +262,10 @@ if [ -d "$IMPL_DIR" ] && [ -n "$(ls -A "$IMPL_DIR" 2>/dev/null)" ]; then
     echo "  exists: true"
     echo "  files:"
 
-    for file in "$IMPL_DIR"/*.md; do
+    for file in "$IMPL_DIR"/*/tracking.md; do
         [ -f "$file" ] || continue
 
-        impl_name=$(basename "$file" .md)
+        impl_name=$(basename "$(dirname "$file")")
         impl_status=$(extract_field "$file" "status")
         impl_status=${impl_status:-"unknown"}
         current_phase=$(extract_field "$file" "current_phase")
@@ -343,7 +343,7 @@ if [ "$plan_count" -gt 0 ] && [ -d "$PLAN_DIR" ]; then
             if [ "$dep_state" = "resolved" ] && [ -n "$dep_task_id" ]; then
                 has_resolved_deps=true
                 # Check if the dependency topic has a tracking file
-                tracking_file="$IMPL_DIR/${dep_topic}.md"
+                tracking_file="$IMPL_DIR/${dep_topic}/tracking.md"
                 task_completed=false
 
                 if [ -f "$tracking_file" ]; then
@@ -441,7 +441,7 @@ if [ "$plan_count" -gt 0 ] && [ -d "$PLAN_DIR" ]; then
                         is_ready=false
                         break
                     elif [ "$dep_state" = "resolved" ] && [ -n "$dep_task_id" ]; then
-                        tracking_file="$IMPL_DIR/${dep_topic}.md"
+                        tracking_file="$IMPL_DIR/${dep_topic}/tracking.md"
                         if [ -f "$tracking_file" ]; then
                             completed=$(extract_completed_tasks "$tracking_file")
                             if ! echo "$completed" | grep -qx "$dep_task_id" 2>/dev/null; then

--- a/tests/scripts/test-discovery-for-implementation.sh
+++ b/tests/scripts/test-discovery-for-implementation.sh
@@ -697,7 +697,8 @@ external_dependencies: []
 # Plan: Core Features
 EOF
 
-cat > "$TEST_DIR/docs/workflow/implementation/core-features.md" << 'EOF'
+mkdir -p "$TEST_DIR/docs/workflow/implementation/core-features"
+cat > "$TEST_DIR/docs/workflow/implementation/core-features/tracking.md" << 'EOF'
 ---
 topic: core-features
 plan: ../planning/core-features.md
@@ -760,7 +761,8 @@ external_dependencies: []
 # Plan: User Auth
 EOF
 
-cat > "$TEST_DIR/docs/workflow/implementation/user-auth.md" << 'EOF'
+mkdir -p "$TEST_DIR/docs/workflow/implementation/user-auth"
+cat > "$TEST_DIR/docs/workflow/implementation/user-auth/tracking.md" << 'EOF'
 ---
 topic: user-auth
 plan: ../planning/user-auth.md
@@ -821,7 +823,8 @@ external_dependencies:
 # Plan: Billing
 EOF
 
-cat > "$TEST_DIR/docs/workflow/implementation/user-auth.md" << 'EOF'
+mkdir -p "$TEST_DIR/docs/workflow/implementation/user-auth"
+cat > "$TEST_DIR/docs/workflow/implementation/user-auth/tracking.md" << 'EOF'
 ---
 topic: user-auth
 plan: ../planning/user-auth.md
@@ -874,7 +877,8 @@ external_dependencies:
 # Plan: Billing
 EOF
 
-cat > "$TEST_DIR/docs/workflow/implementation/core-features.md" << 'EOF'
+mkdir -p "$TEST_DIR/docs/workflow/implementation/core-features"
+cat > "$TEST_DIR/docs/workflow/implementation/core-features/tracking.md" << 'EOF'
 ---
 topic: core-features
 plan: ../planning/core-features.md
@@ -967,7 +971,8 @@ external_dependencies: []
 # Plan: Feature D
 EOF
 
-cat > "$TEST_DIR/docs/workflow/implementation/feature-d.md" << 'EOF'
+mkdir -p "$TEST_DIR/docs/workflow/implementation/feature-d"
+cat > "$TEST_DIR/docs/workflow/implementation/feature-d/tracking.md" << 'EOF'
 ---
 topic: feature-d
 status: completed


### PR DESCRIPTION
## Summary

- Implementation discovery script was globbing `implementation/*.md` but tracking files live at `implementation/{topic}/tracking.md`
- This caused completed plans to still appear as implementable (e.g. tick-core showed as available despite being fully implemented)
- Fixed the glob pattern, dirname extraction, and dependency resolution tracking paths; updated all test fixtures to match

## Test plan

- [x] All 82 implementation discovery tests pass
- [x] All other discovery test suites pass (discussion, planning, review, specification)
- [x] All migration tests pass
- [x] Verified against live tick project — tick-core now correctly shows `status: completed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)