### PR TITLE
refactor: start-review progressive disclosure + standardize output block instructions

### DIFF
--- a/progressive-disclosure/TRACKER.md
+++ b/progressive-disclosure/TRACKER.md
@@ -12,7 +12,7 @@ Ordered by complexity. Work through in order — simpler skills establish patter
 
 - [x] **start-research** (62 lines) — Simple linear flow. 2 references: gather-context, invoke-skill. *(PR #96)*
 - [x] **start-specification** (851 lines → backbone + 14 reference files) — Complex: discovery + conditional routing + display redesign. *(PR #97)*
-- [ ] **start-review** (173 lines) — Linear with discovery script
+- [x] **start-review** (243 lines → backbone + 3 reference files) — Linear discovery + display/select/invoke extraction
 - [ ] **start-planning** (290 lines) — Linear with discovery script + format selection
 - [ ] **start-implementation** (338 lines) — Linear with discovery script + plan reading + format loading
 - [x] **start-discussion** (391 lines → backbone + 8 reference files) — Discovery inline, 3-path gather-context router. *(PR #99)*

--- a/progressive-disclosure/TRACKER.md
+++ b/progressive-disclosure/TRACKER.md
@@ -12,7 +12,7 @@ Ordered by complexity. Work through in order — simpler skills establish patter
 
 - [x] **start-research** (62 lines) — Simple linear flow. 2 references: gather-context, invoke-skill. *(PR #96)*
 - [x] **start-specification** (851 lines → backbone + 14 reference files) — Complex: discovery + conditional routing + display redesign. *(PR #97)*
-- [x] **start-review** (243 lines → backbone + 3 reference files) — Linear discovery + display/select/invoke extraction
+- [x] **start-review** (243 lines → backbone + 3 reference files) — Linear discovery + display/select/invoke extraction. *(PR #106)*
 - [ ] **start-planning** (290 lines) — Linear with discovery script + format selection
 - [ ] **start-implementation** (338 lines) — Linear with discovery script + plan reading + format loading
 - [x] **start-discussion** (391 lines → backbone + 8 reference files) — Discovery inline, 3-path gather-context router. *(PR #99)*

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -28,6 +28,8 @@ Scan the codebase for existing plans:
 
 **If no plans exist:**
 
+**Output the next fenced block as a code block:**
+
 ```
 No plans found in docs/workflow/planning/
 
@@ -37,6 +39,8 @@ There are no plans to link. Create plans first.
 Stop here.
 
 **If only one plan exists:**
+
+**Output the next fenced block as a code block:**
 
 ```
 Only one plan found: {topic}
@@ -51,6 +55,8 @@ Stop here.
 Compare the `format:` field across all discovered plans.
 
 **If plans use different output formats:**
+
+**Output the next fenced block as a code block:**
 
 ```
 Mixed output formats detected:
@@ -76,6 +82,8 @@ For each plan, read the `external_dependencies` field from the frontmatter:
    - **Satisfied externally**: `state: satisfied_externally`
 
 3. **Build a summary**:
+
+**Output the next fenced block as a code block:**
 
 ```
 Dependency Summary
@@ -131,6 +139,8 @@ For each plan that was a dependency target (i.e., other plans depend on it):
 
 Present a summary:
 
+**Output the next fenced block as a code block:**
+
 ```
 Dependency Linking Complete
 
@@ -160,6 +170,8 @@ UPDATED FILES:
 
 If any files were updated:
 
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 · · · · · · · · · · · ·
 Shall I commit these dependency updates?
@@ -167,8 +179,6 @@ Shall I commit these dependency updates?
 - **`n`/`no`** — Skip
 · · · · · · · · · · · ·
 ```
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 If yes, commit with message:
 ```

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -28,7 +28,7 @@ Scan the codebase for existing plans:
 
 **If no plans exist:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No plans found in docs/workflow/planning/
@@ -40,7 +40,7 @@ Stop here.
 
 **If only one plan exists:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Only one plan found: {topic}
@@ -56,7 +56,7 @@ Compare the `format:` field across all discovered plans.
 
 **If plans use different output formats:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Mixed output formats detected:
@@ -83,7 +83,7 @@ For each plan, read the `external_dependencies` field from the frontmatter:
 
 3. **Build a summary**:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Dependency Summary
@@ -139,7 +139,7 @@ For each plan that was a dependency target (i.e., other plans depend on it):
 
 Present a summary:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Dependency Linking Complete
@@ -170,7 +170,7 @@ UPDATED FILES:
 
 If any files were updated:
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -8,7 +8,7 @@ Present everything discovered to help the user make an informed choice.
 
 **Present the full state:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Workflow Status: Discussion Phase
@@ -36,7 +36,7 @@ Key:
 
 #### If research and discussions exist
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -51,7 +51,7 @@ How would you like to proceed?
 
 #### If only research exists
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -65,7 +65,7 @@ How would you like to proceed?
 
 #### If only discussions exist
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -8,6 +8,8 @@ Present everything discovered to help the user make an informed choice.
 
 **Present the full state:**
 
+**Output the next fenced block as a code block:**
+
 ```
 Workflow Status: Discussion Phase
 
@@ -30,12 +32,13 @@ Key:
   ✓ = already has a corresponding discussion
 ```
 
-**Output in a fenced code block exactly as shown above.**
-
 **Then present the options based on what exists:**
 
 #### If research and discussions exist
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 How would you like to proceed?
 
@@ -44,9 +47,13 @@ How would you like to proceed?
 - Continue discussion — name one above (e.g., "continue {topic}")
 - Fresh topic — describe what you want to discuss
 · · · · · · · · · · · ·
+```
 
 #### If only research exists
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 How would you like to proceed?
 
@@ -54,14 +61,19 @@ How would you like to proceed?
 - From research — pick a topic number above (e.g., "1" or "research 1")
 - Fresh topic — describe what you want to discuss
 · · · · · · · · · · · ·
+```
 
 #### If only discussions exist
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 How would you like to proceed?
 
 - Continue discussion — name one above (e.g., "continue {topic}")
 - Fresh topic — describe what you want to discuss
 · · · · · · · · · · · ·
+```
 
 **STOP.** Wait for user response before proceeding.

--- a/skills/start-discussion/references/gather-context-continue.md
+++ b/skills/start-discussion/references/gather-context-continue.md
@@ -6,7 +6,7 @@
 
 Read the existing discussion document first, then ask:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Continuing: {topic}

--- a/skills/start-discussion/references/gather-context-continue.md
+++ b/skills/start-discussion/references/gather-context-continue.md
@@ -6,6 +6,8 @@
 
 Read the existing discussion document first, then ask:
 
+**Output the next fenced block as a code block:**
+
 ```
 Continuing: {topic}
 

--- a/skills/start-discussion/references/gather-context-fresh.md
+++ b/skills/start-discussion/references/gather-context-fresh.md
@@ -10,6 +10,8 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 
 ## Core Problem
 
+**Output the next fenced block as a code block:**
+
 ```
 New discussion: {topic}
 
@@ -22,6 +24,8 @@ What's the core problem or decision we need to work through?
 
 ## Constraints
 
+**Output the next fenced block as a code block:**
+
 ```
 Any constraints or context I should know about?
 ```
@@ -31,6 +35,8 @@ Any constraints or context I should know about?
 ---
 
 ## Codebase
+
+**Output the next fenced block as a code block:**
 
 ```
 Are there specific files in the codebase I should review first?

--- a/skills/start-discussion/references/gather-context-fresh.md
+++ b/skills/start-discussion/references/gather-context-fresh.md
@@ -10,7 +10,7 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 
 ## Core Problem
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 New discussion: {topic}
@@ -24,7 +24,7 @@ What's the core problem or decision we need to work through?
 
 ## Constraints
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Any constraints or context I should know about?
@@ -36,7 +36,7 @@ Any constraints or context I should know about?
 
 ## Codebase
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Are there specific files in the codebase I should review first?

--- a/skills/start-discussion/references/gather-context-research.md
+++ b/skills/start-discussion/references/gather-context-research.md
@@ -6,7 +6,6 @@
 
 Summarise the selected research topic in 2-5 lines, drawing from the source, summary, and key questions in the research analysis.
 
-```
 New discussion: {topic}
 
 Based on research: docs/workflow/research/{filename}.md (lines {start}-{end})
@@ -20,8 +19,7 @@ research you'd like to include — drop them in now.
 - **`n`/`no`** — Continue as-is
 - Describe what you'd like to add
 · · · · · · · · · · · ·
-```
 
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+Do not wrap the above in a code block — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response before proceeding.

--- a/skills/start-discussion/references/gather-context-research.md
+++ b/skills/start-discussion/references/gather-context-research.md
@@ -6,6 +6,8 @@
 
 Summarise the selected research topic in 2-5 lines, drawing from the source, summary, and key questions in the research analysis.
 
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 New discussion: {topic}
 
@@ -21,7 +23,5 @@ research you'd like to include — drop them in now.
 - Describe what you'd like to add
 · · · · · · · · · · · ·
 ```
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response before proceeding.

--- a/skills/start-discussion/references/gather-context-research.md
+++ b/skills/start-discussion/references/gather-context-research.md
@@ -6,6 +6,7 @@
 
 Summarise the selected research topic in 2-5 lines, drawing from the source, summary, and key questions in the research analysis.
 
+```
 New discussion: {topic}
 
 Based on research: docs/workflow/research/{filename}.md (lines {start}-{end})
@@ -19,7 +20,8 @@ research you'd like to include — drop them in now.
 - **`n`/`no`** — Continue as-is
 - Describe what you'd like to add
 · · · · · · · · · · · ·
+```
 
-Do not wrap the above in a code block — output as raw markdown so bold styling renders.
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response before proceeding.

--- a/skills/start-discussion/references/gather-context-research.md
+++ b/skills/start-discussion/references/gather-context-research.md
@@ -6,7 +6,7 @@
 
 Summarise the selected research topic in 2-5 lines, drawing from the source, summary, and key questions in the research analysis.
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 New discussion: {topic}

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -108,7 +108,7 @@ Use `state.scenario` from the discovery output to determine the path:
 
 No plans exist yet.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No plans found in docs/workflow/planning/
@@ -146,7 +146,7 @@ A plan is **Not implementable** if:
 
 **Present the full state:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Implementation Phase
@@ -187,7 +187,7 @@ Numbering is sequential across Implementable and Implemented. Omit any section e
 
 **If Not implementable section is shown**, append after the presentation:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 If a blocked dependency has been resolved outside this workflow, name the plan and the dependency to unblock it.
@@ -197,7 +197,7 @@ If a blocked dependency has been resolved outside this workflow, name the plan a
 
 **If single implementable plan and no implemented plans (auto-select):**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Auto-selecting: {topic} (only implementable plan)
@@ -207,7 +207,7 @@ Auto-selecting: {topic} (only implementable plan)
 **If nothing selectable (no implementable or implemented):**
 Show Not implementable section only (with unblock hint above).
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No implementable plans.
@@ -223,7 +223,7 @@ Then re-run /start-implementation.
 
 **Otherwise (multiple selectable plans, or implemented plans exist):**
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -254,7 +254,7 @@ After the plan is selected:
 
 #### If all deps satisfied (or no deps)
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 External dependencies satisfied.
@@ -266,7 +266,7 @@ External dependencies satisfied.
 
 This should not normally happen for plans classified as "Implementable" in Step 3. However, as an escape hatch:
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Missing dependencies:
@@ -309,7 +309,7 @@ Use the `environment` section from the discovery output:
 
 **If `setup_file_exists: true` and `requires_setup: false`:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Environment: No special setup required.
@@ -318,7 +318,7 @@ Environment: No special setup required.
 
 **If `setup_file_exists: true` and `requires_setup: true`:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Environment setup file found: docs/workflow/environment-setup.md
@@ -329,7 +329,7 @@ Environment setup file found: docs/workflow/environment-setup.md
 
 Ask:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Are there any environment setup instructions I should follow before implementation?

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -108,6 +108,8 @@ Use `state.scenario` from the discovery output to determine the path:
 
 No plans exist yet.
 
+**Output the next fenced block as a code block:**
+
 ```
 No plans found in docs/workflow/planning/
 
@@ -144,6 +146,8 @@ A plan is **Not implementable** if:
 
 **Present the full state:**
 
+**Output the next fenced block as a code block:**
+
 ```
 Implementation Phase
 
@@ -158,8 +162,6 @@ Not implementable:
   · advanced-features [blocked: core-features task core-2-3 not completed]
   · reporting [planning]
 ```
-
-**Output in a fenced code block exactly as shown above.**
 
 **Formatting rules:**
 
@@ -185,6 +187,8 @@ Numbering is sequential across Implementable and Implemented. Omit any section e
 
 **If Not implementable section is shown**, append after the presentation:
 
+**Output the next fenced block as a code block:**
+
 ```
 If a blocked dependency has been resolved outside this workflow, name the plan and the dependency to unblock it.
 ```
@@ -192,6 +196,9 @@ If a blocked dependency has been resolved outside this workflow, name the plan a
 **Then prompt based on what's actionable:**
 
 **If single implementable plan and no implemented plans (auto-select):**
+
+**Output the next fenced block as a code block:**
+
 ```
 Auto-selecting: {topic} (only implementable plan)
 ```
@@ -199,6 +206,8 @@ Auto-selecting: {topic} (only implementable plan)
 
 **If nothing selectable (no implementable or implemented):**
 Show Not implementable section only (with unblock hint above).
+
+**Output the next fenced block as a code block:**
 
 ```
 No implementable plans.
@@ -213,6 +222,9 @@ Then re-run /start-implementation.
 **STOP.** This workflow cannot continue — do not proceed.
 
 **Otherwise (multiple selectable plans, or implemented plans exist):**
+
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 · · · · · · · · · · · ·
 Select a plan (enter number):
@@ -242,6 +254,8 @@ After the plan is selected:
 
 #### If all deps satisfied (or no deps)
 
+**Output the next fenced block as a code block:**
+
 ```
 External dependencies satisfied.
 ```
@@ -251,6 +265,8 @@ External dependencies satisfied.
 #### If any deps are blocking
 
 This should not normally happen for plans classified as "Implementable" in Step 3. However, as an escape hatch:
+
+**Output the next fenced block as markdown (not a code block):**
 
 ```
 Missing dependencies:
@@ -292,12 +308,18 @@ If the user says a dependency has been implemented outside the workflow:
 Use the `environment` section from the discovery output:
 
 **If `setup_file_exists: true` and `requires_setup: false`:**
+
+**Output the next fenced block as a code block:**
+
 ```
 Environment: No special setup required.
 ```
 → Proceed to **Step 6**.
 
 **If `setup_file_exists: true` and `requires_setup: true`:**
+
+**Output the next fenced block as a code block:**
+
 ```
 Environment setup file found: docs/workflow/environment-setup.md
 ```
@@ -306,6 +328,9 @@ Environment setup file found: docs/workflow/environment-setup.md
 **If `setup_file_exists: false` or `requires_setup: unknown`:**
 
 Ask:
+
+**Output the next fenced block as a code block:**
+
 ```
 Are there any environment setup instructions I should follow before implementation?
 (Or "none" if no special setup is needed)

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -97,6 +97,8 @@ Use `state.scenario` from the discovery output to determine the path:
 
 No specifications exist yet.
 
+**Output the next fenced block as a code block:**
+
 ```
 No specifications found in docs/workflow/specification/
 
@@ -125,6 +127,8 @@ Present everything discovered to help the user make an informed choice.
 
 **Present the full state:**
 
+**Output the next fenced block as a code block:**
+
 ```
 Planning Phase
 
@@ -138,8 +142,6 @@ Not plannable specifications:
   · {caching-strategy} [cross-cutting, concluded]
   · {rate-limiting} [cross-cutting, in-progress]
 ```
-
-**Output in a fenced code block exactly as shown above.**
 
 **Formatting rules:**
 
@@ -158,6 +160,9 @@ Omit either section entirely if it has no entries.
 **Then prompt based on what's actionable:**
 
 **If multiple actionable items:**
+
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 · · · · · · · · · · · ·
 Select a specification (enter number):
@@ -166,6 +171,9 @@ Select a specification (enter number):
 **STOP.** Wait for user response.
 
 **If single actionable item (auto-select):**
+
+**Output the next fenced block as a code block:**
+
 ```
 Auto-selecting: {topic} (only actionable specification)
 ```
@@ -173,6 +181,9 @@ Auto-selecting: {topic} (only actionable specification)
 → Proceed directly to **Step 4**.
 
 **If nothing actionable:**
+
+**Output the next fenced block as a code block:**
+
 ```
 No plannable specifications.
 
@@ -229,6 +240,8 @@ If any **in-progress** cross-cutting specifications exist, check whether they co
 
 If any are relevant:
 
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 Note: The following cross-cutting specifications are still in-progress:
   · {rate-limiting} - in-progress
@@ -248,6 +261,8 @@ If the user chooses to stop, end here. If they choose to continue, proceed.
 ### 6b: Summarize concluded cross-cutting specs
 
 If any **concluded** cross-cutting specifications exist, identify which are relevant to the feature being planned and summarize for handoff:
+
+**Output the next fenced block as a code block:**
 
 ```
 Cross-cutting specifications to reference:

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -97,7 +97,7 @@ Use `state.scenario` from the discovery output to determine the path:
 
 No specifications exist yet.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No specifications found in docs/workflow/specification/
@@ -127,7 +127,7 @@ Present everything discovered to help the user make an informed choice.
 
 **Present the full state:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Planning Phase
@@ -161,7 +161,7 @@ Omit either section entirely if it has no entries.
 
 **If multiple actionable items:**
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -172,7 +172,7 @@ Select a specification (enter number):
 
 **If single actionable item (auto-select):**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Auto-selecting: {topic} (only actionable specification)
@@ -182,7 +182,7 @@ Auto-selecting: {topic} (only actionable specification)
 
 **If nothing actionable:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No plannable specifications.
@@ -240,7 +240,7 @@ If any **in-progress** cross-cutting specifications exist, check whether they co
 
 If any are relevant:
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Note: The following cross-cutting specifications are still in-progress:
@@ -262,7 +262,7 @@ If the user chooses to stop, end here. If they choose to continue, proceed.
 
 If any **concluded** cross-cutting specifications exist, identify which are relevant to the feature being planned and summarize for handoff:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Cross-cutting specifications to reference:

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -108,7 +108,9 @@ Plans exist.
 
 ## Step 3: Display Plans
 
-Load **[display-plans.md](references/display-plans.md)** and follow its instructions as written. **STOP.**
+Load **[display-plans.md](references/display-plans.md)** and follow its instructions as written.
+
+**STOP.**
 
 → Proceed to **Step 4**.
 
@@ -116,7 +118,9 @@ Load **[display-plans.md](references/display-plans.md)** and follow its instruct
 
 ## Step 4: Select Plans
 
-Load **[select-plans.md](references/select-plans.md)** and follow its instructions as written. **STOP.**
+Load **[select-plans.md](references/select-plans.md)** and follow its instructions as written.
+
+**STOP.**
 
 → Proceed to **Step 5**.
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -108,7 +108,7 @@ Plans exist.
 
 ## Step 3: Display Plans
 
-Load **[display-plans.md](references/display-plans.md)** and follow its instructions as written.
+Load **[display-plans.md](references/display-plans.md)** and follow its instructions as written. **STOP.**
 
 → Proceed to **Step 4**.
 
@@ -116,7 +116,7 @@ Load **[display-plans.md](references/display-plans.md)** and follow its instruct
 
 ## Step 4: Select Plans
 
-Load **[select-plans.md](references/select-plans.md)** and follow its instructions as written.
+Load **[select-plans.md](references/select-plans.md)** and follow its instructions as written. **STOP.**
 
 → Proceed to **Step 5**.
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -90,13 +90,13 @@ Use `state.scenario` from the discovery output to determine the path:
 
 No plans exist yet.
 
+**Output the next fenced block as a code block:**
+
 ```
 No plans found in docs/workflow/planning/
 
 The review phase requires a completed implementation based on a plan. Please run /start-planning first to create a plan, then /start-implementation to build it.
 ```
-
-**Output in a fenced code block exactly as shown above.**
 
 **STOP.** Wait for user to acknowledge before ending.
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -96,6 +96,8 @@ No plans found in docs/workflow/planning/
 The review phase requires a completed implementation based on a plan. Please run /start-planning first to create a plan, then /start-implementation to build it.
 ```
 
+**Output in a fenced code block exactly as shown above.**
+
 **STOP.** Wait for user to acknowledge before ending.
 
 #### If scenario is "single_plan" or "multiple_plans"

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -90,7 +90,7 @@ Use `state.scenario` from the discovery output to determine the path:
 
 No plans exist yet.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No plans found in docs/workflow/planning/

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -106,107 +106,17 @@ Plans exist.
 
 ---
 
-## Step 3: Present Plans and Select Scope
+## Step 3: Display Plans
 
-Present all discovered plans with implementation status to help the user understand what's reviewable.
+Load **[display-plans.md](references/display-plans.md)** and follow its instructions as written.
 
-**Present the full state:**
-
-```
-Review Phase
-
-Reviewable:
-  1. ✓ {topic-1} (completed) - format: {format}, spec: {exists|missing}
-  2. ▶ {topic-2} (in-progress) - format: {format}, spec: {exists|missing}
-
-Not reviewable:
-  · {topic-3} [no implementation]
-```
-
-**Output in a fenced code block exactly as shown above.**
-
-**Formatting rules:**
-
-Reviewable (numbered, selectable):
-- **`✓`** — implementation_status: completed
-- **`▶`** — implementation_status: in-progress
-
-Not reviewable (not numbered, not selectable):
-- **`·`** — implementation_status: none
-
-Omit either section entirely if it has no entries.
-
-**Then route based on what's reviewable:**
-
-#### If no reviewable plans
-
-```
-No implemented plans found.
-
-The review phase requires at least one plan with an implementation.
-Please run /start-implementation first.
-```
-
-**STOP.** Wait for user to acknowledge before ending.
-
-#### If single reviewable plan
-
-```
-Auto-selecting: {topic} (only reviewable plan)
-Scope: single
-```
-
-→ Proceed directly to **Step 5**.
-
-#### If multiple reviewable plans
-
-```
-· · · · · · · · · · · ·
-What scope would you like to review?
-
-- **`s`/`single`** — Review one plan's implementation
-- **`m`/`multi`** — Review selected plans together (cross-cutting)
-- **`a`/`all`** — Review all implemented plans (full product)
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-→ Based on user choice, proceed to **Step 4**.
+→ Proceed to **Step 4**.
 
 ---
 
-## Step 4: Plan Selection
+## Step 4: Select Plans
 
-This step only applies for `single` or `multi` scope chosen in Step 3.
-
-#### If scope is "all"
-
-All reviewable plans are included. No selection needed.
-
-→ Proceed directly to **Step 5**.
-
-#### If scope is "single"
-
-```
-· · · · · · · · · · · ·
-Which plan would you like to review? (Enter a number from Step 3)
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-→ Proceed to **Step 5**.
-
-#### If scope is "multi"
-
-```
-· · · · · · · · · · · ·
-Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
+Load **[select-plans.md](references/select-plans.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
 
@@ -214,29 +124,4 @@ Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
 
 ## Step 5: Invoke the Skill
 
-After completing the steps above, this skill's purpose is fulfilled.
-
-Invoke the [technical-review](../technical-review/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
-
-**Example handoff (single):**
-```
-Review session for: {topic}
-Review scope: single
-Plan: docs/workflow/planning/{topic}.md
-Format: {format}
-Plan ID: {plan_id} (if applicable)
-Specification: {specification} (exists: {true|false})
-
-Invoke the technical-review skill.
-```
-
-**Example handoff (multi/all):**
-```
-Review session for: {scope description}
-Review scope: {multi | all}
-Plans:
-  - docs/workflow/planning/{topic-1}.md (format: {format}, spec: {spec})
-  - docs/workflow/planning/{topic-2}.md (format: {format}, spec: {spec})
-
-Invoke the technical-review skill.
-```
+Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -110,8 +110,6 @@ Plans exist.
 
 Load **[display-plans.md](references/display-plans.md)** and follow its instructions as written.
 
-**STOP.**
-
 → Proceed to **Step 4**.
 
 ---
@@ -119,8 +117,6 @@ Load **[display-plans.md](references/display-plans.md)** and follow its instruct
 ## Step 4: Select Plans
 
 Load **[select-plans.md](references/select-plans.md)** and follow its instructions as written.
-
-**STOP.**
 
 → Proceed to **Step 5**.
 

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -43,6 +43,8 @@ The review phase requires at least one plan with an implementation.
 Please run /start-implementation first.
 ```
 
+**Output in a fenced code block exactly as shown above.**
+
 **STOP.** Wait for user to acknowledge before ending.
 
 #### If single reviewable plan
@@ -52,11 +54,12 @@ Auto-selecting: {topic} (only reviewable plan)
 Scope: single
 ```
 
+**Output in a fenced code block exactly as shown above.**
+
 → Proceed directly to **Step 5**.
 
 #### If multiple reviewable plans
 
-```
 · · · · · · · · · · · ·
 What scope would you like to review?
 
@@ -64,7 +67,8 @@ What scope would you like to review?
 - **`m`/`multi`** — Review selected plans together (cross-cutting)
 - **`a`/`all`** — Review all implemented plans (full product)
 · · · · · · · · · · · ·
-```
+
+Do not wrap the above in a code block — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -8,7 +8,7 @@ Present all discovered plans with implementation status to help the user underst
 
 **Present the full state:**
 
-> Output the next fenced block as a code block:
+> *Output the next fenced block as a code block:*
 
 ```
 Review Phase
@@ -36,7 +36,7 @@ Omit either section entirely if it has no entries.
 
 #### If no reviewable plans
 
-*Output the next fenced block as a code block:*
+> *Output the next fenced block as a code block:*
 
 ```
 No implemented plans found.

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -60,6 +60,7 @@ Scope: single
 
 #### If multiple reviewable plans
 
+```
 · · · · · · · · · · · ·
 What scope would you like to review?
 
@@ -67,8 +68,9 @@ What scope would you like to review?
 - **`m`/`multi`** — Review selected plans together (cross-cutting)
 - **`a`/`all`** — Review all implemented plans (full product)
 · · · · · · · · · · · ·
+```
 
-Do not wrap the above in a code block — output as raw markdown so bold styling renders.
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -1,0 +1,71 @@
+# Display Plans
+
+*Reference for **[start-review](../SKILL.md)***
+
+---
+
+Present all discovered plans with implementation status to help the user understand what's reviewable.
+
+**Present the full state:**
+
+```
+Review Phase
+
+Reviewable:
+  1. ✓ {topic-1} (completed) - format: {format}, spec: {exists|missing}
+  2. ▶ {topic-2} (in-progress) - format: {format}, spec: {exists|missing}
+
+Not reviewable:
+  · {topic-3} [no implementation]
+```
+
+**Output in a fenced code block exactly as shown above.**
+
+**Formatting rules:**
+
+Reviewable (numbered, selectable):
+- **`✓`** — implementation_status: completed
+- **`▶`** — implementation_status: in-progress
+
+Not reviewable (not numbered, not selectable):
+- **`·`** — implementation_status: none
+
+Omit either section entirely if it has no entries.
+
+**Then route based on what's reviewable:**
+
+#### If no reviewable plans
+
+```
+No implemented plans found.
+
+The review phase requires at least one plan with an implementation.
+Please run /start-implementation first.
+```
+
+**STOP.** Wait for user to acknowledge before ending.
+
+#### If single reviewable plan
+
+```
+Auto-selecting: {topic} (only reviewable plan)
+Scope: single
+```
+
+→ Proceed directly to **Step 5**.
+
+#### If multiple reviewable plans
+
+```
+· · · · · · · · · · · ·
+What scope would you like to review?
+
+- **`s`/`single`** — Review one plan's implementation
+- **`m`/`multi`** — Review selected plans together (cross-cutting)
+- **`a`/`all`** — Review all implemented plans (full product)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+→ Based on user choice, proceed to **Step 4**.

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -8,7 +8,7 @@ Present all discovered plans with implementation status to help the user underst
 
 **Present the full state:**
 
-> *Output the next fenced block as a code block:*
+> Output the next fenced block as a code block:
 
 ```
 Review Phase
@@ -36,7 +36,7 @@ Omit either section entirely if it has no entries.
 
 #### If no reviewable plans
 
-> *Output the next fenced block as a code block:*
+*Output the next fenced block as a code block:*
 
 ```
 No implemented plans found.

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -8,6 +8,8 @@ Present all discovered plans with implementation status to help the user underst
 
 **Present the full state:**
 
+**Output the next fenced block as a code block:**
+
 ```
 Review Phase
 
@@ -18,8 +20,6 @@ Reviewable:
 Not reviewable:
   · {topic-3} [no implementation]
 ```
-
-**Output in a fenced code block exactly as shown above.**
 
 **Formatting rules:**
 
@@ -36,6 +36,8 @@ Omit either section entirely if it has no entries.
 
 #### If no reviewable plans
 
+**Output the next fenced block as a code block:**
+
 ```
 No implemented plans found.
 
@@ -43,22 +45,22 @@ The review phase requires at least one plan with an implementation.
 Please run /start-implementation first.
 ```
 
-**Output in a fenced code block exactly as shown above.**
-
 **STOP.** Wait for user to acknowledge before ending.
 
 #### If single reviewable plan
+
+**Output the next fenced block as a code block:**
 
 ```
 Auto-selecting: {topic} (only reviewable plan)
 Scope: single
 ```
 
-**Output in a fenced code block exactly as shown above.**
-
 → Proceed directly to **Step 5**.
 
 #### If multiple reviewable plans
+
+**Output the next fenced block as markdown (not a code block):**
 
 ```
 · · · · · · · · · · · ·
@@ -69,8 +71,6 @@ What scope would you like to review?
 - **`a`/`all`** — Review all implemented plans (full product)
 · · · · · · · · · · · ·
 ```
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -8,7 +8,7 @@ Present all discovered plans with implementation status to help the user underst
 
 **Present the full state:**
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Review Phase
@@ -36,7 +36,7 @@ Omit either section entirely if it has no entries.
 
 #### If no reviewable plans
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No implemented plans found.
@@ -49,7 +49,7 @@ Please run /start-implementation first.
 
 #### If single reviewable plan
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Auto-selecting: {topic} (only reviewable plan)
@@ -60,7 +60,7 @@ Scope: single
 
 #### If multiple reviewable plans
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/start-review/references/invoke-skill.md
+++ b/skills/start-review/references/invoke-skill.md
@@ -1,0 +1,32 @@
+# Invoke the Skill
+
+*Reference for **[start-review](../SKILL.md)***
+
+---
+
+After completing the steps above, this skill's purpose is fulfilled.
+
+Invoke the [technical-review](../../technical-review/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
+
+**Example handoff (single):**
+```
+Review session for: {topic}
+Review scope: single
+Plan: docs/workflow/planning/{topic}.md
+Format: {format}
+Plan ID: {plan_id} (if applicable)
+Specification: {specification} (exists: {true|false})
+
+Invoke the technical-review skill.
+```
+
+**Example handoff (multi/all):**
+```
+Review session for: {scope description}
+Review scope: {multi | all}
+Plans:
+  - docs/workflow/planning/{topic-1}.md (format: {format}, spec: {spec})
+  - docs/workflow/planning/{topic-2}.md (format: {format}, spec: {spec})
+
+Invoke the technical-review skill.
+```

--- a/skills/start-review/references/select-plans.md
+++ b/skills/start-review/references/select-plans.md
@@ -14,7 +14,7 @@ All reviewable plans are included. No selection needed.
 
 #### If scope is "single"
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -28,7 +28,7 @@ Which plan would you like to review? (Enter a number from Step 3)
 
 #### If scope is "multi"
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/start-review/references/select-plans.md
+++ b/skills/start-review/references/select-plans.md
@@ -1,0 +1,37 @@
+# Select Plans
+
+*Reference for **[start-review](../SKILL.md)***
+
+---
+
+This step only applies for `single` or `multi` scope chosen in Step 3.
+
+#### If scope is "all"
+
+All reviewable plans are included. No selection needed.
+
+→ Proceed directly to **Step 5**.
+
+#### If scope is "single"
+
+```
+· · · · · · · · · · · ·
+Which plan would you like to review? (Enter a number from Step 3)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+→ Proceed to **Step 5**.
+
+#### If scope is "multi"
+
+```
+· · · · · · · · · · · ·
+Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+→ Proceed to **Step 5**.

--- a/skills/start-review/references/select-plans.md
+++ b/skills/start-review/references/select-plans.md
@@ -14,11 +14,13 @@ All reviewable plans are included. No selection needed.
 
 #### If scope is "single"
 
+```
 · · · · · · · · · · · ·
 Which plan would you like to review? (Enter a number from Step 3)
 · · · · · · · · · · · ·
+```
 
-Do not wrap the above in a code block — output as raw markdown so bold styling renders.
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 
@@ -26,11 +28,13 @@ Do not wrap the above in a code block — output as raw markdown so bold styling
 
 #### If scope is "multi"
 
+```
 · · · · · · · · · · · ·
 Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
 · · · · · · · · · · · ·
+```
 
-Do not wrap the above in a code block — output as raw markdown so bold styling renders.
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-review/references/select-plans.md
+++ b/skills/start-review/references/select-plans.md
@@ -14,13 +14,13 @@ All reviewable plans are included. No selection needed.
 
 #### If scope is "single"
 
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 · · · · · · · · · · · ·
 Which plan would you like to review? (Enter a number from Step 3)
 · · · · · · · · · · · ·
 ```
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 
@@ -28,13 +28,13 @@ Which plan would you like to review? (Enter a number from Step 3)
 
 #### If scope is "multi"
 
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 · · · · · · · · · · · ·
 Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
 · · · · · · · · · · · ·
 ```
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-review/references/select-plans.md
+++ b/skills/start-review/references/select-plans.md
@@ -14,11 +14,11 @@ All reviewable plans are included. No selection needed.
 
 #### If scope is "single"
 
-```
 · · · · · · · · · · · ·
 Which plan would you like to review? (Enter a number from Step 3)
 · · · · · · · · · · · ·
-```
+
+Do not wrap the above in a code block — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 
@@ -26,11 +26,11 @@ Which plan would you like to review? (Enter a number from Step 3)
 
 #### If scope is "multi"
 
-```
 · · · · · · · · · · · ·
 Which plans to include? (Enter numbers separated by commas, e.g. 1,3)
 · · · · · · · · · · · ·
-```
+
+Do not wrap the above in a code block — output as raw markdown so bold styling renders.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/analysis-flow.md
+++ b/skills/start-specification/references/analysis-flow.md
@@ -6,6 +6,8 @@
 
 ## A. Gather Analysis Context
 
+**Output the next fenced block as a code block:**
+
 ```
 Before analyzing, is there anything about how these discussions relate
 that would help me group them appropriately?

--- a/skills/start-specification/references/analysis-flow.md
+++ b/skills/start-specification/references/analysis-flow.md
@@ -6,7 +6,7 @@
 
 ## A. Gather Analysis Context
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Before analyzing, is there anything about how these discussions relate

--- a/skills/start-specification/references/confirm-continue.md
+++ b/skills/start-specification/references/confirm-continue.md
@@ -6,6 +6,8 @@
 
 #### If spec is in-progress with pending sources
 
+**Output the next fenced block as a code block:**
+
 ```
 Continuing specification: {Title Case Name}
 
@@ -18,13 +20,19 @@ Previously extracted (for reference):
   • {discussion-name}
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 #### If spec is in-progress with all sources extracted
+
+**Output the next fenced block as a code block:**
 
 ```
 Continuing specification: {Title Case Name}
@@ -36,13 +44,19 @@ All sources extracted:
   • {discussion-name}
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 #### If spec is concluded with pending sources
+
+**Output the next fenced block as a code block:**
 
 ```
 Continuing specification: {Title Case Name}
@@ -56,11 +70,15 @@ Previously extracted (for reference):
   • {discussion-name}
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 **STOP.** Wait for user response.
 
@@ -77,6 +95,8 @@ Proceed?
 #### If user declines (n)
 
 #### If single discussion (no menu to return to)
+
+**Output the next fenced block as a code block:**
 
 ```
 Understood. You can run /start-discussion to continue working on

--- a/skills/start-specification/references/confirm-continue.md
+++ b/skills/start-specification/references/confirm-continue.md
@@ -6,7 +6,7 @@
 
 #### If spec is in-progress with pending sources
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Continuing specification: {Title Case Name}
@@ -20,7 +20,7 @@ Previously extracted (for reference):
   • {discussion-name}
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -32,7 +32,7 @@ Proceed?
 
 #### If spec is in-progress with all sources extracted
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Continuing specification: {Title Case Name}
@@ -44,7 +44,7 @@ All sources extracted:
   • {discussion-name}
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -56,7 +56,7 @@ Proceed?
 
 #### If spec is concluded with pending sources
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Continuing specification: {Title Case Name}
@@ -70,7 +70,7 @@ Previously extracted (for reference):
   • {discussion-name}
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -96,7 +96,7 @@ Proceed?
 
 #### If single discussion (no menu to return to)
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Understood. You can run /start-discussion to continue working on

--- a/skills/start-specification/references/confirm-create.md
+++ b/skills/start-specification/references/confirm-create.md
@@ -6,6 +6,8 @@
 
 #### If no source discussions have individual specs
 
+**Output the next fenced block as a code block:**
+
 ```
 Creating specification: {Title Case Name}
 
@@ -16,15 +18,21 @@ Sources:
 Output: docs/workflow/specification/{kebab-case-name}.md
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 #### If any source discussion has an individual spec
 
 Note the supersession (`has_individual_spec: true`):
+
+**Output the next fenced block as a code block:**
 
 ```
 Creating specification: {Title Case Name}
@@ -39,11 +47,15 @@ After completion:
   specification/{discussion-name}.md → marked as superseded
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 **STOP.** Wait for user response.
 
@@ -60,6 +72,8 @@ Proceed?
 #### If user declines (n)
 
 #### If single discussion (no menu to return to)
+
+**Output the next fenced block as a code block:**
 
 ```
 Understood. You can run /start-discussion to continue working on

--- a/skills/start-specification/references/confirm-create.md
+++ b/skills/start-specification/references/confirm-create.md
@@ -6,7 +6,7 @@
 
 #### If no source discussions have individual specs
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Creating specification: {Title Case Name}
@@ -18,7 +18,7 @@ Sources:
 Output: docs/workflow/specification/{kebab-case-name}.md
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -32,7 +32,7 @@ Proceed?
 
 Note the supersession (`has_individual_spec: true`):
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Creating specification: {Title Case Name}
@@ -47,7 +47,7 @@ After completion:
   specification/{discussion-name}.md → marked as superseded
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -73,7 +73,7 @@ Proceed?
 
 #### If single discussion (no menu to return to)
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Understood. You can run /start-discussion to continue working on

--- a/skills/start-specification/references/confirm-refine.md
+++ b/skills/start-specification/references/confirm-refine.md
@@ -4,7 +4,7 @@
 
 ---
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Refining specification: {Title Case Name}
@@ -15,7 +15,7 @@ All sources extracted:
   • {discussion-name}
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -35,7 +35,7 @@ Proceed?
 
 #### If single discussion (no menu to return to)
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Understood. You can run /start-discussion to continue working on

--- a/skills/start-specification/references/confirm-refine.md
+++ b/skills/start-specification/references/confirm-refine.md
@@ -4,6 +4,8 @@
 
 ---
 
+**Output the next fenced block as a code block:**
+
 ```
 Refining specification: {Title Case Name}
 
@@ -13,11 +15,15 @@ All sources extracted:
   • {discussion-name}
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 **STOP.** Wait for user response.
 
@@ -28,6 +34,8 @@ Proceed?
 #### If user declines (n)
 
 #### If single discussion (no menu to return to)
+
+**Output the next fenced block as a code block:**
 
 ```
 Understood. You can run /start-discussion to continue working on

--- a/skills/start-specification/references/confirm-unify.md
+++ b/skills/start-specification/references/confirm-unify.md
@@ -6,7 +6,7 @@
 
 #### If existing specifications will be superseded
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Creating specification: Unified
@@ -23,7 +23,7 @@ Existing specifications to incorporate:
 Output: docs/workflow/specification/unified.md
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -35,7 +35,7 @@ Proceed?
 
 #### If no existing specifications
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Creating specification: Unified
@@ -48,7 +48,7 @@ Sources:
 Output: docs/workflow/specification/unified.md
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/start-specification/references/confirm-unify.md
+++ b/skills/start-specification/references/confirm-unify.md
@@ -6,6 +6,8 @@
 
 #### If existing specifications will be superseded
 
+**Output the next fenced block as a code block:**
+
 ```
 Creating specification: Unified
 
@@ -21,13 +23,19 @@ Existing specifications to incorporate:
 Output: docs/workflow/specification/unified.md
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 #### If no existing specifications
+
+**Output the next fenced block as a code block:**
 
 ```
 Creating specification: Unified
@@ -40,11 +48,15 @@ Sources:
 Output: docs/workflow/specification/unified.md
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -8,7 +8,7 @@ Prompted when multiple concluded discussions exist, no specifications exist, and
 
 ## Display
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Specification Overview
@@ -25,7 +25,7 @@ List all concluded discussions from discovery output.
 
 ### If in-progress discussions exist
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Discussions not ready for specification:
@@ -40,7 +40,7 @@ No `---` separator before these messages.
 
 #### If cache status is "none"
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 These discussions will be analyzed for natural groupings to determine
@@ -48,7 +48,7 @@ how they should be organized into specifications. Results are cached
 and reused until discussions change.
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -60,7 +60,7 @@ Proceed with analysis?
 
 #### If cache status is "stale"
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 A previous grouping analysis exists but is outdated — discussions
@@ -70,7 +70,7 @@ These discussions will be re-analyzed for natural groupings. Results
 are cached and reused until discussions change.
 ```
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -93,7 +93,7 @@ rm docs/workflow/.cache/discussion-consolidation-analysis.md
 
 #### If user declines (n)
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Understood. You can run /start-discussion to continue working on

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -8,6 +8,8 @@ Prompted when multiple concluded discussions exist, no specifications exist, and
 
 ## Display
 
+**Output the next fenced block as a code block:**
+
 ```
 Specification Overview
 
@@ -23,6 +25,8 @@ List all concluded discussions from discovery output.
 
 ### If in-progress discussions exist
 
+**Output the next fenced block as a code block:**
+
 ```
 Discussions not ready for specification:
 These discussions are still in progress and must be concluded
@@ -36,19 +40,27 @@ No `---` separator before these messages.
 
 #### If cache status is "none"
 
+**Output the next fenced block as a code block:**
+
 ```
 These discussions will be analyzed for natural groupings to determine
 how they should be organized into specifications. Results are cached
 and reused until discussions change.
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed with analysis?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 #### If cache status is "stale"
+
+**Output the next fenced block as a code block:**
 
 ```
 A previous grouping analysis exists but is outdated — discussions
@@ -58,11 +70,15 @@ These discussions will be re-analyzed for natural groupings. Results
 are cached and reused until discussions change.
 ```
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 Proceed with analysis?
 - **`y`/`yes`**
 - **`n`/`no`**
 · · · · · · · · · · · ·
+```
 
 **STOP.** Wait for user response.
 
@@ -76,6 +92,8 @@ rm docs/workflow/.cache/discussion-consolidation-analysis.md
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions.
 
 #### If user declines (n)
+
+**Output the next fenced block as a code block:**
 
 ```
 Understood. You can run /start-discussion to continue working on

--- a/skills/start-specification/references/display-blocks.md
+++ b/skills/start-specification/references/display-blocks.md
@@ -8,6 +8,8 @@ Two terminal paths — the command stops and cannot proceed.
 
 ## If no discussions exist
 
+**Output the next fenced block as a code block:**
+
 ```
 Specification Phase
 
@@ -23,6 +25,8 @@ Run /start-discussion to begin documenting technical decisions.
 **STOP.** Wait for user acknowledgment. Command ends here.
 
 ## If discussions exist but none concluded
+
+**Output the next fenced block as a code block:**
 
 ```
 Specification Phase

--- a/skills/start-specification/references/display-blocks.md
+++ b/skills/start-specification/references/display-blocks.md
@@ -8,7 +8,7 @@ Two terminal paths — the command stops and cannot proceed.
 
 ## If no discussions exist
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Specification Phase
@@ -26,7 +26,7 @@ Run /start-discussion to begin documenting technical decisions.
 
 ## If discussions exist but none concluded
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Specification Phase

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -127,7 +127,6 @@ After all grouping entries, append meta options:
 
 **Example assembled menu** (2 groupings, specs exist):
 
-```
 · · · · · · · · · · · ·
 1. Start "Auth Flow" — 2 ready discussions
 2. Continue "Data Model" — 1 source(s) pending extraction
@@ -141,9 +140,8 @@ After all grouping entries, append meta options:
 
 Select an option (enter number):
 · · · · · · · · · · · ·
-```
 
-**Output in a fenced code block exactly as shown above.** Every meta option (Unify, Re-analyze) MUST include its description lines.
+Do not wrap the above in a code block — output as raw markdown so bold styling renders. Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -50,6 +50,8 @@ For each discussion: status is `ready`. Spec status: `none`.
 
 All items are first-class — every grouping (including single-discussion entries) is a numbered item.
 
+**Output the next fenced block as a code block:**
+
 ```
 Specification Overview
 
@@ -67,9 +69,9 @@ Recommended breakdown for specifications with their source discussions.
       └─ {discussion-name} (ready)
 ```
 
-**Output in a fenced code block exactly as shown above.**
-
 ### If in-progress discussions exist
+
+**Output the next fenced block as a code block:**
 
 ```
 Discussions not ready for specification:
@@ -81,6 +83,8 @@ before they can be included in a specification.
 ### Key/Legend
 
 Show only the statuses that appear in the current display. No `---` separator before this section.
+
+**Output the next fenced block as a code block:**
 
 ```
 Key:
@@ -100,6 +104,8 @@ Key:
 ### Tip (show when 2+ groupings)
 
 No `---` separator before this section.
+
+**Output the next fenced block as a code block:**
 
 ```
 Tip: To restructure groupings or pull a discussion into its own
@@ -127,6 +133,8 @@ After all grouping entries, append meta options:
 
 **Example assembled menu** (2 groupings, specs exist):
 
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 · · · · · · · · · · · ·
 1. Start "Auth Flow" — 2 ready discussions
@@ -143,7 +151,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders. Every meta option (Unify, Re-analyze) MUST include its description lines.
+Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -50,7 +50,7 @@ For each discussion: status is `ready`. Spec status: `none`.
 
 All items are first-class — every grouping (including single-discussion entries) is a numbered item.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Specification Overview
@@ -71,7 +71,7 @@ Recommended breakdown for specifications with their source discussions.
 
 ### If in-progress discussions exist
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Discussions not ready for specification:
@@ -84,7 +84,7 @@ before they can be included in a specification.
 
 Show only the statuses that appear in the current display. No `---` separator before this section.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Key:
@@ -105,7 +105,7 @@ Key:
 
 No `---` separator before this section.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Tip: To restructure groupings or pull a discussion into its own
@@ -133,7 +133,7 @@ After all grouping entries, append meta options:
 
 **Example assembled menu** (2 groupings, specs exist):
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -127,6 +127,7 @@ After all grouping entries, append meta options:
 
 **Example assembled menu** (2 groupings, specs exist):
 
+```
 · · · · · · · · · · · ·
 1. Start "Auth Flow" — 2 ready discussions
 2. Continue "Data Model" — 1 source(s) pending extraction
@@ -140,8 +141,9 @@ After all grouping entries, append meta options:
 
 Select an option (enter number):
 · · · · · · · · · · · ·
+```
 
-Do not wrap the above in a code block — output as raw markdown so bold styling renders. Every meta option (Unify, Re-analyze) MUST include its description lines.
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders. Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 **STOP.** Wait for user response.
 

--- a/skills/start-specification/references/display-single-grouped.md
+++ b/skills/start-specification/references/display-single-grouped.md
@@ -15,7 +15,7 @@ Extraction count: X = sources with `status: incorporated`, Y = total source coun
 
 ## Display
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Specification Overview
@@ -31,7 +31,7 @@ Single concluded discussion found with existing multi-source specification.
 
 ### If in-progress discussions exist
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Discussions not ready for specification:
@@ -44,7 +44,7 @@ before they can be included in a specification.
 
 Show only the statuses that appear in the current display. No `---` separator before this section.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Key:
@@ -61,7 +61,7 @@ Key:
 
 ## After Display
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Automatically proceeding with "{Spec Title Case Name}".

--- a/skills/start-specification/references/display-single-grouped.md
+++ b/skills/start-specification/references/display-single-grouped.md
@@ -15,6 +15,8 @@ Extraction count: X = sources with `status: incorporated`, Y = total source coun
 
 ## Display
 
+**Output the next fenced block as a code block:**
+
 ```
 Specification Overview
 
@@ -27,9 +29,9 @@ Single concluded discussion found with existing multi-source specification.
       └─ {source-name} (extracted, reopened)
 ```
 
-**Output in a fenced code block exactly as shown above.**
-
 ### If in-progress discussions exist
+
+**Output the next fenced block as a code block:**
 
 ```
 Discussions not ready for specification:
@@ -41,6 +43,8 @@ before they can be included in a specification.
 ### Key/Legend
 
 Show only the statuses that appear in the current display. No `---` separator before this section.
+
+**Output the next fenced block as a code block:**
 
 ```
 Key:
@@ -56,6 +60,8 @@ Key:
 ```
 
 ## After Display
+
+**Output the next fenced block as a code block:**
 
 ```
 Automatically proceeding with "{Spec Title Case Name}".

--- a/skills/start-specification/references/display-single-has-spec.md
+++ b/skills/start-specification/references/display-single-has-spec.md
@@ -10,7 +10,7 @@ Determine extraction count: check the spec's `sources` array from discovery. Cou
 
 ## Display
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Specification Overview
@@ -25,7 +25,7 @@ Single concluded discussion found with existing specification.
 
 ### If in-progress discussions exist
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Discussions not ready for specification:
@@ -38,7 +38,7 @@ before they can be included in a specification.
 
 No `---` separator before this section.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Key:
@@ -52,7 +52,7 @@ Key:
 
 ## After Display
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Automatically proceeding with "{Title Case Name}".

--- a/skills/start-specification/references/display-single-has-spec.md
+++ b/skills/start-specification/references/display-single-has-spec.md
@@ -10,6 +10,8 @@ Determine extraction count: check the spec's `sources` array from discovery. Cou
 
 ## Display
 
+**Output the next fenced block as a code block:**
+
 ```
 Specification Overview
 
@@ -21,9 +23,9 @@ Single concluded discussion found with existing specification.
       └─ {discussion-name} (extracted)
 ```
 
-**Output in a fenced code block exactly as shown above.**
-
 ### If in-progress discussions exist
+
+**Output the next fenced block as a code block:**
 
 ```
 Discussions not ready for specification:
@@ -36,6 +38,8 @@ before they can be included in a specification.
 
 No `---` separator before this section.
 
+**Output the next fenced block as a code block:**
+
 ```
 Key:
 
@@ -47,6 +51,8 @@ Key:
 ```
 
 ## After Display
+
+**Output the next fenced block as a code block:**
 
 ```
 Automatically proceeding with "{Title Case Name}".

--- a/skills/start-specification/references/display-single-no-spec.md
+++ b/skills/start-specification/references/display-single-no-spec.md
@@ -8,6 +8,8 @@ No specification exists for this discussion.
 
 ## Display
 
+**Output the next fenced block as a code block:**
+
 ```
 Specification Overview
 
@@ -19,9 +21,9 @@ Single concluded discussion found.
       └─ {discussion-name} (ready)
 ```
 
-**Output in a fenced code block exactly as shown above.**
-
 ### If in-progress discussions exist
+
+**Output the next fenced block as a code block:**
 
 ```
 Discussions not ready for specification:
@@ -34,6 +36,8 @@ before they can be included in a specification.
 
 No `---` separator before this section.
 
+**Output the next fenced block as a code block:**
+
 ```
 Key:
 
@@ -45,6 +49,8 @@ Key:
 ```
 
 ## After Display
+
+**Output the next fenced block as a code block:**
 
 ```
 Automatically proceeding with "{Title Case Name}".

--- a/skills/start-specification/references/display-single-no-spec.md
+++ b/skills/start-specification/references/display-single-no-spec.md
@@ -8,7 +8,7 @@ No specification exists for this discussion.
 
 ## Display
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Specification Overview
@@ -23,7 +23,7 @@ Single concluded discussion found.
 
 ### If in-progress discussions exist
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Discussions not ready for specification:
@@ -36,7 +36,7 @@ before they can be included in a specification.
 
 No `---` separator before this section.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Key:
@@ -50,7 +50,7 @@ Key:
 
 ## After Display
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Automatically proceeding with "{Title Case Name}".

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -8,7 +8,7 @@ Shows when multiple concluded discussions exist, specifications exist, and cache
 
 ## A. Display
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Specification Overview
@@ -20,7 +20,7 @@ Existing specifications:
 
 For each non-superseded specification from discovery output, display as nested tree:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 1. {Spec Title Case Name}
@@ -41,7 +41,7 @@ Extraction count: X = sources with `status: incorporated`, Y = total source coun
 
 List concluded discussions that are not in any specification's `sources` array:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Concluded discussions not in a specification:
@@ -51,7 +51,7 @@ Concluded discussions not in a specification:
 
 ### If in-progress discussions exist
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Discussions not ready for specification:
@@ -64,7 +64,7 @@ before they can be included in a specification.
 
 Show only the statuses that appear in the current display. No `---` separator before this section.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 Key:
@@ -84,7 +84,7 @@ No `---` separator before these messages.
 
 #### If cache status is "none"
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No grouping analysis exists.
@@ -92,7 +92,7 @@ No grouping analysis exists.
 
 #### If cache status is "stale"
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 A previous grouping analysis exists but is outdated — discussions
@@ -113,7 +113,7 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 
 **Example assembled menu** (2 specs exist):
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -101,7 +101,6 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 
 **Example assembled menu** (2 specs exist):
 
-```
 · · · · · · · · · · · ·
 1. Analyze for groupings (recommended)
    `All discussions are analyzed for natural groupings. Existing`
@@ -112,9 +111,8 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 
 Select an option (enter number):
 · · · · · · · · · · · ·
-```
 
-**Output in a fenced code block exactly as shown above.**
+Do not wrap the above in a code block — output as raw markdown so bold styling renders.
 
 Menu descriptions are wrapped in backticks to visually distinguish them from the choice labels.
 

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -101,6 +101,7 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 
 **Example assembled menu** (2 specs exist):
 
+```
 · · · · · · · · · · · ·
 1. Analyze for groupings (recommended)
    `All discussions are analyzed for natural groupings. Existing`
@@ -111,8 +112,9 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 
 Select an option (enter number):
 · · · · · · · · · · · ·
+```
 
-Do not wrap the above in a code block — output as raw markdown so bold styling renders.
+**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 Menu descriptions are wrapped in backticks to visually distinguish them from the choice labels.
 

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -8,6 +8,8 @@ Shows when multiple concluded discussions exist, specifications exist, and cache
 
 ## A. Display
 
+**Output the next fenced block as a code block:**
+
 ```
 Specification Overview
 
@@ -18,6 +20,8 @@ Existing specifications:
 
 For each non-superseded specification from discovery output, display as nested tree:
 
+**Output the next fenced block as a code block:**
+
 ```
 1. {Spec Title Case Name}
    └─ Spec: {status} ({X} of {Y} sources extracted)
@@ -25,8 +29,6 @@ For each non-superseded specification from discovery output, display as nested t
       ├─ {source-name} (extracted)
       └─ {source-name} (extracted)
 ```
-
-**Output in a fenced code block exactly as shown above.**
 
 Determine discussion status from the spec's `sources` array:
 - `incorporated` + `discussion_status: concluded` or `not-found` → `extracted`
@@ -39,6 +41,8 @@ Extraction count: X = sources with `status: incorporated`, Y = total source coun
 
 List concluded discussions that are not in any specification's `sources` array:
 
+**Output the next fenced block as a code block:**
+
 ```
 Concluded discussions not in a specification:
   • {discussion-name}
@@ -46,6 +50,8 @@ Concluded discussions not in a specification:
 ```
 
 ### If in-progress discussions exist
+
+**Output the next fenced block as a code block:**
 
 ```
 Discussions not ready for specification:
@@ -57,6 +63,8 @@ before they can be included in a specification.
 ### Key/Legend
 
 Show only the statuses that appear in the current display. No `---` separator before this section.
+
+**Output the next fenced block as a code block:**
 
 ```
 Key:
@@ -76,11 +84,15 @@ No `---` separator before these messages.
 
 #### If cache status is "none"
 
+**Output the next fenced block as a code block:**
+
 ```
 No grouping analysis exists.
 ```
 
 #### If cache status is "stale"
+
+**Output the next fenced block as a code block:**
 
 ```
 A previous grouping analysis exists but is outdated — discussions
@@ -101,6 +113,8 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 
 **Example assembled menu** (2 specs exist):
 
+**Output the next fenced block as markdown (not a code block):**
+
 ```
 · · · · · · · · · · · ·
 1. Analyze for groupings (recommended)
@@ -113,8 +127,6 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
 
 Menu descriptions are wrapped in backticks to visually distinguish them from the choice labels.
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -33,7 +33,7 @@ docs/workflow/planning/
 
 Research is project-wide exploration. From discussion onwards, work is organised by **topic** - different topics may be at different stages.
 
-Show a summary like this:
+**Output the next fenced block as a code block:**
 
 ```
 ## Workflow Status
@@ -74,6 +74,8 @@ Keep suggestions brief - the user knows their project's dependencies better than
 ## Step 4: Mention Plan Viewing
 
 If planning files exist, let the user know they can view plan details:
+
+**Output the next fenced block as a code block:**
 
 ```
 To view a plan's tasks and progress, use /view-plan

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -33,7 +33,7 @@ docs/workflow/planning/
 
 Research is project-wide exploration. From discussion onwards, work is organised by **topic** - different topics may be at different stages.
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 ## Workflow Status
@@ -75,7 +75,7 @@ Keep suggestions brief - the user knows their project's dependencies better than
 
 If planning files exist, let the user know they can view plan details:
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 To view a plan's tasks and progress, use /view-plan

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -166,6 +166,9 @@ Commit: `impl({topic}): start implementation`
 
 Present the existing configuration for confirmation:
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 Previous session used these project skills:
 - `{skill-name}` — {path}
 - ...
@@ -174,8 +177,7 @@ Previous session used these project skills:
 - **`y`/`yes`** — Keep these, proceed
 - **`c`/`change`** — Re-discover and choose skills
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user choice.
 
@@ -183,6 +185,8 @@ Previous session used these project skills:
 - **`change`**: Clear `project_skills` and fall through to discovery below.
 
 #### If `.claude/skills/` does not exist or is empty
+
+**Output the next fenced block as a code block:**
 
 ```
 No project skills found. Proceeding without project-specific conventions.
@@ -194,6 +198,9 @@ No project skills found. Proceeding without project-specific conventions.
 
 Scan `.claude/skills/` for project-specific skill directories. Present findings:
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 Found these project skills that may be relevant to implementation:
 - `{skill-name}` — {brief description}
 - `{skill-name}` — {brief description}
@@ -204,8 +211,7 @@ Found these project skills that may be relevant to implementation:
 - **`n`/`none`** — Skip project skills
 - **Or list the ones you want** — e.g. "golang-pro, react-patterns"
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user to confirm which skills are relevant.
 
@@ -223,6 +229,9 @@ If `linters` is already populated in the tracking file, present the existing con
 
 Otherwise, present discovery findings to the user:
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 **Linter discovery:**
 - {tool} — `{command}` (installed / not installed)
 - ...
@@ -234,8 +243,7 @@ Recommendations: {any suggested tools with install commands}
 - **`c`/`change`** — Modify the linter list
 - **`s`/`skip`** — Skip linter setup (no linting during TDD)
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user choice.
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -166,7 +166,7 @@ Commit: `impl({topic}): start implementation`
 
 Present the existing configuration for confirmation:
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Previous session used these project skills:
@@ -186,7 +186,7 @@ Previous session used these project skills:
 
 #### If `.claude/skills/` does not exist or is empty
 
-**Output the next fenced block as a code block:**
+> *Output the next fenced block as a code block:*
 
 ```
 No project skills found. Proceeding without project-specific conventions.
@@ -198,7 +198,7 @@ No project skills found. Proceeding without project-specific conventions.
 
 Scan `.claude/skills/` for project-specific skill directories. Present findings:
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Found these project skills that may be relevant to implementation:
@@ -229,7 +229,7 @@ If `linters` is already populated in the tracking file, present the existing con
 
 Otherwise, present discovery findings to the user:
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 **Linter discovery:**

--- a/skills/technical-implementation/references/steps/analysis-loop.md
+++ b/skills/technical-implementation/references/steps/analysis-loop.md
@@ -32,12 +32,14 @@ If `analysis_cycle > 3`:
 
 Analysis has run {N-1} times so far. You can continue (recommended if issues were still found last cycle) or skip to completion.
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 - **`p`/`proceed`** — Continue analysis *(default)*
 - **`s`/`skip`** — Skip analysis, proceed to completion
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user choice. You MUST NOT choose on the user's behalf.
 
@@ -61,13 +63,15 @@ If there are unstaged changes or untracked files, categorize them:
 - `{file}` ({status: modified/untracked})
 - ...
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 - **`y`/`yes`** — Include all in the checkpoint commit
 - **`s`/`skip`** — Exclude unexpected files, commit only implementation files
 - **Comment** — Specify which to include
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user choice.
 
@@ -145,13 +149,15 @@ Sources: {sources}
 **Tests**:
 {tests}
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 - **`a`/`approve`** — Approve this task
 - **`s`/`skip`** — Skip this task
 - **Comment** — Revise based on feedback
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user input.
 

--- a/skills/technical-implementation/references/steps/analysis-loop.md
+++ b/skills/technical-implementation/references/steps/analysis-loop.md
@@ -32,7 +32,7 @@ If `analysis_cycle > 3`:
 
 Analysis has run {N-1} times so far. You can continue (recommended if issues were still found last cycle) or skip to completion.
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -63,7 +63,7 @@ If there are unstaged changes or untracked files, categorize them:
 - `{file}` ({status: modified/untracked})
 - ...
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -149,7 +149,7 @@ Sources: {sources}
 **Tests**:
 {tests}
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -44,13 +44,15 @@ Present the executor's ISSUES to the user:
 
 {executor's ISSUES content}
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 - **`r`/`retry`** — Re-invoke the executor with your comments (provide below)
 - **`s`/`skip`** — Skip this task and move to the next
 - **`t`/`stop`** — Stop implementation entirely
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user choice.
 
@@ -103,14 +105,16 @@ Present the reviewer's findings and fix analysis to the user:
 Notes (non-blocking):
 {NOTES from reviewer}
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 - **`y`/`yes`** — Accept the review and fix analysis, pass to executor
 - **`a`/`auto`** — Accept and auto-approve future fix analyses
 - **`s`/`skip`** — Override the reviewer and proceed as-is
 - **Comment** — Any commentary, adjustments, alternative approaches, or questions before passing to executor
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user choice.
 
@@ -134,14 +138,16 @@ Present a summary and wait for user input:
 Phase: {phase number} — {phase name}
 {executor's SUMMARY — brief commentary, decisions, implementation notes}
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **Options:**
 - **`y`/`yes`** — Approve, commit, continue to next task
 - **`a`/`auto`** — Approve this and all future reviewer-approved tasks automatically
 - **Comment** — Feedback the reviewer missed (triggers a fix round)
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user input.
 

--- a/skills/technical-implementation/references/steps/task-loop.md
+++ b/skills/technical-implementation/references/steps/task-loop.md
@@ -44,7 +44,7 @@ Present the executor's ISSUES to the user:
 
 {executor's ISSUES content}
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -105,7 +105,7 @@ Present the reviewer's findings and fix analysis to the user:
 Notes (non-blocking):
 {NOTES from reviewer}
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -138,7 +138,7 @@ Present a summary and wait for user input:
 Phase: {phase number} — {phase name}
 {executor's SUMMARY — brief commentary, decisions, implementation notes}
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -84,7 +84,7 @@ Found existing plan for **{topic}** (previously reached phase {N}, task {M}).
 
 {spec change summary from spec-change-detection.md}
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -130,7 +130,7 @@ Present the recommendation:
 
 Existing plans use **{format}**. Use the same format for consistency?
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -84,12 +84,14 @@ Found existing plan for **{topic}** (previously reached phase {N}, task {M}).
 
 {spec change summary from spec-change-detection.md}
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 - **`c`/`continue`** — Walk through the plan from the start. You can review, amend, or navigate at any point — including straight to the leading edge.
 - **`r`/`restart`** — Erase all planning work for this topic and start fresh. This deletes the Plan Index File and any Authored Tasks. Other topics are unaffected.
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user response.
 
@@ -128,12 +130,14 @@ Present the recommendation:
 
 Existing plans use **{format}**. Use the same format for consistency?
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 - **`y`/`yes`** — Use {format}
 - **`n`/`no`** — See all available formats
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for user choice. If declined, fall through to the full list below.
 

--- a/skills/technical-planning/references/steps/analyze-task-graph.md
+++ b/skills/technical-planning/references/steps/analyze-task-graph.md
@@ -38,7 +38,7 @@ The natural task order is already correct. Present as rendered markdown (not in 
 
 {notes from agent output}"
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
@@ -76,7 +76,7 @@ Dependencies and priorities have already been written to the task files. Present
 
 {any notes from agent output}"
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/steps/analyze-task-graph.md
+++ b/skills/technical-planning/references/steps/analyze-task-graph.md
@@ -38,13 +38,15 @@ The natural task order is already correct. Present as rendered markdown (not in 
 
 {notes from agent output}"
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Confirmed.
 - **Or tell me what to change.**
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for the user's response.
 
@@ -74,13 +76,15 @@ Dependencies and priorities have already been written to the task files. Present
 
 {any notes from agent output}"
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved.
 - **Or tell me what to change.**
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-planning/references/steps/author-tasks.md
+++ b/skills/technical-planning/references/steps/author-tasks.md
@@ -31,7 +31,7 @@ After presenting, ask:
 
 **Task {M} of {total}: {Task Name}**
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/steps/author-tasks.md
+++ b/skills/technical-planning/references/steps/author-tasks.md
@@ -31,14 +31,16 @@ After presenting, ask:
 
 **Task {M} of {total}: {Task Name}**
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved. I'll log it to the plan.
 - **Or tell me what to change.**
 - **Or navigate** — a different phase or task, or the leading edge.
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-planning/references/steps/define-phases.md
+++ b/skills/technical-planning/references/steps/define-phases.md
@@ -59,14 +59,16 @@ Present the phase structure to the user as rendered markdown (not in a code bloc
 
 **Phase Structure**
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved. I'll proceed to task breakdown.
 - **Or tell me what to change** — reorder, split, merge, add, edit, or remove phases.
 - **Or navigate** — a different phase or task, or the leading edge.
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 #### If the user provides feedback
 

--- a/skills/technical-planning/references/steps/define-phases.md
+++ b/skills/technical-planning/references/steps/define-phases.md
@@ -59,7 +59,7 @@ Present the phase structure to the user as rendered markdown (not in a code bloc
 
 **Phase Structure**
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/steps/define-tasks.md
+++ b/skills/technical-planning/references/steps/define-tasks.md
@@ -42,14 +42,16 @@ Present the task overview to the user as rendered markdown (not in a code block)
 
 **STOP.** Ask:
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved.
 - **Or tell me what to change** — reorder, split, merge, add, edit, or remove tasks.
 - **Or navigate** — a different phase or task, or the leading edge.
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 #### If the user provides feedback
 

--- a/skills/technical-planning/references/steps/define-tasks.md
+++ b/skills/technical-planning/references/steps/define-tasks.md
@@ -42,7 +42,7 @@ Present the task overview to the user as rendered markdown (not in a code block)
 
 **STOP.** Ask:
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/steps/plan-construction.md
+++ b/skills/technical-planning/references/steps/plan-construction.md
@@ -71,7 +71,7 @@ Present the task list to the user as rendered markdown (not in a code block).
 
 **Phase {N}: {Phase Name}** — {M} tasks.
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/steps/plan-construction.md
+++ b/skills/technical-planning/references/steps/plan-construction.md
@@ -71,14 +71,16 @@ Present the task list to the user as rendered markdown (not in a code block).
 
 **Phase {N}: {Phase Name}** — {M} tasks.
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Confirmed.
 - **Or tell me what to change.**
 - **Or navigate** — a different phase or task, or the leading edge.
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-planning/references/steps/resolve-dependencies.md
+++ b/skills/technical-planning/references/steps/resolve-dependencies.md
@@ -43,13 +43,15 @@ Skip the resolution and reverse check — there is nothing to resolve against. D
 
 **STOP.** Present a summary of the dependency state: what was documented, what was resolved, what remains unresolved, and any reverse resolutions made.
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved. I'll proceed to plan review.
 - **Or tell me what to change.**
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 #### If the user provides feedback
 

--- a/skills/technical-planning/references/steps/resolve-dependencies.md
+++ b/skills/technical-planning/references/steps/resolve-dependencies.md
@@ -43,7 +43,7 @@ Skip the resolution and reverse check — there is nothing to resolve against. D
 
 **STOP.** Present a summary of the dependency state: what was documented, what was resolved, what remains unresolved, and any reverse resolutions made.
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/steps/review-integrity.md
+++ b/skills/technical-planning/references/steps/review-integrity.md
@@ -171,7 +171,7 @@ After presenting the finding and proposed fix, ask:
 
 **Finding {N} of {total}: {Brief Title}**
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/steps/review-integrity.md
+++ b/skills/technical-planning/references/steps/review-integrity.md
@@ -171,14 +171,16 @@ After presenting the finding and proposed fix, ask:
 
 **Finding {N} of {total}: {Brief Title}**
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved. I'll apply it to the plan verbatim.
 - **`s`/`skip`** — Leave this as-is and move to the next finding.
 - **Or tell me what to change.**
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-planning/references/steps/review-traceability.md
+++ b/skills/technical-planning/references/steps/review-traceability.md
@@ -149,7 +149,7 @@ After presenting the finding and proposed fix, ask:
 
 **Finding {N} of {total}: {Brief Title}**
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/steps/review-traceability.md
+++ b/skills/technical-planning/references/steps/review-traceability.md
@@ -149,14 +149,16 @@ After presenting the finding and proposed fix, ask:
 
 **Finding {N} of {total}: {Brief Title}**
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved. I'll apply it to the plan verbatim.
 - **`s`/`skip`** — Leave this as-is and move to the next finding.
 - **Or tell me what to change.**
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **STOP.** Wait for the user's response.
 

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -87,13 +87,15 @@ When you notice convergence, **flag it and give the user options**:
 
 This thread seems to be converging — we've explored {topic} enough that the tradeoffs are clear and it's approaching decision territory.
 
+**Output the next fenced block as markdown (not a code block):**
+
+```
 · · · · · · · · · · · ·
 - **`p`/`park`** — Mark as discussion-ready and move to another topic
 - **`k`/`keep`** — Keep digging, there's more to understand
 - Comment — your call
 · · · · · · · · · · · ·
-
-**Do not wrap the above in a code block** — output as raw markdown so bold styling renders.
+```
 
 **Never decide for the user.** Even if the answer seems obvious, flag it and ask.
 

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -87,7 +87,7 @@ When you notice convergence, **flag it and give the user options**:
 
 This thread seems to be converging — we've explored {topic} enough that the tradeoffs are clear and it's approaching decision territory.
 
-**Output the next fenced block as markdown (not a code block):**
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -518,13 +518,17 @@ For each item, follow the **same workflow as the main specification process**:
 
    [content as rendered markdown]
 
+   **Output the next fenced block as markdown (not a code block):**
+
+   ```
    · · · · · · · · · · · ·
    **To proceed:**
    - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim**.
    - **Or tell me what to change.**
    · · · · · · · · · · · ·
+   ```
 
-   **Do not wrap content or choices in a code block.** Content and choices must be visually distinct.
+   Content and choices must be visually distinct.
 
 4. **Wait for explicit approval** - same rules as always: `y`/`yes` or equivalent before writing
 5. **Log verbatim** when approved
@@ -652,13 +656,17 @@ For each item:
 
    [content as rendered markdown]
 
+   **Output the next fenced block as markdown (not a code block):**
+
+   ```
    · · · · · · · · · · · ·
    **To proceed:**
    - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim**.
    - **Or tell me what to change.**
    · · · · · · · · · · · ·
+   ```
 
-   **Do not wrap content or choices in a code block.** Content and choices must be visually distinct.
+   Content and choices must be visually distinct.
 
 4. **Wait for explicit approval**
 5. **Log verbatim** when approved

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -84,7 +84,7 @@ Then, **separately from the content above** (clear visual break), present the ch
 - **Or tell me what to change.**
 · · · · · · · · · · · ·
 
-**Do not wrap content or choices in a code block** — both must render as styled markdown. The content and choices must be visually distinct (not run together).
+Content and choices must be visually distinct (not run together).
 
 > **CHECKPOINT**: After presenting, you MUST STOP and wait for the user's response. Do NOT proceed to logging. Do NOT present the next topic. WAIT.
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -518,7 +518,7 @@ For each item, follow the **same workflow as the main specification process**:
 
    [content as rendered markdown]
 
-   **Output the next fenced block as markdown (not a code block):**
+   > *Output the next fenced block as markdown (not a code block):*
 
    ```
    · · · · · · · · · · · ·
@@ -656,7 +656,7 @@ For each item:
 
    [content as rendered markdown]
 
-   **Output the next fenced block as markdown (not a code block):**
+   > *Output the next fenced block as markdown (not a code block):*
 
    ```
    · · · · · · · · · · · ·


### PR DESCRIPTION
## Summary

- **start-review refactoring**: Split monolithic SKILL.md (243 lines) into backbone + 3 reference files (display-plans, select-plans, invoke-skill) following the progressive disclosure pattern
- **Output block instruction standardization**: Replaced ~6 inconsistent phrasings across all entry-point and processing skills with two consistent patterns:
  - `**Output the next fenced block as a code block:**` — structured displays
  - `**Output the next fenced block as markdown (not a code block):**` — choice prompts with bold styling
- Instructions placed BEFORE blocks (not after). Unfenced choice sections wrapped in backtick fences. File-content templates, handoff templates, and commit messages correctly left untouched.

## Files changed

- 1 modified backbone (`start-review/SKILL.md`)
- 3 new reference files (`display-plans.md`, `select-plans.md`, `invoke-skill.md`)
- 26 files updated with standardized output block instructions across all skills
- Tracker updated

## Test plan

- [ ] Verify backbone is scannable with Load directives for Steps 3-5
- [ ] Verify each reference file is self-contained with standard header
- [ ] Verify no content lost from original SKILL.md
- [ ] Spot-check output block instructions: code block instruction before structured displays, markdown instruction before choice prompts
- [ ] Verify file-content templates (yaml, markdown, bash tagged blocks) have no instruction
- [ ] Verify handoff and commit message templates have no instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)