### PR TITLE
feat: show implementation tracking progress in status skill

### DIFF
--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -27,32 +27,36 @@ docs/workflow/research/
 docs/workflow/discussion/
 docs/workflow/specification/
 docs/workflow/planning/
+docs/workflow/implementation/
 ```
+
+For implementation, check `docs/workflow/implementation/{topic}/tracking.md` files and extract frontmatter fields: `status`, `current_phase`, `current_task`, `completed_tasks`, `completed_phases`.
 
 ## Step 2: Present Status
 
 Research is project-wide exploration. From discussion onwards, work is organised by **topic** - different topics may be at different stages.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-## Workflow Status
-
 **Research:** 2 files (exploration.md, market-analysis.md)
 
-**Topics:**
-
-| Topic        | Discussion | Spec | Plan | Implemented |
-|--------------|------------|------|------|-------------|
-| auth-system  | ✓          | ✓    | ✓    | in progress |
-| payment-flow | ✓          | ✓    | -    | -           |
-| notifications| ✓          | -    | -    | -           |
+| Topic        | Discussion | Spec | Plan | Implemented              |
+|--------------|------------|------|------|--------------------------|
+| auth-system  | ✓          | ✓    | ✓    | phase 2 (3/8 tasks done) |
+| payment-flow | ✓          | ✓    | -    | -                        |
+| notifications| ✓          | -    | -    | -                        |
 ```
 
 Adapt based on what exists:
 - If a directory is empty or missing, show "Not started"
 - For planning, note the output format if specified in frontmatter
 - Match topics across phases by filename
+- For implementation, derive the Implemented column from tracking file data:
+  - No tracking file → `-`
+  - `status: not-started` → `not started`
+  - `status: in-progress` → `phase {current_phase} ({n}/{total} tasks done)` — count `completed_tasks` for n; use total task count from `completed_tasks` + remaining if available, otherwise just show completed count
+  - `status: completed` → `✓`
 
 ## Step 3: Suggest Next Steps
 


### PR DESCRIPTION
## Summary

- Scan `docs/workflow/implementation/{topic}/tracking.md` files during status check
- Derive Implemented column from tracking frontmatter (`status`, `current_phase`, `completed_tasks`) — shows `phase 2 (3/8 tasks done)` instead of generic "in progress"
- Render status output as markdown (not code block) for proper table display; remove redundant H2 heading

## Test plan

- [ ] Run `/status` on a project with implementation tracking files — verify phase/task counts appear
- [ ] Run `/status` on a project with no implementation — verify `-` shows in Implemented column
- [ ] Verify table renders as markdown, not inside a code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)