### PR TITLE
style: normalize display conventions across all skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,16 @@ Always parenthetical `(term)`. Never brackets or dash-separated.
 
 Core vocabulary: `none`, `in-progress`, `concluded`, `ready`, `completed`, `extracted`, `pending`, `reopened`. Phase-specific terms are fine but format is always `(term)`.
 
+### Cross-Plan References
+
+Use colon notation to reference a task within a plan: `{plan}:{task-id}`.
+
+```
+  · advanced-features (blocked by core-features:core-2-3)
+```
+
+Reads as: "advanced-features is blocked by task core-2-3 in the core-features plan."
+
 ### "Not Ready" Blocks
 
 Separate code block. Descriptive heading as `{Artifacts} not ready for {phase}:`, explanatory line, then `·` bullets with parenthetical status. **Blank line after the explanation, before the list.**
@@ -340,9 +350,9 @@ All skill files (entry-point and processing) MUST follow these structural conven
 
 ### Stop Gates
 
-Use `**STOP.**` (bold, period) followed by a brief instruction. This is the only pattern for user interaction boundaries.
+Use `**STOP.**` (bold, period). This is the only pattern for user interaction boundaries.
 
-Three categories:
+Two categories:
 
 **Interaction stop** — waiting for real user input to continue:
 ```
@@ -350,17 +360,12 @@ Three categories:
 **STOP.** Wait for user response before proceeding.
 ```
 
-**Terminal stop** — skill is done, nothing to process:
+**Terminal stop** — skill is done, nothing to process. The output block preceding it already explains the situation, so no follow-up text is needed:
 ```
-**STOP.** Command ends.
-```
-
-**Blocked stop** — items exist but none are actionable:
-```
-**STOP.** This workflow cannot continue — do not proceed.
+**STOP.**
 ```
 
-Never use `Stop here.`, `Wait for user to acknowledge before ending.`, or other variations.
+Never use `Stop here.`, `Command ends.`, `Wait for user to acknowledge before ending.`, or other variations.
 
 ### Heading Hierarchy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,3 +333,106 @@ Inside code blocks, maintain **one blank line** between:
 - Key categories
 
 Between code blocks (overview → not-ready → key → menu), no `---` separators — just the natural block separation.
+
+## Structural Conventions (IMPORTANT)
+
+All skill files (entry-point and processing) MUST follow these structural conventions for consistency.
+
+### Stop Gates
+
+Use `**STOP.**` (bold, period) followed by a brief instruction. This is the only pattern for user interaction boundaries.
+
+```
+**STOP.** Wait for user response.
+**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user to acknowledge before ending.
+**STOP.** This workflow cannot continue — do not proceed.
+```
+
+Never use `Stop here.`, `STOP`, or other variations.
+
+### Heading Hierarchy
+
+- **H1** (`#`): File title only — one per file, at the top
+- **H2** (`##`): Steps and major sections (`## Step N: {Name}`, `## Notes`, `## Instructions`)
+- **H3** (`###`): Subsections within steps (`### 6a: Warn about in-progress specs`)
+- **H4** (`####`): Conditional routing only (`#### If {condition}`, `#### Otherwise`)
+
+### Step Numbering
+
+Sequential: `## Step 0`, `## Step 1`, `## Step 2`, etc.
+
+- **Step 0** is reserved for migrations — mandatory in all entry-point skills
+- Steps are separated by `---` horizontal rules
+- Each step completes fully before the next begins
+
+### Conditional Routing
+
+Use H4 headings for if/else branches within a step:
+
+```
+#### If scenario is "no_specs"
+{content}
+
+#### If scenario is "has_options"
+{content}
+```
+
+Never use else-if chains. Each condition gets its own `#### If` heading.
+
+### Navigation Arrows
+
+Use `→` for flow control between steps or to external files:
+
+```
+→ Proceed to **Step 4**.
+→ Go directly to **Step 7** to invoke the skill.
+→ Load **[file.md](file.md)** and follow its instructions.
+```
+
+### Reference File Headers
+
+Reference files loaded by skills use this header pattern:
+
+```
+# Title
+
+*Reference for **[parent-skill](../SKILL.md)***
+
+---
+```
+
+### Critical / Important Markers
+
+Use bold labels with colons for emphasis levels:
+
+```
+**CRITICAL**: This guidance is mandatory.
+**IMPORTANT**: Use ONLY this script for discovery.
+**CHECKPOINT**: Summarize progress before continuing.
+```
+
+### Zero Output Rule
+
+Entry-point skills that invoke processing skills use this exact blockquote to prevent narration:
+
+```
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+```
+
+### Rendering Instructions for Ask Blocks
+
+When a step asks the user a question, wrap it in a rendering instruction and code block — don't use bare `Ask:` labels:
+
+```
+> *Output the next fenced block as a code block:*
+
+\```
+What's on your mind?
+
+- What idea or topic do you want to explore?
+- What prompted this - a problem, opportunity, curiosity?
+\```
+
+**STOP.** Wait for user response before proceeding.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ Each part is optional — use only what's needed for clarity.
 @if(condition) truthy content @else falsy content @endif
 ```
 
-Example: `@if(has_discussion) {topic}.md ({status:[in-progress|concluded]}) @else no discussion @endif`
+Example: `@if(has_discussion) {topic}.md ({status:[in-progress|concluded]}) @else (no discussion) @endif`
 
 **When to use placeholders vs concrete examples:** Placeholders work well for structural templates (tree displays, status blocks) where each field has a clear source. Selection menus should use concrete examples instead — they encode conditional logic (which verb maps to which state) that placeholders obscure.
 
@@ -223,7 +223,7 @@ Every actionable item gets a numbered entry with `└─` branches showing its s
 
 ```
 1. {topic:(titlecase)}
-   └─ Plan: {plan_status:[none|in-progress|concluded]}
+   └─ Plan: @if(has_plan) {plan_status:[in-progress|concluded]} @else (no plan) @endif
    └─ Spec: {spec_status:[in-progress|concluded]}
 
 2. ...
@@ -243,7 +243,7 @@ For richer hierarchies (specification phase):
 
 Always parenthetical `(term)`. Never brackets or dash-separated.
 
-Core vocabulary: `none`, `in-progress`, `concluded`, `ready`, `completed`, `extracted`, `pending`, `reopened`. Phase-specific terms are fine but format is always `(term)`.
+Core vocabulary: `in-progress`, `concluded`, `ready`, `completed`, `extracted`, `pending`, `reopened`. Phase-specific terms are fine but format is always `(term)`.
 
 ### Cross-Plan References
 
@@ -276,7 +276,6 @@ Separate code block. Categorized. Em dash (`—`) separators. **No `---` separat
 Key:
 
   Plan status:
-    none        — no plan exists yet
     in-progress — planning work is ongoing
     concluded   — plan is complete
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,9 +360,9 @@ Two categories:
 **STOP.** Wait for user response before proceeding.
 ```
 
-**Terminal stop** — skill is done, nothing to process. The output block preceding it already explains the situation, so no follow-up text is needed:
+**Terminal stop** — skill is done, nothing to process:
 ```
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 ```
 
 Never use `Stop here.`, `Command ends.`, `Wait for user to acknowledge before ending.`, or other variations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,14 +342,25 @@ All skill files (entry-point and processing) MUST follow these structural conven
 
 Use `**STOP.**` (bold, period) followed by a brief instruction. This is the only pattern for user interaction boundaries.
 
+Three categories:
+
+**Interaction stop** — waiting for real user input to continue:
 ```
 **STOP.** Wait for user response.
 **STOP.** Wait for user response before proceeding.
-**STOP.** Wait for user to acknowledge before ending.
+```
+
+**Terminal stop** — skill is done, nothing to process:
+```
+**STOP.** Command ends.
+```
+
+**Blocked stop** — items exist but none are actionable:
+```
 **STOP.** This workflow cannot continue — do not proceed.
 ```
 
-Never use `Stop here.`, `STOP`, or other variations.
+Never use `Stop here.`, `Wait for user to acknowledge before ending.`, or other variations.
 
 ### Heading Hierarchy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,28 +192,41 @@ Planning Overview
 4 specifications found. 2 plans exist.
 ```
 
-### Tree Structure
+### Template Placeholders
 
-Every actionable item gets a numbered entry with `└─` branches showing its state. Depth varies by phase but structure is consistent. **Blank line between each numbered item.**
+Skill files use placeholders in fenced block templates. The syntax is:
 
 ```
-1. Auth Flow
-   └─ Plan: none
-   └─ Spec: concluded
+{name}                                    — raw value, output as-is
+{name:[option1|option2|option3]}          — enumerated options (pick one)
+{name:(casing)}                           — with casing hint
+{name:[option1|option2]:(casing)}         — options and casing
+```
 
-2. Data Model
-   └─ Plan: in-progress
-   └─ Spec: concluded
+Casing hints: `titlecase`, `lowercase`, `kebabcase`. No hint means output the raw value.
+
+Each part is optional — use only what's needed for clarity.
+
+### Tree Structure
+
+Every actionable item gets a numbered entry with `└─` branches showing its state. Depth varies by phase but structure is consistent. **Blank line between each numbered item.** Show one full entry, then `2. ...` to indicate repetition.
+
+```
+1. {topic:(titlecase)}
+   └─ Plan: {plan_status:[none|in-progress|concluded]}
+   └─ Spec: {spec_status:[in-progress|concluded]}
+
+2. ...
 ```
 
 For richer hierarchies (specification phase):
 
 ```
-1. Auth Flow
-   └─ Spec: in-progress (2 of 3 sources extracted)
+1. {topic:(titlecase)}
+   └─ Spec: {spec_status:[in-progress|concluded]} ({extraction_summary})
    └─ Discussions:
-      ├─ auth-tokens (extracted)
-      └─ session-mgmt (pending)
+      ├─ {discussion} ({status:[extracted|pending]})
+      └─ ...
 ```
 
 ### Status Terms
@@ -270,9 +283,8 @@ Rendered as markdown (not code blocks). Framed with dot separators. Verb-based l
 
 ```
 · · · · · · · · · · · ·
-1. Create "Auth Flow" — concluded spec, no plan
-2. Continue "Data Model" — plan in-progress
-3. Review "Billing" — plan concluded
+1. {verb:[Create|Continue|Review]} "{topic:(titlecase)}" — {description}
+2. ...
 
 Select an option (enter number):
 · · · · · · · · · · · ·
@@ -313,7 +325,7 @@ What scope would you like to review?
 When only one actionable item exists:
 
 ```
-Automatically proceeding with "Auth Flow".
+Automatically proceeding with "{topic:(titlecase)}".
 ```
 
 ### Block / Terminal Messages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,15 +257,15 @@ Reads as: "advanced-features is blocked by task core-2-3 in the core-features pl
 
 ### "Not Ready" Blocks
 
-Separate code block. Descriptive heading as `{Artifacts} not ready for {phase}:`, explanatory line, then `·` bullets with parenthetical status. **Blank line after the explanation, before the list.**
+Separate code block. Descriptive heading as `{Artifacts} not ready for {phase}:`, explanatory line, then `•` bullets with parenthetical status. **Blank line after the explanation, before the list.**
 
 ```
 Specifications not ready for planning:
 These specifications are either still in progress or cross-cutting
 and cannot be planned directly.
 
-  · caching-strategy (cross-cutting, concluded)
-  · rate-limiting (cross-cutting, in-progress)
+  • caching-strategy (cross-cutting, concluded)
+  • rate-limiting (cross-cutting, in-progress)
 ```
 
 ### Key / Legend
@@ -353,8 +353,7 @@ Run /start-specification first.
 
 ### Bullet Characters
 
-- `•` — simple lists (sources, files, items)
-- `·` — excluded / not-ready items in "not ready" blocks
+Use `•` for all bulleted lists (sources, files, not-ready items, etc.).
 
 ### Spacing Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,14 @@ Casing hints: `titlecase`, `lowercase`, `kebabcase`. No hint means output the ra
 
 Each part is optional — use only what's needed for clarity.
 
+**Conditional directives** for branches that render differently based on state:
+
+```
+@if(condition) truthy content @else falsy content @endif
+```
+
+Example: `@if(has_discussion) {topic}.md ({status:[in-progress|concluded]}) @else no discussion @endif`
+
 **When to use placeholders vs concrete examples:** Placeholders work well for structural templates (tree displays, status blocks) where each field has a clear source. Selection menus should use concrete examples instead — they encode conditional logic (which verb maps to which state) that placeholders obscure.
 
 ### Tree Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,3 +161,175 @@ awk '/^---$/ && c<2 {c++; next} c>=2 {print}' "$file"
 ```
 
 Also avoid BSD sed incompatibilities: `sed '/range/{cmd1;cmd2}'` syntax fails on macOS. Use awk or separate `sed -e` expressions instead.
+
+## Display & Output Conventions (IMPORTANT)
+
+All entry-point skills that present discovery state, menus, or interactive choices MUST follow these conventions. This ensures a consistent, scannable experience across all phases.
+
+### Rendering Instructions
+
+Every fenced block in skill files must be preceded by a rendering instruction:
+
+```
+> *Output the next fenced block as a code block:*
+```
+
+or:
+
+```
+> *Output the next fenced block as markdown (not a code block):*
+```
+
+Code blocks are used for informational displays (overviews, status, keys). Markdown is used for interactive elements (menus, prompts) where bold formatting is needed.
+
+### Title Pattern
+
+Always `{Phase} Overview` as the first line of the opening code block, followed by a blank line and a summary sentence.
+
+```
+Planning Overview
+
+4 specifications found. 2 plans exist.
+```
+
+### Tree Structure
+
+Every actionable item gets a numbered entry with `└─` branches showing its state. Depth varies by phase but structure is consistent. **Blank line between each numbered item.**
+
+```
+1. Auth Flow
+   └─ Plan: none
+   └─ Spec: concluded
+
+2. Data Model
+   └─ Plan: in-progress
+   └─ Spec: concluded
+```
+
+For richer hierarchies (specification phase):
+
+```
+1. Auth Flow
+   └─ Spec: in-progress (2 of 3 sources extracted)
+   └─ Discussions:
+      ├─ auth-tokens (extracted)
+      └─ session-mgmt (pending)
+```
+
+### Status Terms
+
+Always parenthetical `(term)`. Never brackets or dash-separated.
+
+Core vocabulary: `none`, `in-progress`, `concluded`, `ready`, `completed`, `extracted`, `pending`, `reopened`. Phase-specific terms are fine but format is always `(term)`.
+
+### "Not Ready" Blocks
+
+Separate code block. Descriptive heading as `{Artifacts} not ready for {phase}:`, explanatory line, then `·` bullets with parenthetical status. **Blank line after the explanation, before the list.**
+
+```
+Specifications not ready for planning:
+These specifications are either still in progress or cross-cutting
+and cannot be planned directly.
+
+  · caching-strategy (cross-cutting, concluded)
+  · rate-limiting (cross-cutting, in-progress)
+```
+
+### Key / Legend
+
+Separate code block. Categorized. Em dash (`—`) separators. **No `---` separator before the Key block.** Only show statuses that appear in the current display. **Blank line between categories.**
+
+```
+Key:
+
+  Plan status:
+    none        — no plan exists yet
+    in-progress — planning work is ongoing
+    concluded   — plan is complete
+
+  Spec type:
+    cross-cutting — architectural policy, not directly plannable
+    feature       — plannable feature specification
+```
+
+### Menus / Interactive Prompts
+
+Rendered as markdown (not code blocks). Framed with dot separators. Verb-based labels for selection menus. No single-character icons.
+
+**Selection menu:**
+
+```
+· · · · · · · · · · · ·
+1. Create "Auth Flow" — concluded spec, no plan
+2. Continue "Data Model" — plan in-progress
+3. Review "Billing" — plan concluded
+
+Select an option (enter number):
+· · · · · · · · · · · ·
+```
+
+**Yes/no prompt:**
+
+```
+· · · · · · · · · · · ·
+Proceed?
+- **`y`/`yes`**
+- **`n`/`no`**
+· · · · · · · · · · · ·
+```
+
+**Multi-choice prompt:**
+
+```
+· · · · · · · · · · · ·
+What scope would you like to review?
+
+- **`s`/`single`** — Review one plan's implementation
+- **`m`/`multi`** — Review selected plans together
+- **`a`/`all`** — Review all implemented plans
+· · · · · · · · · · · ·
+```
+
+**Meta options** in selection menus get backtick-wrapped descriptions:
+
+```
+3. Unify all into single specification
+   `All discussions combined into one specification.`
+   `Existing specifications are incorporated and superseded.`
+```
+
+### Auto-Select
+
+When only one actionable item exists:
+
+```
+Automatically proceeding with "Auth Flow".
+```
+
+### Block / Terminal Messages
+
+When a phase can't proceed — use the phase title pattern, then explain:
+
+```
+Planning Overview
+
+No specifications found in docs/workflow/specification/
+
+The planning phase requires a concluded specification.
+Run /start-specification first.
+```
+
+### Bullet Characters
+
+- `•` — simple lists (sources, files, items)
+- `·` — excluded / not-ready items in "not ready" blocks
+
+### Spacing Rules
+
+Inside code blocks, maintain **one blank line** between:
+- Title/summary and first content
+- Each numbered tree item
+- Section headings and their content
+- Key categories
+
+Between code blocks (overview → not-ready → key → menu), no `---` separators — just the natural block separation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ Casing hints: `titlecase`, `lowercase`, `kebabcase`. No hint means output the ra
 
 Each part is optional — use only what's needed for clarity.
 
+**When to use placeholders vs concrete examples:** Placeholders work well for structural templates (tree displays, status blocks) where each field has a clear source. Selection menus should use concrete examples instead — they encode conditional logic (which verb maps to which state) that placeholders obscure.
+
 ### Tree Structure
 
 Every actionable item gets a numbered entry with `└─` branches showing its state. Depth varies by phase but structure is consistent. **Blank line between each numbered item.** Show one full entry, then `2. ...` to indicate repetition.
@@ -279,12 +281,13 @@ Key:
 
 Rendered as markdown (not code blocks). Framed with dot separators. Verb-based labels for selection menus. No single-character icons.
 
-**Selection menu:**
+**Selection menu** — use concrete examples showing verb-to-state mapping:
 
 ```
 · · · · · · · · · · · ·
-1. {verb:[Create|Continue|Review]} "{topic:(titlecase)}" — {description}
-2. ...
+1. Create "Auth Flow" — concluded spec, no plan
+2. Continue "Data Model" — plan in-progress
+3. Review "Billing" — plan concluded
 
 Select an option (enter number):
 · · · · · · · · · · · ·

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -96,20 +96,11 @@ Dependency Summary
 
 {N} plans found. {M} unresolved dependencies.
 
-Plan: Authentication (format: {format})
-  • billing-system: Invoice generation (unresolved)
-  • user-management: User profiles (resolved, {task-id})
+Plan: {topic:(titlecase)} (format: {format})
+  • {dependency}: {description} ({state:[unresolved|resolved|satisfied externally]})
 
-Plan: Billing System (format: {format})
-  • authentication: User context (unresolved)
-  • payment-gateway: Payment processing (satisfied externally)
-
-Plan: Notifications (format: {format})
-  • authentication: User lookup (unresolved)
-  • billing-system: Invoice events (unresolved)
+Plan: ...
 ```
-
-Convert topic filenames to title case (`auth-flow` → `Auth Flow`).
 
 > *Output the next fenced block as a code block:*
 
@@ -166,21 +157,19 @@ Present a summary:
 Dependency Linking Complete
 
 Resolved (newly linked):
-  • authentication → billing-system: {task-id} (Invoice generation)
-  • notifications → authentication: {task-id} (Session management)
+  • {source} → {target}: {task-id} ({description})
 
 Already resolved (no action needed):
-  • authentication → user-management: {task-id}
+  • {source} → {target}: {task-id}
 
 Satisfied externally (no action needed):
-  • billing-system → payment-gateway
+  • {source} → {target}
 
 Unresolved (no matching plan exists):
-  • notifications → email-service: Email delivery
+  • {source} → {target}: {description}
 
 Updated files:
-  • docs/workflow/planning/authentication.md
-  • docs/workflow/planning/notifications.md
+  • docs/workflow/planning/{topic}.md
 ```
 
 If any dependencies remain unresolved:

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -38,7 +38,7 @@ No plans found in docs/workflow/planning/
 There are no plans to link. Create plans first.
 ```
 
-**STOP.** Command ends.
+**STOP.**
 
 **If only one plan exists:**
 
@@ -52,7 +52,7 @@ Only one plan found: {topic}
 Cross-topic dependency linking requires at least two plans.
 ```
 
-**STOP.** Command ends.
+**STOP.**
 
 ## Step 2: Check Output Format Consistency
 
@@ -75,7 +75,7 @@ Cross-topic dependencies can only be wired within the same output
 format. Consolidate your plans to a single format before linking.
 ```
 
-**STOP.** Command ends.
+**STOP.**
 
 ## Step 3: Extract External Dependencies
 

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -67,9 +67,8 @@ Dependency Linking
 
 Mixed output formats detected:
 
-  • authentication ({format-a})
-  • billing-system ({format-b})
-  • notifications ({format-a})
+  • {topic} ({format})
+  • ...
 
 Cross-topic dependencies can only be wired within the same output
 format. Consolidate your plans to a single format before linking.

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -38,7 +38,7 @@ No plans found in docs/workflow/planning/
 There are no plans to link. Create plans first.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 **If only one plan exists:**
 
@@ -52,7 +52,7 @@ Only one plan found: {topic}
 Cross-topic dependency linking requires at least two plans.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 ## Step 2: Check Output Format Consistency
 
@@ -75,7 +75,7 @@ Cross-topic dependencies can only be wired within the same output
 format. Consolidate your plans to a single format before linking.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 ## Step 3: Extract External Dependencies
 

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -31,24 +31,28 @@ Scan the codebase for existing plans:
 > *Output the next fenced block as a code block:*
 
 ```
+Dependency Linking
+
 No plans found in docs/workflow/planning/
 
 There are no plans to link. Create plans first.
 ```
 
-Stop here.
+**STOP.** Wait for user to acknowledge before ending.
 
 **If only one plan exists:**
 
 > *Output the next fenced block as a code block:*
 
 ```
+Dependency Linking
+
 Only one plan found: {topic}
 
 Cross-topic dependency linking requires at least two plans.
 ```
 
-Stop here.
+**STOP.** Wait for user to acknowledge before ending.
 
 ## Step 2: Check Output Format Consistency
 
@@ -59,17 +63,19 @@ Compare the `format:` field across all discovered plans.
 > *Output the next fenced block as a code block:*
 
 ```
+Dependency Linking
+
 Mixed output formats detected:
 
-- authentication: {format-a}
-- billing-system: {format-b}
-- notifications: {format-a}
+  • authentication ({format-a})
+  • billing-system ({format-b})
+  • notifications ({format-a})
 
-Cross-topic dependencies can only be wired within the same output format.
-Please consolidate your plans to use a single output format before linking dependencies.
+Cross-topic dependencies can only be wired within the same output
+format. Consolidate your plans to a single format before linking.
 ```
 
-Stop here.
+**STOP.** Wait for user to acknowledge before ending.
 
 ## Step 3: Extract External Dependencies
 
@@ -88,17 +94,32 @@ For each plan, read the `external_dependencies` field from the frontmatter:
 ```
 Dependency Summary
 
-Plan: authentication (format: {format})
-  - billing-system: Invoice generation (unresolved)
-  - user-management: User profiles → {task-id} (resolved)
+{N} plans found. {M} unresolved dependencies.
 
-Plan: billing-system (format: {format})
-  - authentication: User context (unresolved)
-  - payment-gateway: Payment processing (satisfied externally)
+Plan: Authentication (format: {format})
+  • billing-system: Invoice generation (unresolved)
+  • user-management: User profiles (resolved, {task-id})
 
-Plan: notifications (format: {format})
-  - authentication: User lookup (unresolved)
-  - billing-system: Invoice events (unresolved)
+Plan: Billing System (format: {format})
+  • authentication: User context (unresolved)
+  • payment-gateway: Payment processing (satisfied externally)
+
+Plan: Notifications (format: {format})
+  • authentication: User lookup (unresolved)
+  • billing-system: Invoice events (unresolved)
+```
+
+Convert topic filenames to title case (`auth-flow` → `Auth Flow`).
+
+> *Output the next fenced block as a code block:*
+
+```
+Key:
+
+  Dependency state:
+    unresolved           — no task linked yet
+    resolved             — linked to a task in another plan
+    satisfied externally — implemented outside this workflow
 ```
 
 ## Step 4: Match Dependencies to Plans
@@ -144,26 +165,32 @@ Present a summary:
 ```
 Dependency Linking Complete
 
-RESOLVED (newly linked):
-  - authentication → billing-system: {task-id} (Invoice generation)
-  - notifications → authentication: {task-id} (Session management)
+Resolved (newly linked):
+  • authentication → billing-system: {task-id} (Invoice generation)
+  • notifications → authentication: {task-id} (Session management)
 
-ALREADY RESOLVED (no action needed):
-  - authentication → user-management: {task-id}
+Already resolved (no action needed):
+  • authentication → user-management: {task-id}
 
-SATISFIED EXTERNALLY (no action needed):
-  - billing-system → payment-gateway
+Satisfied externally (no action needed):
+  • billing-system → payment-gateway
 
-UNRESOLVED (no matching plan exists):
-  - notifications → email-service: Email delivery
+Unresolved (no matching plan exists):
+  • notifications → email-service: Email delivery
 
-  These dependencies have no corresponding plan. Either:
-  - Create a plan for the topic
-  - Mark as "satisfied externally" if already implemented
+Updated files:
+  • docs/workflow/planning/authentication.md
+  • docs/workflow/planning/notifications.md
+```
 
-UPDATED FILES:
-  - docs/workflow/planning/authentication.md
-  - docs/workflow/planning/notifications.md
+If any dependencies remain unresolved:
+
+> *Output the next fenced block as a code block:*
+
+```
+Unresolved dependencies have no corresponding plan. Either:
+  • Create a plan for the topic
+  • Mark as "satisfied externally" if already implemented
 ```
 
 ## Step 8: Commit Changes
@@ -179,6 +206,8 @@ Shall I commit these dependency updates?
 - **`n`/`no`** — Skip
 · · · · · · · · · · · ·
 ```
+
+**STOP.** Wait for user response.
 
 If yes, commit with message:
 ```

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -38,7 +38,7 @@ No plans found in docs/workflow/planning/
 There are no plans to link. Create plans first.
 ```
 
-**STOP.** Wait for user to acknowledge before ending.
+**STOP.** Command ends.
 
 **If only one plan exists:**
 
@@ -52,7 +52,7 @@ Only one plan found: {topic}
 Cross-topic dependency linking requires at least two plans.
 ```
 
-**STOP.** Wait for user to acknowledge before ending.
+**STOP.** Command ends.
 
 ## Step 2: Check Output Format Consistency
 
@@ -75,7 +75,7 @@ Cross-topic dependencies can only be wired within the same output
 format. Consolidate your plans to a single format before linking.
 ```
 
-**STOP.** Wait for user to acknowledge before ending.
+**STOP.** Command ends.
 
 ## Step 3: Extract External Dependencies
 

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -11,25 +11,47 @@ Present everything discovered to help the user make an informed choice.
 > *Output the next fenced block as a code block:*
 
 ```
-Workflow Status: Discussion Phase
+Discussion Overview
+
+{N} research topics found. {M} existing discussions.
 
 Research topics:
-  1. · {Theme name} - undiscussed
-       Source: {filename}.md (lines {start}-{end})
-       "{Brief summary}"
 
-  2. ✓ {Theme name} → {topic}.md
-       Source: {filename}.md (lines {start}-{end})
-       "{Brief summary}"
+1. {Theme name}
+   └─ Source: {filename}.md (lines {start}-{end})
+   └─ Discussion: none
+   └─ "{Brief summary}"
 
-Discussions:
-  - {topic}.md (in-progress)
-  - {topic}.md (concluded)
+2. {Theme name}
+   └─ Source: {filename}.md (lines {start}-{end})
+   └─ Discussion: {topic}.md (in-progress)
+   └─ "{Brief summary}"
+```
 
----
+If discussions exist that are NOT linked to a research topic, list them separately:
+
+> *Output the next fenced block as a code block:*
+
+```
+Existing discussions:
+
+  • {topic}.md (in-progress)
+  • {topic}.md (concluded)
+```
+
+### Key/Legend
+
+No `---` separator before this section.
+
+> *Output the next fenced block as a code block:*
+
+```
 Key:
-  · = undiscussed topic (potential new discussion)
-  ✓ = already has a corresponding discussion
+
+  Discussion status:
+    none        — no discussion exists yet
+    in-progress — discussion is ongoing
+    concluded   — discussion is complete
 ```
 
 **Then present the options based on what exists:**

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -19,15 +19,10 @@ Research topics:
 
 1. {theme_name}
    └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: no discussion
+   └─ Discussion: @if(has_discussion) {topic}.md ({status:[in-progress|concluded]}) @else no discussion @endif
    └─ "{summary}"
 
-2. {theme_name}
-   └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: {topic}.md ({status:[in-progress|concluded]})
-   └─ "{summary}"
-
-3. ...
+2. ...
 ```
 
 If discussions exist that are NOT linked to a research topic, list them separately:

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -17,15 +17,12 @@ Discussion Overview
 
 Research topics:
 
-1. {Theme name}
+1. {theme_name}
    └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: none
-   └─ "{Brief summary}"
+   └─ Discussion: {status:[none|{topic}.md (in-progress)]}
+   └─ "{summary}"
 
-2. {Theme name}
-   └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: {topic}.md (in-progress)
-   └─ "{Brief summary}"
+2. ...
 ```
 
 If discussions exist that are NOT linked to a research topic, list them separately:
@@ -35,8 +32,7 @@ If discussions exist that are NOT linked to a research topic, list them separate
 ```
 Existing discussions:
 
-  • {topic}.md (in-progress)
-  • {topic}.md (concluded)
+  • {topic}.md ({status:[in-progress|concluded]})
 ```
 
 ### Key/Legend

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -19,16 +19,13 @@ Research topics:
 
 1. {theme_name}
    └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: none
+   └─ Discussion: no discussion
    └─ "{summary}"
 
-2. {theme_name}
-   └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: {topic}.md ({status:[in-progress|concluded]})
-   └─ "{summary}"
-
-3. ...
+2. ...
 ```
+
+**Discussion branch:** Show `no discussion` when no discussion file exists. When one exists, show the filename and status: `{topic}.md (in-progress)` or `{topic}.md (concluded)`.
 
 If discussions exist that are NOT linked to a research topic, list them separately:
 
@@ -49,10 +46,10 @@ No `---` separator before this section.
 ```
 Key:
 
-  Discussion status:
-    none        — no discussion exists yet
-    in-progress — discussion is ongoing
-    concluded   — discussion is complete
+  Discussion:
+    no discussion — no discussion file exists
+    in-progress   — discussion is ongoing
+    concluded     — discussion is complete
 ```
 
 **Then present the options based on what exists:**

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -19,10 +19,15 @@ Research topics:
 
 1. {theme_name}
    └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: {status:[none|{topic}.md (in-progress)]}
+   └─ Discussion: none
    └─ "{summary}"
 
-2. ...
+2. {theme_name}
+   └─ Source: {filename}.md (lines {start}-{end})
+   └─ Discussion: {topic}.md ({status:[in-progress|concluded]})
+   └─ "{summary}"
+
+3. ...
 ```
 
 If discussions exist that are NOT linked to a research topic, list them separately:

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -46,10 +46,9 @@ No `---` separator before this section.
 ```
 Key:
 
-  Discussion:
-    no discussion — no discussion file exists
-    in-progress   — discussion is ongoing
-    concluded     — discussion is complete
+  Discussion status:
+    in-progress — discussion is ongoing
+    concluded   — discussion is complete
 ```
 
 **Then present the options based on what exists:**

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -22,10 +22,13 @@ Research topics:
    └─ Discussion: no discussion
    └─ "{summary}"
 
-2. ...
-```
+2. {theme_name}
+   └─ Source: {filename}.md (lines {start}-{end})
+   └─ Discussion: {topic}.md ({status:[in-progress|concluded]})
+   └─ "{summary}"
 
-**Discussion branch:** Show `no discussion` when no discussion file exists. When one exists, show the filename and status: `{topic}.md (in-progress)` or `{topic}.md (concluded)`.
+3. ...
+```
 
 If discussions exist that are NOT linked to a research topic, list them separately:
 

--- a/skills/start-discussion/references/display-options.md
+++ b/skills/start-discussion/references/display-options.md
@@ -19,7 +19,7 @@ Research topics:
 
 1. {theme_name}
    └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: @if(has_discussion) {topic}.md ({status:[in-progress|concluded]}) @else no discussion @endif
+   └─ Discussion: @if(has_discussion) {topic}.md ({status:[in-progress|concluded]}) @else (no discussion) @endif
    └─ "{summary}"
 
 2. ...

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -258,8 +258,9 @@ The verb in the menu depends on the implementation state:
 
 ```
 · · · · · · · · · · · ·
-1. {verb:[Continue|Start|Re-review]} "{topic:(titlecase)}" — {description}
-2. ...
+1. Continue "Billing" — in-progress (Phase 2, Task 3)
+2. Start "Core Features" — not yet started
+3. Re-review "User Auth" — completed
 
 Select an option (enter number):
 · · · · · · · · · · · ·

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -119,7 +119,7 @@ The implementation phase requires a plan.
 Run /start-planning first to create a plan from a specification.
 ```
 
-**STOP.** Wait for user to acknowledge before ending.
+**STOP.** Command ends.
 
 #### If scenario is "single_plan" or "multiple_plans"
 

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -160,7 +160,7 @@ Implementation Overview
 
 1. {topic:(titlecase)}
    └─ Plan: {plan_status:[concluded]} ({format})
-   └─ Implementation: {impl_status:[none|in-progress|completed]}
+   └─ Implementation: @if(has_implementation) {impl_status:[in-progress|completed]} @else (not started) @endif
 
 2. ...
 ```
@@ -169,7 +169,7 @@ Implementation Overview
 
 Implementable:
 - Implementation `status: in-progress` → `Implementation: in-progress (Phase N, Task M)`
-- Concluded plan, deps met, not started → `Implementation: none`
+- Concluded plan, deps met, not started → `Implementation: (not started)`
 
 Implemented:
 - Implementation `status: completed` → `Implementation: completed`
@@ -211,7 +211,6 @@ Key:
   Implementation status:
     in-progress — work is ongoing
     completed   — all tasks implemented
-    none        — not yet started
 
   Blocking reason:
     blocked     — depends on another plan's task

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -149,7 +149,7 @@ A plan is **Not implementable** if:
 
 **Present the full state:**
 
-Show implementable and implemented plans as numbered tree items. Convert topic filenames to title case (`auth-flow` → `Auth Flow`).
+Show implementable and implemented plans as numbered tree items.
 
 > *Output the next fenced block as a code block:*
 
@@ -158,17 +158,11 @@ Implementation Overview
 
 {N} plans found. {M} implementations in progress.
 
-1. Billing
-   └─ Plan: concluded (local-markdown)
-   └─ Implementation: in-progress (Phase 2, Task 3)
+1. {topic:(titlecase)}
+   └─ Plan: {plan_status:[concluded]} ({format})
+   └─ Implementation: {impl_status:[none|in-progress|completed]}
 
-2. Core Features
-   └─ Plan: concluded (local-markdown)
-   └─ Implementation: none
-
-3. User Auth
-   └─ Plan: concluded (local-markdown)
-   └─ Implementation: completed
+2. ...
 ```
 
 **Tree rules:**
@@ -231,7 +225,7 @@ Key:
 > *Output the next fenced block as a code block:*
 
 ```
-Automatically proceeding with "{Topic}".
+Automatically proceeding with "{topic:(titlecase)}".
 ```
 
 → Proceed directly to **Step 4**.
@@ -264,9 +258,8 @@ The verb in the menu depends on the implementation state:
 
 ```
 · · · · · · · · · · · ·
-1. Continue "Billing" — in-progress (Phase 2, Task 3)
-2. Start "Core Features" — not yet started
-3. Re-review "User Auth" — completed
+1. {verb:[Continue|Start|Re-review]} "{topic:(titlecase)}" — {description}
+2. ...
 
 Select an option (enter number):
 · · · · · · · · · · · ·

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -119,7 +119,7 @@ The implementation phase requires a plan.
 Run /start-planning first to create a plan from a specification.
 ```
 
-**STOP.** Command ends.
+**STOP.**
 
 #### If scenario is "single_plan" or "multiple_plans"
 
@@ -196,7 +196,7 @@ Plans not ready for implementation:
 These plans are either still in progress or have unresolved
 dependencies that must be addressed first.
 
-  · advanced-features (blocked: core-features task core-2-3)
+  · advanced-features (blocked by core-features:core-2-3)
   · reporting (in-progress)
 ```
 
@@ -251,7 +251,7 @@ Complete blocking dependencies first, or finish plans still
 in progress with /start-planning. Then re-run /start-implementation.
 ```
 
-**STOP.** This workflow cannot continue — do not proceed.
+**STOP.**
 
 **Otherwise (multiple selectable plans, or implemented plans exist):**
 

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -308,23 +308,28 @@ External dependencies satisfied.
 
 This should not normally happen for plans classified as "Implementable" in Step 3. However, as an escape hatch:
 
+> *Output the next fenced block as a code block:*
+
+```
+Missing Dependencies
+
+Unresolved (not yet planned):
+  • {topic}: {description}
+    No plan exists. Create with /start-planning or mark as
+    satisfied externally.
+
+Incomplete (planned but not implemented):
+  • {topic}: {plan}:{task-id} not yet completed
+    This task must be completed first.
+```
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-Missing dependencies:
-
-UNRESOLVED (not yet planned):
-- {topic}: {description}
-  -> No plan exists for this topic. Create with /start-planning or mark as satisfied externally.
-
-INCOMPLETE (planned but not implemented):
-- {topic}: task {task_id} not yet completed
-  -> This task must be completed first.
-
 · · · · · · · · · · · ·
 - **`i`/`implement`** — Implement the blocking dependencies first
 - **`l`/`link`** — Run /link-dependencies to wire up recently completed plans
-- Mark as "satisfied externally" — tell me which dependency was implemented outside this workflow
+- **`s`/`satisfied`** — Mark a dependency as satisfied externally
 · · · · · · · · · · · ·
 ```
 

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -111,9 +111,12 @@ No plans exist yet.
 > *Output the next fenced block as a code block:*
 
 ```
+Implementation Overview
+
 No plans found in docs/workflow/planning/
 
-The implementation phase requires a plan. Please run /start-planning first to create a plan from a specification.
+The implementation phase requires a plan.
+Run /start-planning first to create a plan from a specification.
 ```
 
 **STOP.** Wait for user to acknowledge before ending.
@@ -128,7 +131,7 @@ Plans exist.
 
 ## Step 3: Present Plans and Select
 
-Present all discovered plans using the icon system below. Classify each plan into one of three sections based on its state.
+Present all discovered plans. Classify each plan into one of three categories based on its state.
 
 **Classification logic:**
 
@@ -146,51 +149,79 @@ A plan is **Not implementable** if:
 
 **Present the full state:**
 
+Show implementable and implemented plans as numbered tree items. Convert topic filenames to title case (`auth-flow` → `Auth Flow`).
+
 > *Output the next fenced block as a code block:*
 
 ```
-Implementation Phase
+Implementation Overview
 
-Implementable:
-  1. ▶ billing - continue [Phase 2, Task 3]
-  2. + core-features - start
+{N} plans found. {M} implementations in progress.
 
-Implemented:
-  3. > user-auth
+1. Billing
+   └─ Plan: concluded (local-markdown)
+   └─ Implementation: in-progress (Phase 2, Task 3)
 
-Not implementable:
-  · advanced-features [blocked: core-features task core-2-3 not completed]
-  · reporting [planning]
+2. Core Features
+   └─ Plan: concluded (local-markdown)
+   └─ Implementation: none
+
+3. User Auth
+   └─ Plan: concluded (local-markdown)
+   └─ Implementation: completed
 ```
 
-**Formatting rules:**
+**Tree rules:**
 
-Implementable (numbered, selectable):
-- **`▶`** — implementation `status: in-progress`, show current position `[Phase N, Task M]`
-- **`+`** — concluded plan, deps met, no tracking file or tracking `status: not-started`
+Implementable:
+- Implementation `status: in-progress` → `Implementation: in-progress (Phase N, Task M)`
+- Concluded plan, deps met, not started → `Implementation: none`
 
-Implemented (numbered, selectable):
-- **`>`** — implementation `status: completed`
-
-Not implementable (not numbered, not selectable):
-- **`·`** — blocked or plan not concluded
-- `[blocked: {topic} task {id} not completed]` — resolved dep, task not done
-- `[blocked: unresolved dep on {topic}]` — no task linked
-- `[planning]` — plan status is not `concluded`
+Implemented:
+- Implementation `status: completed` → `Implementation: completed`
 
 **Ordering:**
-1. Implementable first: `▶` in-progress, then `+` new (foundational before dependent)
-2. Implemented next: `>` completed
-3. Not implementable last
+1. Implementable first: in-progress, then new (foundational before dependent)
+2. Implemented next: completed
+3. Not implementable last (separate block below)
 
 Numbering is sequential across Implementable and Implemented. Omit any section entirely if it has no entries.
 
-**If Not implementable section is shown**, append after the presentation:
+**If non-implementable plans exist**, show them in a separate code block:
 
 > *Output the next fenced block as a code block:*
 
 ```
-If a blocked dependency has been resolved outside this workflow, name the plan and the dependency to unblock it.
+Plans not ready for implementation:
+These plans are either still in progress or have unresolved
+dependencies that must be addressed first.
+
+  · advanced-features (blocked: core-features task core-2-3)
+  · reporting (in-progress)
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+If a blocked dependency has been resolved outside this workflow,
+name the plan and the dependency to unblock it.
+```
+
+**Key/Legend** — show only statuses that appear in the current display. No `---` separator before this section.
+
+> *Output the next fenced block as a code block:*
+
+```
+Key:
+
+  Implementation status:
+    in-progress — work is ongoing
+    completed   — all tasks implemented
+    none        — not yet started
+
+  Blocking reason:
+    blocked     — depends on another plan's task
+    in-progress — plan not yet concluded
 ```
 
 **Then prompt based on what's actionable:**
@@ -200,34 +231,45 @@ If a blocked dependency has been resolved outside this workflow, name the plan a
 > *Output the next fenced block as a code block:*
 
 ```
-Auto-selecting: {topic} (only implementable plan)
+Automatically proceeding with "{Topic}".
 ```
+
 → Proceed directly to **Step 4**.
 
 **If nothing selectable (no implementable or implemented):**
-Show Not implementable section only (with unblock hint above).
+
+Show "not ready" block only (with unblock hint above).
 
 > *Output the next fenced block as a code block:*
 
 ```
-No implementable plans.
+Implementation Overview
 
-Before you can start implementation:
-- Complete blocking dependencies first, or
-- Finish plans still in progress with /start-planning
+No implementable plans found.
 
-Then re-run /start-implementation.
+Complete blocking dependencies first, or finish plans still
+in progress with /start-planning. Then re-run /start-implementation.
 ```
 
 **STOP.** This workflow cannot continue — do not proceed.
 
 **Otherwise (multiple selectable plans, or implemented plans exist):**
 
+The verb in the menu depends on the implementation state:
+- Implementation in-progress → **Continue**
+- Not yet started → **Start**
+- Completed → **Re-review**
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Select a plan (enter number):
+1. Continue "Billing" — in-progress (Phase 2, Task 3)
+2. Start "Core Features" — not yet started
+3. Re-review "User Auth" — completed
+
+Select an option (enter number):
+· · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -266,6 +266,8 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
+Recreate with actual topics and states from discovery.
+
 **STOP.** Wait for user response.
 
 #### If the user requests an unblock

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -119,7 +119,7 @@ The implementation phase requires a plan.
 Run /start-planning first to create a plan from a specification.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 #### If scenario is "single_plan" or "multiple_plans"
 
@@ -251,7 +251,7 @@ Complete blocking dependencies first, or finish plans still
 in progress with /start-planning. Then re-run /start-implementation.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 **Otherwise (multiple selectable plans, or implemented plans exist):**
 

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -190,8 +190,8 @@ Plans not ready for implementation:
 These plans are either still in progress or have unresolved
 dependencies that must be addressed first.
 
-  · advanced-features (blocked by core-features:core-2-3)
-  · reporting (in-progress)
+  • advanced-features (blocked by core-features:core-2-3)
+  • reporting (in-progress)
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -138,7 +138,7 @@ Planning Overview
 {N} specifications found. {M} plans exist.
 
 1. {topic:(titlecase)}
-   └─ Plan: {plan_status:[none|in-progress|concluded]}
+   └─ Plan: @if(has_plan) {plan_status:[in-progress|concluded]} @else (no plan) @endif
    └─ Spec: concluded
 
 2. ...
@@ -147,7 +147,7 @@ Planning Overview
 **Tree rules:**
 
 Each numbered item shows a feature specification that is actionable:
-- Concluded spec with no plan → `Plan: none`
+- Concluded spec with no plan → `Plan: (no plan)`
 - Has a plan with `plan_status: planning` → `Plan: in-progress`
 - Has a plan with `plan_status: concluded` → `Plan: concluded`
 
@@ -171,7 +171,6 @@ and cannot be planned directly.
 Key:
 
   Plan status:
-    none        — no plan exists yet
     in-progress — planning work is ongoing
     concluded   — plan is complete
 

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -203,6 +203,8 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
+Recreate with actual topics and states from discovery.
+
 **STOP.** Wait for user response.
 
 **If single actionable item (auto-select):**

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -108,7 +108,7 @@ The planning phase requires a concluded specification.
 Run /start-specification first.
 ```
 
-**STOP.** Wait for user to acknowledge before ending.
+**STOP.** Command ends.
 
 #### If scenario is "nothing_actionable"
 

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -137,17 +137,11 @@ Planning Overview
 
 {N} specifications found. {M} plans exist.
 
-1. {Topic Title Case}
-   └─ Plan: none
+1. {topic:(titlecase)}
+   └─ Plan: {plan_status:[none|in-progress|concluded]}
    └─ Spec: concluded
 
-2. {Topic Title Case}
-   └─ Plan: in-progress
-   └─ Spec: concluded
-
-3. {Topic Title Case}
-   └─ Plan: concluded
-   └─ Spec: concluded
+2. ...
 ```
 
 **Tree rules:**
@@ -156,8 +150,6 @@ Each numbered item shows a feature specification that is actionable:
 - Concluded spec with no plan → `Plan: none`
 - Has a plan with `plan_status: planning` → `Plan: in-progress`
 - Has a plan with `plan_status: concluded` → `Plan: concluded`
-
-Convert topic filenames to title case (`auth-flow` → `Auth Flow`).
 
 **If non-plannable specifications exist**, show them in a separate code block:
 
@@ -168,9 +160,7 @@ Specifications not ready for planning:
 These specifications are either still in progress or cross-cutting
 and cannot be planned directly.
 
-  · {topic} (feature, in-progress)
-  · {caching-strategy} (cross-cutting, concluded)
-  · {rate-limiting} (cross-cutting, in-progress)
+  · {topic} ({type:[feature|cross-cutting]}, {status:[in-progress|concluded]})
 ```
 
 **Key/Legend** — show only statuses that appear in the current display. No `---` separator before this section.
@@ -205,9 +195,8 @@ The verb in the menu depends on the plan state:
 
 ```
 · · · · · · · · · · · ·
-1. Create "{Topic}" — concluded spec, no plan
-2. Continue "{Topic}" — plan in-progress
-3. Review "{Topic}" — plan concluded
+1. {verb:[Create|Continue|Review]} "{topic:(titlecase)}" — {description}
+2. ...
 
 Select an option (enter number):
 · · · · · · · · · · · ·
@@ -220,7 +209,7 @@ Select an option (enter number):
 > *Output the next fenced block as a code block:*
 
 ```
-Automatically proceeding with "{Topic}".
+Automatically proceeding with "{topic:(titlecase)}".
 ```
 
 → Proceed directly to **Step 4**.

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -195,8 +195,9 @@ The verb in the menu depends on the plan state:
 
 ```
 · · · · · · · · · · · ·
-1. {verb:[Create|Continue|Review]} "{topic:(titlecase)}" — {description}
-2. ...
+1. Create "Auth Flow" — concluded spec, no plan
+2. Continue "Data Model" — plan in-progress
+3. Review "Billing" — plan concluded
 
 Select an option (enter number):
 · · · · · · · · · · · ·

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -263,13 +263,15 @@ The plan already has its context from when it was created. Skip context gatherin
 
 ## Step 5: Gather Additional Context
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
+· · · · · · · · · · · ·
 Any additional context since the specification was concluded?
 
-- Priorities, constraints, or new considerations?
-- Or "none" if nothing has changed.
+- **`c`/`continue`** — Continue with the specification as-is
+- Or provide additional context (priorities, constraints, new considerations)
+· · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -263,9 +263,14 @@ The plan already has its context from when it was created. Skip context gatherin
 
 ## Step 5: Gather Additional Context
 
-Ask:
-- Any additional context or priorities to consider?
-- Any constraints since the specification was concluded?
+> *Output the next fenced block as a code block:*
+
+```
+Any additional context since the specification was concluded?
+
+- Priorities, constraints, or new considerations?
+- Or "none" if nothing has changed.
+```
 
 **STOP.** Wait for user response.
 

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -160,7 +160,7 @@ Specifications not ready for planning:
 These specifications are either still in progress or cross-cutting
 and cannot be planned directly.
 
-  · {topic} ({type:[feature|cross-cutting]}, {status:[in-progress|concluded]})
+  • {topic} ({type:[feature|cross-cutting]}, {status:[in-progress|concluded]})
 ```
 
 **Key/Legend** — show only statuses that appear in the current display. No `---` separator before this section.
@@ -289,7 +289,7 @@ If any are relevant:
 Cross-cutting specifications still in progress:
 These may contain architectural decisions relevant to this plan.
 
-  · {topic} (in-progress)
+  • {topic}
 
 · · · · · · · · · · · ·
 - **`c`/`continue`** — Plan without them

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -108,7 +108,7 @@ The planning phase requires a concluded specification.
 Run /start-specification first.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 #### If scenario is "nothing_actionable"
 
@@ -239,7 +239,7 @@ Complete any in-progress specifications with /start-specification,
 or create a new specification first.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 → Based on user choice, proceed to **Step 4**.
 

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -108,7 +108,7 @@ The planning phase requires a concluded specification.
 Run /start-specification first.
 ```
 
-**STOP.** Command ends.
+**STOP.**
 
 #### If scenario is "nothing_actionable"
 
@@ -239,7 +239,7 @@ Complete any in-progress specifications with /start-specification,
 or create a new specification first.
 ```
 
-**STOP.** This workflow cannot continue — do not proceed.
+**STOP.**
 
 → Based on user choice, proceed to **Step 4**.
 

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -289,7 +289,7 @@ If any are relevant:
 Cross-cutting specifications still in progress:
 These may contain architectural decisions relevant to this plan.
 
-  · {rate-limiting} (in-progress)
+  · {topic} (in-progress)
 
 · · · · · · · · · · · ·
 - **`c`/`continue`** — Plan without them

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -100,9 +100,12 @@ No specifications exist yet.
 > *Output the next fenced block as a code block:*
 
 ```
+Planning Overview
+
 No specifications found in docs/workflow/specification/
 
-The planning phase requires a concluded specification. Please run /start-specification first.
+The planning phase requires a concluded specification.
+Run /start-specification first.
 ```
 
 **STOP.** Wait for user to acknowledge before ending.
@@ -130,42 +133,84 @@ Present everything discovered to help the user make an informed choice.
 > *Output the next fenced block as a code block:*
 
 ```
-Planning Phase
+Planning Overview
 
-Available:
-  1. + {topic-2} - create new plan
-  2. ▶ {topic-3} - continue in-progress plan
-  3. > {topic-4} - review concluded plan
+{N} specifications found. {M} plans exist.
 
-Not plannable specifications:
-  · {topic-1} [feature, in-progress]
-  · {caching-strategy} [cross-cutting, concluded]
-  · {rate-limiting} [cross-cutting, in-progress]
+1. {Topic Title Case}
+   └─ Plan: none
+   └─ Spec: concluded
+
+2. {Topic Title Case}
+   └─ Plan: in-progress
+   └─ Spec: concluded
+
+3. {Topic Title Case}
+   └─ Plan: concluded
+   └─ Spec: concluded
 ```
 
-**Formatting rules:**
+**Tree rules:**
 
-Available (numbered, selectable):
-- **`+`** — concluded spec with no plan yet
-- **`▶`** — has a plan with `plan_status: planning`
-- **`>`** — has a plan with `plan_status: concluded`
+Each numbered item shows a feature specification that is actionable:
+- Concluded spec with no plan → `Plan: none`
+- Has a plan with `plan_status: planning` → `Plan: in-progress`
+- Has a plan with `plan_status: concluded` → `Plan: concluded`
 
-Not plannable specifications (no number, not selectable — `[type, status]` format):
-- **`·`** — feature specs still in-progress, or cross-cutting specifications
-- Feature specs: `[feature, in-progress]`
-- Cross-cutting specs: `[cross-cutting, {status}]`
+Convert topic filenames to title case (`auth-flow` → `Auth Flow`).
 
-Omit either section entirely if it has no entries.
+**If non-plannable specifications exist**, show them in a separate code block:
+
+> *Output the next fenced block as a code block:*
+
+```
+Specifications not ready for planning:
+These specifications are either still in progress or cross-cutting
+and cannot be planned directly.
+
+  · {topic} (feature, in-progress)
+  · {caching-strategy} (cross-cutting, concluded)
+  · {rate-limiting} (cross-cutting, in-progress)
+```
+
+**Key/Legend** — show only statuses that appear in the current display. No `---` separator before this section.
+
+> *Output the next fenced block as a code block:*
+
+```
+Key:
+
+  Plan status:
+    none        — no plan exists yet
+    in-progress — planning work is ongoing
+    concluded   — plan is complete
+
+  Spec type:
+    cross-cutting — architectural policy, not directly plannable
+    feature       — plannable feature specification
+```
+
+Omit any section entirely if it has no entries.
 
 **Then prompt based on what's actionable:**
 
 **If multiple actionable items:**
 
+The verb in the menu depends on the plan state:
+- No plan exists → **Create**
+- Plan is `in-progress` → **Continue**
+- Plan is `concluded` → **Review**
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Select a specification (enter number):
+1. Create "{Topic}" — concluded spec, no plan
+2. Continue "{Topic}" — plan in-progress
+3. Review "{Topic}" — plan concluded
+
+Select an option (enter number):
+· · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
@@ -175,7 +220,7 @@ Select a specification (enter number):
 > *Output the next fenced block as a code block:*
 
 ```
-Auto-selecting: {topic} (only actionable specification)
+Automatically proceeding with "{Topic}".
 ```
 
 → Proceed directly to **Step 4**.
@@ -185,13 +230,13 @@ Auto-selecting: {topic} (only actionable specification)
 > *Output the next fenced block as a code block:*
 
 ```
-No plannable specifications.
+Planning Overview
 
-Before you can start planning:
-- Complete any in-progress specifications with /start-specification, or
-- Create a new specification first
+No plannable specifications found.
 
-Then re-run /start-planning.
+The planning phase requires a concluded feature specification.
+Complete any in-progress specifications with /start-specification,
+or create a new specification first.
 ```
 
 **STOP.** This workflow cannot continue — do not proceed.
@@ -243,10 +288,10 @@ If any are relevant:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-Note: The following cross-cutting specifications are still in-progress:
-  · {rate-limiting} - in-progress
-
+Cross-cutting specifications still in progress:
 These may contain architectural decisions relevant to this plan.
+
+  · {rate-limiting} (in-progress)
 
 · · · · · · · · · · · ·
 - **`c`/`continue`** — Plan without them

--- a/skills/start-research/references/gather-context.md
+++ b/skills/start-research/references/gather-context.md
@@ -10,7 +10,7 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 
 ## Seed Idea
 
-Ask:
+> *Output the next fenced block as a code block:*
 
 ```
 What's on your mind?
@@ -25,7 +25,7 @@ What's on your mind?
 
 ## Current Knowledge
 
-Ask:
+> *Output the next fenced block as a code block:*
 
 ```
 What do you already know?
@@ -40,7 +40,7 @@ What do you already know?
 
 ## Starting Point
 
-Ask:
+> *Output the next fenced block as a code block:*
 
 ```
 Where should we start?
@@ -55,7 +55,7 @@ Where should we start?
 
 ## Final Context
 
-Ask:
+> *Output the next fenced block as a code block:*
 
 ```
 Any constraints or context I should know about upfront?

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -102,7 +102,7 @@ Run /start-planning first to create a plan, then /start-implementation
 to build it.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 #### If scenario is "single_plan" or "multiple_plans"
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -102,7 +102,7 @@ Run /start-planning first to create a plan, then /start-implementation
 to build it.
 ```
 
-**STOP.** Wait for user to acknowledge before ending.
+**STOP.** Command ends.
 
 #### If scenario is "single_plan" or "multiple_plans"
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -102,7 +102,7 @@ Run /start-planning first to create a plan, then /start-implementation
 to build it.
 ```
 
-**STOP.** Command ends.
+**STOP.**
 
 #### If scenario is "single_plan" or "multiple_plans"
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -93,9 +93,13 @@ No plans exist yet.
 > *Output the next fenced block as a code block:*
 
 ```
+Review Overview
+
 No plans found in docs/workflow/planning/
 
-The review phase requires a completed implementation based on a plan. Please run /start-planning first to create a plan, then /start-implementation to build it.
+The review phase requires a completed implementation based on a plan.
+Run /start-planning first to create a plan, then /start-implementation
+to build it.
 ```
 
 **STOP.** Wait for user to acknowledge before ending.

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -8,7 +8,7 @@ Present all discovered plans with implementation status to help the user underst
 
 **Present the full state:**
 
-Show reviewable plans as numbered tree items. Convert topic filenames to title case (`auth-flow` → `Auth Flow`).
+Show reviewable plans as numbered tree items.
 
 > *Output the next fenced block as a code block:*
 
@@ -17,15 +17,12 @@ Review Overview
 
 {N} plans found. {M} with implementations.
 
-1. {Topic Title Case}
+1. {topic:(titlecase)}
    └─ Plan: concluded ({format})
-   └─ Implementation: completed
-   └─ Spec: exists
+   └─ Implementation: {impl_status:[completed|in-progress]}
+   └─ Spec: {spec:[exists|missing]}
 
-2. {Topic Title Case}
-   └─ Plan: concluded ({format})
-   └─ Implementation: in-progress
-   └─ Spec: exists
+2. ...
 ```
 
 **Tree rules:**
@@ -81,7 +78,7 @@ Run /start-implementation first.
 > *Output the next fenced block as a code block:*
 
 ```
-Automatically proceeding with "{Topic}".
+Automatically proceeding with "{topic:(titlecase)}".
 Scope: single
 ```
 

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -74,7 +74,7 @@ The review phase requires at least one plan with an implementation.
 Run /start-implementation first.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 #### If single reviewable plan
 

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -41,7 +41,7 @@ Omit any section entirely if it has no entries.
 Plans not ready for review:
 These plans have no implementation to review.
 
-  · {topic} (no implementation)
+  • {topic} (no implementation)
 ```
 
 **Key/Legend** — show only statuses that appear in the current display. No `---` separator before this section.

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -8,29 +8,56 @@ Present all discovered plans with implementation status to help the user underst
 
 **Present the full state:**
 
+Show reviewable plans as numbered tree items. Convert topic filenames to title case (`auth-flow` → `Auth Flow`).
+
 > *Output the next fenced block as a code block:*
 
 ```
-Review Phase
+Review Overview
 
-Reviewable:
-  1. ✓ {topic-1} (completed) - format: {format}, spec: {exists|missing}
-  2. ▶ {topic-2} (in-progress) - format: {format}, spec: {exists|missing}
+{N} plans found. {M} with implementations.
 
-Not reviewable:
-  · {topic-3} [no implementation]
+1. {Topic Title Case}
+   └─ Plan: concluded ({format})
+   └─ Implementation: completed
+   └─ Spec: exists
+
+2. {Topic Title Case}
+   └─ Plan: concluded ({format})
+   └─ Implementation: in-progress
+   └─ Spec: exists
 ```
 
-**Formatting rules:**
+**Tree rules:**
 
-Reviewable (numbered, selectable):
-- **`✓`** — implementation_status: completed
-- **`▶`** — implementation_status: in-progress
+Reviewable (numbered):
+- Implementation `status: completed` → `Implementation: completed`
+- Implementation `status: in-progress` → `Implementation: in-progress`
 
-Not reviewable (not numbered, not selectable):
-- **`·`** — implementation_status: none
+Omit any section entirely if it has no entries.
 
-Omit either section entirely if it has no entries.
+**If non-reviewable plans exist**, show them in a separate code block:
+
+> *Output the next fenced block as a code block:*
+
+```
+Plans not ready for review:
+These plans have no implementation to review.
+
+  · {topic} (no implementation)
+```
+
+**Key/Legend** — show only statuses that appear in the current display. No `---` separator before this section.
+
+> *Output the next fenced block as a code block:*
+
+```
+Key:
+
+  Implementation status:
+    completed   — all tasks implemented
+    in-progress — implementation still ongoing
+```
 
 **Then route based on what's reviewable:**
 
@@ -39,10 +66,12 @@ Omit either section entirely if it has no entries.
 > *Output the next fenced block as a code block:*
 
 ```
+Review Overview
+
 No implemented plans found.
 
 The review phase requires at least one plan with an implementation.
-Please run /start-implementation first.
+Run /start-implementation first.
 ```
 
 **STOP.** Wait for user to acknowledge before ending.
@@ -52,7 +81,7 @@ Please run /start-implementation first.
 > *Output the next fenced block as a code block:*
 
 ```
-Auto-selecting: {topic} (only reviewable plan)
+Automatically proceeding with "{Topic}".
 Scope: single
 ```
 

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -74,7 +74,7 @@ The review phase requires at least one plan with an implementation.
 Run /start-implementation first.
 ```
 
-**STOP.** Wait for user to acknowledge before ending.
+**STOP.** Command ends.
 
 #### If single reviewable plan
 

--- a/skills/start-review/references/display-plans.md
+++ b/skills/start-review/references/display-plans.md
@@ -74,7 +74,7 @@ The review phase requires at least one plan with an implementation.
 Run /start-implementation first.
 ```
 
-**STOP.** Command ends.
+**STOP.**
 
 #### If single reviewable plan
 

--- a/skills/start-specification/references/confirm-continue.md
+++ b/skills/start-specification/references/confirm-continue.md
@@ -103,7 +103,7 @@ Understood. You can run /start-discussion to continue working on
 discussions, or re-run this command when ready.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 #### If groupings or specs menu
 

--- a/skills/start-specification/references/confirm-continue.md
+++ b/skills/start-specification/references/confirm-continue.md
@@ -103,7 +103,7 @@ Understood. You can run /start-discussion to continue working on
 discussions, or re-run this command when ready.
 ```
 
-Command ends.
+**STOP.**
 
 #### If groupings or specs menu
 

--- a/skills/start-specification/references/confirm-create.md
+++ b/skills/start-specification/references/confirm-create.md
@@ -80,7 +80,7 @@ Understood. You can run /start-discussion to continue working on
 discussions, or re-run this command when ready.
 ```
 
-Command ends.
+**STOP.**
 
 #### If groupings or specs menu
 

--- a/skills/start-specification/references/confirm-create.md
+++ b/skills/start-specification/references/confirm-create.md
@@ -80,7 +80,7 @@ Understood. You can run /start-discussion to continue working on
 discussions, or re-run this command when ready.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 #### If groupings or specs menu
 

--- a/skills/start-specification/references/confirm-refine.md
+++ b/skills/start-specification/references/confirm-refine.md
@@ -42,7 +42,7 @@ Understood. You can run /start-discussion to continue working on
 discussions, or re-run this command when ready.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 #### If groupings or specs menu
 

--- a/skills/start-specification/references/confirm-refine.md
+++ b/skills/start-specification/references/confirm-refine.md
@@ -42,7 +42,7 @@ Understood. You can run /start-discussion to continue working on
 discussions, or re-run this command when ready.
 ```
 
-Command ends.
+**STOP.**
 
 #### If groupings or specs menu
 

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -101,4 +101,4 @@ Understood. You can run /start-discussion to continue working on
 discussions, or re-run this command when ready.
 ```
 
-**Command ends.** Control returns to the user.
+**STOP.**

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -101,4 +101,4 @@ Understood. You can run /start-discussion to continue working on
 discussions, or re-run this command when ready.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -32,7 +32,7 @@ Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
 
-  · {discussion-name} (in-progress)
+  • {discussion-name}
 ```
 
 ### Cache-Aware Message

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -31,6 +31,7 @@ List all concluded discussions from discovery output.
 Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
+
   · {discussion-name} (in-progress)
 ```
 

--- a/skills/start-specification/references/display-blocks.md
+++ b/skills/start-specification/references/display-blocks.md
@@ -22,7 +22,7 @@ that specifications are built upon.
 Run /start-discussion to begin documenting technical decisions.
 ```
 
-**STOP.** Wait for user acknowledgment. Command ends here.
+**STOP.**
 
 ## If discussions exist but none concluded
 
@@ -44,4 +44,4 @@ Run /start-discussion to continue working on a discussion.
 
 List all in-progress discussions from discovery output.
 
-**STOP.** Wait for user acknowledgment. Command ends here.
+**STOP.**

--- a/skills/start-specification/references/display-blocks.md
+++ b/skills/start-specification/references/display-blocks.md
@@ -35,8 +35,8 @@ No concluded discussions found.
 
 The following discussions are still in progress:
 
-  · {discussion-name} (in-progress)
-  · {discussion-name} (in-progress)
+  • {discussion-name}
+  • {discussion-name}
 
 Specifications can only be created from concluded discussions.
 Run /start-discussion to continue working on a discussion.

--- a/skills/start-specification/references/display-blocks.md
+++ b/skills/start-specification/references/display-blocks.md
@@ -22,7 +22,7 @@ that specifications are built upon.
 Run /start-discussion to begin documenting technical decisions.
 ```
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.
 
 ## If discussions exist but none concluded
 
@@ -44,4 +44,4 @@ Run /start-discussion to continue working on a discussion.
 
 List all in-progress discussions from discovery output.
 
-**STOP.**
+**STOP.** Do not proceed — terminal condition.

--- a/skills/start-specification/references/display-blocks.md
+++ b/skills/start-specification/references/display-blocks.md
@@ -11,7 +11,7 @@ Two terminal paths — the command stops and cannot proceed.
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Phase
+Specification Overview
 
 No discussions found.
 
@@ -29,11 +29,12 @@ Run /start-discussion to begin documenting technical decisions.
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Phase
+Specification Overview
 
 No concluded discussions found.
 
 The following discussions are still in progress:
+
   · {discussion-name} (in-progress)
   · {discussion-name} (in-progress)
 

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -57,16 +57,13 @@ Specification Overview
 
 Recommended breakdown for specifications with their source discussions.
 
-1. {Grouping Name}
-   └─ Spec: {status} {(X of Y sources extracted) if applicable}
+1. {grouping_name:(titlecase)}
+   └─ Spec: @if(has_spec) {spec_status:[in-progress|concluded]} ({extraction_summary}) @else (no spec) @endif
    └─ Discussions:
-      ├─ {discussion-name} ({status})
-      └─ {discussion-name} ({status})
+      ├─ {discussion} ({status:[extracted|pending|ready|reopened]})
+      └─ ...
 
-2. {Grouping Name}
-   └─ Spec: none
-   └─ Discussions:
-      └─ {discussion-name} (ready)
+2. ...
 ```
 
 ### If in-progress discussions exist
@@ -97,7 +94,6 @@ Key:
     reopened  — was extracted but discussion has regressed to in-progress
 
   Spec status:
-    none        — no specification file exists yet
     in-progress — specification work is ongoing
     concluded   — specification is complete
 ```

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -77,6 +77,7 @@ Recommended breakdown for specifications with their source discussions.
 Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
+
   · {discussion-name} (in-progress)
 ```
 

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -138,8 +138,8 @@ After all grouping entries, append meta options:
 
 ```
 · · · · · · · · · · · ·
-1. {verb:[Start|Continue]} "{topic:(titlecase)}" — {description}
-2. ...
+1. Start "Auth Flow" — 2 ready discussions
+2. Continue "Data Model" — 1 source(s) pending extraction
 3. Unify all into single specification
    `All discussions are combined into one specification. Existing`
    `specifications are incorporated and superseded.`

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -138,8 +138,8 @@ After all grouping entries, append meta options:
 
 ```
 · · · · · · · · · · · ·
-1. Start "Auth Flow" — 2 ready discussions
-2. Continue "Data Model" — 1 source(s) pending extraction
+1. {verb:[Start|Continue]} "{topic:(titlecase)}" — {description}
+2. ...
 3. Unify all into single specification
    `All discussions are combined into one specification. Existing`
    `specifications are incorporated and superseded.`

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -152,6 +152,8 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
+Recreate with actual topics and states from discovery.
+
 Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 **STOP.** Wait for user response.

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -75,7 +75,7 @@ Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
 
-  · {discussion-name} (in-progress)
+  • {discussion-name}
 ```
 
 ### Key/Legend

--- a/skills/start-specification/references/display-single-grouped.md
+++ b/skills/start-specification/references/display-single-grouped.md
@@ -65,7 +65,7 @@ Key:
 > *Output the next fenced block as a code block:*
 
 ```
-Automatically proceeding with "{Spec Title Case Name}".
+Automatically proceeding with "{topic:(titlecase)}".
 ```
 
 Auto-proceed uses the spec name. Verb rule:

--- a/skills/start-specification/references/display-single-grouped.md
+++ b/skills/start-specification/references/display-single-grouped.md
@@ -22,8 +22,8 @@ Specification Overview
 
 Single concluded discussion found with existing multi-source specification.
 
-1. {Spec Title Case Name}
-   └─ Spec: {spec_status} ({X} of {Y} sources extracted)
+1. {topic:(titlecase)}
+   └─ Spec: {spec_status:[in-progress|concluded]} ({X} of {Y} sources extracted)
    └─ Discussions:
       ├─ {source-name} (extracted)
       └─ {source-name} (extracted, reopened)

--- a/skills/start-specification/references/display-single-grouped.md
+++ b/skills/start-specification/references/display-single-grouped.md
@@ -38,7 +38,7 @@ Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
 
-  · {discussion-name} (in-progress)
+  • {discussion-name}
 ```
 
 ### Key/Legend

--- a/skills/start-specification/references/display-single-grouped.md
+++ b/skills/start-specification/references/display-single-grouped.md
@@ -37,6 +37,7 @@ Single concluded discussion found with existing multi-source specification.
 Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
+
   · {discussion-name} (in-progress)
 ```
 

--- a/skills/start-specification/references/display-single-has-spec.md
+++ b/skills/start-specification/references/display-single-has-spec.md
@@ -31,6 +31,7 @@ Single concluded discussion found with existing specification.
 Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
+
   · {discussion-name} (in-progress)
 ```
 

--- a/skills/start-specification/references/display-single-has-spec.md
+++ b/skills/start-specification/references/display-single-has-spec.md
@@ -17,8 +17,8 @@ Specification Overview
 
 Single concluded discussion found with existing specification.
 
-1. {Title Case Name}
-   └─ Spec: {spec_status} ({X} of {Y} sources extracted)
+1. {topic:(titlecase)}
+   └─ Spec: {spec_status:[in-progress|concluded]} ({X} of {Y} sources extracted)
    └─ Discussions:
       └─ {discussion-name} (extracted)
 ```
@@ -48,7 +48,8 @@ Key:
     extracted — content has been incorporated into the specification
 
   Spec status:
-    {spec_status} — {in-progress: "specification work is ongoing" | concluded: "specification is complete"}
+    in-progress — specification work is ongoing
+    concluded   — specification is complete
 ```
 
 ## After Display

--- a/skills/start-specification/references/display-single-has-spec.md
+++ b/skills/start-specification/references/display-single-has-spec.md
@@ -32,7 +32,7 @@ Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
 
-  · {discussion-name} (in-progress)
+  • {discussion-name}
 ```
 
 ### Key/Legend

--- a/skills/start-specification/references/display-single-has-spec.md
+++ b/skills/start-specification/references/display-single-has-spec.md
@@ -56,7 +56,7 @@ Key:
 > *Output the next fenced block as a code block:*
 
 ```
-Automatically proceeding with "{Title Case Name}".
+Automatically proceeding with "{topic:(titlecase)}".
 ```
 
 Auto-proceed. Verb rule:

--- a/skills/start-specification/references/display-single-no-spec.md
+++ b/skills/start-specification/references/display-single-no-spec.md
@@ -29,6 +29,7 @@ Single concluded discussion found.
 Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
+
   · {discussion-name} (in-progress)
 ```
 

--- a/skills/start-specification/references/display-single-no-spec.md
+++ b/skills/start-specification/references/display-single-no-spec.md
@@ -15,8 +15,8 @@ Specification Overview
 
 Single concluded discussion found.
 
-1. {Title Case Name}
-   └─ Spec: none
+1. {topic:(titlecase)}
+   └─ Spec: (no spec)
    └─ Discussions:
       └─ {discussion-name} (ready)
 ```
@@ -44,9 +44,6 @@ Key:
 
   Discussion status:
     ready — concluded and available to be specified
-
-  Spec status:
-    none — no specification file exists yet
 ```
 
 ## After Display

--- a/skills/start-specification/references/display-single-no-spec.md
+++ b/skills/start-specification/references/display-single-no-spec.md
@@ -30,7 +30,7 @@ Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
 
-  · {discussion-name} (in-progress)
+  • {discussion-name}
 ```
 
 ### Key/Legend

--- a/skills/start-specification/references/display-single-no-spec.md
+++ b/skills/start-specification/references/display-single-no-spec.md
@@ -54,7 +54,7 @@ Key:
 > *Output the next fenced block as a code block:*
 
 ```
-Automatically proceeding with "{Title Case Name}".
+Automatically proceeding with "{topic:(titlecase)}".
 ```
 
 Auto-proceed with verb **"Creating"**.

--- a/skills/start-specification/references/display-single.md
+++ b/skills/start-specification/references/display-single.md
@@ -6,8 +6,6 @@
 
 Auto-proceed path — only one concluded discussion exists, so no selection menu is needed.
 
-Convert discussion filename to title case (`auth-flow` → `Auth Flow`).
-
 ## Route by Spec Coverage
 
 Check if a spec covers this discussion — either by name match (`has_individual_spec`) or by listing it in a spec's `sources` array.

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -58,7 +58,7 @@ Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
 
-  · {discussion-name} (in-progress)
+  • {discussion-name}
 ```
 
 ### Key/Legend

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -129,6 +129,8 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
+Recreate with actual topics and states from discovery.
+
 Menu descriptions are wrapped in backticks to visually distinguish them from the choice labels.
 
 **STOP.** Wait for user response.

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -122,8 +122,8 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
    `All discussions are analyzed for natural groupings. Existing`
    `specification names are preserved. You can provide guidance`
    `in the next step.`
-2. {verb:[Continue|Refine]} "{topic:(titlecase)}" — {description}
-3. ...
+2. Continue "Auth Flow" — in-progress
+3. Refine "Data Model" — concluded
 
 Select an option (enter number):
 · · · · · · · · · · · ·

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -122,8 +122,8 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
    `All discussions are analyzed for natural groupings. Existing`
    `specification names are preserved. You can provide guidance`
    `in the next step.`
-2. Continue "Auth Flow" — in-progress
-3. Refine "Data Model" — concluded
+2. {verb:[Continue|Refine]} "{topic:(titlecase)}" — {description}
+3. ...
 
 Select an option (enter number):
 · · · · · · · · · · · ·

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -57,6 +57,7 @@ Concluded discussions not in a specification:
 Discussions not ready for specification:
 These discussions are still in progress and must be concluded
 before they can be included in a specification.
+
   · {discussion-name} (in-progress)
 ```
 

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -23,8 +23,8 @@ For each non-superseded specification from discovery output, display as nested t
 > *Output the next fenced block as a code block:*
 
 ```
-1. {Spec Title Case Name}
-   └─ Spec: {status} ({X} of {Y} sources extracted)
+1. {topic:(titlecase)}
+   └─ Spec: {spec_status:[in-progress|concluded]} ({X} of {Y} sources extracted)
    └─ Discussions:
       ├─ {source-name} (extracted)
       └─ {source-name} (extracted)

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -36,27 +36,30 @@ For implementation, check `docs/workflow/implementation/{topic}/tracking.md` fil
 
 Research is project-wide exploration. From discussion onwards, work is organised by **topic** - different topics may be at different stages.
 
-> *Output the next fenced block as markdown (not a code block):*
+> *Output the next fenced block as a code block:*
 
 ```
-**Research:** 2 files (exploration.md, market-analysis.md)
+Workflow Overview
 
-| Topic        | Discussion | Spec | Plan | Implemented              |
-|--------------|------------|------|------|--------------------------|
-| auth-system  | ✓          | ✓    | ✓    | phase 2 (3/8 tasks done) |
-| payment-flow | ✓          | ✓    | -    | -                        |
-| notifications| ✓          | -    | -    | -                        |
+Research: 2 files (exploration.md, market-analysis.md)
+
+Topics:
+
+  Topic          Discussion   Spec         Plan         Implemented
+  auth-system    concluded    concluded    concluded    phase 2 (3/8 tasks done)
+  payment-flow   concluded    concluded    none         none
+  notifications  concluded    none         none         none
 ```
 
 Adapt based on what exists:
-- If a directory is empty or missing, show "Not started"
+- If a directory is empty or missing, show `none`
 - For planning, note the output format if specified in frontmatter
 - Match topics across phases by filename
 - For implementation, derive the Implemented column from tracking file data:
-  - No tracking file → `-`
+  - No tracking file → `none`
   - `status: not-started` → `not started`
   - `status: in-progress` → `phase {current_phase} ({n}/{total} tasks done)` — count `completed_tasks` for n; use total task count from `completed_tasks` + remaining if available, otherwise just show completed count
-  - `status: completed` → `✓`
+  - `status: completed` → `completed`
 
 ## Step 3: Suggest Next Steps
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -46,16 +46,16 @@ Research: {count} files ({filenames})
 Topics:
 
   Topic          Discussion   Spec         Plan         Implemented
-  {topic}        {status}     {status}     {status}     {impl_status}
+  {topic}        {discussion_status}   {spec_status}   {plan_status}   {impl_status}
   ...
 ```
 
 Adapt based on what exists:
-- If a directory is empty or missing, show `none`
+- If a directory is empty or missing, show `-`
 - For planning, note the output format if specified in frontmatter
 - Match topics across phases by filename
 - For implementation, derive the Implemented column from tracking file data:
-  - No tracking file → `none`
+  - No tracking file → `-`
   - `status: not-started` → `not started`
   - `status: in-progress` → `phase {current_phase} ({n}/{total} tasks done)` — count `completed_tasks` for n; use total task count from `completed_tasks` + remaining if available, otherwise just show completed count
   - `status: completed` → `completed`

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -36,18 +36,17 @@ For implementation, check `docs/workflow/implementation/{topic}/tracking.md` fil
 
 Research is project-wide exploration. From discussion onwards, work is organised by **topic** - different topics may be at different stages.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Workflow Overview
+**Workflow Overview**
 
-Research: {count} files ({filenames})
+**Research:** {count} files ({filenames})
 
-Topics:
-
-  Topic          Discussion   Spec         Plan         Implemented
-  {topic}        {discussion_status}   {spec_status}   {plan_status}   {impl_status}
-  ...
+| Topic | Discussion | Spec | Plan | Implemented |
+|-------|------------|------|------|-------------|
+| {topic} | {discussion_status} | {spec_status} | {plan_status} | {impl_status} |
+| ... | | | | |
 ```
 
 Adapt based on what exists:

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -41,14 +41,13 @@ Research is project-wide exploration. From discussion onwards, work is organised
 ```
 Workflow Overview
 
-Research: 2 files (exploration.md, market-analysis.md)
+Research: {count} files ({filenames})
 
 Topics:
 
   Topic          Discussion   Spec         Plan         Implemented
-  auth-system    concluded    concluded    concluded    phase 2 (3/8 tasks done)
-  payment-flow   concluded    concluded    none         none
-  notifications  concluded    none         none         none
+  {topic}        {status}     {status}     {status}     {impl_status}
+  ...
 ```
 
 Adapt based on what exists:

--- a/skills/view-plan/SKILL.md
+++ b/skills/view-plan/SKILL.md
@@ -38,8 +38,10 @@ Follow the reading reference to locate and read the actual plan content.
 
 Display a readable summary:
 
+> *Output the next fenced block as a code block:*
+
 ```
-## Plan: {topic}
+Plan: {topic}
 
 **Format:** {format}
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Added comprehensive "Display & Output Conventions" section covering tree structures, key/legends, menus, spacing rules, and all display patterns
- **Removed icons** (`✓`, `▶`, `+`, `>`) from all overview displays in favor of tree structures (`└─`, `├─`) with clear status terms
- **Standardized across 6 skills**: consistent `{Phase} Overview` titles, categorized key/legends with em dashes, verb-based menu labels (Create/Continue/Review/Start), parenthetical status terms, "not ready" blocks with explanatory lead-ins, and proper spacing between all display elements

### Skills updated
- `start-discussion` — tree structure for research topics, categorized key
- `start-planning` — tree structure, key/legend, verb-based menu
- `start-implementation` — tree structure, key/legend, verb-based menu
- `start-review` — tree structure, key/legend, removed icons
- `start-specification` — spacing fixes in 7 reference files, title normalization
- `status` — word-based status, code block rendering, title pattern

## Test plan

- [ ] Run `/start-specification` with various discussion states — verify tree display, key, spacing
- [ ] Run `/start-planning` with mixed spec states — verify tree, key, verb-based menu
- [ ] Run `/start-implementation` with mixed plan states — verify tree, key, "not ready" block
- [ ] Run `/start-review` with mixed implementation states — verify tree, key
- [ ] Run `/start-discussion` with research topics — verify tree structure, key format
- [ ] Run `/status` — verify word-based status terms, "Workflow Overview" title
- [ ] Verify no `✓`, `▶`, `+`, `>` icons appear in any overview display

🤖 Generated with [Claude Code](https://claude.com/claude-code)