### PR TITLE
fix: batch review dispatch and write findings to files

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,7 +18,8 @@
       "Bash(gh release list:*)",
       "Bash(git -C /Users/leeovery/Code/claude/claude-technical-workflows show:*)",
       "Bash(git -C /Users/leeovery/Code/claude/claude-technical-workflows log --oneline --format=\"%h %ad %s\" --date=short 4ce0a16..8e672cf -- skills/technical-implementation/ agents/implementation-*)",
-      "Bash(git -C /Users/leeovery/Code/claude/claude-technical-workflows log --oneline --format=\"%h %ad %s\" --date=short 8ad63e3^..4ce0a16 -- skills/technical-implementation/ agents/implementation-*)"
+      "Bash(git -C /Users/leeovery/Code/claude/claude-technical-workflows log --oneline --format=\"%h %ad %s\" --date=short 8ad63e3^..4ce0a16 -- skills/technical-implementation/ agents/implementation-*)",
+      "Bash(gh pr create:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,9 +16,6 @@
       "Bash(chmod:*)",
       "Bash(git log:*)",
       "Bash(gh release list:*)",
-      "Bash(git -C /Users/leeovery/Code/claude/claude-technical-workflows show:*)",
-      "Bash(git -C /Users/leeovery/Code/claude/claude-technical-workflows log --oneline --format=\"%h %ad %s\" --date=short 4ce0a16..8e672cf -- skills/technical-implementation/ agents/implementation-*)",
-      "Bash(git -C /Users/leeovery/Code/claude/claude-technical-workflows log --oneline --format=\"%h %ad %s\" --date=short 8ad63e3^..4ce0a16 -- skills/technical-implementation/ agents/implementation-*)",
       "Bash(gh pr create:*)"
     ],
     "deny": [],

--- a/agents/review-task-verifier.md
+++ b/agents/review-task-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: review-task-verifier
-description: Verifies a single plan task was implemented correctly. Checks implementation, tests, and code quality against the task's acceptance criteria and spec context. Invoked by technical-review to verify ALL plan tasks in PARALLEL.
-tools: Read, Glob, Grep
+description: Verifies a single plan task was implemented correctly. Checks implementation, tests, and code quality against the task's acceptance criteria and spec context. Writes structured findings to file, returns brief status to orchestrator.
+tools: Read, Write, Glob, Grep
 model: opus
 ---
 
@@ -17,6 +17,8 @@ You receive:
 3. **Plan path**: The full plan for additional context
 4. **Project skill paths**: Relevant `.claude/skills/` paths for framework conventions
 5. **Review checklist path**: Path to the review checklist (`skills/technical-review/references/review-checklist.md`) — read this for detailed verification criteria
+6. **Topic name**: The plan topic (used for output file path)
+7. **Task index**: Sequential number for this task (used for output file naming)
 
 ## Your Task
 
@@ -82,9 +84,9 @@ Review the implementation as a senior architect would:
 - **Security**: No obvious vulnerabilities (injection, exposure, etc.)
 - **Performance**: No obvious inefficiencies (N+1 queries, unnecessary loops, etc.)
 
-## Your Output
+## Output File Format
 
-Return a structured finding:
+Write to `docs/workflow/review/{topic}/qa-task-{index}.md`:
 
 ```
 TASK: [Task name/description]
@@ -120,11 +122,21 @@ NON-BLOCKING NOTES:
 - [Suggestions for improvement]
 ```
 
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+STATUS: Complete | Incomplete | Issues Found
+FINDINGS_COUNT: {N blocking issues}
+SUMMARY: {1 sentence}
+```
+
 ## Rules
 
-1. **One task only** - You verify exactly one plan task per invocation
-2. **Be thorough** - Check implementation, tests, AND quality
-3. **Be specific** - Include file paths and line numbers
-4. **Balanced test review** - Flag both under-testing AND over-testing
-5. **Report findings** - Don't fix anything, just report what you find
-6. **Fast and focused** - You're one of many running in parallel
+1. **One task only** — you verify exactly one plan task per invocation
+2. **Be thorough** — check implementation, tests, AND quality
+3. **Be specific** — include file paths and line numbers
+4. **Balanced test review** — flag both under-testing AND over-testing
+5. **Report findings** — don't fix anything, just report what you find
+6. **No git writes** — writing the output file is your only file write

--- a/skills/technical-review/references/invoke-task-verifiers.md
+++ b/skills/technical-review/references/invoke-task-verifiers.md
@@ -48,9 +48,9 @@ Dispatch verifiers in **batches of 5** via the Task tool.
 
 1. Group tasks into batches of 5
 2. For each batch:
-   a. Dispatch all agents in the batch in parallel
-   b. Wait for all agents in the batch to return
-   c. Record statuses
+   - Dispatch all agents in the batch in parallel
+   - Wait for all agents in the batch to return
+   - Record statuses
 3. After all batches complete, proceed to aggregation
 
 Each verifier receives:

--- a/skills/technical-review/references/invoke-task-verifiers.md
+++ b/skills/technical-review/references/invoke-task-verifiers.md
@@ -4,7 +4,7 @@
 
 ---
 
-This step dispatches `review-task-verifier` agents in parallel to verify ALL tasks across the selected plan(s). Each verifier independently checks one task for implementation, tests, and code quality.
+This step dispatches `review-task-verifier` agents in batches to verify ALL tasks across the selected plan(s). Each verifier independently checks one task for implementation, tests, and code quality, writing its full findings to a file and returning a brief status.
 
 ---
 
@@ -26,14 +26,32 @@ From each plan in scope, list every task across all phases:
 - Note each task's description
 - Note each task's acceptance criteria
 - Note expected micro acceptance (test name)
+- Assign each task a sequential **index** (1, 2, 3...) for file naming
 
 ---
 
-## Dispatch Verifiers
+## Create Output Directory
 
-Dispatch **one verifier per task, all in parallel** via the Task tool.
+For each topic in scope, ensure the review output directory exists:
+
+```bash
+mkdir -p docs/workflow/review/{topic}
+```
+
+---
+
+## Batch Dispatch
+
+Dispatch verifiers in **batches of 5** via the Task tool.
 
 - **Agent path**: `../../../agents/review-task-verifier.md`
+
+1. Group tasks into batches of 5
+2. For each batch:
+   a. Dispatch all agents in the batch in parallel
+   b. Wait for all agents in the batch to return
+   c. Record statuses
+3. After all batches complete, proceed to aggregation
 
 Each verifier receives:
 
@@ -42,63 +60,35 @@ Each verifier receives:
 3. **Plan path** — the full plan for phase context
 4. **Project skill paths** — from Step 2 discovery
 5. **Review checklist path** — `skills/technical-review/references/review-checklist.md`
+6. **Topic name** — for output file path
+7. **Task index** — sequential number for file naming (1, 2, 3...)
 
----
-
-## Wait for Completion
-
-**STOP.** Do not proceed until all verifiers have returned.
-
-Each verifier returns a structured finding. If any verifier fails (error, timeout), record the failure and continue — aggregate what's available.
+If any verifier fails (error, timeout), record the failure and continue — aggregate what's available.
 
 ---
 
 ## Expected Result
 
-Each verifier returns:
+Each verifier returns a brief status:
 
 ```
-TASK: [Task name/description]
-
-ACCEPTANCE CRITERIA: [List from plan]
-
 STATUS: Complete | Incomplete | Issues Found
-
-SPEC CONTEXT: [Brief summary of relevant spec context]
-
-IMPLEMENTATION:
-- Status: [Implemented/Missing/Partial/Drifted]
-- Location: [file:line references]
-- Notes: [Any concerns]
-
-TESTS:
-- Status: [Adequate/Under-tested/Over-tested/Missing]
-- Coverage: [What is/isn't tested]
-- Notes: [Specific issues]
-
-CODE QUALITY:
-- Project conventions: [Followed/Violations/N/A]
-- SOLID principles: [Good/Concerns]
-- Complexity: [Low/Acceptable/High]
-- Modern idioms: [Yes/Opportunities]
-- Readability: [Good/Concerns]
-- Issues: [Specific problems if any]
-
-BLOCKING ISSUES:
-- [List any issues that must be fixed]
-
-NON-BLOCKING NOTES:
-- [Suggestions for improvement]
+FINDINGS_COUNT: {N blocking issues}
+SUMMARY: {1 sentence}
 ```
+
+Full findings are written to `docs/workflow/review/{topic}/qa-task-{index}.md`.
 
 ---
 
 ## Aggregate Findings
 
-Once all verifiers have returned, synthesize their reports:
+Once all batches have completed:
 
-- Collect all tasks with `STATUS: Incomplete` or `STATUS: Issues Found` as blocking issues
-- Collect all test issues (under/over-tested)
-- Collect all code quality concerns
-- Include specific file:line references
-- Check overall plan completion (see [review-checklist.md](review-checklist.md) — Plan Completion Check)
+1. Read all `docs/workflow/review/{topic}/qa-task-*.md` files
+2. Synthesize findings from file contents:
+   - Collect all tasks with `STATUS: Incomplete` or `STATUS: Issues Found` as blocking issues
+   - Collect all test issues (under/over-tested)
+   - Collect all code quality concerns
+   - Include specific file:line references
+   - Check overall plan completion (see [review-checklist.md](review-checklist.md) — Plan Completion Check)


### PR DESCRIPTION
## Summary

- Dispatch review-task-verifier agents in batches of 5 instead of all at once, preventing context overflow on large plans
- Verifiers now write full structured findings to `docs/workflow/review/{topic}/qa-task-{index}.md` and return only brief status to orchestrator
- Orchestrator aggregates from files instead of in-context returns, matching the implementation-analysis pattern

## Test plan

- [ ] Run `/start-review` on a plan with 10+ tasks
- [ ] Confirm agents dispatch in batches of 5
- [ ] Confirm `qa-task-*.md` files are created in review directory
- [ ] Confirm orchestrator reads files for aggregation
- [ ] Confirm final review document is produced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)