### PR TITLE
refactor: relationship-aware status skill with discovery script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ skills/
   start-review/              # Begin review
     scripts/discovery.sh     #   Discovery script
   status/                    # Show workflow status and next steps
+    scripts/discovery.sh     #   Discovery script
   view-plan/                 # View plan tasks and progress
 
 .claude/skills/

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -2,6 +2,7 @@
 name: status
 description: "Show workflow status - what exists, where you are, and what to do next."
 disable-model-invocation: true
+allowed-tools: Bash(.claude/skills/status/scripts/discovery.sh)
 ---
 
 Show the current state of the workflow for this project.
@@ -12,81 +13,190 @@ Show the current state of the workflow for this project.
 
 Invoke the `/migrate` skill and assess its output.
 
-**If files were updated**: STOP and wait for the user to review the changes (e.g., via `git diff`) and confirm before proceeding to Step 1. Do not continue automatically.
+**If files were updated**: STOP and wait for the user to review the changes (e.g., via `git diff`) and confirm before proceeding to Step 1.
 
 **If no updates needed**: Proceed to Step 1.
 
 ---
 
-## Step 1: Scan Directories
+## Step 1: Discovery State
 
-Check for files in each workflow directory:
+!`.claude/skills/status/scripts/discovery.sh`
 
-```
-docs/workflow/research/
-docs/workflow/discussion/
-docs/workflow/specification/
-docs/workflow/planning/
-docs/workflow/implementation/
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
+
+```bash
+.claude/skills/status/scripts/discovery.sh
 ```
 
-For implementation, check `docs/workflow/implementation/{topic}/tracking.md` files and extract frontmatter fields: `status`, `current_phase`, `current_task`, `completed_tasks`, `completed_phases`.
+If YAML content is already displayed, it has been run on your behalf.
+
+Parse the discovery output. **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
+
+→ Proceed to **Step 2**.
+
+---
 
 ## Step 2: Present Status
 
-Research is project-wide exploration. From discussion onwards, work is organised by **topic** - different topics may be at different stages.
+Build the display from discovery data. Only show sections for phases that have content.
 
-> *Output the next fenced block as markdown (not a code block):*
+**CRITICAL**: Entities don't flow one-to-one across phases. Multiple discussions may combine into one specification, topic names may change between phases, and specs may be superseded. The display must make these relationships visible — primarily through the specification's `sources` array.
 
-```
-**Workflow Overview**
-
-**Research:** {count} files ({filenames})
-
-| Topic | Discussion | Spec | Plan | Implemented |
-|-------|------------|------|------|-------------|
-| {topic} | {discussion_status} | {spec_status} | {plan_status} | {impl_status} |
-| ... | | | | |
-```
-
-Adapt based on what exists:
-- If a directory is empty or missing, show `-`
-- For planning, note the output format if specified in frontmatter
-- Match topics across phases by filename
-- For implementation, derive the Implemented column from tracking file data:
-  - No tracking file → `-`
-  - `status: not-started` → `not started`
-  - `status: in-progress` → `phase {current_phase} ({n}/{total} tasks done)` — count `completed_tasks` for n; use total task count from `completed_tasks` + remaining if available, otherwise just show completed count
-  - `status: completed` → `completed`
-
-## Step 3: Suggest Next Steps
-
-Based on what exists, offer relevant options. Don't assume linear progression - topics may have dependencies on each other.
-
-**If nothing exists:**
-- "Start with `/start-research` to explore ideas, or `/start-discussion` if you already know what you're building."
-
-**If topics exist at various stages**, summarise options without being prescriptive:
-- Topics in discussion can move to specification
-- Topics with specs can move to planning
-- Topics with plans can move to implementation
-- Completed implementations can be reviewed
-
-Example: "auth-system has a plan ready. payment-flow needs a spec before planning. You might want to complete planning for related topics before implementing if there are dependencies."
-
-Keep suggestions brief - the user knows their project's dependencies better than we do.
-
-## Step 4: Mention Plan Viewing
-
-If planning files exist, let the user know they can view plan details:
+### 2a: Summary
 
 > *Output the next fenced block as a code block:*
 
 ```
-To view a plan's tasks and progress, use /view-plan
+Workflow Status
+
+  Research:       {count} file(s)
+  Discussion:     {count} ({concluded} concluded, {in_progress} in-progress)
+  Specification:  {active} active ({feature} feature, {crosscutting} cross-cutting)
+  Planning:       {count} ({concluded} concluded, {in_progress} in-progress)
+  Implementation: {count} ({completed} completed, {in_progress} in-progress)
 ```
+
+Only show lines for phases that have content. If a phase has zero items but a later phase has content, show the line as `(none)` to highlight the gap.
+
+#### If no workflow content exists at all
+
+> *Output the next fenced block as a code block:*
+
+```
+Workflow Status
+
+No workflow files found in docs/workflow/
+
+Start with /start-research to explore ideas,
+or /start-discussion if you already know what to build.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+### 2b: Specifications
+
+Show if any specifications exist. This is the most important section — it reveals many-to-one relationships between discussions and specifications.
+
+> *Output the next fenced block as a code block:*
+
+```
+Specifications
+
+  1. {name:(titlecase)} ({status})
+     └─ Sources: {src1} ({src1_status}), {src2} ({src2_status})
+
+  2. ...
+```
+
+**Rules:**
+
+- Each numbered item is an active (non-superseded) specification
+- Show `(cross-cutting)` after status for cross-cutting specs; omit type label for feature specs
+- Sources come from the spec's `sources` array — show all with their incorporation status
+- If a spec has no sources, show `└─ Sources: (none)`
+- Blank line between numbered items
+- If superseded specs exist, show after the numbered list:
+
+```
+  Superseded:
+    • {name} → {superseded_by}
+```
+
+### 2c: Plans
+
+Show if any plans exist.
+
+> *Output the next fenced block as a code block:*
+
+```
+Plans
+
+  1. {name:(titlecase)} ({status})
+     └─ Spec: {specification_name}
+
+  2. ...
+```
+
+**Rules:**
+
+- Map raw `planning` status to `in-progress` in the display
+- Show spec name without `.md` extension
+- If `has_unresolved_deps`, add line: `└─ Blocked: {dep_topic}:{dep_task_id} ({dep_state})`
+
+### 2d: Implementation
+
+Show if any implementations exist.
+
+> *Output the next fenced block as a code block:*
+
+```
+Implementation
+
+  1. {topic:(titlecase)} ({status})
+     └─ Phase {current_phase}, {completed_tasks}/{total_tasks} tasks done
+
+  2. ...
+```
+
+**Rules:**
+
+- `not-started` → `└─ Not started`
+- `in-progress` → phase and task progress; if `total_tasks` is 0, show `{completed_tasks} tasks done` without denominator
+- `completed` → `└─ Complete`
+
+### 2e: Unlinked Discussions
+
+Derive which discussions are NOT referenced in any active (non-superseded) specification's `sources` array. Show only if unlinked discussions exist.
+
+> *Output the next fenced block as a code block:*
+
+```
+Discussions not yet in a specification:
+
+  • {name} ({status})
+```
+
+### 2f: Key
+
+Show if the display uses statuses that benefit from explanation. Only include statuses actually shown. No `---` separator before this section.
+
+> *Output the next fenced block as a code block:*
+
+```
+Key:
+
+  Status:
+    in-progress — work is ongoing
+    concluded   — complete, ready for next step
+    superseded  — replaced by another specification
+
+  Spec type:
+    cross-cutting — architectural policy, not directly plannable
+```
+
+Omit categories with no entries.
+
+---
+
+## Step 3: Suggest Next Steps
+
+Based on gaps in the workflow, briefly suggest 2-3 most relevant actions:
+
+- Concluded discussions not in any spec → `/start-specification`
+- In-progress specs → finish with `/start-specification`
+- Concluded feature specs without plans → `/start-planning`
+- Concluded plans not yet implemented → `/start-implementation`
+- Completed implementations → `/start-review`
+
+If plans exist, mention `/view-plan` for detailed plan viewing.
+
+Keep suggestions brief — the user knows their project better than we do.
 
 ## Notes
 
-- Keep output concise - this is a quick status check
-- Use tables for scannable information
+- Keep output scannable — this is a status check, not a deep analysis
+- Discussions may appear in multiple specifications' sources
+- A discussion not appearing in any active spec's sources is "unlinked"
+- Research files are project-wide, not topic-specific
+- Topic names may differ across phases (e.g., discussions "auth-flow" and "session-mgmt" may combine into specification "auth-system")

--- a/skills/status/scripts/discovery.sh
+++ b/skills/status/scripts/discovery.sh
@@ -1,0 +1,420 @@
+#!/bin/bash
+#
+# Discovers the full workflow state across all phases
+# for the /status command.
+#
+# Outputs structured YAML that the command can consume directly.
+#
+
+set -eo pipefail
+
+RESEARCH_DIR="docs/workflow/research"
+DISCUSSION_DIR="docs/workflow/discussion"
+SPEC_DIR="docs/workflow/specification"
+PLAN_DIR="docs/workflow/planning"
+IMPL_DIR="docs/workflow/implementation"
+
+# Helper: Extract a frontmatter field value from a file
+# Usage: extract_field <file> <field_name>
+extract_field() {
+    local file="$1"
+    local field="$2"
+    local value=""
+
+    if head -1 "$file" 2>/dev/null | grep -q "^---$"; then
+        value=$(sed -n '2,/^---$/p' "$file" 2>/dev/null | \
+            grep -i -m1 "^${field}:" | \
+            sed -E "s/^${field}:[[:space:]]*//i" || true)
+    fi
+
+    echo "$value"
+}
+
+# Helper: Extract frontmatter content (between first pair of --- delimiters)
+extract_frontmatter() {
+    local file="$1"
+    awk 'BEGIN{c=0} /^---$/{c++; if(c==2) exit; next} c==1{print}' "$file" 2>/dev/null
+}
+
+# Helper: Extract sources from specification frontmatter
+# Outputs: name|status per line (object format only; legacy converted by migration 004)
+extract_sources() {
+    local file="$1"
+    local in_sources=false
+    local current_name=""
+    local current_status=""
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^sources: ]]; then
+            in_sources=true
+            continue
+        fi
+
+        if $in_sources && [[ "$line" =~ ^[a-z_]+: ]] && [[ ! "$line" =~ ^[[:space:]] ]]; then
+            if [ -n "$current_name" ]; then
+                echo "${current_name}|${current_status:-incorporated}"
+            fi
+            break
+        fi
+
+        if $in_sources; then
+            if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*name:[[:space:]]*(.+)$ ]]; then
+                if [ -n "$current_name" ]; then
+                    echo "${current_name}|${current_status:-incorporated}"
+                fi
+                current_name="${BASH_REMATCH[1]}"
+                current_name=$(echo "$current_name" | sed 's/^"//' | sed 's/"$//' | xargs)
+                current_status=""
+            elif [[ "$line" =~ ^[[:space:]]*status:[[:space:]]*(.+)$ ]]; then
+                current_status="${BASH_REMATCH[1]}"
+                current_status=$(echo "$current_status" | sed 's/^"//' | sed 's/"$//' | xargs)
+            fi
+        fi
+    done < <(extract_frontmatter "$file")
+
+    if [ -n "$current_name" ]; then
+        echo "${current_name}|${current_status:-incorporated}"
+    fi
+}
+
+# Helper: Extract external_dependencies from plan frontmatter
+# Outputs: topic|state|task_id per line
+extract_external_deps() {
+    local file="$1"
+    local frontmatter
+    frontmatter=$(extract_frontmatter "$file")
+
+    if ! echo "$frontmatter" | grep -q "^external_dependencies:" 2>/dev/null; then
+        return 0
+    fi
+
+    if echo "$frontmatter" | grep -q "^external_dependencies:[[:space:]]*\[\]" 2>/dev/null; then
+        return 0
+    fi
+
+    echo "$frontmatter" | awk '
+/^external_dependencies:/ { in_block=1; next }
+in_block && /^[a-z_]+:/ && !/^[[:space:]]/ { exit }
+in_block && /^[[:space:]]*- topic:/ {
+    if (topic != "") print topic "|" state "|" task_id
+    line=$0; gsub(/^[[:space:]]*- topic:[[:space:]]*/, "", line)
+    topic=line; state=""; task_id=""
+    next
+}
+in_block && /^[[:space:]]*state:/ {
+    line=$0; gsub(/^[[:space:]]*state:[[:space:]]*/, "", line)
+    state=line; next
+}
+in_block && /^[[:space:]]*task_id:/ {
+    line=$0; gsub(/^[[:space:]]*task_id:[[:space:]]*/, "", line)
+    task_id=line; next
+}
+END { if (topic != "") print topic "|" state "|" task_id }
+'
+}
+
+# Helper: Count completed tasks from implementation tracking
+count_completed_tasks() {
+    local file="$1"
+    local frontmatter
+    frontmatter=$(extract_frontmatter "$file")
+
+    if echo "$frontmatter" | grep -q "^completed_tasks:[[:space:]]*\[\]" 2>/dev/null; then
+        echo 0
+        return
+    fi
+
+    local count
+    count=$(echo "$frontmatter" | awk '
+/^completed_tasks:/ { in_block=1; next }
+in_block && /^[a-z_]+:/ { exit }
+in_block && /^[[:space:]]*-[[:space:]]/ { c++ }
+END { print c+0 }
+')
+    echo "$count"
+}
+
+# Helper: Count completed phases from implementation tracking
+count_completed_phases() {
+    local file="$1"
+    local frontmatter
+    frontmatter=$(extract_frontmatter "$file")
+
+    # Handle inline array format: [1, 2, 3]
+    local inline
+    inline=$(echo "$frontmatter" | grep "^completed_phases:" | sed 's/^completed_phases:[[:space:]]*//' || true)
+    if echo "$inline" | grep -q '^\['; then
+        local items
+        items=$(echo "$inline" | tr -d '[]' | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$')
+        if [ -n "$items" ]; then
+            echo "$items" | wc -l | tr -d ' '
+        else
+            echo 0
+        fi
+        return
+    fi
+
+    if echo "$frontmatter" | grep -q "^completed_phases:[[:space:]]*\[\]" 2>/dev/null; then
+        echo 0
+        return
+    fi
+
+    local count
+    count=$(echo "$frontmatter" | awk '
+/^completed_phases:/ { in_block=1; next }
+in_block && /^[a-z_]+:/ { exit }
+in_block && /^[[:space:]]*-[[:space:]]/ { c++ }
+END { print c+0 }
+')
+    echo "$count"
+}
+
+
+# Start YAML output
+echo "# Workflow Status Discovery"
+echo "# Generated: $(date -Iseconds)"
+echo ""
+
+#
+# RESEARCH
+#
+echo "research:"
+
+research_count=0
+if [ -d "$RESEARCH_DIR" ] && [ -n "$(ls -A "$RESEARCH_DIR" 2>/dev/null)" ]; then
+    echo "  exists: true"
+    echo "  files:"
+    for file in "$RESEARCH_DIR"/*; do
+        [ -f "$file" ] || continue
+        name=$(basename "$file" .md)
+        echo "    - \"$name\""
+        research_count=$((research_count + 1))
+    done
+    echo "  count: $research_count"
+else
+    echo "  exists: false"
+    echo "  files: []"
+    echo "  count: 0"
+fi
+
+echo ""
+
+#
+# DISCUSSIONS
+#
+echo "discussions:"
+
+disc_count=0
+disc_concluded=0
+disc_in_progress=0
+
+if [ -d "$DISCUSSION_DIR" ] && [ -n "$(ls -A "$DISCUSSION_DIR" 2>/dev/null)" ]; then
+    echo "  exists: true"
+    echo "  files:"
+    for file in "$DISCUSSION_DIR"/*.md; do
+        [ -f "$file" ] || continue
+        name=$(basename "$file" .md)
+        status=$(extract_field "$file" "status")
+        status=${status:-"unknown"}
+
+        echo "    - name: \"$name\""
+        echo "      status: \"$status\""
+
+        disc_count=$((disc_count + 1))
+        [ "$status" = "concluded" ] && disc_concluded=$((disc_concluded + 1))
+        [ "$status" = "in-progress" ] && disc_in_progress=$((disc_in_progress + 1))
+    done
+    echo "  count: $disc_count"
+    echo "  concluded: $disc_concluded"
+    echo "  in_progress: $disc_in_progress"
+else
+    echo "  exists: false"
+    echo "  files: []"
+    echo "  count: 0"
+    echo "  concluded: 0"
+    echo "  in_progress: 0"
+fi
+
+echo ""
+
+#
+# SPECIFICATIONS
+#
+echo "specifications:"
+
+spec_count=0
+spec_active=0
+spec_superseded=0
+spec_feature=0
+spec_crosscutting=0
+
+if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
+    echo "  exists: true"
+    echo "  files:"
+    for file in "$SPEC_DIR"/*.md; do
+        [ -f "$file" ] || continue
+        name=$(basename "$file" .md)
+        status=$(extract_field "$file" "status")
+        status=${status:-"in-progress"}
+        spec_type=$(extract_field "$file" "type")
+        spec_type=${spec_type:-"feature"}
+        superseded_by=$(extract_field "$file" "superseded_by")
+
+        echo "    - name: \"$name\""
+        echo "      status: \"$status\""
+        echo "      type: \"$spec_type\""
+        [ -n "$superseded_by" ] && echo "      superseded_by: \"$superseded_by\""
+
+        # Sources
+        sources_output=$(extract_sources "$file")
+        if [ -n "$sources_output" ]; then
+            echo "      sources:"
+            while IFS='|' read -r src_name src_status; do
+                [ -z "$src_name" ] && continue
+                echo "        - name: \"$src_name\""
+                echo "          status: \"$src_status\""
+            done <<< "$sources_output"
+        else
+            echo "      sources: []"
+        fi
+
+        spec_count=$((spec_count + 1))
+        if [ "$status" = "superseded" ]; then
+            spec_superseded=$((spec_superseded + 1))
+        else
+            spec_active=$((spec_active + 1))
+            [ "$spec_type" = "cross-cutting" ] && spec_crosscutting=$((spec_crosscutting + 1))
+            [ "$spec_type" != "cross-cutting" ] && spec_feature=$((spec_feature + 1))
+        fi
+    done
+    echo "  count: $spec_count"
+    echo "  active: $spec_active"
+    echo "  superseded: $spec_superseded"
+    echo "  feature: $spec_feature"
+    echo "  crosscutting: $spec_crosscutting"
+else
+    echo "  exists: false"
+    echo "  files: []"
+    echo "  count: 0"
+    echo "  active: 0"
+    echo "  superseded: 0"
+    echo "  feature: 0"
+    echo "  crosscutting: 0"
+fi
+
+echo ""
+
+#
+# PLANS
+#
+echo "plans:"
+
+plan_count=0
+plan_concluded=0
+plan_in_progress=0
+
+if [ -d "$PLAN_DIR" ] && [ -n "$(ls -A "$PLAN_DIR" 2>/dev/null)" ]; then
+    echo "  exists: true"
+    echo "  files:"
+    for file in "$PLAN_DIR"/*.md; do
+        [ -f "$file" ] || continue
+        name=$(basename "$file" .md)
+        status=$(extract_field "$file" "status")
+        status=${status:-"unknown"}
+        format=$(extract_field "$file" "format")
+        format=${format:-"unknown"}
+        specification=$(extract_field "$file" "specification")
+        specification=${specification:-"${name}.md"}
+
+        echo "    - name: \"$name\""
+        echo "      status: \"$status\""
+        echo "      format: \"$format\""
+        echo "      specification: \"$specification\""
+
+        # External dependencies
+        deps_output=$(extract_external_deps "$file")
+        has_unresolved="false"
+        if [ -n "$deps_output" ]; then
+            echo "      external_deps:"
+            while IFS='|' read -r dep_topic dep_state dep_task_id; do
+                [ -z "$dep_topic" ] && continue
+                echo "        - topic: \"$dep_topic\""
+                echo "          state: \"$dep_state\""
+                [ -n "$dep_task_id" ] && echo "          task_id: \"$dep_task_id\""
+                [ "$dep_state" = "unresolved" ] && has_unresolved="true"
+            done <<< "$deps_output"
+        else
+            echo "      external_deps: []"
+        fi
+        echo "      has_unresolved_deps: $has_unresolved"
+
+        plan_count=$((plan_count + 1))
+        [ "$status" = "concluded" ] && plan_concluded=$((plan_concluded + 1))
+        { [ "$status" = "planning" ] || [ "$status" = "in-progress" ]; } && plan_in_progress=$((plan_in_progress + 1))
+    done
+    echo "  count: $plan_count"
+    echo "  concluded: $plan_concluded"
+    echo "  in_progress: $plan_in_progress"
+else
+    echo "  exists: false"
+    echo "  files: []"
+    echo "  count: 0"
+    echo "  concluded: 0"
+    echo "  in_progress: 0"
+fi
+
+echo ""
+
+#
+# IMPLEMENTATION
+#
+echo "implementation:"
+
+impl_count=0
+impl_completed=0
+impl_in_progress=0
+
+if [ -d "$IMPL_DIR" ] && [ -n "$(ls -A "$IMPL_DIR" 2>/dev/null)" ]; then
+    echo "  exists: true"
+    echo "  files:"
+    for file in "$IMPL_DIR"/*/tracking.md; do
+        [ -f "$file" ] || continue
+        topic=$(basename "$(dirname "$file")")
+        status=$(extract_field "$file" "status")
+        status=${status:-"unknown"}
+        current_phase=$(extract_field "$file" "current_phase")
+
+        completed_tasks=$(count_completed_tasks "$file")
+        completed_phases=$(count_completed_phases "$file")
+
+        # Count total tasks from plan directory (local-markdown format)
+        total_tasks=0
+        plan_file="$PLAN_DIR/${topic}.md"
+        if [ -f "$plan_file" ]; then
+            plan_format=$(extract_field "$plan_file" "format")
+            if [ "$plan_format" = "local-markdown" ] && [ -d "$PLAN_DIR/${topic}" ]; then
+                total_tasks=$(ls -1 "$PLAN_DIR/${topic}/"*.md 2>/dev/null | wc -l | tr -d ' ')
+            fi
+        fi
+
+        echo "    - topic: \"$topic\""
+        echo "      status: \"$status\""
+        [ -n "$current_phase" ] && [ "$current_phase" != "~" ] && echo "      current_phase: $current_phase"
+        echo "      completed_tasks: $completed_tasks"
+        echo "      completed_phases: $completed_phases"
+        echo "      total_tasks: $total_tasks"
+
+        impl_count=$((impl_count + 1))
+        [ "$status" = "completed" ] && impl_completed=$((impl_completed + 1))
+        [ "$status" = "in-progress" ] && impl_in_progress=$((impl_in_progress + 1))
+    done
+    echo "  count: $impl_count"
+    echo "  completed: $impl_completed"
+    echo "  in_progress: $impl_in_progress"
+else
+    echo "  exists: false"
+    echo "  files: []"
+    echo "  count: 0"
+    echo "  completed: 0"
+    echo "  in_progress: 0"
+fi

--- a/tests/scripts/test-discovery-for-status.sh
+++ b/tests/scripts/test-discovery-for-status.sh
@@ -1,0 +1,867 @@
+#!/bin/bash
+#
+# Tests the discovery script for /status command against various workflow states.
+# Creates temporary fixtures and validates YAML output.
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISCOVERY_SCRIPT="$SCRIPT_DIR/../../skills/status/scripts/discovery.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Helper functions
+#
+
+setup_fixture() {
+    # Clean up from previous test
+    rm -rf "$TEST_DIR/docs"
+    mkdir -p "$TEST_DIR/docs/workflow"
+}
+
+run_discovery() {
+    cd "$TEST_DIR"
+    bash "$DISCOVERY_SCRIPT" 2>/dev/null
+}
+
+assert_contains() {
+    local output="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$output" | grep -q "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local output="$1"
+    local pattern="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if ! echo "$output" | grep -q "$pattern"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Did not expect to find: $pattern"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+#
+# Test: Empty state (no workflow files)
+#
+test_empty_state() {
+    echo -e "${YELLOW}Test: Empty state (no workflow files)${NC}"
+    setup_fixture
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'research:' "Has research section"
+    assert_contains "$output" 'discussions:' "Has discussions section"
+    assert_contains "$output" 'specifications:' "Has specifications section"
+    assert_contains "$output" 'plans:' "Has plans section"
+    assert_contains "$output" 'implementation:' "Has implementation section"
+    assert_contains "$output" 'count: 0' "Counts are zero"
+
+    echo ""
+}
+
+#
+# Test: Research files detected
+#
+test_research_files() {
+    echo -e "${YELLOW}Test: Research files detected${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/research"
+    cat > "$TEST_DIR/docs/workflow/research/market-analysis.md" << 'EOF'
+---
+topic: market-analysis
+---
+
+# Market Analysis
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/research/tech-feasibility.md" << 'EOF'
+---
+topic: tech-feasibility
+---
+
+# Tech Feasibility
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'exists: true' "Research exists"
+    assert_contains "$output" '"market-analysis"' "Found market-analysis"
+    assert_contains "$output" '"tech-feasibility"' "Found tech-feasibility"
+    assert_contains "$output" 'count: 2' "Research count is 2"
+
+    echo ""
+}
+
+#
+# Test: Discussion status detection
+#
+test_discussions() {
+    echo -e "${YELLOW}Test: Discussion status detection${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+---
+topic: auth-flow
+status: concluded
+---
+
+# Auth Flow
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/discussion/caching.md" << 'EOF'
+---
+topic: caching
+status: in-progress
+---
+
+# Caching
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'name: "auth-flow"' "Found auth-flow"
+    assert_contains "$output" 'name: "caching"' "Found caching"
+    assert_contains "$output" 'count: 2' "Discussion count is 2"
+    assert_contains "$output" 'concluded: 1' "Concluded count is 1"
+    assert_contains "$output" 'in_progress: 1' "In-progress count is 1"
+
+    echo ""
+}
+
+#
+# Test: Specification with multiple sources (many-to-one)
+#
+test_spec_multiple_sources() {
+    echo -e "${YELLOW}Test: Specification with multiple sources (many-to-one)${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification"
+    cat > "$TEST_DIR/docs/workflow/specification/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+type: feature
+sources:
+  - name: auth-flow
+    status: incorporated
+  - name: session-management
+    status: incorporated
+---
+
+# Auth System Specification
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'name: "auth-system"' "Found auth-system spec"
+    assert_contains "$output" 'status: "concluded"' "Status is concluded"
+    assert_contains "$output" 'type: "feature"' "Type is feature"
+    assert_contains "$output" 'name: "auth-flow"' "Source auth-flow found"
+    assert_contains "$output" 'name: "session-management"' "Source session-management found"
+    assert_contains "$output" 'status: "incorporated"' "Sources marked incorporated"
+    assert_contains "$output" 'feature: 1' "Feature count is 1"
+
+    echo ""
+}
+
+#
+# Test: Specification with pending source
+#
+test_spec_pending_source() {
+    echo -e "${YELLOW}Test: Specification with pending source${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification"
+    cat > "$TEST_DIR/docs/workflow/specification/billing.md" << 'EOF'
+---
+topic: billing
+status: in-progress
+type: feature
+sources:
+  - name: payment-processing
+    status: incorporated
+  - name: rate-limiting
+    status: pending
+---
+
+# Billing Specification
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'status: "pending"' "Pending source detected"
+    assert_contains "$output" 'status: "incorporated"' "Incorporated source detected"
+
+    echo ""
+}
+
+#
+# Test: Cross-cutting specification
+#
+test_crosscutting_spec() {
+    echo -e "${YELLOW}Test: Cross-cutting specification${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification"
+    cat > "$TEST_DIR/docs/workflow/specification/caching-policy.md" << 'EOF'
+---
+topic: caching-policy
+status: concluded
+type: cross-cutting
+---
+
+# Caching Policy
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'type: "cross-cutting"' "Type is cross-cutting"
+    assert_contains "$output" 'crosscutting: 1' "Cross-cutting count is 1"
+    assert_contains "$output" 'feature: 0' "Feature count is 0"
+
+    echo ""
+}
+
+#
+# Test: Superseded specification
+#
+test_superseded_spec() {
+    echo -e "${YELLOW}Test: Superseded specification${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification"
+    cat > "$TEST_DIR/docs/workflow/specification/old-auth.md" << 'EOF'
+---
+topic: old-auth
+status: superseded
+type: feature
+superseded_by: auth-system
+---
+
+# Old Auth Specification
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/specification/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+type: feature
+---
+
+# Auth System Specification
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'superseded_by: "auth-system"' "Superseded_by field extracted"
+    assert_contains "$output" 'superseded: 1' "Superseded count is 1"
+    assert_contains "$output" 'active: 1' "Active count is 1"
+    assert_contains "$output" 'count: 2' "Total count includes superseded"
+
+    echo ""
+}
+
+#
+# Test: Specification with no sources
+#
+test_spec_no_sources() {
+    echo -e "${YELLOW}Test: Specification with no sources${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification"
+    cat > "$TEST_DIR/docs/workflow/specification/quick-feature.md" << 'EOF'
+---
+topic: quick-feature
+status: concluded
+type: feature
+---
+
+# Quick Feature
+
+Created via /start-feature with no discussions.
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'sources: \[\]' "Empty sources array"
+
+    echo ""
+}
+
+#
+# Test: Plan with external dependencies
+#
+test_plan_with_deps() {
+    echo -e "${YELLOW}Test: Plan with external dependencies${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/planning"
+    cat > "$TEST_DIR/docs/workflow/planning/billing.md" << 'EOF'
+---
+topic: billing
+status: concluded
+format: local-markdown
+specification: billing.md
+external_dependencies:
+  - topic: auth-system
+    description: User authentication
+    state: unresolved
+---
+
+# Billing Plan
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'has_unresolved_deps: true' "Unresolved deps detected"
+    assert_contains "$output" 'topic: "auth-system"' "Dep topic extracted"
+    assert_contains "$output" 'state: "unresolved"' "Dep state extracted"
+
+    echo ""
+}
+
+#
+# Test: Plan with resolved dependencies
+#
+test_plan_resolved_deps() {
+    echo -e "${YELLOW}Test: Plan with resolved dependencies${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/planning"
+    cat > "$TEST_DIR/docs/workflow/planning/billing.md" << 'EOF'
+---
+topic: billing
+status: concluded
+format: local-markdown
+specification: billing.md
+external_dependencies:
+  - topic: auth-system
+    description: User authentication
+    state: resolved
+    task_id: auth-system-1-3
+---
+
+# Billing Plan
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'has_unresolved_deps: false' "No unresolved deps"
+    assert_contains "$output" 'state: "resolved"' "Resolved state extracted"
+    assert_contains "$output" 'task_id: "auth-system-1-3"' "Task ID extracted"
+
+    echo ""
+}
+
+#
+# Test: Plan with empty dependencies array
+#
+test_plan_empty_deps() {
+    echo -e "${YELLOW}Test: Plan with empty dependencies array${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/planning"
+    cat > "$TEST_DIR/docs/workflow/planning/simple.md" << 'EOF'
+---
+topic: simple
+status: concluded
+format: local-markdown
+specification: simple.md
+external_dependencies: []
+---
+
+# Simple Plan
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'external_deps:' "External deps section exists"
+    assert_contains "$output" 'has_unresolved_deps: false' "No unresolved deps"
+
+    echo ""
+}
+
+#
+# Test: Implementation tracking
+#
+test_implementation_tracking() {
+    echo -e "${YELLOW}Test: Implementation tracking${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+
+    # Create plan with tasks
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+format: local-markdown
+---
+
+# Auth System Plan
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/auth-system-1-1.md" << 'EOF'
+---
+task_id: auth-system-1-1
+---
+Task 1
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/auth-system-1-2.md" << 'EOF'
+---
+task_id: auth-system-1-2
+---
+Task 2
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/auth-system-1-3.md" << 'EOF'
+---
+task_id: auth-system-1-3
+---
+Task 3
+EOF
+
+    # Create tracking file
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+---
+status: in-progress
+current_phase: 1
+current_task: auth-system-1-2
+completed_tasks:
+  - auth-system-1-1
+completed_phases: []
+---
+
+# Auth System Implementation
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'topic: "auth-system"' "Implementation topic found"
+    assert_contains "$output" 'status: "in-progress"' "Status is in-progress"
+    assert_contains "$output" 'current_phase: 1' "Current phase is 1"
+    assert_contains "$output" 'completed_tasks: 1' "1 completed task"
+    assert_contains "$output" 'total_tasks: 3' "3 total tasks from plan"
+    assert_contains "$output" 'in_progress: 1' "1 in-progress implementation"
+
+    echo ""
+}
+
+#
+# Test: Completed implementation
+#
+test_completed_implementation() {
+    echo -e "${YELLOW}Test: Completed implementation${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+format: local-markdown
+---
+
+# Auth System Plan
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/auth-system-1-1.md" << 'EOF'
+---
+task_id: auth-system-1-1
+---
+Task 1
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+---
+status: completed
+current_phase: ~
+current_task: ~
+completed_tasks:
+  - auth-system-1-1
+completed_phases:
+  - 1
+---
+
+# Auth System Implementation
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'status: "completed"' "Status is completed"
+    assert_contains "$output" 'completed_tasks: 1' "1 completed task"
+    assert_contains "$output" 'completed_phases: 1' "1 completed phase"
+    assert_contains "$output" 'completed: 1' "Completed count is 1"
+
+    echo ""
+}
+
+#
+# Test: Implementation with inline completed_phases format
+#
+test_implementation_inline_phases() {
+    echo -e "${YELLOW}Test: Implementation with inline completed_phases format${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+---
+status: in-progress
+current_phase: 3
+completed_tasks:
+  - auth-system-1-1
+  - auth-system-1-2
+  - auth-system-2-1
+completed_phases: [1, 2]
+---
+
+# Auth System Implementation
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'completed_tasks: 3' "3 completed tasks"
+    assert_contains "$output" 'completed_phases: 2' "2 completed phases (inline format)"
+
+    echo ""
+}
+
+#
+# Test: Full workflow state across all phases
+#
+test_full_workflow() {
+    echo -e "${YELLOW}Test: Full workflow state across all phases${NC}"
+    setup_fixture
+
+    # Research
+    mkdir -p "$TEST_DIR/docs/workflow/research"
+    cat > "$TEST_DIR/docs/workflow/research/market-analysis.md" << 'EOF'
+---
+topic: market-analysis
+---
+Research
+EOF
+
+    # Discussions (3 total: 2 concluded into 1 spec, 1 in-progress)
+    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+---
+topic: auth-flow
+status: concluded
+---
+Discussion
+EOF
+    cat > "$TEST_DIR/docs/workflow/discussion/session-mgmt.md" << 'EOF'
+---
+topic: session-mgmt
+status: concluded
+---
+Discussion
+EOF
+    cat > "$TEST_DIR/docs/workflow/discussion/caching.md" << 'EOF'
+---
+topic: caching
+status: in-progress
+---
+Discussion
+EOF
+
+    # Specifications (1 feature with 2 sources, 1 cross-cutting)
+    mkdir -p "$TEST_DIR/docs/workflow/specification"
+    cat > "$TEST_DIR/docs/workflow/specification/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+type: feature
+sources:
+  - name: auth-flow
+    status: incorporated
+  - name: session-mgmt
+    status: incorporated
+---
+Spec
+EOF
+    cat > "$TEST_DIR/docs/workflow/specification/caching-policy.md" << 'EOF'
+---
+topic: caching-policy
+status: in-progress
+type: cross-cutting
+sources:
+  - name: caching
+    status: pending
+---
+Spec
+EOF
+
+    # Plan
+    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+format: local-markdown
+specification: auth-system.md
+external_dependencies: []
+---
+Plan
+EOF
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/auth-system-1-1.md" << 'EOF'
+---
+task_id: auth-system-1-1
+---
+Task
+EOF
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/auth-system-1-2.md" << 'EOF'
+---
+task_id: auth-system-1-2
+---
+Task
+EOF
+
+    # Implementation
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+---
+status: in-progress
+current_phase: 1
+current_task: auth-system-1-2
+completed_tasks:
+  - auth-system-1-1
+completed_phases: []
+---
+Tracking
+EOF
+
+    local output=$(run_discovery)
+
+    # Research
+    assert_contains "$output" '"market-analysis"' "Research file found"
+
+    # Discussions
+    assert_contains "$output" 'concluded: 2' "2 concluded discussions"
+    assert_contains "$output" 'in_progress: 1' "1 in-progress discussion"
+
+    # Specifications
+    assert_contains "$output" 'active: 2' "2 active specifications"
+    assert_contains "$output" 'feature: 1' "1 feature spec"
+    assert_contains "$output" 'crosscutting: 1' "1 cross-cutting spec"
+    # auth-system spec has 2 sources
+    assert_contains "$output" 'name: "auth-flow"' "Source auth-flow found"
+    assert_contains "$output" 'name: "session-mgmt"' "Source session-mgmt found"
+
+    # Plans
+    assert_contains "$output" 'concluded: 1' "1 concluded plan"
+
+    # Implementation
+    assert_contains "$output" 'completed_tasks: 1' "1 completed task"
+    assert_contains "$output" 'total_tasks: 2' "2 total tasks"
+
+    echo ""
+}
+
+#
+# Test: Plan status counts
+#
+test_plan_status_counts() {
+    echo -e "${YELLOW}Test: Plan status counts${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/planning"
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+format: local-markdown
+specification: auth-system.md
+external_dependencies: []
+---
+Plan
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/billing.md" << 'EOF'
+---
+topic: billing
+status: planning
+format: local-markdown
+specification: billing.md
+external_dependencies: []
+---
+Plan
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'count: 2' "2 plans total"
+    assert_contains "$output" 'concluded: 1' "1 concluded"
+    assert_contains "$output" 'in_progress: 1' "1 in-progress (planning status)"
+
+    echo ""
+}
+
+#
+# Test: Spec defaults to feature type when missing
+#
+test_spec_default_type() {
+    echo -e "${YELLOW}Test: Spec defaults to feature type when missing${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification"
+    cat > "$TEST_DIR/docs/workflow/specification/legacy.md" << 'EOF'
+---
+topic: legacy
+status: concluded
+---
+No type field
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'type: "feature"' "Defaults to feature"
+    assert_contains "$output" 'feature: 1' "Counted as feature"
+
+    echo ""
+}
+
+#
+# Test: Plan specification link
+#
+test_plan_spec_link() {
+    echo -e "${YELLOW}Test: Plan specification link${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/planning"
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+format: local-markdown
+specification: auth-system.md
+---
+Plan
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'specification: "auth-system.md"' "Specification link extracted"
+
+    echo ""
+}
+
+#
+# Test: Plan defaults specification to {name}.md when missing
+#
+test_plan_default_spec() {
+    echo -e "${YELLOW}Test: Plan defaults specification when missing${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/planning"
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+format: local-markdown
+---
+Plan
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'specification: "auth-system.md"' "Defaults to {name}.md"
+
+    echo ""
+}
+
+#
+# Run all tests
+#
+echo "=========================================="
+echo "Running discovery-for-status.sh tests"
+echo "=========================================="
+echo ""
+
+test_empty_state
+test_research_files
+test_discussions
+test_spec_multiple_sources
+test_spec_pending_source
+test_crosscutting_spec
+test_superseded_spec
+test_spec_no_sources
+test_plan_with_deps
+test_plan_resolved_deps
+test_plan_empty_deps
+test_implementation_tracking
+test_completed_implementation
+test_implementation_inline_phases
+test_full_workflow
+test_plan_status_counts
+test_spec_default_type
+test_plan_spec_link
+test_plan_default_spec
+
+#
+# Summary
+#
+echo "=========================================="
+echo "Test Summary"
+echo "=========================================="
+echo -e "Total:  $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo ""
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    echo -e "${RED}Some tests failed!${NC}"
+    exit 1
+else
+    echo -e "${GREEN}All tests passed!${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- **Discovery script** (`skills/status/scripts/discovery.sh`): scans all 5 workflow phases, extracts spec `sources` arrays (many-to-one discussion→spec), `superseded_by`, `type` (feature/cross-cutting), plan `external_dependencies`, and implementation progress with total task counts
- **Rewritten SKILL.md**: replaces flat topic-matching table with phase-by-phase tree display showing relationships — specs list their source discussions, plans show spec links and blocked deps, unlinked discussions surfaced separately
- **Test suite** (`tests/scripts/test-discovery-for-status.sh`): 19 test cases, 70 assertions covering empty state, multi-source specs, superseded specs, external deps, implementation tracking, and full workflow integration

## Test plan

- [x] Discovery script runs cleanly with no workflow files (empty state)
- [x] Discovery script correctly extracts many-to-one relationships (multiple discussions → single spec via sources array)
- [x] All 70 test assertions pass
- [ ] Manual test: run `/status` on a project with active workflow files to verify display output

🤖 Generated with [Claude Code](https://claude.com/claude-code)