### PR TITLE
feat: add Ask option and improve Comment wording at task gate

### DIFF
--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -94,18 +94,21 @@ Announce the fix round (one line, no stop):
 
 #### If `fix_gate_mode: gated`, or `fix_attempts >= 3`
 
-If `fix_attempts >= 3`, the executor and reviewer have failed to converge. Prepend:
+If `fix_attempts >= 3`, the executor and reviewer have failed to converge. Prepend the convergence warning in the code block below.
 
-The executor and reviewer have not converged after {N} attempts. Escalating for human review.
+> *Output the next fenced block as a code block:*
 
-Present the reviewer's findings and fix analysis to the user:
+```
+@if(fix_attempts >= 3) The executor and reviewer have not converged after {N} attempts. Escalating for human review.
 
-**Review for Task {id}: {Task Name} — needs changes** (attempt {N})
+@endif
+Review for Task {id}: {Task Name} — needs changes (attempt {N})
 
 {ISSUES from reviewer, including FIX, ALTERNATIVE, and CONFIDENCE for each}
 
 Notes (non-blocking):
 {NOTES from reviewer}
+```
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -38,11 +38,13 @@ E. Update progress + commit
 
 ### Executor Blocked
 
-Present the executor's ISSUES to the user:
+> *Output the next fenced block as a code block:*
 
-**Task {id}: {Task Name} — {blocked/failed}**
+```
+Task {id}: {Task Name} — {blocked/failed}
 
 {executor's ISSUES content}
+```
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -88,7 +88,11 @@ Increment `fix_attempts` in the implementation tracking file.
 
 Announce the fix round (one line, no stop):
 
-**Review for Task {id}: {Task Name} — needs changes** (attempt {N}/{max 3}, fix analysis included). Re-invoking executor.
+> *Output the next fenced block as a code block:*
+
+```
+Review for Task {id}: {Task Name} — needs changes (attempt {N}/{max 3}, fix analysis included). Re-invoking executor.
+```
 
 → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 
@@ -138,10 +142,14 @@ After the reviewer approves a task, check the `task_gate_mode` field in the impl
 
 Present a summary and wait for user input:
 
-**Task {id}: {Task Name} — approved**
+> *Output the next fenced block as a code block:*
+
+```
+Task {id}: {Task Name} — approved
 
 Phase: {phase number} — {phase name}
 {executor's SUMMARY — brief commentary, decisions, implementation notes}
+```
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -166,7 +174,11 @@ Phase: {phase number} — {phase name}
 
 Announce the result (one line, no stop):
 
-**Task {id}: {Task Name} — approved** (phase {N}: {phase name}, {brief summary}). Committing.
+> *Output the next fenced block as a code block:*
+
+```
+Task {id}: {Task Name} — approved (phase {N}: {phase name}, {brief summary}). Committing.
+```
 
 → Proceed to **E. Update Progress and Commit**.
 

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -121,7 +121,8 @@ Notes (non-blocking):
 - **`y`/`yes`** — Accept the review and fix analysis, pass to executor
 - **`a`/`auto`** — Accept and auto-approve future fix analyses
 - **`s`/`skip`** — Override the reviewer and proceed as-is
-- **Comment** — Any commentary, adjustments, alternative approaches, or questions before passing to executor
+- **Ask** — Ask questions about the review (doesn't accept or reject)
+- **Comment** — Any commentary, adjustments, or alternative approaches before passing to executor
 · · · · · · · · · · · ·
 ```
 
@@ -130,6 +131,7 @@ Notes (non-blocking):
 - **`y`/`yes`**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 - **`auto`**: Note that `fix_gate_mode` should be updated to `auto` during the next commit step. → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 - **`skip`**: → Proceed to **D. Task Gate**.
+- **Ask**: Answer the user's questions about the review. When complete, re-present the Review Changes options above. Repeat until the user selects a terminal option (`yes`, `auto`, `skip`, or Comment).
 - **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content, the reviewer's notes, and the user's commentary.
 
 ---

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -122,7 +122,7 @@ Notes (non-blocking):
 - **`a`/`auto`** — Accept and auto-approve future fix analyses
 - **`s`/`skip`** — Override the reviewer and proceed as-is
 - **Ask** — Ask questions about the review (doesn't accept or reject)
-- **Comment** — Any commentary, adjustments, or alternative approaches before passing to executor
+- **Comment** — Accept with adjustments — pass your own direction to the executor alongside the review
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -105,7 +105,6 @@ If `fix_attempts >= 3`, the executor and reviewer have failed to converge. Prepe
 ```
 @if(fix_attempts >= 3)
   The executor and reviewer have not converged after {N} attempts. Escalating for human review.
-
 @endif
 Review for Task {id}: {Task Name} — needs changes (attempt {N})
 

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -103,7 +103,8 @@ If `fix_attempts >= 3`, the executor and reviewer have failed to converge. Prepe
 > *Output the next fenced block as a code block:*
 
 ```
-@if(fix_attempts >= 3) The executor and reviewer have not converged after {N} attempts. Escalating for human review.
+@if(fix_attempts >= 3)
+  The executor and reviewer have not converged after {N} attempts. Escalating for human review.
 
 @endif
 Review for Task {id}: {Task Name} — needs changes (attempt {N})

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -144,8 +144,9 @@ Phase: {phase number} — {phase name}
 · · · · · · · · · · · ·
 **Options:**
 - **`y`/`yes`** — Approve, commit, continue to next task
-- **`a`/`auto`** — Approve this and all future reviewer-approved tasks automatically
-- **Comment** — Feedback the reviewer missed (triggers a fix round)
+- **`a`/`auto`** — Approve this and all future tasks automatically (skips review prompts and questions)
+- **Ask** — Ask questions about the implementation (doesn't approve or reject)
+- **Comment** — Request changes — pass feedback or commentary (triggers a fix round)
 · · · · · · · · · · · ·
 ```
 
@@ -153,7 +154,8 @@ Phase: {phase number} — {phase name}
 
 - **`y`/`yes`**: → Proceed to **E. Update Progress and Commit**.
 - **`auto`**: Note that `task_gate_mode` should be updated to `auto` during the commit step. → Proceed to **E. Update Progress and Commit**.
-- **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the user's notes.
+- **Ask**: Answer the user's questions about the implementation. When complete, re-present the Task Gate options above. Repeat until the user selects a terminal option (`yes`, `auto`, or Comment).
+- **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the user's feedback.
 
 ### If `task_gate_mode: auto`
 


### PR DESCRIPTION
## Summary

- Adds **Ask** as a free-text option at the task gate — lets users ask questions about the implementation without approving or rejecting, then re-presents all options
- Rewords **Comment** from "feedback the reviewer missed" to "request changes — pass feedback or commentary" for clearer intent at the approval gate
- Updates **auto** description to note it skips both review prompts and questions

## Test plan

- [ ] Run a gated implementation session and verify all four options render correctly at the task gate
- [ ] Confirm Ask loops back to re-present options after answering
- [ ] Confirm Comment still triggers a fix round via executor re-invocation
- [ ] Confirm auto mode skips the gate entirely on subsequent tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)