### PR TITLE
feat: add auto-mode approval gates to planning and specification

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,14 +16,15 @@
       "Bash(chmod:*)",
       "Bash(git log:*)",
       "Bash(gh release list:*)",
-      "Bash(gh pr create:*)"
+      "Bash(gh pr create:*)",
+      "Bash(git -C /Users/leeovery/Code/claude/claude-technical-workflows log --oneline -30 -- skills/technical-research/)"
     ],
     "deny": [],
     "ask": []
   },
+  "outputStyle": "Explanatory",
   "sandbox": {
     "enabled": false,
     "autoAllowBashIfSandboxed": false
-  },
-  "outputStyle": "Explanatory"
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,7 +466,7 @@ Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STO
 
 **Frontmatter tracking**: Gate modes are stored in the relevant frontmatter file (`gated` or `auto`). This ensures they survive context refresh.
 
-**Behavior when `auto`**: Present the same content as gated mode (so the user can monitor), then proceed without a STOP gate. Use a rendering instruction + code block for the one-line announcement:
+**Behavior when `auto`**: Content is always rendered above the gate check (so both modes see identical output). Auto mode proceeds without a STOP gate. Use a rendering instruction + code block for the one-line announcement:
 
 ```
 > *Output the next fenced block as a code block:*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,6 +460,35 @@ Entry-point skills that invoke processing skills use this exact blockquote to pr
 > **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
 ```
 
+### Auto-Mode Gates
+
+Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STOP gates. This pattern is used in implementation (task + fix gates), planning (task authoring + review findings), and specification (review findings).
+
+**Frontmatter tracking**: Gate modes are stored in the relevant frontmatter file (`gated` or `auto`). This ensures they survive context refresh.
+
+**Behavior when `auto`**: Present the same content as gated mode (so the user can monitor), then proceed without a STOP gate. Use a rendering instruction + code block for the one-line announcement:
+
+```
+> *Output the next fenced block as a code block:*
+
+\```
+Task {M} of {total}: {Task Name} — authored. Logging to plan.
+\```
+```
+
+**Lifecycle**:
+- Default: `gated` (set in frontmatter template on creation)
+- Opt-in: user chooses `a`/`auto` at any per-item gate → frontmatter updated before next commit
+- Reset: entry-point skills reset gates to `gated` on fresh invocation (not on `continue`)
+- Context refresh: read gate modes from frontmatter and preserve
+
+**Menu option format**: Add between the primary action and secondary options:
+```
+- **`a`/`auto`** — Approve this and all remaining {items} automatically
+```
+
+**Re-loop safety cap**: When auto-mode enables automatic re-analysis loops, cap at 5 cycles before escalating to the user. This prevents infinite cascading.
+
 ### Rendering Instructions for Ask Blocks
 
 When a step asks the user a question, wrap it in a rendering instruction and code block — don't use bare `Ask:` labels:

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ When using the full workflow, it progresses through six distinct phases:
 
 **Phase 2 - Discussion:** Captures the back-and-forth exploration of a problem. Documents competing solutions, why certain approaches won or lost, edge cases discovered, and the journey to decisions, not just the decisions themselves.
 
-**Phase 3 - Specification:** Transforms discussion(s) into validated, standalone specifications. Automatically analyses multiple discussions for natural groupings, filters hallucinations and inaccuracies, enriches gaps, and builds documents that planning can execute against without referencing other sources.
+**Phase 3 - Specification:** Transforms discussion(s) into validated, standalone specifications. Automatically analyses multiple discussions for natural groupings, filters hallucinations and inaccuracies, enriches gaps, and builds documents that planning can execute against without referencing other sources. Review findings have per-item approval gates (auto mode available).
 
-**Phase 4 - Planning:** Converts specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (local markdown, Linear).
+**Phase 4 - Planning:** Converts specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (local markdown, Linear). Task authoring and review findings have per-item approval gates (auto mode available).
 
 **Phase 5 - Implementation:** Executes the plan using strict TDD. Writes tests first, implements to pass, commits frequently, with per-task approval gates (auto mode available).
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Pick your entry point based on where you are:
 │ • Ideas       │   │ • Architecture│   │ • Validate    │
 │ • Market      │   │ • Decisions   │   │ • Filter      │
 │ • Viability   │   │ • Edge cases  │   │ • Enrich      │
-│               │   │ • Rationale   │   │ • Standalone   │
+│               │   │ • Rationale   │   │ • Standalone  │
 └───────────────┘   └───────────────┘   └───────────────┘
                                                 │
                                                 ▼

--- a/README.md
+++ b/README.md
@@ -52,33 +52,76 @@ See [Installation](#installation) for details.
 
 ## How do I use it?
 
-### Two Ways to Use the Skills
+### Where to Start
 
-**1. Full Workflow** - Sequential phases that build on each other:
+Pick your entry point based on where you are:
+
+- **Seeds of an idea?** → Start with `/start-research` *(recommended)*
+  You have a rough idea but haven't explored feasibility, alternatives, or scope yet. Research lets you think freely before committing to anything.
+
+- **Know what you're building?** → Start with `/start-discussion`
+  You've moved past exploration and want to capture architecture decisions, edge cases, and rationale for specific topics.
+
+- **Clear feature, ready to spec?** → Use `/start-feature`
+  You already know the what and why. Jump straight to building a specification from inline context — no prior documents needed.
+
+**Why research is the recommended default:** When you move from research to discussion, the skill analyses your research document and automatically breaks it into focused discussion topics. Skip research and you manage topic structure yourself. That automatic topic breakdown is one of the highest-value transitions in the workflow.
+
+### The Workflow
 
 ```
-Research → Discussion → Specification → Planning → Implementation → Review
+┌───────────────┐   ┌───────────────┐   ┌───────────────┐
+│   Research    │──▶│  Discussion   │──▶│ Specification │
+│   (Phase 1)   │   │   (Phase 2)   │   │   (Phase 3)   │
+├───────────────┤   ├───────────────┤   ├───────────────┤
+│ EXPLORING     │   │ WHAT & WHY    │   │ REFINING      │
+│               │   │               │   │               │
+│ • Ideas       │   │ • Architecture│   │ • Validate    │
+│ • Market      │   │ • Decisions   │   │ • Filter      │
+│ • Viability   │   │ • Edge cases  │   │ • Enrich      │
+│               │   │ • Rationale   │   │ • Standalone   │
+└───────────────┘   └───────────────┘   └───────────────┘
+                                                │
+                                                ▼
+┌───────────────┐   ┌───────────────┐   ┌───────────────┐
+│    Review     │◀──│Implementation │◀──│   Planning    │
+│   (Phase 6)   │   │   (Phase 5)   │   │   (Phase 4)   │
+├───────────────┤   ├───────────────┤   ├───────────────┤
+│ VALIDATING    │   │ DOING         │   │ HOW           │
+│               │   │               │   │               │
+│ • Plan check  │   │ • Tests first │   │ • Phases      │
+│ • Specs check │   │ • Then code   │   │ • Tasks       │
+│ • Test quality│   │ • Commit often│   │ • Criteria    │
+│ • Code quality│   │ • Task gates  │   │ • Outputs     │
+└───────────────┘   └───────────────┘   └───────────────┘
 ```
 
-Start with `/start-research` or `/start-discussion` and follow the flow. Each phase outputs files that the next phase consumes.
+Each phase produces documents that feed the next. Here's the journey:
 
-**2. Standalone Skills** - Jump directly to a processing skill with flexible inputs:
+**Research** — Free-form exploration. Investigate ideas, market fit, technical feasibility, business viability. The output is a research document capturing everything you've explored. The key benefit: when you move to discussion, the skill analyses this document and breaks it into focused topics automatically.
+
+**Discussion** — Per-topic deep dives into architecture, edge cases, competing approaches, and rationale. Each topic gets its own document. This captures not just decisions, but *why* you made them — the alternatives considered, the trade-offs weighed, the journey to the decision. Conclude each topic when its decisions are made.
+
+**Specification** — This is where the magic happens. The skill analyses *all* your discussions and creates intelligent groupings — 10 discussions might become 3–5 specifications, or you can unify everything into one. It filters hallucinations, enriches gaps, and validates decisions against each other. The spec becomes the golden document: planning only references this, not earlier phases.
+
+**Planning** — Converts each specification into phased implementation plans with tasks, acceptance criteria, and dependency ordering. Supports multiple output formats. Task authoring has per-item approval gates (with auto-mode for faster flow).
+
+**Implementation** — Executes plans via strict TDD. Tests first, then code, commit after each task. Per-task approval gates keep you in control, with auto-mode available when you trust the flow.
+
+**Review** — Validates the implementation against spec and plan. Catches drift, missing requirements, and quality issues. The spec is the source of truth here — earlier phases may contain rejected ideas that were intentionally filtered out. Produces structured feedback without fixing code directly.
+
+### Standalone Skills
+
+Not every task needs the full workflow. These skills gather inputs flexibly and invoke processing skills directly:
 
 | Skill | What it does |
 |-------|-------------|
 | `/start-feature` | Create a spec directly from inline context (skip research/discussion) |
+| `/link-dependencies` | Wire cross-topic dependencies across plans |
 
-*More standalone skills coming soon.*
+### Under the Hood
 
-### The Two-Tier Skill Architecture
-
-**Processing skills** (`technical-*`) are input-agnostic. They don't know or care where their inputs came from: a discussion document, inline context, or external sources. They just process what they receive.
-
-**Entry-point skills** (`/start-*`, `/status`, etc.) are the input layer. They gather context (from files, prompts, or inline) and pass it to processing skills. This separation means:
-
-- The same processing skill can be invoked from different entry points
-- You can create custom entry-point skills that feed processing skills in new ways
-- Processing skills remain reusable without coupling to specific workflows
+Skills are organised in two tiers. **Entry-point skills** (`/start-*`, `/status`, etc.) gather context from files, prompts, or inline input. **Processing skills** (`technical-*`) receive those inputs and do the work — they don't know or care where inputs came from. This means the same processing skill can be invoked from different entry points, and you can create custom entry-point skills that feed them in new ways.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -148,49 +191,6 @@ Due to bugs in npm 7+ ([issue #3042](https://github.com/npm/cli/issues/3042)) an
 npx claude-manager remove @leeovery/claude-technical-workflows && npm rm @leeovery/claude-technical-workflows
 ```
 </details>
-
-## The Six-Phase Workflow
-
-When using the full workflow, it progresses through six distinct phases:
-
-```
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│   Research    │──▶│  Discussion   │──▶│ Specification │
-│   (Phase 1)   │   │   (Phase 2)   │   │   (Phase 3)   │
-├───────────────┤   ├───────────────┤   ├───────────────┤
-│ EXPLORING     │   │ WHAT & WHY    │   │ REFINING      │
-│               │   │               │   │               │
-│ • Ideas       │   │ • Architecture│   │ • Validate    │
-│ • Market      │   │ • Decisions   │   │ • Filter      │
-│ • Viability   │   │ • Edge cases  │   │ • Enrich      │
-│               │   │ • Rationale   │   │ • Standalone  │
-└───────────────┘   └───────────────┘   └───────────────┘
-                                                │
-                                                ▼
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│    Review     │◀──│Implementation │◀──│   Planning    │
-│   (Phase 6)   │   │   (Phase 5)   │   │   (Phase 4)   │
-├───────────────┤   ├───────────────┤   ├───────────────┤
-│ VALIDATING    │   │ DOING         │   │ HOW           │
-│               │   │               │   │               │
-│ • Plan check  │   │ • Tests first │   │ • Phases      │
-│ • Specs check │   │ • Then code   │   │ • Tasks       │
-│ • Test quality│   │ • Commit often│   │ • Criteria    │
-│ • Code quality│   │ • Task gates  │   │ • Outputs     │
-└───────────────┘   └───────────────┘   └───────────────┘
-```
-
-**Phase 1 - Research:** Explore ideas from their earliest seed. Investigate market fit, technical feasibility, business viability. Free-flowing exploration that may or may not lead to building something.
-
-**Phase 2 - Discussion:** Captures the back-and-forth exploration of a problem. Documents competing solutions, why certain approaches won or lost, edge cases discovered, and the journey to decisions, not just the decisions themselves.
-
-**Phase 3 - Specification:** Transforms discussion(s) into validated, standalone specifications. Automatically analyses multiple discussions for natural groupings, filters hallucinations and inaccuracies, enriches gaps, and builds documents that planning can execute against without referencing other sources. Review findings have per-item approval gates (auto mode available).
-
-**Phase 4 - Planning:** Converts specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (local markdown, Linear). Task authoring and review findings have per-item approval gates (auto mode available).
-
-**Phase 5 - Implementation:** Executes the plan using strict TDD. Writes tests first, implements to pass, commits frequently, with per-task approval gates (auto mode available).
-
-**Phase 6 - Review:** Validates completed work against specification requirements and plan acceptance criteria. The specification is the validated source of truth; earlier phases may contain rejected ideas that were intentionally filtered out. Provides structured feedback without fixing code directly.
 
 ## Project Structure
 

--- a/skills/start-specification/references/handoffs/continue-concluded.md
+++ b/skills/start-specification/references/handoffs/continue-concluded.md
@@ -4,6 +4,8 @@
 
 ---
 
+Before invoking the skill, reset `finding_gate_mode` to `gated` in the specification frontmatter if present. Commit if changed: `spec({topic}): reset gate mode`
+
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
 
 ```

--- a/skills/start-specification/references/handoffs/continue.md
+++ b/skills/start-specification/references/handoffs/continue.md
@@ -4,6 +4,8 @@
 
 ---
 
+Before invoking the skill, reset `finding_gate_mode` to `gated` in the specification frontmatter if present. Commit if changed: `spec({topic}): reset gate mode`
+
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
 
 ```

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -84,22 +84,6 @@ Task {id}: {Task Name} — {blocked/failed}
 
 Increment `fix_attempts` in the implementation tracking file.
 
-#### If `fix_gate_mode: auto` and `fix_attempts < 3`
-
-Announce the fix round (one line, no stop):
-
-> *Output the next fenced block as a code block:*
-
-```
-Review for Task {id}: {Task Name} — needs changes (attempt {N}/{max 3}, fix analysis included). Re-invoking executor.
-```
-
-→ Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
-
-#### If `fix_gate_mode: gated`, or `fix_attempts >= 3`
-
-If `fix_attempts >= 3`, the executor and reviewer have failed to converge. Prepend the convergence warning in the code block below.
-
 > *Output the next fenced block as a code block:*
 
 ```
@@ -113,6 +97,12 @@ Review for Task {id}: {Task Name} — needs changes (attempt {N})
 Notes (non-blocking):
 {NOTES from reviewer}
 ```
+
+#### If `fix_gate_mode: auto` and `fix_attempts < 3`
+
+→ Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
+
+#### If `fix_gate_mode: gated`, or `fix_attempts >= 3`
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -138,11 +128,7 @@ Notes (non-blocking):
 
 ## D. Task Gate
 
-After the reviewer approves a task, check the `task_gate_mode` field in the implementation tracking file.
-
-### If `task_gate_mode: gated`
-
-Present a summary and wait for user input:
+After the reviewer approves a task, present the result:
 
 > *Output the next fenced block as a code block:*
 
@@ -152,6 +138,14 @@ Task {id}: {Task Name} — approved
 Phase: {phase number} — {phase name}
 {executor's SUMMARY — brief commentary, decisions, implementation notes}
 ```
+
+Check the `task_gate_mode` field in the implementation tracking file.
+
+#### If `task_gate_mode: auto`
+
+→ Proceed to **E. Update Progress and Commit**.
+
+#### If `task_gate_mode: gated`
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -171,18 +165,6 @@ Phase: {phase number} — {phase name}
 - **`auto`**: Note that `task_gate_mode` should be updated to `auto` during the commit step. → Proceed to **E. Update Progress and Commit**.
 - **Ask**: Answer the user's questions about the implementation. When complete, re-present the Task Gate options above. Repeat until the user selects a terminal option (`yes`, `auto`, or Comment).
 - **Comment**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the user's feedback.
-
-### If `task_gate_mode: auto`
-
-Announce the result (one line, no stop):
-
-> *Output the next fenced block as a code block:*
-
-```
-Task {id}: {Task Name} — approved (phase {N}: {phase name}, {brief summary}). Committing.
-```
-
-→ Proceed to **E. Update Progress and Commit**.
 
 ---
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -62,6 +62,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 2. **Read all tracking and state files** for the current topic — plan index files, review tracking files, implementation tracking files, or any working documents this skill creates. These are your source of truth for progress.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
+5. **Check `author_gate_mode` and `finding_gate_mode`** in the Plan Index File frontmatter — if `auto`, the user previously opted in during this session. Preserve these values.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 
@@ -116,6 +117,8 @@ Found existing plan for **{topic}** (previously reached phase {N}, task {M}).
 #### If `continue`
 
 If the specification changed, update `spec_commit` in the Plan Index File frontmatter to the current commit hash.
+
+Reset `author_gate_mode` and `finding_gate_mode` to `gated` in the Plan Index File frontmatter (fresh invocation = fresh gates).
 
 → Proceed to **Step 1**.
 
@@ -183,6 +186,8 @@ spec_commit: {output of git rev-parse HEAD}
 created: YYYY-MM-DD  # Use today's actual date
 updated: YYYY-MM-DD  # Use today's actual date
 external_dependencies: []
+author_gate_mode: gated
+finding_gate_mode: gated
 planning:
   phase: 1
   task: ~

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -25,9 +25,13 @@ Invoke `planning-task-author` with these file paths:
 
 ### Check Gate Mode
 
-The agent returns complete task detail following the task template from task-design.md.
+The agent returns complete task detail following the task template from task-design.md. What the user sees is what gets logged.
 
-Present the task detail to the user as rendered markdown (not in a code block) **exactly as it will be written** — what the user sees is what gets logged.
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+{task detail from planning-task-author agent}
+```
 
 Check `author_gate_mode` in the Plan Index File frontmatter.
 

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -31,7 +31,9 @@ Check `author_gate_mode` in the Plan Index File frontmatter.
 
 #### If `author_gate_mode: auto`
 
-Announce (one line, no stop):
+Present the task detail to the user as rendered markdown (not in a code block) — same content as gated mode, so the user can monitor output as it flows.
+
+Then announce (one line, no stop):
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -27,13 +27,11 @@ Invoke `planning-task-author` with these file paths:
 
 The agent returns complete task detail following the task template from task-design.md.
 
+Present the task detail to the user as rendered markdown (not in a code block) **exactly as it will be written** — what the user sees is what gets logged.
+
 Check `author_gate_mode` in the Plan Index File frontmatter.
 
 #### If `author_gate_mode: auto`
-
-Present the task detail to the user as rendered markdown (not in a code block) — same content as gated mode, so the user can monitor output as it flows.
-
-Then announce (one line, no stop):
 
 > *Output the next fenced block as a code block:*
 
@@ -44,10 +42,6 @@ Task {M} of {total}: {Task Name} — authored. Logging to plan.
 → Skip to **If approved** below.
 
 #### If `author_gate_mode: gated`
-
-Present the task detail to the user as rendered markdown (not in a code block) **exactly as it will be written** — what the user sees is what gets logged.
-
-After presenting, ask:
 
 **Task {M} of {total}: {Task Name}**
 

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -23,9 +23,27 @@ Invoke `planning-task-author` with these file paths:
 7. **Target task**: the task name, edge cases, and ID from the table
 8. **Output format authoring reference**: path to the format's `authoring.md` (e.g., `output-formats/{format}/authoring.md`)
 
-### Present the Output
+### Check Gate Mode
 
-The agent returns complete task detail following the task template from task-design.md. Present it to the user as rendered markdown (not in a code block) **exactly as it will be written** — what the user sees is what gets logged.
+The agent returns complete task detail following the task template from task-design.md.
+
+Check `author_gate_mode` in the Plan Index File frontmatter.
+
+#### If `author_gate_mode: auto`
+
+Announce (one line, no stop):
+
+> *Output the next fenced block as a code block:*
+
+```
+Task {M} of {total}: {Task Name} — authored. Logging to plan.
+```
+
+→ Skip to **If approved** below.
+
+#### If `author_gate_mode: gated`
+
+Present the task detail to the user as rendered markdown (not in a code block) **exactly as it will be written** — what the user sees is what gets logged.
 
 After presenting, ask:
 
@@ -37,6 +55,7 @@ After presenting, ask:
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved. I'll log it to the plan.
+- **`a`/`auto`** — Approve this and all remaining tasks automatically
 - **Or tell me what to change.**
 - **Or navigate** — a different phase or task, or the leading edge.
 · · · · · · · · · · · ·
@@ -56,14 +75,21 @@ Present the revised task in full. Ask the same choice again. Repeat until approv
 
 → Return to **Plan Construction**.
 
-#### If approved (`y`/`yes`)
+#### If `auto`
 
-> **CHECKPOINT**: Before logging, verify: (1) You presented this exact content, (2) The user explicitly approved with `y`/`yes` or equivalent — not a question, comment, or "okay" in passing, (3) You are writing exactly what was approved with no modifications.
+Note that `author_gate_mode` should be updated to `auto` during the commit step below.
+
+→ Proceed to **If approved** below.
+
+#### If approved (`y`/`yes` or `auto`)
+
+> **CHECKPOINT**: If `author_gate_mode: gated`, verify before logging: (1) You presented this exact content, (2) The user explicitly approved with `y`/`yes` or equivalent — not a question, comment, or "okay" in passing, (3) You are writing exactly what was approved with no modifications.
 
 1. Write the task to the output format (format-specific — see authoring.md)
 2. Update the task table in the Plan Index File: set `status: authored`
 3. Advance the `planning:` block in frontmatter to the next pending task (or next phase if this was the last task)
-4. Commit: `planning({topic}): author task {task-id} ({task name})`
+4. If user chose `auto` at this gate: update `author_gate_mode: auto` in the Plan Index File frontmatter
+5. Commit: `planning({topic}): author task {task-id} ({task name})`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/technical-planning/references/plan-review.md
+++ b/skills/technical-planning/references/plan-review.md
@@ -54,6 +54,28 @@ Record the current cycle number — passed to both review agents for tracking fi
 
 #### If findings were surfaced
 
+Check `finding_gate_mode` and `review_cycle` in the Plan Index File frontmatter.
+
+#### If `finding_gate_mode: auto` and `review_cycle < 5`
+
+Announce (one line, no stop):
+
+> *Output the next fenced block as a code block:*
+
+```
+Review cycle {N} complete — findings applied. Running follow-up cycle.
+```
+
+→ Return to **A. Cycle Management**.
+
+#### If `finding_gate_mode: auto` and `review_cycle >= 5`
+
+Review has auto-cycled 5 times without converging. Escalating for human review.
+
+→ Present the gated re-loop prompt below.
+
+#### If `finding_gate_mode: gated`
+
 > *Output the next fenced block as a code block:*
 
 ```

--- a/skills/technical-planning/references/process-review-findings.md
+++ b/skills/technical-planning/references/process-review-findings.md
@@ -51,31 +51,9 @@ Let's work through these one at a time, starting with #1.
 
 ## B. Process One Item at a Time
 
-Work through each finding **sequentially**. For each finding: present it, show the proposed fix, wait for approval, then apply or skip.
+Work through each finding **sequentially**. For each finding: present it, show the proposed fix, then route through the gate.
 
-### Check Gate Mode
-
-Check `finding_gate_mode` in the Plan Index File frontmatter.
-
-#### If `finding_gate_mode: auto`
-
-Process all remaining findings automatically. For each finding:
-
-1. Present the finding (same display as gated mode — show full fix content with Current/Proposed so the user can monitor)
-2. Apply the fix to the plan (use **Proposed** content exactly as in tracking file)
-3. Update the tracking file: set resolution to "Fixed"
-4. Commit the tracking file and plan changes
-5. Announce (one line, no stop):
-
-   > *Output the next fenced block as a code block:*
-
-   ```
-   Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
-   ```
-
-After all findings processed → Proceed to **C. After All Findings Processed**.
-
-#### If `finding_gate_mode: gated`
+### Present Finding
 
 Show the finding with its full fix content, read directly from the tracking file.
 
@@ -105,7 +83,25 @@ Show the finding with its full fix content, read directly from the tracking file
 {from tracking file — the replacement content}
 ```
 
-### Ask for Approval
+### Check Gate Mode
+
+Check `finding_gate_mode` in the Plan Index File frontmatter.
+
+#### If `finding_gate_mode: auto`
+
+1. Apply the fix to the plan (use **Proposed** content exactly as in tracking file)
+2. Update the tracking file: set resolution to "Fixed"
+3. Commit the tracking file and plan changes
+
+> *Output the next fenced block as a code block:*
+
+```
+Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
+```
+
+→ Present the next pending finding, or proceed to **C. After All Findings Processed**.
+
+#### If `finding_gate_mode: gated`
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/technical-planning/references/process-review-findings.md
+++ b/skills/technical-planning/references/process-review-findings.md
@@ -53,7 +53,28 @@ Let's work through these one at a time, starting with #1.
 
 Work through each finding **sequentially**. For each finding: present it, show the proposed fix, wait for approval, then apply or skip.
 
-### Present the Finding
+### Check Gate Mode
+
+Check `finding_gate_mode` in the Plan Index File frontmatter.
+
+#### If `finding_gate_mode: auto`
+
+Process all remaining findings automatically. For each finding:
+
+1. Apply the fix to the plan (use **Proposed** content exactly as in tracking file)
+2. Update the tracking file: set resolution to "Fixed"
+3. Commit the tracking file and plan changes
+4. Announce (one line, no stop):
+
+   > *Output the next fenced block as a code block:*
+
+   ```
+   Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
+   ```
+
+After all findings processed → Proceed to **C. After All Findings Processed**.
+
+#### If `finding_gate_mode: gated`
 
 Show the finding with its full fix content, read directly from the tracking file.
 
@@ -91,6 +112,7 @@ Show the finding with its full fix content, read directly from the tracking file
 · · · · · · · · · · · ·
 **Finding {N} of {total}: {Brief Title}**
 - **`y`/`yes`** — Approved. Apply to the plan verbatim.
+- **`a`/`auto`** — Approve this and all remaining findings automatically
 - **`s`/`skip`** — Leave as-is, move to next finding.
 - **Or provide feedback** to adjust the fix.
 · · · · · · · · · · · ·
@@ -114,6 +136,16 @@ Incorporate feedback and re-present the proposed fix **in full**. Update the tra
    ```
 
 → Present the next pending finding, or proceed to **C. After All Findings Processed**.
+
+#### If `auto`
+
+1. Apply the fix (same as "If approved" above)
+2. Update the tracking file: set resolution to "Fixed"
+3. Update `finding_gate_mode: auto` in the Plan Index File frontmatter
+4. Commit
+5. Process all remaining findings using the auto-mode flow above
+
+→ After all processed, proceed to **C. After All Findings Processed**.
 
 #### If skipped
 

--- a/skills/technical-planning/references/process-review-findings.md
+++ b/skills/technical-planning/references/process-review-findings.md
@@ -61,10 +61,11 @@ Check `finding_gate_mode` in the Plan Index File frontmatter.
 
 Process all remaining findings automatically. For each finding:
 
-1. Apply the fix to the plan (use **Proposed** content exactly as in tracking file)
-2. Update the tracking file: set resolution to "Fixed"
-3. Commit the tracking file and plan changes
-4. Announce (one line, no stop):
+1. Present the finding (same display as gated mode — show full fix content with Current/Proposed so the user can monitor)
+2. Apply the fix to the plan (use **Proposed** content exactly as in tracking file)
+3. Update the tracking file: set resolution to "Fixed"
+4. Commit the tracking file and plan changes
+5. Announce (one line, no stop):
 
    > *Output the next fenced block as a code block:*
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -75,6 +75,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 2. **Read all tracking and state files** for the current topic — plan index files, review tracking files, implementation tracking files, or any working documents this skill creates. These are your source of truth for progress.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
+5. **Check `finding_gate_mode`** in the specification frontmatter — if `auto`, the user previously opted in during this session. Preserve this value.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -159,6 +159,7 @@ status: in-progress
 type: feature
 date: YYYY-MM-DD  # Use today's actual date
 review_cycle: 0
+finding_gate_mode: gated
 sources:
   - name: discussion-one
     status: incorporated
@@ -557,7 +558,23 @@ Each item should have enough context that the user understands what they're abou
 
 **Stage 2: Process One Item at a Time**
 
-For each item, follow the **same workflow as the main specification process**:
+For each item, check `finding_gate_mode` in the specification frontmatter.
+
+#### If `finding_gate_mode: auto`
+
+Auto-approve this item: log verbatim, update tracking file (Resolution: Approved), commit, announce:
+
+> *Output the next fenced block as a code block:*
+
+```
+Item {N} of {total}: {Brief Title} — approved. Added to specification.
+```
+
+Then proceed to the next item. After all items processed, continue to **Completing Phase 1**.
+
+#### If `finding_gate_mode: gated`
+
+Follow the **same workflow as the main specification process**:
 
 1. **Present** the item in detail - what you found, where it came from (source reference), and what you propose to add
 2. **Discuss** if needed - clarify ambiguities, answer questions, refine the content
@@ -573,6 +590,7 @@ For each item, follow the **same workflow as the main specification process**:
    · · · · · · · · · · · ·
    **To proceed:**
    - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim**.
+   - **`a`/`auto`** — Approve this and all remaining findings automatically
    - **Or tell me what to change.**
    · · · · · · · · · · · ·
    ```
@@ -582,9 +600,10 @@ For each item, follow the **same workflow as the main specification process**:
 4. **Wait for explicit approval** - same rules as always: `y`/`yes` or equivalent before writing
 5. **Log verbatim** when approved
 6. **Update tracking file** - Mark the item's resolution (Approved/Adjusted/Skipped) and add any notes
-7. **Move to the next item**: "Moving to #2: [Brief title]..."
+7. **If user chose `auto`**: update `finding_gate_mode: auto` in the spec frontmatter, then process all remaining items using the auto-mode flow above → After all processed, continue to **Completing Phase 1**.
+8. **Move to the next item**: "Moving to #2: [Brief title]..."
 
-> **CHECKPOINT**: Each review item requires the full present → approve → log cycle. Do not batch multiple items together. Do not proceed to the next item until the current one is resolved (approved, adjusted, or explicitly skipped by the user).
+> **CHECKPOINT**: Each review item requires the full present → approve → log cycle (unless `finding_gate_mode: auto`). Do not batch multiple items together. Do not proceed to the next item until the current one is resolved (approved, adjusted, or explicitly skipped by the user).
 
 For potential gaps (items not in source material), you're asking questions rather than proposing content. If the user wants to address a gap, discuss it, then present what you'd add for approval.
 
@@ -699,7 +718,21 @@ Let's work through these one at a time, starting with #1.
 
 **Stage 2: Process One Item at a Time**
 
-For each item:
+For each item, check `finding_gate_mode` in the specification frontmatter.
+
+#### If `finding_gate_mode: auto`
+
+Auto-approve this item: log verbatim, update tracking file (Resolution: Approved), commit, announce:
+
+> *Output the next fenced block as a code block:*
+
+```
+Item {N} of {total}: {Brief Title} — approved. Added to specification.
+```
+
+Then proceed to the next item. After all items processed, continue to **Completing Phase 2**.
+
+#### If `finding_gate_mode: gated`
 
 1. **Present** the gap in detail - what's missing or unclear, what questions an implementer would have
 2. **Discuss** - work with the user to determine the correct specification content
@@ -715,6 +748,7 @@ For each item:
    · · · · · · · · · · · ·
    **To proceed:**
    - **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim**.
+   - **`a`/`auto`** — Approve this and all remaining findings automatically
    - **Or tell me what to change.**
    · · · · · · · · · · · ·
    ```
@@ -724,9 +758,10 @@ For each item:
 4. **Wait for explicit approval**
 5. **Log verbatim** when approved
 6. **Update tracking file** - Mark resolution and add notes
-7. **Move to next item**
+7. **If user chose `auto`**: update `finding_gate_mode: auto` in the spec frontmatter, then process all remaining items using the auto-mode flow above → After all processed, continue to **Completing Phase 2**.
+8. **Move to next item**
 
-> **CHECKPOINT**: Same rules apply - each item requires explicit approval before logging. No batching.
+> **CHECKPOINT**: Same rules apply - each item requires explicit approval before logging (unless `finding_gate_mode: auto`). No batching.
 
 #### What You're NOT Doing in Phase 2
 
@@ -757,6 +792,28 @@ After Phase 2 completes, check whether either phase surfaced findings in this cy
 → Skip the re-loop prompt and proceed directly to **Completion** (nothing to re-analyse).
 
 #### If findings were surfaced
+
+Check `finding_gate_mode` and `review_cycle` in the specification frontmatter.
+
+#### If `finding_gate_mode: auto` and `review_cycle < 5`
+
+Announce (one line, no stop):
+
+> *Output the next fenced block as a code block:*
+
+```
+Review cycle {N} complete — findings applied. Running follow-up cycle.
+```
+
+→ Return to the **Review Cycle Gate**.
+
+#### If `finding_gate_mode: auto` and `review_cycle >= 5`
+
+Review has auto-cycled 5 times without converging. Escalating for human review.
+
+→ Present the gated re-loop prompt below.
+
+#### If `finding_gate_mode: gated`
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -857,6 +914,7 @@ status: concluded
 type: feature  # or cross-cutting
 date: YYYY-MM-DD  # Use today's actual date
 review_cycle: {N}
+finding_gate_mode: gated
 ---
 ```
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -562,7 +562,9 @@ For each item, check `finding_gate_mode` in the specification frontmatter.
 
 #### If `finding_gate_mode: auto`
 
-Auto-approve this item: log verbatim, update tracking file (Resolution: Approved), commit, announce:
+Present the proposed content to the user as rendered markdown (same as gated mode — so the user can monitor output as it flows).
+
+Then auto-approve: log verbatim, update tracking file (Resolution: Approved), commit, announce:
 
 > *Output the next fenced block as a code block:*
 
@@ -722,7 +724,9 @@ For each item, check `finding_gate_mode` in the specification frontmatter.
 
 #### If `finding_gate_mode: auto`
 
-Auto-approve this item: log verbatim, update tracking file (Resolution: Approved), commit, announce:
+Present the proposed content to the user as rendered markdown (same as gated mode — so the user can monitor output as it flows).
+
+Then auto-approve: log verbatim, update tracking file (Resolution: Approved), commit, announce:
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -558,13 +558,13 @@ Each item should have enough context that the user understands what they're abou
 
 **Stage 2: Process One Item at a Time**
 
-For each item, check `finding_gate_mode` in the specification frontmatter.
+For each item, present it in detail — what you found, where it came from (source reference), and what you propose to add. Show the proposed content as rendered markdown (not in a code block).
+
+Check `finding_gate_mode` in the specification frontmatter.
 
 #### If `finding_gate_mode: auto`
 
-Present the proposed content to the user as rendered markdown (same as gated mode — so the user can monitor output as it flows).
-
-Then auto-approve: log verbatim, update tracking file (Resolution: Approved), commit, announce:
+Auto-approve: log verbatim, update tracking file (Resolution: Approved), commit.
 
 > *Output the next fenced block as a code block:*
 
@@ -572,19 +572,12 @@ Then auto-approve: log verbatim, update tracking file (Resolution: Approved), co
 Item {N} of {total}: {Brief Title} — approved. Added to specification.
 ```
 
-Then proceed to the next item. After all items processed, continue to **Completing Phase 1**.
+→ Proceed to the next item. After all items processed, continue to **Completing Phase 1**.
 
 #### If `finding_gate_mode: gated`
 
-Follow the **same workflow as the main specification process**:
-
-1. **Present** the item in detail - what you found, where it came from (source reference), and what you propose to add
-2. **Discuss** if needed - clarify ambiguities, answer questions, refine the content
-3. **Present for approval** - show as rendered markdown (not a code block) exactly what will be written to the specification. Then, separately, show the choices:
-
-   "Here's what I'll add to the specification:
-
-   [content as rendered markdown]
+1. **Discuss** if needed - clarify ambiguities, answer questions, refine the content
+2. **Present for approval** - show as rendered markdown (not a code block) exactly what will be written to the specification. Then, separately, show the choices:
 
    > *Output the next fenced block as markdown (not a code block):*
 
@@ -599,11 +592,11 @@ Follow the **same workflow as the main specification process**:
 
    Content and choices must be visually distinct.
 
-4. **Wait for explicit approval** - same rules as always: `y`/`yes` or equivalent before writing
-5. **Log verbatim** when approved
-6. **Update tracking file** - Mark the item's resolution (Approved/Adjusted/Skipped) and add any notes
-7. **If user chose `auto`**: update `finding_gate_mode: auto` in the spec frontmatter, then process all remaining items using the auto-mode flow above → After all processed, continue to **Completing Phase 1**.
-8. **Move to the next item**: "Moving to #2: [Brief title]..."
+3. **Wait for explicit approval** - same rules as always: `y`/`yes` or equivalent before writing
+4. **Log verbatim** when approved
+5. **Update tracking file** - Mark the item's resolution (Approved/Adjusted/Skipped) and add any notes
+6. **If user chose `auto`**: update `finding_gate_mode: auto` in the spec frontmatter, then process all remaining items using the auto-mode flow above → After all processed, continue to **Completing Phase 1**.
+7. **Move to the next item**: "Moving to #2: [Brief title]..."
 
 > **CHECKPOINT**: Each review item requires the full present → approve → log cycle (unless `finding_gate_mode: auto`). Do not batch multiple items together. Do not proceed to the next item until the current one is resolved (approved, adjusted, or explicitly skipped by the user).
 
@@ -720,13 +713,13 @@ Let's work through these one at a time, starting with #1.
 
 **Stage 2: Process One Item at a Time**
 
-For each item, check `finding_gate_mode` in the specification frontmatter.
+For each item, present it in detail — what's missing or unclear, what questions an implementer would have. Show the proposed content as rendered markdown (not in a code block).
+
+Check `finding_gate_mode` in the specification frontmatter.
 
 #### If `finding_gate_mode: auto`
 
-Present the proposed content to the user as rendered markdown (same as gated mode — so the user can monitor output as it flows).
-
-Then auto-approve: log verbatim, update tracking file (Resolution: Approved), commit, announce:
+Auto-approve: log verbatim, update tracking file (Resolution: Approved), commit.
 
 > *Output the next fenced block as a code block:*
 
@@ -734,17 +727,12 @@ Then auto-approve: log verbatim, update tracking file (Resolution: Approved), co
 Item {N} of {total}: {Brief Title} — approved. Added to specification.
 ```
 
-Then proceed to the next item. After all items processed, continue to **Completing Phase 2**.
+→ Proceed to the next item. After all items processed, continue to **Completing Phase 2**.
 
 #### If `finding_gate_mode: gated`
 
-1. **Present** the gap in detail - what's missing or unclear, what questions an implementer would have
-2. **Discuss** - work with the user to determine the correct specification content
-3. **Present for approval** - show as rendered markdown (not a code block) exactly what will be written. Then, separately, show the choices:
-
-   "Here's what I'll add to the specification:
-
-   [content as rendered markdown]
+1. **Discuss** - work with the user to determine the correct specification content
+2. **Present for approval** - show as rendered markdown (not a code block) exactly what will be written. Then, separately, show the choices:
 
    > *Output the next fenced block as markdown (not a code block):*
 
@@ -759,11 +747,11 @@ Then proceed to the next item. After all items processed, continue to **Completi
 
    Content and choices must be visually distinct.
 
-4. **Wait for explicit approval**
-5. **Log verbatim** when approved
-6. **Update tracking file** - Mark resolution and add notes
-7. **If user chose `auto`**: update `finding_gate_mode: auto` in the spec frontmatter, then process all remaining items using the auto-mode flow above → After all processed, continue to **Completing Phase 2**.
-8. **Move to next item**
+3. **Wait for explicit approval**
+4. **Log verbatim** when approved
+5. **Update tracking file** - Mark resolution and add notes
+6. **If user chose `auto`**: update `finding_gate_mode: auto` in the spec frontmatter, then process all remaining items using the auto-mode flow above → After all processed, continue to **Completing Phase 2**.
+7. **Move to next item**
 
 > **CHECKPOINT**: Same rules apply - each item requires explicit approval before logging (unless `finding_gate_mode: auto`). No batching.
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -558,7 +558,13 @@ Each item should have enough context that the user understands what they're abou
 
 **Stage 2: Process One Item at a Time**
 
-For each item, present it in detail — what you found, where it came from (source reference), and what you propose to add. Show the proposed content as rendered markdown (not in a code block).
+For each item, present what you found, where it came from (source reference), and what you propose to add.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+{proposed content for this review item}
+```
 
 Check `finding_gate_mode` in the specification frontmatter.
 
@@ -713,7 +719,13 @@ Let's work through these one at a time, starting with #1.
 
 **Stage 2: Process One Item at a Time**
 
-For each item, present it in detail — what's missing or unclear, what questions an implementer would have. Show the proposed content as rendered markdown (not in a code block).
+For each item, present what's missing or unclear, what questions an implementer would have, and what you propose to add.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+{proposed content for this review item}
+```
 
 Check `finding_gate_mode` in the specification frontmatter.
 

--- a/skills/technical-specification/references/specification-guide.md
+++ b/skills/technical-specification/references/specification-guide.md
@@ -785,11 +785,22 @@ After Phase 2 completes, check whether either phase surfaced findings in this cy
 
 #### If findings were surfaced
 
+Do not skip review autonomously — present the choice and let the user decide.
+
+> *Output the next fenced block as a code block:*
+
+```
+Review cycle {N}
+
+Review has run {N-1} times so far.
+@if(finding_gate_mode = auto and review_cycle >= 5)
+Auto-review has not converged after 5 cycles — escalating for human review.
+@endif
+```
+
 Check `finding_gate_mode` and `review_cycle` in the specification frontmatter.
 
 #### If `finding_gate_mode: auto` and `review_cycle < 5`
-
-Announce (one line, no stop):
 
 > *Output the next fenced block as a code block:*
 
@@ -801,9 +812,7 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 #### If `finding_gate_mode: auto` and `review_cycle >= 5`
 
-Review has auto-cycled 5 times without converging. Escalating for human review.
-
-→ Present the gated re-loop prompt below.
+→ Present the re-loop prompt below.
 
 #### If `finding_gate_mode: gated`
 


### PR DESCRIPTION
## Summary

- Add `author_gate_mode` and `finding_gate_mode` to planning, and `finding_gate_mode` to specification — extending the implementation skill's established auto-mode pattern
- Users opt in via `a`/`auto` at any per-item approval gate; remaining items auto-process with one-line code-block announcements (no STOP)
- Gates persist in frontmatter (survives context refresh), reset to `gated` on fresh invocation, and review re-loops auto-continue with a 5-cycle safety cap

## Test plan

- [ ] **Planning author_gate_mode**: Run `/start-planning`, author tasks manually, choose `a`/`auto` at one, verify remaining tasks auto-log with code-block announcements. Verify frontmatter shows `author_gate_mode: auto`
- [ ] **Planning finding_gate_mode**: Run through to plan review, approve a finding with `a`/`auto`, verify remaining findings auto-apply. Verify re-loop auto-continues. Verify clean cycle proceeds without prompting
- [ ] **Specification finding_gate_mode**: Run `/start-specification` with review findings, approve with `a`/`auto`, verify remaining auto-apply across Phase 1 and Phase 2. Verify re-loop auto-continues
- [ ] **Reset on fresh invocation**: After auto was active, re-run the entry point. Verify gates reset to `gated`
- [ ] **Context refresh preservation**: Mid-session with auto active, verify gates read from frontmatter and preserve `auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)