### PR TITLE
feat: add tick output format adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ The contract and scaffolding templates live in `.claude/skills/create-output-for
 **NEVER list output format names (linear, local-markdown, etc.) anywhere except:**
 - `skills/technical-planning/references/output-formats.md` - the authoritative list
 - `skills/technical-planning/references/output-formats/{format}/` - individual format directories
+- `README.md` - user-facing documentation where format options are presented
 
 **Why this matters:** Listing formats elsewhere creates maintenance dependencies. If a format is added or removed, we should only need to update the planning references - not hunt through other skills or documentation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,9 @@ Phase-first directory structure:
 - Research: `docs/workflow/research/` (flat, semantically named files)
 - Discussion: `docs/workflow/discussion/{topic}.md`
 - Specification: `docs/workflow/specification/{topic}/specification.md`
-- Planning: `docs/workflow/planning/{topic}/plan.md`
+- Planning: `docs/workflow/planning/{topic}/plan.md` + format-specific task storage
+- Implementation: `docs/workflow/implementation/{topic}/tracking.md`
+- Review: `docs/workflow/review/{topic}.md`
 
 Commit docs frequently (natural breaks, before context refresh). Skills capture context, don't implement.
 

--- a/README.md
+++ b/README.md
@@ -123,24 +123,7 @@ Not every task needs the full workflow. These skills gather inputs flexibly and 
 
 ### Under the Hood
 
-Skills are organised in two tiers. **Entry-point skills** (`/start-*`, `/status`, etc.) gather context from files, prompts, or inline input. **Processing skills** (`technical-*`) receive those inputs and do the work — they don't know or care where inputs came from. This means the same processing skill can be invoked from different entry points, and you can create custom entry-point skills that feed them in new ways.
-
-```
-  Entry-Point Skills                Processing Skills
-  (gather inputs)                   (do the work)
-
-  /start-specification ──┐
-                         ├────▶  technical-specification
-  /start-feature ────────┘
-
-  /start-planning ───────────▶  technical-planning
-
-  /start-implementation ─────▶  technical-implementation
-
-  (your custom) ─────────────▶  (any processing skill)
-```
-
-Entry-point skills are interchangeable — `/start-specification` and `/start-feature` both feed the same processing skill with different inputs.
+Skills are organised in two tiers. **Entry-point skills** (`/start-*`, `/status`, etc.) gather context from files, prompts, or inline input. **Processing skills** (`technical-*`) receive those inputs and do the work — they don't know or care where inputs came from. This separation means the same processing skill can be invoked from different entry points: `/start-specification` and `/start-feature` both feed `technical-specification` with different inputs. You can create custom entry-point skills that feed processing skills in new ways.
 
 ### Workflow Skills
 

--- a/README.md
+++ b/README.md
@@ -126,24 +126,21 @@ Not every task needs the full workflow. These skills gather inputs flexibly and 
 Skills are organised in two tiers. **Entry-point skills** (`/start-*`, `/status`, etc.) gather context from files, prompts, or inline input. **Processing skills** (`technical-*`) receive those inputs and do the work — they don't know or care where inputs came from. This means the same processing skill can be invoked from different entry points, and you can create custom entry-point skills that feed them in new ways.
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    ENTRY-POINT SKILLS                        │
-│  (gather inputs from files, prompts, inline context)         │
-├─────────────────────────────────────────────────────────────┤
-│  /start-specification   /start-feature   (your custom)      │
-│         │                       │                 │          │
-│         └───────────┬───────────┘                 │          │
-│                     ▼                             ▼          │
-├─────────────────────────────────────────────────────────────┤
-│                    PROCESSING SKILLS                         │
-│  (process inputs without knowing their source)               │
-├─────────────────────────────────────────────────────────────┤
-│           technical-specification skill                      │
-│           technical-planning skill                           │
-│           technical-implementation skill                     │
-│           etc.                                               │
-└─────────────────────────────────────────────────────────────┘
+  Entry-Point Skills                Processing Skills
+  (gather inputs)                   (do the work)
+
+  /start-specification ──┐
+                         ├────▶  technical-specification
+  /start-feature ────────┘
+
+  /start-planning ───────────▶  technical-planning
+
+  /start-implementation ─────▶  technical-implementation
+
+  (your custom) ─────────────▶  (any processing skill)
 ```
+
+Entry-point skills are interchangeable — `/start-specification` and `/start-feature` both feed the same processing skill with different inputs.
 
 ### Workflow Skills
 
@@ -172,17 +169,11 @@ Choose a format when planning begins. New formats can be scaffolded with `/creat
 
 ## Installation
 
-| Method  | Where files live           | Best for                                        |
-|---------|----------------------------|-------------------------------------------------|
-| **npm** | `.claude/` in your project | Ownership, version control, Claude Code for Web |
-
-### npm
-
 ```bash
 npm install -D @leeovery/claude-technical-workflows
 ```
 
-Skills are copied to `.claude/` and can be committed, giving you ownership and making them available everywhere including Claude Code for Web.
+Skills are copied to `.claude/` in your project and can be committed, giving you ownership and making them available everywhere including Claude Code for Web.
 
 <details>
 <summary>pnpm users</summary>
@@ -210,23 +201,33 @@ npx claude-manager remove @leeovery/claude-technical-workflows && npm rm @leeove
 
 ### Output Files
 
-Documents are stored in your project using a **phase-first** organisation:
+Documents are stored in your project using a **phase-first** organisation. Early phases use flat files; later phases use topic directories with multiple files for tracking and analysis.
 
 ```
 docs/workflow/
-├── research/              # Phase 1 - flat, semantically named files
+├── research/                          # Phase 1 — flat, semantically named
 │   ├── exploration.md
 │   ├── competitor-analysis.md
 │   └── pricing-models.md
-├── discussion/            # Phase 2 - one file per topic
+├── discussion/                        # Phase 2 — one file per topic
 │   └── {topic}.md
-├── specification/         # Phase 3 - one file per topic
-│   └── {topic}.md
-└── planning/              # Phase 4 - one file per topic
+├── specification/                     # Phase 3 — directory per topic
+│   └── {topic}/
+│       └── specification.md
+├── planning/                          # Phase 4 — directory per topic
+│   └── {topic}/
+│       ├── plan.md                    #   Plan index (phases, metadata)
+│       └── tasks/                     #   Task files (local-markdown format)
+│           ├── {topic}-1-1.md
+│           └── {topic}-1-2.md
+├── implementation/                    # Phase 5 — directory per topic
+│   └── {topic}/
+│       └── tracking.md               #   Progress, gates, current task
+└── review/                            # Phase 6 — one file per review
     └── {topic}.md
 ```
 
-Research starts with `exploration.md` and splits into topic files as themes emerge. From discussion onwards, each topic gets its own file per phase.
+Research starts with `exploration.md` and splits into topic files as themes emerge. From specification onwards, each topic gets its own directory. Planning task storage varies by [output format](#output-formats) — the tree above shows local-markdown; Tick and Linear store tasks externally.
 
 ### Package Structure
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Research → Discussion → Specification → Planning → Implementation → Re
 
 **Flexible entry points:** Need the full workflow? Start at Research or Discussion and progress through each phase. Already know what you're building? Jump straight to Specification with `/start-feature`. Entry-point skills gather context and feed it to processing skills.
 
+**Engineered like software.** This isn't a collection of prompts — it's built with the same discipline you'd apply to code. Processing skills follow the single responsibility principle. Entry-point skills compose with them, keeping input gathering DRY. Output formats implement a [5-file adapter contract](#output-formats), so planning works identically regardless of where tasks end up. Agents handle isolated concerns. The result is a natural language workflow that's modular, extensible, and maintainable — software engineering principles applied to agentic workflows.
+
 > [!NOTE]
 > **Work in progress.** The workflow is being refined through real-world usage. Expect updates as patterns evolve.
 
@@ -104,7 +106,7 @@ Each phase produces documents that feed the next. Here's the journey:
 
 **Specification** — This is where the magic happens. The skill analyses *all* your discussions and creates intelligent groupings — 10 discussions might become 3–5 specifications, or you can unify everything into one. It filters hallucinations, enriches gaps, and validates decisions against each other. The spec becomes the golden document: planning only references this, not earlier phases.
 
-**Planning** — Converts each specification into phased implementation plans with tasks, acceptance criteria, and dependency ordering. Supports multiple output formats. Task authoring has per-item approval gates (with auto-mode for faster flow).
+**Planning** — Converts each specification into phased implementation plans with tasks, acceptance criteria, and dependency ordering. Supports [multiple output formats](#output-formats) — from local markdown files to CLI tools with native dependency graphs. Task authoring has per-item approval gates (with auto-mode for faster flow).
 
 **Implementation** — Executes plans via strict TDD. Tests first, then code, commit after each task. Per-task approval gates keep you in control, with auto-mode available when you trust the flow.
 
@@ -155,6 +157,18 @@ Skills are organised in two tiers. **Entry-point skills** (`/start-*`, `/status`
 | Review         | `/start-review`         |
 
 Run the skill directly or ask Claude to run it. Each gathers context from previous phase outputs and passes it to the processing skill.
+
+### Output Formats
+
+Planning supports multiple output formats through an adapter pattern. Each format implements a 5-file contract — about, authoring, reading, updating, and graph — so the planning workflow works identically regardless of where tasks are stored.
+
+| Format | Best for | Setup | |
+|--------|----------|-------|-|
+| **Tick** | AI-driven workflows, native dependencies, token-efficient | `brew install leeovery/tools/tick` | Recommended |
+| **Local Markdown** | Simple features, offline, quick iterations | None | |
+| **Linear** | Team collaboration, visual tracking | Linear account + MCP server | |
+
+Choose a format when planning begins. New formats can be scaffolded with `/create-output-format`.
 
 ## Installation
 
@@ -280,7 +294,7 @@ Sequential skills that expect files from previous phases and pass content to pro
 | [**/start-research**](skills/start-research/)                                | Begin research exploration. For early-stage ideas, feasibility checks, and broad exploration before formal discussion.                                                                                     |
 | [**/start-discussion**](skills/start-discussion/)                            | Begin a new technical discussion. Gathers topic, context, background information, and relevant codebase areas before starting documentation.                                                               |
 | [**/start-specification**](skills/start-specification/)                      | Start a specification session from existing discussion(s). Automatically analyses multiple discussions for natural groupings and consolidates them into unified specifications.                            |
-| [**/start-planning**](skills/start-planning/)                                | Start a planning session from an existing specification. Creates implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats (local markdown, Linear). |
+| [**/start-planning**](skills/start-planning/)                                | Start a planning session from an existing specification. Creates implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats. |
 | [**/start-implementation**](skills/start-implementation/)                    | Start implementing a plan. Executes tasks via strict TDD, committing after each passing test.                                                                                                              |
 | [**/start-review**](skills/start-review/)                                    | Start reviewing completed work. Validates implementation against plan tasks and acceptance criteria.                                                                                                        |
 

--- a/skills/technical-planning/references/output-formats.md
+++ b/skills/technical-planning/references/output-formats.md
@@ -33,3 +33,14 @@ Tasks managed as Linear issues within a Linear project. A thin Plan Index File p
 - **Pros**: Visual tracking, team collaboration, real-time updates, integrates with existing Linear workflows
 - **Cons**: Requires Linear account and MCP server, external dependency, not fully local
 - **Best for**: Teams already using Linear, collaborative projects needing shared visibility
+
+### Tick
+format: `tick`
+
+adapter: [tick/](output-formats/tick/)
+
+CLI task management with native dependencies, priority, and token-efficient output designed for AI agents. Tasks stored in git-friendly JSONL with a SQLite cache.
+
+- **Pros**: Native dependency graph with cycle detection, `tick ready` for next-task resolution, token-efficient TOON output, git-friendly, works offline
+- **Cons**: Requires Tick CLI installation, no visual board or web UI
+- **Best for**: AI-driven workflows needing structured task tracking with dependency resolution

--- a/skills/technical-planning/references/output-formats/tick/about.md
+++ b/skills/technical-planning/references/output-formats/tick/about.md
@@ -1,0 +1,68 @@
+# Tick
+
+*Output format adapter for **[technical-planning](../../../SKILL.md)***
+
+---
+
+Use this format when you want structured task tracking with native dependency resolution, priority ordering, and token-efficient output designed for AI agents.
+
+## Benefits
+
+- Native dependency graph with cycle detection and blocking resolution
+- `tick ready` returns the next available task in one command
+- Token-efficient TOON output format (30-60% fewer tokens than JSON)
+- Git-friendly JSONL storage — append-only, human-readable
+- Parent/child hierarchy maps naturally to topic/phase/task structure
+- SQLite cache for fast queries over large task sets
+
+## Setup
+
+Install Tick:
+
+```bash
+# macOS
+brew install leeovery/tools/tick
+
+# Linux
+curl -fsSL https://raw.githubusercontent.com/leeovery/tick/main/scripts/install.sh | bash
+
+# Go
+go install github.com/leeovery/tick/cmd/tick@latest
+```
+
+Initialize in the project root:
+
+```bash
+tick init
+```
+
+Add to `.gitignore`:
+
+```
+.tick/.store
+.tick/lock
+```
+
+## Structure Mapping
+
+| Concept | Tick Entity |
+|---------|:---|
+| Topic | Top-level parent task |
+| Phase | Subtask of the topic task |
+| Task | Subtask of a phase task |
+| Dependency | Blocking relationship (`tick dep add`) |
+
+The 3-level hierarchy (topic → phase → task) uses Tick's parent/child system. Parent tasks are implicitly blocked by their children — a parent is not "ready" until all children are complete. Explicit dependencies (`tick dep add`) handle cross-phase and cross-topic blocking.
+
+## Output Location
+
+Tasks are stored in a `.tick/` directory at the project root:
+
+```
+.tick/
+├── tasks.jsonl     # Append-only source of truth (git-friendly)
+├── .store          # SQLite cache (auto-rebuilt, do not commit)
+└── lock            # File lock for concurrent access
+```
+
+All task data lives in `tasks.jsonl`. The hierarchy is encoded via parent references — no subdirectories needed.

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -1,0 +1,94 @@
+# Tick: Authoring
+
+## Task Storage
+
+Tasks are created using the `tick create` command. Before creating individual tasks, establish the topic and phase parent tasks.
+
+**1. Create the topic task:**
+
+```bash
+tick create "{Topic Name}"
+```
+
+This returns the topic task ID (e.g., `tick-a1b2`).
+
+**2. Create phase tasks as children of the topic:**
+
+```bash
+tick create "Phase 1: {Phase Name}" --parent tick-a1b2
+tick create "Phase 2: {Phase Name}" --parent tick-a1b2
+```
+
+**3. Create tasks as children of their phase:**
+
+```bash
+tick create "{Task Title}" --parent tick-c3d4 \
+  --description "{Task description content.
+
+Acceptance criteria, edge cases, and implementation
+details go here. Supports multi-line text.}"
+```
+
+Complete example — creating a task under a phase:
+
+```bash
+tick create "Implement authentication middleware" \
+  --parent tick-c3d4 \
+  --description "Create Express middleware that validates JWT tokens on protected routes.
+
+Acceptance criteria:
+- Validates token signature and expiry
+- Extracts user ID from token payload
+- Returns 401 for missing or invalid tokens
+- Passes user context to downstream handlers"
+```
+
+## Task Properties
+
+### Status
+
+Tasks are created with `open` status by default.
+
+| Status | Meaning |
+|--------|---------|
+| `open` | Task has been authored but not started |
+| `in_progress` | Task is currently being worked on |
+| `done` | Task is complete |
+| `cancelled` | Task is no longer needed |
+
+### Phase Grouping
+
+Phases are represented as parent tasks. Each task belongs to a phase by being a child of that phase's task. Use `--parent <phase-id>` during creation.
+
+To list tasks within a phase:
+
+```bash
+tick list --parent <phase-id>
+```
+
+### Labels / Tags
+
+Tick does not have a native label or tag system. Categorisation is handled through the parent/child hierarchy.
+
+## Flagging
+
+When information is missing, prefix the task title with `[NEEDS INFO]` and include questions in the description:
+
+```bash
+tick create "[NEEDS INFO] Rate limiting strategy" \
+  --parent tick-c3d4 \
+  --description "Needs clarification:
+- What is the rate limit threshold?
+- Per-user or per-IP?
+- What response code on limit exceeded?"
+```
+
+## Cleanup (Restart)
+
+Delete the `.tick/` directory and reinitialize:
+
+```bash
+rm -rf .tick && tick init
+```
+
+This removes all tasks and starts fresh. For single-topic projects this is the simplest restart.

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -85,10 +85,22 @@ tick create "[NEEDS INFO] Rate limiting strategy" \
 
 ## Cleanup (Restart)
 
-Delete the `.tick/` directory and reinitialize:
+Cancel the topic task and all its descendants. First, list the tasks to collect their IDs:
+
+```bash
+tick list --parent <topic-id>
+```
+
+Then cancel each task (leaf tasks first, then phases, then the topic):
+
+```bash
+tick cancel <task-id>
+```
+
+Cancelled tasks remain in the JSONL history but are excluded from `tick ready` and active listings.
+
+**Full reset** (removes all tasks across all topics):
 
 ```bash
 rm -rf .tick && tick init
 ```
-
-This removes all tasks and starts fresh. For single-topic projects this is the simplest restart.

--- a/skills/technical-planning/references/output-formats/tick/graph.md
+++ b/skills/technical-planning/references/output-formats/tick/graph.md
@@ -1,0 +1,62 @@
+# Tick: Task Graph
+
+Tick has native support for priority and blocking dependencies with cycle detection. This file is used by the graphing agent after all tasks have been authored.
+
+## Priority
+
+| Level | Name | Value |
+|-------|------|-------|
+| 0 | Critical | Highest priority |
+| 1 | High | |
+| 2 | Medium | Default |
+| 3 | Low | |
+| 4 | Backlog | Lowest priority |
+
+Lower number = higher priority. Tasks are created with priority `2` (medium) by default.
+
+### Setting Priority
+
+```bash
+tick update <task-id> --priority 1
+```
+
+### Removing Priority
+
+Reset to the default medium priority:
+
+```bash
+tick update <task-id> --priority 2
+```
+
+Tick does not support unsetting priority — every task has a priority level. Use `2` (medium) as the neutral default.
+
+## Dependencies
+
+Tick validates all dependency changes: prevents cycles, self-references, and children blocked by their own parent.
+
+### Adding a Dependency
+
+Declare that a task is blocked by another task:
+
+```bash
+tick dep add <task-id> <blocked-by-id>
+```
+
+Example — task `tick-e5f6` depends on `tick-a1b2`:
+
+```bash
+tick dep add tick-e5f6 tick-a1b2
+```
+
+To add multiple dependencies to a single task, run the command for each:
+
+```bash
+tick dep add tick-e5f6 tick-a1b2
+tick dep add tick-e5f6 tick-c3d4
+```
+
+### Removing a Dependency
+
+```bash
+tick dep rm <task-id> <blocked-by-id>
+```

--- a/skills/technical-planning/references/output-formats/tick/reading.md
+++ b/skills/technical-planning/references/output-formats/tick/reading.md
@@ -1,0 +1,61 @@
+# Tick: Reading
+
+## Listing Tasks
+
+To retrieve all tasks for a topic:
+
+```bash
+tick list --parent <topic-id>
+```
+
+This returns all descendants (phases and tasks) with summary-level data: id, title, status, priority, and parent. Results are sorted by priority (ascending), then creation date.
+
+To list tasks within a specific phase:
+
+```bash
+tick list --parent <phase-id>
+```
+
+Additional filtering:
+
+```bash
+tick list --parent <topic-id> --status open       # only open tasks
+tick list --parent <topic-id> --ready              # ready tasks only
+tick list --parent <topic-id> --blocked            # blocked tasks only
+tick list --parent <topic-id> --priority 0         # critical tasks only
+```
+
+## Extracting a Task
+
+To read full task detail including description, blockers, and children:
+
+```bash
+tick show <task-id>
+```
+
+Returns: id, title, status, priority, created/updated timestamps, parent, blocked_by list, children list, and full description.
+
+## Next Available Task
+
+To find the next task to implement:
+
+```bash
+tick ready --parent <phase-id>
+```
+
+This returns tasks that are:
+
+1. Status is `open` (not started, not done, not cancelled)
+2. No unresolved blockers (all `blocked_by` tasks are `done`)
+3. No open children (leaf tasks, or parent tasks whose children are all complete)
+4. Within the specified phase (scoped by `--parent`)
+
+Results are sorted by priority (lower number = higher priority), then creation date. The first result is the next task.
+
+To find the next task across all phases of a topic:
+
+```bash
+tick ready --parent <topic-id>
+```
+
+If `tick ready` returns no results, either all tasks are complete or remaining tasks are blocked.

--- a/skills/technical-planning/references/output-formats/tick/updating.md
+++ b/skills/technical-planning/references/output-formats/tick/updating.md
@@ -1,0 +1,25 @@
+# Tick: Updating
+
+## Status Transitions
+
+Tick uses dedicated commands for each status transition:
+
+| Transition | Command |
+|------------|---------|
+| Start | `tick start <task-id>` (open → in_progress) |
+| Complete | `tick done <task-id>` (in_progress → done) |
+| Cancelled | `tick cancel <task-id>` (any → cancelled) |
+| Reopen | `tick reopen <task-id>` (done/cancelled → open) |
+| Skipped | `tick cancel <task-id>` (no separate skipped status — use cancel) |
+
+`done` and `cancel` set a closed timestamp. `reopen` clears it.
+
+## Updating Task Content
+
+To update a task's properties:
+
+- **Title**: `tick update <task-id> --title "New title"`
+- **Description**: `tick update <task-id> --description "New description"`
+- **Priority**: `tick update <task-id> --priority 1`
+- **Parent**: `tick update <task-id> --parent <new-parent-id>` (pass empty string to clear)
+- **Dependencies**: See [graph.md](graph.md)


### PR DESCRIPTION
## Summary

- Add Tick CLI as a planning output format with 5-file adapter (about, authoring, reading, updating, graph)
- Tick provides native dependency resolution, priority levels (0-4), parent/child task hierarchy, and `tick ready` for next-task selection
- Uses 3-level hierarchy: topic → phase → task mapped to Tick's parent/child system
- Register tick format in output-formats.md

## Test plan

- [ ] Verify all 5 adapter files are present and contain no `{placeholder}` tokens
- [ ] Confirm authoring.md does NOT contain priority or dependency information
- [ ] Confirm reading.md documents `tick ready --parent` for next-task resolution
- [ ] Confirm graph.md documents `tick dep add/rm` for dependencies
- [ ] Verify tick format is registered in output-formats.md
- [ ] Test adapter by running `/start-planning` and selecting tick format

🤖 Generated with [Claude Code](https://claude.com/claude-code)