### PR TITLE
feat(planning): add auto-gate for task list approval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -465,7 +465,7 @@ Entry-point skills that invoke processing skills use this exact blockquote to pr
 
 ### Auto-Mode Gates
 
-Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STOP gates. This pattern is used in implementation (task + fix gates), planning (task authoring + review findings), and specification (review findings).
+Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STOP gates. This pattern is used in implementation (task + fix gates), planning (task list approval + task authoring + review findings), and specification (review findings).
 
 **Frontmatter tracking**: Gate modes are stored in the relevant frontmatter file (`gated` or `auto`). This ensures they survive context refresh.
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -62,7 +62,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 2. **Read all tracking and state files** for the current topic — plan index files, review tracking files, implementation tracking files, or any working documents this skill creates. These are your source of truth for progress.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
-5. **Check `author_gate_mode` and `finding_gate_mode`** in the Plan Index File frontmatter — if `auto`, the user previously opted in during this session. Preserve these values.
+5. **Check `task_list_gate_mode`, `author_gate_mode`, and `finding_gate_mode`** in the Plan Index File frontmatter — if `auto`, the user previously opted in during this session. Preserve these values.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 
@@ -118,7 +118,7 @@ Found existing plan for **{topic}** (previously reached phase {N}, task {M}).
 
 If the specification changed, update `spec_commit` in the Plan Index File frontmatter to the current commit hash.
 
-Reset `author_gate_mode` and `finding_gate_mode` to `gated` in the Plan Index File frontmatter (fresh invocation = fresh gates).
+Reset `task_list_gate_mode`, `author_gate_mode`, and `finding_gate_mode` to `gated` in the Plan Index File frontmatter (fresh invocation = fresh gates).
 
 → Proceed to **Step 1**.
 

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -55,7 +55,7 @@ Task {M} of {total}: {Task Name} — authored. Logging to plan.
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved. I'll log it to the plan.
-- **`a`/`auto`** — Approve this and all remaining tasks automatically
+- **`a`/`auto`** — Approve this and all remaining task authoring gates automatically
 - **Or tell me what to change.**
 - **Or navigate** — a different phase or task, or the leading edge.
 · · · · · · · · · · · ·

--- a/skills/technical-planning/references/define-tasks.md
+++ b/skills/technical-planning/references/define-tasks.md
@@ -43,7 +43,15 @@ planning:
 
 Commit: `planning({topic}): draft Phase {N} task list`
 
-Present the task overview to the user as rendered markdown (not in a code block). Then check the gate mode.
+Present the task overview to the user:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+{task overview from planning-task-designer agent}
+```
+
+Then check the gate mode.
 
 ### Check Gate Mode
 

--- a/skills/technical-planning/references/define-tasks.md
+++ b/skills/technical-planning/references/define-tasks.md
@@ -43,7 +43,23 @@ planning:
 
 Commit: `planning({topic}): draft Phase {N} task list`
 
-Present the task overview to the user as rendered markdown (not in a code block). Then, separately, present the choices:
+Present the task overview to the user as rendered markdown (not in a code block). Then check the gate mode.
+
+### Check Gate Mode
+
+Check `task_list_gate_mode` in the Plan Index File frontmatter.
+
+#### If `task_list_gate_mode: auto`
+
+> *Output the next fenced block as a code block:*
+
+```
+Phase {N}: {Phase Name} — task list approved. Proceeding to authoring.
+```
+
+→ Skip to **If approved** below.
+
+#### If `task_list_gate_mode: gated`
 
 **STOP.** Ask:
 
@@ -53,6 +69,7 @@ Present the task overview to the user as rendered markdown (not in a code block)
 · · · · · · · · · · · ·
 **To proceed:**
 - **`y`/`yes`** — Approved.
+- **`a`/`auto`** — Approve this and all remaining task list gates automatically
 - **Or tell me what to change** — reorder, split, merge, add, edit, or remove tasks.
 - **Or navigate** — a different phase or task, or the leading edge.
 · · · · · · · · · · · ·
@@ -66,12 +83,19 @@ Re-invoke `planning-task-designer` with all original inputs PLUS:
 
 Update the Plan Index File with the revised task table, re-present, and ask again. Repeat until approved.
 
-#### If approved
+#### If `auto`
+
+Note that `task_list_gate_mode` should be updated to `auto` during the commit step below.
+
+→ Proceed to **If approved** below.
+
+#### If approved (`y`/`yes` or `auto`)
 
 **If the task list is new or was amended:**
 
 1. Advance the `planning:` block to the first task in this phase
-2. Commit: `planning({topic}): approve Phase {N} task list`
+2. If user chose `auto` at this gate: update `task_list_gate_mode: auto` in the Plan Index File frontmatter
+3. Commit: `planning({topic}): approve Phase {N} task list`
 
 **If the task list was already approved and unchanged:** No updates needed.
 

--- a/skills/technical-planning/references/plan-construction.md
+++ b/skills/technical-planning/references/plan-construction.md
@@ -79,6 +79,20 @@ After Step A returns with an approved task table, continue to **Author Tasks for
 {task list from the phase's task table}
 ```
 
+Check `task_list_gate_mode` in the Plan Index File frontmatter.
+
+#### If `task_list_gate_mode: auto` (existing task table)
+
+> *Output the next fenced block as a code block:*
+
+```
+Phase {N}: {Phase Name} — task list confirmed. Proceeding to authoring.
+```
+
+→ Continue to **Author Tasks for the Phase** below.
+
+#### If `task_list_gate_mode: gated` (existing task table)
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```

--- a/skills/technical-planning/references/plan-index-schema.md
+++ b/skills/technical-planning/references/plan-index-schema.md
@@ -23,6 +23,7 @@ spec_commit: {commit-hash}
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 external_dependencies: []
+task_list_gate_mode: gated
 author_gate_mode: gated
 finding_gate_mode: gated
 planning:
@@ -43,6 +44,7 @@ planning:
 | `created` | Plan creation — today's date |
 | `updated` | Plan creation — today's date; update on each commit |
 | `external_dependencies` | Dependency resolution (Step 6) |
+| `task_list_gate_mode` | Plan creation → `gated`; user opts in → `auto` |
 | `author_gate_mode` | Plan creation → `gated`; user opts in → `auto` |
 | `finding_gate_mode` | Plan creation → `gated`; user opts in → `auto` |
 | `planning.phase` | Tracks current phase position |


### PR DESCRIPTION
## Summary

- Adds `task_list_gate_mode` as a new independent frontmatter field in the Plan Index File, alongside existing `author_gate_mode` and `finding_gate_mode`
- Users can now choose `a`/`auto` at any task list approval gate to skip all subsequent task list STOP gates
- Auto descriptions clarified: task list gates say "all remaining task list gates", task authoring gates say "all remaining task authoring gates"

## Files Changed

- **plan-index-schema.md** — new `task_list_gate_mode` field in template + table
- **define-tasks.md** — gate check + `a`/`auto` option for new task lists
- **plan-construction.md** — gate check for existing task table review
- **author-tasks.md** — clarified auto description
- **SKILL.md** — added to context refresh check + fresh invocation reset
- **CLAUDE.md** — updated auto-mode gates description

## Test plan

- [ ] Run planning skill on a new topic — verify `task_list_gate_mode: gated` appears in frontmatter
- [ ] Choose `a`/`auto` at first task list gate — verify subsequent phase task lists are auto-approved
- [ ] Verify task authoring gates still operate independently (not affected by task list auto)
- [ ] Resume a plan with `continue` — verify all gate modes reset to `gated`
- [ ] Context refresh — verify `task_list_gate_mode` is preserved when `auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)