### PR TITLE
refactor: split .cache/ into .state/ + .cache/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,5 @@ __pycache__/
 *.so
 .Python
 
-# Workflow ephemeral runtime data (sessions, etc.)
-docs/workflow/.cache/
 
 .claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__/
 *.so
 .Python
 
-# Workflow session state (ephemeral, per-session)
-docs/workflow/.cache/sessions/
+# Workflow ephemeral runtime data (sessions, etc.)
+docs/workflow/.cache/
 
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ The `/migrate` skill keeps workflow files in sync with the current system design
 **How it works:**
 - `skills/migrate/scripts/migrate.sh` runs all migration scripts in `skills/migrate/scripts/migrations/` in numeric order
 - Each migration is idempotent - safe to run multiple times
-- Progress is tracked in `docs/workflow/.cache/migrations.log`
+- Progress is tracked in `docs/workflow/.state/migrations`
 - Delete the log file to force re-running all migrations
 
 **Adding new migrations:**

--- a/progressive-disclosure/start-specification/flows/03-multiple-no-specs-no-cache.md
+++ b/progressive-disclosure/start-specification/flows/03-multiple-no-specs-no-cache.md
@@ -100,7 +100,7 @@ Claude reads all 3 concluded discussion files, considers the user's context, and
 Analyzing discussions...
 ```
 
-Analysis result — writes to `docs/workflow/.cache/discussion-consolidation-analysis.md`:
+Analysis result — writes to `docs/workflow/.state/discussion-consolidation-analysis.md`:
 ```markdown
 ---
 checksum: abc123...
@@ -291,7 +291,7 @@ Steps 0-6 are identical to Scenario A.
 
 Claude deletes the cache:
 ```bash
-rm docs/workflow/.cache/discussion-consolidation-analysis.md
+rm docs/workflow/.state/discussion-consolidation-analysis.md
 ```
 
 Loops back to Step 4:

--- a/progressive-disclosure/start-specification/flows/04-multiple-no-specs-valid-cache.md
+++ b/progressive-disclosure/start-specification/flows/04-multiple-no-specs-valid-cache.md
@@ -48,7 +48,7 @@ cache:
 
 Valid cache, no specs → show groupings directly from cache.
 
-Claude loads `docs/workflow/.cache/discussion-consolidation-analysis.md` and presents:
+Claude loads `docs/workflow/.state/discussion-consolidation-analysis.md` and presents:
 
 ```
 Specification Overview
@@ -151,7 +151,7 @@ Steps 0-3 are identical to Scenario A.
 
 Claude deletes the cache:
 ```bash
-rm docs/workflow/.cache/discussion-consolidation-analysis.md
+rm docs/workflow/.state/discussion-consolidation-analysis.md
 ```
 
 ### Step 4: Gather Analysis Context

--- a/progressive-disclosure/start-specification/flows/05-multiple-no-specs-stale-cache.md
+++ b/progressive-disclosure/start-specification/flows/05-multiple-no-specs-stale-cache.md
@@ -80,7 +80,7 @@ Proceed with analysis? (y/n)
 
 Claude deletes the stale cache:
 ```bash
-rm docs/workflow/.cache/discussion-consolidation-analysis.md
+rm docs/workflow/.state/discussion-consolidation-analysis.md
 ```
 
 ### Step 4: Gather Analysis Context

--- a/progressive-disclosure/start-specification/flows/06-multiple-with-specs-no-cache.md
+++ b/progressive-disclosure/start-specification/flows/06-multiple-with-specs-no-cache.md
@@ -145,7 +145,7 @@ Your context (or 'none'):
 
 Claude reads all 5 concluded discussions. Considers existing specs and user context. Forms groupings preserving existing spec names (anchored names will apply on subsequent runs).
 
-Cache written to `docs/workflow/.cache/discussion-consolidation-analysis.md`:
+Cache written to `docs/workflow/.state/discussion-consolidation-analysis.md`:
 ```markdown
 ---
 checksum: def456...

--- a/progressive-disclosure/start-specification/flows/07-multiple-with-specs-valid-cache.md
+++ b/progressive-disclosure/start-specification/flows/07-multiple-with-specs-valid-cache.md
@@ -303,7 +303,7 @@ Steps 0-3 identical to Scenario A.
 
 Claude deletes the cache:
 ```bash
-rm docs/workflow/.cache/discussion-consolidation-analysis.md
+rm docs/workflow/.state/discussion-consolidation-analysis.md
 ```
 
 ### Step 4: Gather Analysis Context

--- a/progressive-disclosure/start-specification/flows/08-multiple-with-specs-stale-cache.md
+++ b/progressive-disclosure/start-specification/flows/08-multiple-with-specs-stale-cache.md
@@ -130,7 +130,7 @@ Enter choice (1-3):
 
 Claude deletes the stale cache:
 ```bash
-rm docs/workflow/.cache/discussion-consolidation-analysis.md
+rm docs/workflow/.state/discussion-consolidation-analysis.md
 ```
 
 ### Step 4: Gather Analysis Context

--- a/progressive-disclosure/start-specification/plan.md
+++ b/progressive-disclosure/start-specification/plan.md
@@ -84,7 +84,7 @@ Key observation: `analysis-flow.md` always feeds into `display-groupings.md`, an
 name: start-specification
 description: "Start a specification session from concluded discussions. Discovers available discussions, offers consolidation assessment for multiple discussions, and invokes the technical-specification skill."
 disable-model-invocation: true
-allowed-tools: Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/discussion-consolidation-analysis.md)
+allowed-tools: Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.state), Bash(rm docs/workflow/.state/discussion-consolidation-analysis.md)
 ---
 ```
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -39,7 +39,7 @@ Return control silently - no user interaction needed.
 ## Notes
 
 - This skill is run automatically at the start of every workflow skill
-- Migrations are tracked in `docs/workflow/.cache/migrations.log` (one migration ID per line)
+- Migrations are tracked in `docs/workflow/.state/migrations` (one migration ID per line)
 - The orchestrator skips entire migrations once recorded — individual scripts don't track
 - To force re-running all migrations, delete the tracking file
 - Each migration is idempotent - safe to run multiple times

--- a/skills/migrate/scripts/migrations/010-gitignore-sessions.sh
+++ b/skills/migrate/scripts/migrations/010-gitignore-sessions.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# 010-cache-state-restructure.sh
+#
+# Restructures docs/workflow/.cache/ → .state/ + .cache/:
+#   - .state/ = committed persistent workflow state (analysis files)
+#   - .cache/ = gitignored ephemeral runtime data (sessions)
+#
+# Steps:
+#   1. Move analysis files from .cache/ → .state/ (if they exist)
+#   2. Clean up orphaned .cache/migrations / .cache/migrations.log
+#   3. Add docs/workflow/.cache/ to .gitignore
+#   4. Remove old docs/workflow/.cache/sessions/ entry from .gitignore
+#
+# Idempotent: safe to run multiple times.
+#
+# This script is sourced by migrate.sh and has access to:
+#   - report_update "filepath" "description"
+#   - report_skip "filepath"
+
+STATE_DIR="docs/workflow/.state"
+CACHE_DIR="docs/workflow/.cache"
+GITIGNORE=".gitignore"
+NEW_ENTRY="docs/workflow/.cache/"
+OLD_ENTRY="docs/workflow/.cache/sessions/"
+
+# --- Step 1: Move analysis files from .cache/ to .state/ ---
+
+ANALYSIS_FILES=(
+    "discussion-consolidation-analysis.md"
+    "research-analysis.md"
+)
+
+for file in "${ANALYSIS_FILES[@]}"; do
+    if [ -f "$CACHE_DIR/$file" ]; then
+        mkdir -p "$STATE_DIR"
+        mv "$CACHE_DIR/$file" "$STATE_DIR/$file"
+        report_update "$STATE_DIR/$file" "moved from .cache/"
+    fi
+done
+
+# --- Step 2: Clean up orphaned migration tracking in .cache/ ---
+
+for old_file in "$CACHE_DIR/migrations" "$CACHE_DIR/migrations.log"; do
+    if [ -f "$old_file" ]; then
+        rm "$old_file"
+        report_update "$old_file" "removed orphaned tracking file"
+    fi
+done
+
+# --- Step 3: Add docs/workflow/.cache/ to .gitignore ---
+
+if [ -f "$GITIGNORE" ] && grep -qxF "$NEW_ENTRY" "$GITIGNORE"; then
+    report_skip "$GITIGNORE"
+else
+    echo "$NEW_ENTRY" >> "$GITIGNORE"
+    report_update "$GITIGNORE" "added .cache/ to gitignore"
+fi
+
+# --- Step 4: Remove old sessions/ entry from .gitignore (now redundant) ---
+
+if [ -f "$GITIGNORE" ] && grep -qF "$OLD_ENTRY" "$GITIGNORE"; then
+    # Remove the old entry (and its comment if present)
+    grep -vF "$OLD_ENTRY" "$GITIGNORE" > "${GITIGNORE}.tmp"
+    mv "${GITIGNORE}.tmp" "$GITIGNORE"
+    report_update "$GITIGNORE" "removed redundant sessions/ entry"
+fi

--- a/skills/start-discussion/SKILL.md
+++ b/skills/start-discussion/SKILL.md
@@ -2,7 +2,7 @@
 name: start-discussion
 description: "Start a technical discussion. Discovers research and existing discussions, offers multiple entry paths, and invokes the technical-discussion skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-discussion/scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/research-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh)
+allowed-tools: Bash(.claude/skills/start-discussion/scripts/discovery.sh), Bash(mkdir -p docs/workflow/.state), Bash(rm docs/workflow/.state/research-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh)
 hooks:
   PreToolUse:
     - hooks:

--- a/skills/start-discussion/references/handle-selection.md
+++ b/skills/start-discussion/references/handle-selection.md
@@ -56,7 +56,7 @@ Refreshing analysis...
 
 Delete the cache file:
 ```bash
-rm docs/workflow/.cache/research-analysis.md
+rm docs/workflow/.state/research-analysis.md
 ```
 
 → Return to **Step 3** to re-analyze.

--- a/skills/start-discussion/references/research-analysis.md
+++ b/skills/start-discussion/references/research-analysis.md
@@ -14,7 +14,7 @@ Use `cache.status` from discovery to determine the approach:
 Using cached research analysis (unchanged since {cache.generated})
 ```
 
-Load the topics from `docs/workflow/.cache/research-analysis.md` and proceed.
+Load the topics from `docs/workflow/.state/research-analysis.md` and proceed.
 
 #### If cache.status is "stale" or "none"
 
@@ -40,10 +40,10 @@ Read each research file and extract key themes and potential discussion topics. 
 
 Ensure the cache directory exists:
 ```bash
-mkdir -p docs/workflow/.cache
+mkdir -p docs/workflow/.state
 ```
 
-Create/update `docs/workflow/.cache/research-analysis.md`:
+Create/update `docs/workflow/.state/research-analysis.md`:
 
 ```markdown
 ---

--- a/skills/start-discussion/scripts/discovery.sh
+++ b/skills/start-discussion/scripts/discovery.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 
 RESEARCH_DIR="docs/workflow/research"
 DISCUSSION_DIR="docs/workflow/discussion"
-CACHE_FILE="docs/workflow/.cache/research-analysis.md"
+CACHE_FILE="docs/workflow/.state/research-analysis.md"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>

--- a/skills/start-specification/SKILL.md
+++ b/skills/start-specification/SKILL.md
@@ -2,7 +2,7 @@
 name: start-specification
 description: "Start a specification session from concluded discussions. Discovers available discussions, offers consolidation assessment for multiple discussions, and invokes the technical-specification skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-specification/scripts/discovery.sh), Bash(mkdir -p docs/workflow/.cache), Bash(rm docs/workflow/.cache/discussion-consolidation-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh)
+allowed-tools: Bash(.claude/skills/start-specification/scripts/discovery.sh), Bash(mkdir -p docs/workflow/.state), Bash(rm docs/workflow/.state/discussion-consolidation-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh)
 hooks:
   PreToolUse:
     - hooks:

--- a/skills/start-specification/references/analysis-flow.md
+++ b/skills/start-specification/references/analysis-flow.md
@@ -65,10 +65,10 @@ When forming groupings:
 
 Create the cache directory if needed:
 ```bash
-mkdir -p docs/workflow/.cache
+mkdir -p docs/workflow/.state
 ```
 
-Write to `docs/workflow/.cache/discussion-consolidation-analysis.md`:
+Write to `docs/workflow/.state/discussion-consolidation-analysis.md`:
 
 ```markdown
 ---

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -87,7 +87,7 @@ Proceed with analysis?
 
 If cache is stale, delete it first:
 ```bash
-rm docs/workflow/.cache/discussion-consolidation-analysis.md
+rm docs/workflow/.state/discussion-consolidation-analysis.md
 ```
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions.

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -8,7 +8,7 @@ Shows when cache is valid (directly from routing) or after analysis completes. T
 
 ## A. Load Groupings
 
-Load groupings from `docs/workflow/.cache/discussion-consolidation-analysis.md`. Parse the `### {Name}` headings and their discussion lists.
+Load groupings from `docs/workflow/.state/discussion-consolidation-analysis.md`. Parse the `### {Name}` headings and their discussion lists.
 
 → Proceed to **B. Determine Discussion Status**.
 
@@ -160,7 +160,7 @@ Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 #### If user picks "Unify all"
 
-Update the cache: rewrite `docs/workflow/.cache/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all concluded discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
+Update the cache: rewrite `docs/workflow/.state/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all concluded discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
 
 Spec name: "Unified". Sources: all concluded discussions.
 
@@ -170,7 +170,7 @@ Spec name: "Unified". Sources: all concluded discussions.
 
 Delete the cache:
 ```bash
-rm docs/workflow/.cache/discussion-consolidation-analysis.md
+rm docs/workflow/.state/discussion-consolidation-analysis.md
 ```
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions.

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -139,7 +139,7 @@ Menu descriptions are wrapped in backticks to visually distinguish them from the
 
 If cache is stale, delete it first:
 ```bash
-rm docs/workflow/.cache/discussion-consolidation-analysis.md
+rm docs/workflow/.state/discussion-consolidation-analysis.md
 ```
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions.

--- a/skills/start-specification/scripts/discovery.sh
+++ b/skills/start-specification/scripts/discovery.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 
 DISCUSSION_DIR="docs/workflow/discussion"
 SPEC_DIR="docs/workflow/specification"
-CACHE_FILE="docs/workflow/.cache/discussion-consolidation-analysis.md"
+CACHE_FILE="docs/workflow/.state/discussion-consolidation-analysis.md"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>

--- a/tests/scripts/test-discovery-for-discussion.sh
+++ b/tests/scripts/test-discovery-for-discussion.sh
@@ -304,7 +304,7 @@ test_cache_valid() {
     setup_fixture
 
     mkdir -p "$TEST_DIR/docs/workflow/research"
-    mkdir -p "$TEST_DIR/docs/workflow/.cache"
+    mkdir -p "$TEST_DIR/docs/workflow/.state"
 
     cat > "$TEST_DIR/docs/workflow/research/exploration.md" << 'EOF'
 ---
@@ -318,7 +318,7 @@ EOF
     local checksum=$(cat "$TEST_DIR/docs/workflow/research"/*.md | md5sum | cut -d' ' -f1)
 
     # Create cache with matching checksum
-    cat > "$TEST_DIR/docs/workflow/.cache/research-analysis.md" << EOF
+    cat > "$TEST_DIR/docs/workflow/.state/research-analysis.md" << EOF
 ---
 checksum: $checksum
 generated: 2026-01-21T10:00:00
@@ -354,7 +354,7 @@ test_cache_stale() {
     setup_fixture
 
     mkdir -p "$TEST_DIR/docs/workflow/research"
-    mkdir -p "$TEST_DIR/docs/workflow/.cache"
+    mkdir -p "$TEST_DIR/docs/workflow/.state"
 
     cat > "$TEST_DIR/docs/workflow/research/exploration.md" << 'EOF'
 ---
@@ -367,7 +367,7 @@ This content is different from when cache was created.
 EOF
 
     # Create cache with OLD checksum (doesn't match current)
-    cat > "$TEST_DIR/docs/workflow/.cache/research-analysis.md" << 'EOF'
+    cat > "$TEST_DIR/docs/workflow/.state/research-analysis.md" << 'EOF'
 ---
 checksum: old_checksum_that_doesnt_match
 generated: 2026-01-20T10:00:00

--- a/tests/scripts/test-discovery-for-specification.sh
+++ b/tests/scripts/test-discovery-for-specification.sh
@@ -445,7 +445,7 @@ test_cache_valid() {
     setup_fixture
 
     mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/.cache"
+    mkdir -p "$TEST_DIR/docs/workflow/.state"
 
     cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
 ---
@@ -460,7 +460,7 @@ EOF
     # Compute the checksum that the cache should have
     local checksum=$(cat "$TEST_DIR/docs/workflow/discussion"/*.md | md5sum | cut -d' ' -f1)
 
-    cat > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md" << EOF
+    cat > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" << EOF
 ---
 checksum: $checksum
 generated: 2026-01-20T10:00:00
@@ -487,7 +487,7 @@ test_cache_stale() {
     setup_fixture
 
     mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/.cache"
+    mkdir -p "$TEST_DIR/docs/workflow/.state"
 
     cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
 ---
@@ -500,7 +500,7 @@ date: 2026-01-20
 EOF
 
     # Use a different checksum to make cache stale
-    cat > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md" << 'EOF'
+    cat > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" << 'EOF'
 ---
 checksum: oldchecksum123
 generated: 2026-01-19T10:00:00
@@ -528,7 +528,7 @@ test_anchored_names() {
 
     mkdir -p "$TEST_DIR/docs/workflow/discussion"
     mkdir -p "$TEST_DIR/docs/workflow/specification"
-    mkdir -p "$TEST_DIR/docs/workflow/.cache"
+    mkdir -p "$TEST_DIR/docs/workflow/.state"
 
     cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
 ---
@@ -556,7 +556,7 @@ EOF
     local checksum=$(cat "$TEST_DIR/docs/workflow/discussion"/*.md | md5sum | cut -d' ' -f1)
 
     # Cache with grouping names
-    cat > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md" << EOF
+    cat > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" << EOF
 ---
 checksum: $checksum
 generated: 2026-01-20T10:00:00

--- a/tests/scripts/test-migration-010.sh
+++ b/tests/scripts/test-migration-010.sh
@@ -1,0 +1,334 @@
+#!/bin/bash
+#
+# Tests migration 010-cache-state-restructure.sh
+# Validates the full .cache/ → .state/ + .cache/ restructure.
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/migrate/scripts/migrations/010-gitignore-sessions.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Mock migration helper functions
+#
+
+report_update() {
+    local file="$1"
+    local description="$2"
+    echo "[UPDATE] $file: $description"
+}
+
+report_skip() {
+    local file="$1"
+    echo "[SKIP] $file"
+}
+
+# Export functions for sourced script
+export -f report_update report_skip
+
+#
+# Helper functions
+#
+
+setup_fixture() {
+    rm -rf "$TEST_DIR/docs"
+    rm -rf "$TEST_DIR/.gitignore"
+}
+
+run_migration() {
+    cd "$TEST_DIR"
+    source "$MIGRATION_SCRIPT"
+}
+
+assert_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local content="$1"
+    local unexpected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$unexpected"; then
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Did not expect to find: $unexpected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    else
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected: $expected"
+        echo -e "    Actual:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_file_exists() {
+    local filepath="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ -f "$filepath" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File not found: $filepath"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_file_not_exists() {
+    local filepath="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ ! -f "$filepath" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File should not exist: $filepath"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_line_count() {
+    local content="$1"
+    local pattern="$2"
+    local expected_count="$3"
+    local description="$4"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    local actual_count
+    actual_count=$(echo "$content" | grep -cF -- "$pattern" || true)
+
+    if [ "$actual_count" = "$expected_count" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected count: $expected_count"
+        echo -e "    Actual count:   $actual_count"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+echo -e "${YELLOW}Test: Move analysis files from .cache/ to .state/${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/.cache"
+echo "analysis content" > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md"
+echo "research content" > "$TEST_DIR/docs/workflow/.cache/research-analysis.md"
+
+run_migration
+
+assert_file_exists "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" "discussion-consolidation-analysis.md moved to .state/"
+assert_file_exists "$TEST_DIR/docs/workflow/.state/research-analysis.md" "research-analysis.md moved to .state/"
+assert_file_not_exists "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md" "discussion-consolidation-analysis.md removed from .cache/"
+assert_file_not_exists "$TEST_DIR/docs/workflow/.cache/research-analysis.md" "research-analysis.md removed from .cache/"
+assert_equals "$(cat "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md")" "analysis content" "Content preserved after move"
+assert_equals "$(cat "$TEST_DIR/docs/workflow/.state/research-analysis.md")" "research content" "Content preserved after move"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Clean up orphaned migration tracking in .cache/${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/.cache"
+echo "001" > "$TEST_DIR/docs/workflow/.cache/migrations"
+echo "001" > "$TEST_DIR/docs/workflow/.cache/migrations.log"
+
+run_migration
+
+assert_file_not_exists "$TEST_DIR/docs/workflow/.cache/migrations" "migrations file removed from .cache/"
+assert_file_not_exists "$TEST_DIR/docs/workflow/.cache/migrations.log" "migrations.log file removed from .cache/"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Add docs/workflow/.cache/ to .gitignore${NC}"
+setup_fixture
+cat > "$TEST_DIR/.gitignore" << 'EOF'
+node_modules/
+.env
+EOF
+
+run_migration
+content=$(cat "$TEST_DIR/.gitignore")
+
+assert_contains "$content" "node_modules/" "Existing entry preserved"
+assert_contains "$content" ".env" "Existing entry preserved"
+assert_contains "$content" "docs/workflow/.cache/" ".cache/ entry appended"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Remove old sessions/ entry from .gitignore${NC}"
+setup_fixture
+cat > "$TEST_DIR/.gitignore" << 'EOF'
+node_modules/
+docs/workflow/.cache/sessions/
+.env
+EOF
+
+run_migration
+content=$(cat "$TEST_DIR/.gitignore")
+
+assert_not_contains "$content" "docs/workflow/.cache/sessions/" "Old sessions/ entry removed"
+assert_contains "$content" "docs/workflow/.cache/" "New .cache/ entry added"
+assert_contains "$content" "node_modules/" "Other entries preserved"
+assert_contains "$content" ".env" "Other entries preserved"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: No .gitignore exists — creates and adds entry${NC}"
+setup_fixture
+
+run_migration
+content=$(cat "$TEST_DIR/.gitignore")
+
+assert_contains "$content" "docs/workflow/.cache/" ".cache/ entry added to new .gitignore"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Idempotent — .cache/ already in .gitignore, no files to move${NC}"
+setup_fixture
+cat > "$TEST_DIR/.gitignore" << 'EOF'
+node_modules/
+docs/workflow/.cache/
+.env
+EOF
+
+original=$(cat "$TEST_DIR/.gitignore")
+output=$(run_migration 2>&1)
+new_content=$(cat "$TEST_DIR/.gitignore")
+
+assert_equals "$new_content" "$original" "File unchanged when already correct"
+assert_contains "$output" "SKIP" "Reported skip for .gitignore"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Idempotency — running migration twice${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/.cache"
+echo "analysis" > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md"
+
+run_migration
+first_gitignore=$(cat "$TEST_DIR/.gitignore")
+
+run_migration
+second_gitignore=$(cat "$TEST_DIR/.gitignore")
+
+assert_equals "$second_gitignore" "$first_gitignore" "Second run produces same .gitignore"
+assert_line_count "$second_gitignore" "docs/workflow/.cache/" "1" ".cache/ entry appears exactly once"
+assert_file_exists "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" "File still in .state/ after second run"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Files already in .state/ — no double move${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/.state"
+echo "existing state content" > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md"
+
+run_migration
+
+assert_equals "$(cat "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md")" "existing state content" "Existing .state/ file not overwritten"
+
+echo ""
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "Tests run: $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "========================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -1378,7 +1378,7 @@ const phases = {
     output: 'docs/workflow/discussion/{topic}.md',
     skill: 'technical-discussion',
     discovery: 'discovery-for-discussion.sh',
-    cache: '.cache/research-analysis.md',
+    cache: '.state/research-analysis.md',
     prerequisites: 'None (but can consume research)',
     scenarios: ['fresh','research_only','discussions_only','research_and_discussions'],
     desc: 'Capture architecture decisions, debates, and edge cases. Cache-aware research analysis.',
@@ -1390,7 +1390,7 @@ const phases = {
     output: 'docs/workflow/specification/{topic}/specification.md',
     skill: 'technical-specification',
     discovery: 'discovery.sh',
-    cache: '.cache/discussion-consolidation-analysis.md',
+    cache: '.state/discussion-consolidation-analysis.md',
     prerequisites: 'Concluded discussions required',
     scenarios: ['single','multi+cache valid','multi+stale+no specs','multi+stale+specs'],
     desc: 'Cache-first routing with progressive disclosure. Analyzes discussion coupling, groups into features, builds validated specs.',
@@ -2714,7 +2714,7 @@ const FLOWCHART_DESCS = {
   },
   'migrate': {
     summary: 'Migration orchestrator — keeps workflow files in sync with the current system design.',
-    body: `<p>Executes <code>skills/migrate/scripts/migrate.sh</code>, which runs all numbered scripts in <code>skills/migrate/scripts/migrations/</code> in order. Each migration is idempotent — safe to run multiple times. Progress is tracked in <code>docs/workflow/.cache/migrations.log</code>.</p>
+    body: `<p>Executes <code>skills/migrate/scripts/migrate.sh</code>, which runs all numbered scripts in <code>skills/migrate/scripts/migrations/</code> in order. Each migration is idempotent — safe to run multiple times. Progress is tracked in <code>docs/workflow/.state/migrations</code>.</p>
 <p>Runs automatically as <strong>Step 0 of every workflow command</strong>. If files were updated, shows changes and waits for user review via git diff. Delete the log file to force re-running all migrations.</p>`,
     meta: { complexity: 'System' }
   },


### PR DESCRIPTION
## Summary

- **Split `docs/workflow/.cache/`** into `.state/` (committed persistent state: migrations tracker, analysis files) and `.cache/` (gitignored ephemeral data: sessions)
- **Rewrite migration 010** to handle the restructure for consumer projects — moves analysis files, cleans orphaned tracking, updates .gitignore
- **Self-healing in orchestrator** — merges entries from both old tracking locations (`.cache/migrations.log`, `.cache/migrations`) into `.state/migrations`
- **26 files updated** across skills, discovery scripts, references, progressive disclosure flows, tests, docs, and workflow explorer

## Test plan

- [x] `bash tests/scripts/test-migration-010.sh` — 22/22 passed (move, cleanup, gitignore, idempotency)
- [x] `bash tests/scripts/test-discovery-for-specification.sh` — 85/85 passed
- [x] `bash tests/scripts/test-discovery-for-discussion.sh` — 50/50 passed
- [x] `bash tests/scripts/test-session-state.sh` — 15/15 passed (no regression)
- [x] `bash tests/scripts/test-compact-recovery.sh` — 13/13 passed (no regression)
- [x] Grep confirms no stale `.cache/` refs for non-session, non-migration files

🤖 Generated with [Claude Code](https://claude.com/claude-code)