### PR TITLE
refactor(bridge): use dynamic injection for begin-* discovery

### DIFF
--- a/skills/begin-implementation/SKILL.md
+++ b/skills/begin-implementation/SKILL.md
@@ -25,11 +25,15 @@ This skill is a **bridge** — it runs pre-flight checks for implementation and 
 
 ## Step 1: Run Discovery
 
-Execute the start-implementation discovery script to gather current state:
+!`.claude/skills/start-implementation/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
 
 ```bash
 .claude/skills/start-implementation/scripts/discovery.sh
 ```
+
+If YAML content is already displayed, it has been run on your behalf.
 
 Parse the output to find the plan matching the provided topic. Extract:
 

--- a/skills/begin-planning/SKILL.md
+++ b/skills/begin-planning/SKILL.md
@@ -25,11 +25,15 @@ This skill is a **bridge** — it runs pre-flight checks for planning and hands 
 
 ## Step 1: Run Discovery
 
-Execute the start-planning discovery script to gather current state:
+!`.claude/skills/start-planning/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
 
 ```bash
 .claude/skills/start-planning/scripts/discovery.sh
 ```
+
+If YAML content is already displayed, it has been run on your behalf.
 
 Parse the output to extract:
 


### PR DESCRIPTION
## Summary

- Migrate `begin-planning` and `begin-implementation` from explicit Bash discovery calls to `!` dynamic injection syntax with bash fallback
- Aligns these bridge skills with the pattern used by all other entry-point/bridge skills
- `allowed-tools` frontmatter unchanged — fallback path still needs Bash access

## Test plan

- [ ] Run `/start-feature` and advance to planning via `continue-feature` — confirm discovery YAML is injected automatically
- [ ] Run `/start-feature` and advance to implementation via `continue-feature` — confirm discovery YAML is injected automatically
- [ ] Verify fallback bash block is still present if preprocessor doesn't run

🤖 Generated with [Claude Code](https://claude.com/claude-code)