### PR TITLE
fix(planning): stop integrity review flagging natural-order deps

### DIFF
--- a/skills/technical-planning/references/output-formats/tick/graph.md
+++ b/skills/technical-planning/references/output-formats/tick/graph.md
@@ -2,6 +2,8 @@
 
 Tick has native support for priority and blocking dependencies with cycle detection. This file is used by the graphing agent after all tasks have been authored.
 
+**Natural ordering principle**: Tasks execute in natural order (by priority, then creation date) when no dependencies override it. The dependency grapher only adds edges that change execution order — if tasks are already in the right sequence, explicit dependencies add noise without value. See also the dependency grapher agent's "When NOT to add a dependency" rules.
+
 ## Priority
 
 | Level | Name | Value |

--- a/skills/technical-planning/references/output-formats/tick/reading.md
+++ b/skills/technical-planning/references/output-formats/tick/reading.md
@@ -59,3 +59,5 @@ tick ready --parent <topic-id>
 ```
 
 If `tick ready` returns no results, either all tasks are complete or remaining tasks are blocked.
+
+**Natural ordering convention**: `tick ready` always returns results in the correct execution order — by priority, then creation date. Consumers should take the first result as the next task. Because creation date preserves authoring order, sequential intra-phase tasks execute in natural order without needing explicit dependencies. Only add dependencies when the correct order differs from the natural order.

--- a/skills/technical-planning/references/review-integrity.md
+++ b/skills/technical-planning/references/review-integrity.md
@@ -47,7 +47,7 @@ Read the plan end-to-end — carefully, as if you were about to implement it. Fo
    - Task dependencies are explicit and correct — each dependency reflects a genuine data or capability requirement
    - No circular dependencies exist in the task graph
    - Priority assignments reflect graph position — foundation tasks and tasks that unblock others are prioritised appropriately
-   - An implementer can determine execution order from the dependency graph and priorities alone
+   - Tasks within a phase execute in natural order (by task ID) unless dependencies or priorities override it. Do not flag missing dependencies for sequential intra-phase tasks where natural order already produces the correct sequence. Only flag dependency issues where: execution would happen in the wrong order without an explicit dependency, a cross-phase dependency is missing, or a convergence point (task needing multiple predecessors) lacks explicit edges.
 
 5. **Task Self-Containment**
    - Each task contains all context needed for execution


### PR DESCRIPTION
## Summary

- Rewrote integrity review criterion #4 to recognise natural task ordering — stops false flags on sequential intra-phase tasks that don't need explicit dependencies
- Added natural ordering convention note to tick reading.md (consumer guidance)
- Added natural ordering principle note to tick graph.md (grapher guidance)

All three align with the dependency grapher's existing "When NOT to add a dependency" rules.

## Test plan

- [ ] Review wording consistency across the three modified files
- [ ] Confirm alignment with `planning-dependency-grapher.md` lines 42, 65-68
- [ ] Run a planning session and verify integrity review no longer flags natural-order deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)