### PR TITLE
feat(pipeline): wire review phase into continue-feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ skills/
   begin-planning/            # Pre-flight for planning, invokes technical-planning
     references/              #   Cross-cutting context
   begin-implementation/      # Pre-flight for implementation, invokes technical-implementation
+  begin-review/              # Pre-flight for review, invokes technical-review
   start-research/            # Begin research exploration
   start-discussion/          # Begin technical discussions
     scripts/discovery.sh     #   Discovery script

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ skills/
   migrate/                   # Keep workflow files in sync with system design
     scripts/migrate.sh       #   Migration orchestrator
     scripts/migrations/      #   Individual migration scripts (numbered)
-  start-feature/             # Start feature pipeline (discussion → spec → plan → impl)
+  start-feature/             # Start feature pipeline (discussion → spec → plan → impl → review)
     references/              #   Interview questions, handoffs, phase bridge
   continue-feature/          # Continue feature through next pipeline phase
     scripts/discovery.sh     #   Cross-phase discovery script

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Not every task needs the full workflow. These skills gather inputs flexibly and 
 /start-feature
     │
     ▼
-Discussion ──▶ Specification ──▶ Planning ──▶ Implementation
+Discussion ──▶ Specification ──▶ Planning ──▶ Implementation ──▶ Review
 ```
 
 **How it works:** After each phase completes, a plan mode bridge clears context and advances to the next phase automatically. You approve each transition with "clear context and continue" — this keeps each phase in a clean context window.
@@ -254,7 +254,7 @@ skills/
 │
 ├── # Entry-point skills (user-invocable)
 ├── migrate/                         # Keep workflow files in sync with system design
-├── start-feature/                   # Pipeline: discussion → spec → plan → impl
+├── start-feature/                   # Pipeline: discussion → spec → plan → impl → review
 ├── continue-feature/                # Pipeline: route feature to next phase
 ├── link-dependencies/               # Standalone: wire cross-topic deps
 ├── start-research/                  # Begin research
@@ -268,7 +268,8 @@ skills/
 │
 ├── # Bridge skills (model-invocable — pipeline pre-flight)
 ├── begin-planning/                  # Pre-flight for planning in pipeline
-└── begin-implementation/            # Pre-flight for implementation in pipeline
+├── begin-implementation/            # Pre-flight for implementation in pipeline
+└── begin-review/                    # Pre-flight for review in pipeline
 
 agents/
 ├── review-task-verifier.md           # Verifies single task implementation for review
@@ -334,7 +335,7 @@ Independent skills that gather inputs flexibly (inline context, files, or prompt
 
 | Skill                                                   | Description                                                                                                                                 |
 |---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| [**/start-feature**](skills/start-feature/)              | Start a new feature through the full pipeline. Gathers context, creates a discussion, then bridges through specification → planning → implementation. |
+| [**/start-feature**](skills/start-feature/)              | Start a new feature through the full pipeline. Gathers context, creates a discussion, then bridges through specification → planning → implementation → review. |
 | [**/continue-feature**](skills/continue-feature/)        | Continue a feature through its next pipeline phase. Routes automatically based on artifact state. Used manually or from plan mode bridges.  |
 | [**/link-dependencies**](skills/link-dependencies/)      | Link external dependencies across topics. Scans plans and wires up unresolved cross-topic dependencies.                                    |
 

--- a/skills/begin-review/SKILL.md
+++ b/skills/begin-review/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: begin-review
+description: "Bridge skill for the feature pipeline. Runs pre-flight checks for review and invokes the technical-review skill. Called by continue-feature — not directly by users."
+user-invocable: false
+allowed-tools: Bash(.claude/skills/start-review/scripts/discovery.sh)
+---
+
+Invoke the **technical-review** skill for this conversation with pre-flight context.
+
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
+## Instructions
+
+Follow these steps EXACTLY as written. Do not skip steps or combine them.
+
+This skill is a **bridge** — it runs pre-flight checks for review and hands off to the processing skill. The topic has already been selected by the caller.
+
+**CRITICAL**: This guidance is mandatory.
+
+- After each user interaction, STOP and wait for their response before proceeding
+- Never assume or anticipate user choices
+- Complete each step fully before moving to the next
+
+---
+
+## Step 1: Run Discovery
+
+!`.claude/skills/start-review/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
+
+```bash
+.claude/skills/start-review/scripts/discovery.sh
+```
+
+If YAML content is already displayed, it has been run on your behalf.
+
+Parse the output to find the plan matching the provided topic. Extract:
+
+- **Plan details**: status, format, plan_id, specification, specification_exists
+- **Implementation status**: implementation_status
+- **Review state**: review_count, latest_review_version
+
+If the plan is missing, this is an error — report it and stop.
+
+If `implementation_status` is `"none"`, this is an error:
+
+> *Output the next fenced block as a code block:*
+
+```
+Review Pre-Flight Failed
+
+"{topic:(titlecase)}" has no implementation to review.
+
+Implementation must be completed or in-progress before review.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+→ Proceed to **Step 2**.
+
+---
+
+## Step 2: Determine Review Version
+
+Check the topic's review state from discovery output:
+
+- If `review_count` is 0 → review version is `r1`
+- If `review_count` > 0 → review version is `r{latest_review_version + 1}`
+
+→ Proceed to **Step 3**.
+
+---
+
+## Step 3: Invoke the Skill
+
+Construct the handoff and invoke the [technical-review](../technical-review/SKILL.md) skill:
+
+```
+Review session
+Plans to review:
+  - topic: {topic}
+    plan: docs/workflow/planning/{topic}/plan.md
+    format: {format}
+    plan_id: {plan_id} (if applicable)
+    specification: {specification} (exists: {true|false})
+    review_version: r{N}
+
+Invoke the technical-review skill.
+```

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: continue-feature
 description: "Continue a feature through the pipeline. Routes to the next phase (specification, planning, or implementation) based on artifact state. Can be invoked manually or from plan mode bridges."
-allowed-tools: Bash(.claude/skills/continue-feature/scripts/discovery.sh), Bash(.claude/hooks/workflows/write-session-state.sh)
+allowed-tools: Bash(.claude/skills/continue-feature/scripts/discovery.sh), Bash(.claude/hooks/workflows/write-session-state.sh), Bash(.claude/skills/start-review/scripts/discovery.sh)
 hooks:
   PreToolUse:
     - hooks:
@@ -33,7 +33,8 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Identify the topic.** Check conversation history for the topic name. If unknown, ask the user.
 3. **Determine current step from artifacts** (check top-down, first match wins):
-   - Implementation tracking exists with `status: completed` → resume at **Step 6** (phase bridge — feature is done)
+   - Review exists for topic → resume at **Step 7** (phase bridge — pipeline complete)
+   - Implementation tracking exists with `status: completed`, no review → resume at **Step 6** (invoke begin-review)
    - Implementation tracking exists with `status: in-progress` → resume at **Step 5** (re-invoke begin-implementation)
    - Plan exists with `status: concluded` → resume at **Step 5** (invoke begin-implementation)
    - Plan exists with other status → resume at **Step 4** (re-invoke begin-planning)
@@ -109,7 +110,7 @@ Present the discovered state as context, then ask the user to select:
 Continue Feature
 
 This skill continues a feature through the pipeline phases:
-Discussion → Specification → Planning → Implementation
+Discussion → Specification → Planning → Implementation → Review
 
 It's designed for features started with /start-feature, but works
 with any topic that has workflow artifacts.
@@ -142,7 +143,7 @@ Select by number, or enter a topic name directly:
 
 Load **[detect-phase.md](references/detect-phase.md)** and follow its instructions.
 
-→ The reference file will route you to **Step 3**, **Step 4**, **Step 5**, or a terminal condition. Follow its routing.
+→ The reference file will route you to **Step 3**, **Step 4**, **Step 5**, **Step 6**, or a terminal condition. Follow its routing.
 
 ---
 
@@ -150,7 +151,7 @@ Load **[detect-phase.md](references/detect-phase.md)** and follow its instructio
 
 Load **[invoke-specification.md](references/invoke-specification.md)** and follow its instructions.
 
-**CRITICAL**: When the specification concludes (status becomes "concluded"), you MUST proceed to **Step 6** below. Do not end the session — the feature pipeline continues to the phase bridge.
+**CRITICAL**: When the specification concludes (status becomes "concluded"), you MUST proceed to **Step 7** below. Do not end the session — the feature pipeline continues to the phase bridge.
 
 ---
 
@@ -158,7 +159,7 @@ Load **[invoke-specification.md](references/invoke-specification.md)** and follo
 
 Load **[invoke-planning.md](references/invoke-planning.md)** and follow its instructions.
 
-**CRITICAL**: When the plan concludes (status becomes "concluded"), you MUST proceed to **Step 6** below. Do not end the session — the feature pipeline continues to the phase bridge.
+**CRITICAL**: When the plan concludes (status becomes "concluded"), you MUST proceed to **Step 7** below. Do not end the session — the feature pipeline continues to the phase bridge.
 
 ---
 
@@ -166,12 +167,20 @@ Load **[invoke-planning.md](references/invoke-planning.md)** and follow its inst
 
 Load **[invoke-implementation.md](references/invoke-implementation.md)** and follow its instructions.
 
-**CRITICAL**: When implementation completes (tracking status becomes "completed"), you MUST proceed to **Step 6** below. Do not end the session — the feature pipeline continues to the phase bridge.
+**CRITICAL**: When implementation completes (tracking status becomes "completed"), you MUST proceed to **Step 7** below. Do not end the session — the feature pipeline continues to the phase bridge.
 
 ---
 
-## Step 6: Phase Bridge
+## Step 6: Review Phase
+
+Load **[invoke-review.md](references/invoke-review.md)** and follow its instructions.
+
+**CRITICAL**: When review concludes, you MUST proceed to **Step 7** below. Do not end the session — the feature pipeline continues to the phase bridge.
+
+---
+
+## Step 7: Phase Bridge
 
 Load **[phase-bridge.md](references/phase-bridge.md)** and follow its instructions.
 
-The bridge will enter plan mode with instructions to invoke continue-feature for the topic in the next session.
+The bridge will enter plan mode with instructions to invoke continue-feature for the topic in the next session, or show a terminal message if the pipeline is complete.

--- a/skills/continue-feature/references/detect-phase.md
+++ b/skills/continue-feature/references/detect-phase.md
@@ -14,23 +14,26 @@ Either use the `next_phase` from discovery output (if discovery was run), or com
 
 Check artifacts in this order (first match wins):
 
-1. Read `docs/workflow/implementation/{topic}/tracking.md`
-   - If exists with `status: completed` → next_phase is **"done"**
+1. Check `docs/workflow/review/{topic}/r*/review.md`
+   - If any review exists → next_phase is **"done"**
+
+2. Read `docs/workflow/implementation/{topic}/tracking.md`
+   - If exists with `status: completed` → next_phase is **"review"**
    - If exists with `status: in-progress` → next_phase is **"implementation"**
 
-2. Read `docs/workflow/planning/{topic}/plan.md`
+3. Read `docs/workflow/planning/{topic}/plan.md`
    - If exists with `status: concluded` → next_phase is **"implementation"**
    - If exists with other status → next_phase is **"planning"**
 
-3. Read `docs/workflow/specification/{topic}/specification.md`
+4. Read `docs/workflow/specification/{topic}/specification.md`
    - If exists with `status: concluded` → next_phase is **"planning"**
    - If exists with other status → next_phase is **"specification"**
 
-4. Check `docs/workflow/discussion/{topic}.md`
+5. Check `docs/workflow/discussion/{topic}.md`
    - If exists with `status: concluded` → next_phase is **"specification"**
    - If exists with other status → next_phase is **"discussion"**
 
-5. If none found → next_phase is **"unknown"**
+6. If none found → next_phase is **"unknown"**
 
 ## Routing
 
@@ -46,17 +49,21 @@ Check artifacts in this order (first match wins):
 
 → Proceed to **Step 5**.
 
+#### If next_phase is "review"
+
+→ Proceed to **Step 6**.
+
 #### If next_phase is "done"
 
 > *Output the next fenced block as a code block:*
 
 ```
-Feature Complete
+Pipeline Complete
 
-"{topic:(titlecase)}" has completed implementation.
+"{topic:(titlecase)}" has completed all pipeline phases
+(implementation and review).
 
-Run /start-review to validate the implementation against the
-specification and plan.
+Use /start-review to re-review or synthesize findings.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/continue-feature/references/invoke-implementation.md
+++ b/skills/continue-feature/references/invoke-implementation.md
@@ -21,7 +21,7 @@ Saving session state so Claude can pick up where it left off and continue the fe
   "{topic}" \
   "skills/technical-implementation/SKILL.md" \
   "docs/workflow/implementation/{topic}/tracking.md" \
-  --pipeline "This session is part of the feature pipeline. After implementation completes, return to the continue-feature skill and execute Step 6 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
+  --pipeline "This session is part of the feature pipeline. After implementation completes, return to the continue-feature skill and execute Step 7 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
 ```
 
 ## Handoff
@@ -33,7 +33,7 @@ Implementation pre-flight for: {topic}
 Plan: docs/workflow/planning/{topic}/plan.md
 
 PIPELINE CONTINUATION — When implementation completes (tracking status: completed),
-you MUST return to the continue-feature skill and execute Step 6 (Phase Bridge).
+you MUST return to the continue-feature skill and execute Step 7 (Phase Bridge).
 Load: skills/continue-feature/references/phase-bridge.md
 Do not end the session after implementation — the feature pipeline continues.
 

--- a/skills/continue-feature/references/invoke-planning.md
+++ b/skills/continue-feature/references/invoke-planning.md
@@ -21,7 +21,7 @@ Saving session state so Claude can pick up where it left off and continue the fe
   "{topic}" \
   "skills/technical-planning/SKILL.md" \
   "docs/workflow/planning/{topic}/plan.md" \
-  --pipeline "This session is part of the feature pipeline. After the plan concludes, return to the continue-feature skill and execute Step 6 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
+  --pipeline "This session is part of the feature pipeline. After the plan concludes, return to the continue-feature skill and execute Step 7 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
 ```
 
 ## Handoff
@@ -33,7 +33,7 @@ Planning pre-flight for: {topic}
 Specification: docs/workflow/specification/{topic}/specification.md
 
 PIPELINE CONTINUATION — When planning concludes (plan status: concluded),
-you MUST return to the continue-feature skill and execute Step 6 (Phase Bridge).
+you MUST return to the continue-feature skill and execute Step 7 (Phase Bridge).
 Load: skills/continue-feature/references/phase-bridge.md
 Do not end the session after planning — the feature pipeline continues.
 

--- a/skills/continue-feature/references/invoke-review.md
+++ b/skills/continue-feature/references/invoke-review.md
@@ -1,0 +1,43 @@
+# Invoke Review
+
+*Reference for **[continue-feature](../SKILL.md)***
+
+---
+
+Invoke the begin-review bridge skill for this topic.
+
+## Save Session State
+
+Before invoking the processing skill, save a session bookmark.
+
+> *Output the next fenced block as a code block:*
+
+```
+Saving session state so Claude can pick up where it left off and continue the feature pipeline if the conversation is compacted.
+```
+
+```bash
+.claude/hooks/workflows/write-session-state.sh \
+  "{topic}" \
+  "skills/technical-review/SKILL.md" \
+  "docs/workflow/review/{topic}/r{N}/review.md" \
+  --pipeline "This session is part of the feature pipeline. After the review concludes, return to the continue-feature skill and execute Step 7 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
+```
+
+## Handoff
+
+Invoke the [begin-review](../../begin-review/SKILL.md) skill:
+
+```
+Review pre-flight for: {topic}
+Plan: docs/workflow/planning/{topic}/plan.md
+
+PIPELINE CONTINUATION — When review concludes,
+you MUST return to the continue-feature skill and execute Step 7 (Phase Bridge).
+Load: skills/continue-feature/references/phase-bridge.md
+Do not end the session after review — the feature pipeline continues.
+
+Invoke the begin-review skill.
+```
+
+The bridge skill handles discovery, validation, version detection, and the handoff to technical-review.

--- a/skills/continue-feature/references/invoke-specification.md
+++ b/skills/continue-feature/references/invoke-specification.md
@@ -31,7 +31,7 @@ Saving session state so Claude can pick up where it left off and continue the fe
   "{topic}" \
   "skills/technical-specification/SKILL.md" \
   "docs/workflow/specification/{topic}/specification.md" \
-  --pipeline "This session is part of the feature pipeline. After the specification concludes, return to the continue-feature skill and execute Step 6 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
+  --pipeline "This session is part of the feature pipeline. After the specification concludes, return to the continue-feature skill and execute Step 7 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
 ```
 
 ## Handoff
@@ -47,7 +47,7 @@ Source material:
 Topic name: {topic}
 
 PIPELINE CONTINUATION — When this specification concludes (status: concluded),
-you MUST return to the continue-feature skill and execute Step 6 (Phase Bridge).
+you MUST return to the continue-feature skill and execute Step 7 (Phase Bridge).
 Load: skills/continue-feature/references/phase-bridge.md
 Do not end the session after the specification — the feature pipeline continues.
 

--- a/skills/continue-feature/references/phase-bridge.md
+++ b/skills/continue-feature/references/phase-bridge.md
@@ -12,9 +12,10 @@ Check which step just completed to determine what continue-feature will route to
 
 - Just completed **specification** (Step 3) → next session routes to planning
 - Just completed **planning** (Step 4) → next session routes to implementation
-- Just completed **implementation** (Step 5) → feature is done
+- Just completed **implementation** (Step 5) → next session routes to review
+- Just completed **review** (Step 6) → pipeline is done
 
-#### If implementation just completed
+#### If review just completed
 
 > *Output the next fenced block as a code block:*
 
@@ -22,8 +23,6 @@ Check which step just completed to determine what continue-feature will route to
 Feature Complete
 
 "{topic:(titlecase)}" has completed all pipeline phases.
-
-Run /start-review to validate the implementation.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/tests/scripts/test-discovery-for-continue-feature.sh
+++ b/tests/scripts/test-discovery-for-continue-feature.sh
@@ -342,10 +342,10 @@ EOF
 }
 
 #
-# Test: Implementation complete
+# Test: Implementation complete (no review)
 #
-test_implementation_complete() {
-    echo -e "${YELLOW}Test: Implementation complete${NC}"
+test_implementation_complete_no_review() {
+    echo -e "${YELLOW}Test: Implementation complete (no review)${NC}"
     setup_fixture
 
     mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
@@ -383,8 +383,67 @@ EOF
 
     local output=$(run_discovery)
 
+    assert_contains "$output" 'next_phase: "review"' "Next phase is review"
+    assert_contains "$output" 'actionable: true' "Topic is actionable"
+
+    echo ""
+}
+
+#
+# Test: Implementation complete with review (done)
+#
+test_implementation_complete_with_review() {
+    echo -e "${YELLOW}Test: Implementation complete with review (done)${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
+    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-flow"
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-flow"
+    mkdir -p "$TEST_DIR/docs/workflow/review/auth-flow/r1"
+
+    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+---
+topic: auth-flow
+status: concluded
+type: feature
+---
+
+# Auth Flow Specification
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-flow/plan.md" << 'EOF'
+---
+topic: auth-flow
+status: concluded
+format: tick
+---
+
+# Auth Flow Plan
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-flow/tracking.md" << 'EOF'
+---
+topic: auth-flow
+status: completed
+---
+
+# Auth Flow Implementation
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/review/auth-flow/r1/review.md" << 'EOF'
+---
+topic: auth-flow
+---
+
+# Auth Flow Review
+EOF
+
+    local output=$(run_discovery)
+
     assert_contains "$output" 'next_phase: "done"' "Next phase is done"
     assert_contains "$output" 'actionable: false' "Topic is not actionable"
+    assert_contains "$output" 'review:' "Has review section"
+    assert_contains "$output" 'exists: true' "Review exists"
 
     echo ""
 }
@@ -465,7 +524,7 @@ EOF
     assert_contains "$output" 'name: "billing"' "Found billing"
     assert_contains "$output" 'name: "dashboard"' "Found dashboard"
     assert_contains "$output" 'topic_count: 3' "Topic count is 3"
-    assert_contains "$output" 'actionable_count: 2' "Actionable count is 2"
+    assert_contains "$output" 'actionable_count: 3' "Actionable count is 3"
     assert_contains "$output" 'scenario: "multiple_topics"' "Scenario is multiple_topics"
 
     echo ""
@@ -606,7 +665,8 @@ test_spec_in_progress
 test_plan_in_progress
 test_plan_concluded_no_impl
 test_implementation_in_progress
-test_implementation_complete
+test_implementation_complete_no_review
+test_implementation_complete_with_review
 test_multiple_topics
 test_crosscutting_excluded
 test_spec_without_discussion

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -1435,7 +1435,7 @@ const phases = {
     color: '#818cf8', bg: 'rgba(129,140,248,0.12)',
     label: 'Start Feature', cmd: '/start-feature',
     complexity: 'Pipeline',
-    desc: 'Gather feature context, create discussion, then bridge to continue-feature for specification, planning, and implementation.',
+    desc: 'Gather feature context, create discussion, then bridge to continue-feature for specification, planning, implementation, and review.',
   },
   'link-deps': {
     color: '#94a3b8', bg: 'rgba(148,163,184,0.12)',
@@ -1858,7 +1858,7 @@ const FLOWCHARTS = {
       { id: 'conflict', label: 'ASK: Resume / new name', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Discussion exists: resume the existing discussion or choose a different name.' },
       { id: 'status-check', label: 'Concluded?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'If resuming: check discussion status. Concluded → skip to bridge. In-progress → invoke discussion.' },
       { id: 'disc-skill', label: 'Invoke discussion skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 3: Invoke technical-discussion skill. When discussion concludes, proceed to phase bridge.', skillLink: 'skill-discussion' },
-      { id: 'bridge', label: 'Phase bridge', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Enter plan mode with handoff to continue-feature for specification, planning, and implementation.' },
+      { id: 'bridge', label: 'Phase bridge', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Enter plan mode with handoff to continue-feature for specification, planning, implementation, and review.' },
       { id: 'end', label: 'Pipeline handoff', shape: 'pill', w: 150, h: 40, color: '#818cf8', bg: 'rgba(129,140,248,0.12)', desc: 'Output: Discussion concluded. Plan mode handoff to continue-feature for remaining phases.' },
     ],
     connections: [
@@ -2650,7 +2650,7 @@ const FLOWCHART_DESCS = {
   'start-feature': {
     summary: 'Pipeline entry — gather context, create discussion, then bridge to continue-feature.',
     body: `<p>Runs migrations, gathers feature context inline (what, scope, constraints), suggests a topic name, and checks for existing discussions. If a discussion exists, offers to <strong>resume</strong> (in-progress → invoke discussion, concluded → skip to bridge) or choose a <strong>new name</strong>.</p>
-<p>Invokes the <strong>technical-discussion</strong> skill with the gathered context. When the discussion concludes, a <strong>phase bridge</strong> enters plan mode with instructions to invoke <code>/continue-feature</code> in the next session for specification, planning, and implementation.</p>`,
+<p>Invokes the <strong>technical-discussion</strong> skill with the gathered context. When the discussion concludes, a <strong>phase bridge</strong> enters plan mode with instructions to invoke <code>/continue-feature</code> in the next session for specification, planning, implementation, and review.</p>`,
     meta: { output: 'docs/workflow/discussion/{topic}.md', skill: 'technical-discussion', complexity: 'Pipeline' }
   },
   'link-deps': {


### PR DESCRIPTION
## Summary

- Add `begin-review` bridge skill and `invoke-review.md` reference to route continue-feature through review after implementation completes
- Update discovery script, phase detection, and phase bridge so `impl completed + no review` → `"review"` (actionable) and `impl completed + review exists` → `"done"` (terminal)
- Renumber Step 6 (Phase Bridge) → Step 7 across all invoke references and compaction recovery map

## Test plan

- [x] All 819 existing tests pass (20 test suites)
- [x] New test: `impl completed, no review` → `next_phase: "review"`, actionable
- [x] New test: `impl completed, review exists` → `next_phase: "done"`, not actionable
- [x] Multi-topic actionable count updated (completed impl without review is now actionable)
- [ ] Manual: `/continue-feature` on implemented topic routes through begin-review to technical-review
- [ ] Manual: after review completes, phase-bridge shows "Feature Complete" terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)