### PR TITLE
fix(start-feature): add standard prompt options to topic name confirmation

### DIFF
--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -80,7 +80,10 @@ This will create: docs/workflow/discussion/{suggested-topic}.md
 
 ```
 · · · · · · · · · · · ·
-Is this name okay, or would you prefer something else?
+Is this name okay?
+
+- **`y`/`yes`** — Use this name
+- **`s`/`something else`** — Suggest a different name
 · · · · · · · · · · · ·
 ```
 


### PR DESCRIPTION
## Summary

- Replaced ambiguous "Is this name okay, or would you prefer something else?" with clear "Is this name okay?"
- Added `y`/`yes` and `s`/`something else` shortcut options matching the multi-choice prompt convention used across the codebase

## Test plan

- [ ] Invoke `/start-feature` and confirm the topic name prompt renders with the two options inside the dot separators

🤖 Generated with [Claude Code](https://claude.com/claude-code)