### PR TITLE
fix(hooks): add observability to session state scripts

### DIFF
--- a/hooks/workflows/session-env.sh
+++ b/hooks/workflows/session-env.sh
@@ -10,8 +10,16 @@
 # Extract session_id from stdin JSON
 session_id=$(cat | grep -o '"session_id" *: *"[^"]*"' | sed 's/.*: *"//;s/"//')
 
-if [ -n "$session_id" ] && [ -n "$CLAUDE_ENV_FILE" ]; then
-  echo "export CLAUDE_SESSION_ID=${session_id}" > "$CLAUDE_ENV_FILE"
+if [ -z "$session_id" ]; then
+  echo "[session-env] WARNING: Could not parse session_id from stdin" >&2
+  exit 0
 fi
+
+if [ -z "$CLAUDE_ENV_FILE" ]; then
+  echo "[session-env] WARNING: CLAUDE_ENV_FILE not set — cannot persist CLAUDE_SESSION_ID" >&2
+  exit 0
+fi
+
+echo "export CLAUDE_SESSION_ID=${session_id}" >> "$CLAUDE_ENV_FILE"
 
 exit 0

--- a/hooks/workflows/write-session-state.sh
+++ b/hooks/workflows/write-session-state.sh
@@ -19,7 +19,7 @@ if [ -z "$PROJECT_DIR" ]; then
 fi
 
 if [ -z "$CLAUDE_SESSION_ID" ]; then
-  # No session ID available — silently skip
+  echo "[write-session-state] WARNING: CLAUDE_SESSION_ID not set — session state will not be saved" >&2
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- **session-env.sh**: Split silent compound conditional into separate checks with stderr warnings for missing `session_id` and `CLAUDE_ENV_FILE`. Changed `>` to `>>` per Claude Code docs convention.
- **write-session-state.sh**: Replaced silent skip with stderr warning when `CLAUDE_SESSION_ID` is not set.
- Root cause: compaction recovery silently failed because `CLAUDE_SESSION_ID` never propagated — these warnings make the failure mode visible for diagnosis.

## Test plan

- [x] Existing tests pass (`test-compact-recovery.sh` — 13/13)
- [ ] Deploy to agntc project, start new session, check stderr for warnings
- [ ] Verify `echo $CLAUDE_SESSION_ID` returns a value in Bash tool calls
- [ ] If working: invoke a skill, confirm `.yaml` session state file is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)