### PR TITLE
feat(impl): add auto-mode gate to analysis approval loop

### DIFF
--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -73,7 +73,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Check task progress in the plan** — use the plan adapter's instructions to read the plan's current state. Also read the implementation tracking file and any other working documents for additional context.
-3. **Check `task_gate_mode`, `fix_gate_mode`, `fix_attempts`, and `analysis_cycle`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*-c{cycle-number}.md` in `{topic}/`) to determine mid-analysis state.
+3. **Check `task_gate_mode`, `fix_gate_mode`, `analysis_gate_mode`, `fix_attempts`, and `analysis_cycle`** in the tracking file — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*-c{cycle-number}.md` in `{topic}/`) to determine mid-analysis state.
 4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 5. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 
@@ -147,7 +147,7 @@ Save their instructions to `docs/workflow/environment-setup.md` (or "No special 
 
 #### If `docs/workflow/implementation/{topic}/tracking.md` already exists
 
-Reset `task_gate_mode` and `fix_gate_mode` to `gated`, `fix_attempts` to `0`, and `analysis_cycle` to `0` (fresh session = fresh gates/cycles).
+Reset `task_gate_mode`, `fix_gate_mode`, and `analysis_gate_mode` to `gated`, `fix_attempts` to `0`, and `analysis_cycle` to `0` (fresh session = fresh gates/cycles).
 
 → Proceed to **Step 4**.
 
@@ -163,6 +163,7 @@ format: {format from plan}
 status: in-progress
 task_gate_mode: gated
 fix_gate_mode: gated
+analysis_gate_mode: gated
 fix_attempts: 0
 linters: []
 analysis_cycle: 0

--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -123,16 +123,24 @@ impl({topic}): analysis cycle {N} — synthesis
 
 Read the staging file from `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle-number}.md`.
 
+Check `analysis_gate_mode` in the implementation tracking file (`gated` or `auto`).
+
 Present an overview:
 
-**Analysis cycle {N}: {K} proposed tasks**
+> *Output the next fenced block as a code block:*
 
-1. {title} ({severity})
-2. {title} ({severity})
-...
+```
+Analysis cycle {N}: {K} proposed tasks
+
+  1. {title} ({severity})
+  2. {title} ({severity})
+```
 
 Then present each task with `status: pending` individually:
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
 **Task {current}/{total}: {title}** ({severity})
 Sources: {sources}
 
@@ -148,12 +156,18 @@ Sources: {sources}
 
 **Tests**:
 {tests}
+```
+
+#### If `analysis_gate_mode: gated`
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-- **`a`/`approve`** — Approve this task
+Approve this task?
+
+- **`y`/`yes`** — Approve this task
+- **`a`/`auto`** — Approve this and all remaining tasks automatically
 - **`s`/`skip`** — Skip this task
 - **Comment** — Revise based on feedback
 · · · · · · · · · · · ·
@@ -161,11 +175,33 @@ Sources: {sources}
 
 **STOP.** Wait for user input.
 
-#### If `approve`
+#### If `analysis_gate_mode: auto`
+
+Update `status: approved` in the staging file. Note that `analysis_gate_mode` should be updated to `auto` in the tracking file during the next commit.
+
+> *Output the next fenced block as a code block:*
+
+```
+Task {current} of {total}: {title} — approved (auto).
+```
+
+→ Continue to next task without stopping.
+
+---
+
+Process user input:
+
+#### If `yes`
 
 Update `status: approved` in the staging file.
 
 → Present the next pending task, or proceed to routing below if all tasks processed.
+
+#### If `auto`
+
+Update `status: approved` in the staging file. Note that `analysis_gate_mode` should be updated to `auto` in the tracking file during the next commit.
+
+→ Continue processing remaining tasks without stopping.
 
 #### If `skip`
 
@@ -185,7 +221,7 @@ After all tasks processed:
 
 → If all tasks were skipped:
 
-Commit the staging file updates:
+Commit the staging file updates (include tracking file if `analysis_gate_mode` was updated):
 
 ```
 impl({topic}): analysis cycle {N} — tasks skipped
@@ -201,7 +237,7 @@ Load **[invoke-task-writer.md](invoke-task-writer.md)** and follow its instructi
 
 **STOP.** Do not proceed until the task writer has returned.
 
-Commit all analysis and plan changes (staging file, plan tasks, Plan Index File):
+Commit all analysis and plan changes (staging file, plan tasks, Plan Index File, and tracking file if `analysis_gate_mode` was updated):
 
 ```
 impl({topic}): add analysis phase {N} ({K} tasks)

--- a/skills/technical-review/references/review-actions-loop.md
+++ b/skills/technical-review/references/review-actions-loop.md
@@ -165,8 +165,10 @@ Sources: {sources}
 
 ```
 · · · · · · · · · · · ·
-- **`a`/`approve`** — Approve this task
-- **`auto`** — Approve this and all remaining tasks automatically
+Approve this task?
+
+- **`y`/`yes`** — Approve this task
+- **`a`/`auto`** — Approve this and all remaining tasks automatically
 - **`s`/`skip`** — Skip this task
 - **Comment** — Revise based on feedback
 · · · · · · · · · · · ·
@@ -188,7 +190,7 @@ Task {current} of {total}: {title} — approved (auto).
 
 Process user input:
 
-#### If `approve`
+#### If `yes`
 
 Update `status: approved` in the staging file.
 


### PR DESCRIPTION
## Summary

- Add `analysis_gate_mode` auto-mode gate to the implementation analysis loop (Section E of `analysis-loop.md`), with tracking file template/reset/context-refresh support in `SKILL.md`
- Restructure analysis approval menu from `a`/`approve` to `y`/`yes` + `a`/`auto` convention matching all other gates
- Consistency pass on `review-actions-loop.md` Section C: same `y`/`yes` + `a`/`auto` + question framing convention

## Test plan

- [ ] Grep for `a.*approve` in approval gate menus — no instances of old convention remain
- [ ] Grep for `analysis_gate_mode` — appears in SKILL.md template, reset, context refresh, and analysis-loop.md
- [ ] Compare gate structure against `task-loop.md` fix/task gates for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)