### PR TITLE
feat(planning): context-aware phase and task design

### DIFF
--- a/DESIGN-unified-entry-point.md
+++ b/DESIGN-unified-entry-point.md
@@ -1,0 +1,101 @@
+# Design: Unified Entry Point & Work Type Flow
+
+## Context
+
+PR #133 (`feat/context-aware-planning`) adds context-aware phase and task design to the planning phase. Instead of always mandating a walking skeleton (greenfield approach), it extracts greenfield content to a dedicated context file and adds `feature` and `bugfix` alternatives. The right context is dispatched via a `work_type` field in the plan frontmatter.
+
+The PR works — context files exist, dispatch mechanism works, agents read the right guidance, all tests pass. But during review, a design question emerged about *where* `work_type` should originate.
+
+---
+
+## The Problem
+
+Currently, `begin-planning` (a bridge skill, not user-invocable) hardcodes `Work type: feature` in its handoff to `technical-planning`. This is the only place `work_type` gets set in the pipeline.
+
+Issues with this:
+
+1. **Too deep in the process** — `begin-planning` is called by `continue-feature`, which is called after `start-feature`. The intent is known at the very top (`start-feature`), but the value isn't set until several layers in.
+
+2. **Bridge skills should relay, not decide** — `begin-planning` is a handoff skill. It shouldn't be the one determining work type; it should receive it from upstream and pass it through.
+
+3. **Hardcoded `feature` is wrong for other paths** — if someone uses the pipeline for a greenfield project or a bugfix (which is possible), they'd incorrectly get feature guidance.
+
+4. **Standalone `start-planning` passes nothing** — falls back to universal principles, which works but means standalone users never get context-specific guidance unless they also happen to set `work_type` manually.
+
+---
+
+## The Discussion
+
+### Where should work_type originate?
+
+Work type is a *user intent* — "I'm building a new product", "I'm adding a feature", "I'm fixing a bug". It should be declared at the very start of the workflow and carried through every phase, not injected midway by a bridge skill.
+
+`start-feature` already knows it's a feature from the moment it's invoked. The work_type should be set there and threaded through: `start-feature` → `continue-feature` → `begin-planning` → `technical-planning`. The bridge relays, doesn't decide.
+
+### This leads to a bigger question: too many entry points?
+
+Current user-invocable entry points:
+- `/start-feature` — full pipeline (discussion → spec → plan → impl → review)
+- `/continue-feature` — continue through pipeline phases
+- `/start-research`, `/start-discussion`, `/start-specification`, `/start-planning`, `/start-implementation`, `/start-review` — standalone phase entry points
+- `/status` — show workflow status
+- `/link-dependencies` — link dependencies across topics
+- `/view-plan` — view plan tasks
+
+The idea: rather than separate commands for each work type (`start-feature`, `start-bugfix`, future `start-greenfield`), consider a **unified entry point** that:
+
+1. Discovers the current project state
+2. Asks the user what they want to do (build the product, add a feature, fix a bug)
+3. Sets `work_type` based on their answer
+4. Routes them to the right place
+
+### Possible command structure (brainstorming, names TBD)
+
+Option A — one command, always asks:
+- `/workflow` → "What would you like to do?" → routes accordingly
+
+Option B — family of commands:
+- `/workflow` → asks what to do (generic entry point)
+- `/workflow feature` → starts/continues a feature (replaces start-feature + continue-feature)
+- `/workflow bugfix` → starts/continues a bugfix
+- `/workflow build` (or similar, name TBD for greenfield) → starts/continues product build
+
+Either way, the unified entry point would:
+- Discover project state (what phase are things in, what's actionable)
+- Offer contextual options based on that state
+- Set `work_type` upfront and carry it through the pipeline
+- Potentially consolidate `start-*` and `continue-*` into a single flow per work type
+
+### What about knowing when "building the product" is done?
+
+We don't need to solve this precisely right now. Just ask the user every time. Later, we could track whether the initial product build is complete and stop offering it as an option. Once the product is built, it's always feature or bugfix (or security scan, or other future work types).
+
+### The key engineering challenge
+
+A robust way to store the `work_type` declaration so it flows through the entire process. Options:
+- Pipeline context (already exists in session state for compaction recovery)
+- Frontmatter in workflow artifacts (plan already has `work_type`)
+- Could extend to discussion and specification frontmatter too
+
+---
+
+## What the Current PR Delivers (Consumption Side)
+
+All of this is needed regardless of how the entry point evolves:
+
+- 6 context files: `phase-design/{greenfield,feature,bugfix}.md`, `task-design/{greenfield,feature,bugfix}.md`
+- Refactored `phase-design.md` and `task-design.md` with universal principles and dispatch sections
+- `work_type` field in plan-index-schema frontmatter
+- Dispatch plumbing in `define-phases.md` and `define-tasks.md`
+- Agent updates in `planning-phase-designer.md` and `planning-task-designer.md`
+- `begin-planning` hardcodes `Work type: feature` (placeholder — will be replaced when entry point redesign lands)
+
+---
+
+## Next Steps
+
+1. **Merge PR #133** — the consumption mechanism is correct and all tests pass
+2. **Design the unified entry point** — decide on command naming, routing logic, and how work_type flows from top to bottom
+3. **Thread work_type through the pipeline** — `start-feature` (or unified command) sets it, carried through `continue-feature` → bridge skills → processing skills
+4. **Consider consolidating start/continue** — may not need separate commands if the unified entry point handles both
+5. **Future: `start-bugfix`** — or its equivalent in the unified command family

--- a/DESIGN-unified-entry-point.md
+++ b/DESIGN-unified-entry-point.md
@@ -20,7 +20,7 @@ Issues with this:
 
 3. **Hardcoded `feature` is wrong for other paths** — if someone uses the pipeline for a greenfield project or a bugfix (which is possible), they'd incorrectly get feature guidance.
 
-4. **Standalone `start-planning` passes nothing** — falls back to universal principles, which works but means standalone users never get context-specific guidance unless they also happen to set `work_type` manually.
+4. **Standalone `start-planning` passes nothing** — defaults to greenfield guidance, which preserves current behavior but means standalone users always get greenfield context even if they're adding a feature or fixing a bug.
 
 ---
 
@@ -84,7 +84,7 @@ A robust way to store the `work_type` declaration so it flows through the entire
 All of this is needed regardless of how the entry point evolves:
 
 - 6 context files: `phase-design/{greenfield,feature,bugfix}.md`, `task-design/{greenfield,feature,bugfix}.md`
-- Refactored `phase-design.md` and `task-design.md` with universal principles and dispatch sections
+- Refactored `phase-design.md` and `task-design.md` with shared principles and dispatch sections
 - `work_type` field in plan-index-schema frontmatter
 - Dispatch plumbing in `define-phases.md` and `define-tasks.md`
 - Agent updates in `planning-phase-designer.md` and `planning-task-designer.md`

--- a/DESIGN-unified-entry-point.md
+++ b/DESIGN-unified-entry-point.md
@@ -92,6 +92,27 @@ All of this is needed regardless of how the entry point evolves:
 
 ---
 
+## Future Consideration: Implementation-Level Work Type Awareness
+
+Currently, `work_type` is used during planning (phase design, task design) but not during implementation. The executor agent has generic codebase guidance that works across all work types.
+
+**Current state:**
+- Plan Index File stores `work_type`
+- `technical-implementation` and executor agent don't read or use it
+- Executor guidance is generic: "find similar implementations, understand inputs/outputs, note testing patterns"
+
+**Question for later:** Does implementation need work-type-specific guidance?
+
+- **Bugfix** implementation could emphasize extra caution about minimal changes, understanding side effects
+- **Feature** implementation could emphasize integration testing, pattern consistency
+- **Greenfield** implementation might not need codebase analysis at all in early phases
+
+**Current thinking:** The implementation guidance is probably generic enough. Work-type-specific concerns are addressed during planning — the tasks themselves carry that context forward. The executor just needs to "follow existing patterns" regardless of type.
+
+This can be revisited after seeing how the current approach works in practice. If implementation struggles in work-type-specific ways, we can add context dispatch at that level too.
+
+---
+
 ## Next Steps
 
 1. **Merge PR #133** — the consumption mechanism is correct and all tests pass
@@ -99,3 +120,4 @@ All of this is needed regardless of how the entry point evolves:
 3. **Thread work_type through the pipeline** — `start-feature` (or unified command) sets it, carried through `continue-feature` → bridge skills → processing skills
 4. **Consider consolidating start/continue** — may not need separate commands if the unified entry point handles both
 5. **Future: `start-bugfix`** — or its equivalent in the unified command family
+6. **Evaluate implementation-level work type awareness** — after observing the current approach in practice

--- a/agents/implementation-task-executor.md
+++ b/agents/implementation-task-executor.md
@@ -36,6 +36,9 @@ You are stateless — each invocation starts fresh. The full task content is alw
    - Read files and tests related to the task's domain
    - Identify patterns, conventions, and structures you'll need to follow or extend
    - Check for existing code that the task builds on or integrates with
+   - Find similar implementations — if the task is "add endpoint X", find existing endpoints and follow the same pattern
+   - Understand inputs, outputs, and callers of any code you'll modify
+   - Note the testing approach used in this area — use the same patterns
 6. **Execute TDD cycle** — follow the process in tdd-workflow.md for each acceptance criterion and test case.
 7. **Verify all acceptance criteria met** — every criterion from the task must be satisfied
 8. **Return structured result**

--- a/agents/planning-phase-designer.md
+++ b/agents/planning-phase-designer.md
@@ -17,7 +17,7 @@ You receive file paths via the orchestrator's prompt:
 2. **Specification path** — The validated specification to plan from
 3. **Cross-cutting spec paths** (if any) — Architectural decisions that influence planning
 4. **phase-design.md** — Phase design principles
-5. **Context-specific phase design** (if provided) — Work-type guidance (greenfield, feature, or bugfix)
+5. **Context-specific phase design** — Work-type guidance (greenfield, feature, or bugfix)
 6. **task-design.md** — Task design principles (for phase granularity awareness)
 7. **plan-index-schema.md** — Canonical plan index structure
 
@@ -31,7 +31,7 @@ On **amendment**, you also receive:
 2. Read the specification in full, following the ingestion protocol
 3. Read any cross-cutting specifications
 4. Read `phase-design.md` — absorb the phase design principles
-5. If context-specific phase design guidance was provided, read it
+5. Read the context-specific phase design guidance
 6. Read `task-design.md` — understand task granularity (needed to judge phase scope)
 7. Read `plan-index-schema.md` — understand the plan index structure
 8. Design the phase structure
@@ -61,7 +61,7 @@ Continue for all phases.
 
 ## Rules
 
-1. **Strongest foundation first** — Phase 1 establishes the pattern for subsequent phases. Follow the Phase 1 strategy from the loaded context guidance. If no context guidance was loaded, infer the appropriate strategy from the specification content.
+1. **Strongest foundation first** — Phase 1 establishes the pattern for subsequent phases. Follow the Phase 1 strategy from the loaded context guidance.
 2. **Vertical phases** — each phase delivers working functionality, not technical layers
 3. **Clear acceptance** — every criterion is pass/fail verifiable
 4. **No forward references** — no phase depends on something not yet built

--- a/agents/planning-phase-designer.md
+++ b/agents/planning-phase-designer.md
@@ -17,8 +17,9 @@ You receive file paths via the orchestrator's prompt:
 2. **Specification path** — The validated specification to plan from
 3. **Cross-cutting spec paths** (if any) — Architectural decisions that influence planning
 4. **phase-design.md** — Phase design principles
-5. **task-design.md** — Task design principles (for phase granularity awareness)
-6. **plan-index-schema.md** — Canonical plan index structure
+5. **Context-specific phase design** (if provided) — Work-type guidance (greenfield, feature, or bugfix)
+6. **task-design.md** — Task design principles (for phase granularity awareness)
+7. **plan-index-schema.md** — Canonical plan index structure
 
 On **amendment**, you also receive:
 - **Previous output** — Your prior phase structure
@@ -30,9 +31,10 @@ On **amendment**, you also receive:
 2. Read the specification in full, following the ingestion protocol
 3. Read any cross-cutting specifications
 4. Read `phase-design.md` — absorb the phase design principles
-5. Read `task-design.md` — understand task granularity (needed to judge phase scope)
-6. Read `plan-index-schema.md` — understand the plan index structure
-7. Design the phase structure
+5. If context-specific phase design guidance was provided, read it
+6. Read `task-design.md` — understand task granularity (needed to judge phase scope)
+7. Read `plan-index-schema.md` — understand the plan index structure
+8. Design the phase structure
 
 If this is an **amendment**: read your previous output and the user's feedback, then revise accordingly.
 
@@ -59,7 +61,7 @@ Continue for all phases.
 
 ## Rules
 
-1. **Walking skeleton first** — Phase 1 is always the thinnest end-to-end slice
+1. **Strongest foundation first** — Phase 1 establishes the pattern for subsequent phases. Follow the Phase 1 strategy from the loaded context guidance. If no context guidance was loaded, infer the appropriate strategy from the specification content.
 2. **Vertical phases** — each phase delivers working functionality, not technical layers
 3. **Clear acceptance** — every criterion is pass/fail verifiable
 4. **No forward references** — no phase depends on something not yet built

--- a/agents/planning-task-designer.md
+++ b/agents/planning-task-designer.md
@@ -17,7 +17,7 @@ You receive file paths via the orchestrator's prompt:
 2. **Specification path** — The validated specification to plan from
 3. **Cross-cutting spec paths** (if any) — Architectural decisions that influence planning
 4. **task-design.md** — Task design principles
-5. **Context-specific task design** (if provided) — Work-type guidance (greenfield, feature, or bugfix)
+5. **Context-specific task design** — Work-type guidance (greenfield, feature, or bugfix)
 6. **All approved phases** — The complete phase structure (from the Plan Index File)
 7. **Target phase number** — Which phase to break into tasks
 8. **plan-index-schema.md** — Canonical plan index structure
@@ -32,7 +32,7 @@ On **amendment**, you also receive:
 2. Read the specification in full, following the ingestion protocol
 3. Read any cross-cutting specifications
 4. Read `task-design.md` — absorb the task design principles
-5. If context-specific task design guidance was provided, read it
+5. Read the context-specific task design guidance
 6. Read the approved phases — understand the full plan structure and where this phase fits
 7. Read `plan-index-schema.md` — understand the plan index structure
 8. Design the task list for the target phase

--- a/agents/planning-task-designer.md
+++ b/agents/planning-task-designer.md
@@ -17,9 +17,10 @@ You receive file paths via the orchestrator's prompt:
 2. **Specification path** — The validated specification to plan from
 3. **Cross-cutting spec paths** (if any) — Architectural decisions that influence planning
 4. **task-design.md** — Task design principles
-5. **All approved phases** — The complete phase structure (from the Plan Index File)
-6. **Target phase number** — Which phase to break into tasks
-7. **plan-index-schema.md** — Canonical plan index structure
+5. **Context-specific task design** (if provided) — Work-type guidance (greenfield, feature, or bugfix)
+6. **All approved phases** — The complete phase structure (from the Plan Index File)
+7. **Target phase number** — Which phase to break into tasks
+8. **plan-index-schema.md** — Canonical plan index structure
 
 On **amendment**, you also receive:
 - **Previous output** — Your prior task list
@@ -31,9 +32,10 @@ On **amendment**, you also receive:
 2. Read the specification in full, following the ingestion protocol
 3. Read any cross-cutting specifications
 4. Read `task-design.md` — absorb the task design principles
-5. Read the approved phases — understand the full plan structure and where this phase fits
-6. Read `plan-index-schema.md` — understand the plan index structure
-7. Design the task list for the target phase
+5. If context-specific task design guidance was provided, read it
+6. Read the approved phases — understand the full plan structure and where this phase fits
+7. Read `plan-index-schema.md` — understand the plan index structure
+8. Design the task list for the target phase
 
 If this is an **amendment**: read your previous output and the user's feedback, then revise accordingly.
 

--- a/skills/begin-planning/SKILL.md
+++ b/skills/begin-planning/SKILL.md
@@ -83,6 +83,7 @@ Construct the handoff and invoke the [technical-planning](../technical-planning/
 ```
 Planning session for: {topic}
 Specification: docs/workflow/specification/{topic}/specification.md
+Work type: feature
 Additional context: {summary of user's answer from Step 3, or "none"}
 Cross-cutting references: {list of applicable cross-cutting specs with brief summaries, or "none"}
 Recommended output format: {common_format from discovery if non-empty, otherwise "none"}

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -24,7 +24,7 @@ Either way: Transform specifications into actionable phases, tasks, and acceptan
 - **Topic name** (optional) - Will derive from specification if not provided
 - **Output format preference** (optional) - Will ask if not specified
 - **Recommended output format** (optional) - A format suggestion for consistency with existing plans
-- **Work type** (optional) — `greenfield`, `feature`, or `bugfix`. Determines which context-specific guidance is loaded during phase and task design. When not provided, agents use universal principles and infer from the specification.
+- **Work type** (optional) — `greenfield`, `feature`, or `bugfix`. Determines which context-specific guidance is loaded during phase and task design. Defaults to `greenfield` when not provided.
 - **Cross-cutting references** (optional) - Cross-cutting specifications that inform technical decisions in this plan
 
 **Before proceeding**, verify the required input is available and unambiguous. If anything is missing or unclear, **STOP** — do not proceed until resolved.

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -24,6 +24,7 @@ Either way: Transform specifications into actionable phases, tasks, and acceptan
 - **Topic name** (optional) - Will derive from specification if not provided
 - **Output format preference** (optional) - Will ask if not specified
 - **Recommended output format** (optional) - A format suggestion for consistency with existing plans
+- **Work type** (optional) — `greenfield`, `feature`, or `bugfix`. Determines which context-specific guidance is loaded during phase and task design. When not provided, agents use universal principles and infer from the specification.
 - **Cross-cutting references** (optional) - Cross-cutting specifications that inform technical decisions in this plan
 
 **Before proceeding**, verify the required input is available and unambiguous. If anything is missing or unclear, **STOP** — do not proceed until resolved.
@@ -173,7 +174,7 @@ Once selected:
 
 1. Read **[output-formats.md](references/output-formats.md)**, find the chosen format entry, and load the format's **[about.md](references/output-formats/{format}/about.md)** and **[authoring.md](references/output-formats/{format}/authoring.md)**
 2. Capture the current git commit hash: `git rev-parse HEAD`
-3. Create the Plan Index File at `docs/workflow/planning/{topic}/plan.md` using the **Frontmatter** and **Title** templates from **[plan-index-schema.md](references/plan-index-schema.md)**. Set `status: planning`, `spec_commit` to the captured git hash, and today's actual date for `created` and `updated`.
+3. Create the Plan Index File at `docs/workflow/planning/{topic}/plan.md` using the **Frontmatter** and **Title** templates from **[plan-index-schema.md](references/plan-index-schema.md)**. Set `status: planning`, `spec_commit` to the captured git hash, and today's actual date for `created` and `updated`. If a work type was provided by the caller, set `work_type` to that value.
 
 3. Commit: `planning({topic}): initialize plan`
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -174,7 +174,7 @@ Once selected:
 
 1. Read **[output-formats.md](references/output-formats.md)**, find the chosen format entry, and load the format's **[about.md](references/output-formats/{format}/about.md)** and **[authoring.md](references/output-formats/{format}/authoring.md)**
 2. Capture the current git commit hash: `git rev-parse HEAD`
-3. Create the Plan Index File at `docs/workflow/planning/{topic}/plan.md` using the **Frontmatter** and **Title** templates from **[plan-index-schema.md](references/plan-index-schema.md)**. Set `status: planning`, `spec_commit` to the captured git hash, and today's actual date for `created` and `updated`. If a work type was provided by the caller, set `work_type` to that value.
+3. Create the Plan Index File at `docs/workflow/planning/{topic}/plan.md` using the **Frontmatter** and **Title** templates from **[plan-index-schema.md](references/plan-index-schema.md)**. Set `status: planning`, `spec_commit` to the captured git hash, today's actual date for `created` and `updated`, and `work_type` to the value provided by the caller (or `greenfield` if not provided).
 
 3. Commit: `planning({topic}): initialize plan`
 

--- a/skills/technical-planning/references/define-phases.md
+++ b/skills/technical-planning/references/define-phases.md
@@ -42,7 +42,7 @@ Invoke `planning-phase-designer` with these file paths:
 2. **Specification**: path from the Plan Index File's `specification:` field
 3. **Cross-cutting specs**: paths from the Plan Index File's `cross_cutting_specs:` field (if any)
 4. **phase-design.md**: `phase-design.md`
-5. **Context guidance**: If `work_type` is set, include `phase-design/{work_type}.md`
+5. **Context guidance**: `phase-design/{work_type}.md` (default to `greenfield` if `work_type` is empty)
 6. **task-design.md**: `task-design.md`
 7. **plan-index-schema.md**: `plan-index-schema.md`
 
@@ -82,7 +82,7 @@ Present the phase structure to the user as rendered markdown (not in a code bloc
 
 #### If the user provides feedback
 
-Re-invoke `planning-phase-designer` with all original inputs (including context guidance if `work_type` is set) PLUS:
+Re-invoke `planning-phase-designer` with all original inputs PLUS:
 - **Previous output**: the current phase structure
 - **User feedback**: what the user wants changed
 

--- a/skills/technical-planning/references/define-phases.md
+++ b/skills/technical-planning/references/define-phases.md
@@ -34,14 +34,17 @@ independently testable stages.
 
 ### Invoke the Agent
 
+Read `work_type` from the Plan Index File frontmatter.
+
 Invoke `planning-phase-designer` with these file paths:
 
 1. **read-specification.md**: `read-specification.md`
 2. **Specification**: path from the Plan Index File's `specification:` field
 3. **Cross-cutting specs**: paths from the Plan Index File's `cross_cutting_specs:` field (if any)
 4. **phase-design.md**: `phase-design.md`
-5. **task-design.md**: `task-design.md`
-6. **plan-index-schema.md**: `plan-index-schema.md`
+5. **Context guidance**: If `work_type` is set, include `phase-design/{work_type}.md`
+6. **task-design.md**: `task-design.md`
+7. **plan-index-schema.md**: `plan-index-schema.md`
 
 The agent returns a complete phase structure. Write it directly to the Plan Index File body.
 
@@ -79,7 +82,7 @@ Present the phase structure to the user as rendered markdown (not in a code bloc
 
 #### If the user provides feedback
 
-Re-invoke `planning-phase-designer` with all original inputs PLUS:
+Re-invoke `planning-phase-designer` with all original inputs (including context guidance if `work_type` is set) PLUS:
 - **Previous output**: the current phase structure
 - **User feedback**: what the user wants changed
 

--- a/skills/technical-planning/references/define-tasks.md
+++ b/skills/technical-planning/references/define-tasks.md
@@ -28,7 +28,7 @@ Invoke `planning-task-designer` with these file paths:
 2. **Specification**: path from the Plan Index File's `specification:` field
 3. **Cross-cutting specs**: paths from the Plan Index File's `cross_cutting_specs:` field (if any)
 4. **task-design.md**: `task-design.md`
-5. **Context guidance**: If `work_type` is set, include `task-design/{work_type}.md`
+5. **Context guidance**: `task-design/{work_type}.md` (default to `greenfield` if `work_type` is empty)
 6. **All approved phases**: the complete phase structure from the Plan Index File body
 7. **Target phase number**: the phase being broken into tasks
 8. **plan-index-schema.md**: `plan-index-schema.md`
@@ -88,7 +88,7 @@ Phase {N}: {Phase Name} — task list approved. Proceeding to authoring.
 
 #### If the user provides feedback
 
-Re-invoke `planning-task-designer` with all original inputs (including context guidance if `work_type` is set) PLUS:
+Re-invoke `planning-task-designer` with all original inputs PLUS:
 - **Previous output**: the current task list
 - **User feedback**: what the user wants changed
 

--- a/skills/technical-planning/references/define-tasks.md
+++ b/skills/technical-planning/references/define-tasks.md
@@ -20,15 +20,18 @@ propose a task list.
 
 ### Invoke the Agent
 
+Read `work_type` from the Plan Index File frontmatter.
+
 Invoke `planning-task-designer` with these file paths:
 
 1. **read-specification.md**: `read-specification.md`
 2. **Specification**: path from the Plan Index File's `specification:` field
 3. **Cross-cutting specs**: paths from the Plan Index File's `cross_cutting_specs:` field (if any)
 4. **task-design.md**: `task-design.md`
-5. **All approved phases**: the complete phase structure from the Plan Index File body
-6. **Target phase number**: the phase being broken into tasks
-7. **plan-index-schema.md**: `plan-index-schema.md`
+5. **Context guidance**: If `work_type` is set, include `task-design/{work_type}.md`
+6. **All approved phases**: the complete phase structure from the Plan Index File body
+7. **Target phase number**: the phase being broken into tasks
+8. **plan-index-schema.md**: `plan-index-schema.md`
 
 ### Present the Output
 
@@ -85,7 +88,7 @@ Phase {N}: {Phase Name} — task list approved. Proceeding to authoring.
 
 #### If the user provides feedback
 
-Re-invoke `planning-task-designer` with all original inputs PLUS:
+Re-invoke `planning-task-designer` with all original inputs (including context guidance if `work_type` is set) PLUS:
 - **Previous output**: the current task list
 - **User feedback**: what the user wants changed
 

--- a/skills/technical-planning/references/phase-design.md
+++ b/skills/technical-planning/references/phase-design.md
@@ -4,9 +4,9 @@
 
 ---
 
-This reference defines the principles for breaking specifications into implementation phases. It is loaded when phases are first proposed and stays in context through phase approval.
+This reference defines generic principles for breaking specifications into implementation phases.
 
-Context-specific guidance supplements these principles. A context file (greenfield, feature, or bugfix) is always loaded alongside this file, providing the Phase 1 strategy, progression model, and examples appropriate to the work type.
+A work-type context file (greenfield, feature, or bugfix) is always loaded alongside this file. The context file provides the Phase 1 strategy, progression model, examples, and work-type-specific guidance. These generic principles apply across all work types.
 
 ## What Makes a Good Phase
 
@@ -17,18 +17,6 @@ Each phase should:
 - **Follow natural boundaries** — domain, feature, or capability boundaries, not architectural layers
 - **Leave the system working** — every phase ends with a green test suite and deployable code
 - **Be independently valuable** — if the project stopped after this phase, something useful would exist
-
----
-
-## Phase 1 Strategy
-
-Phase 1 establishes the pattern for subsequent phases. The right strategy depends on the project context:
-
-- **New system (greenfield)**: Start with a walking skeleton — the thinnest end-to-end slice proving the architecture. See [greenfield.md](phase-design/greenfield.md).
-- **Feature addition**: Start with the most fundamental new capability. The existing codebase is the foundation. See [feature.md](phase-design/feature.md).
-- **Bug fix**: Start with reproducing and fixing the core issue. See [bugfix.md](phase-design/bugfix.md).
-
-Context-specific guidance is always loaded alongside this file. Follow its Phase 1 strategy. If no work type was specified, greenfield guidance is loaded by default.
 
 ---
 

--- a/skills/technical-planning/references/phase-design.md
+++ b/skills/technical-planning/references/phase-design.md
@@ -6,7 +6,7 @@
 
 This reference defines the principles for breaking specifications into implementation phases. It is loaded when phases are first proposed and stays in context through phase approval.
 
-Context-specific guidance supplements these principles. When a context file is loaded (greenfield, feature, or bugfix), it provides the Phase 1 strategy, progression model, and examples appropriate to the work type.
+Context-specific guidance supplements these principles. A context file (greenfield, feature, or bugfix) is always loaded alongside this file, providing the Phase 1 strategy, progression model, and examples appropriate to the work type.
 
 ## What Makes a Good Phase
 
@@ -28,7 +28,7 @@ Phase 1 establishes the pattern for subsequent phases. The right strategy depend
 - **Feature addition**: Start with the most fundamental new capability. The existing codebase is the foundation. See [feature.md](phase-design/feature.md).
 - **Bug fix**: Start with reproducing and fixing the core issue. See [bugfix.md](phase-design/bugfix.md).
 
-If context-specific guidance was loaded alongside this file, follow its Phase 1 strategy. Otherwise, use your judgment based on the specification.
+Context-specific guidance is always loaded alongside this file. Follow its Phase 1 strategy. If no work type was specified, greenfield guidance is loaded by default.
 
 ---
 

--- a/skills/technical-planning/references/phase-design.md
+++ b/skills/technical-planning/references/phase-design.md
@@ -6,6 +6,8 @@
 
 This reference defines the principles for breaking specifications into implementation phases. It is loaded when phases are first proposed and stays in context through phase approval.
 
+Context-specific guidance supplements these principles. When a context file is loaded (greenfield, feature, or bugfix), it provides the Phase 1 strategy, progression model, and examples appropriate to the work type.
+
 ## What Makes a Good Phase
 
 Each phase should:
@@ -18,49 +20,21 @@ Each phase should:
 
 ---
 
-## The Walking Skeleton
+## Phase 1 Strategy
 
-Phase 1 is always a **walking skeleton** — the thinnest possible end-to-end slice that threads through all system layers and proves the architecture works.
+Phase 1 establishes the pattern for subsequent phases. The right strategy depends on the project context:
 
-The walking skeleton:
+- **New system (greenfield)**: Start with a walking skeleton — the thinnest end-to-end slice proving the architecture. See [greenfield.md](phase-design/greenfield.md).
+- **Feature addition**: Start with the most fundamental new capability. The existing codebase is the foundation. See [feature.md](phase-design/feature.md).
+- **Bug fix**: Start with reproducing and fixing the core issue. See [bugfix.md](phase-design/bugfix.md).
 
-- Touches every architectural component the system needs (database, API, UI, external services)
-- Delivers one complete flow, however minimal
-- Establishes the patterns subsequent phases will follow
-- Is production code, not throwaway — it becomes the foundation
-
-**Example** (Slack clone):
-
-> Phase 1: "Any unauthenticated person can post messages in a hardcoded #general room. Messages persist through page refreshes."
->
-> No auth, no accounts, no multiple rooms. Just the thinnest thread through the entire stack.
-
-**Example** (Calendar app):
-
-> Phase 1: "A single event can be created with title, start, and end time, persisted, and retrieved by ID."
->
-> No recurrence, no sharing, no notifications. Just one thing working end-to-end.
-
-The skeleton validates architecture assumptions at the cheapest possible moment. If the end-to-end flow doesn't work, you discover it in Phase 1 — not after building three phases of isolated components.
-
-This is the **steel thread** principle: never have big-bang integration. By threading through all layers immediately, integration is the first thing you solve, not the last.
+If context-specific guidance was loaded alongside this file, follow its Phase 1 strategy. Otherwise, use your judgment based on the specification.
 
 ---
 
 ## Vertical Phases
 
-After the walking skeleton, each subsequent phase adds complete functionality — a vertical slice through the relevant layers.
-
-**Vertical (prefer):**
-
-```
-Phase 1: Walking skeleton — single event CRUD, end-to-end
-Phase 2: Recurring events — rules, instance generation, single-instance editing
-Phase 3: Sharing and permissions — invite users, permission levels, shared calendars
-Phase 4: Notifications — email and push notifications for event changes
-```
-
-Each phase delivers something a user or test suite can validate independently.
+Each phase adds complete functionality — a vertical slice through the relevant layers.
 
 **Horizontal (avoid):**
 
@@ -75,17 +49,6 @@ Phase 5: Wire everything together
 Nothing works until Phase 5. No phase is independently testable. Integration risk concentrates at the end.
 
 A phase may touch multiple architectural layers — that's expected. The test is: **does this phase deliver working functionality, or does it deliver infrastructure that only becomes useful later?**
-
-### Progression
-
-**Skeleton → Core features → Edge cases → Refinement**
-
-- **Skeleton** (Phase 1): Thinnest end-to-end slice proving the architecture
-- **Core features**: Each phase adds a complete capability, building on what exists
-- **Edge cases**: Handling boundary conditions, error scenarios, unusual inputs
-- **Refinement**: Performance optimisation, UX polish, hardening
-
-This ordering means each phase builds on a working system. The skeleton establishes the pattern; core features flesh it out; edge cases harden it; refinement polishes it.
 
 ---
 
@@ -122,20 +85,19 @@ If a phase has only 1-2 trivial tasks, it's probably too thin — merge it. If a
 
 **Maximize cohesion within a phase, minimize dependencies between phases.**
 
-A well-bounded phase could theoretically be reordered or dropped without cascading failures across other phases. In practice, phases have a natural sequence (the skeleton must come first), but each phase should be as self-contained as possible.
+A well-bounded phase could theoretically be reordered or dropped without cascading failures across other phases. In practice, phases have a natural sequence, but each phase should be as self-contained as possible.
 
 Strategies:
 
-- **Walking skeleton first** — subsequent phases add to a working system rather than depending on future phases
+- **Strongest foundation first** — subsequent phases add to a working system rather than depending on future phases
 - **Clear interfaces between phases** — each phase produces defined contracts (API shapes, data models, test suites) that subsequent phases consume
-- **Shared infrastructure in Phase 1** — if multiple phases need the same foundation, it belongs in the skeleton
 - **No forward references** — a phase should never depend on something that hasn't been built yet
 
 ---
 
 ## Anti-Patterns
 
-**Horizontal phases** — organising by technical layer ("all models, then all services, then all controllers"). Defers integration risk, produces phases that aren't independently valuable. The walking skeleton eliminates this by integrating from the start.
+**Horizontal phases** — organising by technical layer ("all models, then all services, then all controllers"). Defers integration risk, produces phases that aren't independently valuable. Vertical slicing eliminates this by integrating from the start.
 
 **God phase** — one massive phase covering too many concerns. Results in unclear success criteria, inability to track progress, and cognitive overload. If you can't summarise a phase's goal in one sentence, it needs splitting.
 

--- a/skills/technical-planning/references/phase-design/bugfix.md
+++ b/skills/technical-planning/references/phase-design/bugfix.md
@@ -61,3 +61,15 @@ Regression tests are first-class deliverables, not afterthoughts:
 - Tests verify the fix doesn't break existing behaviour
 - Edge cases related to the bug get their own test cases
 - If the bug was in a poorly-tested area, the fix improves coverage for that specific area (not a general testing campaign)
+
+---
+
+## Codebase Awareness
+
+Before designing bugfix phases, understand the affected area:
+
+- **Trace the bug's scope** — what code is involved? What calls into it, what does it call? Understanding the boundaries helps design a fix that doesn't cause side effects.
+- **Check existing tests** — what coverage exists? This informs whether the fix needs new test infrastructure or can extend existing tests.
+- **Understand before fixing** — a minimal fix requires knowing exactly what's broken and why. Don't design phases until the root cause is understood.
+
+This is targeted analysis, not a general codebase review — focus on the code paths involved in the bug.

--- a/skills/technical-planning/references/phase-design/bugfix.md
+++ b/skills/technical-planning/references/phase-design/bugfix.md
@@ -1,0 +1,63 @@
+# Bugfix Phase Design
+
+*Context guidance for **[phase-design.md](../phase-design.md)** — bug fixes*
+
+---
+
+## Phase 1 Strategy
+
+Reproduce the bug and implement the fix. Start with a failing test that demonstrates the bug, then fix it.
+
+Phase 1 should:
+
+- Include a test that reliably reproduces the bug (the test fails before the fix, passes after)
+- Fix the root cause, not symptoms
+- Verify that existing tests still pass (no regressions)
+- Be as minimal as possible — change only what's necessary
+
+---
+
+## Single vs Multi-Phase Bugs
+
+Most bugs are **single-phase**: reproduce → fix → regression tests. One phase is sufficient when the bug has a single root cause and the fix is contained.
+
+Multiple phases are warranted when:
+
+- **Multiple root causes** — the bug manifests in one place but originates in different subsystems that need independent fixes
+- **Incremental refactoring required** — the fix requires restructuring code that can't be safely changed in one step
+- **Large impact area** — the fix touches enough code that dedicated regression verification in a separate phase reduces risk
+
+**Example** (Single-phase — N+1 query):
+
+```
+Phase 1: Add eager loading to order query, verify performance, regression tests
+```
+
+**Example** (Multi-phase — Race condition in payment processing):
+
+```
+Phase 1: Add locking mechanism, fix the core race condition, verify with concurrent test
+Phase 2: Add idempotency keys, handle edge cases (duplicate submissions, timeout recovery)
+```
+
+---
+
+## Minimal Change Principle
+
+Fix the root cause, don't redesign. The goal is surgical correction:
+
+- Change the minimum code needed to resolve the issue
+- If related issues are discovered during investigation, create separate specifications rather than expanding scope
+- Resist the temptation to "improve" surrounding code while you're in there
+- The fix should be easy to review — a reviewer should immediately see what changed and why
+
+---
+
+## Regression Prevention
+
+Regression tests are first-class deliverables, not afterthoughts:
+
+- Every fix includes tests that would have caught the original bug
+- Tests verify the fix doesn't break existing behaviour
+- Edge cases related to the bug get their own test cases
+- If the bug was in a poorly-tested area, the fix improves coverage for that specific area (not a general testing campaign)

--- a/skills/technical-planning/references/phase-design/feature.md
+++ b/skills/technical-planning/references/phase-design/feature.md
@@ -1,0 +1,64 @@
+# Feature Phase Design
+
+*Context guidance for **[phase-design.md](../phase-design.md)** — feature additions to existing systems*
+
+---
+
+## Phase 1 Strategy
+
+Deliver the most fundamental new capability first. The existing codebase IS the foundation — no need to re-prove architecture. Integration with established patterns is the priority.
+
+Phase 1 should:
+
+- Add the core new behaviour that all subsequent phases build on
+- Integrate naturally with existing code and conventions
+- Verify both the new functionality AND that existing behaviour isn't broken
+- Follow the project's established architectural patterns
+
+---
+
+## Feature Vertical Phases
+
+Each phase adds a complete slice of the new feature, building on the existing system.
+
+**Example** (Adding OAuth to existing Express API):
+
+```
+Phase 1: Basic OAuth flow — provider registration, callback, token exchange, session creation
+Phase 2: Permission scoping — granular permissions, role mapping, scope enforcement
+Phase 3: Token lifecycle — refresh tokens, expiry handling, revocation
+Phase 4: Edge cases — concurrent sessions, provider downtime, account linking
+```
+
+**Example** (Adding search to existing e-commerce app):
+
+```
+Phase 1: Basic keyword search — index products, query endpoint, display results
+Phase 2: Filtering and facets — category filters, price ranges, attribute facets
+Phase 3: Relevance tuning — boosting, synonyms, typo tolerance
+```
+
+Each phase delivers functionality that users or tests can validate against the existing system.
+
+### Progression
+
+**Core new functionality → Extended capability → Edge cases → Refinement**
+
+- **Core new functionality** (Phase 1): The fundamental new behaviour, integrated with existing code
+- **Extended capability**: Richer variations, additional options, deeper integration
+- **Edge cases**: Boundary conditions, failure modes, interaction with existing features
+- **Refinement**: Performance, UX polish, hardening
+
+---
+
+## Integration Considerations
+
+- **Follow existing patterns** — if the codebase uses service classes, add service classes. If it uses middleware, add middleware. Don't introduce new architectural patterns unless the specification calls for it.
+- **Tests verify both directions** — new functionality works AND existing behaviour isn't broken
+- **Existing infrastructure is available** — don't rebuild what exists. Use established models, services, and utilities.
+
+---
+
+## Scope Discipline
+
+Implement what the specification defines. Don't refactor surrounding code, even if it could be "improved". If the existing code works and the specification doesn't call for changing it, leave it alone. Refactoring discoveries belong in separate specifications.

--- a/skills/technical-planning/references/phase-design/feature.md
+++ b/skills/technical-planning/references/phase-design/feature.md
@@ -59,6 +59,19 @@ Each phase delivers functionality that users or tests can validate against the e
 
 ---
 
+## Codebase Awareness
+
+Before designing phases, understand what exists. You cannot plan feature work without knowing how the feature integrates with the codebase:
+
+- **Analyze the relevant areas** — read the code the feature touches. Understand existing patterns, conventions, and structure in those areas.
+- **Identify integration points** — where does this feature connect to existing code? What modules, services, or APIs will it use or extend?
+- **Follow established patterns** — if similar features exist, note how they're structured. New phases should follow the same approach unless the specification explicitly calls for something different.
+- **Understand before designing** — phase boundaries should respect existing architectural seams. Don't design phases that cut across established module boundaries without good reason.
+
+This is not a full codebase audit — focus on the specific areas relevant to the feature.
+
+---
+
 ## Scope Discipline
 
 Implement what the specification defines. Don't refactor surrounding code, even if it could be "improved". If the existing code works and the specification doesn't call for changing it, leave it alone. Refactoring discoveries belong in separate specifications.

--- a/skills/technical-planning/references/phase-design/greenfield.md
+++ b/skills/technical-planning/references/phase-design/greenfield.md
@@ -1,0 +1,65 @@
+# Greenfield Phase Design
+
+*Context guidance for **[phase-design.md](../phase-design.md)** — new system builds*
+
+---
+
+## The Walking Skeleton
+
+Phase 1 is always a **walking skeleton** — the thinnest possible end-to-end slice that threads through all system layers and proves the architecture works.
+
+The walking skeleton:
+
+- Touches every architectural component the system needs (database, API, UI, external services)
+- Delivers one complete flow, however minimal
+- Establishes the patterns subsequent phases will follow
+- Is production code, not throwaway — it becomes the foundation
+
+**Example** (Slack clone):
+
+> Phase 1: "Any unauthenticated person can post messages in a hardcoded #general room. Messages persist through page refreshes."
+>
+> No auth, no accounts, no multiple rooms. Just the thinnest thread through the entire stack.
+
+**Example** (Calendar app):
+
+> Phase 1: "A single event can be created with title, start, and end time, persisted, and retrieved by ID."
+>
+> No recurrence, no sharing, no notifications. Just one thing working end-to-end.
+
+The skeleton validates architecture assumptions at the cheapest possible moment. If the end-to-end flow doesn't work, you discover it in Phase 1 — not after building three phases of isolated components.
+
+This is the **steel thread** principle: never have big-bang integration. By threading through all layers immediately, integration is the first thing you solve, not the last.
+
+---
+
+## Greenfield Vertical Phases
+
+After the walking skeleton, each subsequent phase adds complete functionality — a vertical slice through the relevant layers.
+
+```
+Phase 1: Walking skeleton — single event CRUD, end-to-end
+Phase 2: Recurring events — rules, instance generation, single-instance editing
+Phase 3: Sharing and permissions — invite users, permission levels, shared calendars
+Phase 4: Notifications — email and push notifications for event changes
+```
+
+Each phase delivers something a user or test suite can validate independently.
+
+### Progression
+
+**Skeleton → Core features → Edge cases → Refinement**
+
+- **Skeleton** (Phase 1): Thinnest end-to-end slice proving the architecture
+- **Core features**: Each phase adds a complete capability, building on what exists
+- **Edge cases**: Handling boundary conditions, error scenarios, unusual inputs
+- **Refinement**: Performance optimisation, UX polish, hardening
+
+This ordering means each phase builds on a working system. The skeleton establishes the pattern; core features flesh it out; edge cases harden it; refinement polishes it.
+
+---
+
+## Cross-Phase Coupling (Greenfield)
+
+- **Walking skeleton first** — subsequent phases add to a working system rather than depending on future phases
+- **Shared infrastructure in Phase 1** — if multiple phases need the same foundation, it belongs in the skeleton

--- a/skills/technical-planning/references/phase-design/greenfield.md
+++ b/skills/technical-planning/references/phase-design/greenfield.md
@@ -63,3 +63,13 @@ This ordering means each phase builds on a working system. The skeleton establis
 
 - **Walking skeleton first** — subsequent phases add to a working system rather than depending on future phases
 - **Shared infrastructure in Phase 1** — if multiple phases need the same foundation, it belongs in the skeleton
+
+---
+
+## Phase 2+ Considerations
+
+After Phase 1 is implemented, code exists. When designing subsequent phases:
+
+- **Review what Phase 1 established** — understand the patterns, conventions, and architectural decisions that were made. Subsequent phases should build on these consistently.
+- **Extend, don't reinvent** — Phase 2+ should use the infrastructure Phase 1 created. If something is missing, add it — don't create parallel structures.
+- **Watch for drift** — if early decisions could be improved, note them but maintain consistency unless the specification calls for restructuring.

--- a/skills/technical-planning/references/plan-index-schema.md
+++ b/skills/technical-planning/references/plan-index-schema.md
@@ -15,6 +15,7 @@ This file defines the canonical structure for Plan Index Files (`docs/workflow/p
 topic: {topic-name}
 status: {status}
 format: {chosen-format}
+work_type:
 ext_id:
 specification: ../specification/{topic}/specification.md
 cross_cutting_specs:
@@ -37,6 +38,7 @@ planning:
 | `topic` | Plan creation (Step 1) |
 | `status` | Plan creation → `planning`; conclusion → `concluded` |
 | `format` | Plan creation — user-chosen output format |
+| `work_type` | Plan creation — set by caller if known. Values: `greenfield`, `feature`, `bugfix`. Empty if unknown or standalone. |
 | `ext_id` | First task authored — external identifier for the plan |
 | `specification` | Plan creation — relative path to source specification |
 | `cross_cutting_specs` | Plan creation — relative paths to cross-cutting specs (omit key if none) |

--- a/skills/technical-planning/references/plan-index-schema.md
+++ b/skills/technical-planning/references/plan-index-schema.md
@@ -38,7 +38,7 @@ planning:
 | `topic` | Plan creation (Step 1) |
 | `status` | Plan creation → `planning`; conclusion → `concluded` |
 | `format` | Plan creation — user-chosen output format |
-| `work_type` | Plan creation — set by caller if known. Values: `greenfield`, `feature`, `bugfix`. Empty if unknown or standalone. |
+| `work_type` | Plan creation — set by caller if known. Values: `greenfield`, `feature`, `bugfix`. Defaults to `greenfield` when empty. |
 | `ext_id` | First task authored — external identifier for the plan |
 | `specification` | Plan creation — relative path to source specification |
 | `cross_cutting_specs` | Plan creation — relative paths to cross-cutting specs (omit key if none) |

--- a/skills/technical-planning/references/task-design.md
+++ b/skills/technical-planning/references/task-design.md
@@ -6,7 +6,7 @@
 
 This reference defines the principles for breaking phases into tasks and writing task detail. It is loaded when tasks are first proposed and stays in context through task detailing.
 
-Context-specific guidance supplements these principles. When a context file is loaded (greenfield, feature, or bugfix), it provides ordering examples and slicing strategies appropriate to the work type.
+Context-specific guidance supplements these principles. A context file (greenfield, feature, or bugfix) is always loaded alongside this file, providing ordering examples and slicing strategies appropriate to the work type.
 
 ## One Task = One TDD Cycle
 
@@ -71,7 +71,7 @@ Within a phase, order tasks by:
 
 What constitutes "foundation" depends on context — in greenfield work it's models and migrations; in feature work it's extensions to existing code; in bugfix work it's the reproduction test.
 
-If context-specific guidance was loaded alongside this file, it provides examples of what "foundation" means in that context.
+Context-specific guidance is always loaded alongside this file and provides examples of what "foundation" means in that context.
 
 **Edge cases as separate tasks**: Keep the happy-path task focused. If a task's acceptance criteria start growing beyond 3-4 items, the edge cases probably deserve their own tasks. This keeps each TDD cycle tight and each task independently verifiable.
 

--- a/skills/technical-planning/references/task-design.md
+++ b/skills/technical-planning/references/task-design.md
@@ -4,9 +4,9 @@
 
 ---
 
-This reference defines the principles for breaking phases into tasks and writing task detail. It is loaded when tasks are first proposed and stays in context through task detailing.
+This reference defines generic principles for breaking phases into tasks and writing task detail.
 
-Context-specific guidance supplements these principles. A context file (greenfield, feature, or bugfix) is always loaded alongside this file, providing ordering examples and slicing strategies appropriate to the work type.
+A work-type context file (greenfield, feature, or bugfix) is always loaded alongside this file. The context file provides ordering examples, slicing strategies, and work-type-specific guidance. These generic principles apply across all work types.
 
 ## One Task = One TDD Cycle
 
@@ -68,10 +68,6 @@ Within a phase, order tasks by:
 2. **Happy path** — the primary expected behaviour, end-to-end
 3. **Error handling** — validation failures, API errors, permission checks
 4. **Edge cases** — boundary conditions, unusual inputs, race conditions
-
-What constitutes "foundation" depends on context — in greenfield work it's models and migrations; in feature work it's extensions to existing code; in bugfix work it's the reproduction test.
-
-Context-specific guidance is always loaded alongside this file and provides examples of what "foundation" means in that context.
 
 **Edge cases as separate tasks**: Keep the happy-path task focused. If a task's acceptance criteria start growing beyond 3-4 items, the edge cases probably deserve their own tasks. This keeps each TDD cycle tight and each task independently verifiable.
 

--- a/skills/technical-planning/references/task-design.md
+++ b/skills/technical-planning/references/task-design.md
@@ -6,6 +6,8 @@
 
 This reference defines the principles for breaking phases into tasks and writing task detail. It is loaded when tasks are first proposed and stays in context through task detailing.
 
+Context-specific guidance supplements these principles. When a context file is loaded (greenfield, feature, or bugfix), it provides ordering examples and slicing strategies appropriate to the work type.
+
 ## One Task = One TDD Cycle
 
 Write test → implement → pass → commit. Each task produces a single, verifiable increment.
@@ -62,12 +64,14 @@ TDD naturally encourages vertical slicing — when you think "what test can I wr
 
 Within a phase, order tasks by:
 
-1. **Foundation / setup** — models, migrations, base configuration needed by other tasks
+1. **Foundation / setup** — whatever other tasks need to build on
 2. **Happy path** — the primary expected behaviour, end-to-end
 3. **Error handling** — validation failures, API errors, permission checks
 4. **Edge cases** — boundary conditions, unusual inputs, race conditions
 
-This ordering means the first tasks establish the pattern and the later tasks extend it. Each task builds on a working foundation rather than building in the dark.
+What constitutes "foundation" depends on context — in greenfield work it's models and migrations; in feature work it's extensions to existing code; in bugfix work it's the reproduction test.
+
+If context-specific guidance was loaded alongside this file, it provides examples of what "foundation" means in that context.
 
 **Edge cases as separate tasks**: Keep the happy-path task focused. If a task's acceptance criteria start growing beyond 3-4 items, the edge cases probably deserve their own tasks. This keeps each TDD cycle tight and each task independently verifiable.
 

--- a/skills/technical-planning/references/task-design/bugfix.md
+++ b/skills/technical-planning/references/task-design/bugfix.md
@@ -50,3 +50,16 @@ Each task changes the minimum code needed:
 - Don't add features while fixing bugs — if the fix area suggests improvements, note them for a separate specification
 - Keep the diff small and reviewable — a reviewer should immediately see what changed and why
 - If a task starts growing beyond the fix, it's probably two tasks
+
+---
+
+## Codebase Analysis During Task Design
+
+Tasks must be designed with knowledge of the affected code:
+
+- **Understand the bug's context** — what code is involved? What tests exist? What are the inputs, outputs, and side effects of the affected code?
+- **Design tasks around existing structure** — bug fixes should work within the existing architecture. Don't design tasks that require restructuring unless the specification explicitly calls for it.
+- **Keep scope surgical** — bugfix tasks should touch as few files as possible. If a task needs to touch many files, question whether the fix is truly minimal.
+- **Leverage existing tests** — if relevant tests exist, tasks can extend them. If not, the reproduction test becomes the foundation.
+
+This analysis happens during task design — it informs what needs to change without being documented separately.

--- a/skills/technical-planning/references/task-design/bugfix.md
+++ b/skills/technical-planning/references/task-design/bugfix.md
@@ -1,0 +1,52 @@
+# Bugfix Task Design
+
+*Context guidance for **[task-design.md](../task-design.md)** — bug fixes*
+
+---
+
+## Root-Cause-First Ordering
+
+In bugfix work, the first task always reproduces the bug with a failing test, then fixes it. Foundation = the reproduction test and the minimal fix.
+
+**Example** ordering within a phase:
+
+```
+Task 1: Failing test for the N+1 query + add eager loading (reproduce + fix)
+Task 2: Verify performance with large dataset (validation)
+Task 3: Regression tests for related query paths (prevention)
+```
+
+The first task proves the bug exists and fixes it. Subsequent tasks harden the fix.
+
+---
+
+## Bugfix Vertical Slicing
+
+Each task changes the minimum code needed. A bugfix task is well-scoped when you can describe both the before (broken) and after (fixed) states in one sentence.
+
+**Example** (Single root cause):
+
+```
+Task 1: Add failing test demonstrating the race condition + add lock (fix)
+Task 2: Handle lock timeout and retry (error handling)
+Task 3: Concurrent access regression tests (prevention)
+```
+
+**Example** (Multiple related issues):
+
+```
+Task 1: Fix primary null pointer with guard clause + test (core fix)
+Task 2: Fix secondary data truncation at boundary + test (related fix)
+Task 3: Add integration test covering the full workflow (regression)
+```
+
+---
+
+## Minimal Change Focus
+
+Each task changes the minimum code needed:
+
+- Don't refactor adjacent code, even if the fix reveals it could be cleaner
+- Don't add features while fixing bugs — if the fix area suggests improvements, note them for a separate specification
+- Keep the diff small and reviewable — a reviewer should immediately see what changed and why
+- If a task starts growing beyond the fix, it's probably two tasks

--- a/skills/technical-planning/references/task-design/feature.md
+++ b/skills/technical-planning/references/task-design/feature.md
@@ -1,0 +1,48 @@
+# Feature Task Design
+
+*Context guidance for **[task-design.md](../task-design.md)** — feature additions to existing systems*
+
+---
+
+## Integration-Aware Ordering
+
+In feature work, the existing codebase provides the foundation. "Foundation" means whatever the existing codebase doesn't provide yet — new model fields, new routes, service extensions — that other tasks in this phase need.
+
+Extend existing code first, then build new behaviour on top.
+
+**Example** ordering within a phase:
+
+```
+Task 1: Add OAuth fields to User model + migration (extends existing model)
+Task 2: OAuth callback endpoint + token exchange (new route, uses existing auth middleware)
+Task 3: Session creation from OAuth token (extends existing session logic)
+Task 4: Handle provider errors and token validation failures (error handling)
+```
+
+The first task extends what exists. Later tasks build the new behaviour using both existing and newly-added code.
+
+---
+
+## Feature Vertical Slicing
+
+Each task delivers a complete, testable increment that integrates with the existing system. Since infrastructure already exists, tasks can focus on behaviour rather than setup.
+
+**Example** (Extending an existing system):
+
+```
+Task 1: Add search index fields to Product model (extends existing)
+Task 2: Search query endpoint returning products (new endpoint, existing model)
+Task 3: Filter results by category and price range (extends search)
+Task 4: Handle empty results and malformed queries (edge cases)
+```
+
+---
+
+## Follow Existing Patterns
+
+Task implementations should match established conventions in the codebase:
+
+- Use the same testing patterns (if the project uses factory functions, use factories; if it uses fixtures, use fixtures)
+- Follow the existing file organisation and naming conventions
+- Use established service/repository/controller patterns rather than introducing new ones
+- Match the existing error handling approach

--- a/skills/technical-planning/references/task-design/feature.md
+++ b/skills/technical-planning/references/task-design/feature.md
@@ -46,3 +46,16 @@ Task implementations should match established conventions in the codebase:
 - Follow the existing file organisation and naming conventions
 - Use established service/repository/controller patterns rather than introducing new ones
 - Match the existing error handling approach
+
+---
+
+## Codebase Analysis During Task Design
+
+Tasks must be designed with knowledge of the existing code. Before finalizing task lists:
+
+- **Identify similar implementations** — find existing code that does something similar. Tasks should reference this as the pattern to follow. "Follow the same approach as UserController" is more effective than abstract descriptions.
+- **Map what needs to change** — which files, modules, or services does each task touch? Understanding this shapes task scope and ordering.
+- **Prefer addition over modification** — when possible, design tasks that add new code (functions, modules, endpoints) and call it from existing code, rather than tasks that heavily modify existing code. This reduces risk and makes changes easier to review.
+- **Keep tasks focused** — tasks touching existing code should ideally stay within one file or module. Multi-file tasks in existing codebases are significantly harder to get right.
+
+This analysis happens during task design — it informs task scope and ordering without being documented separately.

--- a/skills/technical-planning/references/task-design/greenfield.md
+++ b/skills/technical-planning/references/task-design/greenfield.md
@@ -35,3 +35,13 @@ Task 4: Handle empty room and deleted messages (edge cases)
 ```
 
 The first task is slightly larger because it establishes the foundation AND the first working behaviour. Subsequent tasks are narrower because the pattern exists.
+
+---
+
+## Phase 2+ Considerations
+
+After Phase 1 completes, code exists. When designing tasks for subsequent phases:
+
+- **Review what Phase 1 established** — understand the patterns, conventions, and structure that were created. Subsequent tasks should extend these consistently.
+- **Check for drift** — if early implementation decisions could be improved, note them but don't redesign mid-project. Consistency matters more than perfection.
+- **Build on what's there** — subsequent phases have infrastructure to work with. Tasks should use existing models, services, and patterns rather than creating parallel structures.

--- a/skills/technical-planning/references/task-design/greenfield.md
+++ b/skills/technical-planning/references/task-design/greenfield.md
@@ -1,0 +1,37 @@
+# Greenfield Task Design
+
+*Context guidance for **[task-design.md](../task-design.md)** — new system builds*
+
+---
+
+## Foundation-First Ordering
+
+In greenfield projects, the first tasks establish the pattern that all subsequent tasks follow. Foundation means models, migrations, base configuration, and core abstractions that other tasks need to build on.
+
+**Example** ordering within a phase:
+
+```
+Task 1: Create Event model and migration (foundation)
+Task 2: Create event via API endpoint (happy path)
+Task 3: Validate event time ranges (error handling)
+Task 4: Handle overlapping events (edge case)
+```
+
+The first task builds what doesn't exist yet. Later tasks extend it.
+
+---
+
+## Greenfield Vertical Slicing
+
+Each task delivers a complete, testable slice of new functionality. Since nothing exists yet, early tasks often establish both the data layer and the first behaviour in a single TDD cycle.
+
+**Example** (Building new feature surfaces from scratch):
+
+```
+Task 1: Room model + create room endpoint (establishes the pattern)
+Task 2: Post message to room (builds on room, adds messaging)
+Task 3: List messages with pagination (extends messaging)
+Task 4: Handle empty room and deleted messages (edge cases)
+```
+
+The first task is slightly larger because it establishes the foundation AND the first working behaviour. Subsequent tasks are narrower because the pattern exists.

--- a/skills/technical-specification/references/dependencies.md
+++ b/skills/technical-specification/references/dependencies.md
@@ -12,9 +12,9 @@ The same workflow applies: present the dependencies section for approval, then l
 
 Dependencies are **blockers** — things that must exist before implementation can begin.
 
-Think of it like building a house: if you're specifying the roof, the walls are a dependency. You cannot build a roof without walls to support it. The walls must exist first.
+If feature B requires data that feature A produces, then feature A is a dependency — B cannot function without A's output existing first.
 
-**The test**: "If system X doesn't exist, can we still build this feature?"
+**The test**: "If system X doesn't exist, can we still deliver this?"
 - If **no** → X is a dependency
 - If **yes** → X is not a dependency (even if the systems work together)
 


### PR DESCRIPTION
## Summary

- Extracts greenfield-specific content (walking skeleton, examples, progression) from `phase-design.md` and `task-design.md` into dedicated context files under `phase-design/greenfield.md` and `task-design/greenfield.md` — preserving all existing content unchanged
- Adds new `feature.md` and `bugfix.md` context files for both phase design and task design, providing work-type-appropriate guidance (integration-aware ordering, minimal change principle, etc.)
- Introduces `work_type` field in plan frontmatter, dispatched through `define-phases.md` → `planning-phase-designer` and `define-tasks.md` → `planning-task-designer` to load the correct context file — following the same progressive enhancement pattern as output format dispatching
- **Adds codebase awareness guidance**: Feature/bugfix context files now include just-in-time codebase analysis principles — analyze relevant code before designing phases/tasks, identify integration points, follow existing patterns
- **Greenfield Phase 2+ guidance**: After Phase 1 is implemented, subsequent phases should review what was established and extend consistently
- **Strengthened executor agent**: Expanded the "Explore codebase" step with specific guidance (find similar implementations, understand inputs/outputs, note testing patterns)
- **Design document**: Added `DESIGN-unified-entry-point.md` documenting future direction for work_type flow and unified entry points

## Key Behavior Changes

- **Empty `work_type` defaults to greenfield** — preserves current walking skeleton behavior for standalone `start-planning`
- **Pipeline sets `work_type: feature`** — `begin-planning` (called from `continue-feature`) sets feature context
- **Context guidance is always loaded** — no generic "universal principles" fallback; it's always greenfield, feature, or bugfix

## Test plan

- [x] All existing test assertions pass across 20 test files (discovery scripts, migrations, hooks)
- [ ] Verify greenfield planning path: `work_type: greenfield` or empty loads walking skeleton guidance
- [ ] Verify feature planning path: `work_type: feature` loads integration-aware guidance with codebase awareness
- [ ] Trace dispatch chain: `begin-planning` → `technical-planning` → `define-phases` → agent invocation confirms context file inclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)