### PR TITLE
feat(planning): exclude implemented specs from actionable options

### DIFF
--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -74,11 +74,13 @@ Parse the discovery output to understand:
 
 **From `specifications` section:**
 - `exists` - whether any specifications exist
-- `feature` - list of feature specs (name, status, has_plan, plan_status)
+- `feature` - list of feature specs (name, status, has_plan, plan_status, has_impl, impl_status)
 - `crosscutting` - list of cross-cutting specs (name, status)
 - `counts.feature` - total feature specifications
 - `counts.feature_ready` - feature specs ready for planning (concluded + no plan)
 - `counts.feature_with_plan` - feature specs that already have plans
+- `counts.feature_actionable_with_plan` - specs with plans that are NOT fully implemented
+- `counts.feature_implemented` - specs with `impl_status: completed`
 - `counts.crosscutting` - total cross-cutting specifications
 
 **From `plans` section:**

--- a/skills/start-planning/references/display-state.md
+++ b/skills/start-planning/references/display-state.md
@@ -6,6 +6,15 @@
 
 Present everything discovered to help the user make an informed choice.
 
+**Actionable vs. non-actionable:**
+
+A specification is **actionable** for planning if:
+- It is a feature spec (not cross-cutting)
+- Its status is `concluded`
+- It does NOT have `impl_status: completed` (already fully implemented)
+
+Specs with `impl_status: completed` have finished the full workflow and should not be offered for planning work.
+
 **Present the full state:**
 
 > *Output the next fenced block as a code block:*
@@ -18,16 +27,31 @@ Planning Overview
 1. {topic:(titlecase)}
    └─ Plan: @if(has_plan) {plan_status:[in-progress|concluded]} @else (no plan) @endif
    └─ Spec: concluded
+   @if(has_impl && impl_status != completed) └─ Impl: {impl_status} @endif
 
 2. ...
 ```
 
 **Tree rules:**
 
-Each numbered item shows a feature specification that is actionable:
+Each numbered item shows a feature specification that is **actionable** (not fully implemented):
 - Concluded spec with no plan → `Plan: (no plan)`
 - Has a plan with `plan_status: planning` → `Plan: in-progress`
 - Has a plan with `plan_status: concluded` → `Plan: concluded`
+- Has implementation tracking (but not completed) → show `Impl: {impl_status}`
+
+Do NOT include specs with `impl_status: completed` in the numbered list — they go in the "Completed specifications" section.
+
+**If completed specifications exist** (impl_status: completed), show them in a separate code block:
+
+> *Output the next fenced block as a code block:*
+
+```
+Completed specifications:
+These specifications have been fully implemented.
+
+  • {topic} (implementation completed)
+```
 
 **If non-plannable specifications exist**, show them in a separate code block:
 
@@ -52,6 +76,10 @@ Key:
     in-progress — planning work is ongoing
     concluded   — plan is complete
 
+  Impl status:
+    in-progress — implementation work is ongoing
+    completed   — implementation is finished
+
   Spec type:
     cross-cutting — architectural policy, not directly plannable
     feature       — plannable feature specification
@@ -67,6 +95,8 @@ The verb in the menu depends on the plan state:
 - No plan exists → **Create**
 - Plan is `in-progress` → **Continue**
 - Plan is `concluded` → **Review**
+
+Do NOT include specs with `impl_status: completed` in the menu.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/start-planning/scripts/discovery.sh
+++ b/skills/start-planning/scripts/discovery.sh
@@ -10,6 +10,7 @@ set -eo pipefail
 
 SPEC_DIR="docs/workflow/specification"
 PLAN_DIR="docs/workflow/planning"
+IMPL_DIR="docs/workflow/implementation"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>
@@ -41,6 +42,8 @@ echo "specifications:"
 feature_count=0
 feature_ready_count=0
 feature_with_plan_count=0
+feature_actionable_with_plan_count=0
+feature_implemented_count=0
 crosscutting_count=0
 
 if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
@@ -69,11 +72,24 @@ if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
             plan_status=${plan_status:-"unknown"}
         fi
 
+        # Check if implementation tracking exists and its status
+        has_impl="false"
+        impl_status=""
+        if [ -f "$IMPL_DIR/${name}/tracking.md" ]; then
+            has_impl="true"
+            impl_status=$(extract_field "$IMPL_DIR/${name}/tracking.md" "status")
+            impl_status=${impl_status:-"unknown"}
+        fi
+
         echo "    - name: \"$name\""
         echo "      status: \"$status\""
         echo "      has_plan: $has_plan"
         if [ "$has_plan" = "true" ]; then
             echo "      plan_status: \"$plan_status\""
+        fi
+        echo "      has_impl: $has_impl"
+        if [ "$has_impl" = "true" ]; then
+            echo "      impl_status: \"$impl_status\""
         fi
 
         feature_count=$((feature_count + 1))
@@ -83,6 +99,14 @@ if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
         fi
         if [ "$has_plan" = "true" ]; then
             feature_with_plan_count=$((feature_with_plan_count + 1))
+            # Track specs with plans that are still actionable (not fully implemented)
+            if [ "$impl_status" != "completed" ]; then
+                feature_actionable_with_plan_count=$((feature_actionable_with_plan_count + 1))
+            fi
+        fi
+        # Track fully implemented specs
+        if [ "$impl_status" = "completed" ]; then
+            feature_implemented_count=$((feature_implemented_count + 1))
         fi
     done
 
@@ -120,6 +144,8 @@ if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
     echo "    feature: $feature_count"
     echo "    feature_ready: $feature_ready_count"
     echo "    feature_with_plan: $feature_with_plan_count"
+    echo "    feature_actionable_with_plan: $feature_actionable_with_plan_count"
+    echo "    feature_implemented: $feature_implemented_count"
     echo "    crosscutting: $crosscutting_count"
 else
     echo "  exists: false"
@@ -129,6 +155,8 @@ else
     echo "    feature: 0"
     echo "    feature_ready: 0"
     echo "    feature_with_plan: 0"
+    echo "    feature_actionable_with_plan: 0"
+    echo "    feature_implemented: 0"
     echo "    crosscutting: 0"
 fi
 
@@ -206,9 +234,10 @@ echo "  has_specifications: $specs_exist"
 echo "  has_plans: $plans_exist"
 
 # Determine workflow state for routing
+# Actionable = ready for new plan OR has plan that's not fully implemented
 if [ "$specs_exist" = "false" ]; then
     echo "  scenario: \"no_specs\""
-elif [ "$feature_ready_count" -eq 0 ] && [ "$feature_with_plan_count" -eq 0 ]; then
+elif [ "$feature_ready_count" -eq 0 ] && [ "$feature_actionable_with_plan_count" -eq 0 ]; then
     echo "  scenario: \"nothing_actionable\""
 else
     echo "  scenario: \"has_options\""

--- a/tests/scripts/test-discovery-for-planning.sh
+++ b/tests/scripts/test-discovery-for-planning.sh
@@ -763,6 +763,215 @@ EOF
 }
 
 #
+# Test: Spec with completed implementation
+#
+test_spec_with_completed_implementation() {
+    echo -e "${YELLOW}Test: Spec with completed implementation${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+
+    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+type: feature
+---
+
+# Specification: Auth System
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+---
+format: local-markdown
+status: concluded
+---
+
+# Implementation Plan: Auth System
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+---
+topic: auth-system
+status: completed
+---
+
+# Implementation: Auth System
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'has_impl: true' "Implementation tracking exists"
+    assert_contains "$output" 'impl_status: "completed"' "Implementation status is completed"
+    assert_contains "$output" 'feature_implemented: 1' "Feature implemented count is 1"
+    assert_contains "$output" 'feature_actionable_with_plan: 0' "Feature actionable with plan is 0 (implemented)"
+
+    echo ""
+}
+
+#
+# Test: Spec with in-progress implementation
+#
+test_spec_with_in_progress_implementation() {
+    echo -e "${YELLOW}Test: Spec with in-progress implementation${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+
+    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+type: feature
+---
+
+# Specification: Auth System
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+---
+format: local-markdown
+status: concluded
+---
+
+# Implementation Plan: Auth System
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+---
+topic: auth-system
+status: in-progress
+---
+
+# Implementation: Auth System
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'has_impl: true' "Implementation tracking exists"
+    assert_contains "$output" 'impl_status: "in-progress"' "Implementation status is in-progress"
+    assert_contains "$output" 'feature_implemented: 0' "Feature implemented count is 0"
+    assert_contains "$output" 'feature_actionable_with_plan: 1' "Feature actionable with plan is 1 (not completed)"
+    assert_contains "$output" 'scenario: "has_options"' "Scenario is has_options"
+
+    echo ""
+}
+
+#
+# Test: All specs implemented yields nothing_actionable
+#
+test_all_specs_implemented() {
+    echo -e "${YELLOW}Test: All specs implemented yields nothing_actionable${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+
+    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+type: feature
+---
+
+# Specification: Auth System
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+---
+format: local-markdown
+status: concluded
+---
+
+# Implementation Plan: Auth System
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+---
+topic: auth-system
+status: completed
+---
+
+# Implementation: Auth System
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'feature_ready: 0' "No specs ready for new plans"
+    assert_contains "$output" 'feature_actionable_with_plan: 0' "No actionable specs with plans"
+    assert_contains "$output" 'scenario: "nothing_actionable"' "Scenario is nothing_actionable"
+
+    echo ""
+}
+
+#
+# Test: Mix of implemented and ready specs
+#
+test_mix_implemented_and_ready() {
+    echo -e "${YELLOW}Test: Mix of implemented and ready specs${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/specification/billing"
+    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+
+    # Implemented spec
+    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+---
+topic: auth-system
+status: concluded
+type: feature
+---
+
+# Specification: Auth System
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+---
+format: local-markdown
+status: concluded
+---
+
+# Implementation Plan: Auth System
+EOF
+
+    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+---
+topic: auth-system
+status: completed
+---
+
+# Implementation: Auth System
+EOF
+
+    # Ready spec (no plan)
+    cat > "$TEST_DIR/docs/workflow/specification/billing/specification.md" << 'EOF'
+---
+topic: billing
+status: concluded
+type: feature
+---
+
+# Specification: Billing
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'feature: 2' "Feature count is 2"
+    assert_contains "$output" 'feature_ready: 1' "Feature ready count is 1"
+    assert_contains "$output" 'feature_implemented: 1' "Feature implemented count is 1"
+    assert_contains "$output" 'scenario: "has_options"' "Scenario is has_options"
+
+    echo ""
+}
+
+#
 # Run all tests
 #
 echo "=========================================="
@@ -789,6 +998,10 @@ test_common_format_single_plan
 test_common_format_multiple_same
 test_common_format_mixed
 test_common_format_missing_ignored
+test_spec_with_completed_implementation
+test_spec_with_in_progress_implementation
+test_all_specs_implemented
+test_mix_implemented_and_ready
 
 #
 # Summary


### PR DESCRIPTION
## Summary

- Discovery script now detects implementation tracking files and their status (`has_impl`, `impl_status`)
- Specs with `impl_status: completed` are excluded from actionable options and shown in a "Completed specifications" section
- Updated scenario logic to use `feature_actionable_with_plan_count` instead of `feature_with_plan_count`

## Test plan

- [x] Run `bash tests/scripts/test-discovery-for-planning.sh` - all 86 tests pass
- [x] Test against agntc project with core-system (completed) and plugin-authoring (no plan)

🤖 Generated with [Claude Code](https://claude.ai/code)