### PR TITLE
fix: scope discipline and task-design cleanup

### DIFF
--- a/skills/technical-planning/references/phase-design/bugfix.md
+++ b/skills/technical-planning/references/phase-design/bugfix.md
@@ -47,8 +47,8 @@ Phase 2: Add idempotency keys, handle edge cases (duplicate submissions, timeout
 Fix the root cause, don't redesign. The goal is surgical correction:
 
 - Change the minimum code needed to resolve the issue
-- If related issues are discovered during investigation, note them for the user but don't expand scope
-- Resist the temptation to "improve" surrounding code while you're in there
+- Don't expand scope beyond what the specification defines
+- Resist the temptation to "improve" surrounding code
 - The fix should be easy to review — a reviewer should immediately see what changed and why
 
 ---

--- a/skills/technical-planning/references/phase-design/bugfix.md
+++ b/skills/technical-planning/references/phase-design/bugfix.md
@@ -47,7 +47,7 @@ Phase 2: Add idempotency keys, handle edge cases (duplicate submissions, timeout
 Fix the root cause, don't redesign. The goal is surgical correction:
 
 - Change the minimum code needed to resolve the issue
-- If related issues are discovered during investigation, create separate specifications rather than expanding scope
+- If related issues are discovered during investigation, note them for the user but don't expand scope
 - Resist the temptation to "improve" surrounding code while you're in there
 - The fix should be easy to review — a reviewer should immediately see what changed and why
 

--- a/skills/technical-planning/references/phase-design/feature.md
+++ b/skills/technical-planning/references/phase-design/feature.md
@@ -74,4 +74,4 @@ This is not a full codebase audit — focus on the specific areas relevant to th
 
 ## Scope Discipline
 
-Implement what the specification defines. Don't refactor surrounding code, even if it could be "improved". If the existing code works and the specification doesn't call for changing it, leave it alone. Refactoring discoveries belong in separate specifications.
+Implement what the specification defines. Don't refactor surrounding code, even if it could be "improved". If the existing code works and the specification doesn't call for changing it, leave it alone.

--- a/skills/technical-planning/references/task-design.md
+++ b/skills/technical-planning/references/task-design.md
@@ -6,7 +6,7 @@
 
 This reference defines generic principles for breaking phases into tasks and writing task detail.
 
-A work-type context file (greenfield, feature, or bugfix) is always loaded alongside this file. The context file provides ordering examples, slicing strategies, and work-type-specific guidance. These generic principles apply across all work types.
+A work-type context file (greenfield, feature, or bugfix) is always loaded alongside this file. The context file provides task ordering, slicing examples, and work-type-specific guidance. These generic principles apply across all work types.
 
 ## One Task = One TDD Cycle
 
@@ -32,44 +32,11 @@ Cross-cutting references are context, not scope. They shape how tasks are writte
 
 Prefer **vertical slices** that deliver complete, testable functionality over horizontal slices that separate by technical layer.
 
-**Horizontal (avoid)**:
-
-```
-Task 1: Create all database models
-Task 2: Create all service classes
-Task 3: Wire up integrations
-Task 4: Add error handling
-```
-
-Nothing works until Task 4. No task is independently verifiable.
-
-**Vertical (prefer)**:
-
-```
-Task 1: Fetch and store events from provider (happy path)
-Task 2: Handle pagination for large result sets
-Task 3: Handle authentication token refresh
-Task 4: Handle rate limiting
-```
-
-Each task delivers a complete slice of functionality that can be tested in isolation.
-
-Within a bounded feature, vertical slicing means each task completes a coherent unit of that feature's functionality — not that it must touch UI/API/database layers. The test is: *can this task be verified independently?*
+The test: *can this task be verified independently?* If yes, it's a good vertical slice. If it only works once other tasks are complete, it's probably a horizontal slice.
 
 TDD naturally encourages vertical slicing — when you think "what test can I write?", you frame work as complete, verifiable behaviour rather than technical layers.
 
----
-
-## Task Ordering
-
-Within a phase, order tasks by:
-
-1. **Foundation / setup** — whatever other tasks need to build on
-2. **Happy path** — the primary expected behaviour, end-to-end
-3. **Error handling** — validation failures, API errors, permission checks
-4. **Edge cases** — boundary conditions, unusual inputs, race conditions
-
-**Edge cases as separate tasks**: Keep the happy-path task focused. If a task's acceptance criteria start growing beyond 3-4 items, the edge cases probably deserve their own tasks. This keeps each TDD cycle tight and each task independently verifiable.
+The context file provides examples of vertical slicing appropriate to the work type.
 
 ---
 

--- a/skills/technical-planning/references/task-design/bugfix.md
+++ b/skills/technical-planning/references/task-design/bugfix.md
@@ -46,9 +46,9 @@ Task 3: Add integration test covering the full workflow (regression)
 
 Each task changes the minimum code needed:
 
-- Don't refactor adjacent code, even if the fix reveals it could be cleaner
-- Don't add features while fixing bugs — if improvements are apparent, note them for the user but keep the fix focused
-- Keep the diff small and reviewable — a reviewer should immediately see what changed and why
+- Don't refactor adjacent code
+- Don't add features while fixing bugs
+- Keep the diff small and reviewable
 - If a task starts growing beyond the fix, it's probably two tasks
 
 ---

--- a/skills/technical-planning/references/task-design/bugfix.md
+++ b/skills/technical-planning/references/task-design/bugfix.md
@@ -47,7 +47,7 @@ Task 3: Add integration test covering the full workflow (regression)
 Each task changes the minimum code needed:
 
 - Don't refactor adjacent code, even if the fix reveals it could be cleaner
-- Don't add features while fixing bugs — if the fix area suggests improvements, note them for a separate specification
+- Don't add features while fixing bugs — if improvements are apparent, note them for the user but keep the fix focused
 - Keep the diff small and reviewable — a reviewer should immediately see what changed and why
 - If a task starts growing beyond the fix, it's probably two tasks
 


### PR DESCRIPTION
## Summary

Follow-up fixes that should have been in #133:

- Remove out-of-scope "create separate specifications" guidance from context files
- Simplify scope discipline to not imply discovery during planning
- Remove work-type-specific Task Ordering from task-design.md (each context file has its own)

🤖 Generated with [Claude Code](https://claude.com/claude-code)