### PR TITLE
refactor: rename docs/workflow/ to .workflows/

### DIFF
--- a/.claude/skills/update-workflow-explorer/SKILL.md
+++ b/.claude/skills/update-workflow-explorer/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Update Workflow Explorer
 
-Audit `workflow-explorer.html` and sync its flowchart data with the actual command/skill/agent source files.
+Audit `workflow-explorer.html` and sync its flowchart data with the actual skill/agent source files.
 
 ## Step 0: Determine Scope
 
@@ -49,23 +49,23 @@ For each in-scope flowchart key, read its source file(s) and extract the logical
 
 | Key | Source Files |
 |---|---|
-| `research` | `commands/workflow/start-research.md` |
-| `discussion` | `commands/workflow/start-discussion.md` |
-| `specification` | `commands/workflow/start-specification.md` |
-| `planning` | `commands/workflow/start-planning.md` |
-| `implementation` | `commands/workflow/start-implementation.md` |
-| `review` | `commands/workflow/start-review.md` |
+| `research` | `skills/start-research/SKILL.md` |
+| `discussion` | `skills/start-discussion/SKILL.md` |
+| `specification` | `skills/start-specification/SKILL.md` |
+| `planning` | `skills/start-planning/SKILL.md` |
+| `implementation` | `skills/start-implementation/SKILL.md` |
+| `review` | `skills/start-review/SKILL.md` |
 | `skill-research` | `skills/technical-research/SKILL.md` |
 | `skill-discussion` | `skills/technical-discussion/SKILL.md` |
-| `skill-specification` | `skills/technical-specification/SKILL.md` + `skills/technical-specification/references/steps/*.md` |
-| `skill-planning` | `skills/technical-planning/SKILL.md` + `skills/technical-planning/references/steps/*.md` |
-| `skill-implementation` | `skills/technical-implementation/SKILL.md` + `skills/technical-implementation/references/steps/*.md` |
+| `skill-specification` | `skills/technical-specification/SKILL.md` + `skills/technical-specification/references/*.md` |
+| `skill-planning` | `skills/technical-planning/SKILL.md` + `skills/technical-planning/references/*.md` |
+| `skill-implementation` | `skills/technical-implementation/SKILL.md` + `skills/technical-implementation/references/*.md` |
 | `skill-review` | `skills/technical-review/SKILL.md` + `agents/review-task-verifier.md` |
-| `start-feature` | `commands/start-feature.md` |
-| `link-deps` | `commands/link-dependencies.md` |
-| `status` | `commands/workflow/status.md` |
-| `view-plan` | `commands/workflow/view-plan.md` |
-| `migrate` | `commands/migrate.md` |
+| `start-feature` | `skills/start-feature/SKILL.md` |
+| `link-deps` | `skills/link-dependencies/SKILL.md` |
+| `status` | `skills/status/SKILL.md` |
+| `view-plan` | `skills/view-plan/SKILL.md` |
+| `migrate` | `skills/migrate/SKILL.md` |
 | `planning-phase-designer` | `agents/planning-phase-designer.md` |
 | `planning-task-designer` | `agents/planning-task-designer.md` |
 | `planning-task-author` | `agents/planning-task-author.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,12 +117,12 @@ Processing skills should **never hardcode references** to specific workflow phas
 ## Key Conventions
 
 Phase-first directory structure:
-- Research: `docs/workflow/research/` (flat, semantically named files)
-- Discussion: `docs/workflow/discussion/{topic}.md`
-- Specification: `docs/workflow/specification/{topic}/specification.md`
-- Planning: `docs/workflow/planning/{topic}/plan.md` + format-specific task storage
-- Implementation: `docs/workflow/implementation/{topic}/tracking.md`
-- Review: `docs/workflow/review/{topic}/r{N}/review.md`
+- Research: `.workflows/research/` (flat, semantically named files)
+- Discussion: `.workflows/discussion/{topic}.md`
+- Specification: `.workflows/specification/{topic}/specification.md`
+- Planning: `.workflows/planning/{topic}/plan.md` + format-specific task storage
+- Implementation: `.workflows/implementation/{topic}/tracking.md`
+- Review: `.workflows/review/{topic}/r{N}/review.md`
 
 Commit docs frequently (natural breaks, before context refresh). Skills capture context, don't implement.
 
@@ -163,7 +163,7 @@ The `/migrate` skill keeps workflow files in sync with the current system design
 **How it works:**
 - `skills/migrate/scripts/migrate.sh` runs all migration scripts in `skills/migrate/scripts/migrations/` in numeric order
 - Each migration is idempotent - safe to run multiple times
-- Progress is tracked in `docs/workflow/.state/migrations`
+- Progress is tracked in `.workflows/.state/migrations`
 - Delete the log file to force re-running all migrations
 
 **Adding new migrations:**
@@ -194,12 +194,12 @@ Processing skills run long and may hit context compaction. The hook system provi
 
 **How it works:**
 - Project-level hooks in `.claude/settings.json` are snapshotted at session startup and persist through compaction
-- `SessionStart` (compact) hook reads session state from `docs/workflow/.cache/sessions/{session_id}.yaml` and injects recovery context as additionalContext
+- `SessionStart` (compact) hook reads session state from `.workflows/.cache/sessions/{session_id}.yaml` and injects recovery context as additionalContext
 - Entry-point skills write session state (topic, skill, artifact) before invoking processing skills
 - `SessionEnd` hook cleans up session state files
 
 **Session state files:**
-- Stored at `docs/workflow/.cache/sessions/{session_id}.yaml`
+- Stored at `.workflows/.cache/sessions/{session_id}.yaml`
 - Created by entry-point skills before invoking processing skills
 - Contain: topic, skill path, artifact path, optional pipeline context
 - Ephemeral — cleaned up on session end, gitignored
@@ -393,7 +393,7 @@ When a phase can't proceed — use the phase title pattern, then explain:
 ```
 Planning Overview
 
-No specifications found in docs/workflow/specification/
+No specifications found in .workflows/specification/
 
 The planning phase requires a concluded specification.
 Run /start-specification first.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ npx claude-manager remove @leeovery/claude-technical-workflows && npm rm @leeove
 Documents are stored in your project using a **phase-first** organisation. Early phases use flat files; later phases use topic directories with multiple files for tracking and analysis.
 
 ```
-docs/workflow/
+.workflows/
 ├── research/                          # Phase 1 — flat, semantically named
 │   ├── exploration.md
 │   ├── competitor-analysis.md

--- a/agents/implementation-analysis-architecture.md
+++ b/agents/implementation-analysis-architecture.md
@@ -38,7 +38,7 @@ You receive via the orchestrator's prompt:
 3. **Read specification** — understand design intent and boundaries
 4. **Read all implementation files** — understand the full picture
 5. **Analyze architecture** — evaluate how the pieces compose as a whole
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-architecture-c{cycle-number}.md`
+6. **Write findings** to `.workflows/implementation/{topic}/analysis-architecture-c{cycle-number}.md`
 
 ## Hard Rules
 
@@ -52,7 +52,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-architecture-c{cycle-number}.md`:
+Write to `.workflows/implementation/{topic}/analysis-architecture-c{cycle-number}.md`:
 
 ```
 AGENT: architecture

--- a/agents/implementation-analysis-duplication.md
+++ b/agents/implementation-analysis-duplication.md
@@ -34,7 +34,7 @@ You receive via the orchestrator's prompt:
 3. **Read specification** — understand design intent
 4. **Read all implementation files** — build a mental map of the full codebase
 5. **Analyze for duplication** — compare patterns across files, identify extraction candidates
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-duplication-c{cycle-number}.md`
+6. **Write findings** to `.workflows/implementation/{topic}/analysis-duplication-c{cycle-number}.md`
 
 ## Hard Rules
 
@@ -48,7 +48,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-duplication-c{cycle-number}.md`:
+Write to `.workflows/implementation/{topic}/analysis-duplication-c{cycle-number}.md`:
 
 ```
 AGENT: duplication

--- a/agents/implementation-analysis-standards.md
+++ b/agents/implementation-analysis-standards.md
@@ -34,7 +34,7 @@ You receive via the orchestrator's prompt:
 3. **Read code-quality.md** — understand quality standards
 4. **Read all implementation files** — map each file back to its spec requirements
 5. **Compare implementation against spec** — check every decision point
-6. **Write findings** to `docs/workflow/implementation/{topic}/analysis-standards-c{cycle-number}.md`
+6. **Write findings** to `.workflows/implementation/{topic}/analysis-standards-c{cycle-number}.md`
 
 ## Hard Rules
 
@@ -48,7 +48,7 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to `docs/workflow/implementation/{topic}/analysis-standards-c{cycle-number}.md`:
+Write to `.workflows/implementation/{topic}/analysis-standards-c{cycle-number}.md`:
 
 ```
 AGENT: standards

--- a/agents/implementation-analysis-synthesizer.md
+++ b/agents/implementation-analysis-synthesizer.md
@@ -20,13 +20,13 @@ You receive via the orchestrator's prompt:
 
 ## Your Process
 
-1. **Read all findings files** from `docs/workflow/implementation/{topic}/` — look for `analysis-duplication-c{cycle-number}.md`, `analysis-standards-c{cycle-number}.md`, and `analysis-architecture-c{cycle-number}.md`
+1. **Read all findings files** from `.workflows/implementation/{topic}/` — look for `analysis-duplication-c{cycle-number}.md`, `analysis-standards-c{cycle-number}.md`, and `analysis-architecture-c{cycle-number}.md`
 2. **Deduplicate** — same issue found by multiple agents → one finding, note all sources
 3. **Group related findings** — multiple findings about the same pattern become one task (e.g., 3 duplication findings about the same helper pattern = 1 "extract helper" task)
 4. **Filter** — discard low-severity findings unless they cluster into a pattern. Never discard high-severity.
 5. **Normalize** — convert each group into a task using the canonical task template (Problem / Solution / Outcome / Do / Acceptance Criteria / Tests)
-6. **Write report** — output to `docs/workflow/implementation/{topic}/analysis-report-c{cycle-number}.md`
-7. **Write staging file** — if actionable tasks exist, write to `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle-number}.md` with `status: pending` for each task
+6. **Write report** — output to `.workflows/implementation/{topic}/analysis-report-c{cycle-number}.md`
+7. **Write staging file** — if actionable tasks exist, write to `.workflows/implementation/{topic}/analysis-tasks-c{cycle-number}.md` with `status: pending` for each task
 
 ## Report Format
 

--- a/agents/implementation-analysis-task-writer.md
+++ b/agents/implementation-analysis-task-writer.md
@@ -32,7 +32,7 @@ You receive via the orchestrator's prompt:
 
 ## Update the Plan Index File
 
-The Plan Index File (`docs/workflow/planning/{topic}/plan.md`) is the single source of truth for planning progress. After creating task files, you **must** append the new phase and task table to its body.
+The Plan Index File (`.workflows/planning/{topic}/plan.md`) is the single source of truth for planning progress. After creating task files, you **must** append the new phase and task table to its body.
 
 Append at the end of the Plan Index File body, following the **Phase Entry** and **Task Table** templates from plan-index-schema:
 

--- a/agents/review-findings-synthesizer.md
+++ b/agents/review-findings-synthesizer.md
@@ -26,8 +26,8 @@ You receive via the orchestrator's prompt:
 4. **Group related findings** — multiple findings about the same concern become one task (e.g., 3 QA findings about missing error handling in the same module = 1 "add error handling" task)
 5. **Filter** — discard low-severity non-blocking findings unless they cluster into a pattern. Never discard high-severity or blocking findings.
 6. **Normalize** — convert each group into a task using the canonical task template (Problem / Solution / Outcome / Do / Acceptance Criteria / Tests)
-7. **Write report** — output to `docs/workflow/implementation/{topic}/review-report-c{cycle}.md`
-8. **Write staging file** — if actionable tasks exist, write to `docs/workflow/implementation/{topic}/review-tasks-c{cycle}.md` with `status: pending` for each task
+7. **Write report** — output to `.workflows/implementation/{topic}/review-report-c{cycle}.md`
+8. **Write staging file** — if actionable tasks exist, write to `.workflows/implementation/{topic}/review-tasks-c{cycle}.md` with `status: pending` for each task
 
 ## Report Format
 

--- a/agents/review-task-verifier.md
+++ b/agents/review-task-verifier.md
@@ -87,7 +87,7 @@ Review the implementation as a senior architect would:
 
 ## Output File Format
 
-Write to `docs/workflow/review/{topic}/r{N}/qa-task-{index}.md`:
+Write to `.workflows/review/{topic}/r{N}/qa-task-{index}.md`:
 
 ```
 TASK: [Task name/description]

--- a/hooks/workflows/compact-recovery.sh
+++ b/hooks/workflows/compact-recovery.sh
@@ -21,7 +21,7 @@ if [ -z "$session_id" ]; then
   exit 0
 fi
 
-SESSION_FILE="$PROJECT_DIR/docs/workflow/.cache/sessions/${session_id}.yaml"
+SESSION_FILE="$PROJECT_DIR/.workflows/.cache/sessions/${session_id}.yaml"
 
 if [ ! -f "$SESSION_FILE" ]; then
   exit 0

--- a/hooks/workflows/session-cleanup.sh
+++ b/hooks/workflows/session-cleanup.sh
@@ -17,7 +17,7 @@ fi
 session_id=$(cat | grep -o '"session_id" *: *"[^"]*"' | sed 's/.*: *"//;s/"//')
 
 if [ -n "$session_id" ]; then
-  session_file="$PROJECT_DIR/docs/workflow/.cache/sessions/${session_id}.yaml"
+  session_file="$PROJECT_DIR/.workflows/.cache/sessions/${session_id}.yaml"
   if [ -f "$session_file" ]; then
     rm -f "$session_file"
   fi

--- a/hooks/workflows/write-session-state.sh
+++ b/hooks/workflows/write-session-state.sh
@@ -42,7 +42,7 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-SESSIONS_DIR="$PROJECT_DIR/docs/workflow/.cache/sessions"
+SESSIONS_DIR="$PROJECT_DIR/.workflows/.cache/sessions"
 mkdir -p "$SESSIONS_DIR"
 
 SESSION_FILE="$SESSIONS_DIR/${CLAUDE_SESSION_ID}.yaml"

--- a/progressive-disclosure/start-specification/display-design.md
+++ b/progressive-disclosure/start-specification/display-design.md
@@ -211,7 +211,7 @@ Sources:
   • auth-flow
   • user-sessions
 
-Output: docs/workflow/specification/authentication-system.md
+Output: .workflows/specification/authentication-system.md
 
 Proceed? (y/n)
 ```
@@ -220,7 +220,7 @@ Proceed? (y/n)
 ```
 Continuing specification: Authentication System
 
-Existing: docs/workflow/specification/authentication-system.md (in-progress)
+Existing: .workflows/specification/authentication-system.md (in-progress)
 
 Sources to extract:
   • oauth-integration (pending)
@@ -236,7 +236,7 @@ Proceed? (y/n)
 ```
 Refining specification: Caching Layer
 
-Existing: docs/workflow/specification/caching-layer.md (concluded)
+Existing: .workflows/specification/caching-layer.md (concluded)
 
 All sources extracted:
   • caching-layer
@@ -252,7 +252,7 @@ Sources:
   • auth-flow (has individual spec — will be incorporated)
   • user-sessions
 
-Output: docs/workflow/specification/authentication-system.md
+Output: .workflows/specification/authentication-system.md
 
 After completion:
   specification/auth-flow.md → marked as superseded

--- a/progressive-disclosure/start-specification/flows/01-blocks.md
+++ b/progressive-disclosure/start-specification/flows/01-blocks.md
@@ -6,7 +6,7 @@ These are terminal paths — the command stops and cannot proceed.
 
 ## Scenario A: No Discussions Exist
 
-**Entry state:** No discussion files in `docs/workflow/discussion/`
+**Entry state:** No discussion files in `.workflows/discussion/`
 
 **Steps:** 0 → 1 → 2 (STOP)
 

--- a/progressive-disclosure/start-specification/flows/02-single-discussion.md
+++ b/progressive-disclosure/start-specification/flows/02-single-discussion.md
@@ -74,7 +74,7 @@ Creating specification: Auth Flow
 Sources:
   • auth-flow
 
-Output: docs/workflow/specification/auth-flow.md
+Output: .workflows/specification/auth-flow.md
 
 Proceed? (y/n)
 ```
@@ -90,9 +90,9 @@ Handoff to technical-specification skill:
 Specification session for: Auth Flow
 
 Sources:
-- docs/workflow/discussion/auth-flow.md
+- .workflows/discussion/auth-flow.md
 
-Output: docs/workflow/specification/auth-flow.md
+Output: .workflows/specification/auth-flow.md
 
 ---
 Invoke the technical-specification skill.
@@ -184,7 +184,7 @@ Step 3 auto-proceeds — no prompt needed since Step 7 immediately follows.
 ```
 Continuing specification: Auth Flow
 
-Existing: docs/workflow/specification/auth-flow.md (in-progress)
+Existing: .workflows/specification/auth-flow.md (in-progress)
 
 All sources extracted:
   • auth-flow
@@ -202,10 +202,10 @@ Handoff to technical-specification skill:
 ```
 Specification session for: Auth Flow
 
-Continuing existing: docs/workflow/specification/auth-flow.md
+Continuing existing: .workflows/specification/auth-flow.md
 
 Sources for reference:
-- docs/workflow/discussion/auth-flow.md
+- .workflows/discussion/auth-flow.md
 
 Context: This specification already exists. Review and refine it based on the source discussions.
 
@@ -253,7 +253,7 @@ Automatically proceeding with "Auth Flow".
 ```
 Refining specification: Auth Flow
 
-Existing: docs/workflow/specification/auth-flow.md (concluded)
+Existing: .workflows/specification/auth-flow.md (concluded)
 
 All sources extracted:
   • auth-flow

--- a/progressive-disclosure/start-specification/flows/03-multiple-no-specs-no-cache.md
+++ b/progressive-disclosure/start-specification/flows/03-multiple-no-specs-no-cache.md
@@ -100,7 +100,7 @@ Claude reads all 3 concluded discussion files, considers the user's context, and
 Analyzing discussions...
 ```
 
-Analysis result — writes to `docs/workflow/.state/discussion-consolidation-analysis.md`:
+Analysis result — writes to `.workflows/.state/discussion-consolidation-analysis.md`:
 ```markdown
 ---
 checksum: abc123...
@@ -193,7 +193,7 @@ Sources:
   • auth-flow
   • api-design
 
-Output: docs/workflow/specification/api-authentication.md
+Output: .workflows/specification/api-authentication.md
 
 Proceed? (y/n)
 ```
@@ -208,10 +208,10 @@ Proceed? (y/n)
 Specification session for: API Authentication
 
 Sources:
-- docs/workflow/discussion/auth-flow.md
-- docs/workflow/discussion/api-design.md
+- .workflows/discussion/auth-flow.md
+- .workflows/discussion/api-design.md
 
-Output: docs/workflow/specification/api-authentication.md
+Output: .workflows/specification/api-authentication.md
 
 ---
 Invoke the technical-specification skill.
@@ -241,7 +241,7 @@ Sources:
   • api-design
   • error-handling
 
-Output: docs/workflow/specification/unified.md
+Output: .workflows/specification/unified.md
 
 Proceed? (y/n)
 ```
@@ -256,11 +256,11 @@ Proceed? (y/n)
 Specification session for: Unified
 
 Sources:
-- docs/workflow/discussion/auth-flow.md
-- docs/workflow/discussion/api-design.md
-- docs/workflow/discussion/error-handling.md
+- .workflows/discussion/auth-flow.md
+- .workflows/discussion/api-design.md
+- .workflows/discussion/error-handling.md
 
-Output: docs/workflow/specification/unified.md
+Output: .workflows/specification/unified.md
 
 ---
 Invoke the technical-specification skill.
@@ -291,7 +291,7 @@ Steps 0-6 are identical to Scenario A.
 
 Claude deletes the cache:
 ```bash
-rm docs/workflow/.state/discussion-consolidation-analysis.md
+rm .workflows/.state/discussion-consolidation-analysis.md
 ```
 
 Loops back to Step 4:

--- a/progressive-disclosure/start-specification/flows/04-multiple-no-specs-valid-cache.md
+++ b/progressive-disclosure/start-specification/flows/04-multiple-no-specs-valid-cache.md
@@ -48,7 +48,7 @@ cache:
 
 Valid cache, no specs → show groupings directly from cache.
 
-Claude loads `docs/workflow/.state/discussion-consolidation-analysis.md` and presents:
+Claude loads `.workflows/.state/discussion-consolidation-analysis.md` and presents:
 
 ```
 Specification Overview
@@ -113,7 +113,7 @@ Sources:
   • auth-flow
   • api-design
 
-Output: docs/workflow/specification/api-authentication.md
+Output: .workflows/specification/api-authentication.md
 
 Proceed? (y/n)
 ```
@@ -128,10 +128,10 @@ Proceed? (y/n)
 Specification session for: API Authentication
 
 Sources:
-- docs/workflow/discussion/auth-flow.md
-- docs/workflow/discussion/api-design.md
+- .workflows/discussion/auth-flow.md
+- .workflows/discussion/api-design.md
 
-Output: docs/workflow/specification/api-authentication.md
+Output: .workflows/specification/api-authentication.md
 
 ---
 Invoke the technical-specification skill.
@@ -151,7 +151,7 @@ Steps 0-3 are identical to Scenario A.
 
 Claude deletes the cache:
 ```bash
-rm docs/workflow/.state/discussion-consolidation-analysis.md
+rm .workflows/.state/discussion-consolidation-analysis.md
 ```
 
 ### Step 4: Gather Analysis Context

--- a/progressive-disclosure/start-specification/flows/05-multiple-no-specs-stale-cache.md
+++ b/progressive-disclosure/start-specification/flows/05-multiple-no-specs-stale-cache.md
@@ -80,7 +80,7 @@ Proceed with analysis? (y/n)
 
 Claude deletes the stale cache:
 ```bash
-rm docs/workflow/.state/discussion-consolidation-analysis.md
+rm .workflows/.state/discussion-consolidation-analysis.md
 ```
 
 ### Step 4: Gather Analysis Context

--- a/progressive-disclosure/start-specification/flows/06-multiple-with-specs-no-cache.md
+++ b/progressive-disclosure/start-specification/flows/06-multiple-with-specs-no-cache.md
@@ -145,7 +145,7 @@ Your context (or 'none'):
 
 Claude reads all 5 concluded discussions. Considers existing specs and user context. Forms groupings preserving existing spec names (anchored names will apply on subsequent runs).
 
-Cache written to `docs/workflow/.state/discussion-consolidation-analysis.md`:
+Cache written to `.workflows/.state/discussion-consolidation-analysis.md`:
 ```markdown
 ---
 checksum: def456...
@@ -259,7 +259,7 @@ Sources:
   • api-design
   • error-handling
 
-Output: docs/workflow/specification/api-design.md
+Output: .workflows/specification/api-design.md
 
 Proceed? (y/n)
 ```
@@ -274,10 +274,10 @@ Proceed? (y/n)
 Specification session for: API Design
 
 Sources:
-- docs/workflow/discussion/api-design.md
-- docs/workflow/discussion/error-handling.md
+- .workflows/discussion/api-design.md
+- .workflows/discussion/error-handling.md
 
-Output: docs/workflow/specification/api-design.md
+Output: .workflows/specification/api-design.md
 
 ---
 Invoke the technical-specification skill.
@@ -300,7 +300,7 @@ Steps 0-3 identical to Scenario A.
 ```
 Continuing specification: Authentication System
 
-Existing: docs/workflow/specification/authentication-system.md (in-progress)
+Existing: .workflows/specification/authentication-system.md (in-progress)
 
 All sources extracted:
   • auth-flow
@@ -318,11 +318,11 @@ Proceed? (y/n)
 ```
 Specification session for: Authentication System
 
-Continuing existing: docs/workflow/specification/authentication-system.md
+Continuing existing: .workflows/specification/authentication-system.md
 
 Sources for reference:
-- docs/workflow/discussion/auth-flow.md
-- docs/workflow/discussion/user-sessions.md
+- .workflows/discussion/auth-flow.md
+- .workflows/discussion/user-sessions.md
 
 Context: This specification already exists. Review and refine it based on the source discussions.
 
@@ -345,7 +345,7 @@ Steps 0-3 identical. User picks option 2 (Continue "Authentication System").
 ```
 Continuing specification: Authentication System
 
-Existing: docs/workflow/specification/authentication-system.md (in-progress)
+Existing: .workflows/specification/authentication-system.md (in-progress)
 
 All sources extracted:
   • auth-flow

--- a/progressive-disclosure/start-specification/flows/07-multiple-with-specs-valid-cache.md
+++ b/progressive-disclosure/start-specification/flows/07-multiple-with-specs-valid-cache.md
@@ -169,7 +169,7 @@ Enter choice (1-6):
 ```
 Continuing specification: Authentication System
 
-Existing: docs/workflow/specification/authentication-system.md (in-progress)
+Existing: .workflows/specification/authentication-system.md (in-progress)
 
 Sources to extract:
   • oauth-integration (pending)
@@ -190,12 +190,12 @@ Proceed? (y/n)
 ```
 Specification session for: Authentication System
 
-Continuing existing: docs/workflow/specification/authentication-system.md
+Continuing existing: .workflows/specification/authentication-system.md
 
 Sources for reference:
-- docs/workflow/discussion/auth-flow.md
-- docs/workflow/discussion/user-sessions.md
-- docs/workflow/discussion/oauth-integration.md
+- .workflows/discussion/auth-flow.md
+- .workflows/discussion/user-sessions.md
+- .workflows/discussion/oauth-integration.md
 
 Context: This specification already exists. Review and refine it based on the source discussions.
 
@@ -224,7 +224,7 @@ Sources:
   • api-endpoints
   • error-handling
 
-Output: docs/workflow/specification/api-design.md
+Output: .workflows/specification/api-design.md
 
 Proceed? (y/n)
 ```
@@ -237,10 +237,10 @@ Proceed? (y/n)
 Specification session for: API Design
 
 Sources:
-- docs/workflow/discussion/api-endpoints.md
-- docs/workflow/discussion/error-handling.md
+- .workflows/discussion/api-endpoints.md
+- .workflows/discussion/error-handling.md
 
-Output: docs/workflow/specification/api-design.md
+Output: .workflows/specification/api-design.md
 
 ---
 Invoke the technical-specification skill.
@@ -263,7 +263,7 @@ Steps 0-3 identical to Scenario A.
 ```
 Refining specification: Caching Layer
 
-Existing: docs/workflow/specification/caching-layer.md (concluded)
+Existing: .workflows/specification/caching-layer.md (concluded)
 
 All sources extracted:
   • caching-layer
@@ -278,10 +278,10 @@ Proceed? (y/n)
 ```
 Specification session for: Caching Layer
 
-Continuing existing: docs/workflow/specification/caching-layer.md
+Continuing existing: .workflows/specification/caching-layer.md
 
 Sources for reference:
-- docs/workflow/discussion/caching-layer.md
+- .workflows/discussion/caching-layer.md
 
 Context: This specification already exists. Review and refine it based on the source discussions.
 
@@ -303,7 +303,7 @@ Steps 0-3 identical to Scenario A.
 
 Claude deletes the cache:
 ```bash
-rm docs/workflow/.state/discussion-consolidation-analysis.md
+rm .workflows/.state/discussion-consolidation-analysis.md
 ```
 
 ### Step 4: Gather Analysis Context
@@ -427,7 +427,7 @@ Existing specifications to incorporate:
   • authentication-system.md → will be superseded
   • caching-layer.md → will be superseded
 
-Output: docs/workflow/specification/unified.md
+Output: .workflows/specification/unified.md
 
 Proceed? (y/n)
 ```
@@ -442,19 +442,19 @@ Proceed? (y/n)
 Specification session for: Unified
 
 Source discussions:
-- docs/workflow/discussion/auth-flow.md
-- docs/workflow/discussion/user-sessions.md
-- docs/workflow/discussion/oauth-integration.md
-- docs/workflow/discussion/api-endpoints.md
-- docs/workflow/discussion/error-handling.md
-- docs/workflow/discussion/logging-strategy.md
-- docs/workflow/discussion/caching-layer.md
+- .workflows/discussion/auth-flow.md
+- .workflows/discussion/user-sessions.md
+- .workflows/discussion/oauth-integration.md
+- .workflows/discussion/api-endpoints.md
+- .workflows/discussion/error-handling.md
+- .workflows/discussion/logging-strategy.md
+- .workflows/discussion/caching-layer.md
 
 Existing specifications to incorporate:
-- docs/workflow/specification/authentication-system.md
-- docs/workflow/specification/caching-layer.md
+- .workflows/specification/authentication-system.md
+- .workflows/specification/caching-layer.md
 
-Output: docs/workflow/specification/unified.md
+Output: .workflows/specification/unified.md
 
 Context: This consolidates all discussions into a single unified specification. The existing specifications should be incorporated - extract and adapt their content alongside the discussion material.
 
@@ -510,7 +510,7 @@ Sources:
   • auth-flow (has individual spec — will be incorporated)
   • api-design
 
-Output: docs/workflow/specification/api-authentication.md
+Output: .workflows/specification/api-authentication.md
 
 After completion:
   specification/auth-flow.md → marked as superseded
@@ -528,13 +528,13 @@ Proceed? (y/n)
 Specification session for: API Authentication
 
 Source discussions:
-- docs/workflow/discussion/auth-flow.md
-- docs/workflow/discussion/api-design.md
+- .workflows/discussion/auth-flow.md
+- .workflows/discussion/api-design.md
 
 Existing specifications to incorporate:
-- docs/workflow/specification/auth-flow.md (covers: auth-flow discussion)
+- .workflows/specification/auth-flow.md (covers: auth-flow discussion)
 
-Output: docs/workflow/specification/api-authentication.md
+Output: .workflows/specification/api-authentication.md
 
 Context: This consolidates multiple sources. The existing auth-flow.md specification should be incorporated - extract and adapt its content alongside the discussion material. The result should be a unified specification, not a simple merge.
 

--- a/progressive-disclosure/start-specification/flows/08-multiple-with-specs-stale-cache.md
+++ b/progressive-disclosure/start-specification/flows/08-multiple-with-specs-stale-cache.md
@@ -130,7 +130,7 @@ Enter choice (1-3):
 
 Claude deletes the stale cache:
 ```bash
-rm docs/workflow/.state/discussion-consolidation-analysis.md
+rm .workflows/.state/discussion-consolidation-analysis.md
 ```
 
 ### Step 4: Gather Analysis Context
@@ -235,7 +235,7 @@ Steps 0-3 identical to Scenario A.
 ```
 Continuing specification: Authentication System
 
-Existing: docs/workflow/specification/authentication-system.md (in-progress)
+Existing: .workflows/specification/authentication-system.md (in-progress)
 
 All sources extracted:
   • auth-flow
@@ -253,11 +253,11 @@ Proceed? (y/n)
 ```
 Specification session for: Authentication System
 
-Continuing existing: docs/workflow/specification/authentication-system.md
+Continuing existing: .workflows/specification/authentication-system.md
 
 Sources for reference:
-- docs/workflow/discussion/auth-flow.md
-- docs/workflow/discussion/user-sessions.md
+- .workflows/discussion/auth-flow.md
+- .workflows/discussion/user-sessions.md
 
 Context: This specification already exists. Review and refine it based on the source discussions.
 

--- a/progressive-disclosure/start-specification/plan.md
+++ b/progressive-disclosure/start-specification/plan.md
@@ -84,7 +84,7 @@ Key observation: `analysis-flow.md` always feeds into `display-groupings.md`, an
 name: start-specification
 description: "Start a specification session from concluded discussions. Discovers available discussions, offers consolidation assessment for multiple discussions, and invokes the technical-specification skill."
 disable-model-invocation: true
-allowed-tools: Bash(./scripts/discovery.sh), Bash(mkdir -p docs/workflow/.state), Bash(rm docs/workflow/.state/discussion-consolidation-analysis.md)
+allowed-tools: Bash(./scripts/discovery.sh), Bash(mkdir -p .workflows/.state), Bash(rm .workflows/.state/discussion-consolidation-analysis.md)
 ---
 ```
 

--- a/skills/begin-implementation/SKILL.md
+++ b/skills/begin-implementation/SKILL.md
@@ -117,7 +117,7 @@ Environment: No special setup required.
 > *Output the next fenced block as a code block:*
 
 ```
-Environment setup file found: docs/workflow/environment-setup.md
+Environment setup file found: .workflows/environment-setup.md
 ```
 
 → Proceed to **Step 4**.
@@ -133,8 +133,8 @@ Are there any environment setup instructions I should follow before implementati
 
 **STOP.** Wait for user response.
 
-- If the user provides instructions, save them to `docs/workflow/environment-setup.md`, commit
-- If the user says no/none, create `docs/workflow/environment-setup.md` with "No special setup required." and commit
+- If the user provides instructions, save them to `.workflows/environment-setup.md`, commit
+- If the user says no/none, create `.workflows/environment-setup.md` with "No special setup required." and commit
 
 → Proceed to **Step 4**.
 
@@ -150,10 +150,10 @@ Construct the handoff and invoke the [technical-implementation](../technical-imp
 
 ```
 Implementation session for: {topic}
-Plan: docs/workflow/planning/{topic}/plan.md
+Plan: .workflows/planning/{topic}/plan.md
 Format: {format}
 Plan ID: {plan_id} (if applicable)
-Specification: docs/workflow/specification/{topic}/specification.md (exists: {true|false})
+Specification: .workflows/specification/{topic}/specification.md (exists: {true|false})
 Implementation tracking: {exists | new} (status: {status})
 Dependencies: {All satisfied | notes}
 Environment: {Setup required | No special setup required}

--- a/skills/begin-planning/SKILL.md
+++ b/skills/begin-planning/SKILL.md
@@ -82,7 +82,7 @@ Construct the handoff and invoke the [technical-planning](../technical-planning/
 
 ```
 Planning session for: {topic}
-Specification: docs/workflow/specification/{topic}/specification.md
+Specification: .workflows/specification/{topic}/specification.md
 Work type: feature
 Additional context: {summary of user's answer from Step 3, or "none"}
 Cross-cutting references: {list of applicable cross-cutting specs with brief summaries, or "none"}

--- a/skills/begin-review/SKILL.md
+++ b/skills/begin-review/SKILL.md
@@ -80,7 +80,7 @@ Construct the handoff and invoke the [technical-review](../technical-review/SKIL
 Review session
 Plans to review:
   - topic: {topic}
-    plan: docs/workflow/planning/{topic}/plan.md
+    plan: .workflows/planning/{topic}/plan.md
     format: {format}
     plan_id: {plan_id} (if applicable)
     specification: {specification} (exists: {true|false})

--- a/skills/continue-feature/references/detect-phase.md
+++ b/skills/continue-feature/references/detect-phase.md
@@ -14,22 +14,22 @@ Either use the `next_phase` from discovery output (if discovery was run), or com
 
 Check artifacts in this order (first match wins):
 
-1. Check `docs/workflow/review/{topic}/r*/review.md`
+1. Check `.workflows/review/{topic}/r*/review.md`
    - If any review exists → next_phase is **"done"**
 
-2. Read `docs/workflow/implementation/{topic}/tracking.md`
+2. Read `.workflows/implementation/{topic}/tracking.md`
    - If exists with `status: completed` → next_phase is **"review"**
    - If exists with `status: in-progress` → next_phase is **"implementation"**
 
-3. Read `docs/workflow/planning/{topic}/plan.md`
+3. Read `.workflows/planning/{topic}/plan.md`
    - If exists with `status: concluded` → next_phase is **"implementation"**
    - If exists with other status → next_phase is **"planning"**
 
-4. Read `docs/workflow/specification/{topic}/specification.md`
+4. Read `.workflows/specification/{topic}/specification.md`
    - If exists with `status: concluded` → next_phase is **"planning"**
    - If exists with other status → next_phase is **"specification"**
 
-5. Check `docs/workflow/discussion/{topic}.md`
+5. Check `.workflows/discussion/{topic}.md`
    - If exists with `status: concluded` → next_phase is **"specification"**
    - If exists with other status → next_phase is **"discussion"**
 

--- a/skills/continue-feature/references/invoke-implementation.md
+++ b/skills/continue-feature/references/invoke-implementation.md
@@ -20,7 +20,7 @@ Saving session state so Claude can pick up where it left off and continue the fe
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-implementation/SKILL.md" \
-  "docs/workflow/implementation/{topic}/tracking.md" \
+  ".workflows/implementation/{topic}/tracking.md" \
   --pipeline "This session is part of the feature pipeline. After implementation completes, return to the continue-feature skill and execute Step 7 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
 ```
 
@@ -30,7 +30,7 @@ Invoke the [begin-implementation](../../begin-implementation/SKILL.md) skill:
 
 ```
 Implementation pre-flight for: {topic}
-Plan: docs/workflow/planning/{topic}/plan.md
+Plan: .workflows/planning/{topic}/plan.md
 
 PIPELINE CONTINUATION — When implementation completes (tracking status: completed),
 you MUST return to the continue-feature skill and execute Step 7 (Phase Bridge).

--- a/skills/continue-feature/references/invoke-planning.md
+++ b/skills/continue-feature/references/invoke-planning.md
@@ -20,7 +20,7 @@ Saving session state so Claude can pick up where it left off and continue the fe
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-planning/SKILL.md" \
-  "docs/workflow/planning/{topic}/plan.md" \
+  ".workflows/planning/{topic}/plan.md" \
   --pipeline "This session is part of the feature pipeline. After the plan concludes, return to the continue-feature skill and execute Step 7 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
 ```
 
@@ -30,7 +30,7 @@ Invoke the [begin-planning](../../begin-planning/SKILL.md) skill:
 
 ```
 Planning pre-flight for: {topic}
-Specification: docs/workflow/specification/{topic}/specification.md
+Specification: .workflows/specification/{topic}/specification.md
 
 PIPELINE CONTINUATION — When planning concludes (plan status: concluded),
 you MUST return to the continue-feature skill and execute Step 7 (Phase Bridge).

--- a/skills/continue-feature/references/invoke-review.md
+++ b/skills/continue-feature/references/invoke-review.md
@@ -20,7 +20,7 @@ Saving session state so Claude can pick up where it left off and continue the fe
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-review/SKILL.md" \
-  "docs/workflow/review/{topic}/r{N}/review.md" \
+  ".workflows/review/{topic}/r{N}/review.md" \
   --pipeline "This session is part of the feature pipeline. After the review concludes, return to the continue-feature skill and execute Step 7 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
 ```
 
@@ -30,7 +30,7 @@ Invoke the [begin-review](../../begin-review/SKILL.md) skill:
 
 ```
 Review pre-flight for: {topic}
-Plan: docs/workflow/planning/{topic}/plan.md
+Plan: .workflows/planning/{topic}/plan.md
 
 PIPELINE CONTINUATION — When review concludes,
 you MUST return to the continue-feature skill and execute Step 7 (Phase Bridge).

--- a/skills/continue-feature/references/invoke-specification.md
+++ b/skills/continue-feature/references/invoke-specification.md
@@ -10,7 +10,7 @@ Invoke the specification skill for this topic.
 
 The specification needs source material. Check what's available:
 
-1. **Discussion document**: `docs/workflow/discussion/{topic}.md`
+1. **Discussion document**: `.workflows/discussion/{topic}.md`
    - If exists and concluded → use as primary source
    - If exists and in-progress → this shouldn't happen (detect-phase would have routed to discussion)
 
@@ -30,7 +30,7 @@ Saving session state so Claude can pick up where it left off and continue the fe
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-specification/SKILL.md" \
-  "docs/workflow/specification/{topic}/specification.md" \
+  ".workflows/specification/{topic}/specification.md" \
   --pipeline "This session is part of the feature pipeline. After the specification concludes, return to the continue-feature skill and execute Step 7 (Phase Bridge). Load: skills/continue-feature/references/phase-bridge.md"
 ```
 
@@ -42,7 +42,7 @@ Invoke the [technical-specification](../../technical-specification/SKILL.md) ski
 Specification session for: {topic}
 
 Source material:
-- Discussion: docs/workflow/discussion/{topic}.md
+- Discussion: .workflows/discussion/{topic}.md
 
 Topic name: {topic}
 

--- a/skills/continue-feature/scripts/discovery.sh
+++ b/skills/continue-feature/scripts/discovery.sh
@@ -11,11 +11,11 @@
 
 set -eo pipefail
 
-DISC_DIR="docs/workflow/discussion"
-SPEC_DIR="docs/workflow/specification"
-PLAN_DIR="docs/workflow/planning"
-IMPL_DIR="docs/workflow/implementation"
-REVIEW_DIR="docs/workflow/review"
+DISC_DIR=".workflows/discussion"
+SPEC_DIR=".workflows/specification"
+PLAN_DIR=".workflows/planning"
+IMPL_DIR=".workflows/implementation"
+REVIEW_DIR=".workflows/review"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -24,8 +24,8 @@ Use simple, individual commands. Never combine multiple operations into bash loo
 
 Scan the codebase for existing plans:
 
-1. **Find plan files**: Look in `docs/workflow/planning/`
-   - Run `ls docs/workflow/planning/` to list plan files
+1. **Find plan files**: Look in `.workflows/planning/`
+   - Run `ls .workflows/planning/` to list plan files
    - Each topic is a directory containing `plan.md`
 
 2. **Extract plan metadata**: For each plan file
@@ -39,7 +39,7 @@ Scan the codebase for existing plans:
 ```
 Dependency Linking
 
-No plans found in docs/workflow/planning/
+No plans found in .workflows/planning/
 
 There are no plans to link. Create plans first.
 ```
@@ -122,7 +122,7 @@ Key:
 
 For each unresolved dependency:
 
-1. **Search for matching plan**: Does `docs/workflow/planning/{dependency-topic}/plan.md` exist?
+1. **Search for matching plan**: Does `.workflows/planning/{dependency-topic}/plan.md` exist?
    - If no match: Mark as "no plan exists" - cannot resolve yet
 
 2. **If plan exists**: Load the format's reading reference
@@ -174,7 +174,7 @@ Unresolved (no matching plan exists):
   • {source} → {target}: {description}
 
 Updated files:
-  • docs/workflow/planning/{topic}/plan.md
+  • .workflows/planning/{topic}/plan.md
 ```
 
 If any dependencies remain unresolved:

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -39,7 +39,7 @@ Return control silently - no user interaction needed.
 ## Notes
 
 - This skill is run automatically at the start of every workflow skill
-- Migrations are tracked in `docs/workflow/.state/migrations` (one migration ID per line)
+- Migrations are tracked in `.workflows/.state/migrations` (one migration ID per line)
 - The orchestrator skips entire migrations once recorded — individual scripts don't track
 - To force re-running all migrations, delete the tracking file
 - Each migration is idempotent - safe to run multiple times

--- a/skills/migrate/scripts/migrate.sh
+++ b/skills/migrate/scripts/migrate.sh
@@ -24,28 +24,64 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MIGRATIONS_DIR="$SCRIPT_DIR/migrations"
-TRACKING_FILE=".workflows/.state/migrations"
+
+# === LEGACY TRACKING SUPPORT (remove after 2026-06) ===
+#
+# Handles tracking file discovery across historical locations and formats.
+# Once all users have run migration 011, replace this section with:
+#   TRACKING_FILE=".workflows/.state/migrations"
+#   mkdir -p "$(dirname "$TRACKING_FILE")"
+
+find_tracking_file() {
+    for candidate in \
+        ".workflows/.state/migrations" \
+        "docs/workflow/.state/migrations" \
+        "docs/workflow/.cache/migrations" \
+        "docs/workflow/.cache/migrations.log"
+    do
+        [ -f "$candidate" ] && echo "$candidate" && return
+    done
+    echo ".workflows/.state/migrations"
+}
+
+normalize_tracking_format() {
+    local file="$1"
+    [ ! -f "$file" ] && return
+    # Old: "docs/workflow/discussion/auth.md: 001" → New: "001"
+    if grep -q ': [0-9]' "$file" 2>/dev/null; then
+        grep -oE '[0-9]+$' "$file" | sort -u > "${file}.tmp"
+        mv "${file}.tmp" "$file"
+    fi
+}
+
+stabilize_tracking_location() {
+    local file="$1"
+    local stable="docs/workflow/.state/migrations"
+    # If tracking is at a legacy .cache/ location, move to .state/ so it survives migration 010
+    case "$file" in
+        docs/workflow/.cache/*)
+            mkdir -p "$(dirname "$stable")"
+            mv "$file" "$stable"
+            echo "$stable"
+            ;;
+        *)
+            echo "$file"
+            ;;
+    esac
+}
+
+TRACKING_FILE=$(find_tracking_file)
+normalize_tracking_format "$TRACKING_FILE"
+TRACKING_FILE=$(stabilize_tracking_location "$TRACKING_FILE")
+mkdir -p "$(dirname "$TRACKING_FILE")"
+touch "$TRACKING_FILE"
+
+# === END LEGACY TRACKING SUPPORT ===
 
 # Track counts for final report
 FILES_UPDATED=0
 FILES_SKIPPED=0
 MIGRATIONS_RUN=0
-
-# Ensure state directory exists
-mkdir -p "$(dirname "$TRACKING_FILE")"
-
-# Self-healing: merge entries from old locations into .workflows/.state/migrations
-OLD_CACHE_LOG="docs/workflow/.cache/migrations.log"
-OLD_CACHE_FILE="docs/workflow/.cache/migrations"
-OLD_STATE_FILE="docs/workflow/.state/migrations"
-if [ -f "$OLD_CACHE_LOG" ] || [ -f "$OLD_CACHE_FILE" ] || [ -f "$OLD_STATE_FILE" ]; then
-    { cat "$OLD_CACHE_LOG" 2>/dev/null || true; cat "$OLD_CACHE_FILE" 2>/dev/null || true; cat "$OLD_STATE_FILE" 2>/dev/null || true; cat "$TRACKING_FILE" 2>/dev/null || true; } | sort -u > "${TRACKING_FILE}.tmp"
-    mv "${TRACKING_FILE}.tmp" "$TRACKING_FILE"
-    rm -f "$OLD_CACHE_LOG" "$OLD_CACHE_FILE" "$OLD_STATE_FILE"
-fi
-
-# Touch tracking file if it doesn't exist
-touch "$TRACKING_FILE"
 
 #
 # Helper function: Report a file update (for migration scripts to call)
@@ -89,14 +125,6 @@ if [ ${#MIGRATION_SCRIPTS[@]} -eq 0 ]; then
     exit 0
 fi
 
-# One-time: convert old per-file format to per-migration format
-# Old: "docs/workflow/discussion/auth.md: 001" → extracts "001"
-# New: "001" → already correct
-if grep -q ': [0-9]' "$TRACKING_FILE" 2>/dev/null; then
-    grep -oE '[0-9]+$' "$TRACKING_FILE" | sort -u > "${TRACKING_FILE}.tmp"
-    mv "${TRACKING_FILE}.tmp" "$TRACKING_FILE"
-fi
-
 for script in "${MIGRATION_SCRIPTS[@]}"; do
     # Extract migration ID from filename (e.g., "001" from "001-discussion-frontmatter.sh")
     migration_id=$(basename "$script" .sh | grep -oE '^[0-9]+')
@@ -116,6 +144,8 @@ for script in "${MIGRATION_SCRIPTS[@]}"; do
     # shellcheck source=/dev/null
     source "$script"
 
+    # Re-find tracking file (migration 011 moves it)
+    TRACKING_FILE=$(find_tracking_file)
     echo "$migration_id" >> "$TRACKING_FILE"
     MIGRATIONS_RUN=$((MIGRATIONS_RUN + 1))
 done

--- a/skills/migrate/scripts/migrate.sh
+++ b/skills/migrate/scripts/migrate.sh
@@ -9,7 +9,7 @@
 #   ./scripts/migrate.sh
 #
 # Tracking:
-#   Migrations are tracked in docs/workflow/.state/migrations
+#   Migrations are tracked in .workflows/.state/migrations
 #   Format: "migration_id" per line (e.g., "001", "002")
 #   The orchestrator checks/records migration IDs — individual scripts don't track.
 #   Delete the log file to force re-running all migrations.
@@ -24,7 +24,7 @@ set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MIGRATIONS_DIR="$SCRIPT_DIR/migrations"
-TRACKING_FILE="docs/workflow/.state/migrations"
+TRACKING_FILE=".workflows/.state/migrations"
 
 # Track counts for final report
 FILES_UPDATED=0
@@ -34,13 +34,14 @@ MIGRATIONS_RUN=0
 # Ensure state directory exists
 mkdir -p "$(dirname "$TRACKING_FILE")"
 
-# Self-healing: merge entries from old locations into .state/migrations
+# Self-healing: merge entries from old locations into .workflows/.state/migrations
 OLD_CACHE_LOG="docs/workflow/.cache/migrations.log"
 OLD_CACHE_FILE="docs/workflow/.cache/migrations"
-if [ -f "$OLD_CACHE_LOG" ] || [ -f "$OLD_CACHE_FILE" ]; then
-    { cat "$OLD_CACHE_LOG" 2>/dev/null || true; cat "$OLD_CACHE_FILE" 2>/dev/null || true; cat "$TRACKING_FILE" 2>/dev/null || true; } | sort -u > "${TRACKING_FILE}.tmp"
+OLD_STATE_FILE="docs/workflow/.state/migrations"
+if [ -f "$OLD_CACHE_LOG" ] || [ -f "$OLD_CACHE_FILE" ] || [ -f "$OLD_STATE_FILE" ]; then
+    { cat "$OLD_CACHE_LOG" 2>/dev/null || true; cat "$OLD_CACHE_FILE" 2>/dev/null || true; cat "$OLD_STATE_FILE" 2>/dev/null || true; cat "$TRACKING_FILE" 2>/dev/null || true; } | sort -u > "${TRACKING_FILE}.tmp"
     mv "${TRACKING_FILE}.tmp" "$TRACKING_FILE"
-    rm -f "$OLD_CACHE_LOG" "$OLD_CACHE_FILE"
+    rm -f "$OLD_CACHE_LOG" "$OLD_CACHE_FILE" "$OLD_STATE_FILE"
 fi
 
 # Touch tracking file if it doesn't exist

--- a/skills/migrate/scripts/migrations/011-rename-workflow-directory.sh
+++ b/skills/migrate/scripts/migrations/011-rename-workflow-directory.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# 011-rename-workflow-directory.sh
+#
+# Moves docs/workflow/ → .workflows/ at project root.
+# Workflow artefacts aren't documentation — the dot-prefixed directory
+# better communicates their role as planning artefacts.
+#
+# Steps:
+#   1. Skip if docs/workflow/ doesn't exist (fresh install or already migrated)
+#   2. Create .workflows/ if needed
+#   3. Move all contents preserving structure (including .state/, .cache/)
+#   4. Update .gitignore: docs/workflow/.cache/ → .workflows/.cache/
+#   5. Remove docs/workflow/ and docs/ if empty
+#
+# Idempotent: safe to run multiple times.
+#
+# This script is sourced by migrate.sh and has access to:
+#   - report_update "filepath" "description"
+#   - report_skip "filepath"
+
+OLD_DIR="docs/workflow"
+NEW_DIR=".workflows"
+GITIGNORE=".gitignore"
+OLD_GITIGNORE_ENTRY="docs/workflow/.cache/"
+NEW_GITIGNORE_ENTRY=".workflows/.cache/"
+
+# --- Step 1: Skip if nothing to migrate ---
+
+if [ ! -d "$OLD_DIR" ]; then
+    report_skip "$OLD_DIR (not found)"
+else
+    # --- Step 2: Create destination ---
+    mkdir -p "$NEW_DIR"
+
+    # --- Step 3: Move contents ---
+    # Use find to get all top-level items (including hidden dirs like .state/, .cache/)
+    for item in "$OLD_DIR"/* "$OLD_DIR"/.*; do
+        basename_item=$(basename "$item")
+        # Skip . and ..
+        [ "$basename_item" = "." ] || [ "$basename_item" = ".." ] && continue
+        # Skip if glob didn't match anything
+        [ ! -e "$item" ] && continue
+
+        if [ -e "$NEW_DIR/$basename_item" ]; then
+            report_skip "$basename_item (already exists at destination)"
+        else
+            mv "$item" "$NEW_DIR/$basename_item"
+            report_update "$NEW_DIR/$basename_item" "moved from $OLD_DIR/"
+        fi
+    done
+
+    # --- Step 4: Remove old directory ---
+    rmdir "$OLD_DIR" 2>/dev/null && report_update "$OLD_DIR" "removed empty directory" || true
+
+    # Remove docs/ if empty
+    if [ -d "docs" ]; then
+        rmdir "docs" 2>/dev/null && report_update "docs" "removed empty directory" || true
+    fi
+fi
+
+# --- Step 5: Update .gitignore ---
+
+if [ -f "$GITIGNORE" ] && grep -qF "$OLD_GITIGNORE_ENTRY" "$GITIGNORE"; then
+    # Replace old entry with new
+    awk -v old="$OLD_GITIGNORE_ENTRY" -v new="$NEW_GITIGNORE_ENTRY" '{
+        if ($0 == old) print new; else print
+    }' "$GITIGNORE" > "${GITIGNORE}.tmp"
+    mv "${GITIGNORE}.tmp" "$GITIGNORE"
+    report_update "$GITIGNORE" "updated .cache/ path"
+elif [ -f "$GITIGNORE" ] && grep -qxF "$NEW_GITIGNORE_ENTRY" "$GITIGNORE"; then
+    report_skip "$GITIGNORE (already has new entry)"
+fi

--- a/skills/migrate/scripts/migrations/012-environment-setup-to-state.sh
+++ b/skills/migrate/scripts/migrations/012-environment-setup-to-state.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# 012-environment-setup-to-state.sh
+#
+# Moves environment-setup.md into .state/ directory.
+# This file is project state, not a workflow artifact.
+#
+# Idempotent: safe to run multiple times.
+#
+# This script is sourced by migrate.sh and has access to:
+#   - report_update "filepath" "description"
+#   - report_skip "filepath"
+
+OLD_FILE=".workflows/environment-setup.md"
+NEW_FILE=".workflows/.state/environment-setup.md"
+
+if [ -f "$OLD_FILE" ]; then
+    mkdir -p "$(dirname "$NEW_FILE")"
+    mv "$OLD_FILE" "$NEW_FILE"
+    report_update "$NEW_FILE" "moved from workflows root"
+elif [ -f "$NEW_FILE" ]; then
+    report_skip "$NEW_FILE (already in .state/)"
+fi

--- a/skills/start-discussion/SKILL.md
+++ b/skills/start-discussion/SKILL.md
@@ -2,7 +2,7 @@
 name: start-discussion
 description: "Start a technical discussion. Discovers research and existing discussions, offers multiple entry paths, and invokes the technical-discussion skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-discussion/scripts/discovery.sh), Bash(mkdir -p docs/workflow/.state), Bash(rm docs/workflow/.state/research-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh)
+allowed-tools: Bash(.claude/skills/start-discussion/scripts/discovery.sh), Bash(mkdir -p .workflows/.state), Bash(rm .workflows/.state/research-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh)
 hooks:
   PreToolUse:
     - hooks:
@@ -180,7 +180,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-discussion/SKILL.md" \
-  "docs/workflow/discussion/{topic}.md"
+  ".workflows/discussion/{topic}.md"
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/start-discussion/references/gather-context-research.md
+++ b/skills/start-discussion/references/gather-context-research.md
@@ -11,7 +11,7 @@ Summarise the selected research topic in 2-5 lines, drawing from the source, sum
 ```
 New discussion: {topic}
 
-Based on research: docs/workflow/research/{filename}.md (lines {start}-{end})
+Based on research: .workflows/research/{filename}.md (lines {start}-{end})
 
 {2-5 line summary of the topic and what needs discussing}
 

--- a/skills/start-discussion/references/handle-selection.md
+++ b/skills/start-discussion/references/handle-selection.md
@@ -56,7 +56,7 @@ Refreshing analysis...
 
 Delete the cache file:
 ```bash
-rm docs/workflow/.state/research-analysis.md
+rm .workflows/.state/research-analysis.md
 ```
 
 → Return to **Step 3** to re-analyze.

--- a/skills/start-discussion/references/invoke-skill.md
+++ b/skills/start-discussion/references/invoke-skill.md
@@ -11,10 +11,10 @@ Invoke the [technical-discussion](../../technical-discussion/SKILL.md) skill for
 **Example handoff (from research):**
 ```
 Discussion session for: {topic}
-Output: docs/workflow/discussion/{topic}.md
+Output: .workflows/discussion/{topic}.md
 
 Research reference:
-Source: docs/workflow/research/{filename}.md (lines {start}-{end})
+Source: .workflows/research/{filename}.md (lines {start}-{end})
 Summary: {the 1-2 sentence summary from the research analysis}
 
 Invoke the technical-discussion skill.
@@ -24,7 +24,7 @@ Invoke the technical-discussion skill.
 ```
 Discussion session for: {topic}
 Source: {existing discussion | fresh}
-Output: docs/workflow/discussion/{topic}.md
+Output: .workflows/discussion/{topic}.md
 
 Invoke the technical-discussion skill.
 ```

--- a/skills/start-discussion/references/research-analysis.md
+++ b/skills/start-discussion/references/research-analysis.md
@@ -14,7 +14,7 @@ Use `cache.status` from discovery to determine the approach:
 Using cached research analysis (unchanged since {cache.generated})
 ```
 
-Load the topics from `docs/workflow/.state/research-analysis.md` and proceed.
+Load the topics from `.workflows/.state/research-analysis.md` and proceed.
 
 #### If cache.status is "stale" or "none"
 
@@ -40,10 +40,10 @@ Read each research file and extract key themes and potential discussion topics. 
 
 Ensure the cache directory exists:
 ```bash
-mkdir -p docs/workflow/.state
+mkdir -p .workflows/.state
 ```
 
-Create/update `docs/workflow/.state/research-analysis.md`:
+Create/update `.workflows/.state/research-analysis.md`:
 
 ```markdown
 ---

--- a/skills/start-discussion/scripts/discovery.sh
+++ b/skills/start-discussion/scripts/discovery.sh
@@ -8,9 +8,9 @@
 
 set -eo pipefail
 
-RESEARCH_DIR="docs/workflow/research"
-DISCUSSION_DIR="docs/workflow/discussion"
-CACHE_FILE="docs/workflow/.state/research-analysis.md"
+RESEARCH_DIR=".workflows/research"
+DISCUSSION_DIR=".workflows/discussion"
+CACHE_FILE=".workflows/.state/research-analysis.md"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -2,7 +2,7 @@
 name: start-feature
 description: "Start a new feature through the full pipeline. Gathers context via structured interview, creates a discussion, then bridges to continue-feature for specification, planning, and implementation."
 disable-model-invocation: true
-allowed-tools: Bash(ls docs/workflow/discussion/), Bash(.claude/hooks/workflows/write-session-state.sh)
+allowed-tools: Bash(ls .workflows/discussion/), Bash(.claude/hooks/workflows/write-session-state.sh)
 hooks:
   PreToolUse:
     - hooks:
@@ -45,7 +45,7 @@ Invoke the `/migrate` skill and assess its output.
 Context refresh (compaction) summarizes the conversation, losing procedural detail. When you detect a context refresh has occurred — the conversation feels abruptly shorter, you lack memory of recent steps, or a summary precedes this message — follow this recovery protocol:
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
-2. **Identify the topic.** Check conversation history for the topic name. If unknown, check `docs/workflow/discussion/` for recently modified files via `git log --oneline -5`.
+2. **Identify the topic.** Check conversation history for the topic name. If unknown, check `.workflows/discussion/` for recently modified files via `git log --oneline -5`.
 3. **Determine current step from artifacts:**
    - No discussion file exists → resume at **Step 1**
    - Discussion exists with `status: in-progress` → resume at **Step 3** (re-invoke technical-discussion)
@@ -73,7 +73,7 @@ Based on the feature description, suggest a topic name:
 ```
 Suggested topic name: {suggested-topic:(kebabcase)}
 
-This will create: docs/workflow/discussion/{suggested-topic}.md
+This will create: .workflows/discussion/{suggested-topic}.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -92,7 +92,7 @@ Is this name okay?
 Once the topic name is confirmed, check for naming conflicts:
 
 ```bash
-ls docs/workflow/discussion/
+ls .workflows/discussion/
 ```
 
 If a discussion with the same name exists, inform the user:
@@ -130,7 +130,7 @@ Saving session state so Claude can pick up where it left off and continue the fe
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-discussion/SKILL.md" \
-  "docs/workflow/discussion/{topic}.md" \
+  ".workflows/discussion/{topic}.md" \
   --pipeline "This session is part of the feature pipeline. After the discussion concludes, load and follow the phase bridge at skills/start-feature/references/phase-bridge.md for topic '{topic}'."
 ```
 

--- a/skills/start-feature/references/phase-bridge.md
+++ b/skills/start-feature/references/phase-bridge.md
@@ -26,7 +26,7 @@ continue the feature pipeline from specification onwards.
 - Topic: {topic}
 - Completed phase: discussion
 - Expected next phase: specification
-- Discussion: docs/workflow/discussion/{topic}.md
+- Discussion: .workflows/discussion/{topic}.md
 
 ## How to proceed
 

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -119,7 +119,7 @@ No plans exist yet.
 ```
 Implementation Overview
 
-No plans found in docs/workflow/planning/
+No plans found in .workflows/planning/
 
 The implementation phase requires a plan.
 Run /start-planning first to create a plan from a specification.
@@ -369,7 +369,7 @@ Environment: No special setup required.
 > *Output the next fenced block as a code block:*
 
 ```
-Environment setup file found: docs/workflow/environment-setup.md
+Environment setup file found: .workflows/environment-setup.md
 ```
 → Proceed to **Step 6**.
 
@@ -384,8 +384,8 @@ Are there any environment setup instructions I should follow before implementati
 
 **STOP.** Wait for user response.
 
-- If the user provides instructions, save them to `docs/workflow/environment-setup.md`, commit and push
-- If the user says no/none, create `docs/workflow/environment-setup.md` with "No special setup required." and commit
+- If the user provides instructions, save them to `.workflows/environment-setup.md`, commit and push
+- If the user says no/none, create `.workflows/environment-setup.md` with "No special setup required." and commit
 
 → Proceed to **Step 6**.
 
@@ -405,7 +405,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-implementation/SKILL.md" \
-  "docs/workflow/implementation/{topic}/tracking.md"
+  ".workflows/implementation/{topic}/tracking.md"
 ```
 
 After completing the steps above, this skill's purpose is fulfilled.
@@ -415,7 +415,7 @@ Invoke the [technical-implementation](../technical-implementation/SKILL.md) skil
 **Example handoff:**
 ```
 Implementation session for: {topic}
-Plan: docs/workflow/planning/{topic}/plan.md
+Plan: .workflows/planning/{topic}/plan.md
 Format: {format}
 Plan ID: {plan_id} (if applicable)
 Specification: {specification} (exists: {true|false})

--- a/skills/start-implementation/scripts/discovery.sh
+++ b/skills/start-implementation/scripts/discovery.sh
@@ -7,10 +7,10 @@
 
 set -eo pipefail
 
-PLAN_DIR="docs/workflow/planning"
-SPEC_DIR="docs/workflow/specification"
-IMPL_DIR="docs/workflow/implementation"
-ENVIRONMENT_FILE="docs/workflow/environment-setup.md"
+PLAN_DIR=".workflows/planning"
+SPEC_DIR=".workflows/specification"
+IMPL_DIR=".workflows/implementation"
+ENVIRONMENT_FILE=".workflows/environment-setup.md"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -110,7 +110,7 @@ No specifications exist yet.
 ```
 Planning Overview
 
-No specifications found in docs/workflow/specification/
+No specifications found in .workflows/specification/
 
 The planning phase requires a concluded specification.
 Run /start-specification first.
@@ -197,7 +197,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-planning/SKILL.md" \
-  "docs/workflow/planning/{topic}/plan.md"
+  ".workflows/planning/{topic}/plan.md"
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/start-planning/references/invoke-skill.md
+++ b/skills/start-planning/references/invoke-skill.md
@@ -11,7 +11,7 @@ Invoke the [technical-planning](../../technical-planning/SKILL.md) skill for you
 **Example handoff (fresh plan):**
 ```
 Planning session for: {topic}
-Specification: docs/workflow/specification/{topic}/specification.md
+Specification: .workflows/specification/{topic}/specification.md
 Additional context: {summary of user's answers from Step 5}
 Cross-cutting references: {list of applicable cross-cutting specs with brief summaries, or "none"}
 Recommended output format: {common_format from discovery if non-empty, otherwise "none"}
@@ -22,8 +22,8 @@ Invoke the technical-planning skill.
 **Example handoff (continue/review existing plan):**
 ```
 Planning session for: {topic}
-Specification: docs/workflow/specification/{topic}/specification.md
-Existing plan: docs/workflow/planning/{topic}/plan.md
+Specification: .workflows/specification/{topic}/specification.md
+Existing plan: .workflows/planning/{topic}/plan.md
 
 Invoke the technical-planning skill.
 ```

--- a/skills/start-planning/scripts/discovery.sh
+++ b/skills/start-planning/scripts/discovery.sh
@@ -8,9 +8,9 @@
 
 set -eo pipefail
 
-SPEC_DIR="docs/workflow/specification"
-PLAN_DIR="docs/workflow/planning"
-IMPL_DIR="docs/workflow/implementation"
+SPEC_DIR=".workflows/specification"
+PLAN_DIR=".workflows/planning"
+IMPL_DIR=".workflows/implementation"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>

--- a/skills/start-research/SKILL.md
+++ b/skills/start-research/SKILL.md
@@ -78,7 +78,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-research/SKILL.md" \
-  "docs/workflow/research/{topic}.md"
+  ".workflows/research/{topic}.md"
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/start-research/references/invoke-skill.md
+++ b/skills/start-research/references/invoke-skill.md
@@ -11,7 +11,7 @@ Invoke the [technical-research](../../technical-research/SKILL.md) skill for you
 **Example handoff:**
 ```
 Research session for: {topic}
-Output: docs/workflow/research/exploration.md
+Output: .workflows/research/exploration.md
 
 Context:
 - Prompted by: {problem, opportunity, or curiosity}

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -107,7 +107,7 @@ No plans exist yet.
 ```
 Review Overview
 
-No plans found in docs/workflow/planning/
+No plans found in .workflows/planning/
 
 The review phase requires a completed implementation based on a plan.
 Run /start-planning first to create a plan, then /start-implementation

--- a/skills/start-review/references/invoke-skill.md
+++ b/skills/start-review/references/invoke-skill.md
@@ -18,7 +18,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-review/SKILL.md" \
-  "docs/workflow/review/{scope}/r{N}/review.md"
+  ".workflows/review/{scope}/r{N}/review.md"
 ```
 
 ---
@@ -34,13 +34,13 @@ Each plan is reviewed independently. When multiple plans are selected, pass all 
 Review session
 Plans to review:
   - topic: {topic-1}
-    plan: docs/workflow/planning/{topic-1}/plan.md
+    plan: .workflows/planning/{topic-1}/plan.md
     format: {format}
     plan_id: {plan_id} (if applicable)
     specification: {specification} (exists: {true|false})
     review_version: r{N}
   - topic: {topic-2}
-    plan: docs/workflow/planning/{topic-2}/plan.md
+    plan: .workflows/planning/{topic-2}/plan.md
     format: {format}
     specification: {specification} (exists: {true|false})
     review_version: r{N}
@@ -52,7 +52,7 @@ Invoke the technical-review skill.
 ```
 Analysis session for: {topic}
 Review mode: analysis-only
-Review path: docs/workflow/review/{topic}/r{N}/
+Review path: .workflows/review/{topic}/r{N}/
 Format: {format}
 Specification: {spec path}
 

--- a/skills/start-review/scripts/discovery.sh
+++ b/skills/start-review/scripts/discovery.sh
@@ -7,10 +7,10 @@
 
 set -eo pipefail
 
-PLAN_DIR="docs/workflow/planning"
-SPEC_DIR="docs/workflow/specification"
-REVIEW_DIR="docs/workflow/review"
-IMPL_DIR="docs/workflow/implementation"
+PLAN_DIR=".workflows/planning"
+SPEC_DIR=".workflows/specification"
+REVIEW_DIR=".workflows/review"
+IMPL_DIR=".workflows/implementation"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>
@@ -78,7 +78,7 @@ if [ -d "$PLAN_DIR" ] && [ -n "$(ls -A "$PLAN_DIR" 2>/dev/null)" ]; then
         fi
 
         # Check implementation status
-        impl_tracking="docs/workflow/implementation/${name}/tracking.md"
+        impl_tracking=".workflows/implementation/${name}/tracking.md"
         impl_status="none"
         if [ -f "$impl_tracking" ]; then
             impl_status_val=$(extract_field "$impl_tracking" "status")

--- a/skills/start-specification/SKILL.md
+++ b/skills/start-specification/SKILL.md
@@ -2,7 +2,7 @@
 name: start-specification
 description: "Start a specification session from concluded discussions. Discovers available discussions, offers consolidation assessment for multiple discussions, and invokes the technical-specification skill."
 disable-model-invocation: true
-allowed-tools: Bash(.claude/skills/start-specification/scripts/discovery.sh), Bash(mkdir -p docs/workflow/.state), Bash(rm docs/workflow/.state/discussion-consolidation-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh)
+allowed-tools: Bash(.claude/skills/start-specification/scripts/discovery.sh), Bash(mkdir -p .workflows/.state), Bash(rm .workflows/.state/discussion-consolidation-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh)
 hooks:
   PreToolUse:
     - hooks:

--- a/skills/start-specification/references/analysis-flow.md
+++ b/skills/start-specification/references/analysis-flow.md
@@ -65,10 +65,10 @@ When forming groupings:
 
 Create the cache directory if needed:
 ```bash
-mkdir -p docs/workflow/.state
+mkdir -p .workflows/.state
 ```
 
-Write to `docs/workflow/.state/discussion-consolidation-analysis.md`:
+Write to `.workflows/.state/discussion-consolidation-analysis.md`:
 
 ```markdown
 ---

--- a/skills/start-specification/references/confirm-continue.md
+++ b/skills/start-specification/references/confirm-continue.md
@@ -11,7 +11,7 @@
 ```
 Continuing specification: {Title Case Name}
 
-Existing: docs/workflow/specification/{kebab-case-name}/specification.md (in-progress)
+Existing: .workflows/specification/{kebab-case-name}/specification.md (in-progress)
 
 Sources to extract:
   • {discussion-name} (pending)
@@ -37,7 +37,7 @@ Proceed?
 ```
 Continuing specification: {Title Case Name}
 
-Existing: docs/workflow/specification/{kebab-case-name}/specification.md (in-progress)
+Existing: .workflows/specification/{kebab-case-name}/specification.md (in-progress)
 
 All sources extracted:
   • {discussion-name}
@@ -61,7 +61,7 @@ Proceed?
 ```
 Continuing specification: {Title Case Name}
 
-Existing: docs/workflow/specification/{kebab-case-name}/specification.md (concluded)
+Existing: .workflows/specification/{kebab-case-name}/specification.md (concluded)
 
 New sources to extract:
   • {discussion-name} (pending)

--- a/skills/start-specification/references/confirm-create.md
+++ b/skills/start-specification/references/confirm-create.md
@@ -15,7 +15,7 @@ Sources:
   • {discussion-name}
   • {discussion-name}
 
-Output: docs/workflow/specification/{kebab-case-name}/specification.md
+Output: .workflows/specification/{kebab-case-name}/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -41,7 +41,7 @@ Sources:
   • {discussion-name} (has individual spec — will be incorporated)
   • {discussion-name}
 
-Output: docs/workflow/specification/{kebab-case-name}/specification.md
+Output: .workflows/specification/{kebab-case-name}/specification.md
 
 After completion:
   specification/{discussion-name}/specification.md → marked as superseded

--- a/skills/start-specification/references/confirm-refine.md
+++ b/skills/start-specification/references/confirm-refine.md
@@ -9,7 +9,7 @@
 ```
 Refining specification: {Title Case Name}
 
-Existing: docs/workflow/specification/{kebab-case-name}/specification.md (concluded)
+Existing: .workflows/specification/{kebab-case-name}/specification.md (concluded)
 
 All sources extracted:
   • {discussion-name}

--- a/skills/start-specification/references/confirm-unify.md
+++ b/skills/start-specification/references/confirm-unify.md
@@ -20,7 +20,7 @@ Existing specifications to incorporate:
   • {spec-name}/specification.md → will be superseded
   • {spec-name}/specification.md → will be superseded
 
-Output: docs/workflow/specification/unified/specification.md
+Output: .workflows/specification/unified/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -45,7 +45,7 @@ Sources:
   • {discussion-name}
   ...
 
-Output: docs/workflow/specification/unified/specification.md
+Output: .workflows/specification/unified/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -87,7 +87,7 @@ Proceed with analysis?
 
 If cache is stale, delete it first:
 ```bash
-rm docs/workflow/.state/discussion-consolidation-analysis.md
+rm .workflows/.state/discussion-consolidation-analysis.md
 ```
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions.

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -8,7 +8,7 @@ Shows when cache is valid (directly from routing) or after analysis completes. T
 
 ## A. Load Groupings
 
-Load groupings from `docs/workflow/.state/discussion-consolidation-analysis.md`. Parse the `### {Name}` headings and their discussion lists.
+Load groupings from `.workflows/.state/discussion-consolidation-analysis.md`. Parse the `### {Name}` headings and their discussion lists.
 
 → Proceed to **B. Determine Discussion Status**.
 
@@ -160,7 +160,7 @@ Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 #### If user picks "Unify all"
 
-Update the cache: rewrite `docs/workflow/.state/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all concluded discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
+Update the cache: rewrite `.workflows/.state/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all concluded discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
 
 Spec name: "Unified". Sources: all concluded discussions.
 
@@ -170,7 +170,7 @@ Spec name: "Unified". Sources: all concluded discussions.
 
 Delete the cache:
 ```bash
-rm docs/workflow/.state/discussion-consolidation-analysis.md
+rm .workflows/.state/discussion-consolidation-analysis.md
 ```
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions.

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -139,7 +139,7 @@ Menu descriptions are wrapped in backticks to visually distinguish them from the
 
 If cache is stale, delete it first:
 ```bash
-rm docs/workflow/.state/discussion-consolidation-analysis.md
+rm .workflows/.state/discussion-consolidation-analysis.md
 ```
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions.

--- a/skills/start-specification/references/handoffs/continue-concluded.md
+++ b/skills/start-specification/references/handoffs/continue-concluded.md
@@ -18,7 +18,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-specification/SKILL.md" \
-  "docs/workflow/specification/{topic}/specification.md"
+  ".workflows/specification/{topic}/specification.md"
 ```
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
@@ -26,13 +26,13 @@ This skill's purpose is now fulfilled. Invoke the [technical-specification](../.
 ```
 Specification session for: {Title Case Name}
 
-Continuing existing: docs/workflow/specification/{kebab-case-name}/specification.md (concluded)
+Continuing existing: .workflows/specification/{kebab-case-name}/specification.md (concluded)
 
 New sources to extract:
-- docs/workflow/discussion/{new-discussion-name}.md
+- .workflows/discussion/{new-discussion-name}.md
 
 Previously extracted (for reference):
-- docs/workflow/discussion/{existing-discussion-name}.md
+- .workflows/discussion/{existing-discussion-name}.md
 
 Context: This specification was previously concluded. New source discussions have been identified. Extract and incorporate their content while maintaining consistency with the existing specification.
 

--- a/skills/start-specification/references/handoffs/continue.md
+++ b/skills/start-specification/references/handoffs/continue.md
@@ -18,7 +18,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-specification/SKILL.md" \
-  "docs/workflow/specification/{topic}/specification.md"
+  ".workflows/specification/{topic}/specification.md"
 ```
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
@@ -26,11 +26,11 @@ This skill's purpose is now fulfilled. Invoke the [technical-specification](../.
 ```
 Specification session for: {Title Case Name}
 
-Continuing existing: docs/workflow/specification/{kebab-case-name}/specification.md
+Continuing existing: .workflows/specification/{kebab-case-name}/specification.md
 
 Sources for reference:
-- docs/workflow/discussion/{discussion-name}.md
-- docs/workflow/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
 
 Context: This specification already exists. Review and refine it based on the source discussions.
 

--- a/skills/start-specification/references/handoffs/create-with-incorporation.md
+++ b/skills/start-specification/references/handoffs/create-with-incorporation.md
@@ -16,7 +16,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-specification/SKILL.md" \
-  "docs/workflow/specification/{topic}/specification.md"
+  ".workflows/specification/{topic}/specification.md"
 ```
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
@@ -25,13 +25,13 @@ This skill's purpose is now fulfilled. Invoke the [technical-specification](../.
 Specification session for: {Title Case Name}
 
 Source discussions:
-- docs/workflow/discussion/{discussion-name}.md
-- docs/workflow/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
 
 Existing specifications to incorporate:
-- docs/workflow/specification/{spec-name}/specification.md (covers: {discussion-name} discussion)
+- .workflows/specification/{spec-name}/specification.md (covers: {discussion-name} discussion)
 
-Output: docs/workflow/specification/{kebab-case-name}/specification.md
+Output: .workflows/specification/{kebab-case-name}/specification.md
 
 Context: This consolidates multiple sources. The existing {spec-name}.md specification should be incorporated - extract and adapt its content alongside the discussion material. The result should be a unified specification, not a simple merge.
 

--- a/skills/start-specification/references/handoffs/create.md
+++ b/skills/start-specification/references/handoffs/create.md
@@ -16,7 +16,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "{topic}" \
   "skills/technical-specification/SKILL.md" \
-  "docs/workflow/specification/{topic}/specification.md"
+  ".workflows/specification/{topic}/specification.md"
 ```
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
@@ -25,10 +25,10 @@ This skill's purpose is now fulfilled. Invoke the [technical-specification](../.
 Specification session for: {Title Case Name}
 
 Sources:
-- docs/workflow/discussion/{discussion-name}.md
-- docs/workflow/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
 
-Output: docs/workflow/specification/{kebab-case-name}/specification.md
+Output: .workflows/specification/{kebab-case-name}/specification.md
 
 ---
 Invoke the technical-specification skill.

--- a/skills/start-specification/references/handoffs/unify-with-incorporation.md
+++ b/skills/start-specification/references/handoffs/unify-with-incorporation.md
@@ -16,7 +16,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "unified" \
   "skills/technical-specification/SKILL.md" \
-  "docs/workflow/specification/unified/specification.md"
+  ".workflows/specification/unified/specification.md"
 ```
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
@@ -25,15 +25,15 @@ This skill's purpose is now fulfilled. Invoke the [technical-specification](../.
 Specification session for: Unified
 
 Source discussions:
-- docs/workflow/discussion/{discussion-name}.md
-- docs/workflow/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
 ...
 
 Existing specifications to incorporate:
-- docs/workflow/specification/{spec-name}/specification.md
-- docs/workflow/specification/{spec-name}/specification.md
+- .workflows/specification/{spec-name}/specification.md
+- .workflows/specification/{spec-name}/specification.md
 
-Output: docs/workflow/specification/unified/specification.md
+Output: .workflows/specification/unified/specification.md
 
 Context: This consolidates all discussions into a single unified specification. The existing specifications should be incorporated - extract and adapt their content alongside the discussion material.
 

--- a/skills/start-specification/references/handoffs/unify.md
+++ b/skills/start-specification/references/handoffs/unify.md
@@ -16,7 +16,7 @@ Saving session state so Claude can pick up where it left off if the conversation
 .claude/hooks/workflows/write-session-state.sh \
   "unified" \
   "skills/technical-specification/SKILL.md" \
-  "docs/workflow/specification/unified/specification.md"
+  ".workflows/specification/unified/specification.md"
 ```
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
@@ -25,11 +25,11 @@ This skill's purpose is now fulfilled. Invoke the [technical-specification](../.
 Specification session for: Unified
 
 Sources:
-- docs/workflow/discussion/{discussion-name}.md
-- docs/workflow/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
+- .workflows/discussion/{discussion-name}.md
 ...
 
-Output: docs/workflow/specification/unified/specification.md
+Output: .workflows/specification/unified/specification.md
 
 ---
 Invoke the technical-specification skill.

--- a/skills/start-specification/scripts/discovery.sh
+++ b/skills/start-specification/scripts/discovery.sh
@@ -8,9 +8,9 @@
 
 set -eo pipefail
 
-DISCUSSION_DIR="docs/workflow/discussion"
-SPEC_DIR="docs/workflow/specification"
-CACHE_FILE="docs/workflow/.state/discussion-consolidation-analysis.md"
+DISCUSSION_DIR=".workflows/discussion"
+SPEC_DIR=".workflows/specification"
+CACHE_FILE=".workflows/.state/discussion-consolidation-analysis.md"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -72,7 +72,7 @@ Only show lines for phases that have content. If a phase has zero items but a la
 ```
 Workflow Status
 
-No workflow files found in docs/workflow/
+No workflow files found in .workflows/
 
 Start with /start-research to explore ideas,
 or /start-discussion if you already know what to build.

--- a/skills/status/scripts/discovery.sh
+++ b/skills/status/scripts/discovery.sh
@@ -8,11 +8,11 @@
 
 set -eo pipefail
 
-RESEARCH_DIR="docs/workflow/research"
-DISCUSSION_DIR="docs/workflow/discussion"
-SPEC_DIR="docs/workflow/specification"
-PLAN_DIR="docs/workflow/planning"
-IMPL_DIR="docs/workflow/implementation"
+RESEARCH_DIR=".workflows/research"
+DISCUSSION_DIR=".workflows/discussion"
+SPEC_DIR=".workflows/specification"
+PLAN_DIR=".workflows/planning"
+IMPL_DIR=".workflows/implementation"
 
 # Helper: Extract a frontmatter field value from a file
 # Usage: extract_field <file> <field_name>

--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-discussion
-description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in docs/workflow/discussion/{topic}.md that can be used to build validated specifications."
+description: "Document technical discussions as expert architect and meeting assistant. Capture context, decisions, edge cases, debates, and rationale without jumping to specification or implementation. Use when: (1) Users discuss/explore/debate architecture or design, (2) Working through edge cases before specification, (3) Need to document technical decisions and their rationale, (4) Capturing competing solutions and why choices were made. Creates documentation in .workflows/discussion/{topic}.md that can be used to build validated specifications."
 user-invocable: false
 ---
 
@@ -76,7 +76,7 @@ See **[meeting-assistant.md](references/meeting-assistant.md)** for detailed app
 
 ## Structure
 
-**Output**: `docs/workflow/discussion/{topic}.md`
+**Output**: `.workflows/discussion/{topic}.md`
 
 Use **[template.md](references/template.md)** for structure:
 
@@ -135,7 +135,7 @@ Incorporate the user's context into the discussion, commit, then re-present the 
 
 1. Update frontmatter `status: concluded`
 2. Final commit
-3. Check for remaining in-progress discussions in `docs/workflow/discussion/`
+3. Check for remaining in-progress discussions in `.workflows/discussion/`
 
 **If other in-progress discussions exist:**
 

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -4,7 +4,7 @@
 
 ---
 
-Standard structure for `docs/workflow/discussion/{topic}.md`. DOCUMENT only - no plans or code.
+Standard structure for `.workflows/discussion/{topic}.md`. DOCUMENT only - no plans or code.
 
 This is a single file per topic.
 
@@ -98,7 +98,7 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 ## Usage Notes
 
 **When creating**:
-1. Ensure discussion directory exists: `docs/workflow/discussion/`
+1. Ensure discussion directory exists: `.workflows/discussion/`
 2. Create file: `{topic}.md`
 3. Fill frontmatter: topic, status, date
 4. Start with context: why discussing?

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-implementation
-description: "Orchestrate implementation of plans using agent-based TDD workflow with per-task review and approval gate (auto mode available). Use when: (1) Implementing a plan from docs/workflow/planning/{topic}/plan.md, (2) User says 'implement', 'build', or 'code this' with a plan available, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Dispatches executor and reviewer agents per task, commits after review approval."
+description: "Orchestrate implementation of plans using agent-based TDD workflow with per-task review and approval gate (auto mode available). Use when: (1) Implementing a plan from .workflows/planning/{topic}/plan.md, (2) User says 'implement', 'build', or 'code this' with a plan available, (3) Ad hoc coding that should follow TDD and quality standards, (4) Bug fixes or features benefiting from structured implementation. Dispatches executor and reviewer agents per task, commits after review approval."
 user-invocable: false
 ---
 
@@ -36,7 +36,7 @@ Either way: dispatch agents per task — executor implements via TDD, reviewer v
 
 ```
 I need an implementation plan to execute. Could you point me to the plan file
-(e.g., docs/workflow/planning/{topic}/plan.md)?
+(e.g., .workflows/planning/{topic}/plan.md)?
 ```
 
 **STOP.** Wait for user response.
@@ -101,7 +101,7 @@ Complete ALL setup steps before proceeding.
 
 Load **[environment-setup.md](references/environment-setup.md)** and follow its instructions.
 
-#### If `docs/workflow/environment-setup.md` states "No special setup required"
+#### If `.workflows/environment-setup.md` states "No special setup required"
 
 → Proceed to **Step 2**.
 
@@ -122,7 +122,7 @@ I should follow before implementing?
 
 **STOP.** Wait for user response.
 
-Save their instructions to `docs/workflow/environment-setup.md` (or "No special setup required." if none needed). Commit.
+Save their instructions to `.workflows/environment-setup.md` (or "No special setup required." if none needed). Commit.
 
 → Proceed to **Step 2**.
 
@@ -130,7 +130,7 @@ Save their instructions to `docs/workflow/environment-setup.md` (or "No special 
 
 ## Step 2: Read Plan + Load Plan Adapter
 
-1. Read the plan from the provided location (typically `docs/workflow/planning/{topic}/plan.md`)
+1. Read the plan from the provided location (typically `.workflows/planning/{topic}/plan.md`)
 2. Plans can be stored in various formats. The `format` field in the plan's frontmatter identifies which format this plan uses.
 3. Load the format's per-concern adapter files from `../technical-planning/references/output-formats/{format}/`:
    - **reading.md** — how to read tasks from the plan
@@ -145,7 +145,7 @@ Save their instructions to `docs/workflow/environment-setup.md` (or "No special 
 
 ## Step 3: Initialize Implementation Tracking
 
-#### If `docs/workflow/implementation/{topic}/tracking.md` already exists
+#### If `.workflows/implementation/{topic}/tracking.md` already exists
 
 Reset `task_gate_mode`, `fix_gate_mode`, and `analysis_gate_mode` to `gated`, `fix_attempts` to `0`, and `analysis_cycle` to `0` (fresh session = fresh gates/cycles).
 
@@ -153,7 +153,7 @@ Reset `task_gate_mode`, `fix_gate_mode`, and `analysis_gate_mode` to `gated`, `f
 
 #### If no tracking file exists
 
-Create `docs/workflow/implementation/{topic}/tracking.md`:
+Create `.workflows/implementation/{topic}/tracking.md`:
 
 ```yaml
 ---
@@ -326,7 +326,7 @@ Discuss the user's context. If additional work is needed, route back to **Step 6
 
 #### If yes
 
-Update the tracking file (`docs/workflow/implementation/{topic}/tracking.md`):
+Update the tracking file (`.workflows/implementation/{topic}/tracking.md`):
 - Set `status: completed`
 - Set `completed: YYYY-MM-DD` (use today's actual date)
 - Update `updated` date

--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -121,7 +121,7 @@ impl({topic}): analysis cycle {N} — synthesis
 
 ## E. Approval Gate
 
-Read the staging file from `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle-number}.md`.
+Read the staging file from `.workflows/implementation/{topic}/analysis-tasks-c{cycle-number}.md`.
 
 Check `analysis_gate_mode` in the implementation tracking file (`gated` or `auto`).
 

--- a/skills/technical-implementation/references/environment-setup.md
+++ b/skills/technical-implementation/references/environment-setup.md
@@ -17,7 +17,7 @@ Before starting implementation, ensure the environment is ready. This step runs 
 
 ## Setup Document Location
 
-Look for: `docs/workflow/environment-setup.md`
+Look for: `.workflows/environment-setup.md`
 
 This file contains natural language instructions for setting up the implementation environment. It's project-specific.
 
@@ -42,9 +42,9 @@ Ask the user:
 
 If they provide instructions, offer to save them:
 
-> "Would you like me to save these instructions to `docs/workflow/environment-setup.md` for future sessions?"
+> "Would you like me to save these instructions to `.workflows/environment-setup.md` for future sessions?"
 
-If they say no setup is needed, create `docs/workflow/environment-setup.md` with "No special setup required." and commit. This prevents asking the same question in future sessions.
+If they say no setup is needed, create `.workflows/environment-setup.md` with "No special setup required." and commit. This prevents asking the same question in future sessions.
 
 ## No Setup Required
 

--- a/skills/technical-implementation/references/invoke-task-writer.md
+++ b/skills/technical-implementation/references/invoke-task-writer.md
@@ -15,7 +15,7 @@ This step invokes the task writer agent to create plan tasks from approved analy
 Pass via the orchestrator's prompt:
 
 1. **Topic name** — the implementation topic
-2. **Staging file path** — `docs/workflow/implementation/{topic}/analysis-tasks-c{cycle-number}.md`
+2. **Staging file path** — `.workflows/implementation/{topic}/analysis-tasks-c{cycle-number}.md`
 3. **Plan path** — the implementation plan path
 4. **Plan format reading adapter path** — `../../technical-planning/references/output-formats/{format}/reading.md`
 5. **Plan format authoring adapter path** — `../../technical-planning/references/output-formats/{format}/authoring.md`

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -178,7 +178,7 @@ Check the `task_gate_mode` field in the implementation tracking file.
 - If the format's updating.md includes a **Phase / Parent Status** section, follow its phase completion instructions
 - Append the phase number to `completed_phases` in the tracking file
 
-**Mirror to implementation tracking file** (`docs/workflow/implementation/{topic}/tracking.md`):
+**Mirror to implementation tracking file** (`.workflows/implementation/{topic}/tracking.md`):
 - Append the task ID to `completed_tasks`
 - Update `current_phase` if phase changed
 - Update `current_task` to the next task (or `~` if done)

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-planning
-description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation from a specification, (3) Converting specifications from docs/workflow/specification/{topic}/specification.md into implementation plans, (4) User says 'plan this' or 'create a plan', (5) Need to structure how to build something with phases and concrete steps. Creates plans in docs/workflow/planning/{topic}/plan.md that can be executed via strict TDD."
+description: "Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Use when: (1) User asks to create/write an implementation plan, (2) User asks to plan implementation from a specification, (3) Converting specifications from .workflows/specification/{topic}/specification.md into implementation plans, (4) User says 'plan this' or 'create a plan', (5) Need to structure how to build something with phases and concrete steps. Creates plans in .workflows/planning/{topic}/plan.md that can be executed via strict TDD."
 user-invocable: false
 ---
 
@@ -35,7 +35,7 @@ Either way: Transform specifications into actionable phases, tasks, and acceptan
 
 ```
 I need the specification content to plan from. Could you point me to the
-specification file (e.g., docs/workflow/specification/{topic}/specification.md),
+specification file (e.g., .workflows/specification/{topic}/specification.md),
 or provide the content directly?
 ```
 
@@ -60,7 +60,7 @@ this, or is there a more complete version?
 Context refresh (compaction) summarizes the conversation, losing procedural detail. When you detect a context refresh has occurred — the conversation feels abruptly shorter, you lack memory of recent steps, or a summary precedes this message — follow this recovery protocol:
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
-2. **Read all tracking and state files** for the current topic — plan index files, review tracking files, implementation tracking files, or any working documents this skill creates. These are your source of truth for progress. Check for scratch files at `docs/workflow/.cache/planning/{topic}/`. If a scratch file exists, you are mid-authoring for that phase — resume the approval loop in author-tasks.md.
+2. **Read all tracking and state files** for the current topic — plan index files, review tracking files, implementation tracking files, or any working documents this skill creates. These are your source of truth for progress. Check for scratch files at `.workflows/.cache/planning/{topic}/`. If a scratch file exists, you are mid-authoring for that phase — resume the approval loop in author-tasks.md.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 5. **Check `task_list_gate_mode`, `author_gate_mode`, and `finding_gate_mode`** in the Plan Index File frontmatter — if `auto`, the user previously opted in during this session. Preserve these values.
@@ -73,7 +73,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 This process constructs a plan from a specification. A plan consists of:
 
-- **Plan Index File** — `docs/workflow/planning/{topic}/plan.md`. Contains frontmatter (topic, format, status, progress), phases with acceptance criteria, and task tables tracking status. This is the single source of truth for planning progress.
+- **Plan Index File** — `.workflows/planning/{topic}/plan.md`. Contains frontmatter (topic, format, status, progress), phases with acceptance criteria, and task tables tracking status. This is the single source of truth for planning progress.
 - **Authored Tasks** — Detailed task files written to the chosen **Output Format** (selected during planning). The output format determines where and how task detail is stored.
 
 Follow every step in sequence. No steps are optional.
@@ -86,7 +86,7 @@ When announcing a new step, output `── ── ── ── ──` on its o
 
 ## Step 0: Resume Detection
 
-Check if a Plan Index File already exists at `docs/workflow/planning/{topic}/plan.md`.
+Check if a Plan Index File already exists at `.workflows/planning/{topic}/plan.md`.
 
 #### If no Plan Index File exists
 
@@ -127,7 +127,7 @@ Reset `task_list_gate_mode`, `author_gate_mode`, and `finding_gate_mode` to `gat
 
 1. Read **[output-formats.md](references/output-formats.md)**, find the entry matching the `format:` field in the Plan Index File, and load the format's **[authoring.md](references/output-formats/{format}/authoring.md)**
 2. Follow the authoring file's cleanup instructions to remove Authored Tasks for this topic
-3. Delete the scratch directory if it exists: `rm -rf docs/workflow/.cache/planning/{topic}/`
+3. Delete the scratch directory if it exists: `rm -rf .workflows/.cache/planning/{topic}/`
 4. Delete the Plan Index File
 5. Commit: `planning({topic}): restart planning`
 
@@ -174,7 +174,7 @@ Once selected:
 
 1. Read **[output-formats.md](references/output-formats.md)**, find the chosen format entry, and load the format's **[about.md](references/output-formats/{format}/about.md)** and **[authoring.md](references/output-formats/{format}/authoring.md)**
 2. Capture the current git commit hash: `git rev-parse HEAD`
-3. Create the Plan Index File at `docs/workflow/planning/{topic}/plan.md` using the **Frontmatter** and **Title** templates from **[plan-index-schema.md](references/plan-index-schema.md)**. Set `status: planning`, `spec_commit` to the captured git hash, today's actual date for `created` and `updated`, and `work_type` to the value provided by the caller (or `greenfield` if not provided).
+3. Create the Plan Index File at `.workflows/planning/{topic}/plan.md` using the **Frontmatter** and **Title** templates from **[plan-index-schema.md](references/plan-index-schema.md)**. Set `status: planning`, `spec_commit` to the captured git hash, today's actual date for `created` and `updated`, and `work_type` to the value provided by the caller (or `greenfield` if not provided).
 
 3. Commit: `planning({topic}): initialize plan`
 

--- a/skills/technical-planning/references/analyze-task-graph.md
+++ b/skills/technical-planning/references/analyze-task-graph.md
@@ -23,7 +23,7 @@ Read **[output-formats.md](output-formats.md)**, find the entry matching the `fo
 
 Invoke `planning-dependency-grapher` with these file paths:
 
-1. **Plan Index File path**: `docs/workflow/planning/{topic}/plan.md`
+1. **Plan Index File path**: `.workflows/planning/{topic}/plan.md`
 2. **reading.md**: the format's reading reference loaded above
 3. **graph.md**: the format's graph reference loaded above
 

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -10,9 +10,9 @@ This step uses the `planning-task-author` agent (`../../../agents/planning-task-
 
 ## Section 1: Prepare the Scratch File
 
-Scratch file path: `docs/workflow/.cache/planning/{topic}/phase-{N}.md`
+Scratch file path: `.workflows/.cache/planning/{topic}/phase-{N}.md`
 
-Create the `docs/workflow/.cache/planning/{topic}/` directory if it does not exist.
+Create the `.workflows/.cache/planning/{topic}/` directory if it does not exist.
 
 ---
 
@@ -32,7 +32,7 @@ Invoke `planning-task-author` with these file paths:
 4. **task-design.md**: `task-design.md`
 5. **All approved phases**: the complete phase structure from the Plan Index File body
 6. **Task list for current phase**: the approved task table (ALL tasks in the phase)
-7. **Scratch file path**: `docs/workflow/.cache/planning/{topic}/phase-{N}.md`
+7. **Scratch file path**: `.workflows/.cache/planning/{topic}/phase-{N}.md`
 
 The agent writes all tasks to the scratch file and returns.
 
@@ -183,8 +183,8 @@ Repeat for each task.
 
 ## Section 7: Cleanup
 
-Delete the scratch file: `rm docs/workflow/.cache/planning/{topic}/phase-{N}.md`
+Delete the scratch file: `rm .workflows/.cache/planning/{topic}/phase-{N}.md`
 
-Remove the `docs/workflow/.cache/planning/{topic}/` directory if empty.
+Remove the `.workflows/.cache/planning/{topic}/` directory if empty.
 
 → Return to **Plan Construction**.

--- a/skills/technical-planning/references/invoke-review-integrity.md
+++ b/skills/technical-planning/references/invoke-review-integrity.md
@@ -13,7 +13,7 @@ This step invokes the `planning-review-integrity` agent (`../../../agents/planni
 Invoke `planning-review-integrity` with:
 
 1. **Review criteria path**: `review-integrity.md` (in this directory)
-2. **Plan path**: `docs/workflow/planning/{topic}/plan.md`
+2. **Plan path**: `.workflows/planning/{topic}/plan.md`
 3. **Format reading.md path**: load **[output-formats.md](output-formats.md)**, find the entry matching the plan's `format:` field, and pass the format's `reading.md` path
 4. **Cycle number**: current `review_cycle` from the Plan Index File frontmatter
 5. **Topic name**: from the plan's `topic` frontmatter field

--- a/skills/technical-planning/references/invoke-review-traceability.md
+++ b/skills/technical-planning/references/invoke-review-traceability.md
@@ -14,7 +14,7 @@ Invoke `planning-review-traceability` with:
 
 1. **Review criteria path**: `review-traceability.md` (in this directory)
 2. **Specification path**: from the plan's `specification` frontmatter field (resolved relative to the plan directory)
-3. **Plan path**: `docs/workflow/planning/{topic}/plan.md`
+3. **Plan path**: `.workflows/planning/{topic}/plan.md`
 4. **Format reading.md path**: load **[output-formats.md](output-formats.md)**, find the entry matching the plan's `format:` field, and pass the format's `reading.md` path
 5. **Cycle number**: current `review_cycle` from the Plan Index File frontmatter
 6. **Topic name**: from the plan's `topic` frontmatter field

--- a/skills/technical-planning/references/output-formats/local-markdown/about.md
+++ b/skills/technical-planning/references/output-formats/local-markdown/about.md
@@ -21,7 +21,7 @@ No external tools required. This format uses plain markdown files stored in the 
 
 | Concept | Local Markdown Entity |
 |---------|-----------------------|
-| Topic | Directory (`docs/workflow/planning/{topic}/`) |
+| Topic | Directory (`.workflows/planning/{topic}/`) |
 | Phase | Encoded in task ID (`{topic}-{phase}-{seq}`) |
 | Task | Markdown file (`{task-id}.md`) |
 | Dependency | Task ID reference in frontmatter (no native blocking) |
@@ -31,7 +31,7 @@ No external tools required. This format uses plain markdown files stored in the 
 Tasks are stored as individual markdown files in a `tasks/` subdirectory under the topic directory:
 
 ```
-docs/workflow/planning/{topic}/
+.workflows/planning/{topic}/
 ├── plan.md                     # Plan Index File (not a task)
 └── tasks/                      # Task files
     ├── {topic}-1-1.md          # Phase 1, task 1

--- a/skills/technical-planning/references/output-formats/local-markdown/authoring.md
+++ b/skills/technical-planning/references/output-formats/local-markdown/authoring.md
@@ -2,7 +2,7 @@
 
 ## Task Storage
 
-Each task is written to `docs/workflow/planning/{topic}/tasks/{task-id}.md` — a markdown file with frontmatter and a description body.
+Each task is written to `.workflows/planning/{topic}/tasks/{task-id}.md` — a markdown file with frontmatter and a description body.
 
 ```markdown
 ---
@@ -60,5 +60,5 @@ In the task file, add a **Needs Clarification** section:
 Delete the tasks directory — preserves `plan.md` (the Plan Index) and any review tracking files:
 
 ```bash
-rm -rf docs/workflow/planning/{topic}/tasks/
+rm -rf .workflows/planning/{topic}/tasks/
 ```

--- a/skills/technical-planning/references/output-formats/local-markdown/reading.md
+++ b/skills/technical-planning/references/output-formats/local-markdown/reading.md
@@ -4,7 +4,7 @@
 
 To retrieve all tasks for a plan:
 
-1. List all `.md` files in `docs/workflow/planning/{topic}/tasks/` — every file in this directory is a task file, no filtering needed
+1. List all `.md` files in `.workflows/planning/{topic}/tasks/` — every file in this directory is a task file, no filtering needed
 2. Read each file's frontmatter to extract: `id`, `phase`, `status`, `priority`, `depends_on`
 3. Read the first heading for the task title
 
@@ -12,7 +12,7 @@ This provides the summary-level data needed for graphing, progress overview, or 
 
 ## Extracting a Task
 
-To read a specific task, read the file at `docs/workflow/planning/{topic}/tasks/{task-id}.md`.
+To read a specific task, read the file at `.workflows/planning/{topic}/tasks/{task-id}.md`.
 
 The task file is self-contained — frontmatter holds id, phase, and status. The body contains the title and full description.
 
@@ -20,7 +20,7 @@ The task file is self-contained — frontmatter holds id, phase, and status. The
 
 To find the next task to implement:
 
-1. List all `.md` files in `docs/workflow/planning/{topic}/tasks/`
+1. List all `.md` files in `.workflows/planning/{topic}/tasks/`
 2. Filter to tasks where `status` is `pending` or `in-progress` (or missing — treat as `pending`)
 3. If any tasks have `depends_on`, check each referenced task's `status` — exclude the task unless all dependencies have `status: completed`
 4. Order by phase number (from task ID: `{topic}-{phase}-{seq}`) — complete all earlier phases first

--- a/skills/technical-planning/references/output-formats/local-markdown/updating.md
+++ b/skills/technical-planning/references/output-formats/local-markdown/updating.md
@@ -2,7 +2,7 @@
 
 ## Status Transitions
 
-Update the `status` field in the task file frontmatter at `docs/workflow/planning/{topic}/tasks/{task-id}.md`:
+Update the `status` field in the task file frontmatter at `.workflows/planning/{topic}/tasks/{task-id}.md`:
 
 | Transition | Value |
 |------------|-------|

--- a/skills/technical-planning/references/plan-index-schema.md
+++ b/skills/technical-planning/references/plan-index-schema.md
@@ -4,7 +4,7 @@
 
 ---
 
-This file defines the canonical structure for Plan Index Files (`docs/workflow/planning/{topic}/plan.md`). All agents and references that create or update plan index content **must** follow these templates.
+This file defines the canonical structure for Plan Index Files (`.workflows/planning/{topic}/plan.md`). All agents and references that create or update plan index content **must** follow these templates.
 
 ---
 

--- a/skills/technical-planning/references/review-integrity.md
+++ b/skills/technical-planning/references/review-integrity.md
@@ -75,7 +75,7 @@ Read the plan end-to-end — carefully, as if you were about to implement it. Fo
 
 ## Tracking File
 
-After completing the analysis, create a tracking file at `docs/workflow/planning/{topic}/review-integrity-tracking-c{N}.md` (where N is the current review cycle).
+After completing the analysis, create a tracking file at `.workflows/planning/{topic}/review-integrity-tracking-c{N}.md` (where N is the current review cycle).
 
 Categorize each finding by severity:
 

--- a/skills/technical-planning/references/review-traceability.md
+++ b/skills/technical-planning/references/review-traceability.md
@@ -59,7 +59,7 @@ Is everything in the plan actually from the specification? This is the anti-hall
 
 ## Tracking File
 
-After completing the analysis, create a tracking file at `docs/workflow/planning/{topic}/review-traceability-tracking-c{N}.md` (where N is the current review cycle).
+After completing the analysis, create a tracking file at `.workflows/planning/{topic}/review-traceability-tracking-c{N}.md` (where N is the current review cycle).
 
 Tracking files are **never deleted**. After all findings are processed, the orchestrator marks `status: complete`. Previous cycles' files persist as review history.
 

--- a/skills/technical-planning/references/task-design.md
+++ b/skills/technical-planning/references/task-design.md
@@ -107,7 +107,7 @@ Every task should follow this structure:
 > Relevant details from specification: code examples, architectural decisions,
 > data models, or constraints that inform implementation.
 
-**Spec Reference**: `docs/workflow/specification/{topic}/specification.md` (if specification was provided)
+**Spec Reference**: `.workflows/specification/{topic}/specification.md` (if specification was provided)
 ```
 
 ### Field Requirements

--- a/skills/technical-planning/references/verify-source-material.md
+++ b/skills/technical-planning/references/verify-source-material.md
@@ -15,6 +15,6 @@ Verify that all source material exists and is accessible before entering agent-d
 ### Example
 
 ```bash
-ls docs/workflow/specification/{topic}/specification.md
-ls docs/workflow/specification/{cross-cutting-spec}/specification.md
+ls .workflows/specification/{topic}/specification.md
+ls .workflows/specification/{cross-cutting-spec}/specification.md
 ```

--- a/skills/technical-research/SKILL.md
+++ b/skills/technical-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-research
-description: "Explore ideas, validate concepts, and research broadly across technical, business, and market domains. Use when: (1) User has a new idea to explore, (2) Need to research a topic deeply, (3) Validating feasibility - technical, business, or market, (4) Learning and exploration without necessarily building anything, (5) User says 'research this' or 'explore this idea', (6) Brain dumping early thoughts before formal discussion. Creates research documents in docs/workflow/research/ that may feed into discussion or specification."
+description: "Explore ideas, validate concepts, and research broadly across technical, business, and market domains. Use when: (1) User has a new idea to explore, (2) Need to research a topic deeply, (3) Validating feasibility - technical, business, or market, (4) Learning and exploration without necessarily building anything, (5) User says 'research this' or 'explore this idea', (6) Brain dumping early thoughts before formal discussion. Creates research documents in .workflows/research/ that may feed into discussion or specification."
 user-invocable: false
 ---
 
@@ -151,7 +151,7 @@ Ask one question at a time. Wait for the answer. Document. Then ask the next.
 
 ## File Strategy
 
-**Output**: `docs/workflow/research/exploration.md`
+**Output**: `.workflows/research/exploration.md`
 
 **Template**: Use `references/template.md` for document structure. All research documents use YAML frontmatter:
 

--- a/skills/technical-research/references/interview.md
+++ b/skills/technical-research/references/interview.md
@@ -4,7 +4,7 @@ Focused questioning to probe ideas more deeply during research.
 
 ## Process
 
-1. **Check existing context**: Read docs in `docs/workflow/research/` to understand what's already been explored.
+1. **Check existing context**: Read docs in `.workflows/research/` to understand what's already been explored.
 
 2. **Begin interviewing**: Use the AskUserQuestion tool to probe the idea. Focus on:
    - Non-obvious questions (not things already answered)
@@ -15,7 +15,7 @@ Focused questioning to probe ideas more deeply during research.
 
 3. **Go where it leads**: Follow tangents if they reveal something valuable. This isn't a checklist - it's a conversation.
 
-4. **Document as you go**: Don't defer writing to the end. Capture insights in `docs/workflow/research/` using semantic filenames. Ask before documenting: "Shall I capture that?"
+4. **Document as you go**: Don't defer writing to the end. Capture insights in `.workflows/research/` using semantic filenames. Ask before documenting: "Shall I capture that?"
 
 5. **Commit frequently**: At natural breaks and before context refresh.
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -30,7 +30,7 @@ Either way: Verify plan tasks were implemented, tested adequately, and meet qual
 
 ```
 I need the implementation plan to review against. Could you point me to the
-plan file (e.g., docs/workflow/planning/{topic}/plan.md)?
+plan file (e.g., .workflows/planning/{topic}/plan.md)?
 ```
 
 **STOP.** Wait for user response.

--- a/skills/technical-review/references/invoke-review-synthesizer.md
+++ b/skills/technical-review/references/invoke-review-synthesizer.md
@@ -10,10 +10,10 @@ This step dispatches a `review-findings-synthesizer` agent to read review findin
 
 ## Determine Cycle Number
 
-Count existing `review-tasks-c*.md` files in `docs/workflow/implementation/{primary-topic}/` and add 1.
+Count existing `review-tasks-c*.md` files in `.workflows/implementation/{primary-topic}/` and add 1.
 
 ```bash
-ls docs/workflow/implementation/{primary-topic}/review-tasks-c*.md 2>/dev/null | wc -l
+ls .workflows/implementation/{primary-topic}/review-tasks-c*.md 2>/dev/null | wc -l
 ```
 
 ---
@@ -61,4 +61,4 @@ TASKS_PROPOSED: {N}
 SUMMARY: {1-2 sentences}
 ```
 
-The full report is at `docs/workflow/implementation/{primary-topic}/review-report-c{N}.md`. If tasks were proposed, the staging file is at `docs/workflow/implementation/{primary-topic}/review-tasks-c{N}.md`.
+The full report is at `.workflows/implementation/{primary-topic}/review-report-c{N}.md`. If tasks were proposed, the staging file is at `.workflows/implementation/{primary-topic}/review-tasks-c{N}.md`.

--- a/skills/technical-review/references/invoke-review-task-writer.md
+++ b/skills/technical-review/references/invoke-review-task-writer.md
@@ -10,7 +10,7 @@ This step invokes the task writer agent to create plan tasks from approved revie
 
 ## Determine Format
 
-Read the `format` field from the plan's frontmatter (`docs/workflow/planning/{topic}/plan.md`). This determines which output format adapters to pass to the agent.
+Read the `format` field from the plan's frontmatter (`.workflows/planning/{topic}/plan.md`). This determines which output format adapters to pass to the agent.
 
 ---
 
@@ -21,7 +21,7 @@ Read the `format` field from the plan's frontmatter (`docs/workflow/planning/{to
 Pass via the orchestrator's prompt:
 
 1. **Topic name** — the implementation topic (scopes tasks to correct plan)
-2. **Staging file path** — `docs/workflow/implementation/{topic}/review-tasks-c{cycle-number}.md`
+2. **Staging file path** — `.workflows/implementation/{topic}/review-tasks-c{cycle-number}.md`
 3. **Plan path** — the implementation plan path
 4. **Plan format reading adapter path** — `../../technical-planning/references/output-formats/{format}/reading.md`
 5. **Plan format authoring adapter path** — `../../technical-planning/references/output-formats/{format}/authoring.md`

--- a/skills/technical-review/references/invoke-task-verifiers.md
+++ b/skills/technical-review/references/invoke-task-verifiers.md
@@ -35,7 +35,7 @@ From each plan in scope, list every task across all phases:
 Ensure the review output directory exists:
 
 ```bash
-mkdir -p docs/workflow/review/{topic}/r{N}
+mkdir -p .workflows/review/{topic}/r{N}
 ```
 
 ---
@@ -78,7 +78,7 @@ FINDINGS_COUNT: {N blocking issues}
 SUMMARY: {1 sentence}
 ```
 
-Full findings are written to `docs/workflow/review/{topic}/r{N}/qa-task-{index}.md`.
+Full findings are written to `.workflows/review/{topic}/r{N}/qa-task-{index}.md`.
 
 ---
 
@@ -86,7 +86,7 @@ Full findings are written to `docs/workflow/review/{topic}/r{N}/qa-task-{index}.
 
 Once all batches have completed:
 
-1. Read all `docs/workflow/review/{topic}/r{N}/qa-task-*.md` files
+1. Read all `.workflows/review/{topic}/r{N}/qa-task-*.md` files
 2. Synthesize findings from file contents:
    - Collect all tasks with `STATUS: Incomplete` or `STATUS: Issues Found` as blocking issues
    - Collect all test issues (under/over-tested)

--- a/skills/technical-review/references/produce-review.md
+++ b/skills/technical-review/references/produce-review.md
@@ -6,7 +6,7 @@
 
 Aggregate QA findings into a review document using the **[template.md](template.md)**.
 
-Write the review to `docs/workflow/review/{topic}/r{N}/review.md`. The review is always per-plan. The review number `r{N}` is passed in from the entry point.
+Write the review to `.workflows/review/{topic}/r{N}/review.md`. The review is always per-plan. The review number `r{N}` is passed in from the entry point.
 
 **QA Verdict** (from Step 3):
 - **Approve** — All acceptance criteria met, no blocking issues

--- a/skills/technical-review/references/review-actions-loop.md
+++ b/skills/technical-review/references/review-actions-loop.md
@@ -122,7 +122,7 @@ No actionable tasks synthesized.
 
 ## C. Approval Gate
 
-Read the staging file from `docs/workflow/implementation/{topic}/review-tasks-c{cycle-number}.md`.
+Read the staging file from `.workflows/implementation/{topic}/review-tasks-c{cycle-number}.md`.
 
 Check `gate_mode` in the staging file frontmatter (`gated` or `auto`).
 
@@ -254,7 +254,7 @@ review({topic}): add review remediation ({K} tasks)
 
 For each plan that received new tasks:
 
-1. Read the implementation tracking file at `docs/workflow/implementation/{topic}/tracking.md`
+1. Read the implementation tracking file at `.workflows/implementation/{topic}/tracking.md`
 2. Update frontmatter:
    - `status: in-progress`
    - Remove `completed` field (if present)

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-specification
-description: "Build validated specifications from source material through collaborative refinement. Use when: (1) User asks to create/build a specification from source material, (2) User wants to validate and refine content before planning, (3) Converting source material (discussions, research, requirements) into standalone specifications, (4) User says 'specify this' or 'create a spec', (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in docs/workflow/specification/{topic}/specification.md that can be used to build implementation plans."
+description: "Build validated specifications from source material through collaborative refinement. Use when: (1) User asks to create/build a specification from source material, (2) User wants to validate and refine content before planning, (3) Converting source material (discussions, research, requirements) into standalone specifications, (4) User says 'specify this' or 'create a spec', (5) Need to filter hallucinations and enrich gaps before formal planning. Creates specifications in .workflows/specification/{topic}/specification.md that can be used to build implementation plans."
 user-invocable: false
 ---
 
@@ -35,7 +35,7 @@ Either way: Transform unvalidated reference material into a specification that's
 
 ```
 I need source material to build a specification from. Could you point me to the
-source files (e.g., docs/workflow/discussion/{topic}.md), or provide the content
+source files (e.g., .workflows/discussion/{topic}.md), or provide the content
 directly?
 ```
 
@@ -47,7 +47,7 @@ directly?
 
 ```
 What should the specification be named? This determines the output file:
-docs/workflow/specification/{name}/specification.md
+.workflows/specification/{name}/specification.md
 ```
 
 **STOP.** Wait for user response.
@@ -97,7 +97,7 @@ When announcing a new step, output `── ── ── ── ──` on its o
 
 ## Step 0: Resume Detection
 
-Check if `docs/workflow/specification/{topic}/specification.md` exists.
+Check if `.workflows/specification/{topic}/specification.md` exists.
 
 #### If no file exists
 
@@ -147,7 +147,7 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 Load **[specification-format.md](references/specification-format.md)** for the template.
 
-Create the specification file at `docs/workflow/specification/{topic}/specification.md`:
+Create the specification file at `.workflows/specification/{topic}/specification.md`:
 
 1. Use the frontmatter template from specification-format.md
 2. Set `topic` to the kebab-case topic name

--- a/skills/technical-specification/references/review-tracking-format.md
+++ b/skills/technical-specification/references/review-tracking-format.md
@@ -8,7 +8,7 @@ Review tracking files capture analysis findings so work persists across context 
 
 ## Location
 
-Store tracking files in the specification topic directory (`docs/workflow/specification/{topic}/`), cycle-numbered:
+Store tracking files in the specification topic directory (`.workflows/specification/{topic}/`), cycle-numbered:
 - `review-input-tracking-c{N}.md` — Phase 1 findings for cycle N
 - `review-gap-analysis-tracking-c{N}.md` — Phase 2 findings for cycle N
 

--- a/skills/technical-specification/references/specification-format.md
+++ b/skills/technical-specification/references/specification-format.md
@@ -4,7 +4,7 @@
 
 ---
 
-This file defines the canonical structure for specification files (`docs/workflow/specification/{topic}/specification.md`).
+This file defines the canonical structure for specification files (`.workflows/specification/{topic}/specification.md`).
 
 The specification is a single file per topic. Structure is **flexible** — organize around phases and subject matter, not rigid sections. This is a working document.
 

--- a/skills/technical-specification/references/verify-source-material.md
+++ b/skills/technical-specification/references/verify-source-material.md
@@ -15,6 +15,6 @@ Verify that all source material exists and is accessible before beginning specif
 ### Example
 
 ```bash
-ls docs/workflow/discussion/auth-flow.md
-ls docs/workflow/research/api-patterns.md
+ls .workflows/discussion/auth-flow.md
+ls .workflows/research/api-patterns.md
 ```

--- a/skills/view-plan/SKILL.md
+++ b/skills/view-plan/SKILL.md
@@ -17,14 +17,14 @@ Display a readable summary of a plan's phases, tasks, and status.
 If no topic is specified, list available plans:
 
 ```bash
-ls docs/workflow/planning/
+ls .workflows/planning/
 ```
 
 Ask the user which plan to view.
 
 ## Step 2: Read the Plan Index
 
-Read the plan file from `docs/workflow/planning/{topic}/plan.md` and check the `format:` field in the frontmatter.
+Read the plan file from `.workflows/planning/{topic}/plan.md` and check the `format:` field in the frontmatter.
 
 ## Step 3: Load Format Reading Reference
 

--- a/tests/scripts/test-compact-recovery.sh
+++ b/tests/scripts/test-compact-recovery.sh
@@ -32,8 +32,8 @@ echo ""
 #
 
 setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/.cache/sessions"
+    rm -rf "$TEST_DIR/.workflows"
+    mkdir -p "$TEST_DIR/.workflows/.cache/sessions"
 }
 
 run_hook() {
@@ -116,10 +116,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Basic state (no pipeline) — IMMEDIATE section only${NC}"
 setup_fixture
-cat > "$TEST_DIR/docs/workflow/.cache/sessions/session-basic-001.yaml" << 'EOF'
+cat > "$TEST_DIR/.workflows/.cache/sessions/session-basic-001.yaml" << 'EOF'
 topic: auth-flow
 skill: .claude/skills/technical-discussion/SKILL.md
-artifact: docs/workflow/discussion/auth-flow.md
+artifact: .workflows/discussion/auth-flow.md
 EOF
 
 output=$(run_hook "session-basic-001")
@@ -137,10 +137,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Pipeline state — both IMMEDIATE and AFTER CONCLUSION sections${NC}"
 setup_fixture
-cat > "$TEST_DIR/docs/workflow/.cache/sessions/session-pipeline-001.yaml" << 'EOF'
+cat > "$TEST_DIR/.workflows/.cache/sessions/session-pipeline-001.yaml" << 'EOF'
 topic: billing
 skill: .claude/skills/technical-specification/SKILL.md
-artifact: docs/workflow/specification/billing/specification.md
+artifact: .workflows/specification/billing/specification.md
 pipeline:
   after_conclude: |
     Enter plan mode with this message:
@@ -161,7 +161,7 @@ echo ""
 
 echo -e "${YELLOW}Test: Malformed YAML — graceful handling${NC}"
 setup_fixture
-cat > "$TEST_DIR/docs/workflow/.cache/sessions/session-bad-001.yaml" << 'EOF'
+cat > "$TEST_DIR/.workflows/.cache/sessions/session-bad-001.yaml" << 'EOF'
 this is not valid yaml
   : broken : stuff
   @@@ garbage

--- a/tests/scripts/test-discovery-for-continue-feature.sh
+++ b/tests/scripts/test-discovery-for-continue-feature.sh
@@ -33,8 +33,8 @@ echo ""
 
 setup_fixture() {
     # Clean up from previous test
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow"
+    rm -rf "$TEST_DIR/.workflows"
+    mkdir -p "$TEST_DIR/.workflows"
 }
 
 run_discovery() {
@@ -103,8 +103,8 @@ test_discussion_in_progress() {
     echo -e "${YELLOW}Test: Discussion only (in-progress)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -131,8 +131,8 @@ test_discussion_concluded() {
     echo -e "${YELLOW}Test: Discussion only (concluded)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -157,10 +157,10 @@ test_spec_concluded_no_plan() {
     echo -e "${YELLOW}Test: Spec concluded, no plan${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -169,7 +169,7 @@ status: concluded
 # Auth Flow Discussion
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -195,9 +195,9 @@ test_spec_in_progress() {
     echo -e "${YELLOW}Test: Spec in-progress${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -222,10 +222,10 @@ test_plan_in_progress() {
     echo -e "${YELLOW}Test: Plan in-progress${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-flow"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -235,7 +235,7 @@ type: feature
 # Auth Flow Specification
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-flow/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -261,10 +261,10 @@ test_plan_concluded_no_impl() {
     echo -e "${YELLOW}Test: Plan concluded, no implementation${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-flow"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -274,7 +274,7 @@ type: feature
 # Auth Flow Specification
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-flow/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -299,11 +299,11 @@ test_implementation_in_progress() {
     echo -e "${YELLOW}Test: Implementation in-progress${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-flow"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -313,7 +313,7 @@ type: feature
 # Auth Flow Specification
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-flow/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -323,7 +323,7 @@ format: tick
 # Auth Flow Plan
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-flow/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -348,11 +348,11 @@ test_implementation_complete_no_review() {
     echo -e "${YELLOW}Test: Implementation complete (no review)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-flow"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -362,7 +362,7 @@ type: feature
 # Auth Flow Specification
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-flow/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -372,7 +372,7 @@ format: tick
 # Auth Flow Plan
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-flow/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" << 'EOF'
 ---
 topic: auth-flow
 status: completed
@@ -396,12 +396,12 @@ test_implementation_complete_with_review() {
     echo -e "${YELLOW}Test: Implementation complete with review (done)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-flow"
-    mkdir -p "$TEST_DIR/docs/workflow/review/auth-flow/r1"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/review/auth-flow/r1"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -411,7 +411,7 @@ type: feature
 # Auth Flow Specification
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-flow/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -421,7 +421,7 @@ format: tick
 # Auth Flow Plan
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-flow/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" << 'EOF'
 ---
 topic: auth-flow
 status: completed
@@ -430,7 +430,7 @@ status: completed
 # Auth Flow Implementation
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/review/auth-flow/r1/review.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/review/auth-flow/r1/review.md" << 'EOF'
 ---
 topic: auth-flow
 ---
@@ -456,8 +456,8 @@ test_multiple_topics() {
     setup_fixture
 
     # Topic 1: Discussion in-progress
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -467,9 +467,9 @@ status: in-progress
 EOF
 
     # Topic 2: Spec concluded, ready for planning
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/billing"
-    cat > "$TEST_DIR/docs/workflow/discussion/billing.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/specification/billing"
+    cat > "$TEST_DIR/.workflows/discussion/billing.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -477,7 +477,7 @@ status: concluded
 
 # Billing Discussion
 EOF
-    cat > "$TEST_DIR/docs/workflow/specification/billing/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -488,10 +488,10 @@ type: feature
 EOF
 
     # Topic 3: Implementation complete
-    mkdir -p "$TEST_DIR/docs/workflow/specification/dashboard"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/dashboard"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/dashboard"
-    cat > "$TEST_DIR/docs/workflow/specification/dashboard/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/dashboard"
+    mkdir -p "$TEST_DIR/.workflows/planning/dashboard"
+    mkdir -p "$TEST_DIR/.workflows/implementation/dashboard"
+    cat > "$TEST_DIR/.workflows/specification/dashboard/specification.md" << 'EOF'
 ---
 topic: dashboard
 status: concluded
@@ -500,7 +500,7 @@ type: feature
 
 # Dashboard Specification
 EOF
-    cat > "$TEST_DIR/docs/workflow/planning/dashboard/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/dashboard/plan.md" << 'EOF'
 ---
 topic: dashboard
 status: concluded
@@ -509,7 +509,7 @@ format: local-markdown
 
 # Dashboard Plan
 EOF
-    cat > "$TEST_DIR/docs/workflow/implementation/dashboard/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/dashboard/tracking.md" << 'EOF'
 ---
 topic: dashboard
 status: completed
@@ -537,8 +537,8 @@ test_crosscutting_excluded() {
     echo -e "${YELLOW}Test: Cross-cutting specs are excluded${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/caching-strategy"
-    cat > "$TEST_DIR/docs/workflow/specification/caching-strategy/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/caching-strategy"
+    cat > "$TEST_DIR/.workflows/specification/caching-strategy/specification.md" << 'EOF'
 ---
 topic: caching-strategy
 status: concluded
@@ -564,8 +564,8 @@ test_spec_without_discussion() {
     echo -e "${YELLOW}Test: Spec without discussion${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/quick-feature"
-    cat > "$TEST_DIR/docs/workflow/specification/quick-feature/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/quick-feature"
+    cat > "$TEST_DIR/.workflows/specification/quick-feature/specification.md" << 'EOF'
 ---
 topic: quick-feature
 status: concluded
@@ -592,8 +592,8 @@ test_discussion_default_status() {
     echo -e "${YELLOW}Test: Discussion without status defaults to in-progress${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/legacy-topic.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/legacy-topic.md" << 'EOF'
 ---
 topic: legacy-topic
 ---
@@ -619,10 +619,10 @@ test_topic_deduplication() {
     echo -e "${YELLOW}Test: Topic deduplication${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -631,7 +631,7 @@ status: concluded
 # Auth Flow Discussion
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress

--- a/tests/scripts/test-discovery-for-discussion.sh
+++ b/tests/scripts/test-discovery-for-discussion.sh
@@ -33,8 +33,8 @@ echo ""
 
 setup_fixture() {
     # Clean up from previous test
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow"
+    rm -rf "$TEST_DIR/.workflows"
+    mkdir -p "$TEST_DIR/.workflows"
 }
 
 run_discovery() {
@@ -105,8 +105,8 @@ test_research_only() {
     echo -e "${YELLOW}Test: Research only (no discussions)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/research"
-    cat > "$TEST_DIR/docs/workflow/research/exploration.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/research"
+    cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 ---
 topic: exploration
 date: 2026-01-21
@@ -137,8 +137,8 @@ test_discussions_only() {
     echo -e "${YELLOW}Test: Discussions only (no research)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -170,10 +170,10 @@ test_research_and_discussions() {
     echo -e "${YELLOW}Test: Research and discussions${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/research"
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    mkdir -p "$TEST_DIR/.workflows/research"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
 
-    cat > "$TEST_DIR/docs/workflow/research/exploration.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 ---
 topic: exploration
 date: 2026-01-18
@@ -182,7 +182,7 @@ date: 2026-01-18
 # Research: Exploration
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -192,7 +192,7 @@ date: 2026-01-19
 # Discussion: Auth Flow
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/discussion/data-model.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/data-model.md" << 'EOF'
 ---
 topic: data-model
 status: in-progress
@@ -220,9 +220,9 @@ test_multiple_discussions() {
     echo -e "${YELLOW}Test: Multiple discussions with mixed statuses${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/topic-a.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/topic-a.md" << 'EOF'
 ---
 topic: topic-a
 status: concluded
@@ -231,7 +231,7 @@ date: 2026-01-15
 # Discussion: Topic A
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/discussion/topic-b.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/topic-b.md" << 'EOF'
 ---
 topic: topic-b
 status: concluded
@@ -240,7 +240,7 @@ date: 2026-01-16
 # Discussion: Topic B
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/discussion/topic-c.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/topic-c.md" << 'EOF'
 ---
 topic: topic-c
 status: in-progress
@@ -249,7 +249,7 @@ date: 2026-01-17
 # Discussion: Topic C
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/discussion/topic-d.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/topic-d.md" << 'EOF'
 ---
 topic: topic-d
 status: in-progress
@@ -277,8 +277,8 @@ test_cache_none() {
     echo -e "${YELLOW}Test: Cache status none (no cache file)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/research"
-    cat > "$TEST_DIR/docs/workflow/research/exploration.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/research"
+    cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 ---
 topic: exploration
 date: 2026-01-21
@@ -303,10 +303,10 @@ test_cache_valid() {
     echo -e "${YELLOW}Test: Cache status valid (checksums match)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/research"
-    mkdir -p "$TEST_DIR/docs/workflow/.state"
+    mkdir -p "$TEST_DIR/.workflows/research"
+    mkdir -p "$TEST_DIR/.workflows/.state"
 
-    cat > "$TEST_DIR/docs/workflow/research/exploration.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 ---
 topic: exploration
 date: 2026-01-21
@@ -315,10 +315,10 @@ date: 2026-01-21
 EOF
 
     # Compute the checksum of the research file
-    local checksum=$(cat "$TEST_DIR/docs/workflow/research"/*.md | md5sum | cut -d' ' -f1)
+    local checksum=$(cat "$TEST_DIR/.workflows/research"/*.md | md5sum | cut -d' ' -f1)
 
     # Create cache with matching checksum
-    cat > "$TEST_DIR/docs/workflow/.state/research-analysis.md" << EOF
+    cat > "$TEST_DIR/.workflows/.state/research-analysis.md" << EOF
 ---
 checksum: $checksum
 generated: 2026-01-21T10:00:00
@@ -353,10 +353,10 @@ test_cache_stale() {
     echo -e "${YELLOW}Test: Cache status stale (research changed)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/research"
-    mkdir -p "$TEST_DIR/docs/workflow/.state"
+    mkdir -p "$TEST_DIR/.workflows/research"
+    mkdir -p "$TEST_DIR/.workflows/.state"
 
-    cat > "$TEST_DIR/docs/workflow/research/exploration.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 ---
 topic: exploration
 date: 2026-01-21
@@ -367,7 +367,7 @@ This content is different from when cache was created.
 EOF
 
     # Create cache with OLD checksum (doesn't match current)
-    cat > "$TEST_DIR/docs/workflow/.state/research-analysis.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/.state/research-analysis.md" << 'EOF'
 ---
 checksum: old_checksum_that_doesnt_match
 generated: 2026-01-20T10:00:00
@@ -393,10 +393,10 @@ test_research_no_frontmatter() {
     echo -e "${YELLOW}Test: Research files without frontmatter${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/research"
+    mkdir -p "$TEST_DIR/.workflows/research"
 
     # Create research file WITHOUT frontmatter
-    cat > "$TEST_DIR/docs/workflow/research/market-analysis.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/research/market-analysis.md" << 'EOF'
 # Market Analysis
 
 No frontmatter here, just content.
@@ -417,9 +417,9 @@ test_discussion_no_status() {
     echo -e "${YELLOW}Test: Discussion without status field${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/legacy-topic.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/legacy-topic.md" << 'EOF'
 ---
 topic: legacy-topic
 date: 2026-01-15
@@ -444,9 +444,9 @@ test_multiple_research_files() {
     echo -e "${YELLOW}Test: Multiple research files${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/research"
+    mkdir -p "$TEST_DIR/.workflows/research"
 
-    cat > "$TEST_DIR/docs/workflow/research/exploration.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 ---
 topic: exploration
 date: 2026-01-18
@@ -454,7 +454,7 @@ date: 2026-01-18
 # Exploration
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/research/market-landscape.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/research/market-landscape.md" << 'EOF'
 ---
 topic: market-landscape
 date: 2026-01-19
@@ -462,7 +462,7 @@ date: 2026-01-19
 # Market Landscape
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/research/technical-feasibility.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/research/technical-feasibility.md" << 'EOF'
 ---
 topic: technical-feasibility
 date: 2026-01-20

--- a/tests/scripts/test-discovery-for-implementation.sh
+++ b/tests/scripts/test-discovery-for-implementation.sh
@@ -33,8 +33,8 @@ echo ""
 
 setup_fixture() {
     # Clean up from previous test
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow"
+    rm -rf "$TEST_DIR/.workflows"
+    mkdir -p "$TEST_DIR/.workflows"
 }
 
 run_discovery() {
@@ -100,7 +100,7 @@ echo ""
 
 echo -e "${YELLOW}Test: Empty planning directory${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning"
+mkdir -p "$TEST_DIR/.workflows/planning"
 output=$(run_discovery)
 
 assert_contains "$output" "exists: false" "Plans don't exist (empty dir)"
@@ -112,8 +112,8 @@ echo ""
 
 echo -e "${YELLOW}Test: Single plan with full frontmatter${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/user-auth"
-cat > "$TEST_DIR/docs/workflow/planning/user-auth/plan.md" << 'EOF'
+mkdir -p "$TEST_DIR/.workflows/planning/user-auth"
+cat > "$TEST_DIR/.workflows/planning/user-auth/plan.md" << 'EOF'
 ---
 topic: user-auth
 status: in-progress
@@ -147,10 +147,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Multiple plans${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/feature-a"
-mkdir -p "$TEST_DIR/docs/workflow/planning/feature-b"
+mkdir -p "$TEST_DIR/.workflows/planning/feature-a"
+mkdir -p "$TEST_DIR/.workflows/planning/feature-b"
 
-cat > "$TEST_DIR/docs/workflow/planning/feature-a/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/feature-a/plan.md" << 'EOF'
 ---
 topic: feature-a
 status: in-progress
@@ -162,7 +162,7 @@ specification: feature-a/specification.md
 # Implementation Plan: Feature A
 EOF
 
-cat > "$TEST_DIR/docs/workflow/planning/feature-b/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/feature-b/plan.md" << 'EOF'
 ---
 topic: feature-b
 status: concluded
@@ -187,9 +187,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with concluded status${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/completed-feature"
+mkdir -p "$TEST_DIR/.workflows/planning/completed-feature"
 
-cat > "$TEST_DIR/docs/workflow/planning/completed-feature/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/completed-feature/plan.md" << 'EOF'
 ---
 topic: completed-feature
 status: concluded
@@ -212,10 +212,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with linked specification that exists${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/with-spec"
-mkdir -p "$TEST_DIR/docs/workflow/specification/with-spec"
+mkdir -p "$TEST_DIR/.workflows/planning/with-spec"
+mkdir -p "$TEST_DIR/.workflows/specification/with-spec"
 
-cat > "$TEST_DIR/docs/workflow/planning/with-spec/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/with-spec/plan.md" << 'EOF'
 ---
 topic: with-spec
 status: in-progress
@@ -227,7 +227,7 @@ specification: with-spec/specification.md
 # Implementation Plan: With Spec
 EOF
 
-cat > "$TEST_DIR/docs/workflow/specification/with-spec/specification.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/specification/with-spec/specification.md" << 'EOF'
 ---
 topic: with-spec
 status: concluded
@@ -246,9 +246,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with linked specification that doesn't exist${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/no-spec"
+mkdir -p "$TEST_DIR/.workflows/planning/no-spec"
 
-cat > "$TEST_DIR/docs/workflow/planning/no-spec/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/no-spec/plan.md" << 'EOF'
 ---
 topic: no-spec
 status: in-progress
@@ -270,9 +270,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Environment setup file exists with setup required${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/test"
+mkdir -p "$TEST_DIR/.workflows/planning/test"
 
-cat > "$TEST_DIR/docs/workflow/planning/test/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/test/plan.md" << 'EOF'
 ---
 topic: test
 status: in-progress
@@ -284,7 +284,7 @@ specification: test/specification.md
 # Implementation Plan: Test
 EOF
 
-cat > "$TEST_DIR/docs/workflow/environment-setup.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/environment-setup.md" << 'EOF'
 # Environment Setup
 
 Run the following commands:
@@ -304,9 +304,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Environment setup file with no special setup required${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/test"
+mkdir -p "$TEST_DIR/.workflows/planning/test"
 
-cat > "$TEST_DIR/docs/workflow/planning/test/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/test/plan.md" << 'EOF'
 ---
 topic: test
 status: in-progress
@@ -318,7 +318,7 @@ specification: test/specification.md
 # Implementation Plan: Test
 EOF
 
-cat > "$TEST_DIR/docs/workflow/environment-setup.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/environment-setup.md" << 'EOF'
 # Environment Setup
 
 No special setup required.
@@ -335,9 +335,9 @@ echo ""
 
 echo -e "${YELLOW}Test: No environment setup file${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/test"
+mkdir -p "$TEST_DIR/.workflows/planning/test"
 
-cat > "$TEST_DIR/docs/workflow/planning/test/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/test/plan.md" << 'EOF'
 ---
 topic: test
 status: in-progress
@@ -360,9 +360,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with missing frontmatter fields (defaults)${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/minimal"
+mkdir -p "$TEST_DIR/.workflows/planning/minimal"
 
-cat > "$TEST_DIR/docs/workflow/planning/minimal/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/minimal/plan.md" << 'EOF'
 ---
 topic: minimal
 ---
@@ -383,9 +383,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan without frontmatter (legacy edge case)${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/no-frontmatter"
+mkdir -p "$TEST_DIR/.workflows/planning/no-frontmatter"
 
-cat > "$TEST_DIR/docs/workflow/planning/no-frontmatter/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/no-frontmatter/plan.md" << 'EOF'
 # Implementation Plan: No Frontmatter
 
 ## Overview
@@ -405,9 +405,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Different format value${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/beads-plan"
+mkdir -p "$TEST_DIR/.workflows/planning/beads-plan"
 
-cat > "$TEST_DIR/docs/workflow/planning/beads-plan/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/beads-plan/plan.md" << 'EOF'
 ---
 topic: beads-plan
 status: in-progress
@@ -429,9 +429,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with plan_id (beads format)${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/with-plan-id"
+mkdir -p "$TEST_DIR/.workflows/planning/with-plan-id"
 
-cat > "$TEST_DIR/docs/workflow/planning/with-plan-id/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/with-plan-id/plan.md" << 'EOF'
 ---
 topic: with-plan-id
 status: in-progress
@@ -454,9 +454,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan without plan_id (local-markdown)${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/no-plan-id"
+mkdir -p "$TEST_DIR/.workflows/planning/no-plan-id"
 
-cat > "$TEST_DIR/docs/workflow/planning/no-plan-id/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/no-plan-id/plan.md" << 'EOF'
 ---
 topic: no-plan-id
 status: in-progress
@@ -480,9 +480,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with empty external_dependencies${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/no-deps"
+mkdir -p "$TEST_DIR/.workflows/planning/no-deps"
 
-cat > "$TEST_DIR/docs/workflow/planning/no-deps/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/no-deps/plan.md" << 'EOF'
 ---
 topic: no-deps
 status: concluded
@@ -505,9 +505,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with unresolved dependency${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/has-unresolved"
+mkdir -p "$TEST_DIR/.workflows/planning/has-unresolved"
 
-cat > "$TEST_DIR/docs/workflow/planning/has-unresolved/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/has-unresolved/plan.md" << 'EOF'
 ---
 topic: has-unresolved
 status: concluded
@@ -535,9 +535,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with resolved dependency${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/has-resolved"
+mkdir -p "$TEST_DIR/.workflows/planning/has-resolved"
 
-cat > "$TEST_DIR/docs/workflow/planning/has-resolved/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/has-resolved/plan.md" << 'EOF'
 ---
 topic: has-resolved
 status: concluded
@@ -566,9 +566,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with satisfied_externally dependency${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/has-external"
+mkdir -p "$TEST_DIR/.workflows/planning/has-external"
 
-cat > "$TEST_DIR/docs/workflow/planning/has-external/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/has-external/plan.md" << 'EOF'
 ---
 topic: has-external
 status: concluded
@@ -594,9 +594,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with mixed dependencies${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/mixed-deps"
+mkdir -p "$TEST_DIR/.workflows/planning/mixed-deps"
 
-cat > "$TEST_DIR/docs/workflow/planning/mixed-deps/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/mixed-deps/plan.md" << 'EOF'
 ---
 topic: mixed-deps
 status: concluded
@@ -632,9 +632,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan without external_dependencies field (legacy)${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/legacy"
+mkdir -p "$TEST_DIR/.workflows/planning/legacy"
 
-cat > "$TEST_DIR/docs/workflow/planning/legacy/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/legacy/plan.md" << 'EOF'
 ---
 topic: legacy
 status: concluded
@@ -658,9 +658,9 @@ echo ""
 
 echo -e "${YELLOW}Test: No implementation directory${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/test"
+mkdir -p "$TEST_DIR/.workflows/planning/test"
 
-cat > "$TEST_DIR/docs/workflow/planning/test/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/test/plan.md" << 'EOF'
 ---
 topic: test
 status: concluded
@@ -683,10 +683,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Implementation tracking file - in-progress${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/core-features"
-mkdir -p "$TEST_DIR/docs/workflow/implementation"
+mkdir -p "$TEST_DIR/.workflows/planning/core-features"
+mkdir -p "$TEST_DIR/.workflows/implementation"
 
-cat > "$TEST_DIR/docs/workflow/planning/core-features/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/core-features/plan.md" << 'EOF'
 ---
 topic: core-features
 status: concluded
@@ -698,8 +698,8 @@ external_dependencies: []
 # Plan: Core Features
 EOF
 
-mkdir -p "$TEST_DIR/docs/workflow/implementation/core-features"
-cat > "$TEST_DIR/docs/workflow/implementation/core-features/tracking.md" << 'EOF'
+mkdir -p "$TEST_DIR/.workflows/implementation/core-features"
+cat > "$TEST_DIR/.workflows/implementation/core-features/tracking.md" << 'EOF'
 ---
 topic: core-features
 plan: ../planning/core-features/plan.md
@@ -747,10 +747,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Implementation tracking file - completed${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/user-auth"
-mkdir -p "$TEST_DIR/docs/workflow/implementation"
+mkdir -p "$TEST_DIR/.workflows/planning/user-auth"
+mkdir -p "$TEST_DIR/.workflows/implementation"
 
-cat > "$TEST_DIR/docs/workflow/planning/user-auth/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/user-auth/plan.md" << 'EOF'
 ---
 topic: user-auth
 status: concluded
@@ -762,8 +762,8 @@ external_dependencies: []
 # Plan: User Auth
 EOF
 
-mkdir -p "$TEST_DIR/docs/workflow/implementation/user-auth"
-cat > "$TEST_DIR/docs/workflow/implementation/user-auth/tracking.md" << 'EOF'
+mkdir -p "$TEST_DIR/.workflows/implementation/user-auth"
+cat > "$TEST_DIR/.workflows/implementation/user-auth/tracking.md" << 'EOF'
 ---
 topic: user-auth
 plan: ../planning/user-auth/plan.md
@@ -805,10 +805,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Resolved dep with task in completed_tasks${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/billing"
-mkdir -p "$TEST_DIR/docs/workflow/implementation"
+mkdir -p "$TEST_DIR/.workflows/planning/billing"
+mkdir -p "$TEST_DIR/.workflows/implementation"
 
-cat > "$TEST_DIR/docs/workflow/planning/billing/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -824,8 +824,8 @@ external_dependencies:
 # Plan: Billing
 EOF
 
-mkdir -p "$TEST_DIR/docs/workflow/implementation/user-auth"
-cat > "$TEST_DIR/docs/workflow/implementation/user-auth/tracking.md" << 'EOF'
+mkdir -p "$TEST_DIR/.workflows/implementation/user-auth"
+cat > "$TEST_DIR/.workflows/implementation/user-auth/tracking.md" << 'EOF'
 ---
 topic: user-auth
 plan: ../planning/user-auth/plan.md
@@ -859,10 +859,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Resolved dep with task NOT in completed_tasks${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/billing"
-mkdir -p "$TEST_DIR/docs/workflow/implementation"
+mkdir -p "$TEST_DIR/.workflows/planning/billing"
+mkdir -p "$TEST_DIR/.workflows/implementation"
 
-cat > "$TEST_DIR/docs/workflow/planning/billing/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -878,8 +878,8 @@ external_dependencies:
 # Plan: Billing
 EOF
 
-mkdir -p "$TEST_DIR/docs/workflow/implementation/core-features"
-cat > "$TEST_DIR/docs/workflow/implementation/core-features/tracking.md" << 'EOF'
+mkdir -p "$TEST_DIR/.workflows/implementation/core-features"
+cat > "$TEST_DIR/.workflows/implementation/core-features/tracking.md" << 'EOF'
 ---
 topic: core-features
 plan: ../planning/core-features/plan.md
@@ -914,14 +914,14 @@ echo ""
 
 echo -e "${YELLOW}Test: State summary counts with multiple plans${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/feature-a"
-mkdir -p "$TEST_DIR/docs/workflow/planning/feature-b"
-mkdir -p "$TEST_DIR/docs/workflow/planning/feature-c"
-mkdir -p "$TEST_DIR/docs/workflow/planning/feature-d"
-mkdir -p "$TEST_DIR/docs/workflow/implementation"
+mkdir -p "$TEST_DIR/.workflows/planning/feature-a"
+mkdir -p "$TEST_DIR/.workflows/planning/feature-b"
+mkdir -p "$TEST_DIR/.workflows/planning/feature-c"
+mkdir -p "$TEST_DIR/.workflows/planning/feature-d"
+mkdir -p "$TEST_DIR/.workflows/implementation"
 
 # Concluded plan, no deps, no impl -> ready
-cat > "$TEST_DIR/docs/workflow/planning/feature-a/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/feature-a/plan.md" << 'EOF'
 ---
 topic: feature-a
 status: concluded
@@ -934,7 +934,7 @@ external_dependencies: []
 EOF
 
 # Concluded plan with unresolved dep -> not ready
-cat > "$TEST_DIR/docs/workflow/planning/feature-b/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/feature-b/plan.md" << 'EOF'
 ---
 topic: feature-b
 status: concluded
@@ -950,7 +950,7 @@ external_dependencies:
 EOF
 
 # Planning status -> not concluded
-cat > "$TEST_DIR/docs/workflow/planning/feature-c/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/feature-c/plan.md" << 'EOF'
 ---
 topic: feature-c
 status: planning
@@ -963,7 +963,7 @@ external_dependencies: []
 EOF
 
 # Concluded with completed impl
-cat > "$TEST_DIR/docs/workflow/planning/feature-d/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/feature-d/plan.md" << 'EOF'
 ---
 topic: feature-d
 status: concluded
@@ -975,8 +975,8 @@ external_dependencies: []
 # Plan: Feature D
 EOF
 
-mkdir -p "$TEST_DIR/docs/workflow/implementation/feature-d"
-cat > "$TEST_DIR/docs/workflow/implementation/feature-d/tracking.md" << 'EOF'
+mkdir -p "$TEST_DIR/.workflows/implementation/feature-d"
+cat > "$TEST_DIR/.workflows/implementation/feature-d/tracking.md" << 'EOF'
 ---
 topic: feature-d
 status: completed

--- a/tests/scripts/test-discovery-for-planning.sh
+++ b/tests/scripts/test-discovery-for-planning.sh
@@ -33,8 +33,8 @@ echo ""
 
 setup_fixture() {
     # Clean up from previous test
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow"
+    rm -rf "$TEST_DIR/.workflows"
+    mkdir -p "$TEST_DIR/.workflows"
 }
 
 run_discovery() {
@@ -107,8 +107,8 @@ test_single_spec_in_progress() {
     echo -e "${YELLOW}Test: Single feature specification (in-progress)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: in-progress
@@ -138,8 +138,8 @@ test_single_spec_concluded_no_plan() {
     echo -e "${YELLOW}Test: Single feature specification (concluded, no plan)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -166,10 +166,10 @@ test_single_spec_concluded_with_plan() {
     echo -e "${YELLOW}Test: Single feature specification (concluded, has plan)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -179,7 +179,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: planning
@@ -207,11 +207,11 @@ test_multiple_feature_specs() {
     echo -e "${YELLOW}Test: Multiple feature specifications${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/billing"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/dashboard"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/billing"
+    mkdir -p "$TEST_DIR/.workflows/specification/dashboard"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -221,7 +221,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/billing/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -231,7 +231,7 @@ type: feature
 # Specification: Billing
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/dashboard/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/dashboard/specification.md" << 'EOF'
 ---
 topic: dashboard
 status: in-progress
@@ -260,10 +260,10 @@ test_crosscutting_specs() {
     echo -e "${YELLOW}Test: Cross-cutting specifications${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/caching-strategy"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/rate-limiting"
+    mkdir -p "$TEST_DIR/.workflows/specification/caching-strategy"
+    mkdir -p "$TEST_DIR/.workflows/specification/rate-limiting"
 
-    cat > "$TEST_DIR/docs/workflow/specification/caching-strategy/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/caching-strategy/specification.md" << 'EOF'
 ---
 topic: caching-strategy
 status: concluded
@@ -273,7 +273,7 @@ type: cross-cutting
 # Specification: Caching Strategy
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/rate-limiting/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/rate-limiting/specification.md" << 'EOF'
 ---
 topic: rate-limiting
 status: concluded
@@ -302,10 +302,10 @@ test_mixed_specs() {
     echo -e "${YELLOW}Test: Mixed feature and cross-cutting specifications${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/caching-strategy"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/caching-strategy"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -315,7 +315,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/caching-strategy/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/caching-strategy/specification.md" << 'EOF'
 ---
 topic: caching-strategy
 status: concluded
@@ -342,9 +342,9 @@ test_spec_default_type() {
     echo -e "${YELLOW}Test: Specification without type defaults to feature${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/legacy-feature"
+    mkdir -p "$TEST_DIR/.workflows/specification/legacy-feature"
 
-    cat > "$TEST_DIR/docs/workflow/specification/legacy-feature/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/legacy-feature/specification.md" << 'EOF'
 ---
 topic: legacy-feature
 status: concluded
@@ -371,10 +371,10 @@ test_plans_section() {
     echo -e "${YELLOW}Test: Plans section${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/billing"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/billing"
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: In Progress
@@ -383,7 +383,7 @@ status: In Progress
 # Implementation Plan: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/billing/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 format: linear
 status: Ready
@@ -413,9 +413,9 @@ test_plan_missing_format() {
     echo -e "${YELLOW}Test: Plan without format shows MISSING${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/old-plan"
+    mkdir -p "$TEST_DIR/.workflows/planning/old-plan"
 
-    cat > "$TEST_DIR/docs/workflow/planning/old-plan/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/old-plan/plan.md" << 'EOF'
 ---
 status: Draft
 ---
@@ -440,10 +440,10 @@ test_plan_with_plan_id() {
     echo -e "${YELLOW}Test: Plan with plan_id${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/with-plan-id"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/without-plan-id"
+    mkdir -p "$TEST_DIR/.workflows/planning/with-plan-id"
+    mkdir -p "$TEST_DIR/.workflows/planning/without-plan-id"
 
-    cat > "$TEST_DIR/docs/workflow/planning/with-plan-id/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/with-plan-id/plan.md" << 'EOF'
 ---
 topic: with-plan-id
 status: in-progress
@@ -454,7 +454,7 @@ plan_id: my-epic-abc123
 # Implementation Plan: With Plan ID
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/without-plan-id/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/without-plan-id/plan.md" << 'EOF'
 ---
 topic: without-plan-id
 status: in-progress
@@ -481,10 +481,10 @@ test_concluded_plan_is_actionable() {
     echo -e "${YELLOW}Test: Concluded plan is actionable (review/revise)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -494,7 +494,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: concluded
@@ -520,13 +520,13 @@ test_mixed_ready_and_plans() {
     echo -e "${YELLOW}Test: Mix of ready specs and existing plans${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/billing"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/dashboard"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/billing"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/dashboard"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
 
     # Ready spec (no plan)
-    cat > "$TEST_DIR/docs/workflow/specification/billing/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -537,7 +537,7 @@ type: feature
 EOF
 
     # Spec with in-progress plan
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -547,7 +547,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: planning
@@ -557,7 +557,7 @@ status: planning
 EOF
 
     # In-progress spec (not ready)
-    cat > "$TEST_DIR/docs/workflow/specification/dashboard/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/dashboard/specification.md" << 'EOF'
 ---
 topic: dashboard
 status: in-progress
@@ -584,10 +584,10 @@ test_all_in_progress_nothing_actionable() {
     echo -e "${YELLOW}Test: All specs in-progress with no plans${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/billing"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/billing"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: in-progress
@@ -597,7 +597,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/billing/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: in-progress
@@ -638,9 +638,9 @@ test_common_format_single_plan() {
     echo -e "${YELLOW}Test: common_format with single plan${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: planning
@@ -663,10 +663,10 @@ test_common_format_multiple_same() {
     echo -e "${YELLOW}Test: common_format with multiple same format${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/billing"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/billing"
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: beads
 status: planning
@@ -675,7 +675,7 @@ status: planning
 # Implementation Plan: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/billing/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 format: beads
 status: Ready
@@ -698,10 +698,10 @@ test_common_format_mixed() {
     echo -e "${YELLOW}Test: common_format empty with mixed formats${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/billing"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/billing"
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: planning
@@ -710,7 +710,7 @@ status: planning
 # Implementation Plan: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/billing/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 format: linear
 status: Ready
@@ -733,10 +733,10 @@ test_common_format_missing_ignored() {
     echo -e "${YELLOW}Test: common_format ignores MISSING format${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/old-plan"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/old-plan"
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: planning
@@ -745,7 +745,7 @@ status: planning
 # Implementation Plan: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/old-plan/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/old-plan/plan.md" << 'EOF'
 ---
 status: Draft
 ---
@@ -769,11 +769,11 @@ test_spec_with_completed_implementation() {
     echo -e "${YELLOW}Test: Spec with completed implementation${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-system"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -783,7 +783,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: concluded
@@ -792,7 +792,7 @@ status: concluded
 # Implementation Plan: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-system/tracking.md" << 'EOF'
 ---
 topic: auth-system
 status: completed
@@ -818,11 +818,11 @@ test_spec_with_in_progress_implementation() {
     echo -e "${YELLOW}Test: Spec with in-progress implementation${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-system"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -832,7 +832,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: concluded
@@ -841,7 +841,7 @@ status: concluded
 # Implementation Plan: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-system/tracking.md" << 'EOF'
 ---
 topic: auth-system
 status: in-progress
@@ -868,11 +868,11 @@ test_all_specs_implemented() {
     echo -e "${YELLOW}Test: All specs implemented yields nothing_actionable${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-system"
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -882,7 +882,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: concluded
@@ -891,7 +891,7 @@ status: concluded
 # Implementation Plan: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-system/tracking.md" << 'EOF'
 ---
 topic: auth-system
 status: completed
@@ -916,13 +916,13 @@ test_mix_implemented_and_ready() {
     echo -e "${YELLOW}Test: Mix of implemented and ready specs${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/billing"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/billing"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-system"
 
     # Implemented spec
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -932,7 +932,7 @@ type: feature
 # Specification: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 format: local-markdown
 status: concluded
@@ -941,7 +941,7 @@ status: concluded
 # Implementation Plan: Auth System
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-system/tracking.md" << 'EOF'
 ---
 topic: auth-system
 status: completed
@@ -951,7 +951,7 @@ status: completed
 EOF
 
     # Ready spec (no plan)
-    cat > "$TEST_DIR/docs/workflow/specification/billing/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: concluded

--- a/tests/scripts/test-discovery-for-review.sh
+++ b/tests/scripts/test-discovery-for-review.sh
@@ -33,8 +33,8 @@ echo ""
 
 setup_fixture() {
     # Clean up from previous test
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow"
+    rm -rf "$TEST_DIR/.workflows"
+    mkdir -p "$TEST_DIR/.workflows"
 }
 
 run_discovery() {
@@ -100,7 +100,7 @@ echo ""
 
 echo -e "${YELLOW}Test: Empty planning directory${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning"
+mkdir -p "$TEST_DIR/.workflows/planning"
 output=$(run_discovery)
 
 assert_contains "$output" "exists: false" "Plans don't exist (empty dir)"
@@ -112,8 +112,8 @@ echo ""
 
 echo -e "${YELLOW}Test: Single plan with full frontmatter${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/user-auth"
-cat > "$TEST_DIR/docs/workflow/planning/user-auth/plan.md" << 'EOF'
+mkdir -p "$TEST_DIR/.workflows/planning/user-auth"
+cat > "$TEST_DIR/.workflows/planning/user-auth/plan.md" << 'EOF'
 ---
 topic: user-auth
 status: in-progress
@@ -147,10 +147,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Multiple plans${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/feature-a"
-mkdir -p "$TEST_DIR/docs/workflow/planning/feature-b"
+mkdir -p "$TEST_DIR/.workflows/planning/feature-a"
+mkdir -p "$TEST_DIR/.workflows/planning/feature-b"
 
-cat > "$TEST_DIR/docs/workflow/planning/feature-a/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/feature-a/plan.md" << 'EOF'
 ---
 topic: feature-a
 status: in-progress
@@ -162,7 +162,7 @@ specification: feature-a/specification.md
 # Implementation Plan: Feature A
 EOF
 
-cat > "$TEST_DIR/docs/workflow/planning/feature-b/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/feature-b/plan.md" << 'EOF'
 ---
 topic: feature-b
 status: concluded
@@ -187,10 +187,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with linked specification that exists${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/with-spec"
-mkdir -p "$TEST_DIR/docs/workflow/specification/with-spec"
+mkdir -p "$TEST_DIR/.workflows/planning/with-spec"
+mkdir -p "$TEST_DIR/.workflows/specification/with-spec"
 
-cat > "$TEST_DIR/docs/workflow/planning/with-spec/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/with-spec/plan.md" << 'EOF'
 ---
 topic: with-spec
 status: in-progress
@@ -202,7 +202,7 @@ specification: with-spec/specification.md
 # Implementation Plan: With Spec
 EOF
 
-cat > "$TEST_DIR/docs/workflow/specification/with-spec/specification.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/specification/with-spec/specification.md" << 'EOF'
 ---
 topic: with-spec
 status: concluded
@@ -221,9 +221,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with linked specification that doesn't exist${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/no-spec"
+mkdir -p "$TEST_DIR/.workflows/planning/no-spec"
 
-cat > "$TEST_DIR/docs/workflow/planning/no-spec/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/no-spec/plan.md" << 'EOF'
 ---
 topic: no-spec
 status: in-progress
@@ -245,9 +245,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with missing frontmatter fields (defaults)${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/minimal"
+mkdir -p "$TEST_DIR/.workflows/planning/minimal"
 
-cat > "$TEST_DIR/docs/workflow/planning/minimal/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/minimal/plan.md" << 'EOF'
 ---
 topic: minimal
 ---
@@ -268,9 +268,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with plan_id${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/with-plan-id"
+mkdir -p "$TEST_DIR/.workflows/planning/with-plan-id"
 
-cat > "$TEST_DIR/docs/workflow/planning/with-plan-id/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/with-plan-id/plan.md" << 'EOF'
 ---
 topic: with-plan-id
 status: in-progress
@@ -293,9 +293,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan without plan_id${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/no-plan-id"
+mkdir -p "$TEST_DIR/.workflows/planning/no-plan-id"
 
-cat > "$TEST_DIR/docs/workflow/planning/no-plan-id/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/no-plan-id/plan.md" << 'EOF'
 ---
 topic: no-plan-id
 status: in-progress
@@ -317,9 +317,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with no review${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/no-review"
+mkdir -p "$TEST_DIR/.workflows/planning/no-review"
 
-cat > "$TEST_DIR/docs/workflow/planning/no-review/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/no-review/plan.md" << 'EOF'
 ---
 topic: no-review
 status: concluded
@@ -342,10 +342,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with single review${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/single-review"
-mkdir -p "$TEST_DIR/docs/workflow/review/single-review/r1"
+mkdir -p "$TEST_DIR/.workflows/planning/single-review"
+mkdir -p "$TEST_DIR/.workflows/review/single-review/r1"
 
-cat > "$TEST_DIR/docs/workflow/planning/single-review/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/single-review/plan.md" << 'EOF'
 ---
 topic: single-review
 status: concluded
@@ -356,7 +356,7 @@ specification: single-review/specification.md
 # Plan: Single Review
 EOF
 
-cat > "$TEST_DIR/docs/workflow/review/single-review/r1/review.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/review/single-review/r1/review.md" << 'EOF'
 ---
 topic: single-review
 ---
@@ -378,11 +378,11 @@ echo ""
 
 echo -e "${YELLOW}Test: Plan with multiple reviews${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/multi-review"
-mkdir -p "$TEST_DIR/docs/workflow/review/multi-review/r1"
-mkdir -p "$TEST_DIR/docs/workflow/review/multi-review/r2"
+mkdir -p "$TEST_DIR/.workflows/planning/multi-review"
+mkdir -p "$TEST_DIR/.workflows/review/multi-review/r1"
+mkdir -p "$TEST_DIR/.workflows/review/multi-review/r2"
 
-cat > "$TEST_DIR/docs/workflow/planning/multi-review/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/multi-review/plan.md" << 'EOF'
 ---
 topic: multi-review
 status: concluded
@@ -393,7 +393,7 @@ specification: multi-review/specification.md
 # Plan: Multi Review
 EOF
 
-cat > "$TEST_DIR/docs/workflow/review/multi-review/r1/review.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/review/multi-review/r1/review.md" << 'EOF'
 ---
 topic: multi-review
 ---
@@ -403,7 +403,7 @@ topic: multi-review
 # Review: Multi Review r1
 EOF
 
-cat > "$TEST_DIR/docs/workflow/review/multi-review/r2/review.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/review/multi-review/r2/review.md" << 'EOF'
 ---
 topic: multi-review
 ---
@@ -425,10 +425,10 @@ echo ""
 
 echo -e "${YELLOW}Test: Review dir exists but no review.md files${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/empty-review"
-mkdir -p "$TEST_DIR/docs/workflow/review/empty-review/r1"
+mkdir -p "$TEST_DIR/.workflows/planning/empty-review"
+mkdir -p "$TEST_DIR/.workflows/review/empty-review/r1"
 
-cat > "$TEST_DIR/docs/workflow/planning/empty-review/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/empty-review/plan.md" << 'EOF'
 ---
 topic: empty-review
 status: concluded
@@ -452,9 +452,9 @@ echo ""
 
 echo -e "${YELLOW}Test: Review script does not output implementation section${NC}"
 setup_fixture
-mkdir -p "$TEST_DIR/docs/workflow/planning/test"
+mkdir -p "$TEST_DIR/.workflows/planning/test"
 
-cat > "$TEST_DIR/docs/workflow/planning/test/plan.md" << 'EOF'
+cat > "$TEST_DIR/.workflows/planning/test/plan.md" << 'EOF'
 ---
 topic: test
 status: concluded

--- a/tests/scripts/test-discovery-for-specification.sh
+++ b/tests/scripts/test-discovery-for-specification.sh
@@ -33,8 +33,8 @@ echo ""
 
 setup_fixture() {
     # Clean up from previous test
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow"
+    rm -rf "$TEST_DIR/.workflows"
+    mkdir -p "$TEST_DIR/.workflows"
 }
 
 run_discovery() {
@@ -112,8 +112,8 @@ test_discussions_only() {
     echo -e "${YELLOW}Test: Discussions only (no specs)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -123,7 +123,7 @@ date: 2026-01-20
 # Discussion: Auth Flow
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/discussion/api-design.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/api-design.md" << 'EOF'
 ---
 topic: api-design
 status: concluded
@@ -158,8 +158,8 @@ test_specifications_only() {
     echo -e "${YELLOW}Test: Specifications only (no discussions)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: in-progress
@@ -186,10 +186,10 @@ test_discussion_with_spec() {
     echo -e "${YELLOW}Test: Discussion with corresponding spec${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -199,7 +199,7 @@ date: 2026-01-20
 # Discussion: Auth Flow
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -225,10 +225,10 @@ test_discussion_with_concluded_spec() {
     echo -e "${YELLOW}Test: Discussion with corresponding concluded spec${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/billing"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/specification/billing"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/billing.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/billing.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -238,7 +238,7 @@ date: 2026-01-20
 # Discussion: Billing
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/billing/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -264,9 +264,9 @@ test_discussion_without_spec_no_status() {
     echo -e "${YELLOW}Test: Discussion without spec has no spec_status${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/standalone.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/standalone.md" << 'EOF'
 ---
 topic: standalone
 status: concluded
@@ -291,8 +291,8 @@ test_spec_with_sources() {
     echo -e "${YELLOW}Test: Specification with sources in object format${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/combined-feature"
-    cat > "$TEST_DIR/docs/workflow/specification/combined-feature/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/combined-feature"
+    cat > "$TEST_DIR/.workflows/specification/combined-feature/specification.md" << 'EOF'
 ---
 topic: combined-feature
 status: in-progress
@@ -331,9 +331,9 @@ test_spec_sources_discussion_status() {
     echo -e "${YELLOW}Test: Spec sources include discussion_status${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -343,7 +343,7 @@ date: 2026-01-20
 # Discussion: Auth Flow
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/discussion/api-design.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/api-design.md" << 'EOF'
 ---
 topic: api-design
 status: in-progress
@@ -353,8 +353,8 @@ date: 2026-01-19
 # Discussion: API Design
 EOF
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/combined"
-    cat > "$TEST_DIR/docs/workflow/specification/combined/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/combined"
+    cat > "$TEST_DIR/.workflows/specification/combined/specification.md" << 'EOF'
 ---
 topic: combined
 status: in-progress
@@ -388,8 +388,8 @@ test_spec_superseded() {
     echo -e "${YELLOW}Test: Specification with superseded_by${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/old-auth"
-    cat > "$TEST_DIR/docs/workflow/specification/old-auth/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/old-auth"
+    cat > "$TEST_DIR/.workflows/specification/old-auth/specification.md" << 'EOF'
 ---
 topic: old-auth
 status: superseded
@@ -416,8 +416,8 @@ test_cache_none() {
     echo -e "${YELLOW}Test: Cache status none${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/test.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/test.md" << 'EOF'
 ---
 topic: test
 status: in-progress
@@ -444,10 +444,10 @@ test_cache_valid() {
     echo -e "${YELLOW}Test: Cache status valid${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/.state"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/.state"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -458,9 +458,9 @@ date: 2026-01-20
 EOF
 
     # Compute the checksum that the cache should have
-    local checksum=$(cat "$TEST_DIR/docs/workflow/discussion"/*.md | md5sum | cut -d' ' -f1)
+    local checksum=$(cat "$TEST_DIR/.workflows/discussion"/*.md | md5sum | cut -d' ' -f1)
 
-    cat > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" << EOF
+    cat > "$TEST_DIR/.workflows/.state/discussion-consolidation-analysis.md" << EOF
 ---
 checksum: $checksum
 generated: 2026-01-20T10:00:00
@@ -486,10 +486,10 @@ test_cache_stale() {
     echo -e "${YELLOW}Test: Cache status stale${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/.state"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/.state"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -500,7 +500,7 @@ date: 2026-01-20
 EOF
 
     # Use a different checksum to make cache stale
-    cat > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/.state/discussion-consolidation-analysis.md" << 'EOF'
 ---
 checksum: oldchecksum123
 generated: 2026-01-19T10:00:00
@@ -526,11 +526,11 @@ test_anchored_names() {
     echo -e "${YELLOW}Test: Anchored names in cache${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    mkdir -p "$TEST_DIR/docs/workflow/specification"
-    mkdir -p "$TEST_DIR/docs/workflow/.state"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/specification"
+    mkdir -p "$TEST_DIR/.workflows/.state"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -541,8 +541,8 @@ date: 2026-01-20
 EOF
 
     # Create a spec that matches a grouping name in the cache
-    mkdir -p "$TEST_DIR/docs/workflow/specification/authentication"
-    cat > "$TEST_DIR/docs/workflow/specification/authentication/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/authentication"
+    cat > "$TEST_DIR/.workflows/specification/authentication/specification.md" << 'EOF'
 ---
 topic: authentication
 status: in-progress
@@ -553,10 +553,10 @@ date: 2026-01-21
 # Specification: Authentication
 EOF
 
-    local checksum=$(cat "$TEST_DIR/docs/workflow/discussion"/*.md | md5sum | cut -d' ' -f1)
+    local checksum=$(cat "$TEST_DIR/.workflows/discussion"/*.md | md5sum | cut -d' ' -f1)
 
     # Cache with grouping names
-    cat > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" << EOF
+    cat > "$TEST_DIR/.workflows/.state/discussion-consolidation-analysis.md" << EOF
 ---
 checksum: $checksum
 generated: 2026-01-20T10:00:00
@@ -590,9 +590,9 @@ test_current_state_checksum() {
     echo -e "${YELLOW}Test: Current state with discussions checksum${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/test.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/test.md" << 'EOF'
 ---
 topic: test
 status: concluded
@@ -618,8 +618,8 @@ test_spec_default_status() {
     echo -e "${YELLOW}Test: Spec without status defaults to active${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/legacy"
-    cat > "$TEST_DIR/docs/workflow/specification/legacy/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/legacy"
+    cat > "$TEST_DIR/.workflows/specification/legacy/specification.md" << 'EOF'
 ---
 topic: legacy
 type: feature
@@ -645,8 +645,8 @@ test_discussion_default_status() {
     echo -e "${YELLOW}Test: Discussion without status defaults to unknown${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/legacy.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/legacy.md" << 'EOF'
 ---
 topic: legacy
 date: 2026-01-20
@@ -671,8 +671,8 @@ test_spec_many_sources() {
     echo -e "${YELLOW}Test: Specification with many sources (8)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/tick-core"
-    cat > "$TEST_DIR/docs/workflow/specification/tick-core/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/tick-core"
+    cat > "$TEST_DIR/.workflows/specification/tick-core/specification.md" << 'EOF'
 ---
 topic: tick-core
 status: in-progress
@@ -722,8 +722,8 @@ test_spec_with_hr_in_body() {
     echo -e "${YELLOW}Test: Specification with --- in body content${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/tricky-spec"
-    cat > "$TEST_DIR/docs/workflow/specification/tricky-spec/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/tricky-spec"
+    cat > "$TEST_DIR/.workflows/specification/tricky-spec/specification.md" << 'EOF'
 ---
 topic: tricky-spec
 status: in-progress
@@ -772,8 +772,8 @@ test_spec_empty_sources() {
     echo -e "${YELLOW}Test: Specification with empty sources${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/empty-sources"
-    cat > "$TEST_DIR/docs/workflow/specification/empty-sources/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/empty-sources"
+    cat > "$TEST_DIR/.workflows/specification/empty-sources/specification.md" << 'EOF'
 ---
 topic: empty-sources
 status: in-progress
@@ -812,8 +812,8 @@ test_discussion_with_hr_in_body() {
     echo -e "${YELLOW}Test: Discussion with --- in body content${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/tricky-discussion.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/tricky-discussion.md" << 'EOF'
 ---
 topic: tricky-discussion
 status: concluded
@@ -855,9 +855,9 @@ test_spec_count_excludes_superseded() {
     echo -e "${YELLOW}Test: Spec count excludes superseded${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
+    mkdir -p "$TEST_DIR/.workflows/discussion"
 
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -867,8 +867,8 @@ date: 2026-01-20
 # Discussion: Auth Flow
 EOF
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-flow"
-    cat > "$TEST_DIR/docs/workflow/specification/auth-flow/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+    cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: superseded
@@ -880,8 +880,8 @@ superseded_by: auth-system
 # Specification: Auth Flow (superseded)
 EOF
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: in-progress

--- a/tests/scripts/test-discovery-for-status.sh
+++ b/tests/scripts/test-discovery-for-status.sh
@@ -33,8 +33,8 @@ echo ""
 
 setup_fixture() {
     # Clean up from previous test
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow"
+    rm -rf "$TEST_DIR/.workflows"
+    mkdir -p "$TEST_DIR/.workflows"
 }
 
 run_discovery() {
@@ -106,8 +106,8 @@ test_research_files() {
     echo -e "${YELLOW}Test: Research files detected${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/research"
-    cat > "$TEST_DIR/docs/workflow/research/market-analysis.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/research"
+    cat > "$TEST_DIR/.workflows/research/market-analysis.md" << 'EOF'
 ---
 topic: market-analysis
 ---
@@ -115,7 +115,7 @@ topic: market-analysis
 # Market Analysis
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/research/tech-feasibility.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/research/tech-feasibility.md" << 'EOF'
 ---
 topic: tech-feasibility
 ---
@@ -140,8 +140,8 @@ test_discussions() {
     echo -e "${YELLOW}Test: Discussion status detection${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -150,7 +150,7 @@ status: concluded
 # Auth Flow
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/discussion/caching.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/caching.md" << 'EOF'
 ---
 topic: caching
 status: in-progress
@@ -177,8 +177,8 @@ test_spec_multiple_sources() {
     echo -e "${YELLOW}Test: Specification with multiple sources (many-to-one)${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -213,8 +213,8 @@ test_spec_pending_source() {
     echo -e "${YELLOW}Test: Specification with pending source${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/billing"
-    cat > "$TEST_DIR/docs/workflow/specification/billing/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/billing"
+    cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: in-progress
@@ -244,8 +244,8 @@ test_crosscutting_spec() {
     echo -e "${YELLOW}Test: Cross-cutting specification${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/caching-policy"
-    cat > "$TEST_DIR/docs/workflow/specification/caching-policy/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/caching-policy"
+    cat > "$TEST_DIR/.workflows/specification/caching-policy/specification.md" << 'EOF'
 ---
 topic: caching-policy
 status: concluded
@@ -271,9 +271,9 @@ test_superseded_spec() {
     echo -e "${YELLOW}Test: Superseded specification${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/old-auth"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    cat > "$TEST_DIR/docs/workflow/specification/old-auth/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/old-auth"
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    cat > "$TEST_DIR/.workflows/specification/old-auth/specification.md" << 'EOF'
 ---
 topic: old-auth
 status: superseded
@@ -284,7 +284,7 @@ superseded_by: auth-system
 # Old Auth Specification
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -311,8 +311,8 @@ test_spec_no_sources() {
     echo -e "${YELLOW}Test: Specification with no sources${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/quick-feature"
-    cat > "$TEST_DIR/docs/workflow/specification/quick-feature/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/quick-feature"
+    cat > "$TEST_DIR/.workflows/specification/quick-feature/specification.md" << 'EOF'
 ---
 topic: quick-feature
 status: concluded
@@ -338,8 +338,8 @@ test_plan_with_deps() {
     echo -e "${YELLOW}Test: Plan with external dependencies${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/billing"
-    cat > "$TEST_DIR/docs/workflow/planning/billing/plan.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/planning/billing"
+    cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -370,8 +370,8 @@ test_plan_resolved_deps() {
     echo -e "${YELLOW}Test: Plan with resolved dependencies${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/billing"
-    cat > "$TEST_DIR/docs/workflow/planning/billing/plan.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/planning/billing"
+    cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -403,8 +403,8 @@ test_plan_empty_deps() {
     echo -e "${YELLOW}Test: Plan with empty dependencies array${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/simple"
-    cat > "$TEST_DIR/docs/workflow/planning/simple/plan.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/planning/simple"
+    cat > "$TEST_DIR/.workflows/planning/simple/plan.md" << 'EOF'
 ---
 topic: simple
 status: concluded
@@ -431,11 +431,11 @@ test_implementation_tracking() {
     echo -e "${YELLOW}Test: Implementation tracking${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system/tasks"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system/tasks"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-system"
 
     # Create plan with tasks
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -445,21 +445,21 @@ format: local-markdown
 # Auth System Plan
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/tasks/auth-system-1-1.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/tasks/auth-system-1-1.md" << 'EOF'
 ---
 task_id: auth-system-1-1
 ---
 Task 1
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/tasks/auth-system-1-2.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/tasks/auth-system-1-2.md" << 'EOF'
 ---
 task_id: auth-system-1-2
 ---
 Task 2
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/tasks/auth-system-1-3.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/tasks/auth-system-1-3.md" << 'EOF'
 ---
 task_id: auth-system-1-3
 ---
@@ -467,7 +467,7 @@ Task 3
 EOF
 
     # Create tracking file
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-system/tracking.md" << 'EOF'
 ---
 status: in-progress
 current_phase: 1
@@ -499,10 +499,10 @@ test_completed_implementation() {
     echo -e "${YELLOW}Test: Completed implementation${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system/tasks"
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system/tasks"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-system"
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -512,14 +512,14 @@ format: local-markdown
 # Auth System Plan
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/tasks/auth-system-1-1.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/tasks/auth-system-1-1.md" << 'EOF'
 ---
 task_id: auth-system-1-1
 ---
 Task 1
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-system/tracking.md" << 'EOF'
 ---
 status: completed
 current_phase: ~
@@ -550,9 +550,9 @@ test_implementation_inline_phases() {
     echo -e "${YELLOW}Test: Implementation with inline completed_phases format${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-system"
 
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/implementation/auth-system/tracking.md" << 'EOF'
 ---
 status: in-progress
 current_phase: 3
@@ -582,8 +582,8 @@ test_full_workflow() {
     setup_fixture
 
     # Research
-    mkdir -p "$TEST_DIR/docs/workflow/research"
-    cat > "$TEST_DIR/docs/workflow/research/market-analysis.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/research"
+    cat > "$TEST_DIR/.workflows/research/market-analysis.md" << 'EOF'
 ---
 topic: market-analysis
 ---
@@ -591,22 +591,22 @@ Research
 EOF
 
     # Discussions (3 total: 2 concluded into 1 spec, 1 in-progress)
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    cat > "$TEST_DIR/docs/workflow/discussion/auth-flow.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
 ---
 Discussion
 EOF
-    cat > "$TEST_DIR/docs/workflow/discussion/session-mgmt.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/session-mgmt.md" << 'EOF'
 ---
 topic: session-mgmt
 status: concluded
 ---
 Discussion
 EOF
-    cat > "$TEST_DIR/docs/workflow/discussion/caching.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/discussion/caching.md" << 'EOF'
 ---
 topic: caching
 status: in-progress
@@ -615,9 +615,9 @@ Discussion
 EOF
 
     # Specifications (1 feature with 2 sources, 1 cross-cutting)
-    mkdir -p "$TEST_DIR/docs/workflow/specification/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/specification/caching-policy"
-    cat > "$TEST_DIR/docs/workflow/specification/auth-system/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/specification/caching-policy"
+    cat > "$TEST_DIR/.workflows/specification/auth-system/specification.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -630,7 +630,7 @@ sources:
 ---
 Spec
 EOF
-    cat > "$TEST_DIR/docs/workflow/specification/caching-policy/specification.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/specification/caching-policy/specification.md" << 'EOF'
 ---
 topic: caching-policy
 status: in-progress
@@ -643,8 +643,8 @@ Spec
 EOF
 
     # Plan
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system/tasks"
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system/tasks"
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -654,13 +654,13 @@ external_dependencies: []
 ---
 Plan
 EOF
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/tasks/auth-system-1-1.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/tasks/auth-system-1-1.md" << 'EOF'
 ---
 task_id: auth-system-1-1
 ---
 Task
 EOF
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/tasks/auth-system-1-2.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/tasks/auth-system-1-2.md" << 'EOF'
 ---
 task_id: auth-system-1-2
 ---
@@ -668,8 +668,8 @@ Task
 EOF
 
     # Implementation
-    mkdir -p "$TEST_DIR/docs/workflow/implementation/auth-system"
-    cat > "$TEST_DIR/docs/workflow/implementation/auth-system/tracking.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/implementation/auth-system"
+    cat > "$TEST_DIR/.workflows/implementation/auth-system/tracking.md" << 'EOF'
 ---
 status: in-progress
 current_phase: 1
@@ -715,10 +715,10 @@ test_plan_status_counts() {
     echo -e "${YELLOW}Test: Plan status counts${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    mkdir -p "$TEST_DIR/docs/workflow/planning/billing"
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    mkdir -p "$TEST_DIR/.workflows/planning/billing"
 
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -729,7 +729,7 @@ external_dependencies: []
 Plan
 EOF
 
-    cat > "$TEST_DIR/docs/workflow/planning/billing/plan.md" << 'EOF'
+    cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 topic: billing
 status: planning
@@ -756,8 +756,8 @@ test_spec_default_type() {
     echo -e "${YELLOW}Test: Spec defaults to feature type when missing${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/specification/legacy"
-    cat > "$TEST_DIR/docs/workflow/specification/legacy/specification.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/specification/legacy"
+    cat > "$TEST_DIR/.workflows/specification/legacy/specification.md" << 'EOF'
 ---
 topic: legacy
 status: concluded
@@ -780,8 +780,8 @@ test_plan_spec_link() {
     echo -e "${YELLOW}Test: Plan specification link${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded
@@ -805,8 +805,8 @@ test_plan_default_spec() {
     echo -e "${YELLOW}Test: Plan defaults specification when missing${NC}"
     setup_fixture
 
-    mkdir -p "$TEST_DIR/docs/workflow/planning/auth-system"
-    cat > "$TEST_DIR/docs/workflow/planning/auth-system/plan.md" << 'EOF'
+    mkdir -p "$TEST_DIR/.workflows/planning/auth-system"
+    cat > "$TEST_DIR/.workflows/planning/auth-system/plan.md" << 'EOF'
 ---
 topic: auth-system
 status: concluded

--- a/tests/scripts/test-migration-011.sh
+++ b/tests/scripts/test-migration-011.sh
@@ -1,0 +1,389 @@
+#!/bin/bash
+#
+# Tests migration 011-rename-workflow-directory.sh
+# Validates moving docs/workflow/ → .workflows/
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/migrate/scripts/migrations/011-rename-workflow-directory.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Mock migration helper functions
+#
+
+report_update() {
+    local file="$1"
+    local description="$2"
+    echo "[UPDATE] $file: $description"
+}
+
+report_skip() {
+    local file="$1"
+    echo "[SKIP] $file"
+}
+
+# Export functions for sourced script
+export -f report_update report_skip
+
+#
+# Helper functions
+#
+
+setup_fixture() {
+    rm -rf "$TEST_DIR/docs"
+    rm -rf "$TEST_DIR/.workflows"
+    rm -rf "$TEST_DIR/.gitignore"
+}
+
+run_migration() {
+    cd "$TEST_DIR"
+    source "$MIGRATION_SCRIPT"
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected: $expected"
+        echo -e "    Actual:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local content="$1"
+    local unexpected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$unexpected"; then
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Did not expect to find: $unexpected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    else
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+}
+
+assert_file_exists() {
+    local filepath="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ -f "$filepath" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File not found: $filepath"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_file_not_exists() {
+    local filepath="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ ! -f "$filepath" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File should not exist: $filepath"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_dir_exists() {
+    local dirpath="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ -d "$dirpath" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Directory not found: $dirpath"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_dir_not_exists() {
+    local dirpath="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ ! -d "$dirpath" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Directory should not exist: $dirpath"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+echo -e "${YELLOW}Test: Full migration — docs/workflow/ → .workflows/${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/discussion"
+mkdir -p "$TEST_DIR/docs/workflow/specification/auth"
+mkdir -p "$TEST_DIR/docs/workflow/.state"
+mkdir -p "$TEST_DIR/docs/workflow/.cache/sessions"
+echo "discussion content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+echo "spec content" > "$TEST_DIR/docs/workflow/specification/auth/specification.md"
+echo "state data" > "$TEST_DIR/docs/workflow/.state/migrations"
+echo "cache data" > "$TEST_DIR/docs/workflow/.cache/sessions/abc.yaml"
+
+run_migration
+
+assert_file_exists "$TEST_DIR/.workflows/discussion/auth.md" "Discussion file moved"
+assert_equals "$(cat "$TEST_DIR/.workflows/discussion/auth.md")" "discussion content" "Discussion content preserved"
+assert_file_exists "$TEST_DIR/.workflows/specification/auth/specification.md" "Spec file moved"
+assert_equals "$(cat "$TEST_DIR/.workflows/specification/auth/specification.md")" "spec content" "Spec content preserved"
+assert_file_exists "$TEST_DIR/.workflows/.state/migrations" "Hidden .state/ dir moved"
+assert_equals "$(cat "$TEST_DIR/.workflows/.state/migrations")" "state data" ".state content preserved"
+assert_file_exists "$TEST_DIR/.workflows/.cache/sessions/abc.yaml" "Hidden .cache/ dir moved"
+assert_dir_not_exists "$TEST_DIR/docs/workflow" "Old directory removed"
+assert_dir_not_exists "$TEST_DIR/docs" "Empty docs/ removed"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Already migrated — only .workflows/ exists${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/discussion"
+echo "existing" > "$TEST_DIR/.workflows/discussion/auth.md"
+
+output=$(run_migration 2>&1)
+
+assert_contains "$output" "SKIP" "Reports skip when nothing to migrate"
+assert_file_exists "$TEST_DIR/.workflows/discussion/auth.md" "Existing files untouched"
+assert_equals "$(cat "$TEST_DIR/.workflows/discussion/auth.md")" "existing" "Content unchanged"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Fresh install — neither directory exists${NC}"
+setup_fixture
+
+output=$(run_migration 2>&1)
+
+assert_contains "$output" "SKIP" "Reports skip for fresh install"
+assert_dir_not_exists "$TEST_DIR/.workflows" ".workflows/ not created unnecessarily"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Gitignore updated — docs/workflow/.cache/ → .workflows/.cache/${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/discussion"
+echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+cat > "$TEST_DIR/.gitignore" << 'EOF'
+node_modules/
+docs/workflow/.cache/
+.env
+EOF
+
+run_migration
+content=$(cat "$TEST_DIR/.gitignore")
+
+assert_contains "$content" ".workflows/.cache/" "New gitignore entry present"
+assert_not_contains "$content" "docs/workflow/.cache/" "Old gitignore entry removed"
+assert_contains "$content" "node_modules/" "Other entries preserved"
+assert_contains "$content" ".env" "Other entries preserved"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Gitignore already has .workflows/.cache/ — no-op${NC}"
+setup_fixture
+
+cat > "$TEST_DIR/.gitignore" << 'EOF'
+node_modules/
+.workflows/.cache/
+.env
+EOF
+
+original=$(cat "$TEST_DIR/.gitignore")
+output=$(run_migration 2>&1)
+new_content=$(cat "$TEST_DIR/.gitignore")
+
+assert_equals "$new_content" "$original" "Gitignore unchanged"
+assert_contains "$output" "SKIP" "Reports skip for gitignore"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: docs/ preserved if has other contents${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/discussion"
+mkdir -p "$TEST_DIR/docs/api"
+echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+echo "api docs" > "$TEST_DIR/docs/api/readme.md"
+
+run_migration
+
+assert_dir_not_exists "$TEST_DIR/docs/workflow" "Old workflow dir removed"
+assert_dir_exists "$TEST_DIR/docs/api" "Other docs/ contents preserved"
+assert_file_exists "$TEST_DIR/docs/api/readme.md" "Non-workflow file preserved"
+assert_file_exists "$TEST_DIR/.workflows/discussion/auth.md" "Workflow files moved"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Hidden directories (.state/, .cache/) moved correctly${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/.state"
+mkdir -p "$TEST_DIR/docs/workflow/.cache"
+echo "state" > "$TEST_DIR/docs/workflow/.state/migrations"
+echo "cache" > "$TEST_DIR/docs/workflow/.cache/data"
+
+run_migration
+
+assert_dir_exists "$TEST_DIR/.workflows/.state" ".state/ directory moved"
+assert_dir_exists "$TEST_DIR/.workflows/.cache" ".cache/ directory moved"
+assert_file_exists "$TEST_DIR/.workflows/.state/migrations" ".state file moved"
+assert_file_exists "$TEST_DIR/.workflows/.cache/data" ".cache file moved"
+assert_equals "$(cat "$TEST_DIR/.workflows/.state/migrations")" "state" ".state content preserved"
+assert_equals "$(cat "$TEST_DIR/.workflows/.cache/data")" "cache" ".cache content preserved"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Partial migration — item already at destination is skipped${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/discussion"
+mkdir -p "$TEST_DIR/.workflows/discussion"
+echo "old" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+echo "new" > "$TEST_DIR/.workflows/discussion/auth.md"
+echo "other" > "$TEST_DIR/docs/workflow/discussion/billing.md"
+
+output=$(run_migration 2>&1)
+
+assert_contains "$output" "SKIP" "Reports skip for existing item"
+assert_equals "$(cat "$TEST_DIR/.workflows/discussion/auth.md")" "new" "Existing destination not overwritten"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Idempotency — running twice produces same result${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/docs/workflow/discussion"
+echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+cat > "$TEST_DIR/.gitignore" << 'EOF'
+docs/workflow/.cache/
+EOF
+
+run_migration
+first_content=$(cat "$TEST_DIR/.workflows/discussion/auth.md")
+first_gitignore=$(cat "$TEST_DIR/.gitignore")
+
+run_migration
+second_content=$(cat "$TEST_DIR/.workflows/discussion/auth.md")
+second_gitignore=$(cat "$TEST_DIR/.gitignore")
+
+assert_equals "$second_content" "$first_content" "File content same after second run"
+assert_equals "$second_gitignore" "$first_gitignore" "Gitignore same after second run"
+
+echo ""
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "Tests run: $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "========================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/test-migration-012.sh
+++ b/tests/scripts/test-migration-012.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+#
+# Tests migration 012-environment-setup-to-state.sh
+# Validates moving environment-setup.md to .state/ directory.
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/migrate/scripts/migrations/012-environment-setup-to-state.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Mock migration helper functions
+#
+
+report_update() {
+    local file="$1"
+    local description="$2"
+    echo "[UPDATE] $file: $description"
+}
+
+report_skip() {
+    local file="$1"
+    echo "[SKIP] $file"
+}
+
+# Export functions for sourced script
+export -f report_update report_skip
+
+#
+# Helper functions
+#
+
+setup_fixture() {
+    rm -rf "$TEST_DIR/.workflows"
+    rm -rf "$TEST_DIR/docs"
+}
+
+run_migration() {
+    cd "$TEST_DIR"
+    source "$MIGRATION_SCRIPT"
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected: $expected"
+        echo -e "    Actual:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_file_exists() {
+    local filepath="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ -f "$filepath" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File not found: $filepath"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_file_not_exists() {
+    local filepath="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ ! -f "$filepath" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File should not exist: $filepath"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+echo -e "${YELLOW}Test: Move environment-setup.md to .state/${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state"
+echo "environment content" > "$TEST_DIR/.workflows/environment-setup.md"
+
+run_migration
+
+assert_file_exists "$TEST_DIR/.workflows/.state/environment-setup.md" "File moved to .state/"
+assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "File removed from root"
+assert_equals "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")" "environment content" "Content preserved"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Already in .state/ — no-op${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state"
+echo "already there" > "$TEST_DIR/.workflows/.state/environment-setup.md"
+
+output=$(run_migration 2>&1)
+
+assert_file_exists "$TEST_DIR/.workflows/.state/environment-setup.md" "File still in .state/"
+assert_equals "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")" "already there" "Content unchanged"
+assert_contains "$output" "SKIP" "Reports skip"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: No environment-setup.md — no-op${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state"
+
+run_migration
+
+assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "No file created at root"
+assert_file_not_exists "$TEST_DIR/.workflows/.state/environment-setup.md" "No file created in .state/"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: Idempotency — running twice${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state"
+echo "content" > "$TEST_DIR/.workflows/environment-setup.md"
+
+run_migration
+first_content=$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")
+
+run_migration
+second_content=$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")
+
+assert_equals "$second_content" "$first_content" "Content same after second run"
+assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "Root file still gone"
+
+echo ""
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "Tests run: $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "========================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/test-session-state.sh
+++ b/tests/scripts/test-session-state.sh
@@ -34,8 +34,8 @@ echo ""
 #
 
 setup_fixture() {
-    rm -rf "$TEST_DIR/docs" "$TEST_DIR/env"
-    mkdir -p "$TEST_DIR/docs/workflow/.cache/sessions"
+    rm -rf "$TEST_DIR/.workflows" "$TEST_DIR/env"
+    mkdir -p "$TEST_DIR/.workflows/.cache/sessions"
 }
 
 assert_contains() {
@@ -142,14 +142,14 @@ setup_fixture
 
 CLAUDE_SESSION_ID="test-session-001" \
 CLAUDE_PROJECT_DIR="$TEST_DIR" \
-bash "$WRITE_SCRIPT" "auth-flow" ".claude/skills/technical-discussion/SKILL.md" "docs/workflow/discussion/auth-flow.md"
+bash "$WRITE_SCRIPT" "auth-flow" ".claude/skills/technical-discussion/SKILL.md" ".workflows/discussion/auth-flow.md"
 
-session_file="$TEST_DIR/docs/workflow/.cache/sessions/test-session-001.yaml"
+session_file="$TEST_DIR/.workflows/.cache/sessions/test-session-001.yaml"
 assert_file_exists "$session_file" "Session file created"
 content=$(cat "$session_file")
 assert_contains "$content" "^topic: auth-flow$" "Topic field correct"
 assert_contains "$content" "^skill: .claude/skills/technical-discussion/SKILL.md$" "Skill field correct"
-assert_contains "$content" "^artifact: docs/workflow/discussion/auth-flow.md$" "Artifact field correct"
+assert_contains "$content" "^artifact: .workflows/discussion/auth-flow.md$" "Artifact field correct"
 assert_not_contains "$content" "pipeline" "No pipeline section without --pipeline flag"
 
 echo ""
@@ -161,10 +161,10 @@ setup_fixture
 
 CLAUDE_SESSION_ID="test-session-002" \
 CLAUDE_PROJECT_DIR="$TEST_DIR" \
-bash "$WRITE_SCRIPT" "billing" ".claude/skills/technical-specification/SKILL.md" "docs/workflow/specification/billing/specification.md" \
+bash "$WRITE_SCRIPT" "billing" ".claude/skills/technical-specification/SKILL.md" ".workflows/specification/billing/specification.md" \
   --pipeline 'Enter plan mode: "Clear context and continue with /continue-feature for billing"'
 
-session_file="$TEST_DIR/docs/workflow/.cache/sessions/test-session-002.yaml"
+session_file="$TEST_DIR/.workflows/.cache/sessions/test-session-002.yaml"
 assert_file_exists "$session_file" "Session file created"
 content=$(cat "$session_file")
 assert_contains "$content" "^topic: billing$" "Topic field correct"
@@ -199,7 +199,7 @@ echo ""
 
 echo -e "${YELLOW}Test: session-cleanup deletes session file${NC}"
 setup_fixture
-session_file="$TEST_DIR/docs/workflow/.cache/sessions/cleanup-test-001.yaml"
+session_file="$TEST_DIR/.workflows/.cache/sessions/cleanup-test-001.yaml"
 cat > "$session_file" << 'EOF'
 topic: test
 skill: test

--- a/tests/scripts/test-system-check.sh
+++ b/tests/scripts/test-system-check.sh
@@ -32,7 +32,7 @@ echo ""
 #
 
 setup_fixture() {
-    rm -rf "$TEST_DIR/.claude" "$TEST_DIR/docs"
+    rm -rf "$TEST_DIR/.claude" "$TEST_DIR/.workflows"
 }
 
 run_hook() {

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -1179,7 +1179,7 @@
             <div class="ov-badges">
               <span class="ov-badge ov-badge-command ov-badge-link" onclick="event.stopPropagation(); selectPhase('research')"><span class="ov-badge-label">cmd</span>/start-research</span>
               <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-research')"><span class="ov-badge-label">skill</span>technical-research</span>
-              <span class="ov-badge ov-badge-output"><span class="ov-badge-label">output</span>docs/workflow/research/</span>
+              <span class="ov-badge ov-badge-output"><span class="ov-badge-label">output</span>.workflows/research/</span>
             </div>
           </div>
           <div class="ov-arrow-h"><svg width="48" height="12" viewBox="0 0 48 12"><line x1="4" y1="6" x2="38" y2="6" stroke="#8b90a0" stroke-opacity="0.4" stroke-width="1.5" stroke-dasharray="4,3"/><polygon points="38,2 46,6 38,10" fill="#8b90a0" fill-opacity="0.4"/></svg></div>
@@ -1190,7 +1190,7 @@
             <div class="ov-badges">
               <span class="ov-badge ov-badge-command ov-badge-link" onclick="event.stopPropagation(); selectPhase('discussion')"><span class="ov-badge-label">cmd</span>/start-discussion</span>
               <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-discussion')"><span class="ov-badge-label">skill</span>technical-discussion</span>
-              <span class="ov-badge ov-badge-output"><span class="ov-badge-label">output</span>docs/workflow/discussion/</span>
+              <span class="ov-badge ov-badge-output"><span class="ov-badge-label">output</span>.workflows/discussion/</span>
             </div>
           </div>
           <div class="ov-arrow-h"><svg width="48" height="12" viewBox="0 0 48 12"><line x1="4" y1="6" x2="38" y2="6" stroke="#8b90a0" stroke-opacity="0.4" stroke-width="1.5" stroke-dasharray="4,3"/><polygon points="38,2 46,6 38,10" fill="#8b90a0" fill-opacity="0.4"/></svg></div>
@@ -1201,7 +1201,7 @@
             <div class="ov-badges">
               <span class="ov-badge ov-badge-command ov-badge-link" onclick="event.stopPropagation(); selectPhase('specification')"><span class="ov-badge-label">cmd</span>/start-specification</span>
               <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-specification')"><span class="ov-badge-label">skill</span>technical-specification</span>
-              <span class="ov-badge ov-badge-output"><span class="ov-badge-label">output</span>docs/workflow/specification/</span>
+              <span class="ov-badge ov-badge-output"><span class="ov-badge-label">output</span>.workflows/specification/</span>
             </div>
           </div>
         </div>
@@ -1221,7 +1221,7 @@
             <div class="ov-badges">
               <span class="ov-badge ov-badge-command ov-badge-link" onclick="event.stopPropagation(); selectPhase('planning')"><span class="ov-badge-label">cmd</span>/start-planning</span>
               <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-planning')"><span class="ov-badge-label">skill</span>technical-planning</span>
-              <span class="ov-badge ov-badge-output"><span class="ov-badge-label">output</span>docs/workflow/planning/</span>
+              <span class="ov-badge ov-badge-output"><span class="ov-badge-label">output</span>.workflows/planning/</span>
             </div>
           </div>
           <div class="ov-arrow-h"><svg width="48" height="12" viewBox="0 0 48 12"><line x1="4" y1="6" x2="38" y2="6" stroke="#8b90a0" stroke-opacity="0.4" stroke-width="1.5" stroke-dasharray="4,3"/><polygon points="38,2 46,6 38,10" fill="#8b90a0" fill-opacity="0.4"/></svg></div>
@@ -1363,7 +1363,7 @@ const phases = {
     color: 'var(--ask)', bg: 'var(--ask-bg)',
     label: 'Research', cmd: '/start-research',
     complexity: 'Simple', steps: 6,
-    output: 'docs/workflow/research/',
+    output: '.workflows/research/',
     skill: 'technical-research',
     discovery: null,
     cache: null,
@@ -1375,7 +1375,7 @@ const phases = {
     color: '#60a5fa', bg: 'rgba(96,165,250,0.12)',
     label: 'Discussion', cmd: '/start-discussion',
     complexity: 'Moderate', steps: 8,
-    output: 'docs/workflow/discussion/{topic}.md',
+    output: '.workflows/discussion/{topic}.md',
     skill: 'technical-discussion',
     discovery: 'discovery-for-discussion.sh',
     cache: '.state/research-analysis.md',
@@ -1387,7 +1387,7 @@ const phases = {
     color: '#34d399', bg: 'rgba(52,211,153,0.12)',
     label: 'Specification', cmd: '/start-specification',
     complexity: 'Complex', steps: 7,
-    output: 'docs/workflow/specification/{topic}/specification.md',
+    output: '.workflows/specification/{topic}/specification.md',
     skill: 'technical-specification',
     discovery: 'discovery.sh',
     cache: '.state/discussion-consolidation-analysis.md',
@@ -1399,7 +1399,7 @@ const phases = {
     color: '#fbbf24', bg: 'rgba(251,191,36,0.12)',
     label: 'Planning', cmd: '/start-planning',
     complexity: 'Moderate', steps: 8,
-    output: 'docs/workflow/planning/{topic}/plan.md',
+    output: '.workflows/planning/{topic}/plan.md',
     skill: 'technical-planning',
     discovery: 'discovery-for-planning.sh',
     cache: null,
@@ -1854,7 +1854,7 @@ const FLOWCHARTS = {
       { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations.' },
       { id: 'gather', label: 'ASK: Feature context', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 1: Gather feature context — what, scope, constraints.' },
       { id: 'name', label: 'ASK: Suggest topic name', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 2: Suggest a kebab-case topic name for the discussion file.' },
-      { id: 'check', label: 'Discussion exists?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2: Check docs/workflow/discussion/ for existing discussion with same name.' },
+      { id: 'check', label: 'Discussion exists?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2: Check .workflows/discussion/ for existing discussion with same name.' },
       { id: 'conflict', label: 'ASK: Resume / new name', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Discussion exists: resume the existing discussion or choose a different name.' },
       { id: 'status-check', label: 'Concluded?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'If resuming: check discussion status. Concluded → skip to bridge. In-progress → invoke discussion.' },
       { id: 'disc-skill', label: 'Invoke discussion skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 3: Invoke technical-discussion skill. When discussion concludes, proceed to phase bridge.', skillLink: 'skill-discussion' },
@@ -1879,7 +1879,7 @@ const FLOWCHARTS = {
   'link-deps': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /link-dependencies. No migration step.' },
-      { id: 'discover', label: 'Discover all plans', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Scan docs/workflow/planning/ for all plan files. Extract format metadata.' },
+      { id: 'discover', label: 'Discover all plans', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Scan .workflows/planning/ for all plan files. Extract format metadata.' },
       { id: 'gate-count', label: 'Plans >= 2?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Gate: Need at least 2 plans for cross-topic linking. 0-1 = STOP.' },
       { id: 'stop-count', label: 'STOP: Need 2+ plans', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: Fewer than 2 plans. Cannot link across topics.' },
       { id: 'gate-format', label: 'Same format?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Gate: All plans must use the same output format. Mixed formats = STOP.' },
@@ -1919,7 +1919,7 @@ const FLOWCHARTS = {
       { id: 'more', label: 'More to explore?', shape: 'diamond', w: 120, h: 120, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Periodic review: more questions? Themes emerging? Ready for discussion/spec?' },
       { id: 'split', label: 'Themes emerging?', shape: 'diamond', w: 120, h: 120, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Over multiple sessions, topics may become distinct. Split if so.' },
       { id: 'split-files', label: 'Split into files', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Split exploration.md into semantic files (market-landscape.md, technical-feasibility.md, etc).' },
-      { id: 'end', label: 'research/ output', shape: 'pill', w: 150, h: 40, color: 'var(--research)', bg: 'var(--research-bg)', desc: 'Output: docs/workflow/research/ files. Research never "concludes" — always open-ended.' },
+      { id: 'end', label: 'research/ output', shape: 'pill', w: 150, h: 40, color: 'var(--research)', bg: 'var(--research-bg)', desc: 'Output: .workflows/research/ files. Research never "concludes" — always open-ended.' },
       { id: 'next', label: 'Invoke /start-discussion', desc: 'Navigate to the discussion command to begin capturing architecture decisions from research output.', w: 200, h: 44, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'discussion' },
     ],
     connections: [
@@ -2006,7 +2006,7 @@ const FLOWCHARTS = {
   'skill-planning': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-planning skill receives specification and context.' },
-      { id: 'resume', label: 'Existing plan?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if plan index file exists at docs/workflow/planning/{topic}/plan.md.' },
+      { id: 'resume', label: 'Existing plan?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if plan index file exists at .workflows/planning/{topic}/plan.md.' },
       { id: 'resume-choice', label: 'Continue / Restart?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'User chooses: continue from previous position or restart (deletes existing plan).' },
       { id: 'init', label: 'Initialize plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Create plan index file. Choose output format.' },
       { id: 'load-existing', label: 'Load existing plan', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Continue: load existing plan and output format adapter.' },
@@ -2088,7 +2088,7 @@ const FLOWCHARTS = {
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-implementation skill receives plan, env info, and tracking state.' },
       { id: 'env-setup', label: '1. Environment setup', w: 195, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Run setup commands from environment-setup.md. Sequential, exactly as written.' },
       { id: 'read-plan', label: '2. Read plan + adapter', w: 195, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 2: Load plan, read format field, load output format adapters (reading, updating, authoring).' },
-      { id: 'init-track', label: '3. Init tracking file', w: 195, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 3: Create/resume docs/workflow/implementation/{topic}/tracking.md. Reset gate modes and cycles on fresh session.' },
+      { id: 'init-track', label: '3. Init tracking file', w: 195, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 3: Create/resume .workflows/implementation/{topic}/tracking.md. Reset gate modes and cycles on fresh session.' },
       { id: 'skills-disc', label: '4. Project skills', w: 195, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 4: Scan .claude/skills/ for project-specific conventions. ASK user which to pass to agents.' },
       { id: 'linter-disc', label: '5. Linter discovery', w: 195, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 5: Identify project linters via linter-setup.md. ASK user to approve/modify/skip. Store commands in tracking file.' },
       // Task loop (Step 6) — Stages A-E
@@ -2189,7 +2189,7 @@ const FLOWCHARTS = {
       { id: 'v2', label: 'Verify task 2', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'Same checks, different task. Batches of 5 run in parallel.' },
       { id: 'vn', label: 'Verify task N', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'One per task. All within a batch run simultaneously.' },
       { id: 'aggregate', label: 'Aggregate QA findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 3: Read all qa-task-*.md files. Collect blocking issues, test issues, and code quality concerns.' },
-      { id: 'produce', label: 'Produce review', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Aggregate QA findings into structured review document. Determine verdict (approve/changes/comments). Write to docs/workflow/review/.' },
+      { id: 'produce', label: 'Produce review', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Aggregate QA findings into structured review document. Determine verdict (approve/changes/comments). Write to .workflows/review/.' },
       // Review Actions Loop (Step 5)
       { id: 'verdict', label: 'Verdict?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 5A: Route on QA verdict — approve (terminal), request-changes (synthesize recommended), comments-only (synthesize optional).' },
       { id: 'ask-synth', label: 'ASK: Synthesize?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 5A: Ask user whether to synthesize findings into implementation tasks. Recommended for request-changes, optional for comments-only.' },
@@ -2259,7 +2259,7 @@ const FLOWCHARTS = {
   'view-plan': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /view-plan.' },
-      { id: 'gate-plans', label: 'Plans exist?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if any plan files exist in docs/workflow/planning/.' },
+      { id: 'gate-plans', label: 'Plans exist?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if any plan files exist in .workflows/planning/.' },
       { id: 'stop', label: 'STOP: No plans', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No plans found. Run /start-planning first.' },
       { id: 'count', label: 'Single plan?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if there is exactly one plan or multiple.' },
       { id: 'auto', label: 'Auto-select single', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Only one plan exists. Auto-select it.' },
@@ -2614,26 +2614,26 @@ const FLOWCHART_DESCS = {
     summary: 'Explore ideas, feasibility, and validate concepts across technical, business, and market domains.',
     body: `<p>The simplest command — no discovery script, no prerequisites, no cache. Gathers context through 4 sequential questions (seed idea, existing knowledge, starting direction, constraints) then hands off to the <strong>technical-research</strong> skill.</p>
 <p>The skill acts as a research partner, looping through <strong>Ask → Discuss → Document → Commit</strong>. Output starts as a single file and splits as themes emerge. Research never formally "concludes" — it feeds into discussion when ready.</p>`,
-    meta: { output: 'docs/workflow/research/', skill: 'technical-research', complexity: 'Simple' }
+    meta: { output: '.workflows/research/', skill: 'technical-research', complexity: 'Simple' }
   },
   discussion: {
     summary: 'Capture architecture decisions, debates, edge cases, and rationale through structured dialogue.',
     body: `<p>Moderate complexity. A discovery script scans research files, existing discussions, and cache, then classifies the scenario: <strong>fresh</strong>, <strong>research_only</strong>, <strong>discussions_only</strong>, or <strong>research_and_discussions</strong>.</p>
 <p>Research analysis is <strong>cache-aware</strong> — checksums detect stale analysis. The options menu adapts based on what exists (2–4 options). After user selection, context is gathered and the <strong>technical-discussion</strong> skill runs a loop: <strong>Engage → Capture decisions → Document → Commit</strong> until the discussion is concluded.</p>`,
-    meta: { output: 'docs/workflow/discussion/{topic}.md', skill: 'technical-discussion', discovery: 'discovery-for-discussion.sh', cache: 'research-analysis.md' }
+    meta: { output: '.workflows/discussion/{topic}.md', skill: 'technical-discussion', discovery: 'discovery-for-discussion.sh', cache: 'research-analysis.md' }
   },
   specification: {
     summary: 'Analyse discussion coupling, group into features, and build validated specifications.',
     body: `<p>Cache-first routing with progressive disclosure. Two prerequisite gates (discussions must exist and be concluded), then a priority chain: single discussion auto-selects, valid cache shows groupings directly, stale/none cache checks for existing specs before offering analysis.</p>
 <p>The <strong>analysis flow</strong> gathers context about topic relationships, reads all concluded discussions, analyses <strong>data, behavioural, and conceptual coupling</strong>, and caches the result. The <strong>groupings menu</strong> offers per-grouping actions (Start/Continue/Refine), Unify all, and Re-analyze. A separate <strong>specs menu</strong> appears when specs exist but cache is stale — showing existing specs alongside an analyze option.</p>
 <p>The <strong>technical-specification</strong> skill is collaborative — it extracts, filters hallucinations, enriches gaps, presents for approval, and waits for explicit sign-off before writing.</p>`,
-    meta: { output: 'docs/workflow/specification/{topic}/specification.md', skill: 'technical-specification', discovery: 'discovery.sh', cache: 'discussion-consolidation-analysis.md' }
+    meta: { output: '.workflows/specification/{topic}/specification.md', skill: 'technical-specification', discovery: 'discovery.sh', cache: 'discussion-consolidation-analysis.md' }
   },
   planning: {
     summary: 'Transform specifications into phased implementation plans with tasks and acceptance criteria.',
     body: `<p>Discovery classifies into 3 scenarios: <strong>no_specs</strong>, <strong>nothing_actionable</strong>, or <strong>has_options</strong>. After selection, a plan-state check routes new plans through context gathering and cross-cutting spec surfacing, while existing plans skip straight to the skill.</p>
 <p>The <strong>technical-planning</strong> skill runs a structured process with three nested loops. <strong>Plan construction</strong> is the core: the <strong>planning-phase-designer</strong> agent designs the phase structure (user approval gate with revision loop), then for each phase the <strong>planning-task-designer</strong> agent breaks it into tasks (approval gate), then for each task the <strong>planning-task-author</strong> agent writes full detail (approval gate, logged on approval). After construction, the <strong>planning-dependency-grapher</strong> agent analyzes the task graph for dependencies and cycles. Finally, a two-part <strong>plan review</strong> — traceability (spec↔plan completeness and anti-hallucination) then integrity (structural quality) — processes findings one at a time with per-finding approval gates.</p>`,
-    meta: { output: 'docs/workflow/planning/{topic}/plan.md', skill: 'technical-planning', discovery: 'discovery-for-planning.sh' }
+    meta: { output: '.workflows/planning/{topic}/plan.md', skill: 'technical-planning', discovery: 'discovery-for-planning.sh' }
   },
   implementation: {
     summary: 'Discover plans, classify readiness, gate on dependencies, and hand off to agent-based implementation.',
@@ -2651,7 +2651,7 @@ const FLOWCHART_DESCS = {
     summary: 'Pipeline entry — gather context, create discussion, then bridge to continue-feature.',
     body: `<p>Runs migrations, gathers feature context inline (what, scope, constraints), suggests a topic name, and checks for existing discussions. If a discussion exists, offers to <strong>resume</strong> (in-progress → invoke discussion, concluded → skip to bridge) or choose a <strong>new name</strong>.</p>
 <p>Invokes the <strong>technical-discussion</strong> skill with the gathered context. When the discussion concludes, a <strong>phase bridge</strong> enters plan mode with instructions to invoke <code>/continue-feature</code> in the next session for specification, planning, implementation, and review.</p>`,
-    meta: { output: 'docs/workflow/discussion/{topic}.md', skill: 'technical-discussion', complexity: 'Pipeline' }
+    meta: { output: '.workflows/discussion/{topic}.md', skill: 'technical-discussion', complexity: 'Pipeline' }
   },
   'link-deps': {
     summary: 'Wire up cross-topic dependencies across all plans with bidirectional linking.',
@@ -2663,19 +2663,19 @@ const FLOWCHART_DESCS = {
     summary: 'The research skill — an interactive exploration loop across technical, product, and market domains.',
     body: `<p>Acts as a research partner. Uses structured questioning from <code>references/interview.md</code> to guide exploration. The core loop: <strong>Ask → Discuss → Document → Commit → Repeat</strong>.</p>
 <p>Output starts as a single <code>exploration.md</code> file and splits into separate files as distinct themes emerge. Research is open-ended — there is no formal "conclusion" status. When enough insight has accumulated, the user moves to discussion.</p>`,
-    meta: { output: 'docs/workflow/research/', complexity: 'Looping skill' }
+    meta: { output: '.workflows/research/', complexity: 'Looping skill' }
   },
   'skill-discussion': {
     summary: 'The discussion skill — captures decisions, debates, and edge cases through structured dialogue.',
     body: `<p>Engages as an expert architect and meeting assistant. The core loop: <strong>Engage → Capture decisions → Write to disk → Commit → Repeat</strong> until the discussion is concluded. Writes happen at natural pauses — partial and provisional documentation is expected and valuable.</p>
 <p>Each question is structured as <strong>Options → Journey → Decision</strong>. The skill documents competing solutions and why choices were made, capturing the full reasoning trail. The file on disk is the defence against context compaction — what's not written is lost. Frontmatter status progresses from <code>in-progress</code> to <code>concluded</code>.</p>`,
-    meta: { output: 'docs/workflow/discussion/{topic}.md', complexity: 'Looping skill' }
+    meta: { output: '.workflows/discussion/{topic}.md', complexity: 'Looping skill' }
   },
   'skill-specification': {
     summary: 'The specification skill — collaborative refinement that filters hallucinations and enriches gaps.',
     body: `<p>Processes each topic through: <strong>Extract → Filter (validate against source) → Enrich (fill gaps) → Present → STOP &amp; WAIT for approval → Log</strong>. The skill is collaborative, not autonomous — it must wait for explicit user approval before writing anything.</p>
 <p>Self-check before every write: "Was this presented? Was it approved?" Final review includes source traceability and supersede handling for replaced specifications.</p>`,
-    meta: { output: 'docs/workflow/specification/{topic}/specification.md', complexity: 'Collaborative skill' }
+    meta: { output: '.workflows/specification/{topic}/specification.md', complexity: 'Collaborative skill' }
   },
   'skill-planning': {
     summary: 'The planning skill — three nested loops with agent-driven phase design, task design, and task authoring.',
@@ -2683,7 +2683,7 @@ const FLOWCHART_DESCS = {
 <p><strong>Plan construction</strong> is a three-level nested loop. Outer: invoke <strong>planning-phase-designer</strong> agent → user approval gate (revise backloop). Middle: for each phase, invoke <strong>planning-task-designer</strong> agent → approval gate. Inner: for each task, invoke <strong>planning-task-author</strong> agent → approval gate → log task + commit. Independent tasks may be authored in parallel. User can navigate to any position at any approval gate.</p>
 <p>Post-construction: <strong>planning-dependency-grapher</strong> agent analyzes the full task graph (dependencies, priorities, cycle detection) → approval gate. <strong>External dependencies</strong> are matched to tasks in other plans or left unresolved for <code>/link-dependencies</code>.</p>
 <p><strong>Plan review</strong> runs two sequential reviews. <strong>Traceability</strong>: spec→plan completeness + plan→spec fidelity (anti-hallucination gate). <strong>Integrity</strong>: standalone structural quality (templates, slicing, dependencies, self-containment, criteria quality). Both create tracking files and process findings one-at-a-time with per-finding approval gates (approve/skip/revise).</p>`,
-    meta: { output: 'docs/workflow/planning/{topic}/plan.md', complexity: 'Multi-loop skill', agents: 'phase-designer, task-designer, task-author, dependency-grapher' }
+    meta: { output: '.workflows/planning/{topic}/plan.md', complexity: 'Multi-loop skill', agents: 'phase-designer, task-designer, task-author, dependency-grapher' }
   },
   'skill-implementation': {
     summary: 'The implementation skill — agent-based TDD with per-task executor/reviewer, linting, and analysis cycle.',
@@ -2714,7 +2714,7 @@ const FLOWCHART_DESCS = {
   },
   'migrate': {
     summary: 'Migration orchestrator — keeps workflow files in sync with the current system design.',
-    body: `<p>Executes <code>skills/migrate/scripts/migrate.sh</code>, which runs all numbered scripts in <code>skills/migrate/scripts/migrations/</code> in order. Each migration is idempotent — safe to run multiple times. Progress is tracked in <code>docs/workflow/.state/migrations</code>.</p>
+    body: `<p>Executes <code>skills/migrate/scripts/migrate.sh</code>, which runs all numbered scripts in <code>skills/migrate/scripts/migrations/</code> in order. Each migration is idempotent — safe to run multiple times. Progress is tracked in <code>.workflows/.state/migrations</code>.</p>
 <p>Runs automatically as <strong>Step 0 of every workflow command</strong>. If files were updated, shows changes and waits for user review via git diff. Delete the log file to force re-running all migrations.</p>`,
     meta: { complexity: 'System' }
   },
@@ -2758,7 +2758,7 @@ const FLOWCHART_DESCS = {
   },
   'review-task-verifier': {
     summary: 'Verify a single task\'s implementation, tests, and code quality against the plan and spec.',
-    body: `<p>Dispatched <strong>in batches of 5</strong> by the technical-review skill during QA verification. Each verifier writes findings to <code>docs/workflow/review/{topic}/qa-task-{index}.md</code>.</p>
+    body: `<p>Dispatched <strong>in batches of 5</strong> by the technical-review skill during QA verification. Each verifier writes findings to <code>.workflows/review/{topic}/qa-task-{index}.md</code>.</p>
 <p>Three verification stages: <strong>implementation</strong> (exists, matches criteria, aligns with spec), <strong>tests</strong> (adequate coverage, edge cases, not over/under-tested), and <strong>code quality</strong> (conventions, SOLID, DRY, complexity, security, performance). Receives review checklist, topic name, and task index. Compiles a structured finding with blocking issues and non-blocking notes.</p>`,
     meta: { model: 'Opus', invokedBy: 'technical-review', complexity: 'Subagent' }
   },


### PR DESCRIPTION
## Summary

- Renames `docs/workflow/` → `.workflows/` to better communicate that these are planning artefacts, not documentation
- Adds migration 011 with backward-compatible rename for user projects (handles partial migration, updates gitignore, cleans up empty dirs)
- Updates all 114 affected files (784 occurrences) and fixes 10 non-migration test cleanup paths

## Test plan

- [x] All 883 tests pass across 22 test suites
- [x] Migration 011 tests cover: full migration, already-migrated, fresh install, gitignore update, partial migration, hidden dirs, idempotency
- [x] Zero remaining `docs/workflow` references outside migration scripts/tests
- [x] `allowed-tools` frontmatter paths verified updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)