### PR TITLE
docs: use tick remove for topic cleanup

### DIFF
--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -103,22 +103,10 @@ tick create "[NEEDS INFO] Rate limiting strategy" \
 
 ## Cleanup (Restart)
 
-Cancel the topic task and all its descendants. First, list the tasks to collect their IDs:
+Remove the topic task and all its descendants:
 
 ```bash
-tick list --parent <topic-id>
+tick remove <topic-id> --force
 ```
 
-Then cancel each task (leaf tasks first, then phases, then the topic):
-
-```bash
-tick cancel <task-id>
-```
-
-Cancelled tasks remain in the JSONL history but are excluded from `tick ready` and active listings.
-
-**Full reset** (removes all tasks across all topics):
-
-```bash
-rm -rf .tick && tick init
-```
+Removing a parent cascades to all children (phases and tasks). Dependency references to removed tasks are auto-cleaned from surviving tasks.


### PR DESCRIPTION
## Summary

- Replace multi-step cancel workflow with single `tick remove <topic-id> --force`
- Remove out-of-scope global reset (`rm -rf .tick && tick init`)
- Document cascade behavior for parent/children and dependency auto-cleanup

## Test plan

- [x] Verify markdown structure renders correctly
- [ ] Manual verification that `tick remove --force` works as documented

🤖 Generated with [Claude Code](https://claude.ai/code)