### PR TITLE
fix: handle superseded specs in discovery scripts

### DIFF
--- a/skills/start-planning/scripts/discovery.sh
+++ b/skills/start-planning/scripts/discovery.sh
@@ -63,6 +63,9 @@ if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
         # Skip cross-cutting specs in this pass
         [ "$spec_type" = "cross-cutting" ] && continue
 
+        # Skip superseded specs — they've been absorbed into another spec
+        [ "$status" = "superseded" ] && continue
+
         # Check if plan exists and its status
         has_plan="false"
         plan_status=""
@@ -133,6 +136,9 @@ if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
 
         status=$(extract_field "$file" "status")
         status=${status:-"active"}
+
+        # Skip superseded specs
+        [ "$status" = "superseded" ] && continue
 
         echo "    - name: \"$name\""
         echo "      status: \"$status\""

--- a/skills/workflow-bridge/scripts/discovery.sh
+++ b/skills/workflow-bridge/scripts/discovery.sh
@@ -212,6 +212,8 @@ if [ "$work_type" = "feature" ] || [ "$work_type" = "bugfix" ]; then
             next_phase="implementation"
         elif [ "$plan_exists" = "true" ]; then
             next_phase="planning"
+        elif [ "$spec_exists" = "true" ] && [ "$spec_status" = "superseded" ]; then
+            next_phase="superseded"
         elif [ "$spec_exists" = "true" ] && [ "$spec_status" = "concluded" ]; then
             next_phase="planning"
         elif [ "$spec_exists" = "true" ]; then
@@ -242,6 +244,8 @@ if [ "$work_type" = "feature" ] || [ "$work_type" = "bugfix" ]; then
             next_phase="implementation"
         elif [ "$plan_exists" = "true" ]; then
             next_phase="planning"
+        elif [ "$spec_exists" = "true" ] && [ "$spec_status" = "superseded" ]; then
+            next_phase="superseded"
         elif [ "$spec_exists" = "true" ] && [ "$spec_status" = "concluded" ]; then
             next_phase="planning"
         elif [ "$spec_exists" = "true" ]; then
@@ -351,6 +355,9 @@ elif [ "$work_type" = "greenfield" ]; then
             status=${status:-"in-progress"}
             spec_type=$(extract_field "$file" "type")
             spec_type=${spec_type:-"feature"}
+
+            # Skip superseded specs — they've been absorbed into another spec
+            [ "$status" = "superseded" ] && continue
 
             has_plan="false"
             [ -f "$PLAN_DIR/${name}/plan.md" ] && has_plan="true"

--- a/skills/workflow-start/references/work-type-selection.md
+++ b/skills/workflow-start/references/work-type-selection.md
@@ -62,7 +62,7 @@ Use values from `state.greenfield.*`, `state.feature_count`, `state.bugfix_count
 · · · · · · · · · · · ·
 What would you like to work on?
 
-1. **Build the product** — Greenfield development (phase-centric, multi-session)
+1. **Large initiative** — MVP, new build, or multi-spec work (phase-centric, multi-session)
 2. **Add a feature** — Feature work (topic-centric, linear pipeline)
 3. **Fix a bug** — Bugfix (investigation-centric, focused pipeline)
 · · · · · · · · · · · ·
@@ -74,7 +74,7 @@ What would you like to work on?
 
 Map the user's response to a work type:
 
-- "1", "build", "greenfield", "product" → work type is **greenfield**
+- "1", "large", "initiative", "build", "greenfield", "mvp" → work type is **greenfield**
 - "2", "feature", "add" → work type is **feature**
 - "3", "bug", "fix", "bugfix" → work type is **bugfix**
 

--- a/skills/workflow-start/scripts/discovery.sh
+++ b/skills/workflow-start/scripts/discovery.sh
@@ -130,6 +130,9 @@ if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
         # Only include greenfield specs
         [ "$work_type" = "greenfield" ] || continue
 
+        # Skip superseded specs — they've been absorbed into another spec
+        [ "$status" = "superseded" ] && continue
+
         if $first; then
             echo "    files:"
             first=false
@@ -269,6 +272,8 @@ if [ -d "$SPEC_DIR" ]; then
         [ -f "$file" ] || continue
         work_type=$(extract_field "$file" "work_type")
         if [ "$work_type" = "feature" ]; then
+            status=$(extract_field "$file" "status")
+            [ "$status" = "superseded" ] && continue
             name=$(basename "$(dirname "$file")")
             case ",$feature_seen_list," in
                 *,"$name",*) ;;
@@ -362,6 +367,8 @@ else
             next_phase="implementation"
         elif [ "$plan_exists" = "true" ]; then
             next_phase="planning"
+        elif [ "$spec_exists" = "true" ] && [ "$spec_status" = "superseded" ]; then
+            next_phase="superseded"
         elif [ "$spec_exists" = "true" ] && [ "$spec_status" = "concluded" ]; then
             next_phase="planning"
         elif [ "$spec_exists" = "true" ]; then
@@ -443,6 +450,8 @@ if [ -d "$SPEC_DIR" ]; then
         [ -f "$file" ] || continue
         work_type=$(extract_field "$file" "work_type")
         if [ "$work_type" = "bugfix" ]; then
+            status=$(extract_field "$file" "status")
+            [ "$status" = "superseded" ] && continue
             name=$(basename "$(dirname "$file")")
             case ",$bugfix_seen_list," in
                 *,"$name",*) ;;
@@ -536,6 +545,8 @@ else
             next_phase="implementation"
         elif [ "$plan_exists" = "true" ]; then
             next_phase="planning"
+        elif [ "$spec_exists" = "true" ] && [ "$spec_status" = "superseded" ]; then
+            next_phase="superseded"
         elif [ "$spec_exists" = "true" ] && [ "$spec_status" = "concluded" ]; then
             next_phase="planning"
         elif [ "$spec_exists" = "true" ]; then


### PR DESCRIPTION
## Summary

- Exclude superseded specifications from active counts in `workflow-start`, `workflow-bridge`, and `start-planning` discovery scripts — previously they inflated totals (e.g., showing "specs: 2, concluded: 1" when one was superseded)
- Add `next_phase="superseded"` handling in feature/bugfix pipeline routing to prevent dead specs being routed back to specification phase
- Rename greenfield menu label from "Build the product" to "Large initiative" — the phase-centric pipeline is equally useful for large multi-spec work on existing products, not just new builds

## Test plan

- [x] All 219 existing discovery tests pass (63 + 66 + 90)
- [x] Verified against real project (portal) — superseded `zw` spec now excluded, output shows `specifications: 1, concluded: 1`
- [ ] Smoke test `/workflow-start` on a project with superseded specs
- [ ] Verify keyword mapping: "large", "initiative", "mvp" all route to greenfield

🤖 Generated with [Claude Code](https://claude.com/claude-code)