### PR TITLE
fix: remove disable-model-invocation from start-* skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ hooks/
 
 Skills are organised in two tiers:
 
-**Entry-point skills** (`/start-*`, `/status`, `/migrate`, etc.) are user-invocable. They gather context from files, prompts, or inline input, then invoke a processing skill. They have `disable-model-invocation: true` in their frontmatter (except `/migrate`, which other skills invoke).
+**Entry-point skills** (`/start-*`, `/status`, `/migrate`, etc.) are user-invocable. They gather context from files, prompts, or inline input, then invoke a processing skill. Utility entry-points (`/status`, `/view-plan`, `/link-dependencies`, `/workflow-start`) have `disable-model-invocation: true`. Phase entry-points (`/start-*`) do not, since they are invoked by `workflow-start` routing and `workflow-bridge` continuations. `/migrate` has `user-invocable: false` — it is model-invoked only (Step 0 of every entry-point skill).
 
 **Processing skills** (`technical-*`) are model-invocable. They receive inputs and process them without knowing where the inputs came from. Entry-point skills are responsible for gathering inputs.
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: migrate
+user-invocable: false
 allowed-tools: Bash(.claude/skills/migrate/scripts/migrate.sh)
 ---
 

--- a/skills/start-bugfix/SKILL.md
+++ b/skills/start-bugfix/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-bugfix
-disable-model-invocation: true
 allowed-tools: Bash(ls .workflows/investigation/), Bash(.claude/hooks/workflows/write-session-state.sh)
 hooks:
   PreToolUse:

--- a/skills/start-discussion/SKILL.md
+++ b/skills/start-discussion/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-discussion
-disable-model-invocation: true
 allowed-tools: Bash(.claude/skills/start-discussion/scripts/discovery.sh), Bash(mkdir -p .workflows/.state), Bash(rm .workflows/.state/research-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh), Bash(ls .workflows/discussion/)
 hooks:
   PreToolUse:

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-feature
-disable-model-invocation: true
 allowed-tools: Bash(ls .workflows/discussion/), Bash(ls .workflows/research/), Bash(.claude/hooks/workflows/write-session-state.sh)
 hooks:
   PreToolUse:

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-implementation
-disable-model-invocation: true
 allowed-tools: Bash(.claude/skills/start-implementation/scripts/discovery.sh), Bash(.claude/hooks/workflows/write-session-state.sh), Bash(ls .workflows/planning/)
 hooks:
   PreToolUse:

--- a/skills/start-investigation/SKILL.md
+++ b/skills/start-investigation/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-investigation
-disable-model-invocation: true
 allowed-tools: Bash(.claude/skills/start-investigation/scripts/discovery.sh), Bash(.claude/hooks/workflows/write-session-state.sh), Bash(ls .workflows/investigation/)
 hooks:
   PreToolUse:

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-planning
-disable-model-invocation: true
 allowed-tools: Bash(.claude/skills/start-planning/scripts/discovery.sh), Bash(.claude/hooks/workflows/write-session-state.sh), Bash(ls .workflows/specification/)
 hooks:
   PreToolUse:

--- a/skills/start-research/SKILL.md
+++ b/skills/start-research/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-research
-disable-model-invocation: true
 allowed-tools: Bash(.claude/hooks/workflows/write-session-state.sh)
 hooks:
   PreToolUse:

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-review
-disable-model-invocation: true
 allowed-tools: Bash(.claude/skills/start-review/scripts/discovery.sh), Bash(.claude/hooks/workflows/write-session-state.sh), Bash(ls .workflows/planning/), Bash(ls .workflows/implementation/)
 hooks:
   PreToolUse:

--- a/skills/start-specification/SKILL.md
+++ b/skills/start-specification/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: start-specification
-disable-model-invocation: true
 allowed-tools: Bash(.claude/skills/start-specification/scripts/discovery.sh), Bash(mkdir -p .workflows/.state), Bash(rm .workflows/.state/discussion-consolidation-analysis.md), Bash(.claude/hooks/workflows/write-session-state.sh), Bash(ls .workflows/discussion/), Bash(ls .workflows/investigation/)
 hooks:
   PreToolUse:


### PR DESCRIPTION
## Summary

- Remove `disable-model-invocation: true` from all 9 `start-*` skills so `workflow-start` routing and `workflow-bridge` continuations can invoke them via the Skill tool
- Add `user-invocable: false` to `/migrate` (model-only, never user-invoked directly)
- Update CLAUDE.md skill architecture section to document the new invocation rules

## Test plan

- [ ] Run `/workflow-start`, select "Add a feature", confirm — should invoke `start-feature` without error
- [ ] Run `/workflow-start`, select "Fix a bug", confirm — should invoke `start-bugfix` without error
- [ ] Verify `/migrate` no longer appears as a user-invocable skill
- [ ] Verify `/status`, `/view-plan`, `/link-dependencies`, `/workflow-start` still have `disable-model-invocation: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)