### PR TITLE
fix: topic name prompt uses free-text for alt name

### DIFF
--- a/skills/start-bugfix/references/topic-name-check.md
+++ b/skills/start-bugfix/references/topic-name-check.md
@@ -21,7 +21,7 @@ This will create: .workflows/investigation/{suggested-topic}/investigation.md
 Is this name okay?
 
 - **`y`/`yes`** — Use this name
-- **`s`/`something else`** — Suggest a different name
+- **something else** — Suggest a different name
 · · · · · · · · · · · ·
 ```
 

--- a/skills/start-feature/references/topic-name-check.md
+++ b/skills/start-feature/references/topic-name-check.md
@@ -21,7 +21,7 @@ This will create: .workflows/discussion/{suggested-topic}.md
 Is this name okay?
 
 - **`y`/`yes`** — Use this name
-- **`s`/`something else`** — Suggest a different name
+- **something else** — Suggest a different name
 · · · · · · · · · · · ·
 ```
 

--- a/skills/start-investigation/references/gather-context-fresh.md
+++ b/skills/start-investigation/references/gather-context-fresh.md
@@ -36,7 +36,7 @@ This will create: .workflows/investigation/{suggested-topic}/investigation.md
 Is this name okay?
 
 - **`y`/`yes`** — Use this name
-- **`s`/`something else`** — Suggest a different name
+- **something else** — Suggest a different name
 · · · · · · · · · · · ·
 ```
 


### PR DESCRIPTION
## Summary

- Changed the "something else" option in topic name prompts from a command format (`s`/`something else`) to plain text (`something else`)
- Users now just type their preferred name directly instead of using a command prefix
- Updated across all three entry points: start-feature, start-bugfix, start-investigation

## Test plan

- [ ] Run `/start-feature` and verify the topic name prompt shows plain "something else" option
- [ ] Confirm typing `y`/`yes` still accepts the suggested name
- [ ] Confirm typing a custom name directly works as the alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)