### PR TITLE
feat: enrich workflow overview with topic trees and continue options

### DIFF
--- a/skills/workflow-start/references/bugfix-routing.md
+++ b/skills/workflow-start/references/bugfix-routing.md
@@ -51,25 +51,16 @@ Bugfixes
 {bugfix_count} bugfix(es) in progress:
 
 1. {topic:(titlecase)}
-   └─ Next: {next_phase}
+   └─ {phase_label:(titlecase)}
 
 2. ...
 ```
 
-Build tree from `bugfixes.topics` array. Each topic shows `name` (titlecased) and `next_phase`.
+Build tree from `bugfixes.topics` array. Each topic shows `name` (titlecased) and `phase_label` (titlecased).
 
 ## Build Menu Options
 
-Build a numbered menu with all in-progress bugfixes plus option to start new. The description maps `next_phase`:
-
-| next_phase | Description |
-|------------|-------------|
-| investigation | investigation in-progress |
-| specification | ready for specification |
-| planning | ready for planning |
-| implementation | ready for implementation |
-| review | ready for review |
-| done | pipeline complete |
+Build a numbered menu with all in-progress bugfixes plus option to start new. Use `phase_label` from discovery for the description.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -77,7 +68,7 @@ Build a numbered menu with all in-progress bugfixes plus option to start new. Th
 · · · · · · · · · · · ·
 What would you like to do?
 
-1. Continue "Login Timeout" — investigation in-progress
+1. Continue "Login Timeout" — investigation (in-progress)
 2. Continue "Memory Leak" — ready for specification
 3. Continue "Race Condition" — ready for planning
 4. Start new bugfix
@@ -86,7 +77,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual topics and states from discovery.
+Recreate with actual topics and `phase_label` values from discovery.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-start/references/feature-routing.md
+++ b/skills/workflow-start/references/feature-routing.md
@@ -51,25 +51,16 @@ Features
 {feature_count} feature(s) in progress:
 
 1. {topic:(titlecase)}
-   └─ Next: {next_phase}
+   └─ {phase_label:(titlecase)}
 
 2. ...
 ```
 
-Build tree from `features.topics` array. Each topic shows `name` (titlecased) and `next_phase`.
+Build tree from `features.topics` array. Each topic shows `name` (titlecased) and `phase_label` (titlecased).
 
 ## Build Menu Options
 
-Build a numbered menu with all in-progress features plus option to start new. The description maps `next_phase`:
-
-| next_phase | Description |
-|------------|-------------|
-| discussion | discussion in-progress |
-| specification | ready for specification |
-| planning | ready for planning |
-| implementation | ready for implementation |
-| review | ready for review |
-| done | pipeline complete |
+Build a numbered menu with all in-progress features plus option to start new. Use `phase_label` from discovery for the description.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -77,7 +68,7 @@ Build a numbered menu with all in-progress features plus option to start new. Th
 · · · · · · · · · · · ·
 What would you like to do?
 
-1. Continue "Auth Flow" — discussion in-progress
+1. Continue "Auth Flow" — discussion (in-progress)
 2. Continue "Caching" — ready for specification
 3. Continue "Notifications" — ready for planning
 4. Start new feature
@@ -86,7 +77,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual topics and states from discovery.
+Recreate with actual topics and `phase_label` values from discovery.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-start/scripts/discovery.sh
+++ b/skills/workflow-start/scripts/discovery.sh
@@ -381,8 +381,50 @@ else
             next_phase="unknown"
         fi
 
+        # Compute phase_label
+        phase_label=""
+        case "$next_phase" in
+            discussion)
+                phase_label="discussion (in-progress)"
+                ;;
+            specification)
+                if [ "$spec_exists" = "true" ]; then
+                    phase_label="specification (in-progress)"
+                else
+                    phase_label="ready for specification"
+                fi
+                ;;
+            planning)
+                if [ "$plan_exists" = "true" ]; then
+                    phase_label="planning (in-progress)"
+                else
+                    phase_label="ready for planning"
+                fi
+                ;;
+            implementation)
+                if [ "$impl_exists" = "true" ]; then
+                    phase_label="implementation (in-progress)"
+                else
+                    phase_label="ready for implementation"
+                fi
+                ;;
+            review)
+                phase_label="ready for review"
+                ;;
+            done)
+                phase_label="pipeline complete"
+                ;;
+            superseded)
+                phase_label="superseded"
+                ;;
+            *)
+                phase_label="unknown"
+                ;;
+        esac
+
         echo "    - name: \"$topic\""
         echo "      next_phase: \"$next_phase\""
+        echo "      phase_label: \"$phase_label\""
         echo "      discussion:"
         echo "        exists: $disc_exists"
         [ "$disc_exists" = "true" ] && echo "        status: \"$disc_status\""
@@ -559,8 +601,50 @@ else
             next_phase="unknown"
         fi
 
+        # Compute phase_label
+        phase_label=""
+        case "$next_phase" in
+            investigation)
+                phase_label="investigation (in-progress)"
+                ;;
+            specification)
+                if [ "$spec_exists" = "true" ]; then
+                    phase_label="specification (in-progress)"
+                else
+                    phase_label="ready for specification"
+                fi
+                ;;
+            planning)
+                if [ "$plan_exists" = "true" ]; then
+                    phase_label="planning (in-progress)"
+                else
+                    phase_label="ready for planning"
+                fi
+                ;;
+            implementation)
+                if [ "$impl_exists" = "true" ]; then
+                    phase_label="implementation (in-progress)"
+                else
+                    phase_label="ready for implementation"
+                fi
+                ;;
+            review)
+                phase_label="ready for review"
+                ;;
+            done)
+                phase_label="pipeline complete"
+                ;;
+            superseded)
+                phase_label="superseded"
+                ;;
+            *)
+                phase_label="unknown"
+                ;;
+        esac
+
         echo "    - name: \"$topic\""
         echo "      next_phase: \"$next_phase\""
+        echo "      phase_label: \"$phase_label\""
         echo "      investigation:"
         echo "        exists: $inv_exists"
         [ "$inv_exists" = "true" ] && echo "        status: \"$inv_status\""

--- a/tests/scripts/test-discovery-for-start.sh
+++ b/tests/scripts/test-discovery-for-start.sh
@@ -294,6 +294,7 @@ EOF
     assert_contains "$output" 'feature_count: 1' "Feature count is 1"
     assert_contains "$output" 'name: "auth-flow"' "Found auth-flow topic"
     assert_contains "$output" 'next_phase: "specification"' "Next phase is specification"
+    assert_contains "$output" 'phase_label: "ready for specification"' "Phase label is ready for specification"
     echo ""
 }
 
@@ -331,6 +332,7 @@ EOF
 
     assert_contains "$output" 'feature_count: 1' "Feature count is 1 (deduplicated)"
     assert_contains "$output" 'next_phase: "planning"' "Next phase is planning (plan in-progress)"
+    assert_contains "$output" 'phase_label: "planning (in-progress)"' "Phase label is planning (in-progress)"
     echo ""
 }
 
@@ -359,6 +361,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'feature_count: 1' "Only one feature topic (deduplicated)"
+    assert_contains "$output" 'phase_label: "specification (in-progress)"' "Phase label is specification (in-progress)"
     echo ""
 }
 
@@ -471,6 +474,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "discussion"' "Next phase is discussion"
+    assert_contains "$output" 'phase_label: "discussion (in-progress)"' "Phase label is discussion (in-progress)"
     echo ""
 }
 
@@ -507,6 +511,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "implementation"' "Next phase is implementation"
+    assert_contains "$output" 'phase_label: "ready for implementation"' "Phase label is ready for implementation"
     echo ""
 }
 
@@ -551,6 +556,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "review"' "Next phase is review"
+    assert_contains "$output" 'phase_label: "ready for review"' "Phase label is ready for review"
     echo ""
 }
 
@@ -601,6 +607,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "done"' "Next phase is done"
+    assert_contains "$output" 'phase_label: "pipeline complete"' "Phase label is pipeline complete (feature)"
     echo ""
 }
 
@@ -651,6 +658,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "superseded"' "Next phase is superseded"
+    assert_contains "$output" 'phase_label: "superseded"' "Phase label is superseded (feature)"
     echo ""
 }
 
@@ -679,6 +687,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "planning"' "Next phase is planning"
+    assert_contains "$output" 'phase_label: "ready for planning"' "Phase label is ready for planning"
     echo ""
 }
 
@@ -704,6 +713,7 @@ EOF
     assert_contains "$output" 'bugfix_count: 1' "Bugfix count is 1"
     assert_contains "$output" 'name: "login-crash"' "Found login-crash bugfix"
     assert_contains "$output" 'next_phase: "investigation"' "Next phase is investigation"
+    assert_contains "$output" 'phase_label: "investigation (in-progress)"' "Phase label is investigation (in-progress)"
     echo ""
 }
 
@@ -723,6 +733,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "specification"' "Next phase is specification"
+    assert_contains "$output" 'phase_label: "ready for specification"' "Phase label is ready for specification (bugfix)"
     echo ""
 }
 
@@ -773,6 +784,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "done"' "Next phase is done"
+    assert_contains "$output" 'phase_label: "pipeline complete"' "Phase label is pipeline complete (bugfix)"
     echo ""
 }
 
@@ -823,6 +835,7 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'next_phase: "superseded"' "Next phase is superseded"
+    assert_contains "$output" 'phase_label: "superseded"' "Phase label is superseded (bugfix)"
     echo ""
 }
 
@@ -843,6 +856,7 @@ EOF
 
     assert_contains "$output" 'bugfix_count: 1' "Bugfix count is 1"
     assert_contains "$output" 'name: "null-pointer"' "Found null-pointer bugfix"
+    assert_contains "$output" 'phase_label: "unknown"' "Phase label is unknown (bugfix from discussion only)"
     echo ""
 }
 
@@ -863,6 +877,7 @@ EOF
 
     assert_contains "$output" 'bugfix_count: 1' "Bugfix count is 1"
     assert_contains "$output" 'name: "null-pointer"' "Found null-pointer bugfix"
+    assert_contains "$output" 'phase_label: "specification (in-progress)"' "Phase label is specification (in-progress)"
     echo ""
 }
 
@@ -899,6 +914,212 @@ EOF
     local output=$(run_discovery)
 
     assert_contains "$output" 'bugfix_count: 1' "Only one bugfix topic (deduplicated)"
+    assert_contains "$output" 'phase_label: "planning (in-progress)"' "Phase label is planning (in-progress) for bugfix"
+    echo ""
+}
+
+# ──────────────────────────────────────
+# Phase label disambiguation
+# ──────────────────────────────────────
+
+test_feature_phase_label_impl_in_progress() {
+    echo -e "${YELLOW}Test: Feature impl in-progress → phase_label implementation (in-progress)${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/.workflows/discussion"
+    mkdir -p "$TEST_DIR/.workflows/specification/search"
+    mkdir -p "$TEST_DIR/.workflows/planning/search"
+    mkdir -p "$TEST_DIR/.workflows/implementation/search"
+
+    cat > "$TEST_DIR/.workflows/discussion/search.md" << 'EOF'
+---
+topic: search
+status: concluded
+work_type: feature
+---
+EOF
+    cat > "$TEST_DIR/.workflows/specification/search/specification.md" << 'EOF'
+---
+topic: search
+status: concluded
+work_type: feature
+---
+EOF
+    cat > "$TEST_DIR/.workflows/planning/search/plan.md" << 'EOF'
+---
+topic: search
+status: concluded
+work_type: feature
+---
+EOF
+    cat > "$TEST_DIR/.workflows/implementation/search/tracking.md" << 'EOF'
+---
+topic: search
+status: in-progress
+work_type: feature
+---
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'next_phase: "implementation"' "Next phase is implementation"
+    assert_contains "$output" 'phase_label: "implementation (in-progress)"' "Phase label is implementation (in-progress)"
+    echo ""
+}
+
+test_bugfix_phase_label_impl_in_progress() {
+    echo -e "${YELLOW}Test: Bugfix impl in-progress → phase_label implementation (in-progress)${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/.workflows/investigation/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/specification/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/planning/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/implementation/login-crash"
+
+    cat > "$TEST_DIR/.workflows/investigation/login-crash/investigation.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/specification/login-crash/specification.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/planning/login-crash/plan.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/implementation/login-crash/tracking.md" << 'EOF'
+---
+topic: login-crash
+status: in-progress
+work_type: bugfix
+---
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'next_phase: "implementation"' "Next phase is implementation"
+    assert_contains "$output" 'phase_label: "implementation (in-progress)"' "Phase label is implementation (in-progress) for bugfix"
+    echo ""
+}
+
+test_bugfix_phase_label_ready_for_planning() {
+    echo -e "${YELLOW}Test: Bugfix spec concluded, no plan → phase_label ready for planning${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/.workflows/investigation/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/specification/login-crash"
+
+    cat > "$TEST_DIR/.workflows/investigation/login-crash/investigation.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/specification/login-crash/specification.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'next_phase: "planning"' "Next phase is planning"
+    assert_contains "$output" 'phase_label: "ready for planning"' "Phase label is ready for planning (bugfix)"
+    echo ""
+}
+
+test_bugfix_phase_label_ready_for_impl() {
+    echo -e "${YELLOW}Test: Bugfix plan concluded → phase_label ready for implementation${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/.workflows/investigation/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/specification/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/planning/login-crash"
+
+    cat > "$TEST_DIR/.workflows/investigation/login-crash/investigation.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/specification/login-crash/specification.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/planning/login-crash/plan.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'next_phase: "implementation"' "Next phase is implementation"
+    assert_contains "$output" 'phase_label: "ready for implementation"' "Phase label is ready for implementation (bugfix)"
+    echo ""
+}
+
+test_bugfix_phase_label_ready_for_review() {
+    echo -e "${YELLOW}Test: Bugfix impl completed → phase_label ready for review${NC}"
+    setup_fixture
+
+    mkdir -p "$TEST_DIR/.workflows/investigation/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/specification/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/planning/login-crash"
+    mkdir -p "$TEST_DIR/.workflows/implementation/login-crash"
+
+    cat > "$TEST_DIR/.workflows/investigation/login-crash/investigation.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/specification/login-crash/specification.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/planning/login-crash/plan.md" << 'EOF'
+---
+topic: login-crash
+status: concluded
+work_type: bugfix
+---
+EOF
+    cat > "$TEST_DIR/.workflows/implementation/login-crash/tracking.md" << 'EOF'
+---
+topic: login-crash
+status: completed
+work_type: bugfix
+---
+EOF
+
+    local output=$(run_discovery)
+
+    assert_contains "$output" 'next_phase: "review"' "Next phase is review"
+    assert_contains "$output" 'phase_label: "ready for review"' "Phase label is ready for review (bugfix)"
     echo ""
 }
 
@@ -1045,6 +1266,13 @@ test_bugfix_next_phase_superseded
 test_bugfix_from_discussion
 test_bugfix_from_spec
 test_bugfix_deduplication_across_phases
+
+# Phase label disambiguation
+test_feature_phase_label_impl_in_progress
+test_bugfix_phase_label_impl_in_progress
+test_bugfix_phase_label_ready_for_planning
+test_bugfix_phase_label_ready_for_impl
+test_bugfix_phase_label_ready_for_review
 
 # Mixed
 test_mixed_work_types


### PR DESCRIPTION
## Summary

- Add `phase_label` to discovery output for features/bugfixes, replacing flat counts (`Features: 1 in progress`) with per-topic trees showing current phase status (e.g., `discussion (in-progress)`, `ready for specification`)
- Surface continue options directly in the main workflow-start menu so users can resume in-progress work without drilling through sub-menus
- Fix misleading "Next: discussion" labels in feature/bugfix routing — now uses `phase_label` which distinguishes between active work and readiness for next phase

## Test plan

- [x] All 96 discovery tests pass (26 new `phase_label` assertions added)
- [x] Script syntax validated (`bash -n`)
- [x] Verified `phase_label` output against mock project with mixed feature/bugfix states
- [ ] Manual: run `/workflow-start` in a project with in-progress features to confirm rich tree display
- [ ] Manual: select a continue option from the main menu to verify direct skill routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)