### PR TITLE
refactor: make workflow-bridge discovery argument-free for dynamic insertion

### DIFF
--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -71,8 +71,8 @@ Load **[greenfield-continuation.md](references/greenfield-continuation.md)** and
 
 **Feature/bugfix** continuation references:
 1. Use discovery output to compute a single `next_phase`
-2. Enter plan mode with instructions to invoke `start-{next_phase}` with topic + work_type
-3. Exit plan mode for user approval
+2. Call `EnterPlanMode` tool, write plan file with instructions to invoke `start-{next_phase}` with topic + work_type
+3. Call `ExitPlanMode` tool for user approval
 
 The user will then clear context, and the fresh session will invoke the appropriate start-* skill with the topic and work_type provided, causing it to skip discovery and proceed directly to validation/processing.
 

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -21,30 +21,27 @@ This skill receives context from the calling processing skill:
 
 ## Step 1: Run Discovery
 
-Determine the next phase by running discovery.
+!`.claude/skills/workflow-bridge/scripts/discovery.sh`
+
+If the above shows a script invocation rather than YAML output, the dynamic content preprocessor did not run. Execute the script before continuing:
+
+```bash
+.claude/skills/workflow-bridge/scripts/discovery.sh
+```
+
+The output contains three sections: `features:`, `bugfixes:`, and `greenfield:`. Use the known work type and topic from the calling context to extract the relevant data:
 
 #### If work type is "feature"
 
-```bash
-.claude/skills/workflow-bridge/scripts/discovery.sh --feature --topic "{topic}"
-```
+Find the topic entry under `features: > topics:` and extract its `next_phase`.
 
 #### If work type is "bugfix"
 
-```bash
-.claude/skills/workflow-bridge/scripts/discovery.sh --bugfix --topic "{topic}"
-```
-
-Parse the output to extract:
-- `next_phase`: The computed next phase for this topic
+Find the topic entry under `bugfixes: > topics:` and extract its `next_phase`.
 
 #### If work type is "greenfield"
 
-```bash
-.claude/skills/workflow-bridge/scripts/discovery.sh --greenfield
-```
-
-Parse the output to extract:
+Parse the `greenfield:` section for phase-centric state:
 - `state`: Counts of artifacts across all phases
 - Phase-specific file lists with their statuses
 

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -37,7 +37,7 @@ Bugfix Complete
 
 #### Otherwise
 
-Enter plan mode with the following content:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
 
 ```
 # Continue Bugfix: {topic}
@@ -56,4 +56,4 @@ The skill will skip discovery and proceed directly to validation.
 Clear context and continue.
 ```
 
-Exit plan mode. The user will approve and clear context.
+Call the `ExitPlanMode` tool to present the plan to the user for approval. The user will then clear context and continue.

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -38,7 +38,7 @@ Feature Complete
 
 #### Otherwise
 
-Enter plan mode with the following content:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
 
 ```
 # Continue Feature: {topic}
@@ -57,4 +57,4 @@ The skill will skip discovery and proceed directly to validation.
 Clear context and continue.
 ```
 
-Exit plan mode. The user will approve and clear context.
+Call the `ExitPlanMode` tool to present the plan to the user for approval. The user will then clear context and continue.

--- a/skills/workflow-bridge/references/greenfield-continuation.md
+++ b/skills/workflow-bridge/references/greenfield-continuation.md
@@ -181,7 +181,7 @@ Skills receive positional arguments: `$0` = work_type, `$1` = topic.
 
 #### If topic is present
 
-Enter plan mode with the following content:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
 
 ```
 # Continue Greenfield: {selected_phase:(titlecase)}
@@ -202,7 +202,7 @@ Clear context and continue.
 
 #### If topic is absent
 
-Enter plan mode with the following content:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
 
 ```
 # Continue Greenfield: {selected_phase:(titlecase)}
@@ -221,4 +221,4 @@ The skill will run discovery with greenfield context.
 Clear context and continue.
 ```
 
-Exit plan mode. The user will approve and clear context.
+Call the `ExitPlanMode` tool to present the plan to the user for approval. The user will then clear context and continue.

--- a/skills/workflow-bridge/scripts/discovery.sh
+++ b/skills/workflow-bridge/scripts/discovery.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 #
-# Topic-specific discovery script for /workflow-bridge.
+# Unified discovery script for /workflow-bridge.
 #
-# Usage:
-#   discovery.sh --feature --topic <topic>
-#   discovery.sh --bugfix --topic <topic>
-#   discovery.sh --greenfield
-#
-# For feature/bugfix: Checks artifacts for a specific topic and computes next_phase.
-# For greenfield: Does full phase-centric discovery across all phases.
+# No arguments — scans all workflow directories and outputs:
+# - features: per-topic state with computed next_phase
+# - bugfixes: per-topic state with computed next_phase
+# - greenfield: phase-centric view across all phases
+# - state: summary counts
 #
 # Outputs structured YAML that the skill can consume directly.
+# The skill filters by its known work_type and topic from calling context.
 #
 
 set -eo pipefail
@@ -39,169 +38,164 @@ extract_field() {
     echo "$value"
 }
 
-#
-# Parse arguments
-#
-topic=""
-work_type=""
-
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --topic)
-            topic="$2"
-            shift 2
-            ;;
-        --greenfield)
-            work_type="greenfield"
-            shift
-            ;;
-        --feature)
-            work_type="feature"
-            shift
-            ;;
-        --bugfix)
-            work_type="bugfix"
-            shift
-            ;;
-        *)
-            echo "error: \"Unknown argument: $1\""
-            echo "error: \"Usage: discovery.sh --feature|--bugfix --topic <topic> OR discovery.sh --greenfield\""
-            exit 1
-            ;;
-    esac
-done
-
-if [ -z "$work_type" ]; then
-    echo "error: \"Work type flag required: --greenfield, --feature, or --bugfix\""
-    exit 1
-fi
-
-if [ "$work_type" != "greenfield" ] && [ -z "$topic" ]; then
-    echo "error: \"--topic is required for --feature and --bugfix\""
-    exit 1
-fi
+# Helper: Check if a review exists for a topic
+# Usage: has_review <topic>
+has_review() {
+    local topic_name="$1"
+    if [ -d "$REVIEW_DIR/${topic_name}" ]; then
+        for rdir in "$REVIEW_DIR/${topic_name}"/r*/; do
+            [ -d "$rdir" ] || continue
+            [ -f "${rdir}review.md" ] && echo "true" && return
+        done
+    fi
+    echo "false"
+}
 
 # Start YAML output
 echo "# Workflow Bridge Discovery"
 echo "# Generated: $(date -Iseconds)"
 echo ""
-echo "work_type: \"$work_type\""
-echo "topic: \"$topic\""
-echo ""
 
 #
-# TOPIC-SPECIFIC DISCOVERY (feature/bugfix)
+# FEATURES SECTION (topic-centric view for work_type: feature)
 #
-if [ "$work_type" = "feature" ] || [ "$work_type" = "bugfix" ]; then
-    echo "topic_state:"
+echo "features:"
 
-    # Research state (feature only)
-    research_exists="false"
-    research_status=""
-    if [ "$work_type" = "feature" ]; then
+feature_topics=()
+feature_seen_list=""
+
+# Scan all phases for work_type: feature
+if [ -d "$DISCUSSION_DIR" ]; then
+    for file in "$DISCUSSION_DIR"/*.md; do
+        [ -f "$file" ] || continue
+        work_type=$(extract_field "$file" "work_type")
+        if [ "$work_type" = "feature" ]; then
+            name=$(basename "$file" .md)
+            case ",$feature_seen_list," in
+                *,"$name",*) ;;
+                *)
+                    feature_topics+=("$name")
+                    feature_seen_list="${feature_seen_list:+$feature_seen_list,}$name"
+                    ;;
+            esac
+        fi
+    done
+fi
+
+if [ -d "$RESEARCH_DIR" ]; then
+    for file in "$RESEARCH_DIR"/*.md; do
+        [ -f "$file" ] || continue
+        work_type=$(extract_field "$file" "work_type")
+        if [ "$work_type" = "feature" ]; then
+            name=$(basename "$file" .md)
+            case ",$feature_seen_list," in
+                *,"$name",*) ;;
+                *)
+                    feature_topics+=("$name")
+                    feature_seen_list="${feature_seen_list:+$feature_seen_list,}$name"
+                    ;;
+            esac
+        fi
+    done
+fi
+
+if [ -d "$SPEC_DIR" ]; then
+    for file in "$SPEC_DIR"/*/specification.md; do
+        [ -f "$file" ] || continue
+        work_type=$(extract_field "$file" "work_type")
+        if [ "$work_type" = "feature" ]; then
+            status=$(extract_field "$file" "status")
+            [ "$status" = "superseded" ] && continue
+            name=$(basename "$(dirname "$file")")
+            case ",$feature_seen_list," in
+                *,"$name",*) ;;
+                *)
+                    feature_topics+=("$name")
+                    feature_seen_list="${feature_seen_list:+$feature_seen_list,}$name"
+                    ;;
+            esac
+        fi
+    done
+fi
+
+if [ -d "$PLAN_DIR" ]; then
+    for file in "$PLAN_DIR"/*/plan.md; do
+        [ -f "$file" ] || continue
+        work_type=$(extract_field "$file" "work_type")
+        if [ "$work_type" = "feature" ]; then
+            name=$(basename "$(dirname "$file")")
+            case ",$feature_seen_list," in
+                *,"$name",*) ;;
+                *)
+                    feature_topics+=("$name")
+                    feature_seen_list="${feature_seen_list:+$feature_seen_list,}$name"
+                    ;;
+            esac
+        fi
+    done
+fi
+
+feature_count=${#feature_topics[@]}
+
+if [ "$feature_count" -eq 0 ]; then
+    echo "  topics: []"
+else
+    echo "  topics:"
+    for topic in "${feature_topics[@]}"; do
+        # Research state
+        research_exists="false"
         research_file="$RESEARCH_DIR/${topic}.md"
         if [ -f "$research_file" ]; then
-            file_work_type=$(extract_field "$research_file" "work_type")
-            if [ "$file_work_type" = "feature" ]; then
-                research_exists="true"
-                research_status=$(extract_field "$research_file" "status")
-                research_status=${research_status:-"in-progress"}
-            fi
+            file_wt=$(extract_field "$research_file" "work_type")
+            [ "$file_wt" = "feature" ] && research_exists="true"
         fi
-    fi
-    echo "  research:"
-    echo "    exists: $research_exists"
-    [ "$research_exists" = "true" ] && echo "    status: \"$research_status\""
 
-    # Discussion state (feature only)
-    discussion_exists="false"
-    discussion_status=""
-    if [ "$work_type" = "feature" ]; then
-        discussion_file="$DISCUSSION_DIR/${topic}.md"
-        if [ -f "$discussion_file" ]; then
-            discussion_exists="true"
-            discussion_status=$(extract_field "$discussion_file" "status")
-            discussion_status=${discussion_status:-"in-progress"}
+        # Discussion state
+        disc_exists="false"
+        disc_status=""
+        disc_file="$DISCUSSION_DIR/${topic}.md"
+        if [ -f "$disc_file" ]; then
+            disc_exists="true"
+            disc_status=$(extract_field "$disc_file" "status")
+            disc_status=${disc_status:-"in-progress"}
         fi
-    fi
-    echo "  discussion:"
-    echo "    exists: $discussion_exists"
-    [ "$discussion_exists" = "true" ] && echo "    status: \"$discussion_status\""
 
-    # Investigation state (bugfix only)
-    investigation_exists="false"
-    investigation_status=""
-    if [ "$work_type" = "bugfix" ]; then
-        investigation_file="$INVESTIGATION_DIR/${topic}/investigation.md"
-        if [ -f "$investigation_file" ]; then
-            investigation_exists="true"
-            investigation_status=$(extract_field "$investigation_file" "status")
-            investigation_status=${investigation_status:-"in-progress"}
+        # Specification state
+        spec_exists="false"
+        spec_status=""
+        spec_file="$SPEC_DIR/${topic}/specification.md"
+        if [ -f "$spec_file" ]; then
+            spec_exists="true"
+            spec_status=$(extract_field "$spec_file" "status")
+            spec_status=${spec_status:-"in-progress"}
         fi
-    fi
-    echo "  investigation:"
-    echo "    exists: $investigation_exists"
-    [ "$investigation_exists" = "true" ] && echo "    status: \"$investigation_status\""
 
-    # Specification state
-    spec_exists="false"
-    spec_status=""
-    spec_file="$SPEC_DIR/${topic}/specification.md"
-    if [ -f "$spec_file" ]; then
-        spec_exists="true"
-        spec_status=$(extract_field "$spec_file" "status")
-        spec_status=${spec_status:-"in-progress"}
-    fi
-    echo "  specification:"
-    echo "    exists: $spec_exists"
-    [ "$spec_exists" = "true" ] && echo "    status: \"$spec_status\""
+        # Plan state
+        plan_exists="false"
+        plan_status=""
+        plan_file="$PLAN_DIR/${topic}/plan.md"
+        if [ -f "$plan_file" ]; then
+            plan_exists="true"
+            plan_status=$(extract_field "$plan_file" "status")
+            plan_status=${plan_status:-"in-progress"}
+        fi
 
-    # Plan state
-    plan_exists="false"
-    plan_status=""
-    plan_file="$PLAN_DIR/${topic}/plan.md"
-    if [ -f "$plan_file" ]; then
-        plan_exists="true"
-        plan_status=$(extract_field "$plan_file" "status")
-        plan_status=${plan_status:-"in-progress"}
-    fi
-    echo "  plan:"
-    echo "    exists: $plan_exists"
-    [ "$plan_exists" = "true" ] && echo "    status: \"$plan_status\""
+        # Implementation state
+        impl_exists="false"
+        impl_status=""
+        impl_file="$IMPL_DIR/${topic}/tracking.md"
+        if [ -f "$impl_file" ]; then
+            impl_exists="true"
+            impl_status=$(extract_field "$impl_file" "status")
+            impl_status=${impl_status:-"in-progress"}
+        fi
 
-    # Implementation state
-    impl_exists="false"
-    impl_status=""
-    impl_file="$IMPL_DIR/${topic}/tracking.md"
-    if [ -f "$impl_file" ]; then
-        impl_exists="true"
-        impl_status=$(extract_field "$impl_file" "status")
-        impl_status=${impl_status:-"in-progress"}
-    fi
-    echo "  implementation:"
-    echo "    exists: $impl_exists"
-    [ "$impl_exists" = "true" ] && echo "    status: \"$impl_status\""
+        # Review state
+        review_exists=$(has_review "$topic")
 
-    # Review state
-    review_exists="false"
-    if [ -d "$REVIEW_DIR/${topic}" ]; then
-        for rdir in "$REVIEW_DIR/${topic}"/r*/; do
-            [ -d "$rdir" ] || continue
-            [ -f "${rdir}review.md" ] || continue
-            review_exists="true"
-            break
-        done
-    fi
-    echo "  review:"
-    echo "    exists: $review_exists"
-
-    echo ""
-
-    #
-    # Compute next_phase for feature pipeline
-    # (Research) → Discussion → Specification → Planning → Implementation → Review
-    #
-    if [ "$work_type" = "feature" ]; then
+        # Compute next_phase for feature pipeline
+        # (Research) → Discussion → Specification → Planning → Implementation → Review
+        next_phase=""
         if [ "$impl_exists" = "true" ] && [ "$impl_status" = "completed" ] && [ "$review_exists" = "true" ]; then
             next_phase="done"
         elif [ "$impl_exists" = "true" ] && [ "$impl_status" = "completed" ]; then
@@ -218,22 +212,154 @@ if [ "$work_type" = "feature" ] || [ "$work_type" = "bugfix" ]; then
             next_phase="planning"
         elif [ "$spec_exists" = "true" ]; then
             next_phase="specification"
-        elif [ "$discussion_exists" = "true" ] && [ "$discussion_status" = "concluded" ]; then
+        elif [ "$disc_exists" = "true" ] && [ "$disc_status" = "concluded" ]; then
             next_phase="specification"
-        elif [ "$discussion_exists" = "true" ]; then
+        elif [ "$disc_exists" = "true" ]; then
             next_phase="discussion"
         elif [ "$research_exists" = "true" ]; then
             next_phase="discussion"
         else
             next_phase="unknown"
         fi
-    fi
 
-    #
-    # Compute next_phase for bugfix pipeline
-    # Investigation → Specification → Planning → Implementation → Review
-    #
-    if [ "$work_type" = "bugfix" ]; then
+        echo "    - name: \"$topic\""
+        echo "      next_phase: \"$next_phase\""
+        echo "      research:"
+        echo "        exists: $research_exists"
+        echo "      discussion:"
+        echo "        exists: $disc_exists"
+        [ "$disc_exists" = "true" ] && echo "        status: \"$disc_status\""
+        echo "      specification:"
+        echo "        exists: $spec_exists"
+        [ "$spec_exists" = "true" ] && echo "        status: \"$spec_status\""
+        echo "      plan:"
+        echo "        exists: $plan_exists"
+        [ "$plan_exists" = "true" ] && echo "        status: \"$plan_status\""
+        echo "      implementation:"
+        echo "        exists: $impl_exists"
+        [ "$impl_exists" = "true" ] && echo "        status: \"$impl_status\""
+        echo "      review:"
+        echo "        exists: $review_exists"
+    done
+fi
+
+echo "  count: $feature_count"
+
+echo ""
+
+#
+# BUGFIXES SECTION (topic-centric view for work_type: bugfix)
+#
+echo "bugfixes:"
+
+bugfix_topics=()
+bugfix_seen_list=""
+
+# Scan investigation directory first
+if [ -d "$INVESTIGATION_DIR" ]; then
+    for file in "$INVESTIGATION_DIR"/*/investigation.md; do
+        [ -f "$file" ] || continue
+        name=$(basename "$(dirname "$file")")
+        case ",$bugfix_seen_list," in
+            *,"$name",*) ;;
+            *)
+                bugfix_topics+=("$name")
+                bugfix_seen_list="${bugfix_seen_list:+$bugfix_seen_list,}$name"
+                ;;
+        esac
+    done
+fi
+
+# Scan other phases for work_type: bugfix
+if [ -d "$SPEC_DIR" ]; then
+    for file in "$SPEC_DIR"/*/specification.md; do
+        [ -f "$file" ] || continue
+        work_type=$(extract_field "$file" "work_type")
+        if [ "$work_type" = "bugfix" ]; then
+            status=$(extract_field "$file" "status")
+            [ "$status" = "superseded" ] && continue
+            name=$(basename "$(dirname "$file")")
+            case ",$bugfix_seen_list," in
+                *,"$name",*) ;;
+                *)
+                    bugfix_topics+=("$name")
+                    bugfix_seen_list="${bugfix_seen_list:+$bugfix_seen_list,}$name"
+                    ;;
+            esac
+        fi
+    done
+fi
+
+if [ -d "$PLAN_DIR" ]; then
+    for file in "$PLAN_DIR"/*/plan.md; do
+        [ -f "$file" ] || continue
+        work_type=$(extract_field "$file" "work_type")
+        if [ "$work_type" = "bugfix" ]; then
+            name=$(basename "$(dirname "$file")")
+            case ",$bugfix_seen_list," in
+                *,"$name",*) ;;
+                *)
+                    bugfix_topics+=("$name")
+                    bugfix_seen_list="${bugfix_seen_list:+$bugfix_seen_list,}$name"
+                    ;;
+            esac
+        fi
+    done
+fi
+
+bugfix_count=${#bugfix_topics[@]}
+
+if [ "$bugfix_count" -eq 0 ]; then
+    echo "  topics: []"
+else
+    echo "  topics:"
+    for topic in "${bugfix_topics[@]}"; do
+        # Investigation state
+        inv_exists="false"
+        inv_status=""
+        inv_file="$INVESTIGATION_DIR/${topic}/investigation.md"
+        if [ -f "$inv_file" ]; then
+            inv_exists="true"
+            inv_status=$(extract_field "$inv_file" "status")
+            inv_status=${inv_status:-"in-progress"}
+        fi
+
+        # Specification state
+        spec_exists="false"
+        spec_status=""
+        spec_file="$SPEC_DIR/${topic}/specification.md"
+        if [ -f "$spec_file" ]; then
+            spec_exists="true"
+            spec_status=$(extract_field "$spec_file" "status")
+            spec_status=${spec_status:-"in-progress"}
+        fi
+
+        # Plan state
+        plan_exists="false"
+        plan_status=""
+        plan_file="$PLAN_DIR/${topic}/plan.md"
+        if [ -f "$plan_file" ]; then
+            plan_exists="true"
+            plan_status=$(extract_field "$plan_file" "status")
+            plan_status=${plan_status:-"in-progress"}
+        fi
+
+        # Implementation state
+        impl_exists="false"
+        impl_status=""
+        impl_file="$IMPL_DIR/${topic}/tracking.md"
+        if [ -f "$impl_file" ]; then
+            impl_exists="true"
+            impl_status=$(extract_field "$impl_file" "status")
+            impl_status=${impl_status:-"in-progress"}
+        fi
+
+        # Review state
+        review_exists=$(has_review "$topic")
+
+        # Compute next_phase for bugfix pipeline
+        # Investigation → Specification → Planning → Implementation → Review
+        next_phase=""
         if [ "$impl_exists" = "true" ] && [ "$impl_status" = "completed" ] && [ "$review_exists" = "true" ]; then
             next_phase="done"
         elif [ "$impl_exists" = "true" ] && [ "$impl_status" = "completed" ]; then
@@ -250,270 +376,284 @@ if [ "$work_type" = "feature" ] || [ "$work_type" = "bugfix" ]; then
             next_phase="planning"
         elif [ "$spec_exists" = "true" ]; then
             next_phase="specification"
-        elif [ "$investigation_exists" = "true" ] && [ "$investigation_status" = "concluded" ]; then
+        elif [ "$inv_exists" = "true" ] && [ "$inv_status" = "concluded" ]; then
             next_phase="specification"
-        elif [ "$investigation_exists" = "true" ]; then
+        elif [ "$inv_exists" = "true" ]; then
             next_phase="investigation"
         else
             next_phase="unknown"
         fi
-    fi
 
-    echo "next_phase: \"$next_phase\""
-
-#
-# GREENFIELD DISCOVERY (phase-centric)
-#
-elif [ "$work_type" = "greenfield" ]; then
-
-    #
-    # RESEARCH
-    #
-    echo "research:"
-    research_count=0
-    if [ -d "$RESEARCH_DIR" ] && [ -n "$(ls -A "$RESEARCH_DIR" 2>/dev/null)" ]; then
-        echo "  exists: true"
-        echo "  files:"
-        for file in "$RESEARCH_DIR"/*; do
-            [ -f "$file" ] || continue
-            name=$(basename "$file" .md)
-            echo "    - \"$name\""
-            research_count=$((research_count + 1))
-        done
-        echo "  count: $research_count"
-    else
-        echo "  exists: false"
-        echo "  files: []"
-        echo "  count: 0"
-    fi
-
-    echo ""
-
-    #
-    # DISCUSSIONS (greenfield only)
-    #
-    echo "discussions:"
-    disc_count=0
-    disc_concluded=0
-    disc_in_progress=0
-
-    if [ -d "$DISCUSSION_DIR" ] && [ -n "$(ls -A "$DISCUSSION_DIR" 2>/dev/null)" ]; then
-        first=true
-        for file in "$DISCUSSION_DIR"/*.md; do
-            [ -f "$file" ] || continue
-            file_work_type=$(extract_field "$file" "work_type")
-            file_work_type=${file_work_type:-"greenfield"}
-            [ "$file_work_type" = "greenfield" ] || continue
-
-            name=$(basename "$file" .md)
-            status=$(extract_field "$file" "status")
-            status=${status:-"in-progress"}
-
-            if $first; then
-                echo "  files:"
-                first=false
-            fi
-
-            echo "    - name: \"$name\""
-            echo "      status: \"$status\""
-
-            disc_count=$((disc_count + 1))
-            [ "$status" = "concluded" ] && disc_concluded=$((disc_concluded + 1))
-            [ "$status" = "in-progress" ] && disc_in_progress=$((disc_in_progress + 1))
-        done
-        if $first; then
-            echo "  files: []"
-        fi
-    else
-        echo "  files: []"
-    fi
-
-    echo "  count: $disc_count"
-    echo "  concluded: $disc_concluded"
-    echo "  in_progress: $disc_in_progress"
-
-    echo ""
-
-    #
-    # SPECIFICATIONS (greenfield only)
-    #
-    echo "specifications:"
-    spec_count=0
-    spec_concluded=0
-    spec_in_progress=0
-
-    if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
-        first=true
-        for file in "$SPEC_DIR"/*/specification.md; do
-            [ -f "$file" ] || continue
-            file_work_type=$(extract_field "$file" "work_type")
-            file_work_type=${file_work_type:-"greenfield"}
-            [ "$file_work_type" = "greenfield" ] || continue
-
-            name=$(basename "$(dirname "$file")")
-            status=$(extract_field "$file" "status")
-            status=${status:-"in-progress"}
-            spec_type=$(extract_field "$file" "type")
-            spec_type=${spec_type:-"feature"}
-
-            # Skip superseded specs — they've been absorbed into another spec
-            [ "$status" = "superseded" ] && continue
-
-            has_plan="false"
-            [ -f "$PLAN_DIR/${name}/plan.md" ] && has_plan="true"
-
-            if $first; then
-                echo "  files:"
-                first=false
-            fi
-
-            echo "    - name: \"$name\""
-            echo "      status: \"$status\""
-            echo "      type: \"$spec_type\""
-            echo "      has_plan: $has_plan"
-
-            spec_count=$((spec_count + 1))
-            [ "$status" = "concluded" ] && spec_concluded=$((spec_concluded + 1))
-            [ "$status" = "in-progress" ] && spec_in_progress=$((spec_in_progress + 1))
-        done
-        if $first; then
-            echo "  files: []"
-        fi
-    else
-        echo "  files: []"
-    fi
-
-    echo "  count: $spec_count"
-    echo "  concluded: $spec_concluded"
-    echo "  in_progress: $spec_in_progress"
-
-    echo ""
-
-    #
-    # PLANS (greenfield only)
-    #
-    echo "plans:"
-    plan_count=0
-    plan_concluded=0
-    plan_in_progress=0
-
-    if [ -d "$PLAN_DIR" ] && [ -n "$(ls -A "$PLAN_DIR" 2>/dev/null)" ]; then
-        first=true
-        for file in "$PLAN_DIR"/*/plan.md; do
-            [ -f "$file" ] || continue
-            file_work_type=$(extract_field "$file" "work_type")
-            file_work_type=${file_work_type:-"greenfield"}
-            [ "$file_work_type" = "greenfield" ] || continue
-
-            name=$(basename "$(dirname "$file")")
-            status=$(extract_field "$file" "status")
-            status=${status:-"in-progress"}
-
-            has_impl="false"
-            [ -f "$IMPL_DIR/${name}/tracking.md" ] && has_impl="true"
-
-            if $first; then
-                echo "  files:"
-                first=false
-            fi
-
-            echo "    - name: \"$name\""
-            echo "      status: \"$status\""
-            echo "      has_implementation: $has_impl"
-
-            plan_count=$((plan_count + 1))
-            [ "$status" = "concluded" ] && plan_concluded=$((plan_concluded + 1))
-            { [ "$status" = "in-progress" ] || [ "$status" = "planning" ]; } && plan_in_progress=$((plan_in_progress + 1))
-        done
-        if $first; then
-            echo "  files: []"
-        fi
-    else
-        echo "  files: []"
-    fi
-
-    echo "  count: $plan_count"
-    echo "  concluded: $plan_concluded"
-    echo "  in_progress: $plan_in_progress"
-
-    echo ""
-
-    #
-    # IMPLEMENTATION (greenfield only)
-    #
-    echo "implementation:"
-    impl_count=0
-    impl_completed=0
-    impl_in_progress=0
-
-    if [ -d "$IMPL_DIR" ] && [ -n "$(ls -A "$IMPL_DIR" 2>/dev/null)" ]; then
-        first=true
-        for file in "$IMPL_DIR"/*/tracking.md; do
-            [ -f "$file" ] || continue
-            file_work_type=$(extract_field "$file" "work_type")
-            file_work_type=${file_work_type:-"greenfield"}
-            [ "$file_work_type" = "greenfield" ] || continue
-
-            topic_name=$(basename "$(dirname "$file")")
-            status=$(extract_field "$file" "status")
-            status=${status:-"in-progress"}
-
-            has_review="false"
-            if [ -d "$REVIEW_DIR/${topic_name}" ]; then
-                for rdir in "$REVIEW_DIR/${topic_name}"/r*/; do
-                    [ -d "$rdir" ] || continue
-                    [ -f "${rdir}review.md" ] && has_review="true" && break
-                done
-            fi
-
-            if $first; then
-                echo "  files:"
-                first=false
-            fi
-
-            echo "    - topic: \"$topic_name\""
-            echo "      status: \"$status\""
-            echo "      has_review: $has_review"
-
-            impl_count=$((impl_count + 1))
-            [ "$status" = "completed" ] && impl_completed=$((impl_completed + 1))
-            [ "$status" = "in-progress" ] && impl_in_progress=$((impl_in_progress + 1))
-        done
-        if $first; then
-            echo "  files: []"
-        fi
-    else
-        echo "  files: []"
-    fi
-
-    echo "  count: $impl_count"
-    echo "  completed: $impl_completed"
-    echo "  in_progress: $impl_in_progress"
-
-    echo ""
-
-    #
-    # STATE SUMMARY
-    #
-    echo "state:"
-    echo "  research_count: $research_count"
-    echo "  discussion_count: $disc_count"
-    echo "  discussion_concluded: $disc_concluded"
-    echo "  discussion_in_progress: $disc_in_progress"
-    echo "  specification_count: $spec_count"
-    echo "  specification_concluded: $spec_concluded"
-    echo "  specification_in_progress: $spec_in_progress"
-    echo "  plan_count: $plan_count"
-    echo "  plan_concluded: $plan_concluded"
-    echo "  plan_in_progress: $plan_in_progress"
-    echo "  implementation_count: $impl_count"
-    echo "  implementation_completed: $impl_completed"
-    echo "  implementation_in_progress: $impl_in_progress"
-
-    has_any_work="false"
-    if [ "$research_count" -gt 0 ] || [ "$disc_count" -gt 0 ] || [ "$spec_count" -gt 0 ] || \
-       [ "$plan_count" -gt 0 ] || [ "$impl_count" -gt 0 ]; then
-        has_any_work="true"
-    fi
-    echo "  has_any_work: $has_any_work"
+        echo "    - name: \"$topic\""
+        echo "      next_phase: \"$next_phase\""
+        echo "      investigation:"
+        echo "        exists: $inv_exists"
+        [ "$inv_exists" = "true" ] && echo "        status: \"$inv_status\""
+        echo "      specification:"
+        echo "        exists: $spec_exists"
+        [ "$spec_exists" = "true" ] && echo "        status: \"$spec_status\""
+        echo "      plan:"
+        echo "        exists: $plan_exists"
+        [ "$plan_exists" = "true" ] && echo "        status: \"$plan_status\""
+        echo "      implementation:"
+        echo "        exists: $impl_exists"
+        [ "$impl_exists" = "true" ] && echo "        status: \"$impl_status\""
+        echo "      review:"
+        echo "        exists: $review_exists"
+    done
 fi
+
+echo "  count: $bugfix_count"
+
+echo ""
+
+#
+# GREENFIELD SECTION (phase-centric view)
+#
+echo "greenfield:"
+
+#
+# RESEARCH
+#
+echo "  research:"
+research_count=0
+if [ -d "$RESEARCH_DIR" ] && [ -n "$(ls -A "$RESEARCH_DIR" 2>/dev/null)" ]; then
+    echo "    exists: true"
+    echo "    files:"
+    for file in "$RESEARCH_DIR"/*; do
+        [ -f "$file" ] || continue
+        name=$(basename "$file" .md)
+        echo "      - \"$name\""
+        research_count=$((research_count + 1))
+    done
+    echo "    count: $research_count"
+else
+    echo "    exists: false"
+    echo "    files: []"
+    echo "    count: 0"
+fi
+
+echo ""
+
+#
+# DISCUSSIONS (greenfield only)
+#
+echo "  discussions:"
+disc_count=0
+disc_concluded=0
+disc_in_progress=0
+
+if [ -d "$DISCUSSION_DIR" ] && [ -n "$(ls -A "$DISCUSSION_DIR" 2>/dev/null)" ]; then
+    first=true
+    for file in "$DISCUSSION_DIR"/*.md; do
+        [ -f "$file" ] || continue
+        file_work_type=$(extract_field "$file" "work_type")
+        file_work_type=${file_work_type:-"greenfield"}
+        [ "$file_work_type" = "greenfield" ] || continue
+
+        name=$(basename "$file" .md)
+        status=$(extract_field "$file" "status")
+        status=${status:-"in-progress"}
+
+        if $first; then
+            echo "    files:"
+            first=false
+        fi
+
+        echo "      - name: \"$name\""
+        echo "        status: \"$status\""
+
+        disc_count=$((disc_count + 1))
+        [ "$status" = "concluded" ] && disc_concluded=$((disc_concluded + 1))
+        [ "$status" = "in-progress" ] && disc_in_progress=$((disc_in_progress + 1))
+    done
+    if $first; then
+        echo "    files: []"
+    fi
+else
+    echo "    files: []"
+fi
+
+echo "    count: $disc_count"
+echo "    concluded: $disc_concluded"
+echo "    in_progress: $disc_in_progress"
+
+echo ""
+
+#
+# SPECIFICATIONS (greenfield only)
+#
+echo "  specifications:"
+spec_count=0
+spec_concluded=0
+spec_in_progress=0
+
+if [ -d "$SPEC_DIR" ] && [ -n "$(ls -A "$SPEC_DIR" 2>/dev/null)" ]; then
+    first=true
+    for file in "$SPEC_DIR"/*/specification.md; do
+        [ -f "$file" ] || continue
+        file_work_type=$(extract_field "$file" "work_type")
+        file_work_type=${file_work_type:-"greenfield"}
+        [ "$file_work_type" = "greenfield" ] || continue
+
+        name=$(basename "$(dirname "$file")")
+        status=$(extract_field "$file" "status")
+        status=${status:-"in-progress"}
+        spec_type=$(extract_field "$file" "type")
+        spec_type=${spec_type:-"feature"}
+
+        # Skip superseded specs — they've been absorbed into another spec
+        [ "$status" = "superseded" ] && continue
+
+        has_plan="false"
+        [ -f "$PLAN_DIR/${name}/plan.md" ] && has_plan="true"
+
+        if $first; then
+            echo "    files:"
+            first=false
+        fi
+
+        echo "      - name: \"$name\""
+        echo "        status: \"$status\""
+        echo "        type: \"$spec_type\""
+        echo "        has_plan: $has_plan"
+
+        spec_count=$((spec_count + 1))
+        [ "$status" = "concluded" ] && spec_concluded=$((spec_concluded + 1))
+        [ "$status" = "in-progress" ] && spec_in_progress=$((spec_in_progress + 1))
+    done
+    if $first; then
+        echo "    files: []"
+    fi
+else
+    echo "    files: []"
+fi
+
+echo "    count: $spec_count"
+echo "    concluded: $spec_concluded"
+echo "    in_progress: $spec_in_progress"
+
+echo ""
+
+#
+# PLANS (greenfield only)
+#
+echo "  plans:"
+plan_count=0
+plan_concluded=0
+plan_in_progress=0
+
+if [ -d "$PLAN_DIR" ] && [ -n "$(ls -A "$PLAN_DIR" 2>/dev/null)" ]; then
+    first=true
+    for file in "$PLAN_DIR"/*/plan.md; do
+        [ -f "$file" ] || continue
+        file_work_type=$(extract_field "$file" "work_type")
+        file_work_type=${file_work_type:-"greenfield"}
+        [ "$file_work_type" = "greenfield" ] || continue
+
+        name=$(basename "$(dirname "$file")")
+        status=$(extract_field "$file" "status")
+        status=${status:-"in-progress"}
+
+        has_impl="false"
+        [ -f "$IMPL_DIR/${name}/tracking.md" ] && has_impl="true"
+
+        if $first; then
+            echo "    files:"
+            first=false
+        fi
+
+        echo "      - name: \"$name\""
+        echo "        status: \"$status\""
+        echo "        has_implementation: $has_impl"
+
+        plan_count=$((plan_count + 1))
+        [ "$status" = "concluded" ] && plan_concluded=$((plan_concluded + 1))
+        { [ "$status" = "in-progress" ] || [ "$status" = "planning" ]; } && plan_in_progress=$((plan_in_progress + 1))
+    done
+    if $first; then
+        echo "    files: []"
+    fi
+else
+    echo "    files: []"
+fi
+
+echo "    count: $plan_count"
+echo "    concluded: $plan_concluded"
+echo "    in_progress: $plan_in_progress"
+
+echo ""
+
+#
+# IMPLEMENTATION (greenfield only)
+#
+echo "  implementation:"
+impl_count=0
+impl_completed=0
+impl_in_progress=0
+
+if [ -d "$IMPL_DIR" ] && [ -n "$(ls -A "$IMPL_DIR" 2>/dev/null)" ]; then
+    first=true
+    for file in "$IMPL_DIR"/*/tracking.md; do
+        [ -f "$file" ] || continue
+        file_work_type=$(extract_field "$file" "work_type")
+        file_work_type=${file_work_type:-"greenfield"}
+        [ "$file_work_type" = "greenfield" ] || continue
+
+        topic_name=$(basename "$(dirname "$file")")
+        status=$(extract_field "$file" "status")
+        status=${status:-"in-progress"}
+
+        review_flag=$(has_review "$topic_name")
+
+        if $first; then
+            echo "    files:"
+            first=false
+        fi
+
+        echo "      - topic: \"$topic_name\""
+        echo "        status: \"$status\""
+        echo "        has_review: $review_flag"
+
+        impl_count=$((impl_count + 1))
+        [ "$status" = "completed" ] && impl_completed=$((impl_completed + 1))
+        [ "$status" = "in-progress" ] && impl_in_progress=$((impl_in_progress + 1))
+    done
+    if $first; then
+        echo "    files: []"
+    fi
+else
+    echo "    files: []"
+fi
+
+echo "    count: $impl_count"
+echo "    completed: $impl_completed"
+echo "    in_progress: $impl_in_progress"
+
+echo ""
+
+#
+# STATE SUMMARY
+#
+echo "  state:"
+echo "    research_count: $research_count"
+echo "    discussion_count: $disc_count"
+echo "    discussion_concluded: $disc_concluded"
+echo "    discussion_in_progress: $disc_in_progress"
+echo "    specification_count: $spec_count"
+echo "    specification_concluded: $spec_concluded"
+echo "    specification_in_progress: $spec_in_progress"
+echo "    plan_count: $plan_count"
+echo "    plan_concluded: $plan_concluded"
+echo "    plan_in_progress: $plan_in_progress"
+echo "    implementation_count: $impl_count"
+echo "    implementation_completed: $impl_completed"
+echo "    implementation_in_progress: $impl_in_progress"
+
+has_any_work="false"
+if [ "$research_count" -gt 0 ] || [ "$disc_count" -gt 0 ] || [ "$spec_count" -gt 0 ] || \
+   [ "$plan_count" -gt 0 ] || [ "$impl_count" -gt 0 ] || \
+   [ "$feature_count" -gt 0 ] || [ "$bugfix_count" -gt 0 ]; then
+    has_any_work="true"
+fi
+echo "    has_any_work: $has_any_work"


### PR DESCRIPTION
## Summary

- Rewrote bridge discovery script to be argument-free, enabling `!` dynamic insertion syntax consistent with all other skills
- Script now scans all topics across all work types (features, bugfixes, greenfield) in a single pass; the skill filters by its known context
- Updated tests to match new output format (53 tests pass, all other discovery suites unaffected)

## Test plan

- [x] All 53 bridge discovery tests pass
- [x] All 656 discovery tests across all suites pass
- [ ] Manual: run a feature discussion to conclusion and verify workflow-bridge discovers correct `next_phase`

🤖 Generated with [Claude Code](https://claude.com/claude-code)