### PR TITLE
fix: add post-create/update verification to tick output format

### DIFF
--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -61,6 +61,10 @@ Acceptance criteria:
 - Passes user context to downstream handlers"
 ```
 
+## Post-Creation Verification
+
+After every `tick create`, run `tick show <task-id>` and confirm that the title, description, and parent were all set correctly. If any field is empty or wrong, update it immediately with `tick update`.
+
 ## Task Properties
 
 ### Status

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -63,7 +63,11 @@ Acceptance criteria:
 
 ## Post-Creation Verification
 
-After every `tick create`, run `tick show <task-id>` and confirm that the title, description, and parent were all set correctly. If any field is empty or wrong, update it immediately with `tick update`.
+After every `tick create`, run `tick show <task-id>` and confirm that the title, description, and parent were all set correctly.
+
+#### If any field is empty or wrong
+
+Load **[updating.md](updating.md)** and follow its instructions to correct the field using `tick update`.
 
 ## Task Properties
 

--- a/skills/technical-planning/references/output-formats/tick/updating.md
+++ b/skills/technical-planning/references/output-formats/tick/updating.md
@@ -16,7 +16,7 @@ Tick uses dedicated commands for each status transition:
 
 ## Updating Task Content
 
-**Sandbox mode**: When updating large descriptions, use the Write tool + cat pattern to avoid sandbox temp file issues. See [authoring.md](authoring.md) for details.
+**CRITICAL**: Always pass descriptions as inline quoted strings. See [authoring.md](authoring.md) for constraints.
 
 To update a task's properties:
 
@@ -25,6 +25,10 @@ To update a task's properties:
 - **Priority**: `tick update <task-id> --priority 1`
 - **Parent**: `tick update <task-id> --parent <new-parent-id>` (pass empty string to clear)
 - **Dependencies**: See [graph.md](graph.md)
+
+## Post-Update Verification
+
+After every `tick update`, run `tick show <task-id>` and confirm that the updated fields were set correctly. If any field is empty or wrong, re-run the update.
 
 ## Phase / Parent Status
 


### PR DESCRIPTION
## Summary

- Add post-creation verification section to tick authoring — run `tick show` after every `tick create` to catch empty descriptions
- Add post-update verification section to tick updating — run `tick show` after every `tick update` to confirm fields were set
- Fix stale reference in updating.md that incorrectly advised Write tool + cat pattern (contradicted authoring.md's inline-only constraint)

## Test plan

- [ ] Verify authoring.md contains new "Post-Creation Verification" section
- [ ] Verify updating.md contains new "Post-Update Verification" section
- [ ] Verify stale sandbox workaround reference is replaced with correct inline-only guidance
- [ ] Run a planning workflow using tick format and confirm verification steps are followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)