### PR TITLE
feat: add collaborative findings review to investigation

### DIFF
--- a/skills/technical-investigation/SKILL.md
+++ b/skills/technical-investigation/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: false
 
 # Technical Investigation
 
-Act as **expert debugger** tracing through code AND **documentation assistant** capturing findings. These are equally important — the investigation drives understanding, the documentation preserves it. Dig deep: trace code paths, challenge assumptions, explore related areas. Then capture what you found.
+Act as **expert debugger** tracing through code, **documentation assistant** capturing findings, AND **collaborative advisor** presenting analysis and discussing fix direction with the user. These are equally important — the investigation drives understanding, the documentation preserves it, and the collaboration validates findings and aligns on approach. Dig deep: trace code paths, challenge assumptions, explore related areas. Then capture what you found.
 
 ## Purpose in the Workflow
 
@@ -85,7 +85,7 @@ Check if `.workflows/investigation/{topic}/investigation.md` already exists.
 
 #### If the file exists
 
-Read it. Announce what's been documented so far and what phase the investigation is in (symptoms, analysis, or root cause). Ask the user whether to continue or restart.
+Read it. Announce what's been documented so far and what phase the investigation is in (symptoms, analysis, root cause, or findings review). Ask the user whether to continue or restart.
 
 **STOP.** Wait for user response.
 
@@ -144,6 +144,14 @@ Document in the investigation file and commit.
 
 ---
 
-## Step 5: Conclude Investigation
+## Step 5: Findings Review & Fix Discussion
+
+Load **[findings-review.md](references/findings-review.md)** and follow its instructions as written.
+
+→ Proceed to **Step 6**.
+
+---
+
+## Step 6: Conclude Investigation
 
 Load **[conclude-investigation.md](references/conclude-investigation.md)** and follow its instructions as written.

--- a/skills/technical-investigation/references/conclude-investigation.md
+++ b/skills/technical-investigation/references/conclude-investigation.md
@@ -4,26 +4,31 @@
 
 ---
 
-When the root cause is identified and documented:
+The user has already reviewed findings and agreed on fix direction. This step confirms the investigation is complete and handles pipeline continuation.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Root cause identified. Ready to conclude?
+Investigation complete. Ready to conclude?
 
 - **`y`/`yes`** — Conclude investigation and proceed to specification
-- **`m`/`more`** — Continue investigating (more analysis needed)
+- **Comment** — Add context before concluding
+- **`r`/`reopen`** — Reopen investigation (more analysis needed)
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-#### If more
+#### If reopen
 
-Continue investigation. Ask what aspects need more analysis.
+Ask what aspects need more analysis.
 
 → Return to **[the skill](../SKILL.md)** for **Step 3**.
+
+#### If Comment
+
+Incorporate the user's context into the investigation file and commit. Re-present the same conclusion prompt.
 
 #### If yes
 
@@ -37,7 +42,7 @@ Continue investigation. Ask what aspects need more analysis.
 Investigation concluded: {topic}
 
 Root cause: {brief summary}
-Fix direction: {proposed approach}
+Fix direction: {chosen approach}
 
 The investigation is ready for specification. The specification will
 detail the exact fix approach, acceptance criteria, and testing plan.

--- a/skills/technical-investigation/references/findings-review.md
+++ b/skills/technical-investigation/references/findings-review.md
@@ -1,0 +1,146 @@
+# Findings Review & Fix Discussion
+
+*Reference for **[technical-investigation](../SKILL.md)***
+
+---
+
+Present your analysis to the user for validation, then collaboratively agree on fix direction. Simple bugs flow fast (2 STOP gates). Complex bugs expand naturally through discussion.
+
+## A. Present Findings
+
+Summarize the investigation findings in a structured display. Pull from the investigation file — do not invent or embellish.
+
+> *Output the next fenced block as a code block:*
+
+```
+Investigation Findings: {topic}
+
+Root Cause:
+  {clear, precise root cause statement}
+
+Contributing Factors:
+  {factor 1}
+  {factor 2}
+
+Blast Radius:
+  Directly affected:  {components}
+  Potentially affected: {components sharing code/patterns}
+
+Why It Wasn't Caught:
+  {testing gap, edge case, recent change}
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Do these findings match your understanding?
+
+- **`y`/`yes`** — Findings are correct, discuss fix direction
+- **`n`/`no`** — Something's off
+- **`q`/`questions`** — Questions about the analysis
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If no
+
+Address the user's concerns. Re-trace code paths if needed. Update the investigation file with corrections and commit.
+
+Re-present findings using the same format above.
+
+#### If questions
+
+Answer the user's questions about the analysis. Provide supporting evidence from the code trace. Update the investigation file if answers reveal new information, and commit.
+
+Re-present findings using the same format above.
+
+#### If yes
+
+→ Proceed to **B. Fix Direction Discussion**.
+
+---
+
+## B. Fix Direction Discussion
+
+Present 2-3 viable fix approaches. Each should be a genuinely different strategy, not variations of the same idea.
+
+> *Output the next fenced block as a code block:*
+
+```
+Fix Approaches for: {topic}
+
+1. {Approach Name}
+   What:       {one-line description}
+   Trade-offs: {key pros and cons}
+   Fits when:  {conditions where this is the right choice}
+
+2. {Approach Name}
+   What:       {one-line description}
+   Trade-offs: {key pros and cons}
+   Fits when:  {conditions where this is the right choice}
+
+3. {Approach Name}
+   What:       {one-line description}
+   Trade-offs: {key pros and cons}
+   Fits when:  {conditions where this is the right choice}
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Which approach, or what direction?
+
+- **Enter a number** to select an approach
+- **`d`/`discuss`** — Talk through trade-offs before deciding
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If discuss
+
+Engage in collaborative discussion about the approaches. Stay bounded — focus on:
+- Challenging assumptions about each approach
+- Surfacing edge cases and risks
+- Exploring how each interacts with existing code
+- Understanding user priorities (speed, safety, maintainability)
+
+Do not go into implementation detail — that belongs in the specification. When discussion reaches a natural decision point, re-present the approaches (updated if discussion changed them) and ask for selection.
+
+#### If a number is selected
+
+Acknowledge the selection. Present for confirmation:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Confirm fix direction: **{chosen approach name}**
+
+- **`y`/`yes`** — Confirm and document
+- **Comment** — Add context before confirming
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If Comment
+
+Incorporate the user's context into your understanding. Re-present the same confirmation prompt.
+
+#### If yes
+
+Document the Fix Direction section in the investigation file:
+
+1. **Chosen Approach**: The selected approach with deciding factor
+2. **Options Explored**: All approaches presented (including unchosen ones with brief "why not")
+3. **Discussion**: Journey notes — user priorities, concerns raised, edge cases surfaced, what shifted thinking. Brief for simple bugs, detailed for complex.
+4. **Testing Recommendations**: Informed by the discussion
+5. **Risk Assessment**: Informed by the discussion
+
+Commit the updated investigation file.
+
+→ Return to **[the skill](../SKILL.md)**.

--- a/skills/technical-investigation/references/findings-review.md
+++ b/skills/technical-investigation/references/findings-review.md
@@ -57,72 +57,36 @@ Re-present findings using the same format above.
 
 ## B. Fix Direction Discussion
 
-Present 2-3 viable fix approaches. Each should be a genuinely different strategy, not variations of the same idea.
+Present what the analysis surfaced about how to fix this. Let the findings guide the shape — there's no required number of approaches:
 
-> *Output the next fenced block as a code block:*
+- **One obvious fix?** Present it clearly with trade-offs and any risks.
+- **Multiple viable approaches?** Present each with trade-offs so the user can compare.
+- **Unclear?** Say so — this is a discussion, not a presentation.
 
-```
-Fix Approaches for: {topic}
-
-1. {Approach Name}
-   What:       {one-line description}
-   Trade-offs: {key pros and cons}
-   Fits when:  {conditions where this is the right choice}
-
-2. {Approach Name}
-   What:       {one-line description}
-   Trade-offs: {key pros and cons}
-   Fits when:  {conditions where this is the right choice}
-
-3. {Approach Name}
-   What:       {one-line description}
-   Trade-offs: {key pros and cons}
-   Fits when:  {conditions where this is the right choice}
-```
+Use a code block. Format naturally based on what there is to present — a single approach doesn't need numbered alternatives, multiple approaches benefit from comparison structure.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Which approach, or what direction?
+What are your thoughts?
 
-- **Enter a number** to select an approach
-- **`d`/`discuss`** — Talk through trade-offs before deciding
+- **`y`/`yes`** — Agree with this direction
+- **Or provide feedback** to discuss, challenge, or suggest alternatives.
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-#### If discuss
+#### If the user provides feedback
 
-Engage in collaborative discussion about the approaches. Stay bounded — focus on:
-- Challenging assumptions about each approach
+Engage collaboratively. Stay bounded — focus on:
+- Challenging assumptions about approaches
 - Surfacing edge cases and risks
-- Exploring how each interacts with existing code
+- Exploring how fixes interact with existing code
 - Understanding user priorities (speed, safety, maintainability)
 
-Do not go into implementation detail — that belongs in the specification. When discussion reaches a natural decision point, re-present the approaches (updated if discussion changed them) and ask for selection.
-
-#### If a number is selected
-
-Acknowledge the selection. Present for confirmation:
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Confirm fix direction: **{chosen approach name}**
-
-- **`y`/`yes`** — Confirm and document
-- **Comment** — Add context before confirming
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-#### If Comment
-
-Incorporate the user's context into your understanding. Re-present the same confirmation prompt.
+Do not go into implementation detail — that belongs in the specification. When discussion reaches a natural decision point, summarize the agreed direction and present for confirmation.
 
 #### If yes
 

--- a/skills/technical-investigation/references/findings-review.md
+++ b/skills/technical-investigation/references/findings-review.md
@@ -37,15 +37,15 @@ Why It Wasn't Caught:
 Do these findings match your understanding?
 
 - **`y`/`yes`** — Findings are correct, discuss fix direction
-- Or just state your questions or concerns
+- **Or provide feedback** on what's off or unclear.
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-#### If the user raises questions or concerns
+#### If the user provides feedback
 
-Address them directly. Re-trace code paths if needed. Provide supporting evidence from the code trace. Update the investigation file with corrections or new information, and commit.
+Address their concerns directly. Re-trace code paths if needed. Provide supporting evidence from the code trace. Update the investigation file with corrections or new information, and commit.
 
 Re-present findings using the same format above.
 

--- a/skills/technical-investigation/references/findings-review.md
+++ b/skills/technical-investigation/references/findings-review.md
@@ -37,22 +37,15 @@ Why It Wasn't Caught:
 Do these findings match your understanding?
 
 - **`y`/`yes`** — Findings are correct, discuss fix direction
-- **`n`/`no`** — Something's off
-- **`q`/`questions`** — Questions about the analysis
+- Or just state your questions or concerns
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-#### If no
+#### If the user raises questions or concerns
 
-Address the user's concerns. Re-trace code paths if needed. Update the investigation file with corrections and commit.
-
-Re-present findings using the same format above.
-
-#### If questions
-
-Answer the user's questions about the analysis. Provide supporting evidence from the code trace. Update the investigation file if answers reveal new information, and commit.
+Address them directly. Re-trace code paths if needed. Provide supporting evidence from the code trace. Update the investigation file with corrections or new information, and commit.
 
 Re-present findings using the same format above.
 

--- a/skills/technical-investigation/references/template.md
+++ b/skills/technical-investigation/references/template.md
@@ -114,21 +114,29 @@ date: {YYYY-MM-DD}
 
 ## Fix Direction
 
-### Proposed Approach
+### Chosen Approach
 
-{High-level description of the fix direction}
+{High-level description of the chosen fix direction}
 
-### Alternatives Considered
+**Deciding factor:** {Why this approach was selected over alternatives}
 
-**Alternative 1:** {Approach}
-- Pros: {benefits}
-- Cons: {drawbacks}
-- Why not: {reason}
+### Options Explored
 
-**Alternative 2:** {Approach}
-- Pros: {benefits}
-- Cons: {drawbacks}
-- Why not: {reason}
+**Option 1:** {Approach} (chosen)
+- Trade-offs: {key pros and cons}
+- Fits when: {conditions where this is the right choice}
+
+**Option 2:** {Approach}
+- Trade-offs: {key pros and cons}
+- Why not: {reason this wasn't chosen}
+
+**Option 3:** {Approach}
+- Trade-offs: {key pros and cons}
+- Why not: {reason this wasn't chosen}
+
+### Discussion
+
+{Journey notes from the findings review — user priorities, concerns raised, edge cases surfaced, what shifted thinking. Brief for simple bugs, detailed for complex.}
 
 ### Testing Recommendations
 
@@ -161,4 +169,4 @@ Document your investigation journey. Even dead ends are valuable — they show w
 
 ### Fix Direction Section
 
-Don't detail the implementation here — that's for the specification. Focus on high-level direction, alternatives, and risk assessment.
+Don't detail the implementation here — that's for the specification. Focus on high-level direction, options explored, and risk assessment. The chosen approach and discussion notes reflect the collaborative findings review — capture the decision journey, not just the outcome.

--- a/skills/technical-investigation/references/template.md
+++ b/skills/technical-investigation/references/template.md
@@ -122,17 +122,7 @@ date: {YYYY-MM-DD}
 
 ### Options Explored
 
-**Option 1:** {Approach} (chosen)
-- Trade-offs: {key pros and cons}
-- Fits when: {conditions where this is the right choice}
-
-**Option 2:** {Approach}
-- Trade-offs: {key pros and cons}
-- Why not: {reason this wasn't chosen}
-
-**Option 3:** {Approach}
-- Trade-offs: {key pros and cons}
-- Why not: {reason this wasn't chosen}
+{List whatever approaches were discussed — could be one, could be several. For each unchosen option, note why it wasn't selected.}
 
 ### Discussion
 


### PR DESCRIPTION
## Summary

- Insert **Step 5: Findings Review & Fix Discussion** between root cause synthesis and conclusion — presents findings for user validation and collaboratively agrees on fix direction before concluding
- Update investigation template: Proposed Approach → Chosen Approach with deciding factor, Alternatives → Options Explored, new Discussion sub-section for journey notes
- Update conclusion step: add Comment option, reframe "more" as "reopen", reflect that findings were already reviewed

## Test plan

- [ ] Run bugfix workflow through investigation — simple bug: findings presented → quick validation → obvious fix confirmed (2 STOP gates in new step)
- [ ] Complex bug path: findings challenged → corrections → multiple approaches discussed → decision documented with journey notes
- [ ] Context refresh recovery: resume during findings review re-reads file and announces position
- [ ] Conclude flow: Comment option works, "reopen" returns to Step 3
- [ ] Template: new investigation files use updated Fix Direction structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)