### PR TITLE
fix: skip synthesizer when all analysis agents return clean

### DIFF
--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -99,8 +99,6 @@ impl({topic}): analysis cycle {N} — findings
 
 #### If all three agents returned `STATUS: clean`
 
-No findings to synthesize — skip straight to completion.
-
 → Return to **[the skill](../SKILL.md)** for **Step 8**.
 
 #### Otherwise

--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -97,6 +97,14 @@ Commit the analysis findings:
 impl({topic}): analysis cycle {N} — findings
 ```
 
+#### If all three agents returned `STATUS: clean`
+
+No findings to synthesize — skip straight to completion.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 8**.
+
+#### Otherwise
+
 → Proceed to **D. Dispatch Synthesis Agent**.
 
 ---


### PR DESCRIPTION
## Summary

- Analysis loop unconditionally dispatched the synthesis agent even when all three analysis agents (duplication, standards, architecture) returned `STATUS: clean`
- Added a short-circuit gate after Stage C: if all three agents are clean, skip directly to Step 8 (mark complete) instead of dispatching the synthesizer to read empty findings

## Test plan

- [ ] Run implementation through analysis with no findings — verify synthesizer is skipped and flow proceeds to Step 8
- [ ] Run implementation with findings from at least one agent — verify synthesizer is still dispatched normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)