### PR TITLE
refactor: H4 backtick convention + skip synthesizer on clean analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -561,7 +561,7 @@ Rules:
 - Never use else-if chains — each condition gets its own `#### If` heading
 - Lowercase after "If" (e.g., `#### If concluded_count == 1`)
 - Use `#### Otherwise` for else branches
-- No backtick-wrapped code in H4 headings — write conditions as plain text
+- Use backticks around specific values, variables, and statuses in H4 headings (e.g., `` #### If `STATUS` is `clean` ``, `` #### If work type is `feature` ``). Natural language conditions stay plain text (e.g., `#### If no plan provided`)
 - Use "and" between conditions, not commas
 - Drop implied conditions (e.g., if Step 2 already gates on `concluded_count >= 1`, Step 3 doesn't need to repeat it on every branch)
 - H4 for top-level conditionals, bold text for nested — never use H5/H6 for conditional nesting

--- a/skills/start-bugfix/references/topic-name-check.md
+++ b/skills/start-bugfix/references/topic-name-check.md
@@ -48,7 +48,7 @@ An investigation named "{topic}" already exists.
 
 **STOP.** Wait for user response.
 
-#### If resuming
+#### If `resuming`
 
 Check the investigation status. If in-progress:
 

--- a/skills/start-discussion/SKILL.md
+++ b/skills/start-discussion/SKILL.md
@@ -106,11 +106,11 @@ Parse the discovery output to understand:
 
 Check for arguments: work_type = `$0`, topic = `$1`
 
-#### If work_type and topic are both provided
+#### If `work_type` and `topic` are both provided
 
 → Proceed to **Step 3** (Validate Topic).
 
-#### If work_type is provided without topic
+#### If `work_type` is provided without `topic`
 
 Store work_type for the handoff.
 
@@ -126,7 +126,7 @@ Store work_type for the handoff.
 
 Load **[validate-topic.md](references/validate-topic.md)** and follow its instructions as written.
 
-#### If resume
+#### If `resume`
 
 → Proceed to **Step 8**.
 

--- a/skills/start-discussion/references/gather-context.md
+++ b/skills/start-discussion/references/gather-context.md
@@ -6,7 +6,7 @@
 
 Route based on the `source` variable set in earlier steps.
 
-#### If source is "bridge"
+#### If source is `bridge`
 
 Bridge mode: topic and work_type were provided by the caller.
 
@@ -50,7 +50,7 @@ What would you like to discuss? Provide some initial context:
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If source is "research"
+#### If source is `research`
 
 Load **[gather-context-research.md](gather-context-research.md)** and follow its instructions.
 
@@ -58,7 +58,7 @@ Load **[gather-context-research.md](gather-context-research.md)** and follow its
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If source is "fresh"
+#### If source is `fresh`
 
 Load **[gather-context-fresh.md](gather-context-fresh.md)** and follow its instructions.
 
@@ -66,7 +66,7 @@ Load **[gather-context-fresh.md](gather-context-fresh.md)** and follow its instr
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If source is "continue"
+#### If source is `continue`
 
 Load **[gather-context-continue.md](gather-context-continue.md)** and follow its instructions.
 

--- a/skills/start-discussion/references/handle-selection.md
+++ b/skills/start-discussion/references/handle-selection.md
@@ -6,7 +6,7 @@
 
 Route based on the user's choice from the options display.
 
-#### If user chose "From research"
+#### If user chose `From research`
 
 User chose to start from research (e.g., "research 1", "1", "from research", or a topic name).
 
@@ -27,7 +27,7 @@ Which research topic would you like to discuss? (Enter a number or topic name)
 
 **STOP.** Wait for response.
 
-#### If user chose "Continue discussion"
+#### If user chose `Continue discussion`
 
 User chose to continue a discussion (e.g., "continue auth-flow" or "continue discussion").
 
@@ -48,7 +48,7 @@ Which discussion would you like to continue?
 
 **STOP.** Wait for response.
 
-#### If user chose "Fresh topic"
+#### If user chose `Fresh topic`
 
 User wants to start a fresh discussion.
 
@@ -56,7 +56,7 @@ Set source="fresh".
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If user chose "refresh"
+#### If user chose `refresh`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-discussion/references/invoke-skill.md
+++ b/skills/start-discussion/references/invoke-skill.md
@@ -29,7 +29,7 @@ Invoke the [technical-discussion](../../technical-discussion/SKILL.md) skill for
 
 Construct the handoff based on how this discussion was initiated.
 
-#### If source is "research"
+#### If source is `research`
 
 **If work_type is available** (from Step 2), add the Work type line:
 
@@ -45,7 +45,7 @@ Summary: {the 1-2 sentence summary from the research analysis}
 Invoke the technical-discussion skill.
 ```
 
-#### If source is "research-bridge"
+#### If source is `research-bridge`
 
 ```
 Discussion session for: {topic}
@@ -60,7 +60,7 @@ Summary: {the discussion-ready summary from the research file}
 Invoke the technical-discussion skill.
 ```
 
-#### If source is "continue"
+#### If source is `continue`
 
 Read work_type from the existing discussion frontmatter.
 
@@ -73,7 +73,7 @@ Output: .workflows/discussion/{topic}.md
 Invoke the technical-discussion skill.
 ```
 
-#### If source is "fresh"
+#### If source is `fresh`
 
 **If work_type is available** (from Step 2), add the Work type line:
 
@@ -86,7 +86,7 @@ Output: .workflows/discussion/{topic}.md
 Invoke the technical-discussion skill.
 ```
 
-#### If source is "bridge"
+#### If source is `bridge`
 
 ```
 Discussion session for: {topic}

--- a/skills/start-discussion/references/research-analysis.md
+++ b/skills/start-discussion/references/research-analysis.md
@@ -8,7 +8,7 @@ This step only runs when research files exist.
 
 Use `cache.status` from discovery to determine the approach:
 
-#### If cache.status is "valid"
+#### If `cache.status` is `valid`
 
 ```
 Using cached research analysis (unchanged since {cache.generated})
@@ -16,7 +16,7 @@ Using cached research analysis (unchanged since {cache.generated})
 
 Load the topics from `.workflows/.state/research-analysis.md` and proceed.
 
-#### If cache.status is "stale" or "none"
+#### If `cache.status` is `stale` or `none`
 
 ```
 Analyzing research documents...

--- a/skills/start-discussion/references/route-scenario.md
+++ b/skills/start-discussion/references/route-scenario.md
@@ -6,19 +6,19 @@
 
 Use `state.scenario` from the discovery output to determine the path.
 
-#### If scenario is "research_only" or "research_and_discussions"
+#### If scenario is `research_only` or `research_and_discussions`
 
 Research exists and may need analysis.
 
 → Return to **[the skill](../SKILL.md)** for **Step 5**.
 
-#### If scenario is "discussions_only"
+#### If scenario is `discussions_only`
 
 No research exists, but discussions do. Skip research analysis.
 
 → Return to **[the skill](../SKILL.md)** for **Step 6**.
 
-#### If scenario is "fresh"
+#### If scenario is `fresh`
 
 No research or discussions exist yet.
 

--- a/skills/start-discussion/references/validate-topic.md
+++ b/skills/start-discussion/references/validate-topic.md
@@ -14,7 +14,7 @@ ls .workflows/discussion/
 
 Read `.workflows/discussion/{topic}.md` frontmatter to check status.
 
-#### If status is "in-progress"
+#### If status is `in-progress`
 
 > *Output the next fenced block as a code block:*
 
@@ -26,7 +26,7 @@ Set source="continue".
 
 → Return to **[the skill](../SKILL.md)** for **Step 8**.
 
-#### If status is "concluded"
+#### If status is `concluded`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-feature/references/invoke-skill.md
+++ b/skills/start-feature/references/invoke-skill.md
@@ -12,7 +12,7 @@ Save a session bookmark for compaction recovery, then invoke the appropriate pro
 Saving session state for compaction recovery.
 ```
 
-#### If phase is research
+#### If `phase` is `research`
 
 ```bash
 .claude/hooks/workflows/write-session-state.sh \
@@ -23,7 +23,7 @@ Saving session state for compaction recovery.
 
 → Load **[invoke-research.md](invoke-research.md)** and follow its instructions.
 
-#### If phase is discussion
+#### If `phase` is `discussion`
 
 ```bash
 .claude/hooks/workflows/write-session-state.sh \

--- a/skills/start-feature/references/topic-name-check.md
+++ b/skills/start-feature/references/topic-name-check.md
@@ -48,7 +48,7 @@ A discussion named "{topic}" already exists.
 
 **STOP.** Wait for user response.
 
-#### If resuming
+#### If `resuming`
 
 Check the discussion status. If in-progress:
 

--- a/skills/start-implementation/SKILL.md
+++ b/skills/start-implementation/SKILL.md
@@ -112,11 +112,11 @@ Parse the discovery output to understand:
 
 Check for arguments: work_type = `$0`, topic = `$1`
 
-#### If work_type and topic are both provided
+#### If `work_type` and `topic` are both provided
 
 → Proceed to **Step 3**.
 
-#### If work_type is provided without topic
+#### If `work_type` is provided without `topic`
 
 Store work_type for the handoff.
 

--- a/skills/start-implementation/references/environment-check.md
+++ b/skills/start-implementation/references/environment-check.md
@@ -8,7 +8,7 @@
 
 Use the `environment` section from the discovery output:
 
-#### If setup_file_exists is true and requires_setup is false
+#### If `setup_file_exists` is true and `requires_setup` is false
 
 > *Output the next fenced block as a code block:*
 
@@ -18,7 +18,7 @@ Environment: No special setup required.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If setup_file_exists is true and requires_setup is true
+#### If `setup_file_exists` is true and `requires_setup` is true
 
 > *Output the next fenced block as a code block:*
 
@@ -28,7 +28,7 @@ Environment setup file found: .workflows/environment-setup.md
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If setup_file_exists is false or requires_setup is unknown
+#### If `setup_file_exists` is false or `requires_setup` is unknown
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-implementation/references/route-scenario.md
+++ b/skills/start-implementation/references/route-scenario.md
@@ -8,7 +8,7 @@ Discovery mode — use the discovery output from Step 1.
 
 Use `state.scenario` from the discovery output to determine the path:
 
-#### If scenario is "no_plans"
+#### If scenario is `no_plans`
 
 No plans exist yet.
 
@@ -25,7 +25,7 @@ Run /start-planning first to create a plan from a specification.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If scenario is "single_plan" or "multiple_plans"
+#### If scenario is `single_plan` or `multiple_plans`
 
 Plans exist.
 

--- a/skills/start-implementation/references/validate-plan.md
+++ b/skills/start-implementation/references/validate-plan.md
@@ -27,7 +27,7 @@ Run /start-planning {work_type} {topic} to create one.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan exists but status is not "concluded"
+#### If plan exists but status is not `concluded`
 
 > *Output the next fenced block as a code block:*
 
@@ -40,6 +40,6 @@ Run /start-planning {work_type} {topic} to continue.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan exists and status is "concluded"
+#### If plan exists and status is `concluded`
 
 → Return to **[the skill](../SKILL.md)**.

--- a/skills/start-investigation/SKILL.md
+++ b/skills/start-investigation/SKILL.md
@@ -89,11 +89,11 @@ Check for arguments: work_type = `$0`, topic = `$1`
 
 Investigation is always bugfix work_type. If work_type is provided, it should be `bugfix`.
 
-#### If work_type and topic are both provided
+#### If `work_type` and `topic` are both provided
 
 → Proceed to **Step 3** (Validate Investigation).
 
-#### If work_type is provided without topic
+#### If `work_type` is provided without `topic`
 
 → Proceed to **Step 4** (Route Based on Scenario).
 
@@ -107,7 +107,7 @@ Investigation is always bugfix work_type. If work_type is provided, it should be
 
 Load **[validate-investigation.md](references/validate-investigation.md)** and follow its instructions as written.
 
-#### If resume
+#### If `resume`
 
 → Proceed to **Step 6**.
 

--- a/skills/start-investigation/SKILL.md
+++ b/skills/start-investigation/SKILL.md
@@ -121,7 +121,7 @@ Load **[validate-investigation.md](references/validate-investigation.md)** and f
 
 Load **[route-scenario.md](references/route-scenario.md)** and follow its instructions as written.
 
-#### If resuming
+#### If `resuming`
 
 → Proceed to **Step 6**.
 

--- a/skills/start-investigation/references/gather-context-fresh.md
+++ b/skills/start-investigation/references/gather-context-fresh.md
@@ -59,7 +59,7 @@ An investigation named "{topic}" already exists.
 
 **STOP.** Wait for user response.
 
-#### If resuming
+#### If `resuming`
 
 Set source="continue".
 

--- a/skills/start-investigation/references/gather-context.md
+++ b/skills/start-investigation/references/gather-context.md
@@ -6,7 +6,7 @@
 
 Route based on the `source` variable set in earlier steps.
 
-#### If source is "bridge"
+#### If source is `bridge`
 
 Bridge mode: topic and work_type were provided by the caller.
 
@@ -24,7 +24,7 @@ What bug are you investigating? Please provide:
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If source is "fresh"
+#### If source is `fresh`
 
 Load **[gather-context-fresh.md](gather-context-fresh.md)** and follow its instructions.
 

--- a/skills/start-investigation/references/invoke-skill.md
+++ b/skills/start-investigation/references/invoke-skill.md
@@ -29,7 +29,7 @@ Invoke the [technical-investigation](../../technical-investigation/SKILL.md) ski
 
 Construct the handoff based on how this investigation was initiated.
 
-#### If source is "fresh" or "bridge"
+#### If source is `fresh` or `bridge`
 
 ```
 Investigation session for: {topic}
@@ -43,7 +43,7 @@ Bug context:
 Invoke the technical-investigation skill.
 ```
 
-#### If source is "continue"
+#### If source is `continue`
 
 ```
 Investigation session for: {topic}

--- a/skills/start-investigation/references/route-scenario.md
+++ b/skills/start-investigation/references/route-scenario.md
@@ -44,13 +44,13 @@ What would you like to do?
 
 **STOP.** Wait for user response.
 
-#### If resuming
+#### If `resuming`
 
 Set source="continue".
 
 → Return to **[the skill](../SKILL.md)** for **Step 6** with that topic.
 
-#### If new
+#### If `new`
 
 Set source="fresh".
 

--- a/skills/start-investigation/references/route-scenario.md
+++ b/skills/start-investigation/references/route-scenario.md
@@ -6,7 +6,7 @@
 
 Use `state.scenario` from the discovery output to determine the path.
 
-#### If scenario is "has_investigations"
+#### If scenario is `has_investigations`
 
 > *Output the next fenced block as a code block:*
 
@@ -56,7 +56,7 @@ Set source="fresh".
 
 → Return to **[the skill](../SKILL.md)** for **Step 5**.
 
-#### If scenario is "fresh"
+#### If scenario is `fresh`
 
 Set source="fresh".
 

--- a/skills/start-investigation/references/validate-investigation.md
+++ b/skills/start-investigation/references/validate-investigation.md
@@ -14,7 +14,7 @@ ls .workflows/investigation/
 
 Read `.workflows/investigation/{topic}/investigation.md` frontmatter to check status.
 
-#### If status is "in-progress"
+#### If status is `in-progress`
 
 > *Output the next fenced block as a code block:*
 
@@ -26,7 +26,7 @@ Set source="continue".
 
 → Return to **[the skill](../SKILL.md)** for **Step 6**.
 
-#### If status is "concluded"
+#### If status is `concluded`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-planning/SKILL.md
+++ b/skills/start-planning/SKILL.md
@@ -103,11 +103,11 @@ Parse the discovery output to understand:
 
 Check for arguments: work_type = `$0`, topic = `$1`
 
-#### If work_type and topic are both provided
+#### If `work_type` and `topic` are both provided
 
 → Proceed to **Step 3**.
 
-#### If work_type is provided without topic
+#### If `work_type` is provided without `topic`
 
 Store work_type for the handoff.
 

--- a/skills/start-planning/references/route-scenario.md
+++ b/skills/start-planning/references/route-scenario.md
@@ -8,7 +8,7 @@ Discovery mode — use the discovery output from Step 1.
 
 Use `state.scenario` from the discovery output to determine the path:
 
-#### If scenario is "no_specs"
+#### If scenario is `no_specs`
 
 No specifications exist yet.
 
@@ -25,13 +25,13 @@ Run /start-specification first.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If scenario is "nothing_actionable"
+#### If scenario is `nothing_actionable`
 
 Specifications exist but none are actionable — all are still in-progress and no plans exist to continue.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If scenario is "has_options"
+#### If scenario is `has_options`
 
 At least one specification is ready for planning, or an existing plan can be continued or reviewed.
 

--- a/skills/start-planning/references/validate-spec.md
+++ b/skills/start-planning/references/validate-spec.md
@@ -27,7 +27,7 @@ Run /start-specification {work_type} {topic} to create one.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If specification exists but status is "in-progress"
+#### If specification exists but status is `in-progress`
 
 > *Output the next fenced block as a code block:*
 
@@ -40,7 +40,7 @@ Run /start-specification {work_type} {topic} to continue.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If specification exists and status is "concluded"
+#### If specification exists and status is `concluded`
 
 Parse cross-cutting specs from `specifications.crosscutting` in the discovery output.
 

--- a/skills/start-review/SKILL.md
+++ b/skills/start-review/SKILL.md
@@ -100,11 +100,11 @@ Parse the discovery output to understand:
 
 Check for arguments: work_type = `$0`, topic = `$1`
 
-#### If work_type and topic are both provided
+#### If `work_type` and `topic` are both provided
 
 → Proceed to **Step 3**.
 
-#### If work_type is provided without topic
+#### If `work_type` is provided without `topic`
 
 Store work_type for the handoff.
 

--- a/skills/start-review/references/route-scenario.md
+++ b/skills/start-review/references/route-scenario.md
@@ -8,7 +8,7 @@ Discovery mode — use the discovery output from Step 1.
 
 Use `state.scenario` from the discovery output to determine the path:
 
-#### If scenario is "no_plans"
+#### If scenario is `no_plans`
 
 No plans exist yet.
 
@@ -67,7 +67,7 @@ Select an option:
 
 → Return to **[the skill](../SKILL.md)** for **Step 6**.
 
-#### If scenario is "single_plan" or "multiple_plans"
+#### If scenario is `single_plan` or `multiple_plans`
 
 Plans exist (some may have reviews, some may not).
 

--- a/skills/start-review/references/route-scenario.md
+++ b/skills/start-review/references/route-scenario.md
@@ -26,7 +26,7 @@ to build it.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If all_reviewed is true
+#### If `all_reviewed` is true
 
 All implemented plans have been reviewed.
 

--- a/skills/start-review/references/select-plans.md
+++ b/skills/start-review/references/select-plans.md
@@ -6,7 +6,7 @@
 
 This step only applies for `single`, `multi`, or `all` scope chosen in Step 6.
 
-#### If scope is "analysis"
+#### If scope is `analysis`
 
 Select which reviews to analyze.
 
@@ -37,13 +37,13 @@ Automatically proceed with the only available review.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If scope is "all"
+#### If scope is `all`
 
 All reviewable plans are included. No selection needed. Each plan will be reviewed independently.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If scope is "single"
+#### If scope is `single`
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -57,7 +57,7 @@ Which plan would you like to review? (Enter a number from Step 6)
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If scope is "multi"
+#### If scope is `multi`
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/start-review/references/validate-artifacts.md
+++ b/skills/start-review/references/validate-artifacts.md
@@ -45,7 +45,7 @@ Run /start-implementation {work_type} {topic} to start one.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If implementation status is not "completed"
+#### If implementation status is not `completed`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-specification/SKILL.md
+++ b/skills/start-specification/SKILL.md
@@ -92,11 +92,11 @@ Parse the discovery output to understand:
 
 Check for arguments: work_type = `$0`, topic = `$1`
 
-#### If work_type and topic are both provided
+#### If `work_type` and `topic` are both provided
 
 → Proceed to **Step 3**.
 
-#### If work_type is provided without topic
+#### If `work_type` is provided without `topic`
 
 Store work_type for the handoff.
 

--- a/skills/start-specification/references/check-existing-spec.md
+++ b/skills/start-specification/references/check-existing-spec.md
@@ -33,11 +33,11 @@ A specification for "{topic:(titlecase)}" already exists and is in progress.
 
 **STOP.** Wait for user response.
 
-#### If resume
+#### If `resume`
 
 → Return to **[the skill](../SKILL.md)** with verb="Continuing".
 
-#### If start-fresh
+#### If `start-fresh`
 
 Archive the existing spec.
 

--- a/skills/start-specification/references/check-existing-spec.md
+++ b/skills/start-specification/references/check-existing-spec.md
@@ -12,7 +12,7 @@ Read `.workflows/specification/{topic}/specification.md` if it exists.
 
 → Return to **[the skill](../SKILL.md)** with verb="Creating".
 
-#### If specification exists with status "in-progress"
+#### If specification exists with status `in-progress`
 
 > *Output the next fenced block as a code block:*
 
@@ -43,7 +43,7 @@ Archive the existing spec.
 
 → Return to **[the skill](../SKILL.md)** with verb="Creating".
 
-#### If specification exists with status "concluded"
+#### If specification exists with status `concluded`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-specification/references/check-prerequisites.md
+++ b/skills/start-specification/references/check-prerequisites.md
@@ -6,7 +6,7 @@
 
 Discovery mode — use the discovery output from Step 1 to check prerequisites.
 
-#### If has_discussions is false or has_concluded is false
+#### If `has_discussions` is false or `has_concluded` is false
 
 → Load **[display-blocks.md](display-blocks.md)** and follow its instructions.
 

--- a/skills/start-specification/references/confirm-and-handoff.md
+++ b/skills/start-specification/references/confirm-and-handoff.md
@@ -13,18 +13,18 @@
 
 ## Route
 
-#### If selection is "Unify all"
+#### If selection is `Unify all`
 
 → Load **[confirm-unify.md](confirm-unify.md)** and follow its instructions.
 
-#### If verb is "Creating"
+#### If verb is `Creating`
 
 → Load **[confirm-create.md](confirm-create.md)** and follow its instructions.
 
-#### If verb is "Continuing"
+#### If verb is `Continuing`
 
 → Load **[confirm-continue.md](confirm-continue.md)** and follow its instructions.
 
-#### If verb is "Refining"
+#### If verb is `Refining`
 
 → Load **[confirm-refine.md](confirm-refine.md)** and follow its instructions.

--- a/skills/start-specification/references/display-analyze.md
+++ b/skills/start-specification/references/display-analyze.md
@@ -39,7 +39,7 @@ before they can be included in a specification.
 
 No `---` separator before these messages.
 
-#### If cache status is "none"
+#### If cache status is `none`
 
 > *Output the next fenced block as a code block:*
 
@@ -59,7 +59,7 @@ Proceed with analysis?
 · · · · · · · · · · · ·
 ```
 
-#### If cache status is "stale"
+#### If cache status is `stale`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-specification/references/display-groupings.md
+++ b/skills/start-specification/references/display-groupings.md
@@ -158,7 +158,7 @@ Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 → Load **[confirm-and-handoff.md](confirm-and-handoff.md)** and follow its instructions.
 
-#### If user picks "Unify all"
+#### If user picks `Unify all`
 
 Update the cache: rewrite `.workflows/.state/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all concluded discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
 
@@ -166,7 +166,7 @@ Spec name: "Unified". Sources: all concluded discussions.
 
 → Load **[confirm-and-handoff.md](confirm-and-handoff.md)** and follow its instructions.
 
-#### If user picks "Re-analyze"
+#### If user picks `Re-analyze`
 
 Delete the cache:
 ```bash

--- a/skills/start-specification/references/display-specs-menu.md
+++ b/skills/start-specification/references/display-specs-menu.md
@@ -83,7 +83,7 @@ Key:
 
 No `---` separator before these messages.
 
-#### If cache status is "none"
+#### If cache status is `none`
 
 > *Output the next fenced block as a code block:*
 
@@ -91,7 +91,7 @@ No `---` separator before these messages.
 No grouping analysis exists.
 ```
 
-#### If cache status is "stale"
+#### If cache status is `stale`
 
 > *Output the next fenced block as a code block:*
 
@@ -135,7 +135,7 @@ Menu descriptions are wrapped in backticks to visually distinguish them from the
 
 **STOP.** Wait for user response.
 
-#### If user picks "Analyze for groupings"
+#### If user picks `Analyze for groupings`
 
 If cache is stale, delete it first:
 ```bash
@@ -144,7 +144,7 @@ rm .workflows/.state/discussion-consolidation-analysis.md
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions.
 
-#### If user picks "Continue" or "Refine" for a spec
+#### If user picks `Continue` or `Refine` for a spec
 
 The selected spec and its sources become the context for confirmation.
 

--- a/skills/start-specification/references/invoke-skill-bridge.md
+++ b/skills/start-specification/references/invoke-skill-bridge.md
@@ -29,7 +29,7 @@ Invoke the [technical-specification](../../technical-specification/SKILL.md) ski
 
 Construct the handoff based on the work type and verb.
 
-#### If work_type is feature
+#### If `work_type` is `feature`
 
 ```
 Specification session for: {topic}
@@ -51,7 +51,7 @@ The specification frontmatter should include:
 Invoke the technical-specification skill.
 ```
 
-#### If work_type is bugfix
+#### If `work_type` is `bugfix`
 
 ```
 Specification session for: {topic}

--- a/skills/start-specification/references/route-scenario.md
+++ b/skills/start-specification/references/route-scenario.md
@@ -10,11 +10,11 @@ Based on discovery state, load exactly ONE reference file:
 
 → Load **[display-single.md](display-single.md)** and follow its instructions.
 
-#### If cache status is "valid"
+#### If cache status is `valid`
 
 → Load **[display-groupings.md](display-groupings.md)** and follow its instructions.
 
-#### If spec_count == 0 and cache is "none" or "stale"
+#### If spec_count == 0 and cache is `none` or `stale`
 
 → Load **[display-analyze.md](display-analyze.md)** and follow its instructions.
 

--- a/skills/start-specification/references/route-scenario.md
+++ b/skills/start-specification/references/route-scenario.md
@@ -6,7 +6,7 @@
 
 Based on discovery state, load exactly ONE reference file:
 
-#### If concluded_count == 1
+#### If `concluded_count` == 1
 
 → Load **[display-single.md](display-single.md)** and follow its instructions.
 
@@ -14,7 +14,7 @@ Based on discovery state, load exactly ONE reference file:
 
 → Load **[display-groupings.md](display-groupings.md)** and follow its instructions.
 
-#### If spec_count == 0 and cache is `none` or `stale`
+#### If `spec_count` == 0 and cache is `none` or `stale`
 
 → Load **[display-analyze.md](display-analyze.md)** and follow its instructions.
 

--- a/skills/start-specification/references/validate-source.md
+++ b/skills/start-specification/references/validate-source.md
@@ -6,7 +6,7 @@
 
 Check if source material exists and is ready.
 
-#### If work_type is feature
+#### If `work_type` is `feature`
 
 Check if discussion exists and is concluded:
 
@@ -48,7 +48,7 @@ Run /start-discussion feature {topic} to continue.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If work_type is bugfix
+#### If `work_type` is `bugfix`
 
 Check if investigation exists and is concluded:
 

--- a/skills/technical-discussion/references/conclude-discussion.md
+++ b/skills/technical-discussion/references/conclude-discussion.md
@@ -17,11 +17,11 @@ When the user indicates they want to conclude:
 
 **STOP.** Wait for user response.
 
-#### If comment
+#### If `comment`
 
 Incorporate the user's context into the discussion, commit, then re-present the sign-off prompt above.
 
-#### If yes
+#### If `yes`
 
 1. Update frontmatter `status: concluded`
 2. Final commit

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -319,11 +319,11 @@ Before marking complete, present the sign-off:
 
 **STOP.** Wait for user response.
 
-#### If comment
+#### If `comment`
 
 Discuss the user's context. If additional work is needed, route back to **Step 6** or **Step 7** as appropriate. Otherwise, re-present the sign-off prompt above.
 
-#### If yes
+#### If `yes`
 
 Update the tracking file (`.workflows/implementation/{topic}/tracking.md`):
 - Set `status: completed`

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -100,7 +100,7 @@ Complete ALL setup steps before proceeding.
 
 Load **[environment-setup.md](references/environment-setup.md)** and follow its instructions.
 
-#### If `.workflows/environment-setup.md` states "No special setup required"
+#### If `.workflows/environment-setup.md` states `No special setup required`
 
 → Proceed to **Step 2**.
 

--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -99,8 +99,6 @@ impl({topic}): analysis cycle {N} — findings
 
 #### If all three agents returned `STATUS: clean`
 
-No findings to synthesize — skip straight to completion.
-
 → Return to **[the skill](../SKILL.md)** for **Step 8**.
 
 #### Otherwise

--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -97,6 +97,14 @@ Commit the analysis findings:
 impl({topic}): analysis cycle {N} — findings
 ```
 
+#### If all three agents returned `STATUS: clean`
+
+No findings to synthesize — skip straight to completion.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 8**.
+
+#### Otherwise
+
 → Proceed to **D. Dispatch Synthesis Agent**.
 
 ---

--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -215,7 +215,7 @@ Update `status: skipped` in the staging file.
 
 → Present the next pending task, or proceed to routing below if all tasks processed.
 
-#### If comment
+#### If `comment`
 
 Revise the task content in the staging file based on the user's feedback. Re-present this task.
 

--- a/skills/technical-investigation/references/conclude-investigation.md
+++ b/skills/technical-investigation/references/conclude-investigation.md
@@ -20,17 +20,17 @@ Investigation complete. Ready to conclude?
 
 **STOP.** Wait for user response.
 
-#### If reopen
+#### If `reopen`
 
 Ask what aspects need more analysis.
 
 → Return to **[the skill](../SKILL.md)** for **Step 3**.
 
-#### If Comment
+#### If `comment`
 
 Incorporate the user's context into the investigation file and commit. Re-present the same conclusion prompt.
 
-#### If yes
+#### If `yes`
 
 1. Update frontmatter `status: concluded`
 2. Final commit

--- a/skills/technical-investigation/references/findings-review.md
+++ b/skills/technical-investigation/references/findings-review.md
@@ -49,7 +49,7 @@ Address their concerns directly. Re-trace code paths if needed. Provide supporti
 
 Re-present findings using the same format above.
 
-#### If yes
+#### If `yes`
 
 → Proceed to **B. Fix Direction Discussion**.
 
@@ -88,7 +88,7 @@ Engage collaboratively. Stay bounded — focus on:
 
 Do not go into implementation detail — that belongs in the specification. When discussion reaches a natural decision point, summarize the agreed direction and present for confirmation.
 
-#### If yes
+#### If `yes`
 
 Document the Fix Direction section in the investigation file:
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -244,11 +244,11 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 **STOP.** Wait for user response.
 
-#### If comment
+#### If `comment`
 
 Discuss the user's context. If additional work is needed, route back to **Step 6** or **Step 7** as appropriate. Otherwise, re-present the sign-off prompt above.
 
-#### If yes
+#### If `yes`
 
 1. **Update plan status** — Set `status: concluded` in the Plan Index File frontmatter
 2. **Final commit** — Commit the concluded plan: `planning({topic}): conclude plan`

--- a/skills/technical-planning/references/analyze-task-graph.md
+++ b/skills/technical-planning/references/analyze-task-graph.md
@@ -113,6 +113,6 @@ Re-invoke `planning-dependency-grapher` with all original inputs PLUS:
 
 The agent will clear all existing graph data and re-analyze from scratch. Present the revised analysis in full. Ask the same choice again. Repeat until approved.
 
-#### If approved
+#### If `approved`
 
 Commit: `planning({topic}): analyze task dependencies and priorities`

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -42,11 +42,11 @@ The agent writes all tasks to the scratch file and returns.
 
 Read the scratch file and count tasks. Verify task count matches the task table in the Plan Index File for this phase.
 
-#### If mismatch
+#### If `mismatch`
 
 Re-invoke the agent with the same inputs.
 
-#### If valid
+#### If `valid`
 
 → Proceed to **D. Check Gate Mode**.
 

--- a/skills/technical-planning/references/define-phases.md
+++ b/skills/technical-planning/references/define-phases.md
@@ -88,7 +88,7 @@ Re-invoke `planning-phase-designer` with all original inputs PLUS:
 
 Update the Plan Index File with the revised output, re-present, and ask again. Repeat until approved.
 
-#### If approved
+#### If `approved`
 
 **If the phase structure is new or was amended:**
 

--- a/skills/technical-planning/references/plan-review.md
+++ b/skills/technical-planning/references/plan-review.md
@@ -95,11 +95,11 @@ with fresh context — 2-3 cycles typically surface anything cascading.
 
 **STOP.** Wait for user response.
 
-#### If reanalyse
+#### If `reanalyse`
 
 → Return to **A. Cycle Management** to begin a fresh cycle.
 
-#### If proceed
+#### If `proceed`
 
 → Proceed to **E. Completion**.
 

--- a/skills/technical-planning/references/process-review-findings.md
+++ b/skills/technical-planning/references/process-review-findings.md
@@ -8,7 +8,7 @@ Process findings from a review agent interactively with the user. The agent writ
 
 **Review type**: `{review_type:[traceability|integrity]}` — set by the calling context (B or C in plan-review.md).
 
-#### If STATUS is `clean`
+#### If `STATUS` is `clean`
 
 > *Output the next fenced block as a code block:*
 
@@ -18,7 +18,7 @@ Process findings from a review agent interactively with the user. The agent writ
 
 → Return to **[plan-review.md](plan-review.md)** for the next phase.
 
-#### If STATUS is `findings`
+#### If `STATUS` is `findings`
 
 Read the tracking file at the path returned by the agent (`TRACKING_FILE`).
 
@@ -121,7 +121,7 @@ Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
 
 Incorporate feedback and re-present the proposed fix **in full**. Update the tracking file with the revised content. Then ask the same choice again. Repeat until approved or skipped.
 
-#### If approved
+#### If `approved`
 
 1. Apply the fix to the plan — use the **Proposed** content exactly as shown, using the output format adapter to determine how it's written. Do not modify content between approval and writing.
 2. Update the tracking file: set resolution to "Fixed", add any discussion notes.
@@ -144,7 +144,7 @@ Incorporate feedback and re-present the proposed fix **in full**. Update the tra
 
 → After all processed, proceed to **C. After All Findings Processed**.
 
-#### If skipped
+#### If `skipped`
 
 1. Update the tracking file: set resolution to "Skipped", note the reason.
 2. Commit the tracking file — ensures progress survives context refresh.

--- a/skills/technical-planning/references/resolve-dependencies.md
+++ b/skills/technical-planning/references/resolve-dependencies.md
@@ -61,6 +61,6 @@ Present a summary of the dependency state: what was documented, what was resolve
 
 Incorporate feedback, re-present the updated dependency state, and ask again. Repeat until approved.
 
-#### If approved
+#### If `approved`
 
 Commit: `planning({topic}): resolve external dependencies`

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -48,7 +48,7 @@ having it provides better context for the review.
 
 The specification is optional — the review can proceed with just the plan.
 
-#### If review mode is "analysis-only"
+#### If review mode is `analysis-only`
 
 Analysis of existing review findings was requested. The review has already been completed.
 

--- a/skills/technical-review/references/review-actions-loop.md
+++ b/skills/technical-review/references/review-actions-loop.md
@@ -22,7 +22,7 @@ E. Re-open implementation + plan mode handoff
 
 Check the verdict(s) from the review(s) being analyzed.
 
-#### If all verdicts are "Approve" with no required changes
+#### If all verdicts are `Approve` with no required changes
 
 > *Output the next fenced block as a code block:*
 
@@ -56,7 +56,7 @@ All checks passed. The implementation has been validated.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If any verdict is "Request Changes"
+#### If any verdict is `Request Changes`
 
 Blocking issues exist. Synthesis is strongly recommended.
 
@@ -106,7 +106,7 @@ Invoke the workflow-bridge skill to enter plan mode with continuation instructio
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If verdict is "Comments Only"
+#### If verdict is `Comments Only`
 
 Non-blocking improvements only. Synthesis is optional.
 
@@ -146,7 +146,7 @@ Load **[invoke-review-synthesizer.md](invoke-review-synthesizer.md)** and follow
 
 **STOP.** Do not proceed until the synthesizer has returned.
 
-#### If STATUS is "clean"
+#### If `STATUS` is `clean`
 
 > *Output the next fenced block as a code block:*
 
@@ -156,7 +156,7 @@ No actionable tasks synthesized.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If STATUS is "tasks_proposed"
+#### If `STATUS` is `tasks_proposed`
 
 → Proceed to **C. Approval Gate**.
 
@@ -201,7 +201,7 @@ Sources: {sources}
 {tests}
 ```
 
-#### If gate_mode is "gated"
+#### If `gate_mode` is `gated`
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -218,7 +218,7 @@ Approve this task?
 
 **STOP.** Wait for user input.
 
-#### If gate_mode is "auto"
+#### If `gate_mode` is `auto`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/technical-review/references/review-actions-loop.md
+++ b/skills/technical-review/references/review-actions-loop.md
@@ -80,11 +80,11 @@ Proceed with synthesis?
 
 **STOP.** Wait for user response.
 
-#### If yes
+#### If `yes`
 
 → Proceed to **B. Dispatch Review Synthesizer**.
 
-#### If no
+#### If `no`
 
 User has chosen to skip synthesis. This is a terminal condition, but check for pipeline continuation first.
 
@@ -130,11 +130,11 @@ Synthesize non-blocking findings?
 
 **STOP.** Wait for user response.
 
-#### If yes
+#### If `yes`
 
 → Proceed to **B. Dispatch Review Synthesizer**.
 
-#### If no
+#### If `no`
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -250,7 +250,7 @@ Update `status: skipped` in the staging file.
 
 → Present the next pending task, or proceed to routing below if all tasks processed.
 
-#### If comment
+#### If `comment`
 
 Revise the task content in the staging file based on the user's feedback. Re-present this task.
 

--- a/skills/technical-specification/references/process-review-findings.md
+++ b/skills/technical-specification/references/process-review-findings.md
@@ -117,7 +117,7 @@ Finding {N} of {total}: {brief_title:(titlecase)} — approved. Added to specifi
 
 Incorporate feedback and re-present the proposed content **in full**. Update the tracking file with the revised content. Then ask the same choice again. Repeat until approved or skipped.
 
-#### If approved
+#### If `approved`
 
 1. Log the content to the specification verbatim
 2. Update the tracking file: set resolution to "Approved", add any discussion notes
@@ -141,7 +141,7 @@ Finding {N} of {total}: {brief_title:(titlecase)} — added.
 
 → After all processed, proceed to **C. After All Findings Processed**.
 
-#### If skipped
+#### If `skipped`
 
 1. Update the tracking file: set resolution to "Skipped", note the reason
 2. Commit — ensures progress survives context refresh

--- a/skills/technical-specification/references/spec-completion.md
+++ b/skills/technical-specification/references/spec-completion.md
@@ -46,11 +46,11 @@ of functionality to build."}
 
 **STOP.** Wait for user response.
 
-#### If comment
+#### If `comment`
 
 Discuss the user's suggested classification, re-assess, and re-present the assessment display and prompt above.
 
-#### If yes
+#### If `yes`
 
 → Proceed to **B. Verify Tracking Files Complete**.
 
@@ -82,11 +82,11 @@ If any tracking file still shows `status: in-progress`, mark it complete now.
 
 **STOP.** Wait for user response.
 
-#### If comment
+#### If `comment`
 
 Discuss the user's context, apply any changes, then re-present the sign-off prompt above.
 
-#### If yes
+#### If `yes`
 
 → Proceed to **D. Update Frontmatter and Conclude**.
 
@@ -138,7 +138,7 @@ If any of your sources were **existing specifications** (as opposed to discussio
 
 Check the specification frontmatter for `work_type`.
 
-#### If work_type is set (feature, bugfix, or greenfield)
+#### If `work_type` is set (`feature`, `bugfix`, or `greenfield`)
 
 This specification is part of a pipeline. Invoke the `/workflow-bridge` skill:
 
@@ -150,7 +150,7 @@ Completed phase: specification
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
-#### If work_type is not set
+#### If `work_type` is not set
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/technical-specification/references/spec-review.md
+++ b/skills/technical-specification/references/spec-review.md
@@ -109,11 +109,11 @@ Load **[process-review-findings.md](process-review-findings.md)** and follow its
 
 ## D. Re-Loop Prompt
 
-#### If `phase_1_status` is "clean" and `phase_2_status` is "clean"
+#### If `phase_1_status` is `clean` and `phase_2_status` is `clean`
 
 → Proceed to **E. Completion** (nothing to re-analyse).
 
-#### If either status is "findings"
+#### If either status is `findings`
 
 Check `finding_gate_mode` and `review_cycle` in the specification frontmatter.
 

--- a/skills/technical-specification/references/spec-review.md
+++ b/skills/technical-specification/references/spec-review.md
@@ -152,11 +152,11 @@ Auto-review has not converged after 5 cycles — escalating for human review.
 
 **STOP.** Wait for user response.
 
-#### If reanalyse
+#### If `reanalyse`
 
 → Return to **A. Cycle Management** to begin a fresh cycle.
 
-#### If proceed
+#### If `proceed`
 
 → Proceed to **E. Completion**.
 

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -31,15 +31,15 @@ If the above shows a script invocation rather than YAML output, the dynamic cont
 
 The output contains three sections: `features:`, `bugfixes:`, and `greenfield:`. Use the known work type and topic from the calling context to extract the relevant data:
 
-#### If work type is "feature"
+#### If work type is `feature`
 
 Find the topic entry under `features: > topics:` and extract its `next_phase`.
 
-#### If work type is "bugfix"
+#### If work type is `bugfix`
 
 Find the topic entry under `bugfixes: > topics:` and extract its `next_phase`.
 
-#### If work type is "greenfield"
+#### If work type is `greenfield`
 
 Parse the `greenfield:` section for phase-centric state:
 - `state`: Counts of artifacts across all phases
@@ -53,15 +53,15 @@ Parse the `greenfield:` section for phase-centric state:
 
 Based on work type, load the appropriate continuation reference:
 
-#### If work type is "feature"
+#### If work type is `feature`
 
 Load **[feature-continuation.md](references/feature-continuation.md)** and follow its instructions as written.
 
-#### If work type is "bugfix"
+#### If work type is `bugfix`
 
 Load **[bugfix-continuation.md](references/bugfix-continuation.md)** and follow its instructions as written.
 
-#### If work type is "greenfield"
+#### If work type is `greenfield`
 
 Load **[greenfield-continuation.md](references/greenfield-continuation.md)** and follow its instructions as written.
 

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -23,7 +23,7 @@ Use `next_phase` from discovery output to determine the target skill:
 
 ## Generate Plan Mode Content
 
-#### If next_phase is "done"
+#### If `next_phase` is `done`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -24,7 +24,7 @@ Use `next_phase` from discovery output to determine the target skill:
 
 ## Generate Plan Mode Content
 
-#### If next_phase is "done"
+#### If `next_phase` is `done`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-bridge/references/greenfield-continuation.md
+++ b/skills/workflow-bridge/references/greenfield-continuation.md
@@ -136,7 +136,7 @@ Recreate with actual topics and states from discovery. Only include options that
 
 ## C. Route Selection
 
-#### If user chose "Stop here"
+#### If user chose `Stop here`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -84,14 +84,14 @@ The reference will present the current state and ask the user which work type th
 
 Based on the selected work type, load the appropriate routing reference:
 
-#### If work type is "greenfield"
+#### If work type is `greenfield`
 
 Load **[greenfield-routing.md](references/greenfield-routing.md)** and follow its instructions.
 
-#### If work type is "feature"
+#### If work type is `feature`
 
 Load **[feature-routing.md](references/feature-routing.md)** and follow its instructions.
 
-#### If work type is "bugfix"
+#### If work type is `bugfix`
 
 Load **[bugfix-routing.md](references/bugfix-routing.md)** and follow its instructions.

--- a/skills/workflow-start/references/bugfix-routing.md
+++ b/skills/workflow-start/references/bugfix-routing.md
@@ -85,7 +85,7 @@ Recreate with actual topics and `phase_label` values from discovery.
 
 Parse the user's selection, then follow the instructions below.
 
-#### If "start new bugfix"
+#### If `start new bugfix`
 
 Invoke `/start-bugfix`. It will set `work_type: bugfix` and begin the investigation phase.
 

--- a/skills/workflow-start/references/bugfix-routing.md
+++ b/skills/workflow-start/references/bugfix-routing.md
@@ -33,11 +33,11 @@ Ready to start a new bugfix.
 
 **STOP.** Wait for user response.
 
-#### If yes
+#### If `yes`
 
 Invoke `start-bugfix`. It will set `work_type: bugfix` automatically.
 
-#### If no
+#### If `no`
 
 → Return to **[the skill](../SKILL.md)** for **Step 2** (work type selection).
 

--- a/skills/workflow-start/references/feature-routing.md
+++ b/skills/workflow-start/references/feature-routing.md
@@ -33,11 +33,11 @@ Ready to start a new feature.
 
 **STOP.** Wait for user response.
 
-#### If yes
+#### If `yes`
 
 Invoke `start-feature`. It will set `work_type: feature` automatically.
 
-#### If no
+#### If `no`
 
 → Return to **[the skill](../SKILL.md)** for **Step 2** (work type selection).
 

--- a/skills/workflow-start/references/feature-routing.md
+++ b/skills/workflow-start/references/feature-routing.md
@@ -85,7 +85,7 @@ Recreate with actual topics and `phase_label` values from discovery.
 
 Parse the user's selection, then follow the instructions below.
 
-#### If "start new feature"
+#### If `start new feature`
 
 Invoke `/start-feature`. It will set `work_type: feature` automatically.
 


### PR DESCRIPTION
## Summary

- **Skip synthesizer when all analysis agents return clean** — the analysis loop unconditionally dispatched the synthesis agent even when all three agents (duplication, standards, architecture) returned `STATUS: clean`. Added a short-circuit gate after Stage C to go straight to Step 8.
- **Fix inline conditionals in analysis-loop.md** — converted inline arrow conditionals (action on same line as condition) to proper H4 heading pattern with condition and action separated.
- **Update H4 backtick convention** — backticks are now the standard for specific values, variables, and statuses in H4 headings. Updated CLAUDE.md rule and applied across 38 skill files (85 occurrences).

## Test plan

- [ ] Run implementation through analysis with no findings — verify synthesizer is skipped
- [ ] Run implementation with findings — verify synthesizer still dispatches
- [ ] Spot-check H4 headings across skills for correct backtick usage
- [ ] Verify no remaining quoted values in H4 conditionals: `grep -r '^#### If.*"' skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)