### PR TITLE
refactor: derive work_type from manifest, remove from handoffs

### DIFF
--- a/roadmap/IMPLEMENTATION-INDEX.md
+++ b/roadmap/IMPLEMENTATION-INDEX.md
@@ -9,7 +9,7 @@ Overview of remaining PRs for the work-type architecture. PR 1 (Big Bang) is the
 | ✅ | PR 1 | Big Bang — New Architecture | (current branch) |
 | ✅ | PR 4 | Start/Continue Split | [Design](archive/start-continue-split/DESIGN.md) |
 | ✅ | PR 5 | Phase Skills Internal | [PR5-PHASE-SKILLS-INTERNAL.md](PR5-PHASE-SKILLS-INTERNAL.md) |
-| 4th | PR 2 | Bridge Always Fires | [PR2-BRIDGE-ALWAYS-FIRES.md](PR2-BRIDGE-ALWAYS-FIRES.md) |
+| ✅ | PR 2 | Bridge Always Fires | [PR2-BRIDGE-ALWAYS-FIRES.md](PR2-BRIDGE-ALWAYS-FIRES.md) |
 | 5th | PR 3 | Bridge Epic Navigation | [PR3-BRIDGE-EPIC-NAVIGATION.md](PR3-BRIDGE-EPIC-NAVIGATION.md) |
 | 6th | PR 6 | Processing Skills Pipeline-Aware | [PR6-PROCESSING-SKILLS-PIPELINE-AWARE.md](PR6-PROCESSING-SKILLS-PIPELINE-AWARE.md) |
 | 7th | PR 7 | Work Unit Lifecycle | [PR7-WORK-UNIT-LIFECYCLE.md](PR7-WORK-UNIT-LIFECYCLE.md) |

--- a/skills/technical-discussion/references/conclude-discussion.md
+++ b/skills/technical-discussion/references/conclude-discussion.md
@@ -28,14 +28,10 @@ Incorporate the user's context into the discussion, commit, then re-present the 
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase discussion --topic {topic} status concluded
    ```
 2. Final commit
-3. Read work_type from manifest and invoke the bridge:
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-   ```
+3. Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: discussion
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -361,14 +361,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phas
 
 Commit: `impl({work_unit}): complete implementation`
 
-**Pipeline continuation** — Read the work type via manifest CLI and invoke the bridge:
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-```
+**Pipeline continuation** — Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: implementation
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.

--- a/skills/technical-investigation/references/conclude-investigation.md
+++ b/skills/technical-investigation/references/conclude-investigation.md
@@ -50,14 +50,10 @@ Fix direction: {chosen approach}
 The investigation is concluded. Root cause and fix direction are documented.
 ```
 
-4. Read work_type from manifest and invoke the bridge:
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-   ```
+4. Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: bugfix
 Completed phase: investigation
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -328,14 +328,10 @@ The plan contains **{N} phases** with **{M} tasks** total, reviewed for traceabi
 Status has been marked as `concluded`. The plan is ready for implementation.
 ```
 
-4. **Pipeline continuation** — Read the work type via manifest CLI and invoke the bridge:
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-   ```
+4. **Pipeline continuation** — Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: planning
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.

--- a/skills/technical-research/references/convergence-awareness.md
+++ b/skills/technical-research/references/convergence-awareness.md
@@ -26,17 +26,10 @@ Set research status to concluded via manifest CLI:
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase research status concluded
 ```
 
-Check work_type from manifest:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-```
-
 Invoke the `/workflow-bridge` skill:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: research
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.

--- a/skills/technical-review/references/review-actions-loop.md
+++ b/skills/technical-review/references/review-actions-loop.md
@@ -36,15 +36,10 @@ Set the review phase status to completed:
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status completed
 ```
 
-**Pipeline continuation** — Read the work type via manifest CLI and invoke the bridge:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-```
+**Pipeline continuation** — Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: review
 
 Invoke the workflow-bridge skill to enter plan mode with completion confirmation.
@@ -86,15 +81,10 @@ User has chosen to skip synthesis. Set review status to completed — the review
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status completed
 ```
 
-**Pipeline continuation** — Read the work type via manifest CLI and invoke the bridge:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-```
+**Pipeline continuation** — Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: review
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
@@ -136,15 +126,10 @@ Set review status to completed — the review produced a verdict, even if the us
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status completed
 ```
 
-**Pipeline continuation** — Read the work type via manifest CLI and invoke the bridge:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-```
+**Pipeline continuation** — Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: review
 
 Invoke the workflow-bridge skill to enter plan mode with completion confirmation.
@@ -172,15 +157,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phas
 No actionable tasks synthesized. Review complete.
 ```
 
-**Pipeline continuation** — Read the work type via manifest CLI and invoke the bridge:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-```
+**Pipeline continuation** — Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: review
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
@@ -306,15 +286,10 @@ Commit the staging file updates:
 review({work_unit}): synthesis cycle {N} — tasks skipped
 ```
 
-**Pipeline continuation** — Read the work type via manifest CLI and invoke the bridge:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
-```
+**Pipeline continuation** — Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: review
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.

--- a/skills/technical-specification/references/spec-completion.md
+++ b/skills/technical-specification/references/spec-completion.md
@@ -149,11 +149,10 @@ It does not proceed to planning independently.
 
 #### If `type` is `feature` (or not set)
 
-Read the work type via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type`) and invoke the bridge:
+Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}
-Work type: {work_type from manifest}
 Completed phase: specification
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -14,12 +14,17 @@ This skill is invoked by processing skills (technical-discussion, technical-spec
 
 This skill receives context from the calling processing skill:
 - **Work unit**: The work unit name (directory under `.workflows/`) = `{work_unit}`
-- **Work type**: epic, feature, or bugfix = `{work_type}`
 - **Completed phase**: The phase that just concluded = `{completed_phase}`
 
 ---
 
-## Step 1: Run Discovery
+## Step 1: Read Work Type and Run Discovery
+
+Read work type from the manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
+```
 
 #### If work type is `epic`
 
@@ -27,7 +32,7 @@ This skill receives context from the calling processing skill:
 
 #### Otherwise
 
-Run the discovery script with the work unit from the calling context:
+Run the discovery script with the work unit:
 
 ```bash
 node .claude/skills/workflow-bridge/scripts/discovery.js {work_unit}

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -44,7 +44,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
-Store work_type and work_unit for the handoff.
+Store work_unit for the handoff.
 
 #### If `topic` resolved
 

--- a/skills/workflow-discussion-entry/references/gather-context.md
+++ b/skills/workflow-discussion-entry/references/gather-context.md
@@ -8,7 +8,7 @@ Route based on the `source` variable set in earlier steps.
 
 #### If source is `new`
 
-New discussion entry: topic and work_type were provided by the caller.
+New discussion entry: topic was provided by the caller.
 
 Check research status via manifest:
 
@@ -24,7 +24,6 @@ Read `.workflows/{work_unit}/research/*.md` for context to include in the handof
 
 ```
 Starting discussion: {topic:(titlecase)}
-Work type: {work_type}
 
 Research context:
 {key findings and context from research files}

--- a/skills/workflow-discussion-entry/references/invoke-skill.md
+++ b/skills/workflow-discussion-entry/references/invoke-skill.md
@@ -29,14 +29,13 @@ Invoke the [technical-discussion](../../technical-discussion/SKILL.md) skill for
 
 ## Handoff
 
-Construct the handoff based on how this discussion was initiated. Work type is always available (callers always provide it).
+Construct the handoff based on how this discussion was initiated.
 
 #### If source is `research`
 
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
 Output: {output_path}
 
 Research reference:
@@ -51,7 +50,6 @@ Invoke the technical-discussion skill.
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
 Output: {output_path}
 
 Research reference:
@@ -66,7 +64,6 @@ Invoke the technical-discussion skill.
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
 Source: existing discussion
 Output: {output_path}
 
@@ -78,7 +75,6 @@ Invoke the technical-discussion skill.
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
 Source: fresh
 Output: {output_path}
 

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -44,7 +44,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
-Store work_type and work_unit for the handoff.
+Store work_unit for the handoff.
 
 → Proceed to **Step 2**.
 

--- a/skills/workflow-implementation-entry/references/invoke-skill.md
+++ b/skills/workflow-implementation-entry/references/invoke-skill.md
@@ -43,7 +43,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 ```
 Implementation session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
+
 Plan: .workflows/{work_unit}/planning/{topic}/planning.md
 Format: {format}
 Ext ID: {ext_id} (if applicable)

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -41,7 +41,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
-Investigation is always bugfix work_type. Store work_type and work_unit for the handoff.
+Investigation is always bugfix work_type. Store work_unit for the handoff.
 
 Check investigation phase status via manifest CLI:
 

--- a/skills/workflow-investigation-entry/references/invoke-skill.md
+++ b/skills/workflow-investigation-entry/references/invoke-skill.md
@@ -33,7 +33,7 @@ Construct the handoff based on source.
 
 ```
 Investigation session for: {work_unit}
-Work type: bugfix
+
 Output: .workflows/{work_unit}/investigation/{topic}.md
 
 Bug context:
@@ -48,7 +48,7 @@ Invoke the technical-investigation skill.
 
 ```
 Investigation session for: {work_unit}
-Work type: bugfix
+
 Source: existing investigation
 Output: .workflows/{work_unit}/investigation/{topic}.md
 

--- a/skills/workflow-planning-entry/SKILL.md
+++ b/skills/workflow-planning-entry/SKILL.md
@@ -44,7 +44,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
-Store work_type and work_unit for the handoff.
+Store work_unit for the handoff.
 
 → Proceed to **Step 2**.
 

--- a/skills/workflow-planning-entry/references/invoke-skill.md
+++ b/skills/workflow-planning-entry/references/invoke-skill.md
@@ -27,7 +27,7 @@ Invoke the [technical-planning](../../technical-planning/SKILL.md) skill for you
 
 ## Handoff
 
-Construct the handoff based on the plan state. Work type is always available.
+Construct the handoff based on the plan state.
 
 #### If creating fresh plan (no existing plan)
 
@@ -40,7 +40,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 ```
 Planning session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
+
 Specification: .workflows/{work_unit}/specification/{topic}/specification.md
 Additional context: {summary of user's additional context, or "none"}
 Cross-cutting references: {list of applicable cross-cutting specs with brief summaries, or "none"}
@@ -54,7 +54,7 @@ Invoke the technical-planning skill.
 ```
 Planning session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
+
 Specification: .workflows/{work_unit}/specification/{topic}/specification.md
 Existing plan: .workflows/{work_unit}/planning/{topic}/planning.md
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -44,7 +44,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
-Store work_type and work_unit for the handoff.
+Store work_unit for the handoff.
 
 #### If `topic` resolved
 

--- a/skills/workflow-research-entry/references/invoke-skill.md
+++ b/skills/workflow-research-entry/references/invoke-skill.md
@@ -12,14 +12,14 @@ Invoke the [technical-research](../../technical-research/SKILL.md) skill for you
 
 ## Handoff
 
-Construct the handoff. Work type is always available (callers always provide it).
+Construct the handoff.
 
 #### If source is `continue`
 
 ```
 Research session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
+
 Source: existing research
 Output: .workflows/{work_unit}/research/exploration.md
 
@@ -31,7 +31,7 @@ Invoke the technical-research skill.
 ```
 Research session for: {topic}
 Work unit: {work_unit}
-Work type: {work_type}
+
 Output: .workflows/{work_unit}/research/exploration.md
 
 Context:

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -44,7 +44,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
-Store work_type and work_unit for the handoff.
+Store work_unit for the handoff.
 
 → Proceed to **Step 2**.
 

--- a/skills/workflow-review-entry/references/invoke-skill.md
+++ b/skills/workflow-review-entry/references/invoke-skill.md
@@ -41,7 +41,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 ```
 Review session
 Work unit: {work_unit}
-Work type: {work_type}
+
 Plans to review:
   - work_unit: {work_unit}
     plan: .workflows/{work_unit}/planning/{topic}/planning.md

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -44,7 +44,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
-Store work_type and work_unit for the handoff.
+Store work_unit for the handoff.
 
 #### If `topic` resolved
 

--- a/skills/workflow-specification-entry/references/handoffs/continue-concluded.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue-concluded.md
@@ -27,11 +27,8 @@ Saving session state so Claude can pick up where it left off if the conversation
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
 
-Determine work_type: use the value from Step 2 if available. Otherwise, read work_type from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type`).
-
 ```
 Specification session for: {Title Case Name}
-Work type: {work_type}
 
 Continuing existing: .workflows/{work_unit}/specification/{topic}/specification.md (concluded)
 

--- a/skills/workflow-specification-entry/references/handoffs/continue.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue.md
@@ -27,11 +27,8 @@ Saving session state so Claude can pick up where it left off if the conversation
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
 
-Determine work_type: use the value from Step 2 if available. Otherwise, read work_type from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type`).
-
 ```
 Specification session for: {Title Case Name}
-Work type: {work_type}
 
 Continuing existing: .workflows/{work_unit}/specification/{topic}/specification.md
 

--- a/skills/workflow-specification-entry/references/handoffs/create-with-incorporation.md
+++ b/skills/workflow-specification-entry/references/handoffs/create-with-incorporation.md
@@ -21,11 +21,8 @@ Saving session state so Claude can pick up where it left off if the conversation
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
 
-Determine work_type: use the value from Step 2 if available. Otherwise, read work_type from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type`).
-
 ```
 Specification session for: {Title Case Name}
-Work type: {work_type}
 
 Source discussions:
 - .workflows/{work_unit}/discussion/{discussion-name}.md

--- a/skills/workflow-specification-entry/references/handoffs/create.md
+++ b/skills/workflow-specification-entry/references/handoffs/create.md
@@ -21,11 +21,8 @@ Saving session state so Claude can pick up where it left off if the conversation
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
 
-Determine work_type: use the value from Step 2 if available. Otherwise, read work_type from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type`).
-
 ```
 Specification session for: {Title Case Name}
-Work type: {work_type}
 
 Sources:
 - .workflows/{work_unit}/discussion/{discussion-name}.md

--- a/skills/workflow-specification-entry/references/handoffs/unify-with-incorporation.md
+++ b/skills/workflow-specification-entry/references/handoffs/unify-with-incorporation.md
@@ -21,11 +21,8 @@ Saving session state so Claude can pick up where it left off if the conversation
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
 
-Determine work_type: use the value from Step 2 if available. Otherwise, read work_type from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type`).
-
 ```
 Specification session for: Unified
-Work type: {work_type}
 
 Source discussions:
 - .workflows/{work_unit}/discussion/{discussion-name}.md

--- a/skills/workflow-specification-entry/references/handoffs/unify.md
+++ b/skills/workflow-specification-entry/references/handoffs/unify.md
@@ -21,11 +21,8 @@ Saving session state so Claude can pick up where it left off if the conversation
 
 This skill's purpose is now fulfilled. Invoke the [technical-specification](../../../technical-specification/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
 
-Determine work_type: use the value from Step 2 if available. Otherwise, read work_type from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type`).
-
 ```
 Specification session for: Unified
-Work type: {work_type}
 
 Sources:
 - .workflows/{work_unit}/discussion/{discussion-name}.md

--- a/skills/workflow-specification-entry/references/invoke-skill.md
+++ b/skills/workflow-specification-entry/references/invoke-skill.md
@@ -27,13 +27,12 @@ Invoke the [technical-specification](../../technical-specification/SKILL.md) ski
 
 ## Handoff
 
-Construct the handoff based on the work type and verb.
+Construct the handoff based on verb and source material.
 
 #### If `work_type` is `feature`
 
 ```
 Specification session for: {work_unit}
-Work type: {work_type}
 
 Source material:
 - Discussion: .workflows/{work_unit}/discussion/{topic}.md
@@ -48,7 +47,6 @@ Invoke the technical-specification skill.
 
 ```
 Specification session for: {work_unit}
-Work type: {work_type}
 
 Source material:
 - Investigation: .workflows/{work_unit}/investigation/{topic}.md
@@ -65,7 +63,6 @@ Read the spec's source discussions from the manifest: `get {work_unit} --phase s
 
 ```
 Specification session for: {topic}
-Work type: {work_type}
 
 Source material:
 - .workflows/{work_unit}/discussion/{source-discussion-1}.md


### PR DESCRIPTION
## Summary

- Remove `Work type:` from all phase entry → processing skill handoff blocks (processing skills already read work_type from manifest via CLI at conclusion)
- Bridge now explicitly reads work_type from manifest in Step 1 before routing, eliminating the dual-source ambiguity (context vs manifest)
- Clean up vestigial "store work_type for handoff" instructions in phase entry SKILL.md files
- Mark PR2 (Bridge Always Fires) as complete in the implementation index

## Test plan

- [ ] Verify feature pipeline continuation: discussion → specification → planning → implementation → review (bridge fires and routes correctly without work_type in handoff)
- [ ] Verify bugfix pipeline continuation: investigation → specification → planning → implementation → review
- [ ] Verify epic pipeline continuation: bridge reads work_type from manifest, routes to epic-continuation
- [ ] Confirm processing skills can still read work_type from manifest at conclusion (define-phases, define-tasks, spec-review, spec-completion)
- [ ] Confirm phase entry skills still parse work_type from `$0` for topic resolution (`if work_type is not epic, topic = $1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)