### PR TITLE
fix: add full script path to bare manifest CLI references

### DIFF
--- a/skills/workflow-specification-entry/references/invoke-skill.md
+++ b/skills/workflow-specification-entry/references/invoke-skill.md
@@ -59,7 +59,7 @@ Invoke the technical-specification skill.
 
 #### If `work_type` is `epic`
 
-Read the spec's source discussions from the manifest: `get {work_unit} --phase specification --topic {topic} sources`. List each source discussion file.
+Read the spec's source discussions from the manifest: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} sources`. List each source discussion file.
 
 ```
 Specification session for: {topic}

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -8,7 +8,7 @@ Check if source material exists and is ready.
 
 #### If `work_type` is `feature`
 
-Check if discussion exists and is concluded. Read status via manifest CLI: `get {work_unit} --phase discussion --topic {topic} status`.
+Check if discussion exists and is concluded. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion --topic {topic} status`.
 
 **If discussion doesn't exist:**
 
@@ -44,7 +44,7 @@ The discussion must be concluded before specification can begin.
 
 #### If `work_type` is `bugfix`
 
-Check if investigation exists and is concluded. Read status via manifest CLI: `get {work_unit} --phase investigation --topic {topic} status`.
+Check if investigation exists and is concluded. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase investigation --topic {topic} status`.
 
 **If investigation doesn't exist:**
 
@@ -80,7 +80,7 @@ The investigation must be concluded before specification can begin.
 
 #### If `work_type` is `epic`
 
-Check if at least one concluded discussion exists for this work unit. Read discussion phase items via manifest CLI: `get {work_unit} --phase discussion`.
+Check if at least one concluded discussion exists for this work unit. Read discussion phase items via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion`.
 
 **If no discussions exist:**
 


### PR DESCRIPTION
## Summary

- `validate-source.md` and `invoke-skill.md` in `workflow-specification-entry` had inline manifest CLI references using just argument syntax (e.g. `` `get {work_unit} ...` ``) without the full script path
- This caused incorrect command construction (e.g. `manifest-cli.js` instead of `manifest.js`) when the model inferred the script name from context
- All 4 bare references now include the full `node .claude/skills/workflow-manifest/scripts/manifest.js` prefix

## Test plan

- [ ] Verify no bare manifest CLI references remain: `grep -rn 'manifest CLI.*\x60(get|set|init-phase|push) ' skills/`
- [ ] Run `/start-feature` or `/continue-epic` through specification entry to confirm manifest CLI calls resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)