### PR TITLE
feat: PR3 — Bridge Epic Navigation

### DIFF
--- a/roadmap/IMPLEMENTATION-INDEX.md
+++ b/roadmap/IMPLEMENTATION-INDEX.md
@@ -10,7 +10,7 @@ Overview of remaining PRs for the work-type architecture. PR 1 (Big Bang) is the
 | ✅ | PR 4 | Start/Continue Split | [Design](archive/start-continue-split/DESIGN.md) |
 | ✅ | PR 5 | Phase Skills Internal | [PR5-PHASE-SKILLS-INTERNAL.md](PR5-PHASE-SKILLS-INTERNAL.md) |
 | ✅ | PR 2 | Bridge Always Fires | [PR2-BRIDGE-ALWAYS-FIRES.md](PR2-BRIDGE-ALWAYS-FIRES.md) |
-| 5th | PR 3 | Bridge Epic Navigation | [PR3-BRIDGE-EPIC-NAVIGATION.md](PR3-BRIDGE-EPIC-NAVIGATION.md) |
+| ✅ | PR 3 | Bridge Epic Navigation | [PR3-BRIDGE-EPIC-NAVIGATION.md](PR3-BRIDGE-EPIC-NAVIGATION.md) |
 | 6th | PR 6 | Processing Skills Pipeline-Aware | [PR6-PROCESSING-SKILLS-PIPELINE-AWARE.md](PR6-PROCESSING-SKILLS-PIPELINE-AWARE.md) |
 | 7th | PR 7 | Work Unit Lifecycle | [PR7-WORK-UNIT-LIFECYCLE.md](PR7-WORK-UNIT-LIFECYCLE.md) |
 | 8th | PR 8 | Skip Review | [PR8-SKIP-REVIEW.md](PR8-SKIP-REVIEW.md) |

--- a/roadmap/PR3-BRIDGE-EPIC-NAVIGATION.md
+++ b/roadmap/PR3-BRIDGE-EPIC-NAVIGATION.md
@@ -28,6 +28,16 @@ Always valid. Could mean:
 
 The bridge shows concluded artifacts that could be reopened alongside the option to create new ones.
 
+## Status: Complete
+
+Most of PR 3's scope was implemented incrementally alongside the epic display/menu system and bridge integration:
+
+- **Navigation options** (proceed, stay, go back, done for now) — implemented in `epic-display-and-menu.md` Sections C–E
+- **Hard gates** — implemented via `gating` flags in discovery + menu filtering
+- **Backward navigation** — "Resume a concluded topic" menu option + Section E flow
+- **"Done for now"** — "Stop here" menu option + Session Paused terminal
+- **Soft guidance** — added as interactive gates in Section D (proceed anyway? prompts with system recovery reassurance)
+
 ## Dependencies
 
 - Depends on: PR 2 (bridge fires unconditionally)

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -73,6 +73,7 @@ No work started yet.
 | Condition | Recommendation |
 |-----------|---------------|
 | In-progress items across multiple phases | No recommendation |
+| Some research in-progress, some concluded | "Consider concluding remaining research before starting discussion. Topic analysis works best with all research available." |
 | Some discussions in-progress, some concluded | "Consider concluding remaining discussions before starting specification. The grouping analysis works best with all discussions available." |
 | All discussions concluded, specs not started | "All discussions are concluded. Specification will analyze and group them." |
 | Some specs concluded, some in-progress | "Concluding all specifications before planning helps identify cross-cutting dependencies." |
@@ -250,6 +251,45 @@ Commit the change. Then re-present the menu from **C. Menu** (the item may now b
 → Proceed to **E. Resume Concluded**.
 
 #### Otherwise
+
+**Soft gate check** — before routing, check if the user's selection conflicts with a phase-completion recommendation. These are advisory, not blocking. The conditions use the `phases` data from discovery to count in-progress vs total items.
+
+| User selected phase | Condition | Gate message |
+|---------------------|-----------|--------------|
+| discussion (new or continue) | `gating.has_research` is true and some research items are in-progress | "{N} of {M} research topics still in-progress. Discussion topic analysis works best with all research available." |
+| specification (new or continue) | discussion items exist with some in-progress | "{N} of {M} discussions still in-progress. Specification grouping analysis works best with all discussions available." |
+| planning | specification items exist with some in-progress | "{N} of {M} specifications still in-progress. Cross-cutting dependencies are easier to identify with all concluded." |
+| implementation | planning items exist with some in-progress | "{N} of {M} plans still in-progress. Task dependencies across plans may be missed." |
+
+**If a soft gate condition matches:**
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+{N} of {M} {phase items} still in-progress. {Gate message}.
+
+The system will re-analyse if you revisit later — proceeding
+now is safe, but may require rework.
+
+- **`y`/`yes`** — Proceed anyway
+- **`b`/`back`** — Return to menu
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `back`:**
+
+→ Return to **C. Menu**.
+
+**If user chose `yes`:**
+
+Continue to routing below.
+
+**If no soft gate condition matches**, continue to routing below.
+
+---
 
 Store the selected action, phase, and topic (if applicable). Map to a routing entry:
 

--- a/skills/continue-epic/scripts/discovery.js
+++ b/skills/continue-epic/scripts/discovery.js
@@ -85,6 +85,7 @@ function buildEpicDetail(cwd, manifest) {
     phases[phase] = phaseEntries;
   }
 
+  const researchItems = phaseItems(manifest, 'research');
   const discussionItems = phaseItems(manifest, 'discussion');
   const unaccountedDiscussions = [];
   for (const d of discussionItems) {
@@ -135,6 +136,8 @@ function buildEpicDetail(cwd, manifest) {
     }
   }
 
+  const hasResearch = researchItems.length > 0;
+  const hasConcludedResearch = researchItems.some(r => r.status === 'concluded');
   const hasConcludedSpec = specItems.some(s => s.status === 'concluded');
   const hasConcludedPlan = planItems.some(p => p.status === 'concluded');
   const hasConcludedDiscussion = discussionItems.some(d => d.status === 'concluded');
@@ -148,6 +151,8 @@ function buildEpicDetail(cwd, manifest) {
     unaccounted_discussions: unaccountedDiscussions,
     reopened_discussions: reopenedDiscussions,
     gating: {
+      has_research: hasResearch,
+      can_start_discussion: hasConcludedResearch,
       can_start_specification: hasConcludedDiscussion,
       can_start_planning: hasConcludedSpec,
       can_start_implementation: hasConcludedPlan,

--- a/tests/scripts/test-discovery-for-continue-epic.js
+++ b/tests/scripts/test-discovery-for-continue-epic.js
@@ -199,6 +199,7 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
+          research: { items: { 'market-analysis': { status: 'concluded' } } },
           discussion: { items: { auth: { status: 'concluded' } } },
           specification: { items: { auth: { status: 'concluded' } } },
           planning: { items: { auth: { status: 'concluded' } } },
@@ -207,6 +208,8 @@ describe('continue-epic discovery', () => {
       });
       const r = discover(dir);
       const g = r.epics[0].detail.gating;
+      assert.strictEqual(g.has_research, true);
+      assert.strictEqual(g.can_start_discussion, true);
       assert.strictEqual(g.can_start_specification, true);
       assert.strictEqual(g.can_start_planning, true);
       assert.strictEqual(g.can_start_implementation, true);
@@ -217,13 +220,29 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
+          research: { items: { 'market-analysis': { status: 'in-progress' } } },
           discussion: { items: { auth: { status: 'in-progress' } } },
         },
       });
       const r = discover(dir);
       const g = r.epics[0].detail.gating;
+      assert.strictEqual(g.has_research, true);
+      assert.strictEqual(g.can_start_discussion, false);
       assert.strictEqual(g.can_start_specification, false);
       assert.strictEqual(g.can_start_planning, false);
+    });
+
+    it('has_research is false when no research items exist', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { auth: { status: 'concluded' } } },
+        },
+      });
+      const r = discover(dir);
+      const g = r.epics[0].detail.gating;
+      assert.strictEqual(g.has_research, false);
+      assert.strictEqual(g.can_start_discussion, false);
     });
 
     it('includes spec sources in phase items', () => {
@@ -365,6 +384,8 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', { work_type: 'epic' });
       const r = discover(dir);
       const g = r.epics[0].detail.gating;
+      assert.strictEqual(g.has_research, false);
+      assert.strictEqual(g.can_start_discussion, false);
       assert.strictEqual(g.can_start_specification, false);
       assert.strictEqual(g.can_start_planning, false);
       assert.strictEqual(g.can_start_implementation, false);


### PR DESCRIPTION
## Summary

- Most of PR3's scope (navigation options, hard gates, backward nav, "done for now") was already implemented incrementally alongside the epic display/menu system
- Added interactive soft gates that warn when prerequisite phase items are still in-progress (research→discussion, discussion→specification, specification→planning, planning→implementation) with "proceed anyway?" prompts
- Soft gates include reassurance that the system recovers gracefully via re-analysis, so proceeding is safe but may require rework
- Added `has_research` and `can_start_discussion` gating flags to epic discovery script with tests

## Test plan

- [x] All 31 epic discovery tests pass (1 new test added)
- [x] Full test suite passes (9 test files, 0 failures)
- [ ] Manual: verify soft gate fires when selecting "Start specification" with in-progress discussions
- [ ] Manual: verify soft gate does NOT fire for discussion when no research exists
- [ ] Manual: verify "back" from soft gate returns to menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)