### PR TITLE
feat: add `exists` subcommand to manifest CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,7 @@ $MANIFEST get {work_unit} --phase discussion --topic {topic} status    # phase-l
 $MANIFEST set {work_unit} --phase discussion --topic {topic} status concluded  # phase-level write
 $MANIFEST init-phase {work_unit} --phase discussion --topic {topic}    # create phase entry
 $MANIFEST push {work_unit} --phase implementation --topic {topic} completed_tasks "task-1"  # append to array
+$MANIFEST exists {work_unit}                                           # existence check (exits 0, outputs true/false)
 $MANIFEST get {work_unit} work_type                                    # work-unit-level read
 $MANIFEST set {work_unit} phases.research.analysis_cache '{"checksum":"..."}' # work-unit-level write (dot-path)
 ```

--- a/skills/start-bugfix/references/name-check.md
+++ b/skills/start-bugfix/references/name-check.md
@@ -28,7 +28,7 @@ Is this name okay?
 Once the name is confirmed, check for naming conflicts:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}
 ```
 
 #### If a work unit with the same name exists

--- a/skills/start-epic/references/name-check.md
+++ b/skills/start-epic/references/name-check.md
@@ -28,7 +28,7 @@ Is this name okay?
 Once the name is confirmed, check for naming conflicts:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}
 ```
 
 #### If a work unit with the same name exists

--- a/skills/start-feature/references/name-check.md
+++ b/skills/start-feature/references/name-check.md
@@ -28,7 +28,7 @@ Is this name okay?
 Once the name is confirmed, check for naming conflicts:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}
 ```
 
 #### If a work unit with the same name exists

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -32,6 +32,11 @@ $MANIFEST init-phase {work_unit} --phase discussion --topic {topic}
 $MANIFEST get {work_unit} [field]
 $MANIFEST set {work_unit} field value
 
+# Existence checks (always exit 0, outputs true/false):
+$MANIFEST exists {work_unit}
+$MANIFEST exists {work_unit} [field.path]
+$MANIFEST exists {work_unit} --phase <phase> [--topic <topic>] [field.path]
+
 # Management (unchanged):
 $MANIFEST init name --work-type type --description "..."
 $MANIFEST list [--status s] [--work-type t]
@@ -161,6 +166,24 @@ node .claude/skills/workflow-manifest/scripts/manifest.js push <name> tags "v1"
 node .claude/skills/workflow-manifest/scripts/manifest.js push <name> --phase implementation --topic <topic> completed_tasks "task-1"
 node .claude/skills/workflow-manifest/scripts/manifest.js push <name> --phase implementation --topic <topic> completed_phases 1
 ```
+
+### `exists`
+
+Check whether a work unit, field, or phase entry exists. Always exits 0 — both `true` and `false` are valid results. Outputs `true` or `false` to stdout, nothing to stderr.
+
+```bash
+# Does the work unit exist?
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>
+
+# Does a field path exist?
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> phases.discussion
+
+# Does a phase/topic entry exist?
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> --phase discussion --topic auth-flow
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> --phase discussion --topic auth-flow status
+```
+
+If the work unit doesn't exist and a deeper path is requested, outputs `false` (no error). Actual usage errors (missing args, invalid phase name) still use `die()`.
 
 ### `archive`
 

--- a/skills/workflow-manifest/scripts/manifest.js
+++ b/skills/workflow-manifest/scripts/manifest.js
@@ -598,6 +598,44 @@ function cmdPush(args) {
   });
 }
 
+function cmdExists(args) {
+  const { phase, topic, positional } = parseFlags(args);
+
+  if (positional.length < 1) die('Usage: exists <name> [--phase <phase>] [--topic <topic>] [field.path]');
+
+  const name = positional[0];
+  const mp = manifestPath(name);
+
+  // Work-unit level, no field path — just check if manifest file exists
+  if (!phase && positional.length === 1) {
+    process.stdout.write(fs.existsSync(mp) ? 'true\n' : 'false\n');
+    return;
+  }
+
+  // If manifest doesn't exist, any deeper path is false
+  if (!fs.existsSync(mp)) {
+    process.stdout.write('false\n');
+    return;
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(mp, 'utf8'));
+
+  if (!phase) {
+    // Work-unit level with field path
+    const segments = positional[1].split('.');
+    const value = getByPath(manifest, segments);
+    process.stdout.write(value !== undefined ? 'true\n' : 'false\n');
+    return;
+  }
+
+  // Phase-level
+  validatePhase(phase);
+  const fieldSegments = positional.length > 1 ? positional[1].split('.') : [];
+  const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
+  const value = getByPath(manifest, segments);
+  process.stdout.write(value !== undefined ? 'true\n' : 'false\n');
+}
+
 function cmdArchive(args) {
   if (args.length !== 1) die('Usage: archive <name>');
 
@@ -636,7 +674,7 @@ function cmdArchive(args) {
 const [command, ...args] = process.argv.slice(2);
 
 if (!command) {
-  die('Usage: manifest.js <command> [args]\nCommands: init, get, set, list, init-phase, push, archive');
+  die('Usage: manifest.js <command> [args]\nCommands: init, get, set, list, init-phase, push, exists, archive');
 }
 
 switch (command) {
@@ -646,6 +684,7 @@ switch (command) {
   case 'list':     cmdList(args); break;
   case 'init-phase': cmdInitPhase(args); break;
   case 'push':     cmdPush(args); break;
+  case 'exists':   cmdExists(args); break;
   case 'archive':  cmdArchive(args); break;
   default:         die(`Unknown command "${command}"`);
 }

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -870,6 +870,106 @@ assert_equals "$output" "concluded" "Valid item status accepted"
 echo ""
 
 # ============================================================================
+# EXISTS TESTS
+# ============================================================================
+
+echo -e "${YELLOW}Test: exists returns true for existing work unit${NC}"
+setup_fixture
+run_cli init exists-test --work-type feature --description "Exists" >/dev/null 2>&1
+output=$(run_cli_stdout exists exists-test)
+exit_code=$(run_cli_exit_code exists exists-test)
+
+assert_equals "$output" "true" "Existing work unit returns true"
+assert_equals "$exit_code" "0" "Existing work unit exits 0"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists returns false for non-existent work unit${NC}"
+setup_fixture
+output=$(run_cli_stdout exists nonexistent-unit)
+exit_code=$(run_cli_exit_code exists nonexistent-unit)
+
+assert_equals "$output" "false" "Non-existent work unit returns false"
+assert_equals "$exit_code" "0" "Non-existent work unit exits 0"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists with dot-path field that exists${NC}"
+setup_fixture
+run_cli init exists-field --work-type feature --description "Field" >/dev/null 2>&1
+output=$(run_cli_stdout exists exists-field work_type)
+exit_code=$(run_cli_exit_code exists exists-field work_type)
+
+assert_equals "$output" "true" "Existing field returns true"
+assert_equals "$exit_code" "0" "Existing field exits 0"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists with dot-path field that does not exist${NC}"
+setup_fixture
+run_cli init exists-nofield --work-type feature --description "No field" >/dev/null 2>&1
+output=$(run_cli_stdout exists exists-nofield nonexistent.deep.path)
+exit_code=$(run_cli_exit_code exists exists-nofield nonexistent.deep.path)
+
+assert_equals "$output" "false" "Non-existent field returns false"
+assert_equals "$exit_code" "0" "Non-existent field exits 0"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists with --phase and --topic that exists${NC}"
+setup_fixture
+run_cli init exists-phase --work-type epic --description "Phase" >/dev/null 2>&1
+run_cli init-phase exists-phase --phase discussion --topic my-topic >/dev/null 2>&1
+output=$(run_cli_stdout exists exists-phase --phase discussion --topic my-topic)
+exit_code=$(run_cli_exit_code exists exists-phase --phase discussion --topic my-topic)
+
+assert_equals "$output" "true" "Existing phase/topic returns true"
+assert_equals "$exit_code" "0" "Existing phase/topic exits 0"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists with --phase and --topic that does not exist${NC}"
+setup_fixture
+run_cli init exists-nophase --work-type epic --description "No phase" >/dev/null 2>&1
+output=$(run_cli_stdout exists exists-nophase --phase discussion --topic missing-topic)
+exit_code=$(run_cli_exit_code exists exists-nophase --phase discussion --topic missing-topic)
+
+assert_equals "$output" "false" "Non-existent phase/topic returns false"
+assert_equals "$exit_code" "0" "Non-existent phase/topic exits 0"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists with non-existent work unit and deep path returns false${NC}"
+setup_fixture
+output=$(run_cli_stdout exists ghost-unit work_type)
+exit_code=$(run_cli_exit_code exists ghost-unit work_type)
+
+assert_equals "$output" "false" "Non-existent work unit + deep path returns false"
+assert_equals "$exit_code" "0" "Non-existent work unit + deep path exits 0"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists with no args returns non-zero exit${NC}"
+setup_fixture
+assert_exit_nonzero "exists with no args fails" exists
+
+echo ""
+
+# ============================================================================
 # SUMMARY
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- Add `exists` command to manifest CLI — always exits 0, outputs `true`/`false` to stdout, no stderr noise
- Replace `get {work_unit} work_type` with `exists {work_unit}` in start-bugfix, start-feature, and start-epic name-check files (pure existence checks that were abusing `get` error behavior)
- Add documentation to SKILL.md, CLAUDE.md, and tests to test-workflow-manifest.sh

## Test plan

- [x] `bash tests/scripts/test-workflow-manifest.sh` — all 104 tests pass (15 new exists tests)
- [ ] Manual: `exists nonexistent` → `false`, exit 0, no stderr
- [ ] Manual: `exists <real-unit>` → `true`, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)