### PR TITLE
feat: work unit lifecycle (in-progress/concluded/cancelled)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ skills/
   workflow-shared/             # Shared utilities used by other workflow skills
     scripts/discovery-utils.js #   Discovery helpers (manifest loading, phase state, checksums)
   workflow-manifest/           # Manifest CLI — single source of truth for workflow state
-    scripts/manifest.js        #   Node.js CLI (get/set/list/init/init-phase/push/archive)
+    scripts/manifest.js        #   Node.js CLI (get/set/list/init/init-phase/push/exists)
 
   # Entry-point skills (user-invocable — gather context, invoke processing skills)
   migrate/                   # Keep workflow files in sync with system design

--- a/roadmap/IMPLEMENTATION-INDEX.md
+++ b/roadmap/IMPLEMENTATION-INDEX.md
@@ -18,6 +18,7 @@ Overview of remaining PRs for the work-type architecture. PR 1 (Big Bang) is the
 | 10th | PR 10 | Research Refactor | [Design Brief](research-refactor/DESIGN-BRIEF.md) |
 | 11th | PR 11 | Session State Removal | [Design Brief](session-state-removal/DESIGN-BRIEF.md) |
 | 12th | PR 12 | Feature Research Analysis | [PR12-FEATURE-RESEARCH-ANALYSIS.md](PR12-FEATURE-RESEARCH-ANALYSIS.md) |
+| 13th | PR 13 | Manifest CLI — Wildcard Topic | [PR13-MANIFEST-WILDCARD-TOPIC.md](PR13-MANIFEST-WILDCARD-TOPIC.md) |
 
 ## Why This Order
 

--- a/roadmap/PR13-MANIFEST-WILDCARD-TOPIC.md
+++ b/roadmap/PR13-MANIFEST-WILDCARD-TOPIC.md
@@ -1,0 +1,67 @@
+# PR 13: Manifest CLI — Wildcard Topic
+
+## Summary
+
+Add wildcard support to the manifest CLI's `--topic` flag, allowing queries across all topics in a phase without callers needing to know the internal manifest structure.
+
+## Problem
+
+For epics, checking whether *any* topic in a phase has a particular status requires fetching the entire phase object and parsing the JSON. This pushes structural knowledge into skill files (callers must know about `items`) and relies on non-deterministic "parse the JSON output" instructions.
+
+Example from manage-work-unit (epic implementation check):
+
+```bash
+# Current: returns raw JSON, caller must parse
+node .claude/skills/workflow-manifest/scripts/manifest.js get my-epic --phase implementation
+
+# Desired: returns all topic statuses, CLI does the traversal
+node .claude/skills/workflow-manifest/scripts/manifest.js get my-epic --phase implementation --topic "*" status
+```
+
+## Design Discussion
+
+### Option 1: Wildcard `--topic "*"` (chosen for now)
+
+Add `*` as a special topic value. When `resolvePhaseSegments` sees `*`, it iterates all items in the phase and collects the field value from each.
+
+- Preserves the `--phase`/`--topic` abstraction layer
+- Callers don't need to know about `items` vs flat structure
+- For feature/bugfix (single implicit topic), `--topic "*"` would return the same as `--topic {name}`
+- Return format: one value per line, or JSON array
+
+### Option 2: Dot-path syntax with wildcard
+
+Replace `--phase`/`--topic` flags entirely with a dot-path convention:
+
+```bash
+# Instead of --phase impl --topic auth-flow status:
+get my-epic implementation.auth-flow.status
+
+# Wildcard:
+get my-epic implementation.*.status
+```
+
+The CLI would recognise phase names as the first segment and route through the same `resolvePhaseSegments` logic — callers never see `phases.implementation.items`, just `implementation.topic.field`.
+
+**Pros:** Single syntax instead of two. Wildcards work naturally in the dot-path.
+
+**Cons:** Bigger refactor — every skill using `--phase`/`--topic` needs updating. Would need to coexist with flags during migration or be done as a breaking change.
+
+### Decision
+
+Use Option 1 (`--topic "*"`) for PR7 as the minimal change. Option 2 is a potential future simplification of the entire CLI API surface — worth revisiting if the flags feel redundant or if more wildcard use cases emerge.
+
+## Scope
+
+- `get` command: `--topic "*"` returns collected values from all topics
+- `exists` command: `--topic "*"` returns `true` if any topic has the specified field/value
+- Validation: `*` bypasses topic name validation but still validates phase
+- Feature/bugfix: `*` is a no-op (single implicit topic), returns same as without topic
+
+## Touch Points
+
+- `skills/workflow-manifest/scripts/manifest.js` — `resolvePhaseSegments`, `cmdGet`, `cmdExists`
+- `skills/workflow-manifest/SKILL.md` — document wildcard topic
+- `skills/workflow-start/references/manage-work-unit.md` — simplify epic implementation check
+- `tests/scripts/test-workflow-manifest.sh` — wildcard topic tests
+- `CLAUDE.md` — update CLI grammar examples

--- a/roadmap/PR7-DISCUSSION-NOTES.md
+++ b/roadmap/PR7-DISCUSSION-NOTES.md
@@ -1,0 +1,143 @@
+# PR 7: Work Unit Lifecycle — Discussion Notes
+
+*Captured from discussion session on 2026-03-09. Read alongside [PR7-WORK-UNIT-LIFECYCLE.md](PR7-WORK-UNIT-LIFECYCLE.md).*
+
+## Audit Findings
+
+Before discussion began, an audit was performed across the codebase. Key findings:
+
+- **Manifest CLI** already has an `archive` command and `archived` status — but nothing in the workflow uses them. No skill invokes `archive`, no discovery script references `.archive`. It was built speculatively.
+- **`loadActiveManifests()`** in discovery-utils.js filters `status === 'active'`. All continue skills and workflow-start use this.
+- **"Done" detection** is currently computed, not stored: `computeNextPhase()` returns `next_phase: 'done'` when review is completed. Continue skills for feature/bugfix additionally exclude `next_phase === 'done'` from their lists.
+- **workflow-start** is a unified entry point that lists all active work units across all types with continue options, plus start-new options. It delegates to `/continue-*` or `/start-*` skills. User described it as "really a convenience" and "a unified entry point."
+- **Continue skills** (feature, bugfix, epic) show work units filtered to one type and route to phase entry skills.
+
+Full audit details are in the codebase; touch points listed at the bottom of this document.
+
+## What Was Discussed and Decided
+
+### State Machine
+
+Three work unit statuses: `in-progress`, `concluded`, `cancelled`.
+
+```
+                 ┌─────────────┐
+          create │  in-progress │
+                 └──────┬───────┘
+                        │
+              ┌─────────┼──────────┐
+              │ pipeline │  cancel  │
+              │ completes│         │
+              ▼                    ▼
+     ┌────────────┐        ┌───────────┐
+     │  concluded  │        │ cancelled  │
+     └─────┬──────┘        └─────┬─────┘
+           │                     │
+           │ reactivate          │ reactivate
+           └──────────┬──────────┘
+                      ▼
+              ┌─────────────┐
+              │  in-progress │
+              └─────────────┘
+```
+
+**Transitions:**
+- `in-progress` → `concluded`: when the pipeline completes
+- `in-progress` → `cancelled`: user cancels
+- `concluded` → `in-progress`: user reactivates
+- `cancelled` → `in-progress`: user reactivates
+
+**Rules:**
+- `concluded` cannot be cancelled — you can only cancel an in-progress work unit
+- Reactivation from either terminal state returns to `in-progress`
+- When reactivated, you jump into one of the phases. Phase entry already handles setting the phase to in-progress — that part of the feature already exists. We just need to also set the work unit status back to `in-progress`.
+
+### Terminology
+
+- Use `concluded` not `done`/`completed` — consistent with existing phase conventions
+- Use `in-progress` not `active` — also consistent with phase conventions
+- Implementation and review phases currently use `completed` instead of `concluded` — this will be changed as well (separate from this PR)
+
+### Archive: Deferred
+
+- Remove the existing `archive` command from manifest CLI — unused code, shouldn't sit around doing nothing. Easy to re-add later if needed.
+- Archive as a concept is deferred to a future PR.
+- User's question that led to deferral: "if a concluded or cancelled work unit is already hidden from view, do we need the archive?"
+
+### Start Skills
+
+- Start skills (`/start-feature`, `/start-bugfix`, `/start-epic`) should NOT show concluded items
+- User: "if you call Start New, it's assumed that you are literally starting afresh. So I don't think we should show concluded items in there because it's just brand new."
+
+### Continue Skills and Workflow-Start Must Show Concluded/Cancelled Work Units
+
+- Continue skills need to show concluded/cancelled work units, separately from in-progress ones
+- workflow-start also needs to show them (unified view across all types)
+- User noted that viewing concluded stages "should include concluded work units, not just concluded phases within a pending work unit or an in progress work unit"
+
+### Concluded/Cancelled Sub-View Design
+
+**Entry point:** Both workflow-start and continue skills show a one-liner summary of non-active work. With a single menu option to view them — unified, not separate "view completed" / "view cancelled." User: "rather than having view completed and view cancelled, we can unify that into one view."
+
+**Display terminology note:** User said "Completed" and "Cancelled" as display headings, but established `concluded` as the status value. Whether user-facing display says "Completed" or "Concluded" was not resolved.
+
+**Sub-view display:** One view with two headings (Completed/Cancelled or Concluded/Cancelled — see note above), numbered continuously across both sections.
+
+**Sub-view interaction — two-step flow:**
+1. First: select a work unit by number, or go back
+2. After selection: present actions for that specific work unit
+
+**Actions after selecting a work unit:**
+- Reactivate (command-based: with shortcut key)
+- Back to list (command-based: with shortcut key)
+- Questions (prompt-based: no shortcut key)
+
+**Menu convention:** Command-based options (with backtick shortcuts) come first. Prompt-based options (plain text, no shortcuts) come last. This is an established codebase convention — the `Ask`/`Questions` pattern used in task-loop.md and elsewhere.
+
+### Code Sharing Across Continue Skills
+
+User raised concern about duplicated discovery and presentation logic between workflow-start and continue skills. After checking the continue-feature and continue-epic displays, user noted they "look very similar in terms of layout."
+
+The concluded/cancelled sub-view would be needed in workflow-start, continue-feature, continue-bugfix, and continue-epic. Within the continue skills the view would be filtered to one work type. Within workflow-start it would show a unified view across all types.
+
+User acknowledged the overlap might warrant a shared reference file for the continue skills but wasn't certain: "I don't know if they're shared, though, that's the problem, because I don't know if the overlap is sufficient to deduplicate the code."
+
+## Open Questions (Not Yet Resolved)
+
+### Who Sets `concluded` on Pipeline Completion?
+
+Not discussed in detail. The state machine says in-progress → concluded when the pipeline completes, but which skill/mechanism sets this was not agreed.
+
+### Epic Concluded — When and How?
+
+Epics have multiple topics across phases. Auto-detecting "everything is done" is tricky. User discussed several possibilities:
+- Could prompt when everything is done
+- Could be a manual action via continue-epic — user can explicitly mark it as concluded
+- User: "it might be that you want to set it to concluded before it's fully finished because maybe you've decided that it's good enough as it is and you're going to draw a line"
+
+### Early Conclusion Applies to All Work Types
+
+User said the ability to conclude before the pipeline is fully done also applies to features and bugfixes: "maybe that also applies to features and bug fixes, because sometimes you might get to the end of implementation and decide that you're done."
+
+User mentioned this could happen at the continue phase level, and "maybe in the bridge phase possibly."
+
+### Overlap with PR8 (Skip Review)
+
+User noted PR8 (skip review) touches on the same subject of concluding early. Said: "we could always work that PR into this one." Not decided whether to fold PR8 in or keep separate.
+
+### Cancel UX — Where Does It Live?
+
+User wasn't sure. Said "both perhaps" (continue skills and workflow-start) but also said it "might change based on the analysis" of how workflow-start and continue skills relate.
+
+## Codebase Touch Points (from audit)
+
+These were identified during the audit phase. Not all were discussed in detail:
+
+1. **Manifest CLI** (`skills/workflow-manifest/scripts/manifest.js`): Update valid statuses, remove archive command, change init default from `active` to `in-progress`
+2. **Manifest SKILL.md** (`skills/workflow-manifest/SKILL.md`): Update docs to match
+3. **discovery-utils.js** (`skills/workflow-shared/scripts/discovery-utils.js`): `loadActiveManifests()` filter from `active` to `in-progress`
+4. **Continue skills** (`continue-feature/`, `continue-bugfix/`, `continue-epic/`): Add concluded/cancelled visibility + reactivation UX
+5. **workflow-start** (`workflow-start/`): Add concluded/cancelled summary + sub-view
+6. **workflow-bridge**: Mechanism for setting `status: concluded` on pipeline completion
+7. **link-dependencies SKILL.md**: Update `--status active` to `--status in-progress`
+8. **Tests**: Update all references to `active`/`archived` status values

--- a/skills/continue-bugfix/SKILL.md
+++ b/skills/continue-bugfix/SKILL.md
@@ -57,6 +57,8 @@ Parse the discovery output to understand:
 **From top-level fields:**
 - `count` - number of active bugfixes
 - `summary` - human-readable state summary
+- `concluded` / `cancelled` - arrays of non-active bugfixes with name, status, last_phase
+- `concluded_count` / `cancelled_count` - counts for each
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
 

--- a/skills/continue-bugfix/references/select-bugfix.md
+++ b/skills/continue-bugfix/references/select-bugfix.md
@@ -22,6 +22,16 @@ Continue Bugfix
 
 Build from the discovery output's `bugfixes` array. Each bugfix shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
 
+After the tree display, if `concluded_count > 0` or `cancelled_count > 0`, add a summary line:
+
+> *Output the next fenced block as a code block:*
+
+```
+{concluded_count} concluded, {cancelled_count} cancelled.
+```
+
+Only show this block if either count is non-zero.
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
@@ -31,14 +41,27 @@ Which bugfix would you like to continue?
 1. Continue "{bugfix.name:(titlecase)}" — {bugfix.phase_label}
 2. ...
 
+{N+1}. View concluded & cancelled bugfixes
+- **`m`/`manage`** — Manage a bugfix's lifecycle
+
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual bugfixes and `phase_label` values from discovery. No auto-select, even with one item.
+Recreate with actual bugfixes and `phase_label` values from discovery. Only show "View concluded & cancelled" if `concluded_count > 0` or `cancelled_count > 0`. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
+
+**If user chose a bugfix number:**
 
 Store the selected bugfix's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
+
+**If user chose "View concluded & cancelled":**
+
+→ Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `bugfix`. On return, re-run discovery and redisplay from the top of this reference.
+
+**If user chose `m`/`manage`:**
+
+→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)**. On return, re-run discovery and redisplay from the top of this reference.

--- a/skills/continue-bugfix/references/select-bugfix.md
+++ b/skills/continue-bugfix/references/select-bugfix.md
@@ -48,16 +48,16 @@ Recreate with actual bugfixes and `phase_label` values from discovery. No auto-s
 
 **STOP.** Wait for user response.
 
-**If user chose a bugfix number:**
+#### If user chose a bugfix number
 
 Store the selected bugfix's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
 
-**If user chose "View concluded & cancelled":**
+#### If user chose "View concluded & cancelled"
 
 → Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `bugfix`. On return, re-run discovery and redisplay from the top of this reference.
 
-**If user chose `m`/`manage`:**
+#### If user chose `m`/`manage`
 
 → Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)**. On return, re-run discovery and redisplay from the top of this reference.

--- a/skills/continue-bugfix/references/select-bugfix.md
+++ b/skills/continue-bugfix/references/select-bugfix.md
@@ -18,19 +18,13 @@ Continue Bugfix
      └─ {bugfix.phase_label:(titlecase)}
 
 @endforeach
+
+@if(concluded_count > 0 || cancelled_count > 0)
+{concluded_count} concluded, {cancelled_count} cancelled.
+@endif
 ```
 
 Build from the discovery output's `bugfixes` array. Each bugfix shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
-
-After the tree display, if `concluded_count > 0` or `cancelled_count > 0`, add a summary line:
-
-> *Output the next fenced block as a code block:*
-
-```
-{concluded_count} concluded, {cancelled_count} cancelled.
-```
-
-Only show this block if either count is non-zero.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -41,14 +35,16 @@ Which bugfix would you like to continue?
 1. Continue "{bugfix.name:(titlecase)}" — {bugfix.phase_label}
 2. ...
 
+@if(concluded_count > 0 || cancelled_count > 0)
 {N+1}. View concluded & cancelled bugfixes
+@endif
 - **`m`/`manage`** — Manage a bugfix's lifecycle
 
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual bugfixes and `phase_label` values from discovery. Only show "View concluded & cancelled" if `concluded_count > 0` or `cancelled_count > 0`. No auto-select, even with one item.
+Recreate with actual bugfixes and `phase_label` values from discovery. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 

--- a/skills/continue-bugfix/scripts/discovery.js
+++ b/skills/continue-bugfix/scripts/discovery.js
@@ -1,8 +1,17 @@
 'use strict';
 
-const { loadActiveManifests, phaseStatus, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils');
+const { loadActiveManifests, loadAllManifests, phaseStatus, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils');
 
 const BUGFIX_PIPELINE = ['investigation', 'specification', 'planning', 'implementation', 'review'];
+
+function lastCompletedPhase(manifest) {
+  let last = null;
+  for (const phase of BUGFIX_PIPELINE) {
+    const s = phaseStatus(manifest, phase);
+    if (s === 'concluded' || s === 'completed') last = phase;
+  }
+  return last;
+}
 
 function concludedPhases(manifest) {
   const concluded = [];
@@ -31,9 +40,26 @@ function discover(cwd) {
     });
   }
 
+  const allManifests = loadAllManifests(cwd);
+  const concluded = [];
+  const cancelled = [];
+
+  for (const m of allManifests) {
+    if (m.work_type !== 'bugfix') continue;
+    if (m.status === 'concluded') {
+      concluded.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
+    } else if (m.status === 'cancelled') {
+      cancelled.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
+    }
+  }
+
   return {
     bugfixes,
     count: bugfixes.length,
+    concluded,
+    cancelled,
+    concluded_count: concluded.length,
+    cancelled_count: cancelled.length,
     summary: bugfixes.length === 0
       ? 'no active bugfixes'
       : `${bugfixes.length} active bugfix(es)`,

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -63,6 +63,8 @@ Parse the discovery output to understand:
 **From top-level fields:**
 - `count` - number of active epics
 - `summary` - human-readable state summary
+- `concluded` / `cancelled` - arrays of non-active epics with name, status, last_phase (list mode only)
+- `concluded_count` / `cancelled_count` - counts for each
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
 

--- a/skills/continue-epic/references/select-epic.md
+++ b/skills/continue-epic/references/select-epic.md
@@ -22,6 +22,16 @@ Continue Epic
 
 Build from the discovery output's `epics` array. Each epic shows `name` (titlecased) and a comma-separated list of `active_phases` (titlecased). Blank line between each numbered item.
 
+After the tree display, if `concluded_count > 0` or `cancelled_count > 0`, add a summary line:
+
+> *Output the next fenced block as a code block:*
+
+```
+{concluded_count} concluded, {cancelled_count} cancelled.
+```
+
+Only show this block if either count is non-zero.
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
@@ -31,14 +41,27 @@ Which epic would you like to continue?
 1. Continue "{epic.name:(titlecase)}"
 2. ...
 
+{N+1}. View concluded & cancelled epics
+- **`m`/`manage`** — Manage an epic's lifecycle
+
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual epics from discovery. No auto-select, even with one item.
+Recreate with actual epics from discovery. Only show "View concluded & cancelled" if `concluded_count > 0` or `cancelled_count > 0`. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
+
+**If user chose an epic number:**
 
 Store the selected epic's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
+
+**If user chose "View concluded & cancelled":**
+
+→ Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `epic`. On return, re-run discovery and redisplay from the top of this reference.
+
+**If user chose `m`/`manage`:**
+
+→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)**. On return, re-run discovery and redisplay from the top of this reference.

--- a/skills/continue-epic/references/select-epic.md
+++ b/skills/continue-epic/references/select-epic.md
@@ -48,16 +48,16 @@ Recreate with actual epics from discovery. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 
-**If user chose an epic number:**
+#### If user chose an epic number
 
 Store the selected epic's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
 
-**If user chose "View concluded & cancelled":**
+#### If user chose "View concluded & cancelled"
 
 → Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `epic`. On return, re-run discovery and redisplay from the top of this reference.
 
-**If user chose `m`/`manage`:**
+#### If user chose `m`/`manage`
 
 → Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)**. On return, re-run discovery and redisplay from the top of this reference.

--- a/skills/continue-epic/references/select-epic.md
+++ b/skills/continue-epic/references/select-epic.md
@@ -18,19 +18,13 @@ Continue Epic
      └─ {epic.active_phases:(titlecase, comma-separated)}
 
 @endforeach
+
+@if(concluded_count > 0 || cancelled_count > 0)
+{concluded_count} concluded, {cancelled_count} cancelled.
+@endif
 ```
 
 Build from the discovery output's `epics` array. Each epic shows `name` (titlecased) and a comma-separated list of `active_phases` (titlecased). Blank line between each numbered item.
-
-After the tree display, if `concluded_count > 0` or `cancelled_count > 0`, add a summary line:
-
-> *Output the next fenced block as a code block:*
-
-```
-{concluded_count} concluded, {cancelled_count} cancelled.
-```
-
-Only show this block if either count is non-zero.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -41,14 +35,16 @@ Which epic would you like to continue?
 1. Continue "{epic.name:(titlecase)}"
 2. ...
 
+@if(concluded_count > 0 || cancelled_count > 0)
 {N+1}. View concluded & cancelled epics
+@endif
 - **`m`/`manage`** — Manage an epic's lifecycle
 
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual epics from discovery. Only show "View concluded & cancelled" if `concluded_count > 0` or `cancelled_count > 0`. No auto-select, even with one item.
+Recreate with actual epics from discovery. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 

--- a/skills/continue-epic/scripts/discovery.js
+++ b/skills/continue-epic/scripts/discovery.js
@@ -1,8 +1,19 @@
 'use strict';
 
-const { loadActiveManifests, loadManifest, phaseItems, phaseData } = require('../../workflow-shared/scripts/discovery-utils');
+const { loadActiveManifests, loadAllManifests, loadManifest, phaseItems, phaseData } = require('../../workflow-shared/scripts/discovery-utils');
 
 const EPIC_PHASES = ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
+
+function lastCompletedPhaseEpic(manifest) {
+  let last = null;
+  for (const phase of EPIC_PHASES) {
+    const items = phaseItems(manifest, phase);
+    if (items.length > 0 && items.some(i => i.status === 'concluded' || i.status === 'completed')) {
+      last = phase;
+    }
+  }
+  return last;
+}
 
 function resolveDeps(cwd, manifest, planItem) {
   const externalDepsObj = (planItem.external_dependencies && typeof planItem.external_dependencies === 'object' && !Array.isArray(planItem.external_dependencies))
@@ -187,9 +198,28 @@ function discover(cwd, workUnit) {
     });
   }
 
+  // Load concluded/cancelled epics (only in list mode, not detail mode)
+  const concluded = [];
+  const cancelled = [];
+  if (!workUnit) {
+    const allManifests = loadAllManifests(cwd);
+    for (const m of allManifests) {
+      if (m.work_type !== 'epic') continue;
+      if (m.status === 'concluded') {
+        concluded.push({ name: m.name, status: m.status, last_phase: lastCompletedPhaseEpic(m) });
+      } else if (m.status === 'cancelled') {
+        cancelled.push({ name: m.name, status: m.status, last_phase: lastCompletedPhaseEpic(m) });
+      }
+    }
+  }
+
   return {
     epics,
     count: epics.length,
+    concluded,
+    cancelled,
+    concluded_count: concluded.length,
+    cancelled_count: cancelled.length,
     summary: epics.length === 0
       ? 'no active epics'
       : `${epics.length} active epic(s)`,

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -57,6 +57,8 @@ Parse the discovery output to understand:
 **From top-level fields:**
 - `count` - number of active features
 - `summary` - human-readable state summary
+- `concluded` / `cancelled` - arrays of non-active features with name, status, last_phase
+- `concluded_count` / `cancelled_count` - counts for each
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
 

--- a/skills/continue-feature/references/select-feature.md
+++ b/skills/continue-feature/references/select-feature.md
@@ -48,16 +48,16 @@ Recreate with actual features and `phase_label` values from discovery. No auto-s
 
 **STOP.** Wait for user response.
 
-**If user chose a feature number:**
+#### If user chose a feature number
 
 Store the selected feature's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
 
-**If user chose "View concluded & cancelled":**
+#### If user chose "View concluded & cancelled"
 
 → Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `feature`. On return, re-run discovery and redisplay from the top of this reference.
 
-**If user chose `m`/`manage`:**
+#### If user chose `m`/`manage`
 
 → Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)**. On return, re-run discovery and redisplay from the top of this reference.

--- a/skills/continue-feature/references/select-feature.md
+++ b/skills/continue-feature/references/select-feature.md
@@ -22,6 +22,16 @@ Continue Feature
 
 Build from the discovery output's `features` array. Each feature shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
 
+After the tree display, if `concluded_count > 0` or `cancelled_count > 0`, add a summary line:
+
+> *Output the next fenced block as a code block:*
+
+```
+{concluded_count} concluded, {cancelled_count} cancelled.
+```
+
+Only show this block if either count is non-zero.
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
@@ -31,14 +41,27 @@ Which feature would you like to continue?
 1. Continue "{feature.name:(titlecase)}" — {feature.phase_label}
 2. ...
 
+{N+1}. View concluded & cancelled features
+- **`m`/`manage`** — Manage a feature's lifecycle
+
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual features and `phase_label` values from discovery. No auto-select, even with one item.
+Recreate with actual features and `phase_label` values from discovery. Only show "View concluded & cancelled" if `concluded_count > 0` or `cancelled_count > 0`. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
+
+**If user chose a feature number:**
 
 Store the selected feature's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
+
+**If user chose "View concluded & cancelled":**
+
+→ Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `feature`. On return, re-run discovery and redisplay from the top of this reference.
+
+**If user chose `m`/`manage`:**
+
+→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)**. On return, re-run discovery and redisplay from the top of this reference.

--- a/skills/continue-feature/references/select-feature.md
+++ b/skills/continue-feature/references/select-feature.md
@@ -18,19 +18,13 @@ Continue Feature
      └─ {feature.phase_label:(titlecase)}
 
 @endforeach
+
+@if(concluded_count > 0 || cancelled_count > 0)
+{concluded_count} concluded, {cancelled_count} cancelled.
+@endif
 ```
 
 Build from the discovery output's `features` array. Each feature shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
-
-After the tree display, if `concluded_count > 0` or `cancelled_count > 0`, add a summary line:
-
-> *Output the next fenced block as a code block:*
-
-```
-{concluded_count} concluded, {cancelled_count} cancelled.
-```
-
-Only show this block if either count is non-zero.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -41,14 +35,16 @@ Which feature would you like to continue?
 1. Continue "{feature.name:(titlecase)}" — {feature.phase_label}
 2. ...
 
+@if(concluded_count > 0 || cancelled_count > 0)
 {N+1}. View concluded & cancelled features
+@endif
 - **`m`/`manage`** — Manage a feature's lifecycle
 
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual features and `phase_label` values from discovery. Only show "View concluded & cancelled" if `concluded_count > 0` or `cancelled_count > 0`. No auto-select, even with one item.
+Recreate with actual features and `phase_label` values from discovery. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 

--- a/skills/continue-feature/scripts/discovery.js
+++ b/skills/continue-feature/scripts/discovery.js
@@ -1,8 +1,17 @@
 'use strict';
 
-const { loadActiveManifests, phaseStatus, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils');
+const { loadActiveManifests, loadAllManifests, phaseStatus, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils');
 
 const FEATURE_PIPELINE = ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
+
+function lastCompletedPhase(manifest) {
+  let last = null;
+  for (const phase of FEATURE_PIPELINE) {
+    const s = phaseStatus(manifest, phase);
+    if (s === 'concluded' || s === 'completed') last = phase;
+  }
+  return last;
+}
 
 function concludedPhases(manifest) {
   const concluded = [];
@@ -31,9 +40,27 @@ function discover(cwd) {
     });
   }
 
+  // Load concluded/cancelled features
+  const allManifests = loadAllManifests(cwd);
+  const concluded = [];
+  const cancelled = [];
+
+  for (const m of allManifests) {
+    if (m.work_type !== 'feature') continue;
+    if (m.status === 'concluded') {
+      concluded.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
+    } else if (m.status === 'cancelled') {
+      cancelled.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
+    }
+  }
+
   return {
     features,
     count: features.length,
+    concluded,
+    cancelled,
+    concluded_count: concluded.length,
+    cancelled_count: cancelled.length,
     summary: features.length === 0
       ? 'no active features'
       : `${features.length} active feature(s)`,

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -32,7 +32,7 @@ Invoke the `/migrate` skill and assess its output.
 
 Cross-topic dependency linking is only relevant to epic work units (feature and bugfix have a single plan with no cross-topic dependencies).
 
-1. **List epic work units**: Run `node .claude/skills/workflow-manifest/scripts/manifest.js list --work-type epic --status active`
+1. **List epic work units**: Run `node .claude/skills/workflow-manifest/scripts/manifest.js list --work-type epic --status in-progress`
 
 #### If no epic work units exist
 

--- a/skills/migrate/scripts/migrations/019-status-rename.sh
+++ b/skills/migrate/scripts/migrations/019-status-rename.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Migration 019: Rename work unit statuses
+#   active   → in-progress
+#   archived → cancelled
+#   Also: if status is active/in-progress but all phases through review are
+#   completed, set to concluded.
+#
+
+WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+
+if [ ! -d "$WORKFLOWS_DIR" ]; then
+  exit 0
+fi
+
+for manifest in "$WORKFLOWS_DIR"/*/manifest.json; do
+  [ -f "$manifest" ] || continue
+
+  node -e "
+    const fs = require('fs');
+    const f = process.argv[1];
+    const m = JSON.parse(fs.readFileSync(f, 'utf8'));
+    let changed = false;
+
+    // Rename statuses
+    if (m.status === 'active') {
+      m.status = 'in-progress';
+      changed = true;
+    } else if (m.status === 'archived') {
+      m.status = 'cancelled';
+      changed = true;
+    }
+
+    // Check if pipeline is fully done (review completed) but status is still in-progress
+    if (m.status === 'in-progress' && m.phases) {
+      const wt = m.work_type;
+      let reviewDone = false;
+
+      if (wt === 'epic') {
+        const items = (m.phases.review && m.phases.review.items) || {};
+        const vals = Object.values(items);
+        if (vals.length > 0 && vals.every(i => i.status === 'completed')) {
+          reviewDone = true;
+        }
+      } else {
+        if (m.phases.review && m.phases.review.status === 'completed') {
+          reviewDone = true;
+        }
+      }
+
+      if (reviewDone) {
+        m.status = 'concluded';
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      fs.writeFileSync(f, JSON.stringify(m, null, 2) + '\n');
+      process.stderr.write('  updated: ' + f + ' → ' + m.status + '\n');
+    }
+  " "$manifest"
+done

--- a/skills/migrate/scripts/migrations/019-status-rename.sh
+++ b/skills/migrate/scripts/migrations/019-status-rename.sh
@@ -8,55 +8,64 @@
 #
 
 WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+MANIFEST="node ${PROJECT_DIR:-.}/.claude/skills/workflow-manifest/scripts/manifest.js"
 
 if [ ! -d "$WORKFLOWS_DIR" ]; then
   exit 0
 fi
 
-for manifest in "$WORKFLOWS_DIR"/*/manifest.json; do
-  [ -f "$manifest" ] || continue
+for dir in "$WORKFLOWS_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  name=$(basename "$dir")
 
-  node -e "
-    const fs = require('fs');
-    const f = process.argv[1];
-    const m = JSON.parse(fs.readFileSync(f, 'utf8'));
-    let changed = false;
+  # Skip dot-prefixed directories
+  [[ "$name" == .* ]] && continue
 
-    // Rename statuses
-    if (m.status === 'active') {
-      m.status = 'in-progress';
-      changed = true;
-    } else if (m.status === 'archived') {
-      m.status = 'cancelled';
-      changed = true;
-    }
+  [ -f "$dir/manifest.json" ] || continue
 
-    // Check if pipeline is fully done (review completed) but status is still in-progress
-    if (m.status === 'in-progress' && m.phases) {
-      const wt = m.work_type;
-      let reviewDone = false;
+  status=$($MANIFEST get "$name" status 2>/dev/null) || continue
 
-      if (wt === 'epic') {
-        const items = (m.phases.review && m.phases.review.items) || {};
-        const vals = Object.values(items);
-        if (vals.length > 0 && vals.every(i => i.status === 'completed')) {
-          reviewDone = true;
-        }
-      } else {
-        if (m.phases.review && m.phases.review.status === 'completed') {
-          reviewDone = true;
-        }
-      }
+  # Rename old statuses
+  if [ "$status" = "active" ]; then
+    $MANIFEST set "$name" status in-progress 2>/dev/null
+    status="in-progress"
+    echo "  updated: $dir/manifest.json → in-progress" >&2
+  elif [ "$status" = "archived" ]; then
+    $MANIFEST set "$name" status cancelled 2>/dev/null
+    status="cancelled"
+    echo "  updated: $dir/manifest.json → cancelled" >&2
+  fi
 
-      if (reviewDone) {
-        m.status = 'concluded';
-        changed = true;
-      }
-    }
+  # Check if pipeline is fully done but status is still in-progress
+  if [ "$status" = "in-progress" ]; then
+    work_type=$($MANIFEST get "$name" work_type 2>/dev/null) || continue
 
-    if (changed) {
-      fs.writeFileSync(f, JSON.stringify(m, null, 2) + '\n');
-      process.stderr.write('  updated: ' + f + ' → ' + m.status + '\n');
-    }
-  " "$manifest"
+    review_done=false
+
+    if [ "$work_type" = "epic" ]; then
+      # Epic: check if all review items have status completed
+      review_items=$($MANIFEST get "$name" phases.review.items 2>/dev/null) || true
+      if [ -n "$review_items" ] && [ "$review_items" != "undefined" ]; then
+        all_completed=$(node -e "
+          const items = JSON.parse(process.argv[1]);
+          const vals = Object.values(items);
+          console.log(vals.length > 0 && vals.every(i => i.status === 'completed'));
+        " "$review_items" 2>/dev/null) || true
+        if [ "$all_completed" = "true" ]; then
+          review_done=true
+        fi
+      fi
+    else
+      # Feature/bugfix: check flat review status
+      review_status=$($MANIFEST get "$name" --phase review status 2>/dev/null) || true
+      if [ "$review_status" = "completed" ]; then
+        review_done=true
+      fi
+    fi
+
+    if [ "$review_done" = "true" ]; then
+      $MANIFEST set "$name" status concluded 2>/dev/null
+      echo "  updated: $dir/manifest.json → concluded" >&2
+    fi
+  fi
 done

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -25,10 +25,16 @@ Use `next_phase` from discovery output to determine the target skill:
 
 #### If `next_phase` is `done`
 
+Set the work unit status to concluded:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+```
+
 > *Output the next fenced block as a code block:*
 
 ```
-Bugfix Complete
+Bugfix Concluded
 
 "{work_unit:(titlecase)}" has completed all pipeline phases.
 ```
@@ -38,6 +44,52 @@ Bugfix Complete
 #### Otherwise
 
 Set `target_phase` = `next_phase`.
+
+→ Proceed to **A2. Offer Early Conclusion**.
+
+## A2. Offer Early Conclusion
+
+#### If `next_phase` is `review`
+
+Implementation has just concluded. Offer the user a choice to skip review and conclude early.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Implementation concluded for "{work_unit:(titlecase)}".
+
+- **`y`/`yes`** — Proceed to review
+- **`d`/`done`** — Conclude without review
+
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `d`/`done`:**
+
+Set the work unit status to concluded:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Bugfix Concluded
+
+"{work_unit:(titlecase)}" concluded — review skipped.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If user chose `y`/`yes`:**
+
+→ Proceed to **B. Offer Revisit**.
+
+#### Otherwise
 
 → Proceed to **B. Offer Revisit**.
 

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -117,11 +117,11 @@ Check if there are concluded phases earlier in the pipeline that the user could 
 
 **STOP.** Wait for user response.
 
-**If user chose `y`/`yes`:**
+#### If user chose `y`/`yes`
 
 → Proceed to **D. Enter Plan Mode**.
 
-**If user chose `r`/`revisit`:**
+#### If user chose `r`/`revisit`
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -141,11 +141,11 @@ List only concluded phases that come before `next_phase`.
 
 **STOP.** Wait for user response.
 
-**If user chose Back:**
+#### If user chose Back
 
 → Return to **C. Offer Revisit**.
 
-**If user chose a phase:**
+#### If user chose a phase
 
 Set `target_phase` = selected phase.
 

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -45,9 +45,9 @@ Bugfix Concluded
 
 Set `target_phase` = `next_phase`.
 
-→ Proceed to **A2. Offer Early Conclusion**.
+→ Proceed to **B. Offer Early Conclusion**.
 
-## A2. Offer Early Conclusion
+## B. Offer Early Conclusion
 
 #### If `next_phase` is `review`
 
@@ -87,19 +87,19 @@ Bugfix Concluded
 
 **If user chose `y`/`yes`:**
 
-→ Proceed to **B. Offer Revisit**.
+→ Proceed to **C. Offer Revisit**.
 
 #### Otherwise
 
-→ Proceed to **B. Offer Revisit**.
+→ Proceed to **C. Offer Revisit**.
 
-## B. Offer Revisit
+## C. Offer Revisit
 
 Check if there are concluded phases earlier in the pipeline that the user could revisit. Look at the discovery output's `phases` data — any phase with status `concluded` or `completed` that comes before `next_phase` in the pipeline order.
 
 #### If no earlier concluded phases exist
 
-→ Proceed to **C. Enter Plan Mode**.
+→ Proceed to **D. Enter Plan Mode**.
 
 #### If earlier concluded phases exist
 
@@ -119,7 +119,7 @@ Check if there are concluded phases earlier in the pipeline that the user could 
 
 **If user chose `y`/`yes`:**
 
-→ Proceed to **C. Enter Plan Mode**.
+→ Proceed to **D. Enter Plan Mode**.
 
 **If user chose `r`/`revisit`:**
 
@@ -143,15 +143,15 @@ List only concluded phases that come before `next_phase`.
 
 **If user chose Back:**
 
-→ Return to **B. Offer Revisit**.
+→ Return to **C. Offer Revisit**.
 
 **If user chose a phase:**
 
 Set `target_phase` = selected phase.
 
-→ Proceed to **C. Enter Plan Mode**.
+→ Proceed to **D. Enter Plan Mode**.
 
-## C. Enter Plan Mode
+## D. Enter Plan Mode
 
 Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
 

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -18,6 +18,52 @@ node .claude/skills/continue-epic/scripts/discovery.js {work_unit}
 
 Parse the output. Use the epic's `detail` object as the discovery data for the display.
 
+## A2. Check All-Done
+
+Using the enriched discovery data from section A, check if ALL topics across ALL phases have review status `completed`. Specifically: check if any review items exist, and if so, whether every one has `status: completed`, and no topics in earlier phases are still `in-progress`.
+
+#### If all topics have completed review
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+All topics have completed review for "{work_unit:(titlecase)}".
+
+- **`y`/`yes`** — Mark this epic as concluded
+- **`n`/`no`** — Return to the epic menu
+
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `y`/`yes`:**
+
+Set the work unit status to concluded:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Epic Concluded
+
+"{work_unit:(titlecase)}" has completed all topics through review.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If user chose `n`/`no`:**
+
+→ Proceed to **B. Display and Menu**.
+
+#### Otherwise
+
+→ Proceed to **B. Display and Menu**.
+
 ## B. Display and Menu
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -18,7 +18,7 @@ node .claude/skills/continue-epic/scripts/discovery.js {work_unit}
 
 Parse the output. Use the epic's `detail` object as the discovery data for the display.
 
-## A2. Check All-Done
+## B. Check All-Done
 
 Using the enriched discovery data from section A, check if ALL topics across ALL phases have review status `completed`. Specifically: check if any review items exist, and if so, whether every one has `status: completed`, and no topics in earlier phases are still `in-progress`.
 
@@ -58,13 +58,13 @@ Epic Concluded
 
 **If user chose `n`/`no`:**
 
-→ Proceed to **B. Display and Menu**.
+→ Proceed to **C. Display and Menu**.
 
 #### Otherwise
 
-→ Proceed to **B. Display and Menu**.
+→ Proceed to **C. Display and Menu**.
 
-## B. Display and Menu
+## C. Display and Menu
 
 > *Output the next fenced block as a code block:*
 
@@ -76,11 +76,11 @@ Load **[epic-display-and-menu.md](../../continue-epic/references/epic-display-an
 
 **STOP.** Do not proceed until the above has returned with the user's selection.
 
-→ Proceed to **C. Enter Plan Mode**.
+→ Proceed to **D. Enter Plan Mode**.
 
 ---
 
-## C. Enter Plan Mode
+## D. Enter Plan Mode
 
 Map the selection to a skill invocation using this routing table:
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -26,10 +26,16 @@ Use `next_phase` from discovery output to determine the target skill:
 
 #### If `next_phase` is `done`
 
+Set the work unit status to concluded:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+```
+
 > *Output the next fenced block as a code block:*
 
 ```
-Feature Complete
+Feature Concluded
 
 "{work_unit:(titlecase)}" has completed all pipeline phases.
 ```
@@ -39,6 +45,52 @@ Feature Complete
 #### Otherwise
 
 Set `target_phase` = `next_phase`.
+
+→ Proceed to **A2. Offer Early Conclusion**.
+
+## A2. Offer Early Conclusion
+
+#### If `next_phase` is `review`
+
+Implementation has just concluded. Offer the user a choice to skip review and conclude early.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Implementation concluded for "{work_unit:(titlecase)}".
+
+- **`y`/`yes`** — Proceed to review
+- **`d`/`done`** — Conclude without review
+
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `d`/`done`:**
+
+Set the work unit status to concluded:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Feature Concluded
+
+"{work_unit:(titlecase)}" concluded — review skipped.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If user chose `y`/`yes`:**
+
+→ Proceed to **B. Offer Revisit**.
+
+#### Otherwise
 
 → Proceed to **B. Offer Revisit**.
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -118,11 +118,11 @@ Check if there are concluded phases earlier in the pipeline that the user could 
 
 **STOP.** Wait for user response.
 
-**If user chose `y`/`yes`:**
+#### If user chose `y`/`yes`
 
 → Proceed to **D. Enter Plan Mode**.
 
-**If user chose `r`/`revisit`:**
+#### If user chose `r`/`revisit`
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -142,11 +142,11 @@ List only concluded phases that come before `next_phase`.
 
 **STOP.** Wait for user response.
 
-**If user chose Back:**
+#### If user chose Back
 
 → Return to **C. Offer Revisit**.
 
-**If user chose a phase:**
+#### If user chose a phase
 
 Set `target_phase` = selected phase.
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -46,9 +46,9 @@ Feature Concluded
 
 Set `target_phase` = `next_phase`.
 
-→ Proceed to **A2. Offer Early Conclusion**.
+→ Proceed to **B. Offer Early Conclusion**.
 
-## A2. Offer Early Conclusion
+## B. Offer Early Conclusion
 
 #### If `next_phase` is `review`
 
@@ -88,19 +88,19 @@ Feature Concluded
 
 **If user chose `y`/`yes`:**
 
-→ Proceed to **B. Offer Revisit**.
+→ Proceed to **C. Offer Revisit**.
 
 #### Otherwise
 
-→ Proceed to **B. Offer Revisit**.
+→ Proceed to **C. Offer Revisit**.
 
-## B. Offer Revisit
+## C. Offer Revisit
 
 Check if there are concluded phases earlier in the pipeline that the user could revisit. Look at the discovery output's `phases` data — any phase with status `concluded` or `completed` that comes before `next_phase` in the pipeline order.
 
 #### If no earlier concluded phases exist
 
-→ Proceed to **C. Enter Plan Mode**.
+→ Proceed to **D. Enter Plan Mode**.
 
 #### If earlier concluded phases exist
 
@@ -120,7 +120,7 @@ Check if there are concluded phases earlier in the pipeline that the user could 
 
 **If user chose `y`/`yes`:**
 
-→ Proceed to **C. Enter Plan Mode**.
+→ Proceed to **D. Enter Plan Mode**.
 
 **If user chose `r`/`revisit`:**
 
@@ -144,15 +144,15 @@ List only concluded phases that come before `next_phase`.
 
 **If user chose Back:**
 
-→ Return to **B. Offer Revisit**.
+→ Return to **C. Offer Revisit**.
 
 **If user chose a phase:**
 
 Set `target_phase` = selected phase.
 
-→ Proceed to **C. Enter Plan Mode**.
+→ Proceed to **D. Enter Plan Mode**.
 
-## C. Enter Plan Mode
+## D. Enter Plan Mode
 
 Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
 

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -40,7 +40,6 @@ $MANIFEST exists {work_unit} --phase <phase> [--topic <topic>] [field.path]
 # Management (unchanged):
 $MANIFEST init name --work-type type --description "..."
 $MANIFEST list [--status s] [--work-type t]
-$MANIFEST archive name
 ```
 
 **`--topic` is optional for get** — if omitted, returns the whole phase object. Discovery scripts use this to iterate items:
@@ -102,7 +101,7 @@ Write a value. Two modes:
 **Work-unit level** (no flags):
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set <name> description "Updated description"
-node .claude/skills/workflow-manifest/scripts/manifest.js set <name> status archived
+node .claude/skills/workflow-manifest/scripts/manifest.js set <name> status concluded
 ```
 
 **Phase level** (with flags):
@@ -117,7 +116,7 @@ Values are parsed as JSON first (for arrays, objects, numbers, booleans), fallin
 - **phase names**: `research`, `discussion`, `investigation`, `specification`, `planning`, `implementation`, `review`
 - **phase statuses**: per-phase valid values (see Validation section)
 - **gate modes**: `gated`, `auto`
-- **work unit status**: `active`, `archived`
+- **work unit status**: `in-progress`, `concluded`, `cancelled`
 
 ### `list`
 
@@ -128,13 +127,13 @@ Enumerate work units by scanning `.workflows/` for `manifest.json` files. Skips 
 node .claude/skills/workflow-manifest/scripts/manifest.js list
 
 # Filter by status
-node .claude/skills/workflow-manifest/scripts/manifest.js list --status active
+node .claude/skills/workflow-manifest/scripts/manifest.js list --status in-progress
 
 # Filter by work type
 node .claude/skills/workflow-manifest/scripts/manifest.js list --work-type epic
 
 # Combined filters
-node .claude/skills/workflow-manifest/scripts/manifest.js list --status active --work-type feature
+node .claude/skills/workflow-manifest/scripts/manifest.js list --status in-progress --work-type feature
 ```
 
 Output: JSON array of manifest objects.
@@ -185,16 +184,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> --phase 
 
 If the work unit doesn't exist and a deeper path is requested, outputs `false` (no error). Actual usage errors (missing args, invalid phase name) still use `die()`.
 
-### `archive`
-
-Move a work unit to `.workflows/.archive/<name>/` and set status to `archived`.
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js archive <name>
-```
-
-Errors if work unit does not exist.
-
 ## Validation
 
 The CLI validates structural values to prevent invalid state:
@@ -202,7 +191,7 @@ The CLI validates structural values to prevent invalid state:
 | Field                          | Valid Values                             |
 |--------------------------------|------------------------------------------|
 | `work_type`                    | `epic`, `feature`, `bugfix`              |
-| `status` (work unit)           | `active`, `archived`                     |
+| `status` (work unit)           | `in-progress`, `concluded`, `cancelled`  |
 | `phases.research.status`       | `in-progress`, `concluded`               |
 | `phases.discussion.status`     | `in-progress`, `concluded`               |
 | `phases.investigation.status`  | `in-progress`, `concluded`               |
@@ -216,7 +205,7 @@ Item-level statuses within epic phases follow the same phase-level rules.
 
 ## Output Conventions
 
-- **Scalar values**: raw to stdout, no quotes (e.g., `active`, `concluded`)
+- **Scalar values**: raw to stdout, no quotes (e.g., `in-progress`, `concluded`)
 - **Subtrees and lists**: formatted JSON to stdout
 - **Errors**: message to stderr, non-zero exit code
 

--- a/skills/workflow-manifest/scripts/manifest.js
+++ b/skills/workflow-manifest/scripts/manifest.js
@@ -33,7 +33,7 @@ const VALID_PHASE_STATUSES = {
 
 const VALID_GATE_MODES = ['gated', 'auto'];
 
-const VALID_WORK_UNIT_STATUSES = ['active', 'archived'];
+const VALID_WORK_UNIT_STATUSES = ['in-progress', 'concluded', 'cancelled'];
 
 const LOCK_STALE_MS = 30000;
 const LOCK_RETRY_MS = 50;
@@ -334,7 +334,7 @@ function cmdInit(args) {
   const manifest = {
     name,
     work_type: workType,
-    status: 'active',
+    status: 'in-progress',
     created: new Date().toISOString().slice(0, 10),
     description,
     phases: {},
@@ -636,37 +636,6 @@ function cmdExists(args) {
   process.stdout.write(value !== undefined ? 'true\n' : 'false\n');
 }
 
-function cmdArchive(args) {
-  if (args.length !== 1) die('Usage: archive <name>');
-
-  const name = args[0];
-  const dir = manifestDir(name);
-
-  if (!fs.existsSync(dir)) {
-    die(`Work unit "${name}" not found`);
-  }
-
-  const archiveBase = path.join(WORKFLOWS_DIR, '.archive');
-  const archiveDest = path.join(archiveBase, name);
-
-  if (fs.existsSync(archiveDest)) {
-    die(`Archive destination already exists for "${name}"`);
-  }
-
-  withLock(name, () => {
-    // Update status before moving
-    const manifest = readManifest(name);
-    manifest.status = 'archived';
-    writeManifestAtomic(name, manifest);
-
-    // Move to archive
-    fs.mkdirSync(archiveBase, { recursive: true });
-    fs.renameSync(dir, archiveDest);
-  });
-
-  process.stdout.write(`Archived work unit "${name}"\n`);
-}
-
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -674,7 +643,7 @@ function cmdArchive(args) {
 const [command, ...args] = process.argv.slice(2);
 
 if (!command) {
-  die('Usage: manifest.js <command> [args]\nCommands: init, get, set, list, init-phase, push, exists, archive');
+  die('Usage: manifest.js <command> [args]\nCommands: init, get, set, list, init-phase, push, exists');
 }
 
 switch (command) {
@@ -685,6 +654,5 @@ switch (command) {
   case 'init-phase': cmdInitPhase(args); break;
   case 'push':     cmdPush(args); break;
   case 'exists':   cmdExists(args); break;
-  case 'archive':  cmdArchive(args); break;
   default:         die(`Unknown command "${command}"`);
 }

--- a/skills/workflow-manifest/scripts/manifest.js
+++ b/skills/workflow-manifest/scripts/manifest.js
@@ -179,6 +179,35 @@ function resolvePhaseSegments(workType, phase, topic, fieldSegments) {
   return [...base, ...fieldSegments];
 }
 
+/**
+ * Resolve wildcard topic — collect field values from all topics in a phase.
+ * For epic: iterates all items. For feature/bugfix: returns the single flat value.
+ *
+ * @param {object} manifest - The full manifest object
+ * @param {string} phase - The phase name
+ * @param {string[]} fieldSegments - Field path within each topic
+ * @returns {Array<{topic: string, value: *}>} Collected values
+ */
+function resolveWildcardTopic(manifest, phase, fieldSegments) {
+  const phaseData = getByPath(manifest, ['phases', phase]);
+  if (!phaseData) return [];
+
+  if (manifest.work_type === 'epic') {
+    const items = phaseData.items;
+    if (!items || typeof items !== 'object') return [];
+
+    return Object.keys(items).map(topic => ({
+      topic,
+      value: fieldSegments.length ? getByPath(items[topic], fieldSegments) : items[topic],
+    })).filter(entry => entry.value !== undefined);
+  }
+
+  // Feature/bugfix: single implicit topic
+  const value = fieldSegments.length ? getByPath(phaseData, fieldSegments) : phaseData;
+  if (value === undefined) return [];
+  return [{ topic: manifest.name, value }];
+}
+
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
@@ -372,6 +401,17 @@ function cmdGet(args) {
   validatePhase(phase);
 
   const fieldSegments = positional.length > 1 ? positional[1].split('.') : [];
+
+  // Wildcard topic: collect values from all topics
+  if (topic === '*') {
+    const results = resolveWildcardTopic(manifest, phase, fieldSegments);
+    if (results.length === 0) {
+      die(`No items found in phase "${phase}" of "${name}"`);
+    }
+    process.stdout.write(JSON.stringify(results, null, 2) + '\n');
+    return;
+  }
+
   const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
 
   const value = getByPath(manifest, segments);
@@ -631,6 +671,14 @@ function cmdExists(args) {
   // Phase-level
   validatePhase(phase);
   const fieldSegments = positional.length > 1 ? positional[1].split('.') : [];
+
+  // Wildcard topic: check if any topic has the specified field
+  if (topic === '*') {
+    const results = resolveWildcardTopic(manifest, phase, fieldSegments);
+    process.stdout.write(results.length > 0 ? 'true\n' : 'false\n');
+    return;
+  }
+
   const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
   const value = getByPath(manifest, segments);
   process.stdout.write(value !== undefined ? 'true\n' : 'false\n');

--- a/skills/workflow-shared/scripts/discovery-utils.js
+++ b/skills/workflow-shared/scripts/discovery-utils.js
@@ -63,7 +63,18 @@ function loadActiveManifests(cwd) {
   for (const name of listDirs(workflowsDir)) {
     if (name.startsWith('.')) continue;
     const m = loadManifest(cwd, name);
-    if (m && m.status === 'active') results.push(m);
+    if (m && m.status === 'in-progress') results.push(m);
+  }
+  return results;
+}
+
+function loadAllManifests(cwd) {
+  const workflowsDir = path.join(cwd, '.workflows');
+  const results = [];
+  for (const name of listDirs(workflowsDir)) {
+    if (name.startsWith('.')) continue;
+    const m = loadManifest(cwd, name);
+    if (m) results.push(m);
   }
   return results;
 }
@@ -178,4 +189,5 @@ module.exports = {
   filesChecksum,
   computeNextPhase,
   loadActiveManifests,
+  loadAllManifests,
 };

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.js)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.js), Bash(node .claude/skills/workflow-manifest/scripts/manifest.js)
 hooks:
   PreToolUse:
     - hooks:
@@ -54,6 +54,10 @@ Parse the output to understand the current workflow state:
 
 **From `bugfixes` section:**
 - `work_units` — name, next_phase, phase_label
+
+**From `concluded`/`cancelled` arrays:**
+- Non-active work units with name, work_type, status, last_phase
+- `concluded_count`, `cancelled_count`
 
 **From `state` section:**
 - Counts for each work type, `has_any_work` flag

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -43,9 +43,19 @@ Epics:
 
 Build from discovery output. Only show sections that have work units. Numbering is continuous across sections. Feature/bugfix shows `phase_label` (titlecased). Epic shows comma-separated `active_phases` (titlecased). Blank line between each numbered item.
 
+After the tree display, if `concluded_count > 0` or `cancelled_count > 0`, add a summary line:
+
+> *Output the next fenced block as a code block:*
+
+```
+{concluded_count} concluded, {cancelled_count} cancelled.
+```
+
+Only show this block if either count is non-zero.
+
 ## Menu
 
-Build a numbered menu with continue items first, then start-new options separated by a blank line.
+Build a numbered menu with continue items first, then start-new options, then lifecycle options, separated by blank lines.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -61,6 +71,9 @@ What would you like to do?
 5. Start new epic
 6. Start new bugfix
 
+7. View concluded & cancelled work units
+- **`m`/`manage`** — Manage a work unit's lifecycle
+
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
@@ -69,9 +82,13 @@ Select an option (enter number):
 
 **Start-new items:** Always show all three start options.
 
+**Lifecycle items:** Only show "View concluded & cancelled" if `concluded_count > 0` or `cancelled_count > 0`.
+
 Recreate with actual work units from discovery.
 
 **STOP.** Wait for user response.
+
+**If user chose a continue or start-new option:**
 
 Invoke the selected skill:
 
@@ -85,3 +102,11 @@ Invoke the selected skill:
 | Start new bugfix | `/start-bugfix` |
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
+
+**If user chose "View concluded & cancelled":**
+
+→ Load **[view-concluded.md](view-concluded.md)** with no work_type filter (unified across all types). On return, re-run discovery and redisplay from the top of this reference.
+
+**If user chose `m`/`manage`:**
+
+→ Load **[manage-work-unit.md](manage-work-unit.md)**. On return, re-run discovery and redisplay from the top of this reference.

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -82,7 +82,7 @@ Recreate with actual work units from discovery.
 
 **STOP.** Wait for user response.
 
-**If user chose a continue or start-new option:**
+#### If user chose a continue or start-new option
 
 Invoke the selected skill:
 
@@ -97,10 +97,10 @@ Invoke the selected skill:
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
 
-**If user chose "View concluded & cancelled":**
+#### If user chose "View concluded & cancelled"
 
 → Load **[view-concluded.md](view-concluded.md)** with no work_type filter (unified across all types). On return, re-run discovery and redisplay from the top of this reference.
 
-**If user chose `m`/`manage`:**
+#### If user chose `m`/`manage`
 
 → Load **[manage-work-unit.md](manage-work-unit.md)**. On return, re-run discovery and redisplay from the top of this reference.

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -39,19 +39,13 @@ Epics:
 
 @endforeach
 @endif
+
+@if(concluded_count > 0 || cancelled_count > 0)
+{concluded_count} concluded, {cancelled_count} cancelled.
+@endif
 ```
 
 Build from discovery output. Only show sections that have work units. Numbering is continuous across sections. Feature/bugfix shows `phase_label` (titlecased). Epic shows comma-separated `active_phases` (titlecased). Blank line between each numbered item.
-
-After the tree display, if `concluded_count > 0` or `cancelled_count > 0`, add a summary line:
-
-> *Output the next fenced block as a code block:*
-
-```
-{concluded_count} concluded, {cancelled_count} cancelled.
-```
-
-Only show this block if either count is non-zero.
 
 ## Menu
 
@@ -71,7 +65,9 @@ What would you like to do?
 5. Start new epic
 6. Start new bugfix
 
+@if(concluded_count > 0 || cancelled_count > 0)
 7. View concluded & cancelled work units
+@endif
 - **`m`/`manage`** — Manage a work unit's lifecycle
 
 Select an option (enter number):
@@ -81,8 +77,6 @@ Select an option (enter number):
 **Continue items:** Feature/bugfix shows type + phase label. Epic just shows "epic" (detail is in continue-epic). No auto-select — always show the full menu. No "(recommended)" labels.
 
 **Start-new items:** Always show all three start options.
-
-**Lifecycle items:** Only show "View concluded & cancelled" if `concluded_count > 0` or `cancelled_count > 0`.
 
 Recreate with actual work units from discovery.
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -18,11 +18,11 @@ Which work unit would you like to manage? (enter number from list above, or **`b
 
 **STOP.** Wait for user response.
 
-**If user chose `b`/`back`:**
+#### If user chose `b`/`back`
 
 → Return to caller.
 
-**If user chose a number:**
+#### If user chose a number
 
 Store the selected work unit. → Proceed to **B. Action Menu**.
 
@@ -30,17 +30,15 @@ Store the selected work unit. → Proceed to **B. Action Menu**.
 
 Determine whether to show the `d`/`done` option. Check if at least one topic has completed implementation.
 
-First, check whether the implementation phase exists:
-
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name} phases.implementation
 ```
 
-**If the result is `false`:**
+#### If the result is `false`
 
 Set `implementation_completed` = false.
 
-**If the result is `true`:**
+#### If the result is `true`
 
 Get the work type:
 
@@ -87,7 +85,7 @@ Set `implementation_completed` = true.
 
 **STOP.** Wait for user response.
 
-**If user chose `d`/`done`:**
+#### If user chose `d`/`done`
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status concluded
@@ -101,7 +99,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} st
 
 → Return to caller to redisplay main view (re-run discovery, re-render from top).
 
-**If user chose `x`/`cancel`:**
+#### If user chose `x`/`cancel`
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status cancelled
@@ -115,10 +113,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} st
 
 → Return to caller to redisplay main view (re-run discovery, re-render from top).
 
-**If user chose `b`/`back`:**
+#### If user chose `b`/`back`
 
 → Return to caller.
 
-**If user asked a question:**
+#### If user asked a question
 
 Answer the question, then redisplay the action menu (section B).

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -28,7 +28,11 @@ Store the selected work unit. → Proceed to **B. Action Menu**.
 
 ## B. Action Menu
 
-Check if the selected work unit's implementation phase is concluded or completed (via manifest CLI or discovery data).
+Check if the selected work unit has reached implementation (at least one topic has entered the implementation phase):
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name} phases.implementation
+```
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -36,7 +40,7 @@ Check if the selected work unit's implementation phase is concluded or completed
 · · · · · · · · · · · ·
 **{selected.name:(titlecase)}** ({selected.work_type})
 
-@if(implementation_concluded_or_completed)
+@if(has_implementation)
 - **`d`/`done`** — Mark as concluded
 @endif
 - **`x`/`cancel`** — Mark as cancelled

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -40,7 +40,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} wo
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation status
 ```
 
-If the result is `completed`, set `implementation_completed` = true.
+**If the result is `completed`**, set `implementation_completed` = true.
 
 **If work type is `epic`:**
 
@@ -48,9 +48,9 @@ If the result is `completed`, set `implementation_completed` = true.
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation
 ```
 
-Parse the JSON output. If any item in the `items` object has `"status": "completed"`, set `implementation_completed` = true.
+Parse the JSON output. **If any item in the `items` object has `"status": "completed"`**, set `implementation_completed` = true.
 
-If the phase doesn't exist (command errors), `implementation_completed` = false.
+**If the phase doesn't exist** (command errors), `implementation_completed` = false.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -28,7 +28,21 @@ Store the selected work unit. → Proceed to **B. Action Menu**.
 
 ## B. Action Menu
 
-Determine whether to show the `d`/`done` option. Get the work type, then check if at least one topic has completed implementation:
+Determine whether to show the `d`/`done` option. Check if at least one topic has completed implementation.
+
+First, check whether the implementation phase exists:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name} phases.implementation
+```
+
+**If the result is `false`:**
+
+Set `implementation_completed` = false.
+
+**If the result is `true`:**
+
+Get the work type:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} work_type
@@ -40,7 +54,9 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} wo
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation status
 ```
 
-**If the result is `completed`**, set `implementation_completed` = true.
+**If the result is `completed`:**
+
+Set `implementation_completed` = true.
 
 **If work type is `epic`:**
 
@@ -48,9 +64,11 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation
 ```
 
-Parse the JSON output. **If any item in the `items` object has `"status": "completed"`**, set `implementation_completed` = true.
+Parse the JSON output.
 
-**If the phase doesn't exist** (command errors), `implementation_completed` = false.
+**If any item in the `items` object has `"status": "completed"`:**
+
+Set `implementation_completed` = true.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -1,0 +1,85 @@
+# Manage Work Unit
+
+*Reference for **[workflow-start](../SKILL.md)***
+
+---
+
+Manage an in-progress work unit's lifecycle. Self-contained two-step flow. Uses the numbered in-progress items already displayed by the caller.
+
+## A. Select
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Which work unit would you like to manage? (enter number from list above, or **`b`/`back`** to return)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `b`/`back`:**
+
+→ Return to caller.
+
+**If user chose a number:**
+
+Store the selected work unit. → Proceed to **B. Action Menu**.
+
+## B. Action Menu
+
+Check if the selected work unit's implementation phase is concluded or completed (via manifest CLI or discovery data).
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**{selected.name:(titlecase)}** ({selected.work_type})
+
+@if(implementation_concluded_or_completed)
+- **`d`/`done`** — Mark as concluded
+@endif
+- **`x`/`cancel`** — Mark as cancelled
+- **`b`/`back`** — Return
+
+Or ask a question about this work unit.
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `d`/`done`:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status concluded
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+"{selected.name:(titlecase)}" marked as concluded.
+```
+
+→ Return to caller to redisplay main view (re-run discovery, re-render from top).
+
+**If user chose `x`/`cancel`:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status cancelled
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+"{selected.name:(titlecase)}" marked as cancelled.
+```
+
+→ Return to caller to redisplay main view (re-run discovery, re-render from top).
+
+**If user chose `b`/`back`:**
+
+→ Return to caller.
+
+**If user asked a question:**
+
+Answer the question, then redisplay the action menu (section B).

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -28,11 +28,7 @@ Store the selected work unit. → Proceed to **B. Action Menu**.
 
 ## B. Action Menu
 
-Check if the selected work unit has reached implementation (at least one topic has entered the implementation phase):
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name} phases.implementation
-```
+Check if at least one topic has completed implementation. For feature/bugfix, check `phases.implementation.status`. For epic, check if any item in `phases.implementation.items` has `status: completed`. Use the manifest CLI to read the phase data.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -40,7 +36,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name}
 · · · · · · · · · · · ·
 **{selected.name:(titlecase)}** ({selected.work_type})
 
-@if(has_implementation)
+@if(implementation_completed)
 - **`d`/`done`** — Mark as concluded
 @endif
 - **`x`/`cancel`** — Mark as cancelled

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -41,8 +41,7 @@ Check if the selected work unit's implementation phase is concluded or completed
 @endif
 - **`x`/`cancel`** — Mark as cancelled
 - **`b`/`back`** — Return
-
-Or ask a question about this work unit.
+- **Ask** — Ask a question about this work unit
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -4,7 +4,7 @@
 
 ---
 
-Manage an in-progress work unit's lifecycle. Self-contained three-step flow. Uses the numbered in-progress items already displayed by the caller.
+Manage an in-progress work unit's lifecycle. Self-contained four-step flow. Uses the numbered in-progress items already displayed by the caller.
 
 ## A. Select
 
@@ -24,11 +24,11 @@ Which work unit would you like to manage? (enter number from list above, or **`b
 
 #### If user chose a number
 
-Store the selected work unit. → Proceed to **B. Done Check**.
+Store the selected work unit. → Proceed to **B. Implementation Check**.
 
-## B. Done Check
+## B. Implementation Check
 
-Determine whether to show the `d`/`done` option. Default `implementation_completed` = false.
+Default `implementation_completed` = false.
 
 Check whether the implementation phase exists:
 
@@ -38,7 +38,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name}
 
 #### If the result is `false`
 
-→ Proceed to **C. Action Menu**.
+→ Proceed to **D. Action Menu**.
 
 #### If the result is `true`
 
@@ -47,6 +47,10 @@ Get the work type:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} work_type
 ```
+
+→ Proceed to **C. Completion Check**.
+
+## C. Completion Check
 
 #### If work type is `feature` or `bugfix`
 
@@ -58,7 +62,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --
 
 Set `implementation_completed` = true.
 
-→ Proceed to **C. Action Menu**.
+→ Proceed to **D. Action Menu**.
 
 #### If work type is `epic`
 
@@ -72,9 +76,9 @@ Parse the JSON output.
 
 Set `implementation_completed` = true.
 
-→ Proceed to **C. Action Menu**.
+→ Proceed to **D. Action Menu**.
 
-## C. Action Menu
+## D. Action Menu
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -127,4 +131,4 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} st
 
 #### If user asked a question
 
-Answer the question, then redisplay the action menu (section C).
+Answer the question, then redisplay the action menu (section D).

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -42,39 +42,23 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name}
 
 #### If the result is `true`
 
-Get the work type:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} work_type
-```
-
 → Proceed to **C. Completion Check**.
 
 ## C. Completion Check
 
-#### If work type is `feature` or `bugfix`
-
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation --topic "*" status
 ```
 
-**If the result is `completed`:**
+This returns all topic statuses in the implementation phase.
+
+#### If any result has `"value": "completed"`
 
 Set `implementation_completed` = true.
 
 → Proceed to **D. Action Menu**.
 
-#### If work type is `epic`
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation
-```
-
-Parse the JSON output.
-
-**If any item in the `items` object has `"status": "completed"`:**
-
-Set `implementation_completed` = true.
+#### Otherwise
 
 → Proceed to **D. Action Menu**.
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -28,7 +28,29 @@ Store the selected work unit. → Proceed to **B. Action Menu**.
 
 ## B. Action Menu
 
-Check if at least one topic has completed implementation. For feature/bugfix, check `phases.implementation.status`. For epic, check if any item in `phases.implementation.items` has `status: completed`. Use the manifest CLI to read the phase data.
+Determine whether to show the `d`/`done` option. Get the work type, then check if at least one topic has completed implementation:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} work_type
+```
+
+**If work type is `feature` or `bugfix`:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation status
+```
+
+If the result is `completed`, set `implementation_completed` = true.
+
+**If work type is `epic`:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation
+```
+
+Parse the JSON output. If any item in the `items` object has `"status": "completed"`, set `implementation_completed` = true.
+
+If the phase doesn't exist (command errors), `implementation_completed` = false.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -4,7 +4,7 @@
 
 ---
 
-Manage an in-progress work unit's lifecycle. Self-contained two-step flow. Uses the numbered in-progress items already displayed by the caller.
+Manage an in-progress work unit's lifecycle. Self-contained three-step flow. Uses the numbered in-progress items already displayed by the caller.
 
 ## A. Select
 
@@ -24,11 +24,13 @@ Which work unit would you like to manage? (enter number from list above, or **`b
 
 #### If user chose a number
 
-Store the selected work unit. → Proceed to **B. Action Menu**.
+Store the selected work unit. → Proceed to **B. Done Check**.
 
-## B. Action Menu
+## B. Done Check
 
-Determine whether to show the `d`/`done` option. Check if at least one topic has completed implementation.
+Determine whether to show the `d`/`done` option. Default `implementation_completed` = false.
+
+Check whether the implementation phase exists:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name} phases.implementation
@@ -36,7 +38,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name}
 
 #### If the result is `false`
 
-Set `implementation_completed` = false.
+→ Proceed to **C. Action Menu**.
 
 #### If the result is `true`
 
@@ -46,7 +48,7 @@ Get the work type:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} work_type
 ```
 
-**If work type is `feature` or `bugfix`:**
+#### If work type is `feature` or `bugfix`
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation status
@@ -56,7 +58,9 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --
 
 Set `implementation_completed` = true.
 
-**If work type is `epic`:**
+→ Proceed to **C. Action Menu**.
+
+#### If work type is `epic`
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation
@@ -67,6 +71,10 @@ Parse the JSON output.
 **If any item in the `items` object has `"status": "completed"`:**
 
 Set `implementation_completed` = true.
+
+→ Proceed to **C. Action Menu**.
+
+## C. Action Menu
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -119,4 +127,4 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} st
 
 #### If user asked a question
 
-Answer the question, then redisplay the action menu (section B).
+Answer the question, then redisplay the action menu (section C).

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -24,7 +24,9 @@ Which work unit would you like to manage? (enter number from list above, or **`b
 
 #### If user chose a number
 
-Store the selected work unit. → Proceed to **B. Implementation Check**.
+Store the selected work unit.
+
+→ Proceed to **B. Implementation Check**.
 
 ## B. Implementation Check
 

--- a/skills/workflow-start/references/view-concluded.md
+++ b/skills/workflow-start/references/view-concluded.md
@@ -62,11 +62,11 @@ Select an option (enter number):
 
 **STOP.** Wait for user response.
 
-**If user chose `b`/`back`:**
+#### If user chose `b`/`back`
 
 → Return to caller.
 
-**If user chose a number:**
+#### If user chose a number
 
 Store the selected item. → Proceed to **C. Action Menu**.
 
@@ -86,7 +86,7 @@ Store the selected item. → Proceed to **C. Action Menu**.
 
 **STOP.** Wait for user response.
 
-**If user chose `r`/`reactivate`:**
+#### If user chose `r`/`reactivate`
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status in-progress
@@ -100,10 +100,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} st
 
 → Return to caller to redisplay main view (re-run discovery, re-render from top).
 
-**If user chose `b`/`back`:**
+#### If user chose `b`/`back`
 
 → Return to **A. Display List** (re-render with current data).
 
-**If user asked a question:**
+#### If user asked a question
 
 Answer the question, then redisplay the action menu (section C).

--- a/skills/workflow-start/references/view-concluded.md
+++ b/skills/workflow-start/references/view-concluded.md
@@ -1,0 +1,110 @@
+# View Concluded & Cancelled
+
+*Reference for **[workflow-start](../SKILL.md)***
+
+---
+
+Display concluded and cancelled work units. Self-contained — receives context from caller (concluded/cancelled arrays, optional work_type filter).
+
+## A. Display List
+
+#### If no concluded or cancelled work units exist
+
+> *Output the next fenced block as a code block:*
+
+```
+No concluded or cancelled work units found.
+```
+
+→ Return to caller.
+
+#### Otherwise
+
+> *Output the next fenced block as a code block:*
+
+```
+Concluded & Cancelled @if(work_type_filter) {work_type_filter:(titlecase)}s @else Work Units @endif
+
+@if(concluded.length > 0)
+Concluded:
+@foreach(item in concluded)
+  {N}. {item.name:(titlecase)}
+     └─ Concluded after: {item.last_phase}
+
+@endforeach
+@endif
+
+@if(cancelled.length > 0)
+Cancelled:
+@foreach(item in cancelled)
+  {N}. {item.name:(titlecase)}
+     └─ Cancelled during: {item.last_phase}
+
+@endforeach
+@endif
+```
+
+Build from the concluded and cancelled arrays passed by the caller. Numbering is continuous across both sections. Blank line between each numbered item.
+
+→ Proceed to **B. Select**.
+
+## B. Select
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Select a work unit for details, or **`b`/`back`** to return.
+
+Select an option (enter number):
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `b`/`back`:**
+
+→ Return to caller.
+
+**If user chose a number:**
+
+Store the selected item. → Proceed to **C. Action Menu**.
+
+## C. Action Menu
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**{selected.name:(titlecase)}** ({selected.status})
+
+- **`r`/`reactivate`** — Set status back to in-progress
+- **`b`/`back`** — Return to the list
+
+Or ask a question about this work unit.
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `r`/`reactivate`:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status in-progress
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+"{selected.name:(titlecase)}" reactivated.
+```
+
+→ Return to caller to redisplay main view (re-run discovery, re-render from top).
+
+**If user chose `b`/`back`:**
+
+→ Return to **A. Display List** (re-render with current data).
+
+**If user asked a question:**
+
+Answer the question, then redisplay the action menu (section C).

--- a/skills/workflow-start/references/view-concluded.md
+++ b/skills/workflow-start/references/view-concluded.md
@@ -68,7 +68,9 @@ Select an option (enter number):
 
 #### If user chose a number
 
-Store the selected item. → Proceed to **C. Action Menu**.
+Store the selected item.
+
+→ Proceed to **C. Action Menu**.
 
 ## C. Action Menu
 

--- a/skills/workflow-start/references/view-concluded.md
+++ b/skills/workflow-start/references/view-concluded.md
@@ -80,8 +80,7 @@ Store the selected item. → Proceed to **C. Action Menu**.
 
 - **`r`/`reactivate`** — Set status back to in-progress
 - **`b`/`back`** — Return to the list
-
-Or ask a question about this work unit.
+- **Ask** — Ask a question about this work unit
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-start/scripts/discovery.js
+++ b/skills/workflow-start/scripts/discovery.js
@@ -1,8 +1,28 @@
 'use strict';
 
-const { loadActiveManifests, phaseStatus, phaseItems, phaseData, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils');
+const { loadActiveManifests, loadAllManifests, phaseStatus, phaseItems, phaseData, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils');
 
 const EPIC_PHASES = ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
+
+const ALL_PHASES = ['research', 'discussion', 'investigation', 'specification', 'planning', 'implementation', 'review'];
+
+function lastCompletedPhase(manifest) {
+  let last = null;
+  if (manifest.work_type === 'epic') {
+    for (const phase of ALL_PHASES) {
+      const items = phaseItems(manifest, phase);
+      if (items.length > 0 && items.some(i => i.status === 'concluded' || i.status === 'completed')) {
+        last = phase;
+      }
+    }
+  } else {
+    for (const phase of ALL_PHASES) {
+      const s = phaseStatus(manifest, phase);
+      if (s === 'concluded' || s === 'completed') last = phase;
+    }
+  }
+  return last;
+}
 
 function discover(cwd) {
   const manifests = loadActiveManifests(cwd);
@@ -39,10 +59,27 @@ function discover(cwd) {
     }
   }
 
+  // Load concluded/cancelled work units across all types
+  const allManifests = loadAllManifests(cwd);
+  const concluded = [];
+  const cancelled = [];
+
+  for (const m of allManifests) {
+    if (m.status === 'concluded') {
+      concluded.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
+    } else if (m.status === 'cancelled') {
+      cancelled.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
+    }
+  }
+
   return {
     epics: { work_units: epics, count: epics.length },
     features: { work_units: features, count: features.length },
     bugfixes: { work_units: bugfixes, count: bugfixes.length },
+    concluded,
+    cancelled,
+    concluded_count: concluded.length,
+    cancelled_count: cancelled.length,
     state: {
       has_any_work: (epics.length + features.length + bugfixes.length) > 0,
       epic_count: epics.length,

--- a/tests/scripts/discovery-test-utils.js
+++ b/tests/scripts/discovery-test-utils.js
@@ -18,7 +18,7 @@ function createManifest(dir, name, data) {
   const manifest = {
     name,
     work_type: 'feature',
-    status: 'active',
+    status: 'in-progress',
     description: `Test: ${name}`,
     phases: {},
     ...data,

--- a/tests/scripts/test-discovery-for-bridge.js
+++ b/tests/scripts/test-discovery-for-bridge.js
@@ -102,9 +102,9 @@ describe('workflow-bridge discovery', () => {
   });
 
   it('returns status from manifest', () => {
-    createManifest(dir, 'auth', { work_type: 'feature', status: 'active' });
+    createManifest(dir, 'auth', { work_type: 'feature', status: 'in-progress' });
     const r = discover(dir, 'auth');
-    assert.strictEqual(r.status, 'active');
+    assert.strictEqual(r.status, 'in-progress');
   });
 
   it('detects research file existence', () => {

--- a/tests/scripts/test-discovery-for-continue-bugfix.js
+++ b/tests/scripts/test-discovery-for-continue-bugfix.js
@@ -19,7 +19,7 @@ describe('continue-bugfix discovery', () => {
 
   it('lists active bugfixes only', () => {
     createManifest(dir, 'crash', { work_type: 'bugfix', phases: { investigation: { status: 'in-progress' } } });
-    createManifest(dir, 'old', { work_type: 'bugfix', status: 'archived' });
+    createManifest(dir, 'old', { work_type: 'bugfix', status: 'concluded' });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
     assert.strictEqual(r.bugfixes[0].name, 'crash');

--- a/tests/scripts/test-discovery-for-continue-bugfix.js
+++ b/tests/scripts/test-discovery-for-continue-bugfix.js
@@ -66,6 +66,24 @@ describe('continue-bugfix discovery', () => {
     assert.strictEqual(r.summary, '2 active bugfix(es)');
   });
 
+  it('includes concluded bugfixes in separate array', () => {
+    createManifest(dir, 'done', { work_type: 'bugfix', status: 'concluded', phases: { review: { status: 'completed' } } });
+    createManifest(dir, 'active', { work_type: 'bugfix', phases: { investigation: { status: 'in-progress' } } });
+    const r = discover(dir);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.concluded_count, 1);
+    assert.strictEqual(r.concluded[0].name, 'done');
+    assert.strictEqual(r.concluded[0].last_phase, 'review');
+  });
+
+  it('includes cancelled bugfixes in separate array', () => {
+    createManifest(dir, 'stopped', { work_type: 'bugfix', status: 'cancelled', phases: { investigation: { status: 'concluded' } } });
+    const r = discover(dir);
+    assert.strictEqual(r.cancelled_count, 1);
+    assert.strictEqual(r.cancelled[0].name, 'stopped');
+    assert.strictEqual(r.cancelled[0].last_phase, 'investigation');
+  });
+
   describe('edge cases', () => {
     it('recognizes completed as concluded in concluded_phases', () => {
       createManifest(dir, 'crash', {

--- a/tests/scripts/test-discovery-for-continue-epic.js
+++ b/tests/scripts/test-discovery-for-continue-epic.js
@@ -22,7 +22,7 @@ describe('continue-epic discovery', () => {
       work_type: 'epic',
       phases: { discussion: { items: { auth: { status: 'in-progress' } } } },
     });
-    createManifest(dir, 'old', { work_type: 'epic', status: 'archived' });
+    createManifest(dir, 'old', { work_type: 'epic', status: 'concluded' });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
     assert.strictEqual(r.epics[0].name, 'v1');

--- a/tests/scripts/test-discovery-for-continue-epic.js
+++ b/tests/scripts/test-discovery-for-continue-epic.js
@@ -55,6 +55,30 @@ describe('continue-epic discovery', () => {
     assert.strictEqual(r.summary, '2 active epic(s)');
   });
 
+  it('includes concluded epics in list mode', () => {
+    createManifest(dir, 'done', { work_type: 'epic', status: 'concluded', phases: { review: { items: { auth: { status: 'completed' } } } } });
+    createManifest(dir, 'active', { work_type: 'epic', phases: { discussion: { items: { auth: { status: 'in-progress' } } } } });
+    const r = discover(dir);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.concluded_count, 1);
+    assert.strictEqual(r.concluded[0].name, 'done');
+    assert.strictEqual(r.concluded[0].last_phase, 'review');
+  });
+
+  it('includes cancelled epics in list mode', () => {
+    createManifest(dir, 'stopped', { work_type: 'epic', status: 'cancelled', phases: { discussion: { items: { auth: { status: 'concluded' } } } } });
+    const r = discover(dir);
+    assert.strictEqual(r.cancelled_count, 1);
+    assert.strictEqual(r.cancelled[0].name, 'stopped');
+  });
+
+  it('does not include concluded/cancelled in detail mode', () => {
+    createManifest(dir, 'done', { work_type: 'epic', status: 'concluded' });
+    const r = discover(dir, 'done');
+    assert.strictEqual(r.count, 0);
+    assert.strictEqual(r.concluded.length, 0);
+  });
+
   describe('epic detail', () => {
     it('includes phase items in detail', () => {
       createManifest(dir, 'v1', {

--- a/tests/scripts/test-discovery-for-continue-feature.js
+++ b/tests/scripts/test-discovery-for-continue-feature.js
@@ -19,7 +19,7 @@ describe('continue-feature discovery', () => {
 
   it('lists active features only', () => {
     createManifest(dir, 'auth', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
-    createManifest(dir, 'old', { work_type: 'feature', status: 'archived' });
+    createManifest(dir, 'old', { work_type: 'feature', status: 'concluded' });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
     assert.strictEqual(r.features[0].name, 'auth');

--- a/tests/scripts/test-discovery-for-continue-feature.js
+++ b/tests/scripts/test-discovery-for-continue-feature.js
@@ -83,6 +83,30 @@ describe('continue-feature discovery', () => {
     assert.strictEqual(r.summary, '2 active feature(s)');
   });
 
+  it('includes concluded features in separate array', () => {
+    createManifest(dir, 'done', { work_type: 'feature', status: 'concluded', phases: { review: { status: 'completed' } } });
+    createManifest(dir, 'active', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
+    const r = discover(dir);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.concluded_count, 1);
+    assert.strictEqual(r.concluded[0].name, 'done');
+    assert.strictEqual(r.concluded[0].last_phase, 'review');
+  });
+
+  it('includes cancelled features in separate array', () => {
+    createManifest(dir, 'stopped', { work_type: 'feature', status: 'cancelled', phases: { specification: { status: 'concluded' } } });
+    const r = discover(dir);
+    assert.strictEqual(r.cancelled_count, 1);
+    assert.strictEqual(r.cancelled[0].name, 'stopped');
+    assert.strictEqual(r.cancelled[0].last_phase, 'specification');
+  });
+
+  it('excludes non-feature concluded work units', () => {
+    createManifest(dir, 'done-bug', { work_type: 'bugfix', status: 'concluded', phases: { review: { status: 'completed' } } });
+    const r = discover(dir);
+    assert.strictEqual(r.concluded_count, 0);
+  });
+
   describe('edge cases', () => {
     it('recognizes completed as concluded in concluded_phases', () => {
       createManifest(dir, 'auth', {

--- a/tests/scripts/test-discovery-for-start.js
+++ b/tests/scripts/test-discovery-for-start.js
@@ -69,7 +69,7 @@ describe('workflow-start discovery', () => {
   });
 
   it('skips archived work units', () => {
-    createManifest(dir, 'old', { work_type: 'feature', status: 'archived' });
+    createManifest(dir, 'old', { work_type: 'feature', status: 'concluded' });
     createManifest(dir, 'active', { work_type: 'feature' });
     const r = discover(dir);
     assert.strictEqual(r.state.feature_count, 1);
@@ -137,8 +137,8 @@ describe('workflow-start discovery', () => {
     assert.strictEqual(r.features.work_units[0].name, 'active-feat');
   });
 
-  it('has_any_work is false when only archived and done exist', () => {
-    createManifest(dir, 'archived', { work_type: 'feature', status: 'archived' });
+  it('has_any_work is false when only concluded and done exist', () => {
+    createManifest(dir, 'archived', { work_type: 'feature', status: 'concluded' });
     createManifest(dir, 'done', {
       work_type: 'bugfix',
       phases: {

--- a/tests/scripts/test-discovery-for-start.js
+++ b/tests/scripts/test-discovery-for-start.js
@@ -162,6 +162,31 @@ describe('workflow-start discovery', () => {
     assert.deepStrictEqual(r.epics.work_units[0].active_phases, ['research']);
   });
 
+  it('includes concluded work units in separate array', () => {
+    createManifest(dir, 'done-feat', { work_type: 'feature', status: 'concluded', phases: { review: { status: 'completed' } } });
+    createManifest(dir, 'active-feat', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
+    const r = discover(dir);
+    assert.strictEqual(r.concluded_count, 1);
+    assert.strictEqual(r.concluded[0].name, 'done-feat');
+    assert.strictEqual(r.concluded[0].work_type, 'feature');
+    assert.strictEqual(r.concluded[0].last_phase, 'review');
+  });
+
+  it('includes cancelled work units in separate array', () => {
+    createManifest(dir, 'cancelled-bug', { work_type: 'bugfix', status: 'cancelled', phases: { investigation: { status: 'concluded' } } });
+    const r = discover(dir);
+    assert.strictEqual(r.cancelled_count, 1);
+    assert.strictEqual(r.cancelled[0].name, 'cancelled-bug');
+    assert.strictEqual(r.cancelled[0].last_phase, 'investigation');
+  });
+
+  it('concluded and cancelled counts are zero when none exist', () => {
+    createManifest(dir, 'active', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
+    const r = discover(dir);
+    assert.strictEqual(r.concluded_count, 0);
+    assert.strictEqual(r.cancelled_count, 0);
+  });
+
   it('feature in review (in-progress) is not filtered out', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',

--- a/tests/scripts/test-discovery-utils.js
+++ b/tests/scripts/test-discovery-utils.js
@@ -8,7 +8,7 @@ const { setupFixture, cleanupFixture, createFile } = require('./discovery-test-u
 
 const {
   fileExists, listFiles, listDirs, countFiles, filesChecksum,
-  loadManifest, loadActiveManifests,
+  loadManifest, loadActiveManifests, loadAllManifests,
   phaseStatus, phaseItems, phaseData, computeNextPhase,
 } = require('../../skills/workflow-shared/scripts/discovery-utils');
 
@@ -114,10 +114,10 @@ describe('discovery-utils', () => {
   });
 
   describe('loadActiveManifests', () => {
-    it('returns only active manifests', () => {
+    it('returns only in-progress manifests', () => {
       const { createManifest } = require('./discovery-test-utils');
-      createManifest(dir, 'active', { status: 'active' });
-      createManifest(dir, 'archived', { status: 'archived' });
+      createManifest(dir, 'active', { status: 'in-progress' });
+      createManifest(dir, 'concluded', { status: 'concluded' });
       const results = loadActiveManifests(dir);
       assert.strictEqual(results.length, 1);
       assert.strictEqual(results[0].name, 'active');
@@ -128,6 +128,25 @@ describe('discovery-utils', () => {
       createManifest(dir, 'good', {});
       fs.mkdirSync(path.join(dir, '.workflows', '.state'), { recursive: true });
       const results = loadActiveManifests(dir);
+      assert.strictEqual(results.length, 1);
+    });
+  });
+
+  describe('loadAllManifests', () => {
+    it('returns manifests of all statuses', () => {
+      const { createManifest } = require('./discovery-test-utils');
+      createManifest(dir, 'active', { status: 'in-progress' });
+      createManifest(dir, 'done', { status: 'concluded' });
+      createManifest(dir, 'cancelled', { status: 'cancelled' });
+      const results = loadAllManifests(dir);
+      assert.strictEqual(results.length, 3);
+    });
+
+    it('skips dotfiles', () => {
+      const { createManifest } = require('./discovery-test-utils');
+      createManifest(dir, 'good', {});
+      fs.mkdirSync(path.join(dir, '.workflows', '.state'), { recursive: true });
+      const results = loadAllManifests(dir);
       assert.strictEqual(results.length, 1);
     });
   });

--- a/tests/scripts/test-migration-019.sh
+++ b/tests/scripts/test-migration-019.sh
@@ -1,0 +1,472 @@
+#!/bin/bash
+#
+# Tests migration 019-status-rename.sh
+# Validates renaming of work unit statuses: active → in-progress, archived → cancelled.
+# Also validates auto-detection of completed pipelines → concluded.
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/migrate/scripts/migrations/019-status-rename.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Helper functions
+#
+
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+setup_fixture() {
+    rm -rf "$TEST_DIR/.workflows" "$TEST_DIR/.claude"
+    # Symlink .claude/skills → repo skills/ so the migration can find the manifest CLI
+    mkdir -p "$TEST_DIR/.claude"
+    ln -sfn "$REPO_DIR/skills" "$TEST_DIR/.claude/skills"
+}
+
+create_manifest() {
+    local name="$1"
+    local content="$2"
+    mkdir -p "$TEST_DIR/.workflows/$name"
+    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+}
+
+run_migration() {
+    cd "$TEST_DIR"
+    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+}
+
+get_status() {
+    local name="$1"
+    node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/$name/manifest.json"
+}
+
+get_json() {
+    local name="$1"
+    cat "$TEST_DIR/.workflows/$name/manifest.json"
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected: $expected"
+        echo -e "    Actual:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Should not find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    else
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+echo -e "${YELLOW}Test: active → in-progress${NC}"
+setup_fixture
+
+create_manifest "my-feature" '{"work_type":"feature","status":"active","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "my-feature")" "in-progress" "Status changed to in-progress"
+assert_contains "$output" "updated" "Reports update"
+assert_contains "$output" "in-progress" "Reports new status"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: archived → cancelled${NC}"
+setup_fixture
+
+create_manifest "old-feature" '{"work_type":"feature","status":"archived","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "old-feature")" "cancelled" "Status changed to cancelled"
+assert_contains "$output" "updated" "Reports update"
+assert_contains "$output" "cancelled" "Reports new status"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: in-progress unchanged (already correct)${NC}"
+setup_fixture
+
+create_manifest "current" '{"work_type":"feature","status":"in-progress","phases":{}}'
+
+output=$(run_migration)
+status=$(get_status "current")
+
+assert_equals "$status" "in-progress" "Status remains in-progress"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: concluded unchanged${NC}"
+setup_fixture
+
+create_manifest "done-feature" '{"work_type":"feature","status":"concluded","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "done-feature")" "concluded" "Status remains concluded"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: cancelled unchanged${NC}"
+setup_fixture
+
+create_manifest "dead-feature" '{"work_type":"feature","status":"cancelled","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "dead-feature")" "cancelled" "Status remains cancelled"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: feature with completed review → concluded${NC}"
+setup_fixture
+
+create_manifest "done-but-active" '{
+  "work_type": "feature",
+  "status": "active",
+  "phases": {
+    "discussion": {"status": "concluded"},
+    "specification": {"status": "concluded"},
+    "planning": {"status": "concluded"},
+    "implementation": {"status": "concluded"},
+    "review": {"status": "completed"}
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "done-but-active")" "concluded" "Completed pipeline detected and set to concluded"
+assert_contains "$output" "concluded" "Reports concluded status"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: feature in-progress with completed review → concluded${NC}"
+setup_fixture
+
+create_manifest "done-in-progress" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "review": {"status": "completed"}
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "done-in-progress")" "concluded" "In-progress with completed review set to concluded"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: feature with incomplete review stays in-progress${NC}"
+setup_fixture
+
+create_manifest "mid-review" '{
+  "work_type": "feature",
+  "status": "active",
+  "phases": {
+    "review": {"status": "in-progress"}
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "mid-review")" "in-progress" "Incomplete review stays in-progress (not concluded)"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: feature with no review phase stays in-progress${NC}"
+setup_fixture
+
+create_manifest "no-review" '{
+  "work_type": "feature",
+  "status": "active",
+  "phases": {
+    "discussion": {"status": "concluded"}
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "no-review")" "in-progress" "No review phase stays in-progress"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: epic with all review items completed → concluded${NC}"
+setup_fixture
+
+create_manifest "done-epic" '{
+  "work_type": "epic",
+  "status": "active",
+  "phases": {
+    "review": {
+      "items": {
+        "topic-a": {"status": "completed"},
+        "topic-b": {"status": "completed"}
+      }
+    }
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "done-epic")" "concluded" "Epic with all review items completed set to concluded"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: epic with some review items incomplete stays in-progress${NC}"
+setup_fixture
+
+create_manifest "partial-epic" '{
+  "work_type": "epic",
+  "status": "active",
+  "phases": {
+    "review": {
+      "items": {
+        "topic-a": {"status": "completed"},
+        "topic-b": {"status": "in-progress"}
+      }
+    }
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "partial-epic")" "in-progress" "Epic with incomplete review items stays in-progress"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: epic with no review items stays in-progress${NC}"
+setup_fixture
+
+create_manifest "no-review-epic" '{
+  "work_type": "epic",
+  "status": "active",
+  "phases": {
+    "discussion": {
+      "items": {
+        "topic-a": {"status": "concluded"}
+      }
+    }
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "no-review-epic")" "in-progress" "Epic with no review items stays in-progress"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: bugfix with completed review → concluded${NC}"
+setup_fixture
+
+create_manifest "fixed-bug" '{
+  "work_type": "bugfix",
+  "status": "active",
+  "phases": {
+    "review": {"status": "completed"}
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "fixed-bug")" "concluded" "Bugfix with completed review set to concluded"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: multiple work units processed${NC}"
+setup_fixture
+
+create_manifest "feat-a" '{"work_type":"feature","status":"active","phases":{}}'
+create_manifest "feat-b" '{"work_type":"feature","status":"archived","phases":{}}'
+create_manifest "feat-c" '{"work_type":"feature","status":"in-progress","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "feat-a")" "in-progress" "First work unit: active → in-progress"
+assert_equals "$(get_status "feat-b")" "cancelled" "Second work unit: archived → cancelled"
+assert_equals "$(get_status "feat-c")" "in-progress" "Third work unit: in-progress unchanged"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state"
+echo '{"status":"active"}' > "$TEST_DIR/.workflows/.state/manifest.json"
+create_manifest "real" '{"work_type":"feature","status":"active","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_status "real")" "in-progress" "Real work unit updated"
+assert_equals "$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/.state/manifest.json")" "active" "Dot-dir manifest not touched"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
+setup_fixture
+
+create_manifest "idem" '{"work_type":"feature","status":"active","phases":{}}'
+
+run_migration > /dev/null
+before=$(get_json "idem")
+output=$(run_migration)
+after=$(get_json "idem")
+
+assert_equals "$after" "$before" "JSON unchanged after second run"
+assert_not_contains "$output" "updated" "No update on second run"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
+setup_fixture
+
+output=$(run_migration)
+
+assert_not_contains "$output" "updated" "No updates without .workflows dir"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
+setup_fixture
+
+create_manifest "preserve" '{
+  "name": "preserve",
+  "work_type": "feature",
+  "status": "active",
+  "created": "2026-01-15",
+  "description": "test feature",
+  "phases": {
+    "discussion": {"status": "concluded"}
+  }
+}'
+
+run_migration > /dev/null
+
+json=$(get_json "preserve")
+
+assert_contains "$json" '"name": "preserve"' "Name preserved"
+assert_contains "$json" '"work_type": "feature"' "Work type preserved"
+assert_contains "$json" '"created": "2026-01-15"' "Created date preserved"
+assert_contains "$json" '"description": "test feature"' "Description preserved"
+assert_contains "$json" '"status": "concluded"' "Discussion phase status preserved"
+
+echo ""
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "Tests run: $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "========================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Tests for the workflow manifest CLI (manifest.js)
-# Validates init, get, set, list, init-phase, archive commands.
+# Validates init, get, set, list, init-phase, push, exists commands.
 # Uses domain-aware flag syntax (--phase, --topic).
 #
 
@@ -197,7 +197,7 @@ assert_file_exists "$TEST_DIR/.workflows/dark-mode/manifest.json" "manifest.json
 content=$(cat "$TEST_DIR/.workflows/dark-mode/manifest.json")
 assert_contains "$content" '"name": "dark-mode"' "name field set"
 assert_contains "$content" '"work_type": "feature"' "work_type field set"
-assert_contains "$content" '"status": "active"' "status defaults to active"
+assert_contains "$content" '"status": "in-progress"' "status defaults to in-progress"
 assert_contains "$content" '"description": "Add dark mode"' "description set"
 assert_contains "$content" '"phases": {}' "phases initialized empty"
 assert_contains "$content" '"created":' "created date set"
@@ -252,7 +252,7 @@ setup_fixture
 run_cli init scalar-test --work-type bugfix --description "Scalar" >/dev/null 2>&1
 output=$(run_cli_stdout get scalar-test status)
 
-assert_equals "$output" "active" "Scalar value output raw"
+assert_equals "$output" "in-progress" "Scalar value output raw"
 
 echo ""
 
@@ -543,12 +543,12 @@ echo ""
 echo -e "${YELLOW}Test: list filters by status${NC}"
 setup_fixture
 run_cli init active-one --work-type feature --description "Active" >/dev/null 2>&1
-run_cli init archived-one --work-type feature --description "Archived" >/dev/null 2>&1
-run_cli set archived-one status archived >/dev/null 2>&1
-output=$(run_cli_stdout list --status active)
+run_cli init concluded-one --work-type feature --description "Concluded" >/dev/null 2>&1
+run_cli set concluded-one status concluded >/dev/null 2>&1
+output=$(run_cli_stdout list --status in-progress)
 
-assert_contains "$output" '"name": "active-one"' "Active work unit listed"
-assert_not_contains "$output" '"name": "archived-one"' "Archived work unit excluded"
+assert_contains "$output" '"name": "active-one"' "In-progress work unit listed"
+assert_not_contains "$output" '"name": "concluded-one"' "Concluded work unit excluded"
 
 echo ""
 
@@ -573,7 +573,7 @@ run_cli init visible --work-type feature --description "Visible" >/dev/null 2>&1
 # Create dot-prefixed directories that should be skipped
 mkdir -p "$TEST_DIR/.workflows/.archive/old-thing"
 cat > "$TEST_DIR/.workflows/.archive/old-thing/manifest.json" << 'EOF'
-{"name":"old-thing","work_type":"feature","status":"archived"}
+{"name":"old-thing","work_type":"feature","status":"cancelled"}
 EOF
 mkdir -p "$TEST_DIR/.workflows/.cache"
 mkdir -p "$TEST_DIR/.workflows/.state"
@@ -742,38 +742,6 @@ assert_contains "$output" '"v2"' "Second tag appended"
 echo ""
 
 # ============================================================================
-# ARCHIVE TESTS
-# ============================================================================
-
-echo -e "${YELLOW}Test: archive moves directory and updates status${NC}"
-setup_fixture
-run_cli init to-archive --work-type feature --description "Archive me" >/dev/null 2>&1
-# Add some content to verify it moves
-mkdir -p "$TEST_DIR/.workflows/to-archive/discussion"
-echo "# Test" > "$TEST_DIR/.workflows/to-archive/discussion/to-archive.md"
-
-run_cli archive to-archive >/dev/null 2>&1
-
-assert_dir_not_exists "$TEST_DIR/.workflows/to-archive" "Original directory removed"
-assert_dir_exists "$TEST_DIR/.workflows/.archive/to-archive" "Archive directory created"
-assert_file_exists "$TEST_DIR/.workflows/.archive/to-archive/manifest.json" "Manifest in archive"
-assert_file_exists "$TEST_DIR/.workflows/.archive/to-archive/discussion/to-archive.md" "Content preserved in archive"
-
-# Check status updated
-archived_content=$(cat "$TEST_DIR/.workflows/.archive/to-archive/manifest.json")
-assert_contains "$archived_content" '"status": "archived"' "Status set to archived"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: archive errors on missing work unit${NC}"
-setup_fixture
-assert_exit_nonzero "Archive of missing work unit fails" archive nonexistent
-
-echo ""
-
-# ============================================================================
 # DOMAIN ROUTING TESTS
 # ============================================================================
 
@@ -833,7 +801,7 @@ echo ""
 
 echo -e "${YELLOW}Test: set on missing work unit errors${NC}"
 setup_fixture
-assert_exit_nonzero "Set on nonexistent work unit fails" set ghost status archived
+assert_exit_nonzero "Set on nonexistent work unit fails" set ghost status cancelled
 
 echo ""
 

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -938,6 +938,72 @@ assert_exit_nonzero "exists with no args fails" exists
 echo ""
 
 # ============================================================================
+# WILDCARD TOPIC
+# ============================================================================
+
+echo -e "${YELLOW}Test: get with wildcard topic on epic returns all items${NC}"
+setup_fixture
+run_cli init wc-epic --work-type epic --description "Wildcard" >/dev/null 2>&1
+run_cli init-phase wc-epic --phase implementation --topic auth-flow >/dev/null 2>&1
+run_cli init-phase wc-epic --phase implementation --topic billing >/dev/null 2>&1
+run_cli set wc-epic --phase implementation --topic auth-flow status completed >/dev/null 2>&1
+output=$(run_cli_stdout get wc-epic --phase implementation --topic "*" status)
+assert_contains "$output" '"topic": "auth-flow"' "Wildcard get includes auth-flow"
+assert_contains "$output" '"value": "completed"' "Wildcard get shows completed value"
+assert_contains "$output" '"topic": "billing"' "Wildcard get includes billing"
+assert_contains "$output" '"value": "in-progress"' "Wildcard get shows in-progress value"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: get with wildcard topic on feature returns single item${NC}"
+setup_fixture
+run_cli init wc-feat --work-type feature --description "Wildcard" >/dev/null 2>&1
+run_cli init-phase wc-feat --phase implementation --topic wc-feat >/dev/null 2>&1
+run_cli set wc-feat --phase implementation --topic wc-feat status completed >/dev/null 2>&1
+output=$(run_cli_stdout get wc-feat --phase implementation --topic "*" status)
+assert_contains "$output" '"topic": "wc-feat"' "Wildcard get on feature includes topic"
+assert_contains "$output" '"value": "completed"' "Wildcard get on feature shows value"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: get with wildcard topic on empty phase fails${NC}"
+setup_fixture
+run_cli init wc-empty --work-type epic --description "Empty" >/dev/null 2>&1
+run_cli set wc-empty phases.implementation '{}' >/dev/null 2>&1
+assert_exit_nonzero "Wildcard on empty phase returns error" get wc-empty --phase implementation --topic "*" status
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists with wildcard topic returns true when items exist${NC}"
+setup_fixture
+run_cli init wc-exists --work-type epic --description "Exists" >/dev/null 2>&1
+run_cli init-phase wc-exists --phase implementation --topic topic-a >/dev/null 2>&1
+output=$(run_cli_stdout exists wc-exists --phase implementation --topic "*" status)
+exit_code=$?
+assert_equals "$output" "true" "Wildcard exists returns true when items have field"
+assert_equals "$exit_code" "0" "Wildcard exists exits 0"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: exists with wildcard topic returns false when no items${NC}"
+setup_fixture
+run_cli init wc-noitems --work-type epic --description "No items" >/dev/null 2>&1
+output=$(run_cli_stdout exists wc-noitems --phase implementation --topic "*" status)
+exit_code=$?
+assert_equals "$output" "false" "Wildcard exists returns false when no items"
+assert_equals "$exit_code" "0" "Wildcard exists on empty exits 0"
+
+echo ""
+
+# ============================================================================
 # SUMMARY
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- Replace two-status system (`active`/`archived`) with proper lifecycle: `in-progress`, `concluded`, `cancelled`
- Add pipeline conclusion detection — bridge skills set status when pipeline finishes, with skip-review option for feature/bugfix and all-done check for epics
- Add concluded/cancelled visibility — discovery scripts surface non-active work units, new UI for browsing and managing them (view, reactivate, cancel, mark done)
- Remove unused `archive` command from manifest CLI; add migration 019 to rename existing statuses

## Test plan

- [x] All 195 JS tests pass (`node --test tests/scripts/test-*.js`)
- [x] All 98 bash tests pass (`bash tests/scripts/test-workflow-manifest.sh`)
- [x] Migration 019 converts `active` → `in-progress` correctly
- [x] `manifest.js init` creates with `status: 'in-progress'`
- [x] `manifest.js set {wu} status concluded` works
- [x] `manifest.js set {wu} status archived` fails validation
- [x] `manifest.js archive` command no longer exists
- [x] No stale references to `active`/`archived` in source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)