### PR TITLE
refactor: normalise terminal status — concluded → completed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ skills/
     references/              #   Display, selection, revisit phase
   continue-epic/             # Resume in-progress epic — full state display + interactive menu
     scripts/discovery.js     #   List mode (all epics) and detail mode (per-phase items)
-    references/              #   Epic selection, state display, menu, resume concluded
+    references/              #   Epic selection, state display, menu, resume completed
   link-dependencies/         # Link dependencies across topics
 
   # Phase entry skills (internal — invoked by start/continue/bridge skills)
@@ -290,7 +290,7 @@ Domain-aware CLI grammar:
 ```bash
 MANIFEST="node .claude/skills/workflow-manifest/scripts/manifest.js"
 $MANIFEST get {work_unit} --phase discussion --topic {topic} status    # phase-level read
-$MANIFEST set {work_unit} --phase discussion --topic {topic} status concluded  # phase-level write
+$MANIFEST set {work_unit} --phase discussion --topic {topic} status completed  # phase-level write
 $MANIFEST init-phase {work_unit} --phase discussion --topic {topic}    # create phase entry
 $MANIFEST push {work_unit} --phase implementation --topic {topic} completed_tasks "task-1"  # append to array
 $MANIFEST exists {work_unit}                                           # existence check (exits 0, outputs true/false)
@@ -351,7 +351,7 @@ Each part is optional — use only what's needed for clarity.
 @if(condition) truthy content @else falsy content @endif
 ```
 
-Example: `@if(has_discussion) {topic}.md ({status:[in-progress|concluded]}) @else (no discussion) @endif`
+Example: `@if(has_discussion) {topic}.md ({status:[in-progress|completed]}) @else (no discussion) @endif`
 
 **Loop directives** for iterating over collections:
 
@@ -371,8 +371,8 @@ Every actionable item gets a numbered entry with `└─` branches showing its s
 
 ```
 1. {topic:(titlecase)}
-   └─ Plan: @if(has_plan) {plan_status:[in-progress|concluded]} @else (no plan) @endif
-   └─ Spec: {spec_status:[in-progress|concluded]}
+   └─ Plan: @if(has_plan) {plan_status:[in-progress|completed]} @else (no plan) @endif
+   └─ Spec: {spec_status:[in-progress|completed]}
 
 2. ...
 ```
@@ -381,7 +381,7 @@ For richer hierarchies (specification phase):
 
 ```
 1. {topic:(titlecase)}
-   └─ Spec: {spec_status:[in-progress|concluded]} ({extraction_summary})
+   └─ Spec: {spec_status:[in-progress|completed]} ({extraction_summary})
    └─ Discussions:
       ├─ {discussion} ({status:[extracted|pending]})
       └─ ...
@@ -391,7 +391,7 @@ For richer hierarchies (specification phase):
 
 Always parenthetical `(term)`. Never brackets or dash-separated.
 
-Core vocabulary: `in-progress`, `concluded`, `ready`, `completed`, `extracted`, `pending`, `reopened`. Phase-specific terms are fine but format is always `(term)`.
+Core vocabulary: `in-progress`, `completed`, `ready`, `extracted`, `pending`, `reopened`. Phase-specific terms are fine but format is always `(term)`.
 
 ### Cross-Plan References
 
@@ -412,7 +412,7 @@ Specifications not ready for planning:
 These specifications are either still in progress or cross-cutting
 and cannot be planned directly.
 
-  • caching-strategy (cross-cutting, concluded)
+  • caching-strategy (cross-cutting, completed)
   • rate-limiting (cross-cutting, in-progress)
 ```
 
@@ -425,7 +425,7 @@ Key:
 
   Plan status:
     in-progress — planning work is ongoing
-    concluded   — plan is complete
+    completed   — plan is done
 
   Spec type:
     cross-cutting — architectural policy, not directly plannable
@@ -440,9 +440,9 @@ Rendered as markdown (not code blocks). Framed with dot separators. Verb-based l
 
 ```
 · · · · · · · · · · · ·
-1. Create "Auth Flow" — concluded spec, no plan
+1. Create "Auth Flow" — completed spec, no plan
 2. Continue "Data Model" — plan in-progress
-3. Review "Billing" — plan concluded
+3. Review "Billing" — plan completed
 
 Select an option (enter number):
 · · · · · · · · · · · ·
@@ -495,7 +495,7 @@ Planning Overview
 
 No specification found in .workflows/{work_unit}/specification/{topic}/
 
-The planning phase requires a concluded specification.
+The planning phase requires a completed specification.
 ```
 
 ### Bullet Characters
@@ -589,11 +589,11 @@ Use H4 headings for if/else branches within a step:
 
 Rules:
 - Never use else-if chains — each condition gets its own `#### If` heading
-- Lowercase after "If" (e.g., `#### If concluded_count == 1`)
+- Lowercase after "If" (e.g., `#### If completed_count == 1`)
 - Use `#### Otherwise` for else branches
 - Use backticks around specific values, variables, and statuses in H4 headings (e.g., `` #### If `STATUS` is `clean` ``, `` #### If work type is `feature` ``). Natural language conditions stay plain text (e.g., `#### If no plan provided`)
 - Use "and" between conditions, not commas
-- Drop implied conditions (e.g., if Step 2 already gates on `concluded_count >= 1`, Step 3 doesn't need to repeat it on every branch)
+- Drop implied conditions (e.g., if Step 2 already gates on `completed_count >= 1`, Step 3 doesn't need to repeat it on every branch)
 - H4 for top-level conditionals, bold text for nested — never use H5/H6 for conditional nesting
 - If double-nesting would occur, flatten by combining the parent and child conditions into a single bold conditional
 
@@ -798,7 +798,7 @@ Simple reference files use named sections (`## Seed Idea`, `## Current Knowledge
 | `gather-context.md` | User interview / context gathering questions |
 | `invoke-skill.md` | Handoff to processing skill |
 | `route-scenario.md` | Scenario routing (for skills with branching) |
-| `validate-{thing}.md` | Pre-flight validation (plan exists, spec concluded, etc.) |
+| `validate-{thing}.md` | Pre-flight validation (plan exists, spec completed, etc.) |
 | `display-{variant}.md` | Display outputs (for skills with multiple displays) |
 | `analysis-flow.md` | Multi-step analysis logic |
 | `confirm-and-handoff.md` | Confirmation prompt + skill invocation combined |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,10 @@ awk '/^---$/ && c<2 {c++; next} c>=2 {print}' "$file"
 
 Also avoid BSD sed incompatibilities: `sed '/range/{cmd1;cmd2}'` syntax fails on macOS. Use awk or separate `sed -e` expressions instead.
 
+**Critical: Migration scripts must not use the manifest CLI**
+
+Migration scripts are point-in-time snapshots. The manifest CLI validates values against the current schema, which changes over time (e.g., valid statuses). A migration that uses the CLI today may break silently when validation rules change in a later release. Always read and write `manifest.json` directly using `node` (or `jq`) — never via the manifest CLI. This ensures migrations remain stable regardless of future schema changes.
+
 ## Compaction Recovery
 
 Processing skills run long and may hit context compaction. The hook system provides deterministic recovery.

--- a/skills/continue-bugfix/SKILL.md
+++ b/skills/continue-bugfix/SKILL.md
@@ -52,13 +52,13 @@ Parse the discovery output to understand:
 - `name` - the work unit name
 - `next_phase` - the phase to route to
 - `phase_label` - human-readable phase status
-- `concluded_phases` - list of concluded/completed phases (for backwards navigation)
+- `completed_phases` - list of completed phases (for backwards navigation)
 
 **From top-level fields:**
 - `count` - number of active bugfixes
 - `summary` - human-readable state summary
-- `concluded` / `cancelled` - arrays of non-active bugfixes with name, status, last_phase
-- `concluded_count` / `cancelled_count` - counts for each
+- `completed` / `cancelled` - arrays of non-active bugfixes with name, status, last_phase
+- `completed_count` / `cancelled_count` - counts for each
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
 
@@ -132,6 +132,6 @@ Using the selected bugfix's `next_phase`, invoke the appropriate phase skill:
 
 Skills receive positional arguments: `$0` = work_type (`bugfix`), `$1` = work_unit. Topic is inferred from work_unit.
 
-If the user chose to revisit a concluded phase in Step 5, use that phase instead of `next_phase`.
+If the user chose to revisit a completed phase in Step 5, use that phase instead of `next_phase`.
 
 Invoke the skill. This is terminal — do not return to the backbone.

--- a/skills/continue-bugfix/references/revisit-phase.md
+++ b/skills/continue-bugfix/references/revisit-phase.md
@@ -4,19 +4,19 @@
 
 ---
 
-Offer the user a choice between proceeding to the next phase or revisiting an earlier concluded phase.
+Offer the user a choice between proceeding to the next phase or revisiting an earlier completed phase.
 
 ## Check for Earlier Phases
 
-Using the selected bugfix's `concluded_phases` list, determine if there are any concluded phases that come before `next_phase` in the pipeline.
+Using the selected bugfix's `completed_phases` list, determine if there are any completed phases that come before `next_phase` in the pipeline.
 
-#### If no earlier concluded phases exist
+#### If no earlier completed phases exist
 
 Skip this step — route directly to the next phase.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If earlier concluded phases exist
+#### If earlier completed phases exist
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -38,7 +38,7 @@ Continuing "{bugfix.name:(titlecase)}" — {bugfix.phase_label}.
 
 #### If user chose `r`/`revisit`
 
-Show the concluded phases:
+Show the completed phases:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -46,7 +46,7 @@ Show the concluded phases:
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — concluded
+1. {phase:(titlecase)} — completed
 2. ...
 {N}. Back
 
@@ -54,7 +54,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-List only phases from `concluded_phases`. "Back" returns to the proceed/revisit prompt above.
+List only phases from `completed_phases`. "Back" returns to the proceed/revisit prompt above.
 
 **STOP.** Wait for user response.
 

--- a/skills/continue-bugfix/references/select-bugfix.md
+++ b/skills/continue-bugfix/references/select-bugfix.md
@@ -19,8 +19,8 @@ Continue Bugfix
 
 @endforeach
 
-@if(concluded_count > 0 || cancelled_count > 0)
-{concluded_count} concluded, {cancelled_count} cancelled.
+@if(completed_count > 0 || cancelled_count > 0)
+{completed_count} completed, {cancelled_count} cancelled.
 @endif
 ```
 
@@ -35,8 +35,8 @@ Which bugfix would you like to continue?
 1. Continue "{bugfix.name:(titlecase)}" — {bugfix.phase_label}
 2. ...
 
-@if(concluded_count > 0 || cancelled_count > 0)
-{N+1}. View concluded & cancelled bugfixes
+@if(completed_count > 0 || cancelled_count > 0)
+{N+1}. View completed & cancelled bugfixes
 @endif
 - **`m`/`manage`** — Manage a bugfix's lifecycle
 
@@ -54,9 +54,9 @@ Store the selected bugfix's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If user chose "View concluded & cancelled"
+#### If user chose "View completed & cancelled"
 
-→ Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `bugfix`. On return, re-run discovery and redisplay from the top of this reference.
+→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** with work_type filter = `bugfix`. On return, re-run discovery and redisplay from the top of this reference.
 
 #### If user chose `m`/`manage`
 

--- a/skills/continue-bugfix/references/validate-selection.md
+++ b/skills/continue-bugfix/references/validate-selection.md
@@ -22,6 +22,6 @@ Run /continue-bugfix to see available bugfixes, or /start-bugfix to begin a new 
 
 #### Otherwise
 
-Store the matched bugfix's data (name, next_phase, phase_label, concluded_phases).
+Store the matched bugfix's data (name, next_phase, phase_label, completed_phases).
 
 → Return to **[the skill](../SKILL.md)**.

--- a/skills/continue-bugfix/scripts/discovery.js
+++ b/skills/continue-bugfix/scripts/discovery.js
@@ -8,20 +8,20 @@ function lastCompletedPhase(manifest) {
   let last = null;
   for (const phase of BUGFIX_PIPELINE) {
     const s = phaseStatus(manifest, phase);
-    if (s === 'concluded' || s === 'completed') last = phase;
+    if (s === 'completed') last = phase;
   }
   return last;
 }
 
-function concludedPhases(manifest) {
-  const concluded = [];
+function completedPhases(manifest) {
+  const completed = [];
   for (const phase of BUGFIX_PIPELINE) {
     const s = phaseStatus(manifest, phase);
-    if (s === 'concluded' || s === 'completed') {
-      concluded.push(phase);
+    if (s === 'completed') {
+      completed.push(phase);
     }
   }
-  return concluded;
+  return completed;
 }
 
 function discover(cwd) {
@@ -36,18 +36,18 @@ function discover(cwd) {
       name: m.name,
       next_phase: state.next_phase,
       phase_label: state.phase_label,
-      concluded_phases: concludedPhases(m),
+      completed_phases: completedPhases(m),
     });
   }
 
   const allManifests = loadAllManifests(cwd);
-  const concluded = [];
+  const completed = [];
   const cancelled = [];
 
   for (const m of allManifests) {
     if (m.work_type !== 'bugfix') continue;
-    if (m.status === 'concluded') {
-      concluded.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
+    if (m.status === 'completed') {
+      completed.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
     } else if (m.status === 'cancelled') {
       cancelled.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
     }
@@ -56,9 +56,9 @@ function discover(cwd) {
   return {
     bugfixes,
     count: bugfixes.length,
-    concluded,
+    completed,
     cancelled,
-    concluded_count: concluded.length,
+    completed_count: completed.length,
     cancelled_count: cancelled.length,
     summary: bugfixes.length === 0
       ? 'no active bugfixes'
@@ -71,7 +71,7 @@ function format(result) {
   lines.push(`=== BUGFIXES (${result.count}) ===`);
   lines.push(`summary: ${result.summary}`);
   for (const b of result.bugfixes) {
-    lines.push(`  ${b.name}: ${b.phase_label} [concluded: ${b.concluded_phases.join(', ') || 'none'}]`);
+    lines.push(`  ${b.name}: ${b.phase_label} [completed: ${b.completed_phases.join(', ') || 'none'}]`);
   }
   return lines.join('\n') + '\n';
 }

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -54,17 +54,17 @@ Parse the discovery output to understand:
 - `detail` - full phase-by-phase breakdown containing:
   - `phases` - per-phase items with statuses and spec sources
   - `in_progress` - items currently in-progress (name + phase)
-  - `concluded` - items that are concluded/completed (name + phase)
+  - `completed` - items that are completed (name + phase)
   - `next_phase_ready` - items ready for the next phase (name + action + label)
-  - `unaccounted_discussions` - concluded discussions not sourced in any spec
+  - `unaccounted_discussions` - completed discussions not sourced in any spec
   - `reopened_discussions` - in-progress discussions that are sourced in a spec
   - `gating` - boolean flags for phase-forward gating
 
 **From top-level fields:**
 - `count` - number of active epics
 - `summary` - human-readable state summary
-- `concluded` / `cancelled` - arrays of non-active epics with name, status, last_phase (list mode only)
-- `concluded_count` / `cancelled_count` - counts for each
+- `completed` / `cancelled` - arrays of non-active epics with name, status, last_phase (list mode only)
+- `completed_count` / `cancelled_count` - counts for each
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -73,11 +73,11 @@ No work started yet.
 | Condition | Recommendation |
 |-----------|---------------|
 | In-progress items across multiple phases | No recommendation |
-| Some research in-progress, some concluded | "Consider concluding remaining research before starting discussion. Topic analysis works best with all research available." |
-| Some discussions in-progress, some concluded | "Consider concluding remaining discussions before starting specification. The grouping analysis works best with all discussions available." |
-| All discussions concluded, specs not started | "All discussions are concluded. Specification will analyze and group them." |
-| Some specs concluded, some in-progress | "Concluding all specifications before planning helps identify cross-cutting dependencies." |
-| Some plans concluded, some in-progress | "Completing all plans before implementation helps surface task dependencies across plans." |
+| Some research in-progress, some completed | "Consider completing remaining research before starting discussion. Topic analysis works best with all research available." |
+| Some discussions in-progress, some completed | "Consider completing remaining discussions before starting specification. The grouping analysis works best with all discussions available." |
+| All discussions completed, specs not started | "All discussions are completed. Specification will analyze and group them." |
+| Some specs completed, some in-progress | "Completing all specifications before planning helps identify cross-cutting dependencies." |
+| Some plans completed, some in-progress | "Completing all plans before implementation helps surface task dependencies across plans." |
 | Reopened discussion that's a source in a spec | "{Spec} specification sources the reopened {Discussion} discussion. Once that discussion concludes, the specification will need revisiting to extract new content." |
 
 **Not-ready block:** After the main state display, check for plans with `deps_blocking` entries. If any exist, show in a separate code block:
@@ -110,7 +110,7 @@ Key:
 
   Status:
     in-progress — work is ongoing
-    concluded   — phase complete
+    completed   — phase done
     completed   — all tasks implemented
 
   Blocking reason:
@@ -135,18 +135,18 @@ Build a numbered menu with three sections:
 
 **Section 2 — Next-phase-ready items:**
 - From `next_phase_ready` in discovery output
-- Concluded spec with no plan: `Start planning for "{topic:(titlecase)}" — spec concluded`
+- Completed spec with no plan: `Start planning for "{topic:(titlecase)}" — spec completed`
 - Concluded plan with no implementation:
   - If `blocked`: show but mark as not selectable: `Start implementation of "{topic:(titlecase)}" — blocked by {dep_topic}:{task_id}`
-  - Otherwise: `Start implementation of "{topic:(titlecase)}" — plan concluded`
+  - Otherwise: `Start implementation of "{topic:(titlecase)}" — plan completed`
 - Completed implementation with no review: `Start review for "{topic:(titlecase)}" — implementation completed`
 - Unaccounted discussions (from `unaccounted_discussions`): `Start specification — {N} discussion(s) not yet in a spec`
-  - Only show if `gating.can_start_specification` is true (at least one concluded discussion)
+  - Only show if `gating.can_start_specification` is true (at least one completed discussion)
 
 **Section 3 — Standing options:**
 - `Start new discussion topic` (always present)
 - `Start new research` (always present)
-- `Resume a concluded topic` (only shown when `concluded` items exist)
+- `Resume a completed topic` (only shown when `completed` items exist)
 - `Stop here — resume later with /workflow-start` (always present)
 
 **Phase-forward gating:**
@@ -156,9 +156,9 @@ Build a numbered menu with three sections:
 - No "Start specification" unless `gating.can_start_specification` is true
 
 **Recommendation marking:** Mark one item as `(recommended)` based on phase completion state:
-- All discussions concluded, no specifications exist → "Start specification (recommended)"
-- All feature-type specifications concluded, some without plans → first plannable spec "(recommended)"
-- All plans concluded (and deps satisfied), some without implementations → first implementable plan "(recommended)"
+- All discussions completed, no specifications exist → "Start specification (recommended)"
+- All feature-type specifications completed, some without plans → first plannable spec "(recommended)"
+- All plans completed (and deps satisfied), some without implementations → first implementable plan "(recommended)"
 - All implementations completed, some without reviews → first reviewable implementation "(recommended)"
 - Otherwise → no recommendation (complete in-progress work first)
 
@@ -172,14 +172,14 @@ What would you like to do?
 
 1. Continue "Auth Flow" — discussion (in-progress)
 2. Continue "Data Model" — specification (in-progress)
-3. Start planning for "User Profiles" — spec concluded
+3. Start planning for "User Profiles" — spec completed
 4. Continue "Caching" — planning (in-progress)
-5. Start implementation of "Notifications" — plan concluded (recommended)
+5. Start implementation of "Notifications" — plan completed (recommended)
 6. Start implementation of "Reporting" — blocked by core-features:core-2-3
 7. Start specification — 3 discussion(s) not yet in a spec
 8. Start new discussion topic
 9. Start new research
-10. Resume a concluded topic
+10. Resume a completed topic
 11. Stop here — resume later with /workflow-start
 
 Select an option (enter number):
@@ -246,9 +246,9 @@ Commit the change. Then re-present the menu from **C. Menu** (the item may now b
 
 → Return to **C. Menu**.
 
-#### If user chose `Resume a concluded topic`
+#### If user chose `Resume a completed topic`
 
-→ Proceed to **E. Resume Concluded**.
+→ Proceed to **E. Resume Completed**.
 
 #### Otherwise
 
@@ -258,7 +258,7 @@ Commit the change. Then re-present the menu from **C. Menu** (the item may now b
 |---------------------|-----------|--------------|
 | discussion (new or continue) | `gating.has_research` is true and some research items are in-progress | "{N} of {M} research topics still in-progress. Discussion topic analysis works best with all research available." |
 | specification (new or continue) | discussion items exist with some in-progress | "{N} of {M} discussions still in-progress. Specification grouping analysis works best with all discussions available." |
-| planning | specification items exist with some in-progress | "{N} of {M} specifications still in-progress. Cross-cutting dependencies are easier to identify with all concluded." |
+| planning | specification items exist with some in-progress | "{N} of {M} specifications still in-progress. Cross-cutting dependencies are easier to identify with all completed." |
 | implementation | planning items exist with some in-progress | "{N} of {M} plans still in-progress. Task dependencies across plans may be missed." |
 
 **If a soft gate condition matches:**
@@ -311,29 +311,29 @@ Store the selected action, phase, and topic (if applicable). Map to a routing en
 
 ---
 
-## E. Resume Concluded
+## E. Resume Completed
 
-Display all concluded items across all phases and let the user select one to resume.
+Display all completed items across all phases and let the user select one to resume.
 
-Using the `concluded` items from discovery output, group by phase:
+Using the `completed` items from discovery output, group by phase:
 
 > *Output the next fenced block as a code block:*
 
 ```
-Concluded Topics
+Completed Topics
 
 @foreach(phase in phases)
-@if(phase.concluded_items)
+@if(phase.completed_items)
   {phase:(titlecase)}
-@foreach(item in concluded where item.phase == phase)
-    └─ {item.name:(titlecase)} (concluded)
+@foreach(item in completed where item.phase == phase)
+    └─ {item.name:(titlecase)} (completed)
 @endforeach
 @endif
 
 @endforeach
 ```
 
-Only show phases with concluded items. Blank line between phase sections.
+Only show phases with completed items. Blank line between phase sections.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -349,7 +349,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-List all concluded items across all phases.
+List all completed items across all phases.
 
 **STOP.** Wait for user response.
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -136,7 +136,7 @@ Build a numbered menu with three sections:
 **Section 2 — Next-phase-ready items:**
 - From `next_phase_ready` in discovery output
 - Completed spec with no plan: `Start planning for "{topic:(titlecase)}" — spec completed`
-- Concluded plan with no implementation:
+- Completed plan with no implementation:
   - If `blocked`: show but mark as not selectable: `Start implementation of "{topic:(titlecase)}" — blocked by {dep_topic}:{task_id}`
   - Otherwise: `Start implementation of "{topic:(titlecase)}" — plan completed`
 - Completed implementation with no review: `Start review for "{topic:(titlecase)}" — implementation completed`

--- a/skills/continue-epic/references/select-epic.md
+++ b/skills/continue-epic/references/select-epic.md
@@ -19,8 +19,8 @@ Continue Epic
 
 @endforeach
 
-@if(concluded_count > 0 || cancelled_count > 0)
-{concluded_count} concluded, {cancelled_count} cancelled.
+@if(completed_count > 0 || cancelled_count > 0)
+{completed_count} completed, {cancelled_count} cancelled.
 @endif
 ```
 
@@ -35,8 +35,8 @@ Which epic would you like to continue?
 1. Continue "{epic.name:(titlecase)}"
 2. ...
 
-@if(concluded_count > 0 || cancelled_count > 0)
-{N+1}. View concluded & cancelled epics
+@if(completed_count > 0 || cancelled_count > 0)
+{N+1}. View completed & cancelled epics
 @endif
 - **`m`/`manage`** — Manage an epic's lifecycle
 
@@ -54,9 +54,9 @@ Store the selected epic's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If user chose "View concluded & cancelled"
+#### If user chose "View completed & cancelled"
 
-→ Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `epic`. On return, re-run discovery and redisplay from the top of this reference.
+→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** with work_type filter = `epic`. On return, re-run discovery and redisplay from the top of this reference.
 
 #### If user chose `m`/`manage`
 

--- a/skills/continue-epic/scripts/discovery.js
+++ b/skills/continue-epic/scripts/discovery.js
@@ -8,7 +8,7 @@ function lastCompletedPhaseEpic(manifest) {
   let last = null;
   for (const phase of EPIC_PHASES) {
     const items = phaseItems(manifest, phase);
-    if (items.length > 0 && items.some(i => i.status === 'concluded' || i.status === 'completed')) {
+    if (items.length > 0 && items.some(i => i.status === 'completed')) {
       last = phase;
     }
   }
@@ -49,7 +49,7 @@ function resolveDeps(cwd, manifest, planItem) {
 function buildEpicDetail(cwd, manifest) {
   const phases = {};
   const allSourcedDiscussions = new Set();
-  const concludedItems = [];
+  const completedItems = [];
   const inProgressItems = [];
   const nextPhaseReady = [];
 
@@ -88,8 +88,8 @@ function buildEpicDetail(cwd, manifest) {
       if (item.status === 'in-progress') {
         inProgressItems.push({ name: item.name, phase });
       }
-      if (item.status === 'concluded' || item.status === 'completed') {
-        concludedItems.push({ name: item.name, phase });
+      if (item.status === 'completed') {
+        completedItems.push({ name: item.name, phase });
       }
     }
 
@@ -100,7 +100,7 @@ function buildEpicDetail(cwd, manifest) {
   const discussionItems = phaseItems(manifest, 'discussion');
   const unaccountedDiscussions = [];
   for (const d of discussionItems) {
-    if (d.status === 'concluded' && !allSourcedDiscussions.has(d.name)) {
+    if (d.status === 'completed' && !allSourcedDiscussions.has(d.name)) {
       unaccountedDiscussions.push(d.name);
     }
   }
@@ -118,21 +118,21 @@ function buildEpicDetail(cwd, manifest) {
 
   const planTopics = new Set(planItems.map(i => i.name));
   for (const s of specItems) {
-    if (s.status === 'concluded' && !planTopics.has(s.name)) {
-      nextPhaseReady.push({ name: s.name, action: 'start_planning', label: 'spec concluded' });
+    if (s.status === 'completed' && !planTopics.has(s.name)) {
+      nextPhaseReady.push({ name: s.name, action: 'start_planning', label: 'spec completed' });
     }
   }
 
   const implTopics = new Set(implItems.map(i => i.name));
   for (const p of planItems) {
-    if (p.status === 'concluded' && !implTopics.has(p.name)) {
+    if (p.status === 'completed' && !implTopics.has(p.name)) {
       // Check deps before marking as ready for implementation
       const { deps_satisfied, deps_blocking } = resolveDeps(cwd, manifest, p);
       if (deps_satisfied) {
-        nextPhaseReady.push({ name: p.name, action: 'start_implementation', label: 'plan concluded' });
+        nextPhaseReady.push({ name: p.name, action: 'start_implementation', label: 'plan completed' });
       } else {
         nextPhaseReady.push({
-          name: p.name, action: 'start_implementation', label: 'plan concluded',
+          name: p.name, action: 'start_implementation', label: 'plan completed',
           blocked: true, deps_blocking,
         });
       }
@@ -148,25 +148,25 @@ function buildEpicDetail(cwd, manifest) {
   }
 
   const hasResearch = researchItems.length > 0;
-  const hasConcludedResearch = researchItems.some(r => r.status === 'concluded');
-  const hasConcludedSpec = specItems.some(s => s.status === 'concluded');
-  const hasConcludedPlan = planItems.some(p => p.status === 'concluded');
-  const hasConcludedDiscussion = discussionItems.some(d => d.status === 'concluded');
+  const hasCompletedResearch = researchItems.some(r => r.status === 'completed');
+  const hasCompletedSpec = specItems.some(s => s.status === 'completed');
+  const hasCompletedPlan = planItems.some(p => p.status === 'completed');
+  const hasCompletedDiscussion = discussionItems.some(d => d.status === 'completed');
   const hasCompletedImpl = implItems.some(i => i.status === 'completed');
 
   return {
     phases,
     in_progress: inProgressItems,
-    concluded: concludedItems,
+    completed: completedItems,
     next_phase_ready: nextPhaseReady,
     unaccounted_discussions: unaccountedDiscussions,
     reopened_discussions: reopenedDiscussions,
     gating: {
       has_research: hasResearch,
-      can_start_discussion: hasConcludedResearch,
-      can_start_specification: hasConcludedDiscussion,
-      can_start_planning: hasConcludedSpec,
-      can_start_implementation: hasConcludedPlan,
+      can_start_discussion: hasCompletedResearch,
+      can_start_specification: hasCompletedDiscussion,
+      can_start_planning: hasCompletedSpec,
+      can_start_implementation: hasCompletedPlan,
       can_start_review: hasCompletedImpl,
     },
   };
@@ -198,15 +198,15 @@ function discover(cwd, workUnit) {
     });
   }
 
-  // Load concluded/cancelled epics (only in list mode, not detail mode)
-  const concluded = [];
+  // Load completed/cancelled epics (only in list mode, not detail mode)
+  const completed = [];
   const cancelled = [];
   if (!workUnit) {
     const allManifests = loadAllManifests(cwd);
     for (const m of allManifests) {
       if (m.work_type !== 'epic') continue;
-      if (m.status === 'concluded') {
-        concluded.push({ name: m.name, status: m.status, last_phase: lastCompletedPhaseEpic(m) });
+      if (m.status === 'completed') {
+        completed.push({ name: m.name, status: m.status, last_phase: lastCompletedPhaseEpic(m) });
       } else if (m.status === 'cancelled') {
         cancelled.push({ name: m.name, status: m.status, last_phase: lastCompletedPhaseEpic(m) });
       }
@@ -216,9 +216,9 @@ function discover(cwd, workUnit) {
   return {
     epics,
     count: epics.length,
-    concluded,
+    completed,
     cancelled,
-    concluded_count: concluded.length,
+    completed_count: completed.length,
     cancelled_count: cancelled.length,
     summary: epics.length === 0
       ? 'no active epics'
@@ -273,9 +273,9 @@ function format(result) {
     if (d.reopened_discussions.length > 0) {
       lines.push(`    reopened_discussions: ${d.reopened_discussions.join(', ')}`);
     }
-    if (d.concluded.length > 0) {
-      lines.push('    concluded:');
-      for (const c of d.concluded) lines.push(`      - ${c.name} (${c.phase})`);
+    if (d.completed.length > 0) {
+      lines.push('    completed:');
+      for (const c of d.completed) lines.push(`      - ${c.name} (${c.phase})`);
     }
   }
 

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -52,13 +52,13 @@ Parse the discovery output to understand:
 - `name` - the work unit name
 - `next_phase` - the phase to route to
 - `phase_label` - human-readable phase status
-- `concluded_phases` - list of concluded/completed phases (for backwards navigation)
+- `completed_phases` - list of completed phases (for backwards navigation)
 
 **From top-level fields:**
 - `count` - number of active features
 - `summary` - human-readable state summary
-- `concluded` / `cancelled` - arrays of non-active features with name, status, last_phase
-- `concluded_count` / `cancelled_count` - counts for each
+- `completed` / `cancelled` - arrays of non-active features with name, status, last_phase
+- `completed_count` / `cancelled_count` - counts for each
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
 
@@ -133,6 +133,6 @@ Using the selected feature's `next_phase`, invoke the appropriate phase skill:
 
 Skills receive positional arguments: `$0` = work_type (`feature`), `$1` = work_unit. Topic is inferred from work_unit.
 
-If the user chose to revisit a concluded phase in Step 5, use that phase instead of `next_phase`.
+If the user chose to revisit a completed phase in Step 5, use that phase instead of `next_phase`.
 
 Invoke the skill. This is terminal — do not return to the backbone.

--- a/skills/continue-feature/references/revisit-phase.md
+++ b/skills/continue-feature/references/revisit-phase.md
@@ -4,19 +4,19 @@
 
 ---
 
-Offer the user a choice between proceeding to the next phase or revisiting an earlier concluded phase.
+Offer the user a choice between proceeding to the next phase or revisiting an earlier completed phase.
 
 ## Check for Earlier Phases
 
-Using the selected feature's `concluded_phases` list, determine if there are any concluded phases that come before `next_phase` in the pipeline.
+Using the selected feature's `completed_phases` list, determine if there are any completed phases that come before `next_phase` in the pipeline.
 
-#### If no earlier concluded phases exist
+#### If no earlier completed phases exist
 
 Skip this step — route directly to the next phase.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If earlier concluded phases exist
+#### If earlier completed phases exist
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -38,7 +38,7 @@ Continuing "{feature.name:(titlecase)}" — {feature.phase_label}.
 
 #### If user chose `r`/`revisit`
 
-Show the concluded phases:
+Show the completed phases:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -46,7 +46,7 @@ Show the concluded phases:
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — concluded
+1. {phase:(titlecase)} — completed
 2. ...
 {N}. Back
 
@@ -54,7 +54,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-List only phases from `concluded_phases`. "Back" returns to the proceed/revisit prompt above.
+List only phases from `completed_phases`. "Back" returns to the proceed/revisit prompt above.
 
 **STOP.** Wait for user response.
 

--- a/skills/continue-feature/references/select-feature.md
+++ b/skills/continue-feature/references/select-feature.md
@@ -19,8 +19,8 @@ Continue Feature
 
 @endforeach
 
-@if(concluded_count > 0 || cancelled_count > 0)
-{concluded_count} concluded, {cancelled_count} cancelled.
+@if(completed_count > 0 || cancelled_count > 0)
+{completed_count} completed, {cancelled_count} cancelled.
 @endif
 ```
 
@@ -35,8 +35,8 @@ Which feature would you like to continue?
 1. Continue "{feature.name:(titlecase)}" — {feature.phase_label}
 2. ...
 
-@if(concluded_count > 0 || cancelled_count > 0)
-{N+1}. View concluded & cancelled features
+@if(completed_count > 0 || cancelled_count > 0)
+{N+1}. View completed & cancelled features
 @endif
 - **`m`/`manage`** — Manage a feature's lifecycle
 
@@ -54,9 +54,9 @@ Store the selected feature's name as `work_unit`.
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If user chose "View concluded & cancelled"
+#### If user chose "View completed & cancelled"
 
-→ Load **[../../workflow-start/references/view-concluded.md](../../workflow-start/references/view-concluded.md)** with work_type filter = `feature`. On return, re-run discovery and redisplay from the top of this reference.
+→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** with work_type filter = `feature`. On return, re-run discovery and redisplay from the top of this reference.
 
 #### If user chose `m`/`manage`
 

--- a/skills/continue-feature/references/validate-selection.md
+++ b/skills/continue-feature/references/validate-selection.md
@@ -22,6 +22,6 @@ Run /continue-feature to see available features, or /start-feature to begin a ne
 
 #### Otherwise
 
-Store the matched feature's data (name, next_phase, phase_label, concluded_phases).
+Store the matched feature's data (name, next_phase, phase_label, completed_phases).
 
 → Return to **[the skill](../SKILL.md)**.

--- a/skills/continue-feature/scripts/discovery.js
+++ b/skills/continue-feature/scripts/discovery.js
@@ -8,20 +8,20 @@ function lastCompletedPhase(manifest) {
   let last = null;
   for (const phase of FEATURE_PIPELINE) {
     const s = phaseStatus(manifest, phase);
-    if (s === 'concluded' || s === 'completed') last = phase;
+    if (s === 'completed') last = phase;
   }
   return last;
 }
 
-function concludedPhases(manifest) {
-  const concluded = [];
+function completedPhases(manifest) {
+  const completed = [];
   for (const phase of FEATURE_PIPELINE) {
     const s = phaseStatus(manifest, phase);
-    if (s === 'concluded' || s === 'completed') {
-      concluded.push(phase);
+    if (s === 'completed') {
+      completed.push(phase);
     }
   }
-  return concluded;
+  return completed;
 }
 
 function discover(cwd) {
@@ -36,19 +36,19 @@ function discover(cwd) {
       name: m.name,
       next_phase: state.next_phase,
       phase_label: state.phase_label,
-      concluded_phases: concludedPhases(m),
+      completed_phases: completedPhases(m),
     });
   }
 
-  // Load concluded/cancelled features
+  // Load completed/cancelled features
   const allManifests = loadAllManifests(cwd);
-  const concluded = [];
+  const completed = [];
   const cancelled = [];
 
   for (const m of allManifests) {
     if (m.work_type !== 'feature') continue;
-    if (m.status === 'concluded') {
-      concluded.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
+    if (m.status === 'completed') {
+      completed.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
     } else if (m.status === 'cancelled') {
       cancelled.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
     }
@@ -57,9 +57,9 @@ function discover(cwd) {
   return {
     features,
     count: features.length,
-    concluded,
+    completed,
     cancelled,
-    concluded_count: concluded.length,
+    completed_count: completed.length,
     cancelled_count: cancelled.length,
     summary: features.length === 0
       ? 'no active features'
@@ -72,7 +72,7 @@ function format(result) {
   lines.push(`=== FEATURES (${result.count}) ===`);
   lines.push(`summary: ${result.summary}`);
   for (const f of result.features) {
-    lines.push(`  ${f.name}: ${f.phase_label} [concluded: ${f.concluded_phases.join(', ') || 'none'}]`);
+    lines.push(`  ${f.name}: ${f.phase_label} [completed: ${f.completed_phases.join(', ') || 'none'}]`);
   }
   return lines.join('\n') + '\n';
 }

--- a/skills/migrate/scripts/migrations/019-status-rename.sh
+++ b/skills/migrate/scripts/migrations/019-status-rename.sh
@@ -6,9 +6,11 @@
 #   Also: if status is active/in-progress but all phases through review are
 #   completed, set to concluded.
 #
+# Note: writes directly to manifest.json — migration scripts must not use
+# the manifest CLI, whose validation rules may change over time.
+#
 
 WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
-MANIFEST="node ${PROJECT_DIR:-.}/.claude/skills/workflow-manifest/scripts/manifest.js"
 
 if [ ! -d "$WORKFLOWS_DIR" ]; then
   exit 0
@@ -21,51 +23,56 @@ for dir in "$WORKFLOWS_DIR"/*/; do
   # Skip dot-prefixed directories
   [[ "$name" == .* ]] && continue
 
-  [ -f "$dir/manifest.json" ] || continue
+  manifest="$dir/manifest.json"
+  [ -f "$manifest" ] || continue
 
-  status=$($MANIFEST get "$name" status 2>/dev/null) || continue
+  # Use node to do all work directly on the JSON
+  result=$(node -e "
+    const fs = require('fs');
+    const p = process.argv[1];
+    const m = JSON.parse(fs.readFileSync(p, 'utf8'));
+    const updates = [];
 
-  # Rename old statuses
-  if [ "$status" = "active" ]; then
-    $MANIFEST set "$name" status in-progress 2>/dev/null
-    status="in-progress"
-    echo "  updated: $dir/manifest.json → in-progress" >&2
-  elif [ "$status" = "archived" ]; then
-    $MANIFEST set "$name" status cancelled 2>/dev/null
-    status="cancelled"
-    echo "  updated: $dir/manifest.json → cancelled" >&2
-  fi
+    // Rename old statuses
+    if (m.status === 'active') {
+      m.status = 'in-progress';
+      updates.push('in-progress');
+    } else if (m.status === 'archived') {
+      m.status = 'cancelled';
+      updates.push('cancelled');
+    }
 
-  # Check if pipeline is fully done but status is still in-progress
-  if [ "$status" = "in-progress" ]; then
-    work_type=$($MANIFEST get "$name" work_type 2>/dev/null) || continue
+    // Check if pipeline is fully done but status is still in-progress
+    if (m.status === 'in-progress' && m.phases) {
+      let reviewDone = false;
+      const wt = m.work_type;
 
-    review_done=false
+      if (wt === 'epic') {
+        const items = (m.phases.review && m.phases.review.items) || {};
+        const vals = Object.values(items);
+        if (vals.length > 0 && vals.every(i => i.status === 'completed')) {
+          reviewDone = true;
+        }
+      } else {
+        const reviewStatus = m.phases.review && m.phases.review.status;
+        if (reviewStatus === 'completed') {
+          reviewDone = true;
+        }
+      }
 
-    if [ "$work_type" = "epic" ]; then
-      # Epic: check if all review items have status completed
-      review_items=$($MANIFEST get "$name" phases.review.items 2>/dev/null) || true
-      if [ -n "$review_items" ] && [ "$review_items" != "undefined" ]; then
-        all_completed=$(node -e "
-          const items = JSON.parse(process.argv[1]);
-          const vals = Object.values(items);
-          console.log(vals.length > 0 && vals.every(i => i.status === 'completed'));
-        " "$review_items" 2>/dev/null) || true
-        if [ "$all_completed" = "true" ]; then
-          review_done=true
-        fi
-      fi
-    else
-      # Feature/bugfix: check flat review status
-      review_status=$($MANIFEST get "$name" --phase review status 2>/dev/null) || true
-      if [ "$review_status" = "completed" ]; then
-        review_done=true
-      fi
-    fi
+      if (reviewDone) {
+        m.status = 'concluded';
+        updates.push('concluded');
+      }
+    }
 
-    if [ "$review_done" = "true" ]; then
-      $MANIFEST set "$name" status concluded 2>/dev/null
-      echo "  updated: $dir/manifest.json → concluded" >&2
-    fi
+    if (updates.length > 0) {
+      fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
+    }
+    console.log(updates.join(','));
+  " "$manifest" 2>/dev/null) || true
+
+  if [ -n "$result" ]; then
+    echo "  updated: $manifest → $result" >&2
   fi
 done

--- a/skills/migrate/scripts/migrations/020-normalise-terminal-status.sh
+++ b/skills/migrate/scripts/migrations/020-normalise-terminal-status.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Migration 020: Normalise terminal status
+#   concluded → completed for all phase statuses and work unit status.
+#   Implementation and review already use completed — this brings
+#   research, discussion, investigation, specification, and planning
+#   into alignment, along with work unit status.
+#
+
+WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+
+if [ ! -d "$WORKFLOWS_DIR" ]; then
+  exit 0
+fi
+
+for dir in "$WORKFLOWS_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  name=$(basename "$dir")
+
+  # Skip dot-prefixed directories
+  [[ "$name" == .* ]] && continue
+
+  manifest="$dir/manifest.json"
+  [ -f "$manifest" ] || continue
+
+  # Use node to do all replacements atomically
+  updated=$(node -e "
+    const fs = require('fs');
+    const manifest = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+    let changed = false;
+
+    // Update work unit status
+    if (manifest.status === 'concluded') {
+      manifest.status = 'completed';
+      changed = true;
+    }
+
+    // Update phase statuses
+    if (manifest.phases) {
+      for (const [phase, data] of Object.entries(manifest.phases)) {
+        if (!data) continue;
+
+        // Flat phase status
+        if (data.status === 'concluded') {
+          data.status = 'completed';
+          changed = true;
+        }
+
+        // Item-level statuses (epic)
+        if (data.items) {
+          for (const [topic, item] of Object.entries(data.items)) {
+            if (item && item.status === 'concluded') {
+              item.status = 'completed';
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+
+    if (changed) {
+      console.log('changed');
+      fs.writeFileSync(process.argv[1], JSON.stringify(manifest, null, 2) + '\n');
+    }
+  " "$manifest" 2>/dev/null) || true
+
+  if [ "$updated" = "changed" ]; then
+    echo "  updated: $manifest → concluded to completed" >&2
+  fi
+done

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -52,9 +52,9 @@ Workflow Status
   Work units: {total} active ({epic} epic, {feature} feature, {bugfix} bugfix)
 
   Research:       {count} with research
-  Discussion:     {count} ({concluded} concluded, {in_progress} in-progress)
+  Discussion:     {count} ({completed} completed, {in_progress} in-progress)
   Specification:  {active} active ({feature_spec} feature, {crosscutting} cross-cutting)
-  Planning:       {count} ({concluded} concluded, {in_progress} in-progress)
+  Planning:       {count} ({completed} completed, {in_progress} in-progress)
   Implementation: {count} ({completed} completed, {in_progress} in-progress)
 ```
 
@@ -149,7 +149,7 @@ Key:
 
   Status:
     in-progress — work is ongoing
-    concluded   — complete, ready for next step
+    completed   — done, ready for next step
     superseded  — replaced by another specification
 
   Spec type:

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -169,10 +169,10 @@ Omit categories with no entries.
 
 Based on gaps in the workflow, briefly suggest 2-3 most relevant actions:
 
-- Concluded discussions not in any spec → use `/continue-feature` or `/continue-epic` to proceed
+- Completed discussions not in any spec → use `/continue-feature` or `/continue-epic` to proceed
 - In-progress specs → use `/continue-feature` or `/continue-epic` to continue
-- Concluded feature specs without plans → use `/continue-feature` or `/continue-epic` to start planning
-- Concluded plans not yet implemented → use `/continue-feature` or `/continue-epic` to start implementation
+- Completed feature specs without plans → use `/continue-feature` or `/continue-epic` to start planning
+- Completed plans not yet implemented → use `/continue-feature` or `/continue-epic` to start implementation
 - Completed implementations → use `/continue-feature` or `/continue-epic` to start review
 
 If plans exist, mention `/view-plan` for detailed plan viewing.

--- a/skills/status/scripts/discovery.js
+++ b/skills/status/scripts/discovery.js
@@ -11,9 +11,9 @@ function discover(cwd) {
       counts: {
         by_work_type: { epic: 0, feature: 0, bugfix: 0 },
         research: 0,
-        discussion: { total: 0, concluded: 0, in_progress: 0 },
+        discussion: { total: 0, completed: 0, in_progress: 0 },
         specification: { active: 0, feature: 0, crosscutting: 0 },
-        planning: { total: 0, concluded: 0, in_progress: 0 },
+        planning: { total: 0, completed: 0, in_progress: 0 },
         implementation: { total: 0, completed: 0, in_progress: 0 },
       },
       state: { has_any_work: false },
@@ -26,9 +26,9 @@ function discover(cwd) {
   // Aggregated counts
   const byType = { epic: 0, feature: 0, bugfix: 0 };
   let researchCount = 0;
-  let discTotal = 0, discConcluded = 0, discInProgress = 0;
+  let discTotal = 0, discCompleted = 0, discInProgress = 0;
   let specActive = 0, specFeature = 0, specCrosscutting = 0;
-  let planTotal = 0, planConcluded = 0, planInProgress = 0;
+  let planTotal = 0, planCompleted = 0, planInProgress = 0;
   let implTotal = 0, implCompleted = 0, implInProgressCount = 0;
 
   for (const m of manifests) {
@@ -47,12 +47,12 @@ function discover(cwd) {
     }
 
     // Helper: aggregate item statuses into a single representative status
-    // all concluded → 'concluded', any in-progress → 'in-progress', otherwise first item's status
+    // all completed → 'completed', any in-progress → 'in-progress', otherwise first item's status
     function aggregateStatus(items) {
       if (items.length === 0) return null;
       const statuses = items.map(i => i.status).filter(Boolean);
       if (statuses.length === 0) return null;
-      if (statuses.every(s => s === 'concluded' || s === 'completed')) return statuses[0];
+      if (statuses.every(s => s === 'completed')) return 'completed';
       if (statuses.some(s => s === 'in-progress')) return 'in-progress';
       return statuses[0];
     }
@@ -66,7 +66,7 @@ function discover(cwd) {
         discItemCount = items.length;
         discStatus = aggregateStatus(items);
         discTotal += items.length;
-        discConcluded += items.filter(i => i.status === 'concluded').length;
+        discCompleted += items.filter(i => i.status === 'completed').length;
         discInProgress += items.filter(i => i.status === 'in-progress').length;
       }
     } else {
@@ -74,7 +74,7 @@ function discover(cwd) {
       discStatus = disc.status || null;
       if (discStatus) {
         discTotal++;
-        if (discStatus === 'concluded') discConcluded++;
+        if (discStatus === 'completed') discCompleted++;
         if (discStatus === 'in-progress') discInProgress++;
       }
     }
@@ -133,7 +133,7 @@ function discover(cwd) {
         planItemCount = items.length;
         planStatus = aggregateStatus(items);
         planTotal += items.length;
-        planConcluded += items.filter(i => i.status === 'concluded').length;
+        planCompleted += items.filter(i => i.status === 'completed').length;
         planInProgress += items.filter(i => i.status === 'in-progress').length;
         // Use format from first item that has one
         const withFmt = items.find(i => i.format);
@@ -152,7 +152,7 @@ function discover(cwd) {
       planFormat = plan.format || null;
       if (planStatus) {
         planTotal++;
-        if (planStatus === 'concluded') planConcluded++;
+        if (planStatus === 'completed') planCompleted++;
         if (planStatus === 'in-progress') planInProgress++;
       }
       externalDepsObj = (plan.external_dependencies && typeof plan.external_dependencies === 'object' && !Array.isArray(plan.external_dependencies))
@@ -261,9 +261,9 @@ function discover(cwd) {
     counts: {
       by_work_type: byType,
       research: researchCount,
-      discussion: { total: discTotal, concluded: discConcluded, in_progress: discInProgress },
+      discussion: { total: discTotal, completed: discCompleted, in_progress: discInProgress },
       specification: { active: specActive, feature: specFeature, crosscutting: specCrosscutting },
-      planning: { total: planTotal, concluded: planConcluded, in_progress: planInProgress },
+      planning: { total: planTotal, completed: planCompleted, in_progress: planInProgress },
       implementation: { total: implTotal, completed: implCompleted, in_progress: implInProgressCount },
     },
     state: { has_any_work: true },
@@ -303,9 +303,9 @@ function format(result) {
   lines.push('=== COUNTS ===');
   const c = result.counts;
   lines.push(`by_type: ${c.by_work_type.epic} epic, ${c.by_work_type.feature} feature, ${c.by_work_type.bugfix} bugfix`);
-  lines.push(`discussion: ${c.discussion.total} (${c.discussion.concluded} concluded, ${c.discussion.in_progress} in-progress)`);
+  lines.push(`discussion: ${c.discussion.total} (${c.discussion.completed} completed, ${c.discussion.in_progress} in-progress)`);
   lines.push(`specification: ${c.specification.active} active (${c.specification.feature} feature, ${c.specification.crosscutting} cross-cutting)`);
-  lines.push(`planning: ${c.planning.total} (${c.planning.concluded} concluded)`);
+  lines.push(`planning: ${c.planning.total} (${c.planning.completed} completed)`);
   lines.push(`implementation: ${c.implementation.total} (${c.implementation.completed} completed, ${c.implementation.in_progress} in-progress)`);
   lines.push('');
 

--- a/skills/technical-discussion/references/conclude-discussion.md
+++ b/skills/technical-discussion/references/conclude-discussion.md
@@ -10,7 +10,7 @@ When the user indicates they want to conclude:
 
 ```
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Conclude discussion and mark as concluded
+- **`y`/`yes`** — Conclude discussion and mark as completed
 - **Comment** — Add context before concluding
 · · · · · · · · · · · ·
 ```
@@ -23,9 +23,9 @@ Incorporate the user's context into the discussion, commit, then re-present the 
 
 #### If `yes`
 
-1. Set discussion status to concluded via manifest CLI:
+1. Set discussion status to completed via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase discussion --topic {topic} status concluded
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase discussion --topic {topic} status completed
    ```
 2. Final commit
 3. Invoke the bridge:

--- a/skills/technical-discussion/references/discussion-session.md
+++ b/skills/technical-discussion/references/discussion-session.md
@@ -22,7 +22,7 @@ Work through questions one at a time. For each:
 - Explore options and trade-offs
 - Capture the journey — false paths, debates, what changed thinking
 - Document the decision and rationale when reached
-- Check off concluded questions in the Questions list
+- Check off completed questions in the Questions list
 
 ## When the User Signals Conclusion
 

--- a/skills/technical-discussion/references/guidelines.md
+++ b/skills/technical-discussion/references/guidelines.md
@@ -57,7 +57,7 @@ Best practices for documenting discussions. For DOCUMENTATION only - no plans or
 
 ## Write to Disk as Discussing
 
-At natural pauses — not every exchange, but when something meaningful has been concluded, explored, or uncovered — update the file on disk:
+At natural pauses — not every exchange, but when something meaningful has been completed, explored, or uncovered — update the file on disk:
 
 - Check off answered questions
 - Add options as explored

--- a/skills/technical-discussion/references/template.md
+++ b/skills/technical-discussion/references/template.md
@@ -36,7 +36,7 @@ What this is about, why we're discussing it, the problem or opportunity, current
 
 ---
 
-*Each question above gets its own section below. Check off as concluded.*
+*Each question above gets its own section below. Check off as completed.*
 
 ---
 
@@ -101,7 +101,7 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 **During discussion**:
 - Work through questions one at a time
 - Document options, journey, and decision for each
-- Check off questions as concluded
+- Check off questions as completed
 - Keep journey contextual - false paths, debates, and "aha" moments belong with the question they relate to
 
 **Per-question structure**:
@@ -119,6 +119,6 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 - Don't summarise the journey - document it
 
 **Complete when**:
-- Major questions concluded with rationale
+- Major questions completed with rationale
 - Trade-offs understood
 - Path forward clear

--- a/skills/technical-investigation/references/conclude-investigation.md
+++ b/skills/technical-investigation/references/conclude-investigation.md
@@ -32,9 +32,9 @@ Incorporate the user's context into the investigation file and commit. Re-presen
 
 #### If `yes`
 
-1. Set investigation status to concluded via manifest CLI:
+1. Set investigation status to completed via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase investigation --topic {topic} status concluded
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase investigation --topic {topic} status completed
    ```
 2. Final commit
 3. Display conclusion:
@@ -42,12 +42,12 @@ Incorporate the user's context into the investigation file and commit. Re-presen
 > *Output the next fenced block as a code block:*
 
 ```
-Investigation concluded: {work_unit}
+Investigation completed: {work_unit}
 
 Root cause: {brief summary}
 Fix direction: {chosen approach}
 
-The investigation is concluded. Root cause and fix direction are documented.
+The investigation is completed. Root cause and fix direction are documented.
 ```
 
 4. Invoke the bridge:

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -268,7 +268,7 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 ```
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Conclude plan and mark as concluded
+- **`y`/`yes`** — Conclude plan and mark as completed
 - **Comment** — Add context before concluding
 · · · · · · · · · · · ·
 ```
@@ -283,9 +283,9 @@ Discuss the user's context. If additional work is needed, route back to **Step 6
 
 1. **Update plan status** via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} status concluded
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} status completed
    ```
-2. **Final commit** — Commit the concluded plan: `planning({work_unit}): conclude plan`
+2. **Final commit** — Commit the completed plan: `planning({work_unit}): complete plan`
 3. **Present completion summary**:
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -295,7 +295,7 @@ Planning is complete for **{work_unit}**.
 
 The plan contains **{N} phases** with **{M} tasks** total, reviewed for traceability against the specification and structural integrity.
 
-Status has been marked as `concluded`. The plan is ready for implementation.
+Status has been marked as `completed`. The plan is ready for implementation.
 ```
 
 4. **Pipeline continuation** — Invoke the bridge:

--- a/skills/technical-planning/references/plan-index-schema.md
+++ b/skills/technical-planning/references/plan-index-schema.md
@@ -68,7 +68,7 @@ All metadata is managed via the manifest CLI (`node .claude/skills/workflow-mani
 
 | Field (via `--phase planning --topic {topic}`) | Set when |
 |------------|----------|
-| `status` | Plan creation -> `in-progress`; conclusion -> `concluded` |
+| `status` | Plan creation -> `in-progress`; completion -> `completed` |
 | `format` | Plan creation -- user-chosen output format |
 | `spec_commit` | Plan creation -- `git rev-parse HEAD`; updated on continue if spec changed |
 | `ext_id` | First task authored -- external identifier for the plan |

--- a/skills/technical-research/references/convergence-awareness.md
+++ b/skills/technical-research/references/convergence-awareness.md
@@ -20,10 +20,10 @@
 
 #### If the user concludes
 
-Set research status to concluded via manifest CLI:
+Set research status to completed via manifest CLI:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase research status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase research status completed
 ```
 
 Invoke the `/workflow-bridge` skill:

--- a/skills/technical-specification/references/spec-completion.md
+++ b/skills/technical-specification/references/spec-completion.md
@@ -75,7 +75,7 @@ If any tracking file still shows `status: in-progress`, mark it complete now.
 
 ```
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Conclude specification and mark as concluded
+- **`y`/`yes`** — Conclude specification and mark as completed
 - **Comment** — Add context before concluding
 · · · · · · · · · · · ·
 ```
@@ -97,7 +97,7 @@ Discuss the user's context, apply any changes, then re-present the sign-off prom
 Update the specification metadata via manifest CLI:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status completed
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} type {type}  # feature or cross-cutting, as confirmed in Section A
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} date $(date +%Y-%m-%d)
 ```
@@ -141,7 +141,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 > *Output the next fenced block as a code block:*
 
 ```
-Cross-cutting specification concluded: {topic}
+Cross-cutting specification completed: {topic}
 
 This specification defines patterns/policies referenced by feature plans.
 It does not proceed to planning independently.

--- a/skills/technical-specification/references/specification-format.md
+++ b/skills/technical-specification/references/specification-format.md
@@ -25,13 +25,13 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} sources.{source-name}.status
 
 # Write fields
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status completed
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} sources.{source-name}.status incorporated
 ```
 
 | Field | Set when |
 |-------|----------|
-| `status` | Spec creation → `in-progress`; conclusion → `concluded` |
+| `status` | Spec creation → `in-progress`; completion → `completed` |
 | `type` | Spec creation → `feature` (default); completion → `feature` or `cross-cutting` |
 | `date` | Spec creation — today's date; update on each commit |
 | `review_cycle` | Starts at 0; incremented each review cycle. Missing field treated as 0. |
@@ -89,12 +89,12 @@ A source is `incorporated` when you have:
 - Presented and logged all relevant content from that source
 - No more content from that source needs to be extracted
 
-**Important**: The specification's overall status should only be set to `concluded` (via `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status concluded`) when:
+**Important**: The specification's overall status should only be set to `completed` (via `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status completed`) when:
 - All sources are marked as `incorporated`
 - Both review phases are complete
 - User has signed off
 
-If a new source is added to a concluded specification (via grouping analysis), the specification effectively needs updating — even if the manifest still shows `status: concluded`, the presence of `pending` sources indicates work remains.
+If a new source is added to a completed specification (via grouping analysis), the specification effectively needs updating — even if the manifest still shows `status: completed`, the presence of `pending` sources indicates work remains.
 
 ---
 

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -14,7 +14,7 @@ This skill is invoked by processing skills (technical-discussion, technical-spec
 
 This skill receives context from the calling processing skill:
 - **Work unit**: The work unit name (directory under `.workflows/`) = `{work_unit}`
-- **Completed phase**: The phase that just concluded = `{completed_phase}`
+- **Completed phase**: The phase that just completed = `{completed_phase}`
 
 ---
 

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -25,16 +25,16 @@ Use `next_phase` from discovery output to determine the target skill:
 
 #### If `next_phase` is `done`
 
-Set the work unit status to concluded:
+Set the work unit status to completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
 > *Output the next fenced block as a code block:*
 
 ```
-Bugfix Concluded
+Bugfix Completed
 
 "{work_unit:(titlecase)}" has completed all pipeline phases.
 ```
@@ -45,22 +45,22 @@ Bugfix Concluded
 
 Set `target_phase` = `next_phase`.
 
-→ Proceed to **B. Offer Early Conclusion**.
+→ Proceed to **B. Offer Early Completion**.
 
-## B. Offer Early Conclusion
+## B. Offer Early Completion
 
 #### If `next_phase` is `review`
 
-Implementation has just concluded. Offer the user a choice to skip review and conclude early.
+Implementation has just completed. Offer the user a choice to skip review and complete early.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Implementation concluded for "{work_unit:(titlecase)}".
+Implementation completed for "{work_unit:(titlecase)}".
 
 - **`y`/`yes`** — Proceed to review
-- **`d`/`done`** — Conclude without review
+- **`d`/`done`** — Complete without review
 
 · · · · · · · · · · · ·
 ```
@@ -69,18 +69,18 @@ Implementation concluded for "{work_unit:(titlecase)}".
 
 **If user chose `d`/`done`:**
 
-Set the work unit status to concluded:
+Set the work unit status to completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
 > *Output the next fenced block as a code block:*
 
 ```
-Bugfix Concluded
+Bugfix Completed
 
-"{work_unit:(titlecase)}" concluded — review skipped.
+"{work_unit:(titlecase)}" completed — review skipped.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -95,19 +95,19 @@ Bugfix Concluded
 
 ## C. Offer Revisit
 
-Check if there are concluded phases earlier in the pipeline that the user could revisit. Look at the discovery output's `phases` data — any phase with status `concluded` or `completed` that comes before `next_phase` in the pipeline order.
+Check if there are completed phases earlier in the pipeline that the user could revisit. Look at the discovery output's `phases` data — any phase with status `completed` that comes before `next_phase` in the pipeline order.
 
-#### If no earlier concluded phases exist
+#### If no earlier completed phases exist
 
 → Proceed to **D. Enter Plan Mode**.
 
-#### If earlier concluded phases exist
+#### If earlier completed phases exist
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-{previous_phase:(titlecase)} concluded for "{work_unit:(titlecase)}".
+{previous_phase:(titlecase)} completed for "{work_unit:(titlecase)}".
 
 - **`y`/`yes`** — Proceed to {next_phase}
 - **`r`/`revisit`** — Revisit an earlier phase
@@ -129,7 +129,7 @@ Check if there are concluded phases earlier in the pipeline that the user could 
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — concluded
+1. {phase:(titlecase)} — completed
 2. ...
 {N}. Back
 
@@ -137,7 +137,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-List only concluded phases that come before `next_phase`.
+List only completed phases that come before `next_phase`.
 
 **STOP.** Wait for user response.
 
@@ -158,7 +158,7 @@ Call the `EnterPlanMode` tool to enter plan mode. Then write the following conte
 ```
 # Continue Bugfix: {work_unit}
 
-@if(target_phase == next_phase) The previous phase has concluded. Continue the pipeline. @else Revisiting an earlier phase. @endif
+@if(target_phase == next_phase) The previous phase has completed. Continue the pipeline. @else Revisiting an earlier phase. @endif
 
 ## Next Step
 

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -30,7 +30,7 @@ Using the enriched discovery data from section A, check if ALL topics across ALL
 · · · · · · · · · · · ·
 All topics have completed review for "{work_unit:(titlecase)}".
 
-- **`y`/`yes`** — Mark this epic as concluded
+- **`y`/`yes`** — Mark this epic as completed
 - **`n`/`no`** — Return to the epic menu
 
 · · · · · · · · · · · ·
@@ -40,16 +40,16 @@ All topics have completed review for "{work_unit:(titlecase)}".
 
 **If user chose `y`/`yes`:**
 
-Set the work unit status to concluded:
+Set the work unit status to completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
 > *Output the next fenced block as a code block:*
 
 ```
-Epic Concluded
+Epic Completed
 
 "{work_unit:(titlecase)}" has completed all topics through review.
 ```
@@ -69,7 +69,7 @@ Epic Concluded
 > *Output the next fenced block as a code block:*
 
 ```
-{completed_phase:(titlecase)} concluded for "{work_unit:(titlecase)}".
+{completed_phase:(titlecase)} completed for "{work_unit:(titlecase)}".
 ```
 
 Load **[epic-display-and-menu.md](../../continue-epic/references/epic-display-and-menu.md)** and follow its instructions as written.

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -26,16 +26,16 @@ Use `next_phase` from discovery output to determine the target skill:
 
 #### If `next_phase` is `done`
 
-Set the work unit status to concluded:
+Set the work unit status to completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
 > *Output the next fenced block as a code block:*
 
 ```
-Feature Concluded
+Feature Completed
 
 "{work_unit:(titlecase)}" has completed all pipeline phases.
 ```
@@ -46,22 +46,22 @@ Feature Concluded
 
 Set `target_phase` = `next_phase`.
 
-→ Proceed to **B. Offer Early Conclusion**.
+→ Proceed to **B. Offer Early Completion**.
 
-## B. Offer Early Conclusion
+## B. Offer Early Completion
 
 #### If `next_phase` is `review`
 
-Implementation has just concluded. Offer the user a choice to skip review and conclude early.
+Implementation has just completed. Offer the user a choice to skip review and complete early.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Implementation concluded for "{work_unit:(titlecase)}".
+Implementation completed for "{work_unit:(titlecase)}".
 
 - **`y`/`yes`** — Proceed to review
-- **`d`/`done`** — Conclude without review
+- **`d`/`done`** — Complete without review
 
 · · · · · · · · · · · ·
 ```
@@ -70,18 +70,18 @@ Implementation concluded for "{work_unit:(titlecase)}".
 
 **If user chose `d`/`done`:**
 
-Set the work unit status to concluded:
+Set the work unit status to completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
 > *Output the next fenced block as a code block:*
 
 ```
-Feature Concluded
+Feature Completed
 
-"{work_unit:(titlecase)}" concluded — review skipped.
+"{work_unit:(titlecase)}" completed — review skipped.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -96,19 +96,19 @@ Feature Concluded
 
 ## C. Offer Revisit
 
-Check if there are concluded phases earlier in the pipeline that the user could revisit. Look at the discovery output's `phases` data — any phase with status `concluded` or `completed` that comes before `next_phase` in the pipeline order.
+Check if there are completed phases earlier in the pipeline that the user could revisit. Look at the discovery output's `phases` data — any phase with status `completed` that comes before `next_phase` in the pipeline order.
 
-#### If no earlier concluded phases exist
+#### If no earlier completed phases exist
 
 → Proceed to **D. Enter Plan Mode**.
 
-#### If earlier concluded phases exist
+#### If earlier completed phases exist
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-{previous_phase:(titlecase)} concluded for "{work_unit:(titlecase)}".
+{previous_phase:(titlecase)} completed for "{work_unit:(titlecase)}".
 
 - **`y`/`yes`** — Proceed to {next_phase}
 - **`r`/`revisit`** — Revisit an earlier phase
@@ -130,7 +130,7 @@ Check if there are concluded phases earlier in the pipeline that the user could 
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — concluded
+1. {phase:(titlecase)} — completed
 2. ...
 {N}. Back
 
@@ -138,7 +138,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-List only concluded phases that come before `next_phase`.
+List only completed phases that come before `next_phase`.
 
 **STOP.** Wait for user response.
 
@@ -159,7 +159,7 @@ Call the `EnterPlanMode` tool to enter plan mode. Then write the following conte
 ```
 # Continue Feature: {work_unit}
 
-@if(target_phase == next_phase) The previous phase has concluded. Continue the pipeline. @else Revisiting an earlier phase. @endif
+@if(target_phase == next_phase) The previous phase has completed. Continue the pipeline. @else Revisiting an earlier phase. @endif
 
 ## Next Step
 

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -54,7 +54,7 @@ Check discussion phase status via manifest CLI:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion --topic {topic} status
 ```
 
-**If phase exists (in-progress or concluded):**
+**If phase exists (in-progress or completed):**
 
 → Proceed to **Step 2** (Validate Phase).
 
@@ -80,7 +80,7 @@ Parse the discovery output to understand:
 **From `discussions` section:**
 - `exists` - whether discussion entries exist (from manifests)
 - `files` - each discussion's name, work_unit, status, and work_type
-- `counts.in_progress` and `counts.concluded` - totals for routing
+- `counts.in_progress` and `counts.completed` - totals for routing
 
 **From `cache` section:**
 - `entries` - array of cache entries (empty if no cache exists). Each entry has:

--- a/skills/workflow-discussion-entry/references/display-options.md
+++ b/skills/workflow-discussion-entry/references/display-options.md
@@ -19,7 +19,7 @@ Research topics:
 
 1. {theme_name}
    └─ Source: {filename}.md (lines {start}-{end})
-   └─ Discussion: @if(has_discussion) {work_unit}/{topic} ({status:[in-progress|concluded]}) @else (no discussion) @endif
+   └─ Discussion: @if(has_discussion) {work_unit}/{topic} ({status:[in-progress|completed]}) @else (no discussion) @endif
    └─ "{summary}"
 
 2. ...
@@ -32,7 +32,7 @@ If discussions exist that are NOT linked to a research topic, list them separate
 ```
 Existing discussions:
 
-  • {work_unit}/{topic} ({status:[in-progress|concluded]}, {work_type:[epic|feature|bugfix]})
+  • {work_unit}/{topic} ({status:[in-progress|completed]}, {work_type:[epic|feature|bugfix]})
 ```
 
 ### Key/Legend
@@ -46,7 +46,7 @@ Key:
 
   Discussion status:
     in-progress — discussion is ongoing
-    concluded   — discussion is complete
+    completed   — discussion is done
 ```
 
 **Then present the options based on what exists:**

--- a/skills/workflow-discussion-entry/references/gather-context.md
+++ b/skills/workflow-discussion-entry/references/gather-context.md
@@ -16,7 +16,7 @@ Check research status via manifest:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase research status
 ```
 
-**If research status is `concluded`:**
+**If research status is `completed`:**
 
 Read `.workflows/{work_unit}/research/*.md` for context to include in the handoff.
 

--- a/skills/workflow-discussion-entry/references/validate-phase.md
+++ b/skills/workflow-discussion-entry/references/validate-phase.md
@@ -24,7 +24,7 @@ Set source="continue".
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If discussion exists and status is `concluded`
+#### If discussion exists and status is `completed`
 
 Reset to in-progress:
 

--- a/skills/workflow-discussion-entry/scripts/discovery.js
+++ b/skills/workflow-discussion-entry/scripts/discovery.js
@@ -31,7 +31,7 @@ function discover(cwd, workUnit) {
   // --- Discussions from manifests ---
   const discussions = [];
   let inProgress = 0;
-  let concluded = 0;
+  let completed = 0;
 
   for (const m of manifests) {
     const dp = phaseData(m, 'discussion');
@@ -43,17 +43,17 @@ function discover(cwd, workUnit) {
         for (const item of items) {
           discussions.push({ name: item.name, work_unit: m.name, status: item.status || 'unknown', work_type: m.work_type });
           if (item.status === 'in-progress') inProgress++;
-          else if (item.status === 'concluded') concluded++;
+          else if (item.status === 'completed') completed++;
         }
       } else if (dp.status) {
         discussions.push({ name: m.name, work_unit: m.name, status: dp.status, work_type: m.work_type });
         if (dp.status === 'in-progress') inProgress++;
-        else if (dp.status === 'concluded') concluded++;
+        else if (dp.status === 'completed') completed++;
       }
     } else if (dp.status) {
       discussions.push({ name: m.name, work_unit: m.name, status: dp.status, work_type: m.work_type });
       if (dp.status === 'in-progress') inProgress++;
-      else if (dp.status === 'concluded') concluded++;
+      else if (dp.status === 'completed') completed++;
     }
   }
 
@@ -108,7 +108,7 @@ function discover(cwd, workUnit) {
     discussions: {
       exists: hasDiscussions,
       files: discussions,
-      counts: { in_progress: inProgress, concluded },
+      counts: { in_progress: inProgress, completed },
     },
     cache: { entries: cacheEntries },
     state: { has_research: hasResearch, has_discussions: hasDiscussions, scenario },
@@ -136,7 +136,7 @@ function format(result) {
     for (const d of result.discussions.files) {
       lines.push(`  ${d.work_unit}/${d.name} (${d.work_type}): ${d.status}`);
     }
-    lines.push(`  counts: ${result.discussions.counts.in_progress} in-progress, ${result.discussions.counts.concluded} concluded`);
+    lines.push(`  counts: ${result.discussions.counts.in_progress} in-progress, ${result.discussions.counts.completed} completed`);
   }
   lines.push('');
 

--- a/skills/workflow-implementation-entry/references/validate-phase.md
+++ b/skills/workflow-implementation-entry/references/validate-phase.md
@@ -21,24 +21,24 @@ Plan Missing
 
 No plan found for "{topic:(titlecase)}".
 
-A concluded plan is required for implementation.
+A completed plan is required for implementation.
 ```
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan exists but status is not `concluded`
+#### If plan exists but status is not `completed`
 
 > *Output the next fenced block as a code block:*
 
 ```
-Plan Not Concluded
+Plan Not Completed
 
-The plan for "{topic:(titlecase)}" is not yet concluded.
+The plan for "{topic:(titlecase)}" is not yet completed.
 ```
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan exists and status is `concluded`
+#### If plan exists and status is `completed`
 
 Check implementation's own status:
 

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -49,7 +49,7 @@ Check investigation phase status via manifest CLI:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase investigation --topic {topic} status
 ```
 
-**If phase exists (in-progress or concluded):**
+**If phase exists (in-progress or completed):**
 
 → Proceed to **Step 2** (Validate Phase).
 

--- a/skills/workflow-investigation-entry/references/validate-phase.md
+++ b/skills/workflow-investigation-entry/references/validate-phase.md
@@ -22,7 +22,7 @@ Set source="continue".
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If status is `concluded`
+#### If status is `completed`
 
 Reset to in-progress:
 

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -101,12 +101,12 @@ Write a value. Two modes:
 **Work-unit level** (no flags):
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set <name> description "Updated description"
-node .claude/skills/workflow-manifest/scripts/manifest.js set <name> status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set <name> status completed
 ```
 
 **Phase level** (with flags):
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set <name> --phase discussion --topic auth-flow status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set <name> --phase discussion --topic auth-flow status completed
 node .claude/skills/workflow-manifest/scripts/manifest.js set <name> --phase planning --topic auth-flow task_list_gate_mode auto
 ```
 
@@ -116,7 +116,7 @@ Values are parsed as JSON first (for arrays, objects, numbers, booleans), fallin
 - **phase names**: `research`, `discussion`, `investigation`, `specification`, `planning`, `implementation`, `review`
 - **phase statuses**: per-phase valid values (see Validation section)
 - **gate modes**: `gated`, `auto`
-- **work unit status**: `in-progress`, `concluded`, `cancelled`
+- **work unit status**: `in-progress`, `completed`, `cancelled`
 
 ### `list`
 
@@ -191,12 +191,12 @@ The CLI validates structural values to prevent invalid state:
 | Field                          | Valid Values                             |
 |--------------------------------|------------------------------------------|
 | `work_type`                    | `epic`, `feature`, `bugfix`              |
-| `status` (work unit)           | `in-progress`, `concluded`, `cancelled`  |
-| `phases.research.status`       | `in-progress`, `concluded`               |
-| `phases.discussion.status`     | `in-progress`, `concluded`               |
-| `phases.investigation.status`  | `in-progress`, `concluded`               |
-| `phases.specification.status`  | `in-progress`, `concluded`, `superseded` |
-| `phases.planning.status`       | `in-progress`, `concluded`               |
+| `status` (work unit)           | `in-progress`, `completed`, `cancelled`  |
+| `phases.research.status`       | `in-progress`, `completed`               |
+| `phases.discussion.status`     | `in-progress`, `completed`               |
+| `phases.investigation.status`  | `in-progress`, `completed`               |
+| `phases.specification.status`  | `in-progress`, `completed`, `superseded` |
+| `phases.planning.status`       | `in-progress`, `completed`               |
 | `phases.implementation.status` | `in-progress`, `completed`               |
 | `phases.review.status`         | `in-progress`, `completed`               |
 | Gate modes (`*_gate_mode`)     | `gated`, `auto`                          |
@@ -205,7 +205,7 @@ Item-level statuses within epic phases follow the same phase-level rules.
 
 ## Output Conventions
 
-- **Scalar values**: raw to stdout, no quotes (e.g., `in-progress`, `concluded`)
+- **Scalar values**: raw to stdout, no quotes (e.g., `in-progress`, `completed`)
 - **Subtrees and lists**: formatted JSON to stdout
 - **Errors**: message to stderr, non-zero exit code
 

--- a/skills/workflow-manifest/scripts/manifest.js
+++ b/skills/workflow-manifest/scripts/manifest.js
@@ -22,18 +22,18 @@ const VALID_PHASES = [
 const TOPICLESS_PHASES = [];
 
 const VALID_PHASE_STATUSES = {
-  research:       ['in-progress', 'concluded'],
-  discussion:     ['in-progress', 'concluded'],
-  investigation:  ['in-progress', 'concluded'],
-  specification:  ['in-progress', 'concluded', 'superseded'],
-  planning:       ['in-progress', 'concluded'],
+  research:       ['in-progress', 'completed'],
+  discussion:     ['in-progress', 'completed'],
+  investigation:  ['in-progress', 'completed'],
+  specification:  ['in-progress', 'completed', 'superseded'],
+  planning:       ['in-progress', 'completed'],
   implementation: ['in-progress', 'completed'],
   review:         ['in-progress', 'completed'],
 };
 
 const VALID_GATE_MODES = ['gated', 'auto'];
 
-const VALID_WORK_UNIT_STATUSES = ['in-progress', 'concluded', 'cancelled'];
+const VALID_WORK_UNIT_STATUSES = ['in-progress', 'completed', 'cancelled'];
 
 const LOCK_STALE_MS = 30000;
 const LOCK_RETRY_MS = 50;

--- a/skills/workflow-planning-entry/references/cross-cutting-context.md
+++ b/skills/workflow-planning-entry/references/cross-cutting-context.md
@@ -48,9 +48,9 @@ These may contain architectural decisions relevant to this plan.
 
 If the user chooses to stop, end here. If they choose to continue, proceed.
 
-### Summarize concluded cross-cutting specs
+### Summarize completed cross-cutting specs
 
-If any **concluded** cross-cutting specifications exist, identify which are relevant to the feature being planned and summarize for handoff:
+If any **completed** cross-cutting specifications exist, identify which are relevant to the feature being planned and summarize for handoff:
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-planning-entry/references/validate-phase.md
+++ b/skills/workflow-planning-entry/references/validate-phase.md
@@ -12,7 +12,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 
 #### If existing plan (continue or review)
 
-**If status is `concluded`:**
+**If status is `completed`:**
 
 Reset to in-progress:
 
@@ -42,7 +42,7 @@ Set source="existing".
 
 ```
 · · · · · · · · · · · ·
-Any additional context since the specification was concluded?
+Any additional context since the specification was completed?
 
 - **`c`/`continue`** — Continue with the specification as-is
 - Or provide additional context (priorities, constraints, new considerations)

--- a/skills/workflow-planning-entry/references/validate-spec.md
+++ b/skills/workflow-planning-entry/references/validate-spec.md
@@ -19,7 +19,7 @@ Specification Missing
 
 No specification found for "{topic:(titlecase)}".
 
-The specification must be concluded before planning can begin.
+The specification must be completed before planning can begin.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -31,14 +31,14 @@ The specification must be concluded before planning can begin.
 ```
 Specification In Progress
 
-The specification for "{topic:(titlecase)}" is not yet concluded.
+The specification for "{topic:(titlecase)}" is not yet completed.
 
-The specification must be concluded before planning can begin.
+The specification must be completed before planning can begin.
 ```
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If specification exists and status is `concluded`
+#### If specification exists and status is `completed`
 
 **If work_type is `epic`:**
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -54,7 +54,7 @@ Check research phase status via manifest CLI:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase research --topic {topic} status
 ```
 
-**If phase exists (in-progress or concluded):**
+**If phase exists (in-progress or completed):**
 
 → Proceed to **Step 2** (Validate Phase).
 

--- a/skills/workflow-research-entry/references/validate-phase.md
+++ b/skills/workflow-research-entry/references/validate-phase.md
@@ -10,7 +10,7 @@ Check research status via manifest CLI:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase research --topic {topic} status
 ```
 
-#### If status is `concluded`
+#### If status is `completed`
 
 Reset to in-progress:
 

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -19,7 +19,7 @@ Plan Missing
 
 No plan found for "{topic:(titlecase)}".
 
-A concluded plan and completed implementation are required for review.
+A completed plan and completed implementation are required for review.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -62,7 +62,7 @@ Check review's own phase status:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} status
 ```
 
-**If status is `concluded`:**
+**If status is `completed`:**
 
 Reset to in-progress:
 

--- a/skills/workflow-shared/scripts/discovery-utils.js
+++ b/skills/workflow-shared/scripts/discovery-utils.js
@@ -96,14 +96,14 @@ function phaseData(manifest, phase) {
 function computeNextPhase(manifest) {
   const wt = manifest.work_type;
 
-  // For epic, aggregate item statuses: all concluded → 'concluded', any in-progress → 'in-progress'
+  // For epic, aggregate item statuses: all completed → 'completed', any in-progress → 'in-progress'
   const ps = (phase) => {
     if (wt === 'epic') {
       const items = phaseItems(manifest, phase);
       if (items.length === 0) return phaseStatus(manifest, phase); // fallback to flat if no items
       const statuses = items.map(i => i.status).filter(Boolean);
       if (statuses.length === 0) return null;
-      if (statuses.every(s => s === 'concluded' || s === 'completed')) return statuses[0];
+      if (statuses.every(s => s === 'completed')) return 'completed';
       if (statuses.some(s => s === 'in-progress')) return 'in-progress';
       return statuses[0];
     }
@@ -125,13 +125,13 @@ function computeNextPhase(manifest) {
       phase_label: 'implementation (in-progress)',
     };
   }
-  if (ps('planning') === 'concluded') {
+  if (ps('planning') === 'completed') {
     return { next_phase: 'implementation', phase_label: 'ready for implementation' };
   }
   if (ps('planning') === 'in-progress') {
     return { next_phase: 'planning', phase_label: 'planning (in-progress)' };
   }
-  if (ps('specification') === 'concluded') {
+  if (ps('specification') === 'completed') {
     return { next_phase: 'planning', phase_label: 'ready for planning' };
   }
   if (ps('specification') === 'in-progress') {
@@ -142,7 +142,7 @@ function computeNextPhase(manifest) {
   }
 
   if (wt === 'bugfix') {
-    if (ps('investigation') === 'concluded') {
+    if (ps('investigation') === 'completed') {
       return {
         next_phase: 'specification',
         phase_label: 'ready for specification',
@@ -157,7 +157,7 @@ function computeNextPhase(manifest) {
     return { next_phase: 'investigation', phase_label: 'ready for investigation' };
   }
 
-  if (ps('discussion') === 'concluded') {
+  if (ps('discussion') === 'completed') {
     return { next_phase: 'specification', phase_label: 'ready for specification' };
   }
   if (ps('discussion') === 'in-progress') {
@@ -169,7 +169,7 @@ function computeNextPhase(manifest) {
     if (ps('research') === 'in-progress') {
       return { next_phase: 'research', phase_label: 'research (in-progress)' };
     }
-    if (ps('research') === 'concluded') {
+    if (ps('research') === 'completed') {
       return { next_phase: 'discussion', phase_label: 'ready for discussion' };
     }
   }

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -66,7 +66,7 @@ Parse the discovery output to understand:
 
 **From `cache` section:** `entries` array — each entry has `status` (valid/stale), `reason`, `generated`, `anchored_names`. Empty array if no cache exists.
 
-**From `current_state`:** `concluded_count`, `spec_count`, `has_discussions`, `has_concluded`, `has_specs`, and other counts/booleans for routing.
+**From `current_state`:** `completed_count`, `spec_count`, `has_discussions`, `has_completed`, `has_specs`, and other counts/booleans for routing.
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
 

--- a/skills/workflow-specification-entry/references/analysis-flow.md
+++ b/skills/workflow-specification-entry/references/analysis-flow.md
@@ -28,9 +28,9 @@ Your context (or 'none'):
 
 ## B. Analyze Discussions
 
-**This step is critical. You MUST read every concluded discussion document thoroughly.**
+**This step is critical. You MUST read every completed discussion document thoroughly.**
 
-For each concluded discussion:
+For each completed discussion:
 1. Read the ENTIRE document using the Read tool (not just the header)
 2. Understand the decisions, systems, and concepts it defines
 3. Note dependencies on or references to other discussions

--- a/skills/workflow-specification-entry/references/check-prerequisites.md
+++ b/skills/workflow-specification-entry/references/check-prerequisites.md
@@ -6,7 +6,7 @@
 
 Discovery mode — use the discovery output from Step 1 to check prerequisites.
 
-#### If `has_discussions` is false or `has_concluded` is false
+#### If `has_discussions` is false or `has_completed` is false
 
 → Load **[display-blocks.md](display-blocks.md)** and follow its instructions.
 

--- a/skills/workflow-specification-entry/references/confirm-and-handoff.md
+++ b/skills/workflow-specification-entry/references/confirm-and-handoff.md
@@ -8,8 +8,8 @@
 
 - No spec exists → **"Creating"**
 - Spec is `in-progress` → **"Continuing"**
-- Spec is `concluded` with pending sources → **"Continuing"**
-- Spec is `concluded` with all sources extracted → **"Refining"**
+- Spec is `completed` with pending sources → **"Continuing"**
+- Spec is `completed` with all sources extracted → **"Refining"**
 
 ## Route
 

--- a/skills/workflow-specification-entry/references/confirm-continue.md
+++ b/skills/workflow-specification-entry/references/confirm-continue.md
@@ -54,14 +54,14 @@ Proceed?
 · · · · · · · · · · · ·
 ```
 
-#### If spec is concluded with pending sources
+#### If spec is completed with pending sources
 
 > *Output the next fenced block as a code block:*
 
 ```
 Continuing specification: {Title Case Name}
 
-Existing: .workflows/{work_unit}/specification/{topic}/specification.md (concluded)
+Existing: .workflows/{work_unit}/specification/{topic}/specification.md (completed)
 
 New sources to extract:
   • {discussion-name} (pending)
@@ -84,9 +84,9 @@ Proceed?
 
 #### If user confirms (y)
 
-#### If spec is concluded with pending sources
+#### If spec is completed with pending sources
 
-→ Load **[continue-concluded.md](handoffs/continue-concluded.md)** and follow its instructions.
+→ Load **[continue-completed.md](handoffs/continue-completed.md)** and follow its instructions.
 
 #### Otherwise
 

--- a/skills/workflow-specification-entry/references/confirm-refine.md
+++ b/skills/workflow-specification-entry/references/confirm-refine.md
@@ -9,7 +9,7 @@
 ```
 Refining specification: {Title Case Name}
 
-Existing: .workflows/{work_unit}/specification/{topic}/specification.md (concluded)
+Existing: .workflows/{work_unit}/specification/{topic}/specification.md (completed)
 
 All sources extracted:
   • {discussion-name}

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -4,7 +4,7 @@
 
 ---
 
-Prompted when multiple concluded discussions exist, no specifications exist, and cache is none or stale.
+Prompted when multiple completed discussions exist, no specifications exist, and cache is none or stale.
 
 ## Display
 
@@ -13,15 +13,15 @@ Prompted when multiple concluded discussions exist, no specifications exist, and
 ```
 Specification Overview
 
-{N} concluded discussions found. No specifications exist yet.
+{N} completed discussions found. No specifications exist yet.
 
-Concluded discussions:
+Completed discussions:
   • {discussion-name}
   • {discussion-name}
   • {discussion-name}
 ```
 
-List all concluded discussions from discovery output.
+List all completed discussions from discovery output.
 
 #### If in-progress discussions exist
 
@@ -29,7 +29,7 @@ List all concluded discussions from discovery output.
 
 ```
 Discussions not ready for specification:
-These discussions are still in progress and must be concluded
+These discussions are still in progress and must be completed
 before they can be included in a specification.
 
   • {discussion-name}

--- a/skills/workflow-specification-entry/references/display-blocks.md
+++ b/skills/workflow-specification-entry/references/display-blocks.md
@@ -15,30 +15,30 @@ Specification Overview
 
 No discussions found.
 
-The specification phase requires concluded discussions to work from.
+The specification phase requires completed discussions to work from.
 Discussions capture the technical decisions, edge cases, and rationale
 that specifications are built upon.
 
-The specification phase requires concluded discussions to work from.
+The specification phase requires completed discussions to work from.
 ```
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If discussions exist but none concluded
+#### If discussions exist but none completed
 
 > *Output the next fenced block as a code block:*
 
 ```
 Specification Overview
 
-No concluded discussions found.
+No completed discussions found.
 
 The following discussions are still in progress:
 
   • {discussion-name}
   • {discussion-name}
 
-Specifications can only be created from concluded discussions.
+Specifications can only be created from completed discussions.
 Conclude at least one discussion before proceeding.
 ```
 

--- a/skills/workflow-specification-entry/references/display-groupings.md
+++ b/skills/workflow-specification-entry/references/display-groupings.md
@@ -29,7 +29,7 @@ Spec status: show actual status with extraction count `({X} of {Y} sources extra
 
 **Regressed sources:** After processing the grouping's discussions, check the spec's
 `sources` array from discovery. For any source where `discussion_status` is neither
-`concluded` nor `not-found`, and the source is not already in the grouping:
+`completed` nor `not-found`, and the source is not already in the grouping:
 - Add it to the discussion tree with status `(extracted, reopened)`
 
 These represent sources that were incorporated but whose discussions have since
@@ -58,7 +58,7 @@ Specification Overview
 Recommended breakdown for specifications with their source discussions.
 
 1. {grouping_name:(titlecase)}
-   └─ Spec: @if(has_spec) {spec_status:[in-progress|concluded]} ({extraction_summary}) @else (no spec) @endif
+   └─ Spec: @if(has_spec) {spec_status:[in-progress|completed]} ({extraction_summary}) @else (no spec) @endif
    └─ Discussions:
       ├─ {discussion} ({status:[extracted|pending|ready|reopened]})
       └─ ...
@@ -72,7 +72,7 @@ Recommended breakdown for specifications with their source discussions.
 
 ```
 Discussions not ready for specification:
-These discussions are still in progress and must be concluded
+These discussions are still in progress and must be completed
 before they can be included in a specification.
 
   • {discussion-name}
@@ -90,12 +90,12 @@ Key:
   Discussion status:
     extracted — content has been incorporated into the specification
     pending   — listed as source but content not yet extracted
-    ready     — concluded and available to be specified
+    ready     — completed and available to be specified
     reopened  — was extracted but discussion has regressed to in-progress
 
   Spec status:
     in-progress — specification work is ongoing
-    concluded   — specification is complete
+    completed   — specification is done
 ```
 
 ### Tip (show when 2+ groupings)
@@ -120,8 +120,8 @@ Present one numbered menu entry per grouping. The verb and description depend on
 - No spec exists → **Start** "{Name}" — {N} ready discussions
 - Spec is `in-progress` with pending sources → **Continue** "{Name}" — {N} source(s) pending extraction
 - Spec is `in-progress` with all extracted → **Continue** "{Name}" — all sources extracted
-- Spec is `concluded` with no pending sources → **Refine** "{Name}" — concluded spec
-- Spec is `concluded` with pending sources → **Continue** "{Name}" — {N} new source(s) to extract
+- Spec is `completed` with no pending sources → **Refine** "{Name}" — completed spec
+- Spec is `completed` with pending sources → **Continue** "{Name}" — {N} new source(s) to extract
 
 After all grouping entries, append meta options:
 
@@ -160,9 +160,9 @@ Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 #### If user picks `Unify all`
 
-Update the cache: rewrite `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all concluded discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
+Update the cache: rewrite `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all completed discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
 
-Spec name: "Unified". Sources: all concluded discussions.
+Spec name: "Unified". Sources: all completed discussions.
 
 → Load **[confirm-and-handoff.md](confirm-and-handoff.md)** and follow its instructions.
 

--- a/skills/workflow-specification-entry/references/display-single-grouped.md
+++ b/skills/workflow-specification-entry/references/display-single-grouped.md
@@ -7,7 +7,7 @@
 This discussion is covered by a specification with multiple sources.
 
 Use the spec for display. Show the spec name as the title. Show ALL the spec's sources (not just this discussion) with their statuses:
-- `incorporated` + `discussion_status: concluded` or `not-found` → `(extracted)`
+- `incorporated` + `discussion_status: completed` or `not-found` → `(extracted)`
 - `incorporated` + `discussion_status: other` (e.g. `in-progress`) → `(extracted, reopened)`
 - `pending` → `(pending)`
 
@@ -20,10 +20,10 @@ Extraction count: X = sources with `status: incorporated`, Y = total source coun
 ```
 Specification Overview
 
-Single concluded discussion found with existing multi-source specification.
+Single completed discussion found with existing multi-source specification.
 
 1. {work_unit:(titlecase)}
-   └─ Spec: {spec_status:[in-progress|concluded]} ({X} of {Y} sources extracted)
+   └─ Spec: {spec_status:[in-progress|completed]} ({X} of {Y} sources extracted)
    └─ Discussions:
       ├─ {source-name} (extracted)
       └─ {source-name} (extracted, reopened)
@@ -35,7 +35,7 @@ Single concluded discussion found with existing multi-source specification.
 
 ```
 Discussions not ready for specification:
-These discussions are still in progress and must be concluded
+These discussions are still in progress and must be completed
 before they can be included in a specification.
 
   • {discussion-name}
@@ -57,7 +57,7 @@ Key:
 
   Spec status:
     in-progress — specification work is ongoing
-    concluded   — specification is complete
+    completed   — specification is done
 ```
 
 ## After Display
@@ -70,7 +70,7 @@ Automatically proceeding with "{work_unit:(titlecase)}".
 
 Auto-proceed uses the spec name. Verb rule:
 - Spec is `in-progress` → **"Continuing"**
-- Spec is `concluded` with pending sources → **"Continuing"**
-- Spec is `concluded` with all sources extracted → **"Refining"**
+- Spec is `completed` with pending sources → **"Continuing"**
+- Spec is `completed` with all sources extracted → **"Refining"**
 
 → Load **[confirm-and-handoff.md](confirm-and-handoff.md)** and follow its instructions.

--- a/skills/workflow-specification-entry/references/display-single-has-spec.md
+++ b/skills/workflow-specification-entry/references/display-single-has-spec.md
@@ -15,10 +15,10 @@ Determine extraction count: check the spec's `sources` array from discovery. Cou
 ```
 Specification Overview
 
-Single concluded discussion found with existing specification.
+Single completed discussion found with existing specification.
 
 1. {work_unit:(titlecase)}
-   └─ Spec: {spec_status:[in-progress|concluded]} ({X} of {Y} sources extracted)
+   └─ Spec: {spec_status:[in-progress|completed]} ({X} of {Y} sources extracted)
    └─ Discussions:
       └─ {discussion-name} (extracted)
 ```
@@ -29,7 +29,7 @@ Single concluded discussion found with existing specification.
 
 ```
 Discussions not ready for specification:
-These discussions are still in progress and must be concluded
+These discussions are still in progress and must be completed
 before they can be included in a specification.
 
   • {discussion-name}
@@ -49,7 +49,7 @@ Key:
 
   Spec status:
     in-progress — specification work is ongoing
-    concluded   — specification is complete
+    completed   — specification is done
 ```
 
 ## After Display
@@ -62,7 +62,7 @@ Automatically proceeding with "{work_unit:(titlecase)}".
 
 Auto-proceed. Verb rule:
 - Spec is `in-progress` → **"Continuing"**
-- Spec is `concluded` with pending sources → **"Continuing"**
-- Spec is `concluded` with all sources extracted → **"Refining"**
+- Spec is `completed` with pending sources → **"Continuing"**
+- Spec is `completed` with all sources extracted → **"Refining"**
 
 → Load **[confirm-and-handoff.md](confirm-and-handoff.md)** and follow its instructions.

--- a/skills/workflow-specification-entry/references/display-single-no-spec.md
+++ b/skills/workflow-specification-entry/references/display-single-no-spec.md
@@ -13,7 +13,7 @@ No specification exists for this discussion.
 ```
 Specification Overview
 
-Single concluded discussion found.
+Single completed discussion found.
 
 1. {work_unit:(titlecase)}
    └─ Spec: (no spec)
@@ -27,7 +27,7 @@ Single concluded discussion found.
 
 ```
 Discussions not ready for specification:
-These discussions are still in progress and must be concluded
+These discussions are still in progress and must be completed
 before they can be included in a specification.
 
   • {discussion-name}
@@ -43,7 +43,7 @@ No `---` separator before this section.
 Key:
 
   Discussion status:
-    ready — concluded and available to be specified
+    ready — completed and available to be specified
 ```
 
 ## After Display

--- a/skills/workflow-specification-entry/references/display-single.md
+++ b/skills/workflow-specification-entry/references/display-single.md
@@ -4,7 +4,7 @@
 
 ---
 
-Auto-proceed path — only one concluded discussion exists, so no selection menu is needed.
+Auto-proceed path — only one completed discussion exists, so no selection menu is needed.
 
 ## Route by Spec Coverage
 

--- a/skills/workflow-specification-entry/references/display-specs-menu.md
+++ b/skills/workflow-specification-entry/references/display-specs-menu.md
@@ -4,7 +4,7 @@
 
 ---
 
-Shows when multiple concluded discussions exist, specifications exist, and cache is none or stale. Displays existing specs from discovery manifest data (NOT from cache), lists unassigned discussions, and offers analysis or continue options.
+Shows when multiple completed discussions exist, specifications exist, and cache is none or stale. Displays existing specs from discovery manifest data (NOT from cache), lists unassigned discussions, and offers analysis or continue options.
 
 ## A. Display
 
@@ -13,7 +13,7 @@ Shows when multiple concluded discussions exist, specifications exist, and cache
 ```
 Specification Overview
 
-{N} concluded discussions found. {M} specifications exist.
+{N} completed discussions found. {M} specifications exist.
 
 Existing specifications:
 ```
@@ -24,14 +24,14 @@ For each non-superseded specification from discovery output, display as nested t
 
 ```
 1. {work_unit:(titlecase)}
-   └─ Spec: {spec_status:[in-progress|concluded]} ({X} of {Y} sources extracted)
+   └─ Spec: {spec_status:[in-progress|completed]} ({X} of {Y} sources extracted)
    └─ Discussions:
       ├─ {source-name} (extracted)
       └─ {source-name} (extracted)
 ```
 
 Determine discussion status from the spec's `sources` array:
-- `incorporated` + `discussion_status: concluded` or `not-found` → `extracted`
+- `incorporated` + `discussion_status: completed` or `not-found` → `extracted`
 - `incorporated` + `discussion_status: other` (e.g. `in-progress`) → `extracted, reopened`
 - `pending` → `pending`
 
@@ -39,12 +39,12 @@ Extraction count: X = sources with `status: incorporated`, Y = total source coun
 
 ### Unassigned Discussions
 
-List concluded discussions that are not in any specification's `sources` array:
+List completed discussions that are not in any specification's `sources` array:
 
 > *Output the next fenced block as a code block:*
 
 ```
-Concluded discussions not in a specification:
+Completed discussions not in a specification:
   • {discussion-name}
   • {discussion-name}
 ```
@@ -55,7 +55,7 @@ Concluded discussions not in a specification:
 
 ```
 Discussions not ready for specification:
-These discussions are still in progress and must be concluded
+These discussions are still in progress and must be completed
 before they can be included in a specification.
 
   • {discussion-name}
@@ -76,7 +76,7 @@ Key:
 
   Spec status:
     in-progress — specification work is ongoing
-    concluded   — specification is complete
+    completed   — specification is done
 ```
 
 ### Cache-Aware Message
@@ -109,8 +109,8 @@ have changed since it was created. Re-analysis is required.
 List "Analyze for groupings (recommended)" first, then one entry per existing non-superseded specification. The verb depends on the spec's state:
 
 - Spec is `in-progress` → **Continue** "{Name}" — in-progress
-- Spec is `concluded` with pending sources → **Continue** "{Name}" — {N} source(s) pending extraction
-- Spec is `concluded` with no pending sources → **Refine** "{Name}" — concluded
+- Spec is `completed` with pending sources → **Continue** "{Name}" — {N} source(s) pending extraction
+- Spec is `completed` with no pending sources → **Refine** "{Name}" — completed
 
 **Example assembled menu** (2 specs exist):
 
@@ -123,7 +123,7 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
    `specification names are preserved. You can provide guidance`
    `in the next step.`
 2. Continue "Auth Flow" — in-progress
-3. Refine "Data Model" — concluded
+3. Refine "Data Model" — completed
 
 Select an option (enter number):
 · · · · · · · · · · · ·

--- a/skills/workflow-specification-entry/references/handoffs/continue-completed.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue-completed.md
@@ -1,4 +1,4 @@
-# Handoff: Continue Concluded Specification
+# Handoff: Continue Completed Specification
 
 *Reference for **[confirm-continue.md](../confirm-continue.md)***
 
@@ -30,7 +30,7 @@ This skill's purpose is now fulfilled. Invoke the [technical-specification](../.
 ```
 Specification session for: {Title Case Name}
 
-Continuing existing: .workflows/{work_unit}/specification/{topic}/specification.md (concluded)
+Continuing existing: .workflows/{work_unit}/specification/{topic}/specification.md (completed)
 
 New sources to extract:
 - .workflows/{work_unit}/discussion/{new-discussion-name}.md
@@ -38,7 +38,7 @@ New sources to extract:
 Previously extracted (for reference):
 - .workflows/{work_unit}/discussion/{existing-discussion-name}.md
 
-Context: This specification was previously concluded. New source discussions have been identified. Extract and incorporate their content while maintaining consistency with the existing specification.
+Context: This specification was previously completed. New source discussions have been identified. Extract and incorporate their content while maintaining consistency with the existing specification.
 
 ---
 Invoke the technical-specification skill.

--- a/skills/workflow-specification-entry/references/route-scenario.md
+++ b/skills/workflow-specification-entry/references/route-scenario.md
@@ -6,7 +6,7 @@
 
 Based on discovery state, load exactly ONE reference file:
 
-#### If `concluded_count` == 1
+#### If `completed_count` == 1
 
 → Load **[display-single.md](display-single.md)** and follow its instructions.
 

--- a/skills/workflow-specification-entry/references/validate-phase.md
+++ b/skills/workflow-specification-entry/references/validate-phase.md
@@ -43,7 +43,7 @@ Archive the existing spec.
 
 → Return to **[the skill](../SKILL.md)** with verb="Creating".
 
-#### If specification exists with status `concluded`
+#### If specification exists with status `completed`
 
 Reset to in-progress:
 

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -8,7 +8,7 @@ Check if source material exists and is ready.
 
 #### If `work_type` is `feature`
 
-Check if discussion exists and is concluded. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion --topic {topic} status`.
+Check if discussion exists and is completed. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion --topic {topic} status`.
 
 **If discussion doesn't exist:**
 
@@ -19,7 +19,7 @@ Source Material Missing
 
 No discussion found for "{work_unit:(titlecase)}".
 
-A concluded discussion is required before specification can begin.
+A completed discussion is required before specification can begin.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -31,20 +31,20 @@ A concluded discussion is required before specification can begin.
 ```
 Discussion In Progress
 
-The discussion for "{work_unit:(titlecase)}" is not yet concluded.
+The discussion for "{work_unit:(titlecase)}" is not yet completed.
 
-The discussion must be concluded before specification can begin.
+The discussion must be completed before specification can begin.
 ```
 
 **STOP.** Do not proceed — terminal condition.
 
-**If discussion exists and status is "concluded":**
+**If discussion exists and status is "completed":**
 
 → Return to **[the skill](../SKILL.md)**.
 
 #### If `work_type` is `bugfix`
 
-Check if investigation exists and is concluded. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase investigation --topic {topic} status`.
+Check if investigation exists and is completed. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase investigation --topic {topic} status`.
 
 **If investigation doesn't exist:**
 
@@ -55,7 +55,7 @@ Source Material Missing
 
 No investigation found for "{work_unit:(titlecase)}".
 
-A concluded investigation is required before specification can begin.
+A completed investigation is required before specification can begin.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -67,20 +67,20 @@ A concluded investigation is required before specification can begin.
 ```
 Investigation In Progress
 
-The investigation for "{work_unit:(titlecase)}" is not yet concluded.
+The investigation for "{work_unit:(titlecase)}" is not yet completed.
 
-The investigation must be concluded before specification can begin.
+The investigation must be completed before specification can begin.
 ```
 
 **STOP.** Do not proceed — terminal condition.
 
-**If investigation exists and status is "concluded":**
+**If investigation exists and status is "completed":**
 
 → Return to **[the skill](../SKILL.md)**.
 
 #### If `work_type` is `epic`
 
-Check if at least one concluded discussion exists for this work unit. Read discussion phase items via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion`.
+Check if at least one completed discussion exists for this work unit. Read discussion phase items via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion`.
 
 **If no discussions exist:**
 
@@ -91,26 +91,26 @@ Source Material Missing
 
 No discussions found for "{work_unit:(titlecase)}".
 
-At least one concluded discussion is required before specification can begin.
+At least one completed discussion is required before specification can begin.
 ```
 
 **STOP.** Do not proceed — terminal condition.
 
-**If no concluded discussions exist:**
+**If no completed discussions exist:**
 
 > *Output the next fenced block as a code block:*
 
 ```
-No Concluded Discussions
+No Completed Discussions
 
-No concluded discussions found for "{work_unit:(titlecase)}".
+No completed discussions found for "{work_unit:(titlecase)}".
 
-At least one concluded discussion is required before specification can begin.
+At least one completed discussion is required before specification can begin.
 Run /continue-epic to continue an in-progress discussion.
 ```
 
 **STOP.** Do not proceed — terminal condition.
 
-**If at least one concluded discussion exists:**
+**If at least one completed discussion exists:**
 
 → Return to **[the skill](../SKILL.md)**.

--- a/skills/workflow-specification-entry/scripts/discovery.js
+++ b/skills/workflow-specification-entry/scripts/discovery.js
@@ -13,7 +13,7 @@ function discover(cwd, workUnit) {
 
   // --- Discussions ---
   const discussions = [];
-  let discCount = 0, concludedCount = 0, inProgressCount = 0;
+  let discCount = 0, completedCount = 0, inProgressCount = 0;
 
   for (const m of manifests) {
     const dp = phaseData(m, 'discussion');
@@ -24,7 +24,7 @@ function discover(cwd, workUnit) {
       const items = phaseItems(m, 'discussion');
       for (const item of items) {
         discCount++;
-        if (item.status === 'concluded') concludedCount++;
+        if (item.status === 'completed') completedCount++;
         else if (item.status === 'in-progress') inProgressCount++;
 
         // Check if this discussion has an individual spec via sources
@@ -48,7 +48,7 @@ function discover(cwd, workUnit) {
       }
     } else if (dp.status) {
       discCount++;
-      if (dp.status === 'concluded') concludedCount++;
+      if (dp.status === 'completed') completedCount++;
       else if (dp.status === 'in-progress') inProgressCount++;
 
       let hasIndividualSpec = false;
@@ -192,11 +192,11 @@ function discover(cwd, workUnit) {
     current_state: {
       discussions_checksum: discussionsChecksum,
       discussion_count: discCount,
-      concluded_count: concludedCount,
+      completed_count: completedCount,
       in_progress_count: inProgressCount,
       spec_count: specCount,
       has_discussions: discCount > 0,
-      has_concluded: concludedCount > 0,
+      has_completed: completedCount > 0,
       has_specs: specCount > 0,
     },
   };
@@ -246,8 +246,8 @@ function format(result) {
 
   lines.push('=== STATE ===');
   const cs = result.current_state;
-  lines.push(`discussions: ${cs.discussion_count} (${cs.concluded_count} concluded, ${cs.in_progress_count} in-progress)`);
-  lines.push(`specs: ${cs.spec_count}, has_discussions: ${cs.has_discussions}, has_concluded: ${cs.has_concluded}`);
+  lines.push(`discussions: ${cs.discussion_count} (${cs.completed_count} completed, ${cs.in_progress_count} in-progress)`);
+  lines.push(`specs: ${cs.spec_count}, has_discussions: ${cs.has_discussions}, has_completed: ${cs.has_completed}`);
   if (cs.discussions_checksum) lines.push(`checksum: ${cs.discussions_checksum}`);
 
   return lines.join('\n') + '\n';

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -55,9 +55,9 @@ Parse the output to understand the current workflow state:
 **From `bugfixes` section:**
 - `work_units` — name, next_phase, phase_label
 
-**From `concluded`/`cancelled` arrays:**
+**From `completed`/`cancelled` arrays:**
 - Non-active work units with name, work_type, status, last_phase
-- `concluded_count`, `cancelled_count`
+- `completed_count`, `cancelled_count`
 
 **From `state` section:**
 - Counts for each work type, `has_any_work` flag

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -40,8 +40,8 @@ Epics:
 @endforeach
 @endif
 
-@if(concluded_count > 0 || cancelled_count > 0)
-{concluded_count} concluded, {cancelled_count} cancelled.
+@if(completed_count > 0 || cancelled_count > 0)
+{completed_count} completed, {cancelled_count} cancelled.
 @endif
 ```
 
@@ -65,8 +65,8 @@ What would you like to do?
 5. Start new epic
 6. Start new bugfix
 
-@if(concluded_count > 0 || cancelled_count > 0)
-7. View concluded & cancelled work units
+@if(completed_count > 0 || cancelled_count > 0)
+7. View completed & cancelled work units
 @endif
 - **`m`/`manage`** — Manage a work unit's lifecycle
 
@@ -97,9 +97,9 @@ Invoke the selected skill:
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
 
-#### If user chose "View concluded & cancelled"
+#### If user chose "View completed & cancelled"
 
-→ Load **[view-concluded.md](view-concluded.md)** with no work_type filter (unified across all types). On return, re-run discovery and redisplay from the top of this reference.
+→ Load **[view-completed.md](view-completed.md)** with no work_type filter (unified across all types). On return, re-run discovery and redisplay from the top of this reference.
 
 #### If user chose `m`/`manage`
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -73,7 +73,7 @@ Set `implementation_completed` = true.
 **{selected.name:(titlecase)}** ({selected.work_type})
 
 @if(implementation_completed)
-- **`d`/`done`** — Mark as concluded
+- **`d`/`done`** — Mark as completed
 @endif
 - **`x`/`cancel`** — Mark as cancelled
 - **`b`/`back`** — Return
@@ -86,13 +86,13 @@ Set `implementation_completed` = true.
 #### If user chose `d`/`done`
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status concluded
+node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status completed
 ```
 
 > *Output the next fenced block as a code block:*
 
 ```
-"{selected.name:(titlecase)}" marked as concluded.
+"{selected.name:(titlecase)}" marked as completed.
 ```
 
 → Return to caller to redisplay main view (re-run discovery, re-render from top).

--- a/skills/workflow-start/references/view-completed.md
+++ b/skills/workflow-start/references/view-completed.md
@@ -23,13 +23,13 @@ No completed or cancelled work units found.
 > *Output the next fenced block as a code block:*
 
 ```
-Concluded & Cancelled @if(work_type_filter) {work_type_filter:(titlecase)}s @else Work Units @endif
+Completed & Cancelled @if(work_type_filter) {work_type_filter:(titlecase)}s @else Work Units @endif
 
 @if(completed.length > 0)
-Concluded:
+Completed:
 @foreach(item in completed)
   {N}. {item.name:(titlecase)}
-     └─ Concluded after: {item.last_phase}
+     └─ Completed after: {item.last_phase}
 
 @endforeach
 @endif

--- a/skills/workflow-start/references/view-completed.md
+++ b/skills/workflow-start/references/view-completed.md
@@ -1,19 +1,19 @@
-# View Concluded & Cancelled
+# View Completed & Cancelled
 
 *Reference for **[workflow-start](../SKILL.md)***
 
 ---
 
-Display concluded and cancelled work units. Self-contained — receives context from caller (concluded/cancelled arrays, optional work_type filter).
+Display completed and cancelled work units. Self-contained — receives context from caller (completed/cancelled arrays, optional work_type filter).
 
 ## A. Display List
 
-#### If no concluded or cancelled work units exist
+#### If no completed or cancelled work units exist
 
 > *Output the next fenced block as a code block:*
 
 ```
-No concluded or cancelled work units found.
+No completed or cancelled work units found.
 ```
 
 → Return to caller.
@@ -25,9 +25,9 @@ No concluded or cancelled work units found.
 ```
 Concluded & Cancelled @if(work_type_filter) {work_type_filter:(titlecase)}s @else Work Units @endif
 
-@if(concluded.length > 0)
+@if(completed.length > 0)
 Concluded:
-@foreach(item in concluded)
+@foreach(item in completed)
   {N}. {item.name:(titlecase)}
      └─ Concluded after: {item.last_phase}
 
@@ -44,7 +44,7 @@ Cancelled:
 @endif
 ```
 
-Build from the concluded and cancelled arrays passed by the caller. Numbering is continuous across both sections. Blank line between each numbered item.
+Build from the completed and cancelled arrays passed by the caller. Numbering is continuous across both sections. Blank line between each numbered item.
 
 → Proceed to **B. Select**.
 

--- a/skills/workflow-start/scripts/discovery.js
+++ b/skills/workflow-start/scripts/discovery.js
@@ -11,14 +11,14 @@ function lastCompletedPhase(manifest) {
   if (manifest.work_type === 'epic') {
     for (const phase of ALL_PHASES) {
       const items = phaseItems(manifest, phase);
-      if (items.length > 0 && items.some(i => i.status === 'concluded' || i.status === 'completed')) {
+      if (items.length > 0 && items.some(i => i.status === 'completed')) {
         last = phase;
       }
     }
   } else {
     for (const phase of ALL_PHASES) {
       const s = phaseStatus(manifest, phase);
-      if (s === 'concluded' || s === 'completed') last = phase;
+      if (s === 'completed') last = phase;
     }
   }
   return last;
@@ -59,14 +59,14 @@ function discover(cwd) {
     }
   }
 
-  // Load concluded/cancelled work units across all types
+  // Load completed/cancelled work units across all types
   const allManifests = loadAllManifests(cwd);
-  const concluded = [];
+  const completed = [];
   const cancelled = [];
 
   for (const m of allManifests) {
-    if (m.status === 'concluded') {
-      concluded.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
+    if (m.status === 'completed') {
+      completed.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
     } else if (m.status === 'cancelled') {
       cancelled.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
     }
@@ -76,9 +76,9 @@ function discover(cwd) {
     epics: { work_units: epics, count: epics.length },
     features: { work_units: features, count: features.length },
     bugfixes: { work_units: bugfixes, count: bugfixes.length },
-    concluded,
+    completed,
     cancelled,
-    concluded_count: concluded.length,
+    completed_count: completed.length,
     cancelled_count: cancelled.length,
     state: {
       has_any_work: (epics.length + features.length + bugfixes.length) > 0,

--- a/tests/scripts/test-discovery-for-bridge.js
+++ b/tests/scripts/test-discovery-for-bridge.js
@@ -18,19 +18,19 @@ describe('workflow-bridge discovery', () => {
   it('returns basic feature state', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     const r = discover(dir, 'auth');
     assert.strictEqual(r.work_unit, 'auth');
     assert.strictEqual(r.work_type, 'feature');
     assert.strictEqual(r.next_phase, 'specification');
-    assert.strictEqual(r.phases.discussion.status, 'concluded');
+    assert.strictEqual(r.phases.discussion.status, 'completed');
   });
 
   it('detects file existence', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     createFile(dir, '.workflows/auth/discussion/auth.md', '# Discussion');
     const r = discover(dir, 'auth');
@@ -42,9 +42,9 @@ describe('workflow-bridge discovery', () => {
     createManifest(dir, 'done', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
-        specification: { status: 'concluded' },
-        planning: { status: 'concluded' },
+        discussion: { status: 'completed' },
+        specification: { status: 'completed' },
+        planning: { status: 'completed' },
         implementation: { status: 'completed' },
         review: { status: 'completed' },
       },
@@ -59,7 +59,7 @@ describe('workflow-bridge discovery', () => {
       phases: {
         discussion: {
           status: 'in-progress',
-          items: { 'auth-design': { status: 'concluded' }, 'data-model': { status: 'in-progress' } },
+          items: { 'auth-design': { status: 'completed' }, 'data-model': { status: 'in-progress' } },
         },
       },
     });
@@ -71,7 +71,7 @@ describe('workflow-bridge discovery', () => {
   it('computes bugfix pipeline correctly', () => {
     createManifest(dir, 'crash', {
       work_type: 'bugfix',
-      phases: { investigation: { status: 'concluded' } },
+      phases: { investigation: { status: 'completed' } },
     });
     const r = discover(dir, 'crash');
     assert.strictEqual(r.next_phase, 'specification');
@@ -81,9 +81,9 @@ describe('workflow-bridge discovery', () => {
     createManifest(dir, 'full', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
-        specification: { status: 'concluded' },
-        planning: { status: 'concluded' },
+        discussion: { status: 'completed' },
+        specification: { status: 'completed' },
+        planning: { status: 'completed' },
         implementation: { status: 'completed' },
         review: { status: 'completed' },
       },
@@ -144,7 +144,7 @@ describe('workflow-bridge discovery', () => {
       phases: {
         research: {
           items: {
-            'exploration': { status: 'concluded' },
+            'exploration': { status: 'completed' },
             'architecture': { status: 'in-progress' },
           },
         },

--- a/tests/scripts/test-discovery-for-continue-bugfix.js
+++ b/tests/scripts/test-discovery-for-continue-bugfix.js
@@ -19,7 +19,7 @@ describe('continue-bugfix discovery', () => {
 
   it('lists active bugfixes only', () => {
     createManifest(dir, 'crash', { work_type: 'bugfix', phases: { investigation: { status: 'in-progress' } } });
-    createManifest(dir, 'old', { work_type: 'bugfix', status: 'concluded' });
+    createManifest(dir, 'old', { work_type: 'bugfix', status: 'completed' });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
     assert.strictEqual(r.bugfixes[0].name, 'crash');
@@ -36,9 +36,9 @@ describe('continue-bugfix discovery', () => {
     createManifest(dir, 'done', {
       work_type: 'bugfix',
       phases: {
-        investigation: { status: 'concluded' },
-        specification: { status: 'concluded' },
-        planning: { status: 'concluded' },
+        investigation: { status: 'completed' },
+        specification: { status: 'completed' },
+        planning: { status: 'completed' },
         implementation: { status: 'completed' },
         review: { status: 'completed' },
       },
@@ -47,16 +47,16 @@ describe('continue-bugfix discovery', () => {
     assert.strictEqual(r.count, 0);
   });
 
-  it('includes concluded_phases', () => {
+  it('includes completed_phases', () => {
     createManifest(dir, 'crash', {
       work_type: 'bugfix',
       phases: {
-        investigation: { status: 'concluded' },
+        investigation: { status: 'completed' },
         specification: { status: 'in-progress' },
       },
     });
     const r = discover(dir);
-    assert.deepStrictEqual(r.bugfixes[0].concluded_phases, ['investigation']);
+    assert.deepStrictEqual(r.bugfixes[0].completed_phases, ['investigation']);
   });
 
   it('returns summary with count', () => {
@@ -66,18 +66,18 @@ describe('continue-bugfix discovery', () => {
     assert.strictEqual(r.summary, '2 active bugfix(es)');
   });
 
-  it('includes concluded bugfixes in separate array', () => {
-    createManifest(dir, 'done', { work_type: 'bugfix', status: 'concluded', phases: { review: { status: 'completed' } } });
+  it('includes completed bugfixes in separate array', () => {
+    createManifest(dir, 'done', { work_type: 'bugfix', status: 'completed', phases: { review: { status: 'completed' } } });
     createManifest(dir, 'active', { work_type: 'bugfix', phases: { investigation: { status: 'in-progress' } } });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
-    assert.strictEqual(r.concluded_count, 1);
-    assert.strictEqual(r.concluded[0].name, 'done');
-    assert.strictEqual(r.concluded[0].last_phase, 'review');
+    assert.strictEqual(r.completed_count, 1);
+    assert.strictEqual(r.completed[0].name, 'done');
+    assert.strictEqual(r.completed[0].last_phase, 'review');
   });
 
   it('includes cancelled bugfixes in separate array', () => {
-    createManifest(dir, 'stopped', { work_type: 'bugfix', status: 'cancelled', phases: { investigation: { status: 'concluded' } } });
+    createManifest(dir, 'stopped', { work_type: 'bugfix', status: 'cancelled', phases: { investigation: { status: 'completed' } } });
     const r = discover(dir);
     assert.strictEqual(r.cancelled_count, 1);
     assert.strictEqual(r.cancelled[0].name, 'stopped');
@@ -85,28 +85,28 @@ describe('continue-bugfix discovery', () => {
   });
 
   describe('edge cases', () => {
-    it('recognizes completed as concluded in concluded_phases', () => {
+    it('recognizes completed as completed in completed_phases', () => {
       createManifest(dir, 'crash', {
         work_type: 'bugfix',
         phases: {
-          investigation: { status: 'concluded' },
-          specification: { status: 'concluded' },
-          planning: { status: 'concluded' },
+          investigation: { status: 'completed' },
+          specification: { status: 'completed' },
+          planning: { status: 'completed' },
           implementation: { status: 'completed' },
           review: { status: 'in-progress' },
         },
       });
       const r = discover(dir);
-      assert.ok(r.bugfixes[0].concluded_phases.includes('implementation'));
+      assert.ok(r.bugfixes[0].completed_phases.includes('implementation'));
     });
 
     it('bugfix in review in-progress is listed (not filtered as done)', () => {
       createManifest(dir, 'crash', {
         work_type: 'bugfix',
         phases: {
-          investigation: { status: 'concluded' },
-          specification: { status: 'concluded' },
-          planning: { status: 'concluded' },
+          investigation: { status: 'completed' },
+          specification: { status: 'completed' },
+          planning: { status: 'completed' },
           implementation: { status: 'completed' },
           review: { status: 'in-progress' },
         },
@@ -116,16 +116,16 @@ describe('continue-bugfix discovery', () => {
       assert.strictEqual(r.bugfixes[0].next_phase, 'review');
     });
 
-    it('research is not in bugfix concluded_phases even if present', () => {
+    it('research is not in bugfix completed_phases even if present', () => {
       createManifest(dir, 'crash', {
         work_type: 'bugfix',
         phases: {
-          research: { status: 'concluded' },
+          research: { status: 'completed' },
           investigation: { status: 'in-progress' },
         },
       });
       const r = discover(dir);
-      assert.ok(!r.bugfixes[0].concluded_phases.includes('research'));
+      assert.ok(!r.bugfixes[0].completed_phases.includes('research'));
     });
   });
 });

--- a/tests/scripts/test-discovery-for-continue-epic.js
+++ b/tests/scripts/test-discovery-for-continue-epic.js
@@ -22,7 +22,7 @@ describe('continue-epic discovery', () => {
       work_type: 'epic',
       phases: { discussion: { items: { auth: { status: 'in-progress' } } } },
     });
-    createManifest(dir, 'old', { work_type: 'epic', status: 'concluded' });
+    createManifest(dir, 'old', { work_type: 'epic', status: 'completed' });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
     assert.strictEqual(r.epics[0].name, 'v1');
@@ -39,7 +39,7 @@ describe('continue-epic discovery', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
       phases: {
-        research: { items: { exploration: { status: 'concluded' } } },
+        research: { items: { exploration: { status: 'completed' } } },
         discussion: { items: { auth: { status: 'in-progress' } } },
         specification: { items: { auth: { status: 'in-progress' } } },
       },
@@ -55,28 +55,28 @@ describe('continue-epic discovery', () => {
     assert.strictEqual(r.summary, '2 active epic(s)');
   });
 
-  it('includes concluded epics in list mode', () => {
-    createManifest(dir, 'done', { work_type: 'epic', status: 'concluded', phases: { review: { items: { auth: { status: 'completed' } } } } });
+  it('includes completed epics in list mode', () => {
+    createManifest(dir, 'done', { work_type: 'epic', status: 'completed', phases: { review: { items: { auth: { status: 'completed' } } } } });
     createManifest(dir, 'active', { work_type: 'epic', phases: { discussion: { items: { auth: { status: 'in-progress' } } } } });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
-    assert.strictEqual(r.concluded_count, 1);
-    assert.strictEqual(r.concluded[0].name, 'done');
-    assert.strictEqual(r.concluded[0].last_phase, 'review');
+    assert.strictEqual(r.completed_count, 1);
+    assert.strictEqual(r.completed[0].name, 'done');
+    assert.strictEqual(r.completed[0].last_phase, 'review');
   });
 
   it('includes cancelled epics in list mode', () => {
-    createManifest(dir, 'stopped', { work_type: 'epic', status: 'cancelled', phases: { discussion: { items: { auth: { status: 'concluded' } } } } });
+    createManifest(dir, 'stopped', { work_type: 'epic', status: 'cancelled', phases: { discussion: { items: { auth: { status: 'completed' } } } } });
     const r = discover(dir);
     assert.strictEqual(r.cancelled_count, 1);
     assert.strictEqual(r.cancelled[0].name, 'stopped');
   });
 
-  it('does not include concluded/cancelled in detail mode', () => {
-    createManifest(dir, 'done', { work_type: 'epic', status: 'concluded' });
+  it('does not include completed/cancelled in detail mode', () => {
+    createManifest(dir, 'done', { work_type: 'epic', status: 'completed' });
     const r = discover(dir, 'done');
     assert.strictEqual(r.count, 0);
-    assert.strictEqual(r.concluded.length, 0);
+    assert.strictEqual(r.completed.length, 0);
   });
 
   describe('epic detail', () => {
@@ -86,7 +86,7 @@ describe('continue-epic discovery', () => {
         phases: {
           discussion: {
             items: {
-              auth: { status: 'concluded' },
+              auth: { status: 'completed' },
               payments: { status: 'in-progress' },
             },
           },
@@ -112,17 +112,17 @@ describe('continue-epic discovery', () => {
       assert.strictEqual(d.in_progress[0].phase, 'discussion');
     });
 
-    it('tracks concluded items', () => {
+    it('tracks completed items', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          discussion: { items: { auth: { status: 'concluded' } } },
+          discussion: { items: { auth: { status: 'completed' } } },
         },
       });
       const r = discover(dir);
       const d = r.epics[0].detail;
-      assert.strictEqual(d.concluded.length, 1);
-      assert.strictEqual(d.concluded[0].name, 'auth');
+      assert.strictEqual(d.completed.length, 1);
+      assert.strictEqual(d.completed[0].name, 'auth');
     });
 
     it('detects unaccounted discussions', () => {
@@ -131,8 +131,8 @@ describe('continue-epic discovery', () => {
         phases: {
           discussion: {
             items: {
-              auth: { status: 'concluded' },
-              payments: { status: 'concluded' },
+              auth: { status: 'completed' },
+              payments: { status: 'completed' },
             },
           },
           specification: {
@@ -172,11 +172,11 @@ describe('continue-epic discovery', () => {
       assert.deepStrictEqual(r.epics[0].detail.reopened_discussions, ['auth']);
     });
 
-    it('computes next-phase-ready: spec concluded no plan', () => {
+    it('computes next-phase-ready: spec completed no plan', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          specification: { items: { auth: { status: 'concluded' } } },
+          specification: { items: { auth: { status: 'completed' } } },
         },
       });
       const r = discover(dir);
@@ -185,11 +185,11 @@ describe('continue-epic discovery', () => {
       assert.strictEqual(d.next_phase_ready[0].action, 'start_planning');
     });
 
-    it('computes next-phase-ready: plan concluded no impl', () => {
+    it('computes next-phase-ready: plan completed no impl', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          planning: { items: { auth: { status: 'concluded' } } },
+          planning: { items: { auth: { status: 'completed' } } },
         },
       });
       const r = discover(dir);
@@ -211,7 +211,7 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          specification: { items: { auth: { status: 'concluded' } } },
+          specification: { items: { auth: { status: 'completed' } } },
           planning: { items: { auth: { status: 'in-progress' } } },
         },
       });
@@ -223,10 +223,10 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          research: { items: { 'market-analysis': { status: 'concluded' } } },
-          discussion: { items: { auth: { status: 'concluded' } } },
-          specification: { items: { auth: { status: 'concluded' } } },
-          planning: { items: { auth: { status: 'concluded' } } },
+          research: { items: { 'market-analysis': { status: 'completed' } } },
+          discussion: { items: { auth: { status: 'completed' } } },
+          specification: { items: { auth: { status: 'completed' } } },
+          planning: { items: { auth: { status: 'completed' } } },
           implementation: { items: { auth: { status: 'completed' } } },
         },
       });
@@ -240,7 +240,7 @@ describe('continue-epic discovery', () => {
       assert.strictEqual(g.can_start_review, true);
     });
 
-    it('gating is false when no concluded items', () => {
+    it('gating is false when no completed items', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
@@ -260,7 +260,7 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          discussion: { items: { auth: { status: 'concluded' } } },
+          discussion: { items: { auth: { status: 'completed' } } },
         },
       });
       const r = discover(dir);
@@ -298,7 +298,7 @@ describe('continue-epic discovery', () => {
       const d = r.epics[0].detail;
       assert.deepStrictEqual(d.phases, {});
       assert.strictEqual(d.in_progress.length, 0);
-      assert.strictEqual(d.concluded.length, 0);
+      assert.strictEqual(d.completed.length, 0);
     });
   });
 
@@ -307,7 +307,7 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          discussion: { items: { auth: { status: 'concluded' } } },
+          discussion: { items: { auth: { status: 'completed' } } },
           specification: {
             items: {
               'auth-spec': {
@@ -326,7 +326,7 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          discussion: { items: { auth: { status: 'concluded' } } },
+          discussion: { items: { auth: { status: 'completed' } } },
           specification: {
             items: {
               'auth-spec': { status: 'in-progress', sources: [] },
@@ -342,7 +342,7 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          discussion: { items: { auth: { status: 'concluded' } } },
+          discussion: { items: { auth: { status: 'completed' } } },
           specification: {
             items: {
               'auth-spec': { status: 'in-progress' },
@@ -360,13 +360,13 @@ describe('continue-epic discovery', () => {
         phases: {
           specification: {
             items: {
-              auth: { status: 'concluded' },
-              billing: { status: 'concluded' },
+              auth: { status: 'completed' },
+              billing: { status: 'completed' },
             },
           },
           planning: {
             items: {
-              payments: { status: 'concluded' },
+              payments: { status: 'completed' },
             },
           },
           implementation: {
@@ -389,8 +389,8 @@ describe('continue-epic discovery', () => {
         phases: {
           discussion: {
             items: {
-              auth: { status: 'concluded' },
-              billing: { status: 'concluded' },
+              auth: { status: 'completed' },
+              billing: { status: 'completed' },
             },
           },
           specification: {
@@ -416,7 +416,7 @@ describe('continue-epic discovery', () => {
       assert.strictEqual(g.can_start_review, false);
     });
 
-    it('concluded discussion that is in-progress is not both reopened and unaccounted', () => {
+    it('completed discussion that is in-progress is not both reopened and unaccounted', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
@@ -488,8 +488,8 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
-          discussion: { items: { auth: { status: 'concluded' } } },
-          specification: { items: { auth: { status: 'concluded' } } },
+          discussion: { items: { auth: { status: 'completed' } } },
+          specification: { items: { auth: { status: 'completed' } } },
         },
       });
       createManifest(dir, 'v2', {
@@ -499,7 +499,7 @@ describe('continue-epic discovery', () => {
       const r = discover(dir, 'v1');
       assert.strictEqual(r.count, 1);
       const d = r.epics[0].detail;
-      assert.strictEqual(d.concluded.length, 2);
+      assert.strictEqual(d.completed.length, 2);
       assert.strictEqual(d.gating.can_start_specification, true);
       assert.strictEqual(d.gating.can_start_planning, true);
     });

--- a/tests/scripts/test-discovery-for-continue-feature.js
+++ b/tests/scripts/test-discovery-for-continue-feature.js
@@ -19,7 +19,7 @@ describe('continue-feature discovery', () => {
 
   it('lists active features only', () => {
     createManifest(dir, 'auth', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
-    createManifest(dir, 'old', { work_type: 'feature', status: 'concluded' });
+    createManifest(dir, 'old', { work_type: 'feature', status: 'completed' });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
     assert.strictEqual(r.features[0].name, 'auth');
@@ -38,9 +38,9 @@ describe('continue-feature discovery', () => {
     createManifest(dir, 'done', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
-        specification: { status: 'concluded' },
-        planning: { status: 'concluded' },
+        discussion: { status: 'completed' },
+        specification: { status: 'completed' },
+        planning: { status: 'completed' },
         implementation: { status: 'completed' },
         review: { status: 'completed' },
       },
@@ -49,31 +49,31 @@ describe('continue-feature discovery', () => {
     assert.strictEqual(r.count, 0);
   });
 
-  it('includes phase_label and concluded_phases', () => {
+  it('includes phase_label and completed_phases', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
+        discussion: { status: 'completed' },
         specification: { status: 'in-progress' },
       },
     });
     const r = discover(dir);
     assert.strictEqual(r.features[0].phase_label, 'specification (in-progress)');
-    assert.deepStrictEqual(r.features[0].concluded_phases, ['discussion']);
+    assert.deepStrictEqual(r.features[0].completed_phases, ['discussion']);
   });
 
-  it('returns multiple concluded phases', () => {
+  it('returns multiple completed phases', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        research: { status: 'concluded' },
-        discussion: { status: 'concluded' },
-        specification: { status: 'concluded' },
+        research: { status: 'completed' },
+        discussion: { status: 'completed' },
+        specification: { status: 'completed' },
         planning: { status: 'in-progress' },
       },
     });
     const r = discover(dir);
-    assert.deepStrictEqual(r.features[0].concluded_phases, ['research', 'discussion', 'specification']);
+    assert.deepStrictEqual(r.features[0].completed_phases, ['research', 'discussion', 'specification']);
   });
 
   it('returns summary with count', () => {
@@ -83,53 +83,53 @@ describe('continue-feature discovery', () => {
     assert.strictEqual(r.summary, '2 active feature(s)');
   });
 
-  it('includes concluded features in separate array', () => {
-    createManifest(dir, 'done', { work_type: 'feature', status: 'concluded', phases: { review: { status: 'completed' } } });
+  it('includes completed features in separate array', () => {
+    createManifest(dir, 'done', { work_type: 'feature', status: 'completed', phases: { review: { status: 'completed' } } });
     createManifest(dir, 'active', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
     const r = discover(dir);
     assert.strictEqual(r.count, 1);
-    assert.strictEqual(r.concluded_count, 1);
-    assert.strictEqual(r.concluded[0].name, 'done');
-    assert.strictEqual(r.concluded[0].last_phase, 'review');
+    assert.strictEqual(r.completed_count, 1);
+    assert.strictEqual(r.completed[0].name, 'done');
+    assert.strictEqual(r.completed[0].last_phase, 'review');
   });
 
   it('includes cancelled features in separate array', () => {
-    createManifest(dir, 'stopped', { work_type: 'feature', status: 'cancelled', phases: { specification: { status: 'concluded' } } });
+    createManifest(dir, 'stopped', { work_type: 'feature', status: 'cancelled', phases: { specification: { status: 'completed' } } });
     const r = discover(dir);
     assert.strictEqual(r.cancelled_count, 1);
     assert.strictEqual(r.cancelled[0].name, 'stopped');
     assert.strictEqual(r.cancelled[0].last_phase, 'specification');
   });
 
-  it('excludes non-feature concluded work units', () => {
-    createManifest(dir, 'done-bug', { work_type: 'bugfix', status: 'concluded', phases: { review: { status: 'completed' } } });
+  it('excludes non-feature completed work units', () => {
+    createManifest(dir, 'done-bug', { work_type: 'bugfix', status: 'completed', phases: { review: { status: 'completed' } } });
     const r = discover(dir);
-    assert.strictEqual(r.concluded_count, 0);
+    assert.strictEqual(r.completed_count, 0);
   });
 
   describe('edge cases', () => {
-    it('recognizes completed as concluded in concluded_phases', () => {
+    it('recognizes completed as completed in completed_phases', () => {
       createManifest(dir, 'auth', {
         work_type: 'feature',
         phases: {
-          discussion: { status: 'concluded' },
-          specification: { status: 'concluded' },
-          planning: { status: 'concluded' },
+          discussion: { status: 'completed' },
+          specification: { status: 'completed' },
+          planning: { status: 'completed' },
           implementation: { status: 'completed' },
           review: { status: 'in-progress' },
         },
       });
       const r = discover(dir);
-      assert.ok(r.features[0].concluded_phases.includes('implementation'));
+      assert.ok(r.features[0].completed_phases.includes('implementation'));
     });
 
     it('feature in review in-progress is listed (not filtered as done)', () => {
       createManifest(dir, 'auth', {
         work_type: 'feature',
         phases: {
-          discussion: { status: 'concluded' },
-          specification: { status: 'concluded' },
-          planning: { status: 'concluded' },
+          discussion: { status: 'completed' },
+          specification: { status: 'completed' },
+          planning: { status: 'completed' },
           implementation: { status: 'completed' },
           review: { status: 'in-progress' },
         },
@@ -139,13 +139,13 @@ describe('continue-feature discovery', () => {
       assert.strictEqual(r.features[0].next_phase, 'review');
     });
 
-    it('feature with only research concluded has it in concluded_phases', () => {
+    it('feature with only research completed has it in completed_phases', () => {
       createManifest(dir, 'auth', {
         work_type: 'feature',
-        phases: { research: { status: 'concluded' } },
+        phases: { research: { status: 'completed' } },
       });
       const r = discover(dir);
-      assert.deepStrictEqual(r.features[0].concluded_phases, ['research']);
+      assert.deepStrictEqual(r.features[0].completed_phases, ['research']);
     });
   });
 });

--- a/tests/scripts/test-discovery-for-discussion.js
+++ b/tests/scripts/test-discovery-for-discussion.js
@@ -20,7 +20,7 @@ describe('workflow-discussion-entry discovery', () => {
   it('detects research files', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
-      phases: { research: { status: 'concluded' } },
+      phases: { research: { status: 'completed' } },
     });
     createFile(dir, '.workflows/v1/research/market-analysis.md', '# Market Analysis');
     const r = discover(dir);
@@ -51,7 +51,7 @@ describe('workflow-discussion-entry discovery', () => {
         discussion: {
           status: 'in-progress',
           items: {
-            'auth-design': { status: 'concluded' },
+            'auth-design': { status: 'completed' },
             'data-model': { status: 'in-progress' },
           },
         },
@@ -59,7 +59,7 @@ describe('workflow-discussion-entry discovery', () => {
     });
     const r = discover(dir);
     assert.strictEqual(r.discussions.files.length, 2);
-    assert.strictEqual(r.discussions.counts.concluded, 1);
+    assert.strictEqual(r.discussions.counts.completed, 1);
     assert.strictEqual(r.discussions.counts.in_progress, 1);
   });
 
@@ -67,7 +67,7 @@ describe('workflow-discussion-entry discovery', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
       phases: {
-        research: { status: 'concluded' },
+        research: { status: 'completed' },
         discussion: { status: 'in-progress' },
       },
     });
@@ -86,7 +86,7 @@ describe('workflow-discussion-entry discovery', () => {
       work_type: 'epic',
       phases: {
         research: {
-          status: 'concluded',
+          status: 'completed',
           analysis_cache: { checksum, generated: '2026-01-01', files: ['notes.md'] },
         },
       },
@@ -103,7 +103,7 @@ describe('workflow-discussion-entry discovery', () => {
       work_type: 'epic',
       phases: {
         research: {
-          status: 'concluded',
+          status: 'completed',
           analysis_cache: { checksum: 'old-checksum', generated: '2026-01-01', files: ['notes.md'] },
         },
       },
@@ -139,7 +139,7 @@ describe('workflow-discussion-entry discovery', () => {
       work_type: 'epic',
       phases: {
         research: {
-          status: 'concluded',
+          status: 'completed',
           analysis_cache: { checksum, generated: '2026-01-01', files: ['notes.md'] },
         },
       },
@@ -152,7 +152,7 @@ describe('workflow-discussion-entry discovery', () => {
   });
 
   it('computes research checksum', () => {
-    createManifest(dir, 'v1', { work_type: 'epic', phases: { research: { status: 'concluded' } } });
+    createManifest(dir, 'v1', { work_type: 'epic', phases: { research: { status: 'completed' } } });
     createFile(dir, '.workflows/v1/research/a.md', 'content a');
     createFile(dir, '.workflows/v1/research/b.md', 'content b');
     const r = discover(dir);

--- a/tests/scripts/test-discovery-for-specification.js
+++ b/tests/scripts/test-discovery-for-specification.js
@@ -22,7 +22,7 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
+        discussion: { status: 'completed' },
         specification: { status: 'in-progress' },
       },
     });
@@ -30,16 +30,16 @@ describe('workflow-specification-entry discovery', () => {
     assert.strictEqual(r.discussions.length, 1);
     assert.strictEqual(r.discussions[0].has_individual_spec, true);
     assert.strictEqual(r.discussions[0].spec_status, 'in-progress');
-    assert.strictEqual(r.current_state.concluded_count, 1);
+    assert.strictEqual(r.current_state.completed_count, 1);
   });
 
   it('finds specifications with sources', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
+        discussion: { status: 'completed' },
         specification: {
-          status: 'concluded',
+          status: 'completed',
           type: 'feature',
           sources: { 'auth': { status: 'incorporated' } },
         },
@@ -48,10 +48,10 @@ describe('workflow-specification-entry discovery', () => {
     createFile(dir, '.workflows/auth/specification/auth/specification.md', '# Spec');
     const r = discover(dir);
     assert.strictEqual(r.specifications.length, 1);
-    assert.strictEqual(r.specifications[0].status, 'concluded');
+    assert.strictEqual(r.specifications[0].status, 'completed');
     assert.strictEqual(r.specifications[0].sources.length, 1);
     assert.strictEqual(r.specifications[0].sources[0].name, 'auth');
-    assert.strictEqual(r.specifications[0].sources[0].discussion_status, 'concluded');
+    assert.strictEqual(r.specifications[0].sources[0].discussion_status, 'completed');
   });
 
   it('skips superseded specifications', () => {
@@ -73,7 +73,7 @@ describe('workflow-specification-entry discovery', () => {
         discussion: {
           status: 'in-progress',
           items: {
-            'auth-design': { status: 'concluded' },
+            'auth-design': { status: 'completed' },
             'data-model': { status: 'in-progress' },
           },
         },
@@ -101,14 +101,14 @@ describe('workflow-specification-entry discovery', () => {
       phases: {
         discussion: {
           items: {
-            'auth-design': { status: 'concluded' },
-            'data-model': { status: 'concluded' },
+            'auth-design': { status: 'completed' },
+            'data-model': { status: 'completed' },
           },
         },
         specification: {
           items: {
             'auth-spec': {
-              status: 'concluded',
+              status: 'completed',
               type: 'feature',
               sources: { 'auth-design': { status: 'incorporated' } },
             },
@@ -126,11 +126,11 @@ describe('workflow-specification-entry discovery', () => {
     assert.strictEqual(r.specifications.length, 2);
     const authSpec = r.specifications.find(s => s.name === 'auth-spec');
     assert.strictEqual(authSpec.work_unit, 'v1');
-    assert.strictEqual(authSpec.status, 'concluded');
+    assert.strictEqual(authSpec.status, 'completed');
     assert.strictEqual(authSpec.work_type, 'epic');
     assert.strictEqual(authSpec.sources.length, 1);
     assert.strictEqual(authSpec.sources[0].name, 'auth-design');
-    assert.strictEqual(authSpec.sources[0].discussion_status, 'concluded');
+    assert.strictEqual(authSpec.sources[0].discussion_status, 'completed');
     const dataSpec = r.specifications.find(s => s.name === 'data-spec');
     assert.strictEqual(dataSpec.status, 'in-progress');
   });
@@ -157,7 +157,7 @@ describe('workflow-specification-entry discovery', () => {
   it('computes discussion counts correctly', () => {
     createManifest(dir, 'a', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     createManifest(dir, 'b', {
       work_type: 'feature',
@@ -165,11 +165,11 @@ describe('workflow-specification-entry discovery', () => {
     });
     createManifest(dir, 'c', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     const r = discover(dir);
     assert.strictEqual(r.current_state.discussion_count, 3);
-    assert.strictEqual(r.current_state.concluded_count, 2);
+    assert.strictEqual(r.current_state.completed_count, 2);
     assert.strictEqual(r.current_state.in_progress_count, 1);
   });
 
@@ -180,7 +180,7 @@ describe('workflow-specification-entry discovery', () => {
       work_type: 'feature',
       phases: {
         discussion: {
-          status: 'concluded',
+          status: 'completed',
           analysis_cache: { checksum: null, generated: '2026-01-01' },
         },
       },
@@ -194,7 +194,7 @@ describe('workflow-specification-entry discovery', () => {
       work_type: 'feature',
       phases: {
         discussion: {
-          status: 'concluded',
+          status: 'completed',
           analysis_cache: { checksum, generated: '2026-01-01' },
         },
       },
@@ -219,7 +219,7 @@ describe('workflow-specification-entry discovery', () => {
   it('computes discussions checksum', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     createFile(dir, '.workflows/auth/discussion/auth.md', '# Auth discussion');
     const r = discover(dir);
@@ -229,7 +229,7 @@ describe('workflow-specification-entry discovery', () => {
   it('returns null checksum when no discussion files', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     const r = discover(dir);
     assert.strictEqual(r.current_state.discussions_checksum, null);
@@ -251,7 +251,7 @@ describe('workflow-specification-entry discovery', () => {
   it('feature without spec shows has_individual_spec false', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     const r = discover(dir);
     assert.strictEqual(r.discussions[0].has_individual_spec, false);
@@ -261,7 +261,7 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
+        discussion: { status: 'completed' },
         specification: { status: 'in-progress' },
       },
     });
@@ -276,7 +276,7 @@ describe('workflow-specification-entry discovery', () => {
       work_type: 'feature',
       phases: {
         discussion: {
-          status: 'concluded',
+          status: 'completed',
           analysis_cache: { checksum: 'stale-hash', generated: '2026-01-01' },
         },
       },
@@ -290,7 +290,7 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'login-crash', {
       work_type: 'bugfix',
       phases: {
-        investigation: { status: 'concluded' },
+        investigation: { status: 'completed' },
         specification: { status: 'in-progress' },
       },
     });

--- a/tests/scripts/test-discovery-for-start.js
+++ b/tests/scripts/test-discovery-for-start.js
@@ -35,7 +35,7 @@ describe('workflow-start discovery', () => {
   it('computes next_phase for feature pipeline', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     const r = discover(dir);
     assert.strictEqual(r.features.work_units[0].next_phase, 'specification');
@@ -56,9 +56,9 @@ describe('workflow-start discovery', () => {
     createManifest(dir, 'done-feature', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
-        specification: { status: 'concluded' },
-        planning: { status: 'concluded' },
+        discussion: { status: 'completed' },
+        specification: { status: 'completed' },
+        planning: { status: 'completed' },
         implementation: { status: 'completed' },
         review: { status: 'completed' },
       },
@@ -69,7 +69,7 @@ describe('workflow-start discovery', () => {
   });
 
   it('skips archived work units', () => {
-    createManifest(dir, 'old', { work_type: 'feature', status: 'concluded' });
+    createManifest(dir, 'old', { work_type: 'feature', status: 'completed' });
     createManifest(dir, 'active', { work_type: 'feature' });
     const r = discover(dir);
     assert.strictEqual(r.state.feature_count, 1);
@@ -78,7 +78,7 @@ describe('workflow-start discovery', () => {
 
   it('handles multiple features', () => {
     createManifest(dir, 'a', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
-    createManifest(dir, 'b', { work_type: 'feature', phases: { specification: { status: 'concluded' } } });
+    createManifest(dir, 'b', { work_type: 'feature', phases: { specification: { status: 'completed' } } });
     const r = discover(dir);
     assert.strictEqual(r.state.feature_count, 2);
     assert.strictEqual(r.features.work_units.length, 2);
@@ -88,7 +88,7 @@ describe('workflow-start discovery', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
       phases: {
-        research: { items: { exploration: { status: 'concluded' } } },
+        research: { items: { exploration: { status: 'completed' } } },
         discussion: { items: { auth: { status: 'in-progress' } } },
         specification: { items: { auth: { status: 'in-progress' } } },
       },
@@ -110,7 +110,7 @@ describe('workflow-start discovery', () => {
     });
     createManifest(dir, 'crash', {
       work_type: 'bugfix',
-      phases: { investigation: { status: 'concluded' } },
+      phases: { investigation: { status: 'completed' } },
     });
     const r = discover(dir);
     assert.strictEqual(r.features.work_units[0].phase_label, 'discussion (in-progress)');
@@ -125,9 +125,9 @@ describe('workflow-start discovery', () => {
     createManifest(dir, 'done-feat', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
-        specification: { status: 'concluded' },
-        planning: { status: 'concluded' },
+        discussion: { status: 'completed' },
+        specification: { status: 'completed' },
+        planning: { status: 'completed' },
         implementation: { status: 'completed' },
         review: { status: 'completed' },
       },
@@ -137,14 +137,14 @@ describe('workflow-start discovery', () => {
     assert.strictEqual(r.features.work_units[0].name, 'active-feat');
   });
 
-  it('has_any_work is false when only concluded and done exist', () => {
-    createManifest(dir, 'archived', { work_type: 'feature', status: 'concluded' });
+  it('has_any_work is false when only completed and done exist', () => {
+    createManifest(dir, 'archived', { work_type: 'feature', status: 'completed' });
     createManifest(dir, 'done', {
       work_type: 'bugfix',
       phases: {
-        investigation: { status: 'concluded' },
-        specification: { status: 'concluded' },
-        planning: { status: 'concluded' },
+        investigation: { status: 'completed' },
+        specification: { status: 'completed' },
+        planning: { status: 'completed' },
         implementation: { status: 'completed' },
         review: { status: 'completed' },
       },
@@ -162,28 +162,28 @@ describe('workflow-start discovery', () => {
     assert.deepStrictEqual(r.epics.work_units[0].active_phases, ['research']);
   });
 
-  it('includes concluded work units in separate array', () => {
-    createManifest(dir, 'done-feat', { work_type: 'feature', status: 'concluded', phases: { review: { status: 'completed' } } });
+  it('includes completed work units in separate array', () => {
+    createManifest(dir, 'done-feat', { work_type: 'feature', status: 'completed', phases: { review: { status: 'completed' } } });
     createManifest(dir, 'active-feat', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
     const r = discover(dir);
-    assert.strictEqual(r.concluded_count, 1);
-    assert.strictEqual(r.concluded[0].name, 'done-feat');
-    assert.strictEqual(r.concluded[0].work_type, 'feature');
-    assert.strictEqual(r.concluded[0].last_phase, 'review');
+    assert.strictEqual(r.completed_count, 1);
+    assert.strictEqual(r.completed[0].name, 'done-feat');
+    assert.strictEqual(r.completed[0].work_type, 'feature');
+    assert.strictEqual(r.completed[0].last_phase, 'review');
   });
 
   it('includes cancelled work units in separate array', () => {
-    createManifest(dir, 'cancelled-bug', { work_type: 'bugfix', status: 'cancelled', phases: { investigation: { status: 'concluded' } } });
+    createManifest(dir, 'cancelled-bug', { work_type: 'bugfix', status: 'cancelled', phases: { investigation: { status: 'completed' } } });
     const r = discover(dir);
     assert.strictEqual(r.cancelled_count, 1);
     assert.strictEqual(r.cancelled[0].name, 'cancelled-bug');
     assert.strictEqual(r.cancelled[0].last_phase, 'investigation');
   });
 
-  it('concluded and cancelled counts are zero when none exist', () => {
+  it('completed and cancelled counts are zero when none exist', () => {
     createManifest(dir, 'active', { work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
     const r = discover(dir);
-    assert.strictEqual(r.concluded_count, 0);
+    assert.strictEqual(r.completed_count, 0);
     assert.strictEqual(r.cancelled_count, 0);
   });
 
@@ -191,9 +191,9 @@ describe('workflow-start discovery', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'concluded' },
-        specification: { status: 'concluded' },
-        planning: { status: 'concluded' },
+        discussion: { status: 'completed' },
+        specification: { status: 'completed' },
+        planning: { status: 'completed' },
         implementation: { status: 'completed' },
         review: { status: 'in-progress' },
       },

--- a/tests/scripts/test-discovery-for-status.js
+++ b/tests/scripts/test-discovery-for-status.js
@@ -21,9 +21,9 @@ describe('status discovery', () => {
       work_type: 'feature',
       description: 'Auth flow',
       phases: {
-        discussion: { status: 'concluded' },
-        specification: { status: 'concluded', type: 'feature' },
-        planning: { status: 'concluded', format: 'local-markdown' },
+        discussion: { status: 'completed' },
+        specification: { status: 'completed', type: 'feature' },
+        planning: { status: 'completed', format: 'local-markdown' },
         implementation: {
           status: 'in-progress',
           current_phase: 1,
@@ -38,8 +38,8 @@ describe('status discovery', () => {
     assert.strictEqual(r.state.has_any_work, true);
     const u = r.work_units[0];
     assert.strictEqual(u.name, 'auth');
-    assert.strictEqual(u.discussion.status, 'concluded');
-    assert.strictEqual(u.specification.status, 'concluded');
+    assert.strictEqual(u.discussion.status, 'completed');
+    assert.strictEqual(u.specification.status, 'completed');
     assert.strictEqual(u.specification.type, 'feature');
     assert.strictEqual(u.planning.format, 'local-markdown');
     assert.strictEqual(u.implementation.status, 'in-progress');
@@ -62,7 +62,7 @@ describe('status discovery', () => {
   it('counts research files', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
-      phases: { research: { status: 'concluded' } },
+      phases: { research: { status: 'completed' } },
     });
     createFile(dir, '.workflows/v1/research/market.md', '# Market');
     createFile(dir, '.workflows/v1/research/tech.md', '# Tech');
@@ -75,7 +75,7 @@ describe('status discovery', () => {
   it('counts discussion statuses', () => {
     createManifest(dir, 'a', {
       work_type: 'feature',
-      phases: { discussion: { status: 'concluded' } },
+      phases: { discussion: { status: 'completed' } },
     });
     createManifest(dir, 'b', {
       work_type: 'feature',
@@ -84,18 +84,18 @@ describe('status discovery', () => {
 
     const r = discover(dir);
     assert.strictEqual(r.counts.discussion.total, 2);
-    assert.strictEqual(r.counts.discussion.concluded, 1);
+    assert.strictEqual(r.counts.discussion.completed, 1);
     assert.strictEqual(r.counts.discussion.in_progress, 1);
   });
 
   it('separates feature and cross-cutting specs', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { specification: { status: 'concluded', type: 'feature' } },
+      phases: { specification: { status: 'completed', type: 'feature' } },
     });
     createManifest(dir, 'caching', {
       work_type: 'feature',
-      phases: { specification: { status: 'concluded', type: 'cross-cutting' } },
+      phases: { specification: { status: 'completed', type: 'cross-cutting' } },
     });
 
     const r = discover(dir);
@@ -118,7 +118,7 @@ describe('status discovery', () => {
       work_type: 'feature',
       phases: {
         planning: {
-          status: 'concluded',
+          status: 'completed',
           format: 'local-markdown',
           external_dependencies: {
             core: { state: 'unresolved', task_id: 'core-1' },
@@ -136,7 +136,7 @@ describe('status discovery', () => {
       work_type: 'feature',
       phases: {
         specification: {
-          status: 'concluded',
+          status: 'completed',
           type: 'feature',
           sources: { 'auth-discussion': { status: 'incorporated' } },
         },
@@ -163,10 +163,10 @@ describe('status discovery', () => {
   it('handles investigation status for bugfix', () => {
     createManifest(dir, 'crash', {
       work_type: 'bugfix',
-      phases: { investigation: { status: 'concluded' } },
+      phases: { investigation: { status: 'completed' } },
     });
     const r = discover(dir);
-    assert.strictEqual(r.work_units[0].investigation.status, 'concluded');
+    assert.strictEqual(r.work_units[0].investigation.status, 'completed');
   });
 
   it('tracks review status', () => {
@@ -183,7 +183,7 @@ describe('status discovery', () => {
       work_type: 'feature',
       phases: {
         specification: {
-          status: 'concluded',
+          status: 'completed',
           type: 'feature',
           sources: [{ name: 'auth-disc', status: 'incorporated' }],
         },
@@ -238,7 +238,7 @@ describe('status discovery', () => {
       work_type: 'epic',
       phases: {
         research: {
-          items: { 'exploration': { status: 'concluded' } },
+          items: { 'exploration': { status: 'completed' } },
         },
       },
     });
@@ -276,23 +276,23 @@ describe('status discovery', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
       phases: {
-        research: { status: 'concluded' },
+        research: { status: 'completed' },
         discussion: {
           items: {
-            'auth': { status: 'concluded' },
+            'auth': { status: 'completed' },
             'billing': { status: 'in-progress' },
-            'data': { status: 'concluded' },
+            'data': { status: 'completed' },
           },
         },
         specification: {
           items: {
-            'auth-spec': { status: 'concluded', type: 'feature' },
+            'auth-spec': { status: 'completed', type: 'feature' },
             'billing-spec': { status: 'in-progress', type: 'feature' },
           },
         },
         planning: {
           items: {
-            'auth-spec': { status: 'concluded', format: 'local-markdown' },
+            'auth-spec': { status: 'completed', format: 'local-markdown' },
           },
         },
         implementation: {
@@ -306,25 +306,25 @@ describe('status discovery', () => {
     const r = discover(dir);
     const wu = r.work_units[0];
     assert.strictEqual(wu.work_type, 'epic');
-    // Discussion: 3 items, 2 concluded + 1 in-progress → aggregate 'in-progress'
+    // Discussion: 3 items, 2 completed + 1 in-progress → aggregate 'in-progress'
     assert.strictEqual(wu.discussion.status, 'in-progress');
     assert.strictEqual(wu.discussion.item_count, 3);
-    // Specification: 2 items, 1 concluded + 1 in-progress → aggregate 'in-progress'
+    // Specification: 2 items, 1 completed + 1 in-progress → aggregate 'in-progress'
     assert.strictEqual(wu.specification.status, 'in-progress');
     assert.strictEqual(wu.specification.item_count, 2);
-    // Planning: 1 item, concluded
-    assert.strictEqual(wu.planning.status, 'concluded');
+    // Planning: 1 item, completed
+    assert.strictEqual(wu.planning.status, 'completed');
     assert.strictEqual(wu.planning.item_count, 1);
     // Implementation: 1 item, completed
     assert.strictEqual(wu.implementation.status, 'completed');
     assert.strictEqual(wu.implementation.completed_tasks, 2);
     // Global counts
     assert.strictEqual(r.counts.discussion.total, 3);
-    assert.strictEqual(r.counts.discussion.concluded, 2);
+    assert.strictEqual(r.counts.discussion.completed, 2);
     assert.strictEqual(r.counts.discussion.in_progress, 1);
     assert.strictEqual(r.counts.specification.active, 2);
     assert.strictEqual(r.counts.planning.total, 1);
-    assert.strictEqual(r.counts.planning.concluded, 1);
+    assert.strictEqual(r.counts.planning.completed, 1);
     assert.strictEqual(r.counts.implementation.total, 1);
     assert.strictEqual(r.counts.implementation.completed, 1);
   });

--- a/tests/scripts/test-discovery-utils.js
+++ b/tests/scripts/test-discovery-utils.js
@@ -117,7 +117,7 @@ describe('discovery-utils', () => {
     it('returns only in-progress manifests', () => {
       const { createManifest } = require('./discovery-test-utils');
       createManifest(dir, 'active', { status: 'in-progress' });
-      createManifest(dir, 'concluded', { status: 'concluded' });
+      createManifest(dir, 'done', { status: 'completed' });
       const results = loadActiveManifests(dir);
       assert.strictEqual(results.length, 1);
       assert.strictEqual(results[0].name, 'active');
@@ -136,7 +136,7 @@ describe('discovery-utils', () => {
     it('returns manifests of all statuses', () => {
       const { createManifest } = require('./discovery-test-utils');
       createManifest(dir, 'active', { status: 'in-progress' });
-      createManifest(dir, 'done', { status: 'concluded' });
+      createManifest(dir, 'done', { status: 'completed' });
       createManifest(dir, 'cancelled', { status: 'cancelled' });
       const results = loadAllManifests(dir);
       assert.strictEqual(results.length, 3);
@@ -153,7 +153,7 @@ describe('discovery-utils', () => {
 
   describe('phaseStatus', () => {
     it('extracts phase status', () => {
-      assert.strictEqual(phaseStatus({ phases: { discussion: { status: 'concluded' } } }, 'discussion'), 'concluded');
+      assert.strictEqual(phaseStatus({ phases: { discussion: { status: 'completed' } } }, 'discussion'), 'completed');
     });
 
     it('returns null for missing phase', () => {
@@ -167,14 +167,14 @@ describe('discovery-utils', () => {
 
   describe('phaseItems', () => {
     it('extracts items', () => {
-      const items = phaseItems({ phases: { discussion: { items: { auth: { status: 'concluded' } } } } }, 'discussion');
+      const items = phaseItems({ phases: { discussion: { items: { auth: { status: 'completed' } } } } }, 'discussion');
       assert.strictEqual(items.length, 1);
       assert.strictEqual(items[0].name, 'auth');
-      assert.strictEqual(items[0].status, 'concluded');
+      assert.strictEqual(items[0].status, 'completed');
     });
 
     it('returns empty for no items', () => {
-      assert.deepStrictEqual(phaseItems({ phases: { discussion: { status: 'concluded' } } }, 'discussion'), []);
+      assert.deepStrictEqual(phaseItems({ phases: { discussion: { status: 'completed' } } }, 'discussion'), []);
     });
 
     it('returns empty for missing phase', () => {
@@ -196,8 +196,8 @@ describe('discovery-utils', () => {
 
   describe('phaseData', () => {
     it('returns phase object', () => {
-      const data = phaseData({ phases: { discussion: { status: 'concluded', format: 'md' } } }, 'discussion');
-      assert.strictEqual(data.status, 'concluded');
+      const data = phaseData({ phases: { discussion: { status: 'completed', format: 'md' } } }, 'discussion');
+      assert.strictEqual(data.status, 'completed');
       assert.strictEqual(data.format, 'md');
     });
 
@@ -217,18 +217,18 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.next_phase, 'review');
     });
 
-    it('returns implementation when planning concluded', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { planning: { status: 'concluded' } } });
+    it('returns implementation when planning completed', () => {
+      const r = computeNextPhase({ work_type: 'feature', phases: { planning: { status: 'completed' } } });
       assert.strictEqual(r.next_phase, 'implementation');
     });
 
-    it('returns planning when spec concluded', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { specification: { status: 'concluded' } } });
+    it('returns planning when spec completed', () => {
+      const r = computeNextPhase({ work_type: 'feature', phases: { specification: { status: 'completed' } } });
       assert.strictEqual(r.next_phase, 'planning');
     });
 
-    it('returns specification when discussion concluded', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { discussion: { status: 'concluded' } } });
+    it('returns specification when discussion completed', () => {
+      const r = computeNextPhase({ work_type: 'feature', phases: { discussion: { status: 'completed' } } });
       assert.strictEqual(r.next_phase, 'specification');
     });
 
@@ -247,13 +247,13 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.next_phase, 'investigation');
     });
 
-    it('returns specification when investigation concluded (bugfix)', () => {
-      const r = computeNextPhase({ work_type: 'bugfix', phases: { investigation: { status: 'concluded' } } });
+    it('returns specification when investigation completed (bugfix)', () => {
+      const r = computeNextPhase({ work_type: 'bugfix', phases: { investigation: { status: 'completed' } } });
       assert.strictEqual(r.next_phase, 'specification');
     });
 
-    it('returns discussion when research concluded (epic)', () => {
-      const r = computeNextPhase({ work_type: 'epic', phases: { research: { status: 'concluded' } } });
+    it('returns discussion when research completed (epic)', () => {
+      const r = computeNextPhase({ work_type: 'epic', phases: { research: { status: 'completed' } } });
       assert.strictEqual(r.next_phase, 'discussion');
     });
 
@@ -305,8 +305,8 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.phase_label, 'research (in-progress)');
     });
 
-    it('returns discussion when research concluded (feature)', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { research: { status: 'concluded' } } });
+    it('returns discussion when research completed (feature)', () => {
+      const r = computeNextPhase({ work_type: 'feature', phases: { research: { status: 'completed' } } });
       assert.strictEqual(r.next_phase, 'discussion');
     });
 
@@ -321,14 +321,14 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.next_phase, 'done');
     });
 
-    it('epic: returns specification when all discussion items concluded', () => {
+    it('epic: returns specification when all discussion items completed', () => {
       const r = computeNextPhase({
         work_type: 'epic',
         phases: {
           discussion: {
             items: {
-              'auth': { status: 'concluded' },
-              'billing': { status: 'concluded' },
+              'auth': { status: 'completed' },
+              'billing': { status: 'completed' },
             },
           },
         },
@@ -337,13 +337,13 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.phase_label, 'ready for specification');
     });
 
-    it('epic: returns discussion in-progress when some items not concluded', () => {
+    it('epic: returns discussion in-progress when some items not completed', () => {
       const r = computeNextPhase({
         work_type: 'epic',
         phases: {
           discussion: {
             items: {
-              'auth': { status: 'concluded' },
+              'auth': { status: 'completed' },
               'billing': { status: 'in-progress' },
             },
           },
@@ -353,12 +353,12 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.phase_label, 'discussion (in-progress)');
     });
 
-    it('epic: returns planning when all spec items concluded', () => {
+    it('epic: returns planning when all spec items completed', () => {
       const r = computeNextPhase({
         work_type: 'epic',
         phases: {
-          discussion: { items: { 'auth': { status: 'concluded' } } },
-          specification: { items: { 'auth-spec': { status: 'concluded' } } },
+          discussion: { items: { 'auth': { status: 'completed' } } },
+          specification: { items: { 'auth-spec': { status: 'completed' } } },
         },
       });
       assert.strictEqual(r.next_phase, 'planning');
@@ -368,7 +368,7 @@ describe('discovery-utils', () => {
       const r = computeNextPhase({
         work_type: 'epic',
         phases: {
-          discussion: { items: { 'auth': { status: 'concluded' }, 'billing': { status: 'in-progress' } } },
+          discussion: { items: { 'auth': { status: 'completed' }, 'billing': { status: 'in-progress' } } },
           specification: { items: { 'auth-spec': { status: 'in-progress' } } },
         },
       });
@@ -392,7 +392,7 @@ describe('discovery-utils', () => {
         phases: {
           research: {
             items: {
-              'exploration': { status: 'concluded' },
+              'exploration': { status: 'completed' },
               'architecture': { status: 'in-progress' },
             },
           },
@@ -402,13 +402,13 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.phase_label, 'research (in-progress)');
     });
 
-    it('epic: research concluded with items advances to discussion', () => {
+    it('epic: research completed with items advances to discussion', () => {
       const r = computeNextPhase({
         work_type: 'epic',
         phases: {
           research: {
             items: {
-              'exploration': { status: 'concluded' },
+              'exploration': { status: 'completed' },
             },
           },
         },
@@ -423,17 +423,17 @@ describe('discovery-utils', () => {
         phases: {
           discussion: {
             items: {
-              'auth': { status: 'concluded' },
+              'auth': { status: 'completed' },
               'billing': {},
             },
           },
         },
       });
-      // Only 'concluded' is present (billing has no status), so aggregation sees only concluded
+      // Only 'completed' is present (billing has no status), so aggregation sees only completed
       assert.strictEqual(r.next_phase, 'specification');
     });
 
-    it('epic: mixed concluded and completed items returns first status', () => {
+    it('epic: mixed completed and completed items returns first status', () => {
       const r = computeNextPhase({
         work_type: 'epic',
         phases: {

--- a/tests/scripts/test-migration-020.sh
+++ b/tests/scripts/test-migration-020.sh
@@ -1,0 +1,473 @@
+#!/bin/bash
+#
+# Tests migration 020-normalise-terminal-status.sh
+# Validates concluded → completed for phase statuses and work unit status.
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/migrate/scripts/migrations/020-normalise-terminal-status.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Helper functions
+#
+
+setup_fixture() {
+    rm -rf "$TEST_DIR/.workflows"
+}
+
+create_manifest() {
+    local name="$1"
+    local content="$2"
+    mkdir -p "$TEST_DIR/.workflows/$name"
+    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+}
+
+run_migration() {
+    cd "$TEST_DIR"
+    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+}
+
+get_field() {
+    local name="$1"
+    local field="$2"
+    node -e "
+      const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+      const parts = process.argv[2].split('.');
+      let v = m;
+      for (const p of parts) v = (v || {})[p];
+      console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
+    " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
+}
+
+get_json() {
+    local name="$1"
+    cat "$TEST_DIR/.workflows/$name/manifest.json"
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected: $expected"
+        echo -e "    Actual:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Should not find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    else
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+echo -e "${YELLOW}Test: work unit status concluded → completed${NC}"
+setup_fixture
+
+create_manifest "done-feat" '{"work_type":"feature","status":"concluded","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "done-feat" "status")" "completed" "Work unit status changed to completed"
+assert_contains "$output" "updated" "Reports update"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: in-progress work unit unchanged${NC}"
+setup_fixture
+
+create_manifest "active-feat" '{"work_type":"feature","status":"in-progress","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "active-feat" "status")" "in-progress" "Status remains in-progress"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: cancelled work unit unchanged${NC}"
+setup_fixture
+
+create_manifest "dead-feat" '{"work_type":"feature","status":"cancelled","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "dead-feat" "status")" "cancelled" "Status remains cancelled"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: completed work unit unchanged${NC}"
+setup_fixture
+
+create_manifest "already-done" '{"work_type":"feature","status":"completed","phases":{}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "already-done" "status")" "completed" "Status remains completed"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: flat phase statuses concluded → completed${NC}"
+setup_fixture
+
+create_manifest "phases-feat" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "research": {"status": "concluded"},
+    "discussion": {"status": "concluded"},
+    "specification": {"status": "concluded"},
+    "planning": {"status": "concluded"},
+    "implementation": {"status": "completed"},
+    "review": {"status": "in-progress"}
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "phases-feat" "phases.research.status")" "completed" "Research status → completed"
+assert_equals "$(get_field "phases-feat" "phases.discussion.status")" "completed" "Discussion status → completed"
+assert_equals "$(get_field "phases-feat" "phases.specification.status")" "completed" "Specification status → completed"
+assert_equals "$(get_field "phases-feat" "phases.planning.status")" "completed" "Planning status → completed"
+assert_equals "$(get_field "phases-feat" "phases.implementation.status")" "completed" "Implementation status unchanged"
+assert_equals "$(get_field "phases-feat" "phases.review.status")" "in-progress" "Review in-progress unchanged"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: in-progress phase statuses unchanged${NC}"
+setup_fixture
+
+create_manifest "ip-feat" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "discussion": {"status": "in-progress"}
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "ip-feat" "phases.discussion.status")" "in-progress" "In-progress stays in-progress"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: superseded specification unchanged${NC}"
+setup_fixture
+
+create_manifest "super-feat" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "specification": {"status": "superseded"}
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "super-feat" "phases.specification.status")" "superseded" "Superseded stays superseded"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: epic item-level statuses concluded → completed${NC}"
+setup_fixture
+
+create_manifest "my-epic" '{
+  "work_type": "epic",
+  "status": "in-progress",
+  "phases": {
+    "discussion": {
+      "items": {
+        "auth": {"status": "concluded"},
+        "billing": {"status": "in-progress"}
+      }
+    },
+    "specification": {
+      "items": {
+        "auth": {"status": "concluded"}
+      }
+    },
+    "planning": {
+      "items": {
+        "auth": {"status": "concluded"}
+      }
+    },
+    "implementation": {
+      "items": {
+        "auth": {"status": "completed"}
+      }
+    }
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "my-epic" "phases.discussion.items.auth.status")" "completed" "Epic discussion item → completed"
+assert_equals "$(get_field "my-epic" "phases.discussion.items.billing.status")" "in-progress" "In-progress item unchanged"
+assert_equals "$(get_field "my-epic" "phases.specification.items.auth.status")" "completed" "Epic spec item → completed"
+assert_equals "$(get_field "my-epic" "phases.planning.items.auth.status")" "completed" "Epic planning item → completed"
+assert_equals "$(get_field "my-epic" "phases.implementation.items.auth.status")" "completed" "Implementation item unchanged"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: bugfix phases concluded → completed${NC}"
+setup_fixture
+
+create_manifest "my-bug" '{
+  "work_type": "bugfix",
+  "status": "concluded",
+  "phases": {
+    "investigation": {"status": "concluded"},
+    "specification": {"status": "concluded"},
+    "planning": {"status": "concluded"},
+    "implementation": {"status": "completed"},
+    "review": {"status": "completed"}
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "my-bug" "status")" "completed" "Bugfix work unit status → completed"
+assert_equals "$(get_field "my-bug" "phases.investigation.status")" "completed" "Investigation → completed"
+assert_equals "$(get_field "my-bug" "phases.specification.status")" "completed" "Specification → completed"
+assert_equals "$(get_field "my-bug" "phases.planning.status")" "completed" "Planning → completed"
+assert_equals "$(get_field "my-bug" "phases.implementation.status")" "completed" "Implementation unchanged"
+assert_equals "$(get_field "my-bug" "phases.review.status")" "completed" "Review unchanged"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state"
+echo '{"status":"concluded"}' > "$TEST_DIR/.workflows/.state/manifest.json"
+create_manifest "real" '{"work_type":"feature","status":"concluded","phases":{}}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "real" "status")" "completed" "Real work unit updated"
+dot_status=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/.state/manifest.json")
+assert_equals "$dot_status" "concluded" "Dot-dir manifest not touched"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
+setup_fixture
+
+create_manifest "idem" '{
+  "work_type": "feature",
+  "status": "concluded",
+  "phases": {
+    "discussion": {"status": "concluded"},
+    "specification": {"status": "concluded"}
+  }
+}'
+
+run_migration > /dev/null
+before=$(get_json "idem")
+output=$(run_migration)
+after=$(get_json "idem")
+
+assert_equals "$after" "$before" "JSON unchanged after second run"
+assert_not_contains "$output" "updated" "No update on second run"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
+setup_fixture
+
+create_manifest "preserve" '{
+  "name": "preserve",
+  "work_type": "feature",
+  "status": "concluded",
+  "created": "2026-01-15",
+  "description": "test feature",
+  "phases": {
+    "discussion": {"status": "concluded", "analysis_cache": {"checksum": "abc123"}}
+  }
+}'
+
+run_migration > /dev/null
+
+json=$(get_json "preserve")
+
+assert_contains "$json" '"name": "preserve"' "Name preserved"
+assert_contains "$json" '"work_type": "feature"' "Work type preserved"
+assert_contains "$json" '"created": "2026-01-15"' "Created date preserved"
+assert_contains "$json" '"description": "test feature"' "Description preserved"
+assert_contains "$json" '"checksum": "abc123"' "Analysis cache preserved"
+assert_equals "$(get_field "preserve" "phases.discussion.status")" "completed" "Phase status updated"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
+setup_fixture
+
+output=$(run_migration)
+
+assert_not_contains "$output" "updated" "No updates without .workflows dir"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: multiple work units processed${NC}"
+setup_fixture
+
+create_manifest "feat-a" '{"work_type":"feature","status":"concluded","phases":{"discussion":{"status":"concluded"}}}'
+create_manifest "feat-b" '{"work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"concluded"}}}'
+create_manifest "feat-c" '{"work_type":"feature","status":"cancelled","phases":{}}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "feat-a" "status")" "completed" "First: work unit concluded → completed"
+assert_equals "$(get_field "feat-a" "phases.discussion.status")" "completed" "First: phase concluded → completed"
+assert_equals "$(get_field "feat-b" "status")" "in-progress" "Second: in-progress unchanged"
+assert_equals "$(get_field "feat-b" "phases.discussion.status")" "completed" "Second: phase concluded → completed"
+assert_equals "$(get_field "feat-c" "status")" "cancelled" "Third: cancelled unchanged"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: mixed epic with concluded and completed items${NC}"
+setup_fixture
+
+create_manifest "mixed-epic" '{
+  "work_type": "epic",
+  "status": "in-progress",
+  "phases": {
+    "discussion": {
+      "items": {
+        "auth": {"status": "concluded"},
+        "billing": {"status": "concluded"}
+      }
+    },
+    "implementation": {
+      "items": {
+        "auth": {"status": "completed"}
+      }
+    },
+    "review": {
+      "items": {
+        "auth": {"status": "completed"}
+      }
+    }
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "mixed-epic" "phases.discussion.items.auth.status")" "completed" "Discussion auth → completed"
+assert_equals "$(get_field "mixed-epic" "phases.discussion.items.billing.status")" "completed" "Discussion billing → completed"
+assert_equals "$(get_field "mixed-epic" "phases.implementation.items.auth.status")" "completed" "Impl auth unchanged"
+assert_equals "$(get_field "mixed-epic" "phases.review.items.auth.status")" "completed" "Review auth unchanged"
+
+echo ""
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "Tests run: $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "========================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -329,10 +329,10 @@ echo -e "${YELLOW}Test: set phase-level value for feature${NC}"
 setup_fixture
 run_cli init feat-set --work-type feature --description "Set" >/dev/null 2>&1
 run_cli init-phase feat-set --phase discussion --topic feat-set >/dev/null 2>&1
-run_cli set feat-set --phase discussion --topic feat-set status concluded >/dev/null 2>&1
+run_cli set feat-set --phase discussion --topic feat-set status completed >/dev/null 2>&1
 output=$(run_cli_stdout get feat-set --phase discussion --topic feat-set status)
 
-assert_equals "$output" "concluded" "Feature phase-level set works (flat routing)"
+assert_equals "$output" "completed" "Feature phase-level set works (flat routing)"
 
 echo ""
 
@@ -342,10 +342,10 @@ echo -e "${YELLOW}Test: set phase-level value for epic${NC}"
 setup_fixture
 run_cli init epic-set --work-type epic --description "Set" >/dev/null 2>&1
 run_cli init-phase epic-set --phase discussion --topic my-topic >/dev/null 2>&1
-run_cli set epic-set --phase discussion --topic my-topic status concluded >/dev/null 2>&1
+run_cli set epic-set --phase discussion --topic my-topic status completed >/dev/null 2>&1
 output=$(run_cli_stdout get epic-set --phase discussion --topic my-topic status)
 
-assert_equals "$output" "concluded" "Epic phase-level set routes through items"
+assert_equals "$output" "completed" "Epic phase-level set routes through items"
 
 echo ""
 
@@ -379,10 +379,10 @@ echo -e "${YELLOW}Test: set --phase research with --topic for epic uses items${N
 setup_fixture
 run_cli init topicful2 --work-type epic --description "Topic research epic" >/dev/null 2>&1
 run_cli init-phase topicful2 --phase research --topic exploration >/dev/null 2>&1
-run_cli set topicful2 --phase research --topic exploration status concluded >/dev/null 2>&1
+run_cli set topicful2 --phase research --topic exploration status completed >/dev/null 2>&1
 output=$(run_cli_stdout get topicful2 --phase research --topic exploration status)
 
-assert_equals "$output" "concluded" "Epic research with topic uses items path"
+assert_equals "$output" "completed" "Epic research with topic uses items path"
 
 echo ""
 
@@ -391,10 +391,10 @@ echo ""
 echo -e "${YELLOW}Test: get --phase without --topic returns whole phase object${NC}"
 setup_fixture
 run_cli init topicful3 --work-type feature --description "Topic get" >/dev/null 2>&1
-run_cli set topicful3 --phase research --topic exploration status concluded >/dev/null 2>&1
+run_cli set topicful3 --phase research --topic exploration status completed >/dev/null 2>&1
 output=$(run_cli_stdout get topicful3 --phase research)
 
-assert_contains "$output" '"status": "concluded"' "Get phase without topic returns phase object"
+assert_contains "$output" '"status": "completed"' "Get phase without topic returns phase object"
 
 echo ""
 
@@ -427,7 +427,7 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid phase status${NC}"
 setup_fixture
 run_cli init status-check --work-type feature --description "Status" >/dev/null 2>&1
-assert_exit_nonzero "Invalid status for discussion rejected" set status-check --phase discussion --topic status-check status completed
+assert_exit_nonzero "Invalid status for discussion rejected" set status-check --phase discussion --topic status-check status concluded
 assert_exit_nonzero "Invalid status for implementation rejected" set status-check --phase implementation --topic status-check status concluded
 
 echo ""
@@ -437,13 +437,13 @@ echo ""
 echo -e "${YELLOW}Test: set validates correct phase statuses${NC}"
 setup_fixture
 run_cli init valid-status --work-type feature --description "Valid" >/dev/null 2>&1
-run_cli set valid-status --phase discussion --topic valid-status status concluded >/dev/null 2>&1
+run_cli set valid-status --phase discussion --topic valid-status status completed >/dev/null 2>&1
 run_cli set valid-status --phase implementation --topic valid-status status completed >/dev/null 2>&1
 
 disc_status=$(run_cli_stdout get valid-status --phase discussion --topic valid-status status)
 impl_status=$(run_cli_stdout get valid-status --phase implementation --topic valid-status status)
 
-assert_equals "$disc_status" "concluded" "Discussion accepts concluded"
+assert_equals "$disc_status" "completed" "Discussion accepts completed"
 assert_equals "$impl_status" "completed" "Implementation accepts completed"
 
 echo ""
@@ -543,12 +543,12 @@ echo ""
 echo -e "${YELLOW}Test: list filters by status${NC}"
 setup_fixture
 run_cli init active-one --work-type feature --description "Active" >/dev/null 2>&1
-run_cli init concluded-one --work-type feature --description "Concluded" >/dev/null 2>&1
-run_cli set concluded-one status concluded >/dev/null 2>&1
+run_cli init completed-one --work-type feature --description "Completed" >/dev/null 2>&1
+run_cli set completed-one status completed >/dev/null 2>&1
 output=$(run_cli_stdout list --status in-progress)
 
 assert_contains "$output" '"name": "active-one"' "In-progress work unit listed"
-assert_not_contains "$output" '"name": "concluded-one"' "Concluded work unit excluded"
+assert_not_contains "$output" '"name": "completed-one"' "Completed work unit excluded"
 
 echo ""
 
@@ -749,12 +749,12 @@ echo -e "${YELLOW}Test: feature get/set routes to flat structure${NC}"
 setup_fixture
 run_cli init routing-feat --work-type feature --description "Routing" >/dev/null 2>&1
 run_cli init-phase routing-feat --phase discussion --topic routing-feat >/dev/null 2>&1
-run_cli set routing-feat --phase discussion --topic routing-feat status concluded >/dev/null 2>&1
+run_cli set routing-feat --phase discussion --topic routing-feat status completed >/dev/null 2>&1
 
 # Verify internal structure is flat
 content=$(cat "$TEST_DIR/.workflows/routing-feat/manifest.json")
 assert_contains "$content" '"discussion"' "Discussion phase exists"
-assert_contains "$content" '"status": "concluded"' "Status set to concluded"
+assert_contains "$content" '"status": "completed"' "Status set to completed"
 assert_not_contains "$content" '"items"' "No items in feature manifest"
 
 echo ""
@@ -766,7 +766,7 @@ setup_fixture
 run_cli init routing-epic --work-type epic --description "Routing" >/dev/null 2>&1
 run_cli init-phase routing-epic --phase discussion --topic topic-a >/dev/null 2>&1
 run_cli init-phase routing-epic --phase discussion --topic topic-b >/dev/null 2>&1
-run_cli set routing-epic --phase discussion --topic topic-a status concluded >/dev/null 2>&1
+run_cli set routing-epic --phase discussion --topic topic-a status completed >/dev/null 2>&1
 
 # Verify internal structure has items
 content=$(cat "$TEST_DIR/.workflows/routing-epic/manifest.json")
@@ -777,7 +777,7 @@ assert_contains "$content" '"topic-b"' "topic-b exists"
 # Get specific item
 topic_a=$(run_cli_stdout get routing-epic --phase discussion --topic topic-a status)
 topic_b=$(run_cli_stdout get routing-epic --phase discussion --topic topic-b status)
-assert_equals "$topic_a" "concluded" "topic-a status is concluded"
+assert_equals "$topic_a" "completed" "topic-a status is completed"
 assert_equals "$topic_b" "in-progress" "topic-b status is in-progress"
 
 echo ""
@@ -828,12 +828,12 @@ echo -e "${YELLOW}Test: epic item-level status validation${NC}"
 setup_fixture
 run_cli init epic-validation --work-type epic --description "Validate items" >/dev/null 2>&1
 run_cli init-phase epic-validation --phase discussion --topic my-topic >/dev/null 2>&1
-assert_exit_nonzero "Invalid item status rejected" set epic-validation --phase discussion --topic my-topic status completed
+assert_exit_nonzero "Invalid item status rejected" set epic-validation --phase discussion --topic my-topic status concluded
 
 # Valid item status should work
-run_cli set epic-validation --phase discussion --topic my-topic status concluded >/dev/null 2>&1
+run_cli set epic-validation --phase discussion --topic my-topic status completed >/dev/null 2>&1
 output=$(run_cli_stdout get epic-validation --phase discussion --topic my-topic status)
-assert_equals "$output" "concluded" "Valid item status accepted"
+assert_equals "$output" "completed" "Valid item status accepted"
 
 echo ""
 

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -1690,32 +1690,32 @@ const FLOWCHARTS = {
       { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Run discovery.sh. Scans discussions (with has_individual_spec check), specifications, and cache.' },
       { id: 'gate-disc', label: 'Discussions?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2 Gate: Do any discussions exist? If not, STOP.' },
       { id: 'stop-no-disc', label: 'STOP: No discussions', shape: 'stop', w: 170, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No discussions found. User must run /start-discussion first.' },
-      { id: 'gate-concluded', label: 'Concluded?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2 Gate: Are any discussions concluded? If not, STOP.' },
-      { id: 'stop-no-conc', label: 'STOP: None concluded', shape: 'stop', w: 170, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: Discussions exist but none concluded. Complete discussion phase first.' },
-      { id: 'count', label: 'How many?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 3: Route based on concluded discussion count. 1 = auto-select, multiple = check cache.' },
-      { id: 'auto-select', label: 'Auto-select single', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Only one concluded discussion. Routes by spec coverage (no spec, individual spec, grouped spec) for display, then auto-proceeds to confirmation.' },
-      { id: 'cache-check', label: 'Cache valid?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Multiple concluded discussions: Check consolidation analysis cache. Valid = show groupings directly. Stale/none = check for existing specs.' },
+      { id: 'gate-completed', label: 'Completed?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2 Gate: Are any discussions completed? If not, STOP.' },
+      { id: 'stop-no-comp', label: 'STOP: None completed', shape: 'stop', w: 170, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: Discussions exist but none completed. Complete discussion phase first.' },
+      { id: 'count', label: 'How many?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 3: Route based on completed discussion count. 1 = auto-select, multiple = check cache.' },
+      { id: 'auto-select', label: 'Auto-select single', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Only one completed discussion. Routes by spec coverage (no spec, individual spec, grouped spec) for display, then auto-proceeds to confirmation.' },
+      { id: 'cache-check', label: 'Cache valid?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Multiple completed discussions: Check consolidation analysis cache. Valid = show groupings directly. Stale/none = check for existing specs.' },
       { id: 'specs-check', label: 'Specs exist?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Cache stale/none: Do specifications already exist? Routes to different entry points.' },
-      { id: 'ask-analyze', label: 'Analyze?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'No specs exist, cache stale/none. Lists concluded discussions and asks user whether to proceed with coupling analysis.' },
+      { id: 'ask-analyze', label: 'Analyze?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'No specs exist, cache stale/none. Lists completed discussions and asks user whether to proceed with coupling analysis.' },
       { id: 'stop-decline', label: 'STOP: Declined', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: User declined analysis. Can re-run /start-specification when ready.' },
       { id: 'specs-menu', label: 'Present specs menu', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Specs exist but cache stale/none. Shows existing specs with extraction status and unassigned discussions. Menu: Analyze for groupings (recommended) + per-spec Continue/Refine.' },
       { id: 'gather-ctx', label: 'ASK: Analysis context', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Before analyzing, ask about topic relationships — part of same feature, dependencies, topics that must stay separate.' },
-      { id: 'analyze', label: 'Analyze discussions', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read ALL concluded discussions. Analyze coupling (data, behavioral, conceptual). Group into specifications. Preserve anchored spec names. Save to cache.' },
+      { id: 'analyze', label: 'Analyze discussions', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read ALL completed discussions. Analyze coupling (data, behavioral, conceptual). Group into specifications. Preserve anchored spec names. Save to cache.' },
       { id: 'show-groups', label: 'Present groupings menu', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Display cached groupings with discussion status (extracted/pending/ready/reopened). Per-grouping menu items with verb (Start/Continue/Refine) plus Unify all and Re-analyze options.' },
       { id: 'menu-choice', label: 'Menu choice?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Route based on user menu selection from groupings display.' },
-      { id: 'unify', label: 'Unify all', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Combine ALL concluded discussions into one "Unified" specification. Only offered when 2+ groupings. Rewrites cache with single grouping.' },
+      { id: 'unify', label: 'Unify all', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Combine ALL completed discussions into one "Unified" specification. Only offered when 2+ groupings. Rewrites cache with single grouping.' },
       { id: 'refresh', label: 'Re-analyze', w: 180, h: 44, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Delete cache. User can provide guidance for new groupings. Existing spec names are preserved.' },
-      { id: 'confirm', label: 'ASK: Confirm selection', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Show spec name, sources, output path, supersession info. Verb varies: Creating (new), Continuing (in-progress/pending), or Refining (concluded). Wait for y/n. Decline returns to previous menu.' },
+      { id: 'confirm', label: 'ASK: Confirm selection', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Show spec name, sources, output path, supersession info. Verb varies: Creating (new), Continuing (in-progress/pending), or Refining (completed). Wait for y/n. Decline returns to previous menu.' },
       { id: 'skill', label: 'Invoke specification skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Invoke technical-specification skill with sources and output path.', skillLink: 'skill-specification' },
     ],
     connections: [
       { from: 'start', to: 'migrate' },
       { from: 'migrate', to: 'discovery' },
       { from: 'discovery', to: 'gate-disc' },
-      { from: 'gate-disc', to: 'gate-concluded', type: 'yes', label: 'exist', weight: 2 },
+      { from: 'gate-disc', to: 'gate-completed', type: 'yes', label: 'exist', weight: 2 },
       { from: 'gate-disc', to: 'stop-no-disc', type: 'no', label: 'none' },
-      { from: 'gate-concluded', to: 'count', type: 'yes', label: 'yes', weight: 2 },
-      { from: 'gate-concluded', to: 'stop-no-conc', type: 'no', label: 'none' },
+      { from: 'gate-completed', to: 'count', type: 'yes', label: 'yes', weight: 2 },
+      { from: 'gate-completed', to: 'stop-no-comp', type: 'no', label: 'none' },
       { from: 'count', to: 'auto-select', label: 'one' },
       { from: 'count', to: 'cache-check', label: 'multi' },
       // Cache-first routing
@@ -1757,7 +1757,7 @@ const FLOWCHARTS = {
       { id: 'present', label: 'Present options', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 3: Show workflow state. If nothing actionable → STOP. If single → auto-select. If multiple → present menu with Create/Continue/Review verbs.' },
       { id: 'plan-state', label: 'Existing plan?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 4: Route by plan state. New plan gathers context first; existing plan skips straight to skill invocation.' },
       { id: 'gather', label: 'ASK: Additional context', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 5: Gather additional context, priorities, or constraint changes. Only for new plans.' },
-      { id: 'cross-cut', label: 'Surface cross-cutting specs', w: 215, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 6: Read concluded cross-cutting specs and surface relevant ones as reference context for planning. Only for new plans.' },
+      { id: 'cross-cut', label: 'Surface cross-cutting specs', w: 215, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 6: Read completed cross-cutting specs and surface relevant ones as reference context for planning. Only for new plans.' },
       { id: 'skill', label: 'Invoke planning skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 7: Invoke technical-planning skill. Handles format selection, phases, tasks, dependencies.', skillLink: 'skill-planning' },
     ],
     connections: [
@@ -1781,7 +1781,7 @@ const FLOWCHARTS = {
       { id: 'discovery', label: 'Run discovery script', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Step 1: Run discovery-for-implementation-and-review.sh. Scans plans, implementation tracking, dependencies, and environment setup.' },
       { id: 'scenario', label: 'Plans?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2: Route on scenario — no_plans, single_plan, or multiple_plans.' },
       { id: 'stop-no-plan', label: 'STOP: No plans', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No plans found. Run /start-planning first.' },
-      { id: 'present', label: 'Present plans', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 3: Classify plans into Implementable (▶ in-progress, + new), Implemented (> completed), and Not implementable (· blocked/not concluded). Number selectable entries. Includes unblock escape hatch for externally satisfied deps.' },
+      { id: 'present', label: 'Present plans', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 3: Classify plans into Implementable (▶ in-progress, + new), Implemented (> completed), and Not implementable (· blocked/not completed). Number selectable entries. Includes unblock escape hatch for externally satisfied deps.' },
       { id: 'select', label: 'Select plan', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Single implementable = auto-select, otherwise ask user. Implemented plans can be re-selected.' },
       { id: 'unblock', label: 'ASK: Unblock dep', w: 180, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'User requests unblock: identify plan and dep, confirm, mark satisfied_externally in frontmatter, commit, re-present.' },
       { id: 'gate-deps', label: 'Ext deps OK?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 4: Confirm external dependencies satisfied. Pre-analyzed by discovery script. Escape hatch: mark as satisfied externally.' },
@@ -1856,10 +1856,10 @@ const FLOWCHARTS = {
       { id: 'name', label: 'ASK: Suggest topic name', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 2: Suggest a kebab-case topic name for the discussion file.' },
       { id: 'check', label: 'Discussion exists?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 2: Check .workflows/{work_unit}/discussion/ for existing discussion file ({topic}.md).' },
       { id: 'conflict', label: 'ASK: Resume / new name', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Discussion exists: resume the existing discussion or choose a different name.' },
-      { id: 'status-check', label: 'Concluded?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'If resuming: check discussion status. Concluded → skip to bridge. In-progress → invoke discussion.' },
-      { id: 'disc-skill', label: 'Invoke discussion skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 3: Invoke technical-discussion skill. When discussion concludes, proceed to phase bridge.', skillLink: 'skill-discussion' },
+      { id: 'status-check', label: 'Completed?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'If resuming: check discussion status. Completed → skip to bridge. In-progress → invoke discussion.' },
+      { id: 'disc-skill', label: 'Invoke discussion skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 3: Invoke technical-discussion skill. When discussion completes, proceed to phase bridge.', skillLink: 'skill-discussion' },
       { id: 'bridge', label: 'Phase bridge', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Enter plan mode with handoff to continue-feature for specification, planning, implementation, and review.' },
-      { id: 'end', label: 'Pipeline handoff', shape: 'pill', w: 150, h: 40, color: '#818cf8', bg: 'rgba(129,140,248,0.12)', desc: 'Output: Discussion concluded. Plan mode handoff to continue-feature for remaining phases.' },
+      { id: 'end', label: 'Pipeline handoff', shape: 'pill', w: 150, h: 40, color: '#818cf8', bg: 'rgba(129,140,248,0.12)', desc: 'Output: Discussion completed. Plan mode handoff to continue-feature for remaining phases.' },
     ],
     connections: [
       { from: 'start', to: 'migrate' },
@@ -1870,7 +1870,7 @@ const FLOWCHARTS = {
       { from: 'check', to: 'disc-skill', type: 'no', label: 'new', weight: 2 },
       { from: 'conflict', to: 'status-check', label: 'resume' },
       { from: 'conflict', to: 'name', type: 'backloop', label: 'new name' },
-      { from: 'status-check', to: 'bridge', type: 'yes', label: 'concluded' },
+      { from: 'status-check', to: 'bridge', type: 'yes', label: 'completed' },
       { from: 'status-check', to: 'disc-skill', type: 'no', label: 'in-progress', weight: 2 },
       { from: 'disc-skill', to: 'bridge', type: 'transition' },
       { from: 'bridge', to: 'end' },
@@ -1919,7 +1919,7 @@ const FLOWCHARTS = {
       { id: 'more', label: 'More to explore?', shape: 'diamond', w: 120, h: 120, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Periodic review: more questions? Themes emerging? Ready for discussion/spec?' },
       { id: 'split', label: 'Themes emerging?', shape: 'diamond', w: 120, h: 120, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Over multiple sessions, topics may become distinct. Split if so.' },
       { id: 'split-files', label: 'Split into files', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Split exploration.md into semantic files (market-landscape.md, technical-feasibility.md, etc).' },
-      { id: 'end', label: 'research/ output', shape: 'pill', w: 150, h: 40, color: 'var(--research)', bg: 'var(--research-bg)', desc: 'Output: .workflows/{work_unit}/research/ files. Research concludes when parked as discussion-ready.' },
+      { id: 'end', label: 'research/ output', shape: 'pill', w: 150, h: 40, color: 'var(--research)', bg: 'var(--research-bg)', desc: 'Output: .workflows/{work_unit}/research/ files. Research completes when parked as discussion-ready.' },
       { id: 'next', label: 'Invoke /start-discussion', desc: 'Navigate to the discussion command to begin capturing architecture decisions from research output.', w: 200, h: 44, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'discussion' },
     ],
     connections: [
@@ -1948,9 +1948,9 @@ const FLOWCHARTS = {
       { id: 'document', label: 'Write to disk', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Write reasoning and context to the discussion file. Not a verbatim transcript — capture the journey, not the dialogue.' },
       { id: 'commit', label: 'Commit & push', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Commit at natural breaks. Never batch — context refresh loses unpushed work.' },
       { id: 'more', label: 'More topics?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Are there more topics to discuss?' },
-      { id: 'conclude', label: 'Conclude discussion', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Set status: concluded. All decisions documented. Ready for specification.' },
-      { id: 'end', label: '{work_unit}/discussion/{topic}.md', shape: 'pill', w: 175, h: 40, color: 'var(--discussion)', bg: 'var(--discussion-bg)', desc: 'Output: Concluded discussion document ready for specification phase.' },
-      { id: 'next', label: 'Invoke /start-specification', desc: 'Navigate to the specification command to build a validated spec from concluded discussions.', w: 210, h: 44, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'specification' },
+      { id: 'complete', label: 'Complete discussion', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Set status: completed. All decisions documented. Ready for specification.' },
+      { id: 'end', label: '{work_unit}/discussion/{topic}.md', shape: 'pill', w: 175, h: 40, color: 'var(--discussion)', bg: 'var(--discussion-bg)', desc: 'Output: Completed discussion document ready for specification phase.' },
+      { id: 'next', label: 'Invoke /start-specification', desc: 'Navigate to the specification command to build a validated spec from completed discussions.', w: 210, h: 44, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'specification' },
     ],
     connections: [
       { from: 'start', to: 'validate' },
@@ -1961,8 +1961,8 @@ const FLOWCHARTS = {
       { from: 'document', to: 'commit' },
       { from: 'commit', to: 'more' },
       { from: 'more', to: 'engage', type: 'backloop', label: 'yes', port: 'right' },
-      { from: 'more', to: 'conclude', type: 'no', label: 'done' },
-      { from: 'conclude', to: 'end' },
+      { from: 'more', to: 'complete', type: 'no', label: 'done' },
+      { from: 'complete', to: 'end' },
       { from: 'end', to: 'next', type: 'transition' },
     ]
   },
@@ -2034,7 +2034,7 @@ const FLOWCHARTS = {
       { id: 'integrity', label: 'Integrity review', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 7b: Standalone plan quality — task template compliance, vertical slicing, phase structure, dependency ordering, task self-containment, granularity, acceptance criteria quality, external dependencies.' },
       { id: 'integ-finding', label: 'ASK: Approve fix?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Process findings one at a time (Critical/Important/Minor). Present finding + proposed fix. User: approve (y — applies verbatim), skip, or request changes. Commits after each. Tracking file deleted when complete.' },
       // Conclusion
-      { id: 'conclude', label: 'Conclude plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 8: Set status: concluded. Checkpoint: all tasks must be authored before concluding.' },
+      { id: 'complete', label: 'Complete plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 8: Set status: completed. Checkpoint: all tasks must be authored before completing.' },
       { id: 'end', label: '{work_unit}/planning/{topic}/planning.md', shape: 'pill', w: 190, h: 40, color: 'var(--planning)', bg: 'var(--planning-bg)', desc: 'Output: Plan index + authored tasks in chosen output format.' },
       { id: 'next', label: 'Invoke /start-implementation', desc: 'Navigate to the implementation command to execute the plan via strict TDD.', w: 215, h: 44, color: 'var(--next)', bg: 'var(--next-bg)', skillLink: 'implementation' },
     ],
@@ -2076,9 +2076,9 @@ const FLOWCHARTS = {
       // Review — integrity
       { from: 'integrity', to: 'integ-finding' },
       { from: 'integ-finding', to: 'integrity', type: 'backloop', label: 'more findings' },
-      { from: 'integ-finding', to: 'conclude', label: 'all processed' },
+      { from: 'integ-finding', to: 'complete', label: 'all processed' },
       // Conclusion
-      { from: 'conclude', to: 'end' },
+      { from: 'complete', to: 'end' },
       { from: 'end', to: 'next', type: 'transition' },
     ]
   },
@@ -2613,19 +2613,19 @@ const FLOWCHART_DESCS = {
   research: {
     summary: 'Explore ideas, feasibility, and validate concepts across technical, business, and market domains.',
     body: `<p>The simplest command — no discovery script, no prerequisites, no cache. Gathers context through 4 sequential questions (seed idea, existing knowledge, starting direction, constraints) then hands off to the <strong>technical-research</strong> skill.</p>
-<p>The skill acts as a research partner, looping through <strong>Ask → Discuss → Document → Commit</strong>. Output starts as a single file and splits as themes emerge. Research concludes when the user parks a topic as discussion-ready.</p>`,
+<p>The skill acts as a research partner, looping through <strong>Ask → Discuss → Document → Commit</strong>. Output starts as a single file and splits as themes emerge. Research completes when the user parks a topic as discussion-ready.</p>`,
     meta: { output: '.workflows/{work_unit}/research/', skill: 'technical-research', complexity: 'Simple' }
   },
   discussion: {
     summary: 'Capture architecture decisions, debates, edge cases, and rationale through structured dialogue.',
     body: `<p>Moderate complexity. A discovery script scans research files, existing discussions, and cache, then classifies the scenario: <strong>fresh</strong>, <strong>research_only</strong>, <strong>discussions_only</strong>, or <strong>research_and_discussions</strong>.</p>
-<p>Research analysis is <strong>cache-aware</strong> — checksums detect stale analysis. The options menu adapts based on what exists (2–4 options). After user selection, context is gathered and the <strong>technical-discussion</strong> skill runs a loop: <strong>Engage → Capture decisions → Document → Commit</strong> until the discussion is concluded.</p>`,
+<p>Research analysis is <strong>cache-aware</strong> — checksums detect stale analysis. The options menu adapts based on what exists (2–4 options). After user selection, context is gathered and the <strong>technical-discussion</strong> skill runs a loop: <strong>Engage → Capture decisions → Document → Commit</strong> until the discussion is completed.</p>`,
     meta: { output: '.workflows/{work_unit}/discussion/{topic}.md', skill: 'technical-discussion', discovery: 'discovery-for-discussion.sh', cache: '{work_unit}/.state/research-analysis.md' }
   },
   specification: {
     summary: 'Analyse discussion coupling, group into features, and build validated specifications.',
-    body: `<p>Cache-first routing with progressive disclosure. Two prerequisite gates (discussions must exist and be concluded), then a priority chain: single discussion auto-selects, valid cache shows groupings directly, stale/none cache checks for existing specs before offering analysis.</p>
-<p>The <strong>analysis flow</strong> gathers context about topic relationships, reads all concluded discussions, analyses <strong>data, behavioural, and conceptual coupling</strong>, and caches the result. The <strong>groupings menu</strong> offers per-grouping actions (Start/Continue/Refine), Unify all, and Re-analyze. A separate <strong>specs menu</strong> appears when specs exist but cache is stale — showing existing specs alongside an analyze option.</p>
+    body: `<p>Cache-first routing with progressive disclosure. Two prerequisite gates (discussions must exist and be completed), then a priority chain: single discussion auto-selects, valid cache shows groupings directly, stale/none cache checks for existing specs before offering analysis.</p>
+<p>The <strong>analysis flow</strong> gathers context about topic relationships, reads all completed discussions, analyses <strong>data, behavioural, and conceptual coupling</strong>, and caches the result. The <strong>groupings menu</strong> offers per-grouping actions (Start/Continue/Refine), Unify all, and Re-analyze. A separate <strong>specs menu</strong> appears when specs exist but cache is stale — showing existing specs alongside an analyze option.</p>
 <p>The <strong>technical-specification</strong> skill is collaborative — it extracts, filters hallucinations, enriches gaps, presents for approval, and waits for explicit sign-off before writing.</p>`,
     meta: { output: '.workflows/{work_unit}/specification/{topic}/specification.md', skill: 'technical-specification', discovery: 'discovery.sh', cache: '{work_unit}/.state/discussion-consolidation-analysis.md' }
   },
@@ -2637,7 +2637,7 @@ const FLOWCHART_DESCS = {
   },
   implementation: {
     summary: 'Discover plans, classify readiness, gate on dependencies, and hand off to agent-based implementation.',
-    body: `<p>Discovery classifies plans into three sections: <strong>Implementable</strong> (▶ in-progress or + ready to start), <strong>Implemented</strong> (> completed), and <strong>Not implementable</strong> (· blocked deps or plan not concluded). Plan presentation includes an <strong>unblock escape hatch</strong> — users can mark blocked deps as externally satisfied without leaving the selection step. Two gates follow: <strong>external dependencies</strong> (confirmation) and <strong>environment setup</strong> (info gathering only, does not execute setup).</p>
+    body: `<p>Discovery classifies plans into three sections: <strong>Implementable</strong> (▶ in-progress or + ready to start), <strong>Implemented</strong> (> completed), and <strong>Not implementable</strong> (· blocked deps or plan not completed). Plan presentation includes an <strong>unblock escape hatch</strong> — users can mark blocked deps as externally satisfied without leaving the selection step. Two gates follow: <strong>external dependencies</strong> (confirmation) and <strong>environment setup</strong> (info gathering only, does not execute setup).</p>
 <p>Hands off to the <strong>technical-implementation</strong> skill, which dispatches executor and reviewer agents per task with a configurable approval gate (gated or auto mode). Scope selection is handled within the skill, not the command.</p>`,
     meta: { output: 'Code changes (tracked in plan)', skill: 'technical-implementation', discovery: 'discovery-for-implementation-and-review.sh' }
   },
@@ -2649,8 +2649,8 @@ const FLOWCHART_DESCS = {
   },
   'start-feature': {
     summary: 'Pipeline entry — gather context, create discussion, then bridge to continue-feature.',
-    body: `<p>Runs migrations, gathers feature context inline (what, scope, constraints), suggests a topic name, and checks for existing discussions. If a discussion exists, offers to <strong>resume</strong> (in-progress → invoke discussion, concluded → skip to bridge) or choose a <strong>new name</strong>.</p>
-<p>Invokes the <strong>technical-discussion</strong> skill with the gathered context. When the discussion concludes, a <strong>phase bridge</strong> enters plan mode with instructions to invoke <code>/continue-feature</code> in the next session for specification, planning, implementation, and review.</p>`,
+    body: `<p>Runs migrations, gathers feature context inline (what, scope, constraints), suggests a topic name, and checks for existing discussions. If a discussion exists, offers to <strong>resume</strong> (in-progress → invoke discussion, completed → skip to bridge) or choose a <strong>new name</strong>.</p>
+<p>Invokes the <strong>technical-discussion</strong> skill with the gathered context. When the discussion completes, a <strong>phase bridge</strong> enters plan mode with instructions to invoke <code>/continue-feature</code> in the next session for specification, planning, implementation, and review.</p>`,
     meta: { output: '.workflows/{work_unit}/discussion/{topic}.md', skill: 'technical-discussion', complexity: 'Pipeline' }
   },
   'link-deps': {
@@ -2662,13 +2662,13 @@ const FLOWCHART_DESCS = {
   'skill-research': {
     summary: 'The research skill — an interactive exploration loop across technical, product, and market domains.',
     body: `<p>Acts as a research partner. Uses structured questioning from <code>references/interview.md</code> to guide exploration. The core loop: <strong>Ask → Discuss → Document → Commit → Repeat</strong>.</p>
-<p>Output starts as a single <code>exploration.md</code> file and splits into separate files as distinct themes emerge. Research concludes when the user parks a topic as discussion-ready. If they return to it, research reopens — same lifecycle as any other phase.</p>`,
+<p>Output starts as a single <code>exploration.md</code> file and splits into separate files as distinct themes emerge. Research completes when the user parks a topic as discussion-ready. If they return to it, research reopens — same lifecycle as any other phase.</p>`,
     meta: { output: '.workflows/{work_unit}/research/', complexity: 'Looping skill' }
   },
   'skill-discussion': {
     summary: 'The discussion skill — captures decisions, debates, and edge cases through structured dialogue.',
-    body: `<p>Engages as an expert architect and meeting assistant. The core loop: <strong>Engage → Capture decisions → Write to disk → Commit → Repeat</strong> until the discussion is concluded. Writes happen at natural pauses — partial and provisional documentation is expected and valuable.</p>
-<p>Each question is structured as <strong>Options → Journey → Decision</strong>. The skill documents competing solutions and why choices were made, capturing the full reasoning trail. The file on disk is the defence against context compaction — what's not written is lost. Frontmatter status progresses from <code>in-progress</code> to <code>concluded</code>.</p>`,
+    body: `<p>Engages as an expert architect and meeting assistant. The core loop: <strong>Engage → Capture decisions → Write to disk → Commit → Repeat</strong> until the discussion is completed. Writes happen at natural pauses — partial and provisional documentation is expected and valuable.</p>
+<p>Each question is structured as <strong>Options → Journey → Decision</strong>. The skill documents competing solutions and why choices were made, capturing the full reasoning trail. The file on disk is the defence against context compaction — what's not written is lost. Frontmatter status progresses from <code>in-progress</code> to <code>completed</code>.</p>`,
     meta: { output: '.workflows/{work_unit}/discussion/{topic}.md', complexity: 'Looping skill' }
   },
   'skill-specification': {


### PR DESCRIPTION
## Summary

- **Normalise all terminal phase/work-unit statuses from `concluded` to `completed`** — the word "concluded" was awkward and unnatural. Every phase now uses `completed` as terminal, `in-progress` as active. `superseded` and `cancelled` unchanged.
- **Manifest CLI validation updated** — `VALID_PHASE_STATUSES` and `VALID_WORK_UNIT_STATUSES` now accept `completed`, reject `concluded`
- **Migration 020** converts existing manifests (`concluded` → `completed` for flat statuses, epic item-level statuses, and work-unit status). Migration 019 rewritten to write JSON directly instead of using manifest CLI.
- **New rule in CLAUDE.md**: migration scripts must not use the manifest CLI (point-in-time snapshots that break when validation changes)

### Scope

- 86 files changed across manifest CLI, 8 discovery scripts, ~62 skill .md files, workflow-explorer.html, 10 test files
- File renames: `view-concluded.md` → `view-completed.md`, `continue-concluded.md` → `continue-completed.md`
- Exclusions (intentionally unchanged): old migration scripts/tests (001–019), roadmap/archive docs

## Test plan

- [x] All existing test suites pass (0 failures across 21 suites)
- [x] New migration 020 test suite: 49 tests covering work-unit status, flat phases, epic items, bugfix phases, superseded unchanged, idempotency, field preservation, dot-dir skipping, multiple work units, mixed epic
- [x] Migration 019 tests still pass (34 tests) after rewrite to direct JSON
- [x] Manifest CLI validation tests confirm `concluded` is now rejected
- [x] Final sweep: only expected `concluded` references remain (old migrations, their tests, roadmap/archive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)