### PR TITLE
fix: migration 022 crash and double-slash output in 019-021

### DIFF
--- a/skills/migrate/scripts/migrations/019-status-rename.sh
+++ b/skills/migrate/scripts/migrations/019-status-rename.sh
@@ -18,6 +18,7 @@ fi
 
 for dir in "$WORKFLOWS_DIR"/*/; do
   [ -d "$dir" ] || continue
+  dir="${dir%/}"
   name=$(basename "$dir")
 
   # Skip dot-prefixed directories

--- a/skills/migrate/scripts/migrations/020-normalise-terminal-status.sh
+++ b/skills/migrate/scripts/migrations/020-normalise-terminal-status.sh
@@ -15,6 +15,7 @@ fi
 
 for dir in "$WORKFLOWS_DIR"/*/; do
   [ -d "$dir" ] || continue
+  dir="${dir%/}"
   name=$(basename "$dir")
 
   # Skip dot-prefixed directories

--- a/skills/migrate/scripts/migrations/021-research-filename-rename.sh
+++ b/skills/migrate/scripts/migrations/021-research-filename-rename.sh
@@ -14,6 +14,7 @@ fi
 
 for dir in "$WORKFLOWS_DIR"/*/; do
   [ -d "$dir" ] || continue
+  dir="${dir%/}"
   name=$(basename "$dir")
 
   # Skip dot-prefixed directories

--- a/skills/migrate/scripts/migrations/022-remove-session-state.sh
+++ b/skills/migrate/scripts/migrations/022-remove-session-state.sh
@@ -23,7 +23,7 @@ fi
 # Remove our SessionStart and SessionEnd hook entries that reference the deleted scripts.
 # Preserve any other user hooks and settings.
 
-if [ -f "$SETTINGS_FILE" ] && grep -q "workflows/session-env.sh\|workflows/compact-recovery.sh\|workflows/session-cleanup.sh" "$SETTINGS_FILE" 2>/dev/null; then
+if [ -f "$SETTINGS_FILE" ] && grep -qE "workflows/session-env\.sh|workflows/compact-recovery\.sh|workflows/session-cleanup\.sh" "$SETTINGS_FILE" 2>/dev/null; then
   if command -v node >/dev/null 2>&1; then
     result=$(node -e "
       const fs = require('fs');
@@ -69,7 +69,7 @@ if [ -f "$SETTINGS_FILE" ] && grep -q "workflows/session-env.sh\|workflows/compa
           console.log('cleaned');
         }
       }
-    " "$SETTINGS_FILE" 2>/dev/null)
+    " "$SETTINGS_FILE" 2>/dev/null) || true
 
     if [ "$result" = "removed" ]; then
       report_update "$SETTINGS_FILE" "removed (only contained session hooks)"


### PR DESCRIPTION
## Summary

- Migration 022 node command was missing `|| true` guard (unlike 019/020), causing `set -e` to abort the script when processing `.claude/settings.json` with session hooks
- Fixed grep pattern to use `-qE` with `|` instead of BRE `\|` which doesn't work on macOS BSD grep
- Stripped trailing slash from glob dirs in 019-021 to eliminate `//` in output paths

## Test plan

- [x] Set up temp project with tick's manifests (`active`/`concluded` statuses), session hooks in settings.json, and dummy sessions dir
- [x] Ran migration — exit code 0, all phases verified:
  - 019: `active` → `in-progress` + `concluded` detection
  - 020: `concluded` → `completed`
  - 022 Step 1: sessions dir removed
  - 022 Step 2: settings.json removed (only contained hooks)
- [x] No double slashes in output paths
- [x] Migrations log recorded 019-022

🤖 Generated with [Claude Code](https://claude.com/claude-code)