### PR TITLE
fix: disable sandbox for migrate skill settings.json writes

### DIFF
--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -10,11 +10,13 @@ Keeps your workflow files up to date with how the system is designed to work. Ru
 
 ## Instructions
 
-Run the migration script:
+Run the migration script with sandbox disabled (migrations may need to modify `.claude/settings.json`):
 
 ```bash
 .claude/skills/migrate/scripts/migrate.sh
 ```
+
+**CRITICAL**: Use `dangerouslyDisableSandbox: true` when calling the Bash tool for this command.
 
 #### If files were updated
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -27,10 +27,10 @@ The script will list which files were updated. Present this to the user:
 ```
 {list from script output}
 
-Review changes with `git diff`, then proceed when ready.
+Review changes with `git diff`, then restart Claude to pick up the changes.
 ```
 
-Wait for user acknowledgment before returning control to the calling skill.
+**STOP.** Wait for user response. Do not proceed — the user needs to restart Claude.
 
 #### If no updates needed
 


### PR DESCRIPTION
## Summary

- Migration 022 removes session hook entries from `.claude/settings.json`, but the Claude Code sandbox blocks Bash writes to that file
- `fs.writeFileSync`/`fs.unlinkSync` fail silently (caught by `2>/dev/null || true`), so the migration records as complete without actually modifying the file
- The migrate skill now instructs the model to use `dangerouslyDisableSandbox: true` when running the migration script

## Test plan

- [ ] Reset a project with stale session hooks in `.claude/settings.json`
- [ ] Run any workflow skill (triggers `/migrate` as Step 0)
- [ ] Verify the sandbox permission prompt appears
- [ ] After approval, confirm `.claude/settings.json` has hooks removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)