### PR TITLE
fix: allow workflow-start to route to continue-* skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ tests/
 
 Skills are organised in two tiers:
 
-**Entry-point skills** (`/start-*`, `/continue-*`, `/status`, `/migrate`, etc.) are user-invocable. They gather context from files, prompts, or inline input, then invoke a processing skill. Utility entry-points (`/status`, `/view-plan`, `/link-dependencies`, `/workflow-start`, `/continue-feature`, `/continue-bugfix`, `/continue-epic`) have `disable-model-invocation: true`. `/migrate` has `user-invocable: false` — it is model-invoked only (Step 0 of every user-invocable entry-point skill).
+**Entry-point skills** (`/start-*`, `/continue-*`, `/status`, `/migrate`, etc.) are user-invocable. They gather context from files, prompts, or inline input, then invoke a processing skill. Utility entry-points (`/status`, `/view-plan`, `/link-dependencies`, `/workflow-start`) have `disable-model-invocation: true`. `/migrate` has `user-invocable: false` — it is model-invoked only (Step 0 of every user-invocable entry-point skill).
 
 **Phase entry skills** (`workflow-*-entry`) are internal (`user-invocable: false`). They are invoked by start/continue/bridge skills with work_type and work_unit always provided. They handle phase-specific validation, bootstrap questions for new entries, and processing skill invocation.
 

--- a/skills/continue-bugfix/SKILL.md
+++ b/skills/continue-bugfix/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: continue-bugfix
-disable-model-invocation: true
 allowed-tools: Bash(node .claude/skills/continue-bugfix/scripts/discovery.js), Bash(node .claude/skills/workflow-manifest/scripts/manifest.js)
 ---
 

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: continue-epic
-disable-model-invocation: true
 allowed-tools: Bash(node .claude/skills/continue-epic/scripts/discovery.js), Bash(node .claude/skills/workflow-manifest/scripts/manifest.js)
 ---
 

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: continue-feature
-disable-model-invocation: true
 allowed-tools: Bash(node .claude/skills/continue-feature/scripts/discovery.js), Bash(node .claude/skills/workflow-manifest/scripts/manifest.js)
 ---
 


### PR DESCRIPTION
## Summary

- Removed `disable-model-invocation: true` from `continue-bugfix`, `continue-feature`, and `continue-epic` skills
- These skills need to be model-invocable so `workflow-start` can route to them via the Skill tool (same as `start-*` skills which already work)
- Updated CLAUDE.md to reflect the corrected list of `disable-model-invocation` skills

## Test plan

- [ ] Run `/workflow-start` with an active bugfix — selecting "Continue" should invoke `continue-bugfix` without error
- [ ] Same for active feature and epic
- [ ] Direct `/continue-bugfix`, `/continue-feature`, `/continue-epic` invocations still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)