### PR TITLE
fix: use exists before get for own-phase status in entry skills

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -48,17 +48,17 @@ Store work_unit for the handoff.
 
 #### If `topic` resolved
 
-Check discussion phase status via manifest CLI:
+Check if discussion phase entry exists:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase discussion --topic {topic}
 ```
 
-**If phase exists (in-progress or completed):**
+**If exists (`true`):**
 
 → Proceed to **Step 2** (Validate Phase).
 
-**If phase not found (new entry):**
+**If not exists (`false` — new entry):**
 
 → Proceed to **Step 7** (Gather Context) with source="new".
 

--- a/skills/workflow-implementation-entry/references/validate-phase.md
+++ b/skills/workflow-implementation-entry/references/validate-phase.md
@@ -40,7 +40,13 @@ The plan for "{topic:(titlecase)}" is not yet completed.
 
 #### If plan exists and status is `completed`
 
-Check implementation's own status:
+Check if implementation phase entry exists:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase implementation --topic {topic}
+```
+
+**If exists (`true`):**
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} status
@@ -62,8 +68,14 @@ Reopening implementation: {topic:(titlecase)}
 
 → Return to **[the skill](../SKILL.md)**.
 
-**If status is `in-progress` or not found:**
+**If status is `in-progress`:**
 
 Proceed normally.
+
+→ Return to **[the skill](../SKILL.md)**.
+
+**If not exists (`false`):**
+
+Proceed normally (new entry).
 
 → Return to **[the skill](../SKILL.md)**.

--- a/skills/workflow-planning-entry/references/validate-phase.md
+++ b/skills/workflow-planning-entry/references/validate-phase.md
@@ -7,10 +7,14 @@
 Check whether a plan already exists for this topic.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase planning --topic {topic}
 ```
 
-#### If existing plan (continue or review)
+#### If exists (`true`)
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} status
+```
 
 **If status is `completed`:**
 
@@ -36,7 +40,7 @@ Set source="existing".
 
 → Return to **[the skill](../SKILL.md)**.
 
-#### If no existing plan (fresh start)
+#### If not exists (`false` — fresh start)
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -56,7 +56,13 @@ The implementation for "{topic:(titlecase)}" is not yet completed.
 
 #### If plan and implementation are both ready
 
-Check review's own phase status:
+Check if review phase entry exists:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
+```
+
+**If exists (`true`):**
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} status
@@ -78,8 +84,14 @@ Reopening review: {topic:(titlecase)}
 
 → Return to **[the skill](../SKILL.md)**.
 
-**If status is `in-progress` or not found:**
+**If status is `in-progress`:**
 
 Proceed normally.
+
+→ Return to **[the skill](../SKILL.md)**.
+
+**If not exists (`false`):**
+
+Proceed normally (new entry).
 
 → Return to **[the skill](../SKILL.md)**.


### PR DESCRIPTION
## Summary

- Entry skills checking their own phase status now call `exists` before `get` to avoid exit code 1 errors on first entry (before the phase is initialized)
- Fixed in 4 skills: review-entry, implementation-entry, planning-entry, discussion-entry
- Prerequisite phase checks remain as `get` calls — their absence is a true error

## Test plan

- [ ] Start a new feature and proceed through to review — verify no red error output when entering each phase for the first time
- [ ] Continue an in-progress feature at each phase — verify existing phases still route correctly (resume/reopen)
- [ ] Verify completed phase reopening still works (triggers `set` to reset status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)