### PR TITLE
feat: research-to-discussion handoff — pass files, not summaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,7 @@ $MANIFEST list                                                         # enumera
 $MANIFEST get {work_unit} work_type                                    # work-unit-level read
 $MANIFEST set {work_unit} status completed                             # work-unit-level status
 $MANIFEST set {work_unit} phases.research.analysis_cache '{"checksum":"..."}' # work-unit-level write (dot-path)
+$MANIFEST delete {work_unit} phases.research.analysis_cache             # delete a key (work-unit-level)
 $MANIFEST get {work_unit} --phase discussion --topic "*" status        # wildcard: collect from all topics
 ```
 

--- a/roadmap/IMPLEMENTATION-INDEX.md
+++ b/roadmap/IMPLEMENTATION-INDEX.md
@@ -17,7 +17,7 @@ Overview of remaining PRs for the work-type architecture. PR 1 (Big Bang) is the
 | ✅ | PR 9 | Normalise Terminal Status | [PR9-NORMALISE-TERMINAL-STATUS.md](PR9-NORMALISE-TERMINAL-STATUS.md) |
 | ✅ | PR 10 | Research Refactor | [Design Brief](research-refactor/DESIGN-BRIEF.md) |
 | ✅ | PR 11 | Session State Removal | [Design Brief](session-state-removal/DESIGN-BRIEF.md) |
-| 12th | PR 12 | Feature Research Analysis | [PR12-FEATURE-RESEARCH-ANALYSIS.md](PR12-FEATURE-RESEARCH-ANALYSIS.md) |
+| 12th | PR 12 | Research-to-Discussion Handoff | [PR12-FEATURE-RESEARCH-ANALYSIS.md](PR12-FEATURE-RESEARCH-ANALYSIS.md) |
 | 13th | PR 13 | Manifest CLI — Wildcard Topic | [PR13-MANIFEST-WILDCARD-TOPIC.md](PR13-MANIFEST-WILDCARD-TOPIC.md) |
 
 ## Why This Order

--- a/roadmap/PR12-FEATURE-RESEARCH-ANALYSIS.md
+++ b/roadmap/PR12-FEATURE-RESEARCH-ANALYSIS.md
@@ -1,48 +1,109 @@
-# PR 12: Feature Research Analysis for Discussion Seeding
+# PR 12: Research-to-Discussion Handoff
 
 ## Problem
 
-When a feature work unit completes research and enters the discussion phase, the research content is shown as raw context but not analysed. For epic, the discussion entry skill analyses all research files, extracts themes, caches the analysis (with content hashing in the manifest), and presents topic recommendations. Feature has no equivalent — the research-to-discussion transition is unstructured.
+Two issues with how research feeds into discussion:
 
-## Proposal
+### 1. Epic: Double summarization loses information
 
-Introduce research analysis for feature work units entering discussion. Same caching mechanics as epic (content hash tracked in manifest, analysis cached in `.state/`), but different output shape:
+The epic research analysis extracts 1-2 sentence summaries per topic. When a topic is selected, the entry skill further condenses this into a 2-5 line summary. The handoff to `technical-discussion` passes only this twice-distilled snippet plus a file/line reference. The discussion skill never reads the original research files — the actual depth, nuance, and reasoning is lost.
 
-- **Epic**: Analysis breaks research into multiple topic recommendations. User picks which to discuss. Multiple discussions over multiple sessions.
-- **Feature**: Analysis produces a single summary that seeds one discussion. No topic breakdown — the feature pipeline is linear by design. Even if the research suggests multiple themes, they feed into one discussion topic (the feature's work unit name).
+The analysis should be a **topic discovery tool** — it helps the user pick which topic to discuss. Once picked, the discussion skill should work from the **source research files** directly.
 
-## What This Involves
+### 2. Feature: No research analysis at all
 
-### Discussion entry skill (`workflow-discussion-entry`)
+When a feature completes research and enters discussion, the research content is shown as raw context but not analyzed. The `source="new"` path in `gather-context.md` reads research files and shows key findings, but this is ad-hoc — there's no structured analysis step.
 
-The "new entry with research concluded" path in `gather-context.md` currently shows raw research context with "anything to add?". Instead:
+## Design Decisions
 
-1. Check if a cached feature research analysis exists (hash in manifest, file in `.state/`)
-2. If cache is valid — use it to seed the discussion with a structured summary
-3. If no cache or stale — analyse the research file, extract key findings, decisions, open questions, and constraints into a structured summary. Cache the analysis with content hash.
-4. Present the summary to the user with "anything to add?" before proceeding
+### Analysis = topic discovery only
 
-### Caching mechanics
+The research analysis exists to help users pick a discussion topic (epic) or confirm what's being discussed (feature). It is **not** a content proxy. The discussion skill reads source research files directly.
 
-Same pattern as epic research analysis in the discussion discovery script:
-- Hash the research file content
-- Store hash + timestamp in manifest at `phases.research.analysis_cache`
-- Store the analysis in `.workflows/{work_unit}/.state/research-analysis.md`
-- Invalidate when hash changes
+Analysis cache shape per topic:
+- **Theme name** — represents the topic
+- **Summary** — as long as needed to convey what the topic covers (not artificially short)
+- **Sources** — which research file(s) contain relevant material
 
-### Key constraint
+No key questions (the discussion skill derives these from the full research). No line numbers (themes are often scattered across files — pinning line ranges is fragile and usually wrong).
 
-Feature = one topic = one discussion. The analysis must NOT suggest breaking into multiple topics. It produces a consolidated summary of everything the research explored, framed as input to a single discussion.
+### Discussion reads source research
+
+When a topic is selected and has associated research, the handoff tells `technical-discussion` which files to read. The discussion skill reads them directly during Step 1 (Initialize Discussion), pulling relevant material into Context and deriving Questions from the actual research.
+
+### No caching for feature
+
+Epic needs caching because: multiple research files need cross-cutting analysis, multiple sessions enter discussion for different topics, and the topic breakdown menu needs stable output.
+
+Feature has none of these: one research file (or a small set all feeding one topic), one discussion session, no topic selection menu. The analysis happens inline — read research, produce a structured summary, present it, move on.
+
+### Research remains optional
+
+Research is optional for both epic and feature. The distinction between work types is about scope and shape (multi-topic vs single-topic), not certainty. You can have an epic where you already know the architecture, or a feature where you need to explore first.
+
+When research doesn't exist, the existing seeding questions (core problem, constraints, codebase files) gather the context that research would have provided. These are unchanged.
+
+## Changes
+
+### Epic: Fix the handoff
+
+**`workflow-discussion-entry/references/gather-context-research.md`** — instead of summarizing the analysis summary, pass file references:
+
+```
+Discussion session for: {topic}
+Work unit: {work_unit}
+Output: {output_path}
+
+Research files:
+- .workflows/{work_unit}/research/{filename1}.md
+- .workflows/{work_unit}/research/{filename2}.md
+Topic context: {summary from analysis — what this topic is about}
+```
+
+**`workflow-discussion-entry/references/invoke-skill.md`** — update the `source="research"` handoff template to pass file paths instead of a line-reference + summary.
+
+**`technical-discussion` Step 1** — when research files are provided in the handoff, read them and use the content to populate Context and derive Questions.
+
+### Epic: Slim the analysis cache
+
+**`workflow-discussion-entry/references/research-analysis.md`** — update cache format:
+
+```markdown
+# Research Analysis Cache
+
+## Topics
+
+### {Theme name}
+- **Summary**: {as long as needed}
+- **Sources**: {filename1}.md, {filename2}.md
+```
+
+Drop key questions and line numbers.
+
+### Feature: Add inline research analysis
+
+**`workflow-discussion-entry/references/gather-context.md`** — the `source="new"` path when research is completed: read research files, produce a structured summary (theme, what it covers, source files), present with "anything to add?", then pass research file references in handoff.
+
+No caching, no manifest cache fields, no `.state/` file. Inline analysis only.
+
+**`workflow-discussion-entry/references/invoke-skill.md`** — the `source="new-with-research"` handoff passes research file paths so the discussion skill reads them directly.
+
+### Discussion skill: Read research files
+
+**`technical-discussion/SKILL.md` Step 1** — when the handoff includes research file paths, read them as part of initialization. Use the content (not summaries of summaries) to populate Context and seed Questions.
 
 ## Scope
 
-- `workflow-discussion-entry/references/gather-context.md` — new entry path checks for and runs feature research analysis
-- `workflow-discussion-entry/scripts/discovery.js` — may need to compute feature research cache state (currently only does this for epic)
-- Manifest cache fields — same structure as epic, just scoped to feature work units
-- New or updated cache file in `.state/`
+- `workflow-discussion-entry/references/gather-context.md` — feature research analysis (inline)
+- `workflow-discussion-entry/references/gather-context-research.md` — epic: pass file refs not summaries
+- `workflow-discussion-entry/references/research-analysis.md` — slim cache format
+- `workflow-discussion-entry/references/invoke-skill.md` — both handoff templates pass file paths
+- `technical-discussion/SKILL.md` (Step 1) — read research files when provided
+- `technical-discussion/references/template.md` — may need References section guidance
 
 ## Not In Scope
 
 - Bugfix (no research phase)
-- Epic (already has research analysis with topic breakdown)
 - Changes to the research processing skill itself
+- Seeding questions for fresh discussions (already correct)
+- Research optionality (already works — both epic and feature offer research as optional)

--- a/skills/migrate/scripts/migrations/023-clear-research-analysis-cache.sh
+++ b/skills/migrate/scripts/migrations/023-clear-research-analysis-cache.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Migration 023: Clear old-format research analysis caches
+#   The analysis cache format has changed (no more line numbers or key questions).
+#   This migration:
+#   1. Deletes .state/research-analysis.md files from all work units
+#   2. Removes analysis_cache from manifest phases.research so discovery
+#      doesn't think a valid cache exists when the file is gone
+#
+
+WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+
+[ -d "$WORKFLOWS_DIR" ] || exit 0
+
+# --- Step 1: Delete old-format .state/research-analysis.md files ---
+
+for state_file in "$WORKFLOWS_DIR"/*/.state/research-analysis.md; do
+  [ -f "$state_file" ] || continue
+  rm "$state_file"
+  report_update "$state_file" "removed old-format research analysis cache"
+done
+
+# --- Step 2: Clear analysis_cache from manifests ---
+
+for manifest in "$WORKFLOWS_DIR"/*/manifest.json; do
+  [ -f "$manifest" ] || continue
+
+  # Skip dot-prefixed directories
+  dir_name=$(basename "$(dirname "$manifest")")
+  case "$dir_name" in .*) continue ;; esac
+
+  result=$(node -e "
+    const fs = require('fs');
+    const m = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+    if (m.phases && m.phases.research && m.phases.research.analysis_cache) {
+      delete m.phases.research.analysis_cache;
+      fs.writeFileSync(process.argv[1], JSON.stringify(m, null, 2) + '\n');
+      console.log('cleared');
+    }
+  " "$manifest" 2>/dev/null) || true
+
+  if [ "$result" = "cleared" ]; then
+    report_update "$manifest" "removed analysis_cache from manifest"
+  fi
+done

--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -81,7 +81,8 @@ Found existing discussion for **{topic:(titlecase)}**.
 
 1. Ensure the discussion directory exists: `.workflows/{work_unit}/discussion/`
 2. Load **[template.md](references/template.md)** — use it to create the discussion file at `.workflows/{work_unit}/discussion/{topic}.md`.
-3. Populate Context section and initial Questions list
+3. **If the handoff includes a "Research files:" section**: read each listed research file using the Read tool. Use the full research content — guided by the "Topic context" field — to populate the Context section and derive initial Questions.
+   **Otherwise**: populate Context section and initial Questions list from handoff context and user input as before.
 4. Register discussion in manifest:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase discussion --topic {topic}

--- a/skills/technical-discussion/SKILL.md
+++ b/skills/technical-discussion/SKILL.md
@@ -81,8 +81,15 @@ Found existing discussion for **{topic:(titlecase)}**.
 
 1. Ensure the discussion directory exists: `.workflows/{work_unit}/discussion/`
 2. Load **[template.md](references/template.md)** — use it to create the discussion file at `.workflows/{work_unit}/discussion/{topic}.md`.
-3. **If the handoff includes a "Research files:" section**: read each listed research file using the Read tool. Use the full research content — guided by the "Topic context" field — to populate the Context section and derive initial Questions.
-   **Otherwise**: populate Context section and initial Questions list from handoff context and user input as before.
+3. Populate Context section and initial Questions list:
+
+   **If the handoff includes a `Research files:` section:**
+
+   Read each listed research file using the Read tool. Use the full research content — guided by the `Topic context` field — to populate the Context section and derive initial Questions.
+
+   **Otherwise:**
+
+   Populate from handoff context and user input as before.
 4. Register discussion in manifest:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase discussion --topic {topic}

--- a/skills/workflow-discussion-entry/references/display-options.md
+++ b/skills/workflow-discussion-entry/references/display-options.md
@@ -18,7 +18,7 @@ Discussion Overview
 Research topics:
 
 1. {theme_name}
-   └─ Source: {filename}.md (lines {start}-{end})
+   └─ Sources: {filename1}.md, {filename2}.md
    └─ Discussion: @if(has_discussion) {work_unit}/{topic} ({status:[in-progress|completed]}) @else (no discussion) @endif
    └─ "{summary}"
 

--- a/skills/workflow-discussion-entry/references/gather-context-research.md
+++ b/skills/workflow-discussion-entry/references/gather-context-research.md
@@ -4,16 +4,18 @@
 
 ---
 
-Summarise the selected research topic in 2-5 lines, drawing from the source, summary, and key questions in the research analysis.
+Present the analysis summary and source files as-is — do not re-summarize.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 New discussion: {topic}
 
-Based on research: .workflows/{work_unit}/research/{filename}.md (lines {start}-{end})
+Research sources:
+  • .workflows/{work_unit}/research/{filename1}.md
+  • .workflows/{work_unit}/research/{filename2}.md
 
-{2-5 line summary of the topic and what needs discussing}
+Topic: {summary from analysis cache}
 
 · · · · · · · · · · · ·
 Do you have anything to add? Extra context, files, or additional

--- a/skills/workflow-discussion-entry/references/gather-context.md
+++ b/skills/workflow-discussion-entry/references/gather-context.md
@@ -18,15 +18,18 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 
 **If research status is `completed`:**
 
-Read `.workflows/{work_unit}/research/*.md` for context to include in the handoff.
+List the research files via `ls .workflows/{work_unit}/research/*.md`.
 
 > *Output the next fenced block as a code block:*
 
 ```
 Starting discussion: {topic:(titlecase)}
 
-Research context:
-{key findings and context from research files}
+Research available:
+  • .workflows/{work_unit}/research/{filename1}.md
+  • .workflows/{work_unit}/research/{filename2}.md
+
+These will be read when the discussion begins.
 
 Anything to add or adjust before we begin, or "go" to proceed:
 ```

--- a/skills/workflow-discussion-entry/references/handle-selection.md
+++ b/skills/workflow-discussion-entry/references/handle-selection.md
@@ -66,7 +66,7 @@ Refreshing analysis...
 
 Clear the cache metadata from the manifest and delete the cache file:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} phases.research.analysis_cache null
+node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} phases.research.analysis_cache
 rm .workflows/{work_unit}/.state/research-analysis.md
 ```
 

--- a/skills/workflow-discussion-entry/references/handle-selection.md
+++ b/skills/workflow-discussion-entry/references/handle-selection.md
@@ -64,9 +64,10 @@ Set source="fresh".
 Refreshing analysis...
 ```
 
-Delete the cache file:
+Clear the cache metadata from the manifest and delete the cache file:
 ```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} phases.research.analysis_cache null
 rm .workflows/{work_unit}/.state/research-analysis.md
 ```
 
-→ Return to **[the skill](../SKILL.md)** for **Step 5**.
+→ Return to **[the skill](../SKILL.md)** for **Step 4**.

--- a/skills/workflow-discussion-entry/references/invoke-skill.md
+++ b/skills/workflow-discussion-entry/references/invoke-skill.md
@@ -23,9 +23,10 @@ Discussion session for: {topic}
 Work unit: {work_unit}
 Output: {output_path}
 
-Research reference:
-Source: .workflows/{work_unit}/research/{filename}.md (lines {start}-{end})
-Summary: {the 1-2 sentence summary from the research analysis}
+Research files:
+- .workflows/{work_unit}/research/{filename1}.md
+- .workflows/{work_unit}/research/{filename2}.md
+Topic context: {summary from analysis cache}
 
 Invoke the technical-discussion skill.
 ```
@@ -37,9 +38,10 @@ Discussion session for: {topic}
 Work unit: {work_unit}
 Output: {output_path}
 
-Research reference:
-Source: .workflows/{work_unit}/research/{research_filename}.md
-Summary: {the discussion-ready summary from the research file}
+Research files:
+- .workflows/{work_unit}/research/{filename1}.md
+- .workflows/{work_unit}/research/{filename2}.md
+Topic context: {brief orientation from user context}
 
 Invoke the technical-discussion skill.
 ```

--- a/skills/workflow-discussion-entry/references/research-analysis.md
+++ b/skills/workflow-discussion-entry/references/research-analysis.md
@@ -27,9 +27,8 @@ Analyzing research documents...
 ```
 
 Read each research file and extract key themes and potential discussion topics. For each theme:
-- Note the source file and relevant line numbers
-- Summarize what the theme is about in 1-2 sentences
-- Identify key questions or decisions that need discussion
+- Note the source file(s) that contributed to it
+- Summarize what the theme covers (as long as needed to convey the topic — no length constraint)
 
 **Be thorough**: This analysis will be cached, so identify ALL potential topics:
 - Major architectural decisions
@@ -63,14 +62,12 @@ Create/update `.workflows/{work_unit}/.state/research-analysis.md` (pure markdow
 ## Topics
 
 ### {Theme name}
-- **Source**: {filename}.md (lines {start}-{end})
-- **Summary**: {1-2 sentence summary}
-- **Key questions**: {what needs deciding}
+- **Summary**: {as long as needed to convey what this topic covers}
+- **Sources**: {filename1}.md, {filename2}.md
 
 ### {Another theme}
-- **Source**: {filename}.md (lines {start}-{end})
-- **Summary**: {1-2 sentence summary}
-- **Key questions**: {what needs deciding}
+- **Summary**: {as long as needed to convey what this topic covers}
+- **Sources**: {filename1}.md, {filename2}.md
 ```
 
 **Cross-reference**: For each topic, note if a discussion already exists (from `discussions.files` in discovery).

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -31,6 +31,7 @@ $MANIFEST init-phase {work_unit} --phase discussion --topic {topic}
 # Work-unit operations (no flags):
 $MANIFEST get {work_unit} [field]
 $MANIFEST set {work_unit} field value
+$MANIFEST delete {work_unit} field.path
 
 # Existence checks (always exit 0, outputs true/false):
 $MANIFEST exists {work_unit}
@@ -117,6 +118,22 @@ Values are parsed as JSON first (for arrays, objects, numbers, booleans), fallin
 - **phase statuses**: per-phase valid values (see Validation section)
 - **gate modes**: `gated`, `auto`
 - **work unit status**: `in-progress`, `completed`, `cancelled`
+
+### `delete`
+
+Remove a key from the manifest. Two modes:
+
+**Work-unit level** (no flags):
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js delete <name> <field.path>
+```
+
+**Phase level** (with flags):
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js delete <name> --phase research --topic <topic> analysis_cache
+```
+
+Errors if the path does not exist. Deletes the key entirely (not just setting to null). Parent keys are preserved.
 
 ### `list`
 

--- a/skills/workflow-manifest/scripts/manifest.js
+++ b/skills/workflow-manifest/scripts/manifest.js
@@ -311,6 +311,20 @@ function setByPath(obj, segments, value) {
   current[segments[segments.length - 1]] = value;
 }
 
+function deleteByPath(obj, segments) {
+  let current = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    if (current == null || typeof current !== 'object') return false;
+    current = current[seg];
+  }
+  if (current == null || typeof current !== 'object') return false;
+  const last = segments[segments.length - 1];
+  if (!(last in current)) return false;
+  delete current[last];
+  return true;
+}
+
 function parseValue(raw) {
   try {
     return JSON.parse(raw);
@@ -477,6 +491,57 @@ function cmdSet(args) {
     const fresh = readManifest(name);
     setByPath(fresh, segments, value);
     writeManifestAtomic(name, fresh);
+  });
+}
+
+function cmdDelete(args) {
+  const { phase, topic, positional } = parseFlags(args);
+
+  if (!phase) {
+    // Work-unit-level: delete <name> <field.path>
+    if (positional.length !== 2) die('Usage: delete <name> <field.path>');
+
+    const name = positional[0];
+    const segments = positional[1].split('.');
+
+    if (!fs.existsSync(manifestPath(name))) {
+      die(`Work unit "${name}" not found`);
+    }
+
+    withLock(name, () => {
+      const manifest = readManifest(name);
+      if (!deleteByPath(manifest, segments)) {
+        die(`Path "${positional[1]}" not found in "${name}"`);
+      }
+      writeManifestAtomic(name, manifest);
+    });
+    return;
+  }
+
+  // Phase-level: delete <name> --phase <phase> [--topic <topic>] <field.path>
+  if (positional.length !== 2) {
+    die('Usage: delete <name> --phase <phase> [--topic <topic>] <field.path>');
+  }
+
+  const name = positional[0];
+  validatePhase(phase);
+  if (!topic && !TOPICLESS_PHASES.includes(phase)) {
+    die(`--topic is required for phase "${phase}"`);
+  }
+
+  const fieldSegments = positional[1].split('.');
+
+  if (!fs.existsSync(manifestPath(name))) {
+    die(`Work unit "${name}" not found`);
+  }
+
+  withLock(name, () => {
+    const manifest = readManifest(name);
+    const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
+    if (!deleteByPath(manifest, segments)) {
+      die(`Path "${segments.join('.')}" not found in "${name}"`);
+    }
+    writeManifestAtomic(name, manifest);
   });
 }
 
@@ -691,13 +756,14 @@ function cmdExists(args) {
 const [command, ...args] = process.argv.slice(2);
 
 if (!command) {
-  die('Usage: manifest.js <command> [args]\nCommands: init, get, set, list, init-phase, push, exists');
+  die('Usage: manifest.js <command> [args]\nCommands: init, get, set, delete, list, init-phase, push, exists');
 }
 
 switch (command) {
   case 'init':     cmdInit(args); break;
   case 'get':      cmdGet(args); break;
   case 'set':      cmdSet(args); break;
+  case 'delete':   cmdDelete(args); break;
   case 'list':     cmdList(args); break;
   case 'init-phase': cmdInitPhase(args); break;
   case 'push':     cmdPush(args); break;

--- a/tests/scripts/test-migration-023.sh
+++ b/tests/scripts/test-migration-023.sh
@@ -1,0 +1,407 @@
+#!/bin/bash
+#
+# Tests migration 023-clear-research-analysis-cache.sh
+# Validates removal of old-format analysis caches and manifest cleanup.
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/migrate/scripts/migrations/023-clear-research-analysis-cache.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Helper functions
+#
+
+setup_fixture() {
+    rm -rf "$TEST_DIR/.workflows"
+}
+
+create_manifest() {
+    local name="$1"
+    local content="$2"
+    mkdir -p "$TEST_DIR/.workflows/$name"
+    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+}
+
+create_state_file() {
+    local name="$1"
+    local content="$2"
+    mkdir -p "$TEST_DIR/.workflows/$name/.state"
+    echo "$content" > "$TEST_DIR/.workflows/$name/.state/research-analysis.md"
+}
+
+# Stub report_update for migration script
+export -f report_update 2>/dev/null || true
+report_update() { echo "updated: $1 — $2"; }
+export -f report_update
+
+run_migration() {
+    cd "$TEST_DIR"
+    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+}
+
+get_field() {
+    local name="$1"
+    local field="$2"
+    node -e "
+      const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+      const parts = process.argv[2].split('.');
+      let v = m;
+      for (const p of parts) v = (v || {})[p];
+      console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
+    " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected: $expected"
+        echo -e "    Actual:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_file_exists() {
+    local path="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ -f "$path" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File not found: $path"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_file_not_exists() {
+    local path="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ ! -f "$path" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File should not exist: $path"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Should not find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    else
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+echo -e "${YELLOW}Test: deletes .state/research-analysis.md${NC}"
+setup_fixture
+
+create_manifest "my-feat" '{"work_type":"feature","status":"in-progress","phases":{"research":{}}}'
+create_state_file "my-feat" "# Research Analysis Cache\n\n## Topics\n\n### Theme\n- old format"
+
+output=$(run_migration)
+
+assert_file_not_exists "$TEST_DIR/.workflows/my-feat/.state/research-analysis.md" "State file deleted"
+assert_contains "$output" "removed old-format research analysis cache" "Reports file removal"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: clears analysis_cache from manifest${NC}"
+setup_fixture
+
+create_manifest "cached-feat" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "research": {
+      "status": "completed",
+      "analysis_cache": {
+        "checksum": "abc123",
+        "generated": "2026-01-15T10:00:00Z",
+        "files": ["intro.md", "deep-dive.md"]
+      }
+    }
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "cached-feat" "phases.research.analysis_cache")" "undefined" "analysis_cache removed from manifest"
+assert_equals "$(get_field "cached-feat" "phases.research.status")" "completed" "Research status preserved"
+assert_contains "$output" "removed analysis_cache from manifest" "Reports manifest cleanup"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: both file and manifest cleaned together${NC}"
+setup_fixture
+
+create_manifest "both" '{
+  "work_type": "epic",
+  "status": "in-progress",
+  "phases": {
+    "research": {
+      "status": "completed",
+      "analysis_cache": {"checksum": "xyz789", "generated": "2026-02-01", "files": ["a.md"]}
+    }
+  }
+}'
+create_state_file "both" "# old cache content"
+
+output=$(run_migration)
+
+assert_file_not_exists "$TEST_DIR/.workflows/both/.state/research-analysis.md" "State file deleted"
+assert_equals "$(get_field "both" "phases.research.analysis_cache")" "undefined" "analysis_cache removed"
+assert_equals "$(get_field "both" "phases.research.status")" "completed" "Research status preserved"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: manifest without analysis_cache unchanged${NC}"
+setup_fixture
+
+create_manifest "no-cache" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "research": {"status": "completed"},
+    "discussion": {"status": "in-progress"}
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "no-cache" "phases.research.status")" "completed" "Research status unchanged"
+assert_equals "$(get_field "no-cache" "phases.discussion.status")" "in-progress" "Discussion status unchanged"
+assert_not_contains "$output" "removed analysis_cache" "No manifest update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: manifest without research phase unchanged${NC}"
+setup_fixture
+
+create_manifest "no-research" '{"work_type":"bugfix","status":"in-progress","phases":{"investigation":{"status":"in-progress"}}}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "no-research" "phases.investigation.status")" "in-progress" "Investigation unchanged"
+assert_not_contains "$output" "updated" "No update reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state"
+echo '{"phases":{"research":{"analysis_cache":{"checksum":"old"}}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
+create_manifest "real" '{"work_type":"feature","status":"in-progress","phases":{"research":{"analysis_cache":{"checksum":"old"}}}}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "real" "phases.research.analysis_cache")" "undefined" "Real manifest cleaned"
+dot_cache=$(node -e "
+  const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+  console.log(m.phases.research.analysis_cache ? 'present' : 'absent');
+" "$TEST_DIR/.workflows/.state/manifest.json")
+assert_equals "$dot_cache" "present" "Dot-dir manifest not touched"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
+setup_fixture
+
+create_manifest "idem" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "research": {
+      "status": "completed",
+      "analysis_cache": {"checksum": "abc", "generated": "2026-01-01", "files": ["x.md"]}
+    }
+  }
+}'
+create_state_file "idem" "# old cache"
+
+run_migration > /dev/null
+output=$(run_migration)
+
+assert_file_not_exists "$TEST_DIR/.workflows/idem/.state/research-analysis.md" "State file still gone"
+assert_equals "$(get_field "idem" "phases.research.analysis_cache")" "undefined" "analysis_cache still gone"
+assert_not_contains "$output" "removed" "No updates on second run"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
+setup_fixture
+
+create_manifest "preserve" '{
+  "name": "preserve",
+  "work_type": "feature",
+  "status": "in-progress",
+  "created": "2026-01-15",
+  "phases": {
+    "research": {
+      "status": "completed",
+      "analysis_cache": {"checksum": "abc"}
+    },
+    "discussion": {"status": "in-progress"}
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "preserve" "name")" "preserve" "Name preserved"
+assert_equals "$(get_field "preserve" "work_type")" "feature" "Work type preserved"
+assert_equals "$(get_field "preserve" "created")" "2026-01-15" "Created date preserved"
+assert_equals "$(get_field "preserve" "phases.research.status")" "completed" "Research status preserved"
+assert_equals "$(get_field "preserve" "phases.discussion.status")" "in-progress" "Discussion status preserved"
+assert_equals "$(get_field "preserve" "phases.research.analysis_cache")" "undefined" "analysis_cache removed"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: multiple work units processed${NC}"
+setup_fixture
+
+create_manifest "feat-a" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {"research": {"status": "completed", "analysis_cache": {"checksum": "a1"}}}
+}'
+create_state_file "feat-a" "# cache a"
+
+create_manifest "feat-b" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {"research": {"status": "completed", "analysis_cache": {"checksum": "b2"}}}
+}'
+
+create_manifest "feat-c" '{
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {"research": {"status": "completed"}}
+}'
+
+run_migration > /dev/null
+
+assert_file_not_exists "$TEST_DIR/.workflows/feat-a/.state/research-analysis.md" "feat-a state file deleted"
+assert_equals "$(get_field "feat-a" "phases.research.analysis_cache")" "undefined" "feat-a cache cleared"
+assert_equals "$(get_field "feat-b" "phases.research.analysis_cache")" "undefined" "feat-b cache cleared"
+assert_equals "$(get_field "feat-c" "phases.research.analysis_cache")" "undefined" "feat-c had no cache, still none"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
+setup_fixture
+
+output=$(run_migration)
+
+assert_not_contains "$output" "removed" "No updates without .workflows dir"
+
+echo ""
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "Tests run: $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "========================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -1004,6 +1004,135 @@ assert_equals "$exit_code" "0" "Wildcard exists on empty exits 0"
 echo ""
 
 # ============================================================================
+# DELETE TESTS
+# ============================================================================
+
+echo -e "${YELLOW}Test: delete work-unit-level field${NC}"
+setup_fixture
+run_cli init del-wu --work-type feature --description "Delete WU" >/dev/null 2>&1
+run_cli set del-wu phases.research.analysis_cache '{"checksum":"abc","generated":"2026-01-01"}' >/dev/null 2>&1
+run_cli delete del-wu phases.research.analysis_cache >/dev/null 2>&1
+output=$(run_cli_stdout exists del-wu phases.research.analysis_cache)
+
+assert_equals "$output" "false" "Deleted field no longer exists"
+
+# Verify sibling fields preserved
+run_cli set del-wu phases.research.status completed >/dev/null 2>&1
+
+# Re-create and delete to check siblings
+run_cli set del-wu phases.research.analysis_cache '{"checksum":"xyz"}' >/dev/null 2>&1
+run_cli delete del-wu phases.research.analysis_cache >/dev/null 2>&1
+research_status=$(run_cli_stdout get del-wu --phase research --topic del-wu status 2>/dev/null || run_cli_stdout get del-wu phases.research.status)
+
+assert_equals "$research_status" "completed" "Sibling fields preserved after delete"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete phase-level field for feature${NC}"
+setup_fixture
+run_cli init del-feat --work-type feature --description "Delete feat" >/dev/null 2>&1
+run_cli init-phase del-feat --phase planning --topic del-feat >/dev/null 2>&1
+run_cli set del-feat --phase planning --topic del-feat task_gate_mode auto >/dev/null 2>&1
+run_cli delete del-feat --phase planning --topic del-feat task_gate_mode >/dev/null 2>&1
+output=$(run_cli_stdout exists del-feat --phase planning --topic del-feat task_gate_mode)
+
+assert_equals "$output" "false" "Deleted phase-level field gone"
+
+# Verify status preserved
+plan_status=$(run_cli_stdout get del-feat --phase planning --topic del-feat status)
+assert_equals "$plan_status" "in-progress" "Phase status preserved after delete"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete phase-level field for epic${NC}"
+setup_fixture
+run_cli init del-epic --work-type epic --description "Delete epic" >/dev/null 2>&1
+run_cli init-phase del-epic --phase implementation --topic auth >/dev/null 2>&1
+run_cli push del-epic --phase implementation --topic auth completed_tasks "task-1" >/dev/null 2>&1
+run_cli delete del-epic --phase implementation --topic auth completed_tasks >/dev/null 2>&1
+output=$(run_cli_stdout exists del-epic --phase implementation --topic auth completed_tasks)
+
+assert_equals "$output" "false" "Deleted epic item field gone"
+
+# Verify status preserved
+impl_status=$(run_cli_stdout get del-epic --phase implementation --topic auth status)
+assert_equals "$impl_status" "in-progress" "Epic item status preserved after delete"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete nested dot-path field${NC}"
+setup_fixture
+run_cli init del-nested --work-type feature --description "Nested" >/dev/null 2>&1
+run_cli set del-nested phases.research.analysis_cache.checksum "abc123" >/dev/null 2>&1
+run_cli set del-nested phases.research.analysis_cache.generated "2026-01-01" >/dev/null 2>&1
+run_cli delete del-nested phases.research.analysis_cache.checksum >/dev/null 2>&1
+
+checksum_exists=$(run_cli_stdout exists del-nested phases.research.analysis_cache.checksum)
+generated_exists=$(run_cli_stdout exists del-nested phases.research.analysis_cache.generated)
+
+assert_equals "$checksum_exists" "false" "Nested field deleted"
+assert_equals "$generated_exists" "true" "Sibling nested field preserved"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete entire subtree${NC}"
+setup_fixture
+run_cli init del-tree --work-type feature --description "Tree" >/dev/null 2>&1
+run_cli set del-tree phases.research.analysis_cache '{"checksum":"abc","generated":"2026-01-01","files":["a.md","b.md"]}' >/dev/null 2>&1
+run_cli delete del-tree phases.research.analysis_cache >/dev/null 2>&1
+
+cache_exists=$(run_cli_stdout exists del-tree phases.research.analysis_cache)
+research_exists=$(run_cli_stdout exists del-tree phases.research)
+
+assert_equals "$cache_exists" "false" "Entire subtree deleted"
+assert_equals "$research_exists" "true" "Parent key preserved"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete errors on missing path${NC}"
+setup_fixture
+run_cli init del-missing --work-type feature --description "Missing" >/dev/null 2>&1
+assert_exit_nonzero "Delete missing path errors" delete del-missing nonexistent.deep.path
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete errors on missing work unit${NC}"
+setup_fixture
+assert_exit_nonzero "Delete missing work unit errors" delete ghost-unit some.field
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete requires --topic for topic-required phases${NC}"
+setup_fixture
+run_cli init del-notopic --work-type feature --description "No topic" >/dev/null 2>&1
+assert_exit_nonzero "Delete without topic errors" delete del-notopic --phase discussion status
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete rejects invalid phase${NC}"
+setup_fixture
+run_cli init del-badphase --work-type feature --description "Bad phase" >/dev/null 2>&1
+assert_exit_nonzero "Delete invalid phase errors" delete del-badphase --phase cooking --topic del-badphase status
+
+echo ""
+
+# ============================================================================
 # SUMMARY
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- **Analysis cache is now topic discovery only** — summaries have no length constraint, line numbers and key questions dropped. Once a topic is picked, the discussion skill reads original research files directly.
- **Feature path gets same treatment** — lists research file paths instead of reading and summarizing them upfront; files are read when the discussion begins.
- **Migration 023** clears old-format `.state/research-analysis.md` files and strips `analysis_cache` from manifests so stale caches don't interfere.

## Test plan

- [x] Migration 023 tests pass (29/29): `bash tests/scripts/test-migration-023.sh`
- [ ] Trace epic flow: research-analysis.md → display-options.md → handle-selection.md → gather-context-research.md → invoke-skill.md → technical-discussion Step 1
- [ ] Trace feature flow: gather-context.md (source="new" + research) → invoke-skill.md → technical-discussion Step 1
- [ ] Verify handle-selection.md still works (references topics by number/name, no format dependency on line numbers)
- [ ] Verify refresh action still works (deletes `.state/research-analysis.md`, loops back to regenerate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)