### PR TITLE
docs: add delete to manifest CLI command list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ skills/
   workflow-shared/             # Shared utilities used by other workflow skills
     scripts/discovery-utils.js #   Discovery helpers (manifest loading, phase state, checksums)
   workflow-manifest/           # Manifest CLI — single source of truth for workflow state
-    scripts/manifest.js        #   Node.js CLI (get/set/list/init/init-phase/push/exists)
+    scripts/manifest.js        #   Node.js CLI (get/set/delete/list/init/init-phase/push/exists)
 
   # Entry-point skills (user-invocable — gather context, invoke processing skills)
   migrate/                   # Keep workflow files in sync with system design


### PR DESCRIPTION
## Summary
- Add `delete` to the manifest CLI command list in CLAUDE.md structure tree (was missing after the delete command was added in d608306)

## Test plan
- [ ] Verify CLAUDE.md structure tree shows `(get/set/delete/list/init/init-phase/push/exists)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)