### PR TITLE
fix: reset analysis_cycle and fix_attempts on impl completion

### DIFF
--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -314,6 +314,8 @@ Discuss the user's context. If additional work is needed, route back to **Step 6
 Update implementation status via manifest CLI:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_cycle 0
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_attempts 0
 ```
 
 Commit: `impl({work_unit}): complete implementation`


### PR DESCRIPTION
## Summary
- Reset `analysis_cycle` and `fix_attempts` counters to 0 when implementation completes in Step 8
- Prevents stale counters from causing premature threshold warnings when review sends remediation tasks back to implementation
- Existing resets in `review-actions-loop.md` and Step 3 remain as safety nets

## Test plan
- [ ] Complete an implementation phase and verify counters are reset in manifest
- [ ] Send remediation tasks back from review and confirm no premature threshold warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)