### PR TITLE
fix: add format reading adapter and review presentation

### DIFF
--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -57,6 +57,7 @@ For each plan:
 1. Read the plan — understand phases, tasks, and acceptance criteria
 2. Read the linked specification — load design context
 3. Extract all tasks across all phases
+4. Load the format's reading adapter from `../technical-planning/references/output-formats/{format}/reading.md` — this tells you how to locate and read individual task files
 
 → Proceed to **Step 2**.
 
@@ -100,7 +101,15 @@ Load **[produce-review.md](references/produce-review.md)** and follow its instru
 
 ---
 
-## Step 5: Review Actions
+## Step 5: Present Review
+
+Load **[present-review.md](references/present-review.md)** and follow its instructions as written.
+
+→ Proceed to **Step 6**.
+
+---
+
+## Step 6: Review Actions
 
 Load **[review-actions-loop.md](references/review-actions-loop.md)** and follow its instructions.
 

--- a/skills/technical-review/references/invoke-task-verifiers.md
+++ b/skills/technical-review/references/invoke-task-verifiers.md
@@ -22,7 +22,7 @@ This captures all files touched by implementation commits for the topic.
 
 ## Extract All Tasks
 
-From each plan in scope, list every task across all phases:
+Using the format reading adapter loaded in Step 1, extract every task across all phases from each plan in scope:
 - Note each task's description
 - Note each task's acceptance criteria
 - Note expected micro acceptance (test name)

--- a/skills/technical-review/references/present-review.md
+++ b/skills/technical-review/references/present-review.md
@@ -1,0 +1,79 @@
+# Present Review
+
+*Reference for **[technical-review](../SKILL.md)***
+
+---
+
+Read the review file at `.workflows/{work_unit}/review/{topic}/r{N}/review.md`.
+
+Present a structured summary to the user:
+
+> *Output the next fenced block as a code block:*
+
+```
+Review: {topic} (r{N})
+
+Verdict: {Approve | Request Changes | Comments Only}
+
+{One paragraph summary from the review}
+```
+
+#### If verdict is `Approve`
+
+> *Output the next fenced block as a code block:*
+
+```
+All acceptance criteria met. No blocking issues found.
+
+{Any recommendations, if present}
+```
+
+#### If verdict is `Request Changes`
+
+> *Output the next fenced block as a code block:*
+
+```
+Required Changes:
+
+  1. {change description}
+     {file:line reference if available}
+
+  2. ...
+
+{Recommendations section, if present}
+```
+
+#### If verdict is `Comments Only`
+
+> *Output the next fenced block as a code block:*
+
+```
+Comments:
+
+  {Recommendations from the review}
+```
+
+---
+
+## Q&A Loop
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+- **`c`/`continue`** — Proceed to review actions
+- **Or ask a question** about the review findings
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If user asks a question
+
+Answer the question using the review file, QA task files, specification, and plan as context. After answering:
+
+→ Return to **Q&A Loop**.
+
+#### If `continue`
+
+→ Return to **[the skill](../SKILL.md)**.


### PR DESCRIPTION
## Summary

- **Format reading adapter**: Review skill now loads `output-formats/{format}/reading.md` in Step 1 so task extraction knows how to locate and parse task files (matching what the implementation skill already does)
- **Review presentation**: New Step 5 (`present-review.md`) displays a structured verdict summary with a Q&A loop before entering the actions loop — users now see findings before being asked about synthesis
- Old Step 5 (review actions) renumbered to Step 6

## Test plan

- [ ] Run a review on a topic with local-markdown format — verify format adapter is loaded and tasks are extracted correctly
- [ ] Confirm review findings are presented after `produce-review.md` writes the review file
- [ ] Test Q&A loop: ask a question, get an answer, then `continue` to proceed
- [ ] Verify the actions loop (now Step 6) still works correctly after renumbering

🤖 Generated with [Claude Code](https://claude.com/claude-code)