### PR TITLE
fix: anchor research analysis theme names to existing discussions

### DIFF
--- a/skills/workflow-discussion-entry/references/research-analysis.md
+++ b/skills/workflow-discussion-entry/references/research-analysis.md
@@ -39,6 +39,15 @@ Read each research file and extract key themes and potential discussion topics. 
 - Security or performance considerations
 - Edge cases or error handling mentioned
 
+### Anchor to Existing Discussions
+
+**CRITICAL**: Check `discussions.files` from discovery. These are discussion filenames that already exist for this work unit.
+
+When naming themes:
+- If a theme clearly maps to an existing discussion, you MUST use that discussion's filename (converted from kebab-case) as the theme name. E.g., if `data-schema-design.md` exists and you identify a matching theme, name it "Data Schema Design" — not "Database Schema Architecture" or any variation.
+- Only create new names for themes with no matching existing discussion.
+- For each topic, note if a discussion already exists.
+
 **Save to cache:**
 
 Write cache metadata to manifest:
@@ -69,7 +78,5 @@ Create/update `.workflows/{work_unit}/.state/research-analysis.md` (pure markdow
 - **Summary**: {as long as needed to convey what this topic covers}
 - **Sources**: {filename1}.md, {filename2}.md
 ```
-
-**Cross-reference**: For each topic, note if a discussion already exists (from `discussions.files` in discovery).
 
 → Return to **[the skill](../SKILL.md)**.


### PR DESCRIPTION
## Summary

- Research analysis theme names were assigned freely with no regard for existing discussion files, causing broken cross-references when cache was regenerated (stale/missing cache or manual refresh)
- Added anchoring instructions so themes MUST reuse existing discussion filenames (kebab→title case), matching the pattern already used by the spec phase's `anchored_names`
- Migration 023 (clear old-format analysis cache) is now safe — regenerated analysis will anchor to existing discussions automatically

## Test plan

- [ ] Verify an epic with existing discussions regenerates analysis with matching theme names
- [ ] Verify the display correctly links research themes to existing discussions
- [ ] Verify new themes (no matching discussion) still get fresh names
- [ ] Verify "refresh" action produces anchored results

🤖 Generated with [Claude Code](https://claude.com/claude-code)