### PR TITLE
fix: standardise menu option conventions across all skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,7 +431,7 @@ Rendered as markdown (not code blocks). Framed with dot separators. Verb-based l
 
 **Option types** — menus contain two kinds of option:
 
-- **Command option** (explicit): A discrete input the user types verbatim. Formatted with backtick-wrapped shorthand: **`y`/`yes`**, **`s`/`single`**, **`a`/`auto`**. The conditional branch uses the command value (e.g., `#### If \`yes\``).
+- **Command option** (explicit): A discrete input the user types verbatim. Formatted with backtick-wrapped shorthand: **`y`/`yes`**, **`s`/`single`**, **`a`/`auto`**. The shorthand is the first letter of the word; if two options in the same menu share a first letter, use the second letter for the conflicting option (e.g., **`a`/`approve`** and **`b`/`abort`**). The conditional branch uses the command value (e.g., `#### If \`yes\``).
 - **Prompt option** (implicit): The user responds naturally rather than issuing a command. Formatted with plain bold text (no backticks): **Keep going**, **Comment**, **Ask**. The conditional branch uses the label in lowercase (e.g., `#### If keep going`). Limit to one prompt option per menu to avoid ambiguity — since routing is intent-based, multiple prompt options would be hard to distinguish.
 
 Both types use `— description` to explain what the option does (unless self-evident, as with yes/no).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,10 +431,21 @@ Rendered as markdown (not code blocks). Framed with dot separators. Verb-based l
 
 **Option types** — menus contain two kinds of option:
 
-- **Command option**: A discrete input the user types verbatim. Formatted with backtick-wrapped shorthand: **`y`/`yes`**, **`s`/`single`**, **`a`/`auto`**. The conditional branch uses the command value (e.g., `#### If \`yes\``).
-- **Prompt option**: A natural-language response — the user keeps talking rather than issuing a command. Formatted with plain bold text (no backticks): **Keep going**, **Comment**, **Ask**. The conditional branch uses the label in lowercase (e.g., `#### If keep going`).
+- **Command option** (explicit): A discrete input the user types verbatim. Formatted with backtick-wrapped shorthand: **`y`/`yes`**, **`s`/`single`**, **`a`/`auto`**. The conditional branch uses the command value (e.g., `#### If \`yes\``).
+- **Prompt option** (implicit): The user responds naturally rather than issuing a command. Formatted with plain bold text (no backticks): **Keep going**, **Comment**, **Ask**. The conditional branch uses the label in lowercase (e.g., `#### If keep going`). Limit to one prompt option per menu to avoid ambiguity — since routing is intent-based, multiple prompt options would be hard to distinguish.
 
-The distinction matters for routing: command options match exact input, prompt options match intent.
+Both types use `— description` to explain what the option does (unless self-evident, as with yes/no).
+
+**Mixed prompt** — command and prompt options together:
+
+```
+· · · · · · · · · · · ·
+Investigation complete. Ready to conclude?
+
+- **`y`/`yes`** — Conclude investigation
+- **Keep going** — Continue discussing to explore further
+· · · · · · · · · · · ·
+```
 
 **Selection menu** — use concrete examples showing verb-to-state mapping:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,7 +427,7 @@ Key:
 
 ### Menus / Interactive Prompts
 
-Rendered as markdown (not code blocks). Framed with dot separators. Verb-based labels for selection menus. No single-character icons.
+Rendered as markdown (not code blocks). Framed with `· · · · · · · · · · · ·` dot separators at top and bottom — no blank lines between the dots and the content they frame. A question or contextual label appears first inside the dots, followed by a blank line, then the options. Verb-based labels for selection menus. No single-character icons.
 
 **Option types** — menus contain two kinds of option:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,13 @@ Key:
 
 Rendered as markdown (not code blocks). Framed with dot separators. Verb-based labels for selection menus. No single-character icons.
 
+**Option types** — menus contain two kinds of option:
+
+- **Command option**: A discrete input the user types verbatim. Formatted with backtick-wrapped shorthand: **`y`/`yes`**, **`s`/`single`**, **`a`/`auto`**. The conditional branch uses the command value (e.g., `#### If \`yes\``).
+- **Prompt option**: A natural-language response — the user keeps talking rather than issuing a command. Formatted with plain bold text (no backticks): **Keep going**, **Comment**, **Ask**. The conditional branch uses the label in lowercase (e.g., `#### If keep going`).
+
+The distinction matters for routing: command options match exact input, prompt options match intent.
+
 **Selection menu** — use concrete examples showing verb-to-state mapping:
 
 ```

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -175,7 +175,9 @@ Previous session used these project skills:
 - ...
 
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Keep these, proceed
+Keep these project skills?
+
+- **`y`/`yes`** — Keep and proceed
 - **`c`/`change`** — Re-discover and choose skills
 · · · · · · · · · · · ·
 ```
@@ -208,9 +210,11 @@ Found these project skills that may be relevant to implementation:
 - ...
 
 · · · · · · · · · · · ·
+Which project skills should be used?
+
 - **`a`/`all`** — Use all listed skills
 - **`n`/`none`** — Skip project skills
-- **Or list the ones you want** — e.g. "golang-pro, react-patterns"
+- **List the ones you want** — e.g. "golang-pro, react-patterns"
 · · · · · · · · · · · ·
 ```
 
@@ -244,7 +248,9 @@ Otherwise, present discovery findings to the user:
 Recommendations: {any suggested tools with install commands}
 
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Approve these linter commands
+Approve these linters?
+
+- **`y`/`yes`** — Approve and proceed
 - **`c`/`change`** — Modify the linter list
 - **`s`/`skip`** — Skip linter setup (no linting during TDD)
 · · · · · · · · · · · ·
@@ -298,7 +304,9 @@ Before marking complete, present the sign-off:
 
 ```
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Mark implementation as completed
+Ready to mark implementation as completed?
+
+- **`y`/`yes`** — Mark as completed
 - **Comment** — Add context before completing
 · · · · · · · · · · · ·
 ```

--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -38,7 +38,9 @@ Analysis has run {N-1} times so far. You can continue (recommended if issues wer
 
 ```
 · · · · · · · · · · · ·
-- **`p`/`proceed`** — Continue analysis *(default)*
+Continue with analysis?
+
+- **`p`/`proceed`** — Continue analysis
 - **`s`/`skip`** — Skip analysis, proceed to completion
 · · · · · · · · · · · ·
 ```
@@ -73,7 +75,9 @@ Categorize them:
 
 ```
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Include all in the checkpoint commit
+Include unexpected files in the checkpoint commit?
+
+- **`y`/`yes`** — Include all
 - **`s`/`skip`** — Exclude unexpected files, commit only implementation files
 - **Comment** — Specify which to include
 · · · · · · · · · · · ·
@@ -185,7 +189,7 @@ Approve this task?
 - **`y`/`yes`** — Approve this task
 - **`a`/`auto`** — Approve this and all remaining tasks automatically
 - **`s`/`skip`** — Skip this task
-- **Comment** — Revise based on feedback
+- **Revise** — Provide feedback to adjust
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -52,6 +52,8 @@ Task {id}: {Task Name} — {blocked/failed}
 
 ```
 · · · · · · · · · · · ·
+Task failed. How would you like to proceed?
+
 - **`r`/`retry`** — Re-invoke the executor with your comments (provide below)
 - **`s`/`skip`** — Skip this task and move to the next
 - **`t`/`stop`** — Stop implementation entirely
@@ -112,11 +114,13 @@ Check `fix_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/s
 
 ```
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Accept the review and fix analysis, pass to executor
+Accept the reviewer's fix analysis?
+
+- **`y`/`yes`** — Pass to executor
 - **`a`/`auto`** — Accept and auto-approve future fix analyses
 - **`s`/`skip`** — Override the reviewer and proceed as-is
 - **Ask** — Ask questions about the review (doesn't accept or reject)
-- **Comment** — Accept with adjustments — pass your own direction to the executor alongside the review
+- **Comment** — Accept with adjustments — pass your own direction alongside the review
 · · · · · · · · · · · ·
 ```
 
@@ -155,11 +159,12 @@ Check the `task_gate_mode` via manifest CLI (`node .claude/skills/workflow-manif
 
 ```
 · · · · · · · · · · · ·
-**Options:**
-- **`y`/`yes`** — Approve, commit, continue to next task
-- **`a`/`auto`** — Approve this and all future tasks automatically (skips review prompts and questions)
+Approve this task?
+
+- **`y`/`yes`** — Commit and continue to next task
+- **`a`/`auto`** — Approve this and all future tasks automatically
 - **Ask** — Ask questions about the implementation (doesn't approve or reject)
-- **Comment** — Request changes — pass feedback or commentary (triggers a fix round)
+- **Comment** — Request changes (triggers a fix round)
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-investigation/references/conclude-investigation.md
+++ b/skills/technical-investigation/references/conclude-investigation.md
@@ -13,22 +13,15 @@ The user has already reviewed findings and agreed on fix direction. This step co
 Investigation complete. Ready to conclude?
 
 - **`y`/`yes`** — Conclude investigation
-- **Comment** — Add context before concluding
-- **`r`/`reopen`** — Reopen investigation (more analysis needed)
+- **Keep going** — Continue discussing to explore further
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-#### If `reopen`
-
-Ask what aspects need more analysis.
+#### If keep going
 
 → Return to **[the skill](../SKILL.md)** for **Step 3**.
-
-#### If `comment`
-
-Incorporate the user's context into the investigation file and commit. Re-present the same conclusion prompt.
 
 #### If `yes`
 

--- a/skills/technical-investigation/references/findings-review.md
+++ b/skills/technical-investigation/references/findings-review.md
@@ -37,7 +37,7 @@ Why It Wasn't Caught:
 Do these findings match your understanding?
 
 - **`y`/`yes`** — Findings are correct, discuss fix direction
-- **Or provide feedback** on what's off or unclear.
+- **Provide feedback** — Tell me what's off or unclear
 · · · · · · · · · · · ·
 ```
 
@@ -80,7 +80,7 @@ multiple approaches benefit from comparison structure.}
 What are your thoughts?
 
 - **`y`/`yes`** — Agree with this direction
-- **Or provide feedback** to discuss, challenge, or suggest alternatives.
+- **Provide feedback** — Discuss, challenge, or suggest alternatives
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-planning/references/analyze-task-graph.md
+++ b/skills/technical-planning/references/analyze-task-graph.md
@@ -54,9 +54,10 @@ I've analyzed all {M} tasks and the natural execution order is already correct �
 
 ```
 · · · · · · · · · · · ·
-**To proceed:**
-- **`y`/`yes`** — Confirmed.
-- **Or tell me what to change.**
+Approve the dependency graph?
+
+- **`y`/`yes`** — Proceed
+- **Tell me what to change** — Adjust priorities or dependencies
 · · · · · · · · · · · ·
 ```
 
@@ -102,9 +103,10 @@ I've analyzed and applied dependencies and priorities across all {M} tasks:
 
 ```
 · · · · · · · · · · · ·
-**To proceed:**
-- **`y`/`yes`** — Approved.
-- **Or tell me what to change.**
+Approve the updated graph?
+
+- **`y`/`yes`** — Proceed
+- **Tell me what to change** — Adjust priorities or dependencies
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -99,11 +99,12 @@ Present the full task content:
 
 ```
 · · · · · · · · · · · ·
-**To proceed:**
-- **`y`/`yes`** — Approved. I'll write it to the plan.
+Approve this task?
+
+- **`y`/`yes`** — Write it to the plan
 - **`a`/`auto`** — Approve this and all remaining tasks automatically
-- **Or tell me what to change.**
-- **Or navigate** — a different phase or task, or the leading edge.
+- **Tell me what to change** — Revise this task's detail
+- **Navigate** — a different phase or task, or the leading edge
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-planning/references/define-phases.md
+++ b/skills/technical-planning/references/define-phases.md
@@ -71,10 +71,11 @@ Present the phase structure to the user as rendered markdown (not in a code bloc
 
 ```
 · · · · · · · · · · · ·
-**To proceed:**
-- **`y`/`yes`** — Approved. I'll proceed to task breakdown.
-- **Or tell me what to change** — reorder, split, merge, add, edit, or remove phases.
-- **Or navigate** — a different phase or task, or the leading edge.
+Approve this phase structure?
+
+- **`y`/`yes`** — Proceed to task breakdown
+- **Tell me what to change** — reorder, split, merge, add, edit, or remove phases
+- **Navigate** — a different phase or task, or the leading edge
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-planning/references/define-tasks.md
+++ b/skills/technical-planning/references/define-tasks.md
@@ -81,11 +81,12 @@ Phase {N}: {Phase Name} — task list approved. Proceeding to authoring.
 
 ```
 · · · · · · · · · · · ·
-**To proceed:**
-- **`y`/`yes`** — Approved.
+Approve this task list?
+
+- **`y`/`yes`** — Proceed to authoring
 - **`a`/`auto`** — Approve this and all remaining task list gates automatically
-- **Or tell me what to change** — reorder, split, merge, add, edit, or remove tasks.
-- **Or navigate** — a different phase or task, or the leading edge.
+- **Tell me what to change** — reorder, split, merge, add, edit, or remove tasks
+- **Navigate** — a different phase or task, or the leading edge
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-planning/references/plan-construction.md
+++ b/skills/technical-planning/references/plan-construction.md
@@ -81,10 +81,11 @@ Phase {N}: {Phase Name} — task list confirmed. Proceeding to authoring.
 
 ```
 · · · · · · · · · · · ·
-**To proceed:**
-- **`y`/`yes`** — Confirmed.
-- **Or tell me what to change.**
-- **Or navigate** — a different phase or task, or the leading edge.
+Approve this task list?
+
+- **`y`/`yes`** — Proceed to authoring
+- **Tell me what to change** — Revise tasks in this phase
+- **Navigate** — a different phase or task, or the leading edge
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-planning/references/plan-review.md
+++ b/skills/technical-planning/references/plan-review.md
@@ -101,7 +101,9 @@ with fresh context — 2-3 cycles typically surface anything cascading.
 
 ```
 · · · · · · · · · · · ·
-- **`r`/`reanalyse`** — Run another round of review (traceability + integrity)
+Run another review round?
+
+- **`r`/`reanalyse`** — Run another round (traceability + integrity)
 - **`p`/`proceed`** — Proceed to conclusion
 · · · · · · · · · · · ·
 ```

--- a/skills/technical-planning/references/process-review-findings.md
+++ b/skills/technical-planning/references/process-review-findings.md
@@ -111,10 +111,11 @@ Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
 ```
 · · · · · · · · · · · ·
 **Finding {N} of {total}: {Brief Title}**
-- **`y`/`yes`** — Approved. Apply to the plan verbatim.
+
+- **`y`/`yes`** — Apply to the plan verbatim
 - **`a`/`auto`** — Approve this and all remaining findings automatically
-- **`s`/`skip`** — Leave as-is, move to next finding.
-- **Or provide feedback** to adjust the fix.
+- **`s`/`skip`** — Leave as-is, move to next finding
+- **Provide feedback** — Adjust before approving
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-planning/references/resolve-dependencies.md
+++ b/skills/technical-planning/references/resolve-dependencies.md
@@ -49,9 +49,10 @@ Present a summary of the dependency state: what was documented, what was resolve
 
 ```
 · · · · · · · · · · · ·
-**To proceed:**
-- **`y`/`yes`** — Approved.
-- **Or tell me what to change.**
+Approve the dependency resolution?
+
+- **`y`/`yes`** — Proceed
+- **Tell me what to change** — Adjust resolutions or add missing links
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-review/references/present-review.md
+++ b/skills/technical-review/references/present-review.md
@@ -61,8 +61,10 @@ Comments:
 
 ```
 · · · · · · · · · · · ·
+Any questions before proceeding?
+
 - **`c`/`continue`** — Proceed to review actions
-- **Or ask a question** about the review findings
+- **Ask a question** — Ask about the review findings
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-review/references/review-actions-loop.md
+++ b/skills/technical-review/references/review-actions-loop.md
@@ -60,10 +60,10 @@ Synthesizing findings into actionable tasks is recommended.
 
 ```
 · · · · · · · · · · · ·
+Proceed with synthesis?
+
 - **`y`/`yes`** — Synthesize findings into tasks *(recommended)*
 - **`n`/`no`** — Skip synthesis
-
-Proceed with synthesis?
 · · · · · · · · · · · ·
 ```
 
@@ -105,10 +105,10 @@ You can synthesize these into tasks or skip.
 
 ```
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Synthesize findings into tasks
-- **`n`/`no`** — Skip synthesis *(default)*
-
 Synthesize non-blocking findings?
+
+- **`y`/`yes`** — Synthesize findings into tasks
+- **`n`/`no`** — Skip synthesis
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-specification/references/process-review-findings.md
+++ b/skills/technical-specification/references/process-review-findings.md
@@ -104,10 +104,11 @@ Finding {N} of {total}: {brief_title:(titlecase)} — approved. Added to specifi
 ```
 · · · · · · · · · · · ·
 **Finding {N} of {total}: {brief_title:(titlecase)}**
-- **`y`/`yes`** — Approved. Add to the specification verbatim.
+
+- **`y`/`yes`** — Add to the specification verbatim
 - **`a`/`auto`** — Approve this and all remaining findings automatically
-- **`s`/`skip`** — Leave as-is, move to next finding.
-- **Or provide feedback** to adjust.
+- **`s`/`skip`** — Leave as-is, move to next finding
+- **Provide feedback** — Adjust before approving
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-specification/references/spec-construction.md
+++ b/skills/technical-specification/references/spec-construction.md
@@ -53,9 +53,10 @@ Then, **separately from the content above** (clear visual break):
 
 ```
 · · · · · · · · · · · ·
-**To proceed:**
-- **`y`/`yes`** — Approved. I'll add the above to the specification **verbatim** (exactly as shown, no modifications).
-- **Or tell me what to change.**
+Record this to the specification verbatim?
+
+- **`y`/`yes`** — Add exactly as shown, no modifications
+- **Tell me what to change** — Revise before recording
 · · · · · · · · · · · ·
 ```
 

--- a/skills/technical-specification/references/spec-review.md
+++ b/skills/technical-specification/references/spec-review.md
@@ -61,7 +61,9 @@ were still found last cycle) or skip to completion.
 
 ```
 · · · · · · · · · · · ·
-- **`p`/`proceed`** — Continue review *(default)*
+Continue with review?
+
+- **`p`/`proceed`** — Continue review
 - **`s`/`skip`** — Skip review, proceed to completion
 · · · · · · · · · · · ·
 ```
@@ -176,6 +178,8 @@ Auto-review has not converged after 5 cycles — escalating for human review.
 
 ```
 · · · · · · · · · · · ·
+Run another review cycle?
+
 - **`r`/`reanalyse`** — Run another review cycle (Phase 1 + Phase 2)
 - **`p`/`proceed`** — Proceed to completion
 · · · · · · · · · · · ·

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -75,7 +75,7 @@ Set `implementation_completed` = true.
 @if(implementation_completed)
 - **`d`/`done`** — Mark as completed
 @endif
-- **`x`/`cancel`** — Mark as cancelled
+- **`c`/`cancel`** — Mark as cancelled
 - **`b`/`back`** — Return
 - **Ask** — Ask a question about this work unit
 · · · · · · · · · · · ·
@@ -97,7 +97,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} st
 
 → Return to caller to redisplay main view (re-run discovery, re-render from top).
 
-#### If user chose `x`/`cancel`
+#### If user chose `c`/`cancel`
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status cancelled


### PR DESCRIPTION
## Summary

- **Define option types in CLAUDE.md**: Document command options (explicit, backtick-wrapped shorthand) vs prompt options (implicit, plain bold) with shorthand derivation rules and one-prompt-option-per-menu guidance
- **Standardise all menus**: Add question at top of every dot-framed menu, fix shorthand violations (`x`/`cancel` → `c`/`cancel`), remove `Or` prefixes from prompt options, remove `*(default)*` annotations, add `— description` to all bare options
- **Simplify investigation conclusion**: Replace reopen/comment options with a single "Keep going" prompt option

## Test plan

- [ ] Verify CLAUDE.md option type definitions are clear and complete
- [ ] Spot-check menus in planning, implementation, and review skills render correctly
- [ ] Confirm `c`/`cancel` shorthand works in manage-work-unit flow
- [ ] Verify investigation conclude prompt offers yes/keep-going options only

🤖 Generated with [Claude Code](https://claude.com/claude-code)