### PR TITLE
refactor: normalise Step 0 and init-phase across all processing skills

### DIFF
--- a/roadmap/IMPLEMENTATION-INDEX.md
+++ b/roadmap/IMPLEMENTATION-INDEX.md
@@ -17,7 +17,7 @@ Overview of remaining PRs for the work-type architecture. PR 1 (Big Bang) is the
 | ✅ | PR 9 | Normalise Terminal Status | [PR9-NORMALISE-TERMINAL-STATUS.md](PR9-NORMALISE-TERMINAL-STATUS.md) |
 | ✅ | PR 10 | Research Refactor | [Design Brief](research-refactor/DESIGN-BRIEF.md) |
 | ✅ | PR 11 | Session State Removal | [Design Brief](session-state-removal/DESIGN-BRIEF.md) |
-| 12th | PR 12 | Research-to-Discussion Handoff | [PR12-FEATURE-RESEARCH-ANALYSIS.md](PR12-FEATURE-RESEARCH-ANALYSIS.md) |
+| ✅ | PR 12 | Research-to-Discussion Handoff | [PR12-FEATURE-RESEARCH-ANALYSIS.md](PR12-FEATURE-RESEARCH-ANALYSIS.md) |
 | 13th | PR 13 | Manifest CLI — Wildcard Topic | [PR13-MANIFEST-WILDCARD-TOPIC.md](PR13-MANIFEST-WILDCARD-TOPIC.md) |
 
 ## Why This Order

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -30,7 +30,9 @@ The script will list which files were updated. Present this to the user:
 Review changes with `git diff`, then restart Claude to pick up the changes.
 ```
 
-**STOP.** Wait for user response. Do not proceed — the user needs to restart Claude.
+The user needs to restart Claude before proceeding.
+
+**STOP.** Wait for user response.
 
 #### If no updates needed
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -91,7 +91,7 @@ Do NOT modify commands based on other project documentation (CLAUDE.md, etc.).
 Do NOT parallelize steps — execute each command sequentially.
 Complete ALL setup steps before proceeding.
 
-Load **[environment-setup.md](references/environment-setup.md)** and follow its instructions.
+Load **[environment-setup.md](references/environment-setup.md)** and follow its instructions as written.
 
 #### If `.workflows/.state/environment-setup.md` states `No special setup required`
 
@@ -204,8 +204,13 @@ Keep these project skills?
 
 **STOP.** Wait for user choice.
 
-- **`yes`**: → Proceed to **Step 5**.
-- **`change`**: Clear `project_skills` and fall through to discovery below.
+#### If `yes`
+
+→ Proceed to **Step 5**.
+
+#### If `change`
+
+Clear `project_skills` and fall through to discovery below.
 
 #### If `.claude/skills/` does not exist or is empty
 
@@ -252,7 +257,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} --pha
 
 ## Step 5: Linter Discovery
 
-Load **[linter-setup.md](references/linter-setup.md)** and follow its discovery process to identify project linters.
+Load **[linter-setup.md](references/linter-setup.md)** and follow its instructions as written.
 
 Check `linters` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} linters`). If already populated, present the existing configuration for confirmation (same pattern as project skills in Step 4). If confirmed, skip discovery and proceed.
 
@@ -278,9 +283,19 @@ Approve these linters?
 
 **STOP.** Wait for user choice.
 
-- **`yes`**: Store the approved linter commands via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters [...]`).
-- **`change`**: Adjust based on user input, re-present for confirmation.
-- **`skip`**: Store empty linters array via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters []`).
+#### If `yes`
+
+Store the approved linter commands via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters [...]`).
+
+→ Proceed to **Step 6**.
+
+#### If `change`
+
+Adjust based on user input, re-present for confirmation.
+
+#### If `skip`
+
+Store empty linters array via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters []`).
 
 → Proceed to **Step 6**.
 
@@ -333,7 +348,7 @@ Ready to mark implementation as completed?
 
 **STOP.** Wait for user response.
 
-#### If `comment`
+#### If comment
 
 Discuss the user's context. If additional work is needed, route back to **Step 6** or **Step 7** as appropriate. Otherwise, re-present the sign-off prompt above.
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -350,7 +350,15 @@ Ready to mark implementation as completed?
 
 #### If comment
 
-Discuss the user's context. If additional work is needed, → Return to **Step 6** or **Step 7** as appropriate. Otherwise, re-present the sign-off prompt above.
+Discuss the user's context.
+
+**If additional work is needed:**
+
+→ Return to **Step 6** or **Step 7** as appropriate.
+
+**Otherwise:**
+
+Re-present the sign-off prompt above.
 
 #### If `yes`
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -55,6 +55,35 @@ When announcing a new step, output `── ── ── ── ──` on its o
 
 ---
 
+## Step 0: Resume Detection
+
+Check if an implementation file exists at `.workflows/{work_unit}/implementation/{topic}/implementation.md`.
+
+#### If no implementation file exists
+
+→ Proceed to **Step 1**.
+
+#### If implementation file exists
+
+> *Output the next fenced block as a code block:*
+
+```
+Found existing implementation for "{topic:(titlecase)}". Resuming from previous session.
+```
+
+Reset gate modes and counters via manifest CLI (fresh session = fresh gates/cycles):
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} task_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_attempts 0
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_cycle 0
+```
+
+→ Proceed to **Step 1**.
+
+---
+
 ## Step 1: Environment Setup
 
 Run setup commands EXACTLY as written, one step at a time.
@@ -116,15 +145,6 @@ Save their instructions to `.workflows/.state/environment-setup.md` (or "No spec
 ## Step 3: Initialize Implementation Tracking
 
 #### If `.workflows/{work_unit}/implementation/{topic}/implementation.md` already exists
-
-Reset gate modes and counters via manifest CLI (fresh session = fresh gates/cycles):
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} task_gate_mode gated
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_gate_mode gated
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_gate_mode gated
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_attempts 0
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_cycle 0
-```
 
 → Proceed to **Step 4**.
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -202,7 +202,7 @@ Keep these project skills?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user choice.
+**STOP.** Wait for user response.
 
 #### If `yes`
 
@@ -243,7 +243,7 @@ Which project skills should be used?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user to confirm which skills are relevant.
+**STOP.** Wait for user response.
 
 Store the selected skill paths via manifest CLI, pushing each path individually:
 ```bash
@@ -350,7 +350,7 @@ Ready to mark implementation as completed?
 
 #### If comment
 
-Discuss the user's context. If additional work is needed, route back to **Step 6** or **Step 7** as appropriate. Otherwise, re-present the sign-off prompt above.
+Discuss the user's context. If additional work is needed, → Return to **Step 6** or **Step 7** as appropriate. Otherwise, re-present the sign-off prompt above.
 
 #### If `yes`
 

--- a/skills/technical-implementation/SKILL.md
+++ b/skills/technical-implementation/SKILL.md
@@ -281,7 +281,7 @@ Approve these linters?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user choice.
+**STOP.** Wait for user response.
 
 #### If `yes`
 

--- a/skills/technical-implementation/references/analysis-loop.md
+++ b/skills/technical-implementation/references/analysis-loop.md
@@ -45,10 +45,17 @@ Continue with analysis?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user choice. You MUST NOT choose on the user's behalf.
+You MUST NOT choose on the user's behalf.
 
-- **`proceed`**: → Proceed to **B. Git Checkpoint**.
-- **`skip`**: → Return to **[the skill](../SKILL.md)** for **Step 8**.
+**STOP.** Wait for user response.
+
+#### If `proceed`
+
+→ Proceed to **B. Git Checkpoint**.
+
+#### If `skip`
+
+→ Return to **[the skill](../SKILL.md)** for **Step 8**.
 
 ---
 
@@ -83,7 +90,7 @@ Include unexpected files in the checkpoint commit?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user choice.
+**STOP.** Wait for user response.
 
 Commit included files:
 
@@ -97,9 +104,9 @@ impl({work_unit}): pre-analysis checkpoint
 
 ## C. Dispatch Analysis Agents
 
-Load **[invoke-analysis.md](invoke-analysis.md)** and follow its instructions.
+Load **[invoke-analysis.md](invoke-analysis.md)** and follow its instructions as written.
 
-**STOP.** Do not proceed until all agents have returned.
+> **CHECKPOINT**: Do not proceed until all agents have returned.
 
 Commit the analysis findings:
 
@@ -119,9 +126,9 @@ impl({work_unit}): analysis cycle {N} — findings
 
 ## D. Dispatch Synthesis Agent
 
-Load **[invoke-synthesizer.md](invoke-synthesizer.md)** and follow its instructions.
+Load **[invoke-synthesizer.md](invoke-synthesizer.md)** and follow its instructions as written.
 
-**STOP.** Do not proceed until the synthesizer has returned.
+> **CHECKPOINT**: Do not proceed until the synthesizer has returned.
 
 Commit the synthesis output:
 
@@ -189,11 +196,11 @@ Approve this task?
 - **`y`/`yes`** — Approve this task
 - **`a`/`auto`** — Approve this and all remaining tasks automatically
 - **`s`/`skip`** — Skip this task
-- **Revise** — Provide feedback to adjust
+- **Comment** — Provide feedback to adjust
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user input.
+**STOP.** Wait for user response.
 
 #### If `analysis_gate_mode: auto`
 
@@ -229,7 +236,7 @@ Update `status: skipped` in the staging file.
 
 → Present the next pending task, or proceed to routing below if all tasks processed.
 
-#### If `comment`
+#### If comment
 
 Revise the task content in the staging file based on the user's feedback. Re-present this task.
 
@@ -255,9 +262,9 @@ impl({work_unit}): analysis cycle {N} — tasks skipped
 
 ## F. Create Tasks in Plan
 
-Load **[invoke-task-writer.md](invoke-task-writer.md)** and follow its instructions.
+Load **[invoke-task-writer.md](invoke-task-writer.md)** and follow its instructions as written.
 
-**STOP.** Do not proceed until the task writer has returned.
+> **CHECKPOINT**: Do not proceed until the task writer has returned.
 
 Commit all analysis and plan changes (staging file, plan tasks, Plan Index File, and manifest if `analysis_gate_mode` was updated):
 

--- a/skills/technical-implementation/references/invoke-analysis.md
+++ b/skills/technical-implementation/references/invoke-analysis.md
@@ -49,6 +49,6 @@ Each agent knows its own output path convention and writes findings independentl
 
 ## Wait for Completion
 
-**STOP.** Do not proceed until all three agents have returned.
+> **CHECKPOINT**: Do not proceed until all three agents have returned.
 
 Each agent writes its findings to its own output file and returns a brief status. If any agent fails (error, timeout), record the failure and continue — the synthesizer works with whatever findings files are available.

--- a/skills/technical-implementation/references/task-loop.md
+++ b/skills/technical-implementation/references/task-loop.md
@@ -32,9 +32,11 @@ E. Update progress + phase check + commit
 
 ## B. Execute Task
 
-1. Load **[invoke-executor.md](invoke-executor.md)** and follow its instructions. Pass the normalised task content.
-2. **STOP.** Do not proceed until the executor has returned its result.
-3. On receipt of result, route on STATUS:
+1. Load **[invoke-executor.md](invoke-executor.md)** and follow its instructions as written. Pass the normalised task content.
+
+> **CHECKPOINT**: Do not proceed until the executor has returned its result.
+
+2. On receipt of result, route on STATUS:
    - `blocked` or `failed` → follow **Executor Blocked** below
    - `complete` → proceed to **C. Review Task**
 
@@ -60,7 +62,7 @@ Task failed. How would you like to proceed?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user choice.
+**STOP.** Wait for user response.
 
 #### If `retry`
 
@@ -78,9 +80,11 @@ Task failed. How would you like to proceed?
 
 ## C. Review Task
 
-1. Load **[invoke-reviewer.md](invoke-reviewer.md)** and follow its instructions. Pass the executor's result.
-2. **STOP.** Do not proceed until the reviewer has returned its result.
-3. On receipt of result, route on VERDICT:
+1. Load **[invoke-reviewer.md](invoke-reviewer.md)** and follow its instructions as written. Pass the executor's result.
+
+> **CHECKPOINT**: Do not proceed until the reviewer has returned its result.
+
+2. On receipt of result, route on VERDICT:
    - `needs-changes` → follow **Review Changes** below
    - `approved` → proceed to **D. Task Gate**
 
@@ -124,7 +128,7 @@ Accept the reviewer's fix analysis?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user choice.
+**STOP.** Wait for user response.
 
 - **`y`/`yes`**: → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
 - **`auto`**: Note that `fix_gate_mode` should be updated to `auto` via manifest CLI during the next commit step. → Return to the top of **B. Execute Task** and re-invoke the executor with the full task content and the reviewer's notes (including fix analysis).
@@ -168,7 +172,7 @@ Approve this task?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user input.
+**STOP.** Wait for user response.
 
 - **`y`/`yes`**: → Proceed to **E. Update Progress and Commit**.
 - **`auto`**: Note that `task_gate_mode` should be updated to `auto` via manifest CLI during the commit step. → Proceed to **E. Update Progress and Commit**.

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -106,19 +106,7 @@ Found existing plan for {work_unit} (previously reached phase {N}, task {M}).
 
 #### If `continue`
 
-If the specification changed, update `spec_commit` in the manifest:
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} spec_commit $(git rev-parse HEAD)
-```
-
-Reset gate modes to `gated` in the manifest (fresh invocation = fresh gates):
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task_list_gate_mode gated
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} author_gate_mode gated
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} finding_gate_mode gated
-```
-
-→ Proceed to **Step 1**.
+→ Proceed to **Step 2**.
 
 #### If `restart`
 
@@ -138,20 +126,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phas
 
 ## Step 1: Initialize Plan
 
-#### If Plan Index File already exists
-
-Read the `format` from the manifest:
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format
-```
-
-Read **[output-formats.md](references/output-formats.md)**, find the entry matching the format, and load the format's **[about.md](references/output-formats/{format}/about.md)** and **[authoring.md](references/output-formats/{format}/authoring.md)**.
-
-→ Proceed to **Step 2**.
-
-#### If no Plan Index File exists
-
-First, choose the Output Format.
+Choose the Output Format.
 
 **If a recommended output format was provided** (non-empty, not "none"):
 
@@ -191,10 +166,9 @@ Select a format (enter number):
 
 Once selected:
 
-1. Read **[output-formats.md](references/output-formats.md)**, find the chosen format entry, and load the format's **[about.md](references/output-formats/{format}/about.md)** and **[authoring.md](references/output-formats/{format}/authoring.md)**
-2. Capture the current git commit hash: `git rev-parse HEAD`
-3. Create the Plan Index File at `.workflows/{work_unit}/planning/{topic}/planning.md` using the **Title** template from **[plan-index-schema.md](references/plan-index-schema.md)**.
-4. Register planning and set metadata in the manifest:
+1. Capture the current git commit hash: `git rev-parse HEAD`
+2. Create the Plan Index File at `.workflows/{work_unit}/planning/{topic}/planning.md` using the **Title** template from **[plan-index-schema.md](references/plan-index-schema.md)**.
+3. Register planning and set metadata in the manifest:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase planning --topic {topic}
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} format {chosen-format}
@@ -206,61 +180,83 @@ Once selected:
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task ~
    ```
 
-5. Commit: `planning({work_unit}): initialize plan`
+4. Commit: `planning({work_unit}): initialize plan`
 
 → Proceed to **Step 2**.
 
 ---
 
-## Step 2: Load Planning Principles
+## Step 2: Session Setup
 
-Load **[planning-principles.md](references/planning-principles.md)** and follow its instructions as written.
+1. Read the `format` from the manifest:
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format
+   ```
+2. Read **[output-formats.md](references/output-formats.md)**, find the entry matching the format, and load the format's **[about.md](references/output-formats/{format}/about.md)** and **[authoring.md](references/output-formats/{format}/authoring.md)**
+3. Reset gate modes to `gated` in the manifest:
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task_list_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} author_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} finding_gate_mode gated
+   ```
+4. Update `spec_commit` to current HEAD:
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} spec_commit $(git rev-parse HEAD)
+   ```
 
 → Proceed to **Step 3**.
 
 ---
 
-## Step 3: Verify Source Material
+## Step 3: Load Planning Principles
 
-Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
+Load **[planning-principles.md](references/planning-principles.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
 
 ---
 
-## Step 4: Plan Construction
+## Step 4: Verify Source Material
 
-Load **[plan-construction.md](references/plan-construction.md)** and follow its instructions as written.
+Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
 
 ---
 
-## Step 5: Analyze Task Graph
+## Step 5: Plan Construction
 
-Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow its instructions as written.
+Load **[plan-construction.md](references/plan-construction.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
 
 ---
 
-## Step 6: Resolve External Dependencies
+## Step 6: Analyze Task Graph
 
-Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follow its instructions as written.
+Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow its instructions as written.
 
 → Proceed to **Step 7**.
 
 ---
 
-## Step 7: Plan Review
+## Step 7: Resolve External Dependencies
 
-Load **[plan-review.md](references/plan-review.md)** and follow its instructions as written.
+Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follow its instructions as written.
 
 → Proceed to **Step 8**.
 
 ---
 
-## Step 8: Conclude the Plan
+## Step 8: Plan Review
+
+Load **[plan-review.md](references/plan-review.md)** and follow its instructions as written.
+
+→ Proceed to **Step 9**.
+
+---
+
+## Step 9: Conclude the Plan
 
 > **CHECKPOINT**: Do not conclude if any tasks in the Plan Index File show `status: pending`. All tasks must be `authored` before concluding.
 
@@ -277,7 +273,7 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 #### If `comment`
 
-Discuss the user's context. If additional work is needed, route back to **Step 6** or **Step 7** as appropriate. Otherwise, re-present the sign-off prompt above.
+Discuss the user's context. If additional work is needed, route back to **Step 7** or **Step 8** as appropriate. Otherwise, re-present the sign-off prompt above.
 
 #### If `yes`
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -97,6 +97,8 @@ Found existing plan for {work_unit} (previously reached phase {N}, task {M}).
 
 ```
 · · · · · · · · · · · ·
+Continue or restart?
+
 - **`c`/`continue`** — Walk through the plan from the start. You can review, amend, or navigate at any point — including straight to the leading edge.
 - **`r`/`restart`** — Erase all planning work for this topic and start fresh. This deletes the Plan Index File and any Authored Tasks. Other topics are unaffected.
 · · · · · · · · · · · ·
@@ -128,7 +130,7 @@ Found existing plan for {work_unit} (previously reached phase {N}, task {M}).
 
 Choose the Output Format.
 
-**If a recommended output format was provided** (non-empty, not "none"):
+#### If a recommended output format was provided (non-empty, not "none")
 
 Present the recommendation:
 
@@ -145,7 +147,7 @@ Existing plans use **{format}**. Use the same format for consistency?
 
 **STOP.** Wait for user choice. If declined, fall through to the full list below.
 
-#### If no recommendation, or user declined
+#### If no recommendation or user declined
 
 Read **[output-formats.md](references/output-formats.md)** and present each format to the user.
 
@@ -264,6 +266,8 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 ```
 · · · · · · · · · · · ·
+Ready to conclude?
+
 - **`y`/`yes`** — Conclude plan and mark as completed
 - **Comment** — Add context before concluding
 · · · · · · · · · · · ·
@@ -271,7 +275,7 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 **STOP.** Wait for user response.
 
-#### If `comment`
+#### If comment
 
 Discuss the user's context. If additional work is needed, route back to **Step 7** or **Step 8** as appropriate. Otherwise, re-present the sign-off prompt above.
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -145,7 +145,7 @@ Existing plans use **{format}**. Use the same format for consistency?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user response. If declined, fall through to the full list below.
+**STOP.** Wait for user response.
 
 #### If no recommendation or user declined
 
@@ -277,7 +277,15 @@ Ready to conclude?
 
 #### If comment
 
-Discuss the user's context. If additional work is needed, → Return to **Step 7** or **Step 8** as appropriate. Otherwise, re-present the sign-off prompt above.
+Discuss the user's context.
+
+**If additional work is needed:**
+
+→ Return to **Step 7** or **Step 8** as appropriate.
+
+**Otherwise:**
+
+Re-present the sign-off prompt above.
 
 #### If `yes`
 

--- a/skills/technical-planning/SKILL.md
+++ b/skills/technical-planning/SKILL.md
@@ -61,11 +61,11 @@ When announcing a new step, output `── ── ── ── ──` on its o
 
 Check if a Plan Index File already exists at `.workflows/{work_unit}/planning/{topic}/planning.md`.
 
-#### If no Plan Index File exists
+#### If no plan index file exists
 
 → Proceed to **Step 1**.
 
-#### If Plan Index File exists
+#### If plan index file exists
 
 Check the planning status via manifest CLI:
 ```bash
@@ -83,7 +83,7 @@ Check `spec_commit` from the manifest:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} spec_commit
 ```
 
-Load **[spec-change-detection.md](references/spec-change-detection.md)** to check whether the specification has changed since planning started. Then present the user with an informed choice:
+Load **[spec-change-detection.md](references/spec-change-detection.md)** and follow its instructions as written. Then present the user with an informed choice:
 
 > *Output the next fenced block as a code block:*
 
@@ -130,7 +130,7 @@ Continue or restart?
 
 Choose the Output Format.
 
-#### If a recommended output format was provided (non-empty, not "none")
+#### If a recommended output format was provided (non-empty, not `none`)
 
 Present the recommendation:
 
@@ -145,7 +145,7 @@ Existing plans use **{format}**. Use the same format for consistency?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user choice. If declined, fall through to the full list below.
+**STOP.** Wait for user response. If declined, fall through to the full list below.
 
 #### If no recommendation or user declined
 
@@ -164,7 +164,7 @@ Select a format (enter number):
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for the user to choose.
+**STOP.** Wait for user response.
 
 Once selected:
 
@@ -277,7 +277,7 @@ Ready to conclude?
 
 #### If comment
 
-Discuss the user's context. If additional work is needed, route back to **Step 7** or **Step 8** as appropriate. Otherwise, re-present the sign-off prompt above.
+Discuss the user's context. If additional work is needed, → Return to **Step 7** or **Step 8** as appropriate. Otherwise, re-present the sign-off prompt above.
 
 #### If `yes`
 

--- a/skills/technical-planning/references/analyze-task-graph.md
+++ b/skills/technical-planning/references/analyze-task-graph.md
@@ -61,7 +61,7 @@ Approve the dependency graph?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for the user's response.
+**STOP.** Wait for user response.
 
 #### If the agent reports a cycle (`STATUS: blocked`)
 
@@ -77,7 +77,7 @@ The dependency analysis found a circular dependency:
 This must be resolved before continuing. The cycle usually means two tasks each assume the other is done first — one needs to be restructured or the dependency removed.
 ```
 
-**STOP.** Wait for the user to decide how to resolve.
+**STOP.** Wait for user response.
 
 Options include adjusting task scope, merging tasks, or removing a dependency. Re-invoke the agent after changes.
 
@@ -110,7 +110,7 @@ Approve the updated graph?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for the user's response.
+**STOP.** Wait for user response.
 
 #### If the user provides feedback
 

--- a/skills/technical-planning/references/author-tasks.md
+++ b/skills/technical-planning/references/author-tasks.md
@@ -108,7 +108,7 @@ Approve this task?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for the user's response.
+**STOP.** Wait for user response.
 
 #### If approved (`y`/`yes`)
 

--- a/skills/technical-planning/references/output-formats/linear/authoring.md
+++ b/skills/technical-planning/references/output-formats/linear/authoring.md
@@ -72,7 +72,7 @@ The official Linear MCP server does not support deletion. Ask the user to delete
 
 > "The Linear project **{project name}** needs to be deleted before restarting. Please delete it in the Linear UI (Project Settings → Delete project), then confirm so I can proceed."
 
-**STOP.** Wait for the user to confirm.
+**STOP.** Wait for user response.
 
 ### Fallback
 

--- a/skills/technical-planning/references/plan-construction.md
+++ b/skills/technical-planning/references/plan-construction.md
@@ -89,7 +89,7 @@ Approve this task list?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for the user's response.
+**STOP.** Wait for user response.
 
 **If the user wants changes:**
 

--- a/skills/technical-planning/references/plan-index-schema.md
+++ b/skills/technical-planning/references/plan-index-schema.md
@@ -72,7 +72,7 @@ All metadata is managed via the manifest CLI (`node .claude/skills/workflow-mani
 | `format` | Plan creation -- user-chosen output format |
 | `spec_commit` | Plan creation -- `git rev-parse HEAD`; updated on continue if spec changed |
 | `external_id` | First task authored -- external identifier for the plan |
-| `external_dependencies` | Dependency resolution (Step 6) |
+| `external_dependencies` | Dependency resolution (Step 7) |
 | `task_list_gate_mode` | Plan creation -> `gated`; user opts in -> `auto` |
 | `author_gate_mode` | Plan creation -> `gated`; user opts in -> `auto` |
 | `finding_gate_mode` | Plan creation -> `gated`; user opts in -> `auto` |

--- a/skills/technical-planning/references/plan-review.md
+++ b/skills/technical-planning/references/plan-review.md
@@ -37,9 +37,11 @@ Record the current cycle number — passed to both review agents for tracking fi
 
 ## B. Traceability Review
 
-1. Load **[invoke-review-traceability.md](invoke-review-traceability.md)** and follow its instructions to dispatch the agent.
-2. **STOP.** Do not proceed until the agent has returned its result.
-3. On receipt of result, load **[process-review-findings.md](process-review-findings.md)** and follow its instructions to process the findings with the user.
+1. Load **[invoke-review-traceability.md](invoke-review-traceability.md)** and follow its instructions as written.
+
+> **CHECKPOINT**: Do not proceed until the agent has returned its result.
+
+2. On receipt of result, load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
 
 → Proceed to **C. Plan Integrity Review**.
 
@@ -47,9 +49,11 @@ Record the current cycle number — passed to both review agents for tracking fi
 
 ## C. Plan Integrity Review
 
-1. Load **[invoke-review-integrity.md](invoke-review-integrity.md)** and follow its instructions to dispatch the agent.
-2. **STOP.** Do not proceed until the agent has returned its result.
-3. On receipt of result, load **[process-review-findings.md](process-review-findings.md)** and follow its instructions to process the findings with the user.
+1. Load **[invoke-review-integrity.md](invoke-review-integrity.md)** and follow its instructions as written.
+
+> **CHECKPOINT**: Do not proceed until the agent has returned its result.
+
+2. On receipt of result, load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
 
 → Proceed to **D. Re-Loop Prompt**.
 
@@ -85,7 +89,7 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 Review has auto-cycled 5 times without converging. Escalating for human review.
 
-→ Present the gated re-loop prompt below.
+Present the gated re-loop prompt below.
 
 #### If `finding_gate_mode: gated`
 

--- a/skills/technical-planning/references/plan-review.md
+++ b/skills/technical-planning/references/plan-review.md
@@ -134,4 +134,4 @@ Run another review round?
 Plan review complete — {N} cycle(s), all tracking files finalised.
 ```
 
-→ Return to **[the skill](../SKILL.md)** for **Step 8**.
+→ Return to **[the skill](../SKILL.md)** for **Step 9**.

--- a/skills/technical-planning/references/resolve-dependencies.md
+++ b/skills/technical-planning/references/resolve-dependencies.md
@@ -56,7 +56,7 @@ Approve the dependency resolution?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for the user's response.
+**STOP.** Wait for user response.
 
 #### If the user provides feedback
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -65,6 +65,8 @@ Check if a review file exists at `.workflows/{work_unit}/review/{topic}/review.m
 Found existing review for **{topic:(titlecase)}**.
 
 · · · · · · · · · · · ·
+Continue or restart?
+
 - **`c`/`continue`** — Continue the review from its current state
 - **`r`/`restart`** — Delete the review and all QA files. Start fresh.
 · · · · · · · · · · · ·
@@ -252,7 +254,7 @@ Scan `.claude/skills/` for project-specific skill directories. Note which are re
 
 Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and follow its instructions as written.
 
-**STOP.** Do not proceed until ALL task verifiers have returned and findings are aggregated.
+> **CHECKPOINT**: Do not proceed until ALL task verifiers have returned and findings are aggregated.
 
 → Proceed to **Step 5**.
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -59,11 +59,15 @@ Check if a review file exists at `.workflows/{work_unit}/review/{topic}/review.m
 
 #### If review file exists
 
+> *Output the next fenced block as a code block:*
+
+```
+Found existing review for "{topic:(titlecase)}".
+```
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-Found existing review for **{topic:(titlecase)}**.
-
 · · · · · · · · · · · ·
 Continue or restart?
 
@@ -95,13 +99,15 @@ Check if review phase is registered in manifest:
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
 ```
 
-**If `false`:**
+#### If `false`
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase review --topic {topic}
 ```
 
-**If `true`:** Phase already registered (e.g. reopened review). Skip init-phase.
+#### If `true`
+
+Phase already registered (e.g. reopened review). Skip init-phase.
 
 Now determine review mode. Check if the review file exists at `.workflows/{work_unit}/review/{topic}/review.md`.
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -93,15 +93,13 @@ Check if review phase is registered in manifest:
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
 ```
 
-#### If `false`
+**If `false`:**
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase review --topic {topic}
 ```
 
-#### If `true`
-
-Phase already registered (e.g. reopened review). Skip init-phase.
+**If `true`:** Phase already registered (e.g. reopened review). Skip init-phase.
 
 Now determine review mode. Check if the review file exists at `.workflows/{work_unit}/review/{topic}/review.md`.
 
@@ -129,15 +127,13 @@ No prior review tracking. Store `review_mode = full`.
 
 → Proceed to **Step 2**.
 
-**If `reviewed_tasks` exists:**
+**If `reviewed_tasks` exists and no unreviewed tasks (arrays match):**
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} reviewed_tasks
 ```
 
-Compare `completed_tasks` against `reviewed_tasks`. Any internal ID in `completed_tasks` but not in `reviewed_tasks` is unreviewed.
-
-**If no unreviewed tasks** (arrays match):
+Compare `completed_tasks` against `reviewed_tasks`.
 
 > *Output the next fenced block as a code block:*
 
@@ -163,7 +159,13 @@ Commit: `review({work_unit}): clear review data for full re-review`
 
 → Proceed to **Step 2**.
 
-**If unreviewed tasks exist:**
+**If `reviewed_tasks` exists and unreviewed tasks exist:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} reviewed_tasks
+```
+
+Compare `completed_tasks` against `reviewed_tasks`. Any internal ID in `completed_tasks` but not in `reviewed_tasks` is unreviewed.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -17,8 +17,6 @@ Follows implementation. Verify plan tasks were implemented, tested adequately, a
 - **Review scope** (required) - single, multi, or all
 - **Plan content** (required) - Tasks and acceptance criteria to verify against (one or more plans)
 - **Specification content** (required) - The specification from the prior phase, for design decision context
-- **Review mode** (required) - `full` or `incremental`
-- **Unreviewed tasks** (for incremental) - list of internal IDs to review, or "all" for full
 
 ---
 
@@ -51,7 +49,168 @@ When announcing a new step, output `── ── ── ── ──` on its o
 
 ---
 
-## Step 1: Read Plan(s) and Specification(s)
+## Step 0: Resume Detection
+
+Check if a review file exists at `.workflows/{work_unit}/review/{topic}/review.md`.
+
+#### If no review file exists
+
+Store `review_mode = full`.
+
+→ Proceed to **Step 1**.
+
+#### If review file exists
+
+Determine whether new tasks have been implemented since the last review.
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} completed_tasks
+```
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic} reviewed_tasks
+```
+
+**If `reviewed_tasks` does not exist:**
+
+No prior review tracking. Store `review_mode = full`.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+Found existing review for **{topic:(titlecase)}**.
+
+· · · · · · · · · · · ·
+- **`c`/`continue`** — Continue the review from its current state
+- **`r`/`restart`** — Delete the review and all QA files. Start fresh.
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `continue`
+
+→ Proceed to **Step 2**.
+
+#### If `restart`
+
+1. Delete the review file and all QA files (`qa-task-*.md`) in the review directory (`.workflows/{work_unit}/review/{topic}/`)
+2. Commit: `review({work_unit}): restart review`
+
+Store `review_mode = full`.
+
+→ Proceed to **Step 1**.
+
+**If `reviewed_tasks` exists:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} reviewed_tasks
+```
+
+Compare `completed_tasks` against `reviewed_tasks`. Any internal ID in `completed_tasks` but not in `reviewed_tasks` is unreviewed.
+
+**If no unreviewed tasks** (arrays match):
+
+> *Output the next fenced block as code block:*
+
+```
+Reopening review: {topic:(titlecase)}
+
+All tasks have been reviewed. Starting a full re-review.
+```
+
+Store `review_mode = full`.
+
+Clear prior review data for a clean slate:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --phase review --topic {topic} reviewed_tasks
+```
+
+```bash
+rm .workflows/{work_unit}/review/{topic}/qa-task-*.md
+```
+
+1. Delete the review file
+2. Commit: `review({work_unit}): restart review for full re-review`
+
+→ Proceed to **Step 1**.
+
+**If unreviewed tasks exist:**
+
+> *Output the next fenced block as a code block:*
+
+```
+New Implementation Detected
+
+Review covered {R} of {C} tasks. {U} task(s) not yet reviewed.
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Review mode?
+
+- **`i`/`incremental`** — Review only new tasks ({U} tasks)
+- **`f`/`full`** — Re-review all tasks
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `incremental`
+
+Store `review_mode = incremental` and `unreviewed_tasks = [{list of unreviewed internal IDs}]`.
+
+→ Proceed to **Step 2**.
+
+#### If `full`
+
+Store `review_mode = full`.
+
+Clear prior review data for a clean slate:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --phase review --topic {topic} reviewed_tasks
+```
+
+```bash
+rm .workflows/{work_unit}/review/{topic}/qa-task-*.md
+```
+
+1. Delete the review file
+2. Commit: `review({work_unit}): restart review for full re-review`
+
+→ Proceed to **Step 1**.
+
+---
+
+## Step 1: Initialize Review
+
+Check if review phase is registered in manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
+```
+
+#### If `false`
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase review --topic {topic}
+```
+
+→ Proceed to **Step 2**.
+
+#### If `true`
+
+Phase already registered (e.g. reopened review). Skip init-phase.
+
+→ Proceed to **Step 2**.
+
+---
+
+## Step 2: Read Plan(s) and Specification(s)
 
 Read all plan(s) provided for the selected scope.
 
@@ -61,11 +220,11 @@ For each plan:
 3. Extract all tasks across all phases
 4. Load the format's reading adapter from `../technical-planning/references/output-formats/{format}/reading.md` — this tells you how to locate and read individual task files
 
-→ Proceed to **Step 2**.
+→ Proceed to **Step 3**.
 
 ---
 
-## Step 2: Project Skills Discovery
+## Step 3: Project Skills Discovery
 
 #### If `.claude/skills/` does not exist or is empty
 
@@ -75,43 +234,43 @@ For each plan:
 No project skills found. Proceeding without project-specific conventions.
 ```
 
-→ Proceed to **Step 3**.
+→ Proceed to **Step 4**.
 
 #### If project skills exist
 
 Scan `.claude/skills/` for project-specific skill directories. Note which are relevant to the review (framework guidelines, code style, architecture patterns).
 
-→ Proceed to **Step 3**.
+→ Proceed to **Step 4**.
 
 ---
 
-## Step 3: QA Verification
+## Step 4: QA Verification
 
 Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and follow its instructions as written.
 
 **STOP.** Do not proceed until ALL task verifiers have returned and findings are aggregated.
 
-→ Proceed to **Step 4**.
-
----
-
-## Step 4: Produce Review
-
-Load **[produce-review.md](references/produce-review.md)** and follow its instructions as written.
-
 → Proceed to **Step 5**.
 
 ---
 
-## Step 5: Present Review
+## Step 5: Produce Review
 
-Load **[present-review.md](references/present-review.md)** and follow its instructions as written.
+Load **[produce-review.md](references/produce-review.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
 
 ---
 
-## Step 6: Review Actions
+## Step 6: Present Review
+
+Load **[present-review.md](references/present-review.md)** and follow its instructions as written.
+
+→ Proceed to **Step 7**.
+
+---
+
+## Step 7: Review Actions
 
 Load **[review-actions-loop.md](references/review-actions-loop.md)** and follow its instructions.
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -55,25 +55,9 @@ Check if a review file exists at `.workflows/{work_unit}/review/{topic}/review.m
 
 #### If no review file exists
 
-Store `review_mode = full`.
-
 → Proceed to **Step 1**.
 
 #### If review file exists
-
-Determine whether new tasks have been implemented since the last review.
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} completed_tasks
-```
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic} reviewed_tasks
-```
-
-**If `reviewed_tasks` does not exist:**
-
-No prior review tracking. Store `review_mode = full`.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -90,16 +74,60 @@ Found existing review for **{topic:(titlecase)}**.
 
 #### If `continue`
 
-→ Proceed to **Step 2**.
+→ Proceed to **Step 1**.
 
 #### If `restart`
 
 1. Delete the review file and all QA files (`qa-task-*.md`) in the review directory (`.workflows/{work_unit}/review/{topic}/`)
 2. Commit: `review({work_unit}): restart review`
 
+→ Proceed to **Step 1**.
+
+---
+
+## Step 1: Initialize Review
+
+Check if review phase is registered in manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
+```
+
+#### If `false`
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase review --topic {topic}
+```
+
+#### If `true`
+
+Phase already registered (e.g. reopened review). Skip init-phase.
+
+Now determine review mode. Check if the review file exists at `.workflows/{work_unit}/review/{topic}/review.md`.
+
+#### If no review file exists
+
 Store `review_mode = full`.
 
-→ Proceed to **Step 1**.
+→ Proceed to **Step 2**.
+
+#### If review file exists
+
+Continuing from a previous session — determine scope.
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} completed_tasks
+```
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic} reviewed_tasks
+```
+
+**If `reviewed_tasks` does not exist:**
+
+No prior review tracking. Store `review_mode = full`.
+
+→ Proceed to **Step 2**.
 
 **If `reviewed_tasks` exists:**
 
@@ -111,7 +139,7 @@ Compare `completed_tasks` against `reviewed_tasks`. Any internal ID in `complete
 
 **If no unreviewed tasks** (arrays match):
 
-> *Output the next fenced block as code block:*
+> *Output the next fenced block as a code block:*
 
 ```
 Reopening review: {topic:(titlecase)}
@@ -131,10 +159,9 @@ node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --p
 rm .workflows/{work_unit}/review/{topic}/qa-task-*.md
 ```
 
-1. Delete the review file
-2. Commit: `review({work_unit}): restart review for full re-review`
+Commit: `review({work_unit}): clear review data for full re-review`
 
-→ Proceed to **Step 1**.
+→ Proceed to **Step 2**.
 
 **If unreviewed tasks exist:**
 
@@ -179,32 +206,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --p
 rm .workflows/{work_unit}/review/{topic}/qa-task-*.md
 ```
 
-1. Delete the review file
-2. Commit: `review({work_unit}): restart review for full re-review`
-
-→ Proceed to **Step 1**.
-
----
-
-## Step 1: Initialize Review
-
-Check if review phase is registered in manifest:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
-```
-
-#### If `false`
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase review --topic {topic}
-```
-
-→ Proceed to **Step 2**.
-
-#### If `true`
-
-Phase already registered (e.g. reopened review). Skip init-phase.
+Commit: `review({work_unit}): clear review data for full re-review`
 
 → Proceed to **Step 2**.
 

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -278,5 +278,5 @@ Load **[present-review.md](references/present-review.md)** and follow its instru
 
 ## Step 7: Review Actions
 
-Load **[review-actions-loop.md](references/review-actions-loop.md)** and follow its instructions.
+Load **[review-actions-loop.md](references/review-actions-loop.md)** and follow its instructions as written.
 

--- a/skills/technical-review/references/invoke-review-synthesizer.md
+++ b/skills/technical-review/references/invoke-review-synthesizer.md
@@ -35,7 +35,7 @@ The synthesizer receives:
 
 ## Wait for Completion
 
-**STOP.** Do not proceed until the synthesizer has returned.
+> **CHECKPOINT**: Do not proceed until the synthesizer has returned.
 
 If the agent fails (error, timeout), record the failure and report "synthesis failed" to the user.
 

--- a/skills/technical-review/references/invoke-task-verifiers.md
+++ b/skills/technical-review/references/invoke-task-verifiers.md
@@ -22,7 +22,7 @@ This captures all files touched by implementation commits for the topic.
 
 ## Extract All Tasks
 
-Using the format reading adapter loaded in Step 1, extract every task across all phases from each plan in scope:
+Using the format reading adapter loaded in Step 2, extract every task across all phases from each plan in scope:
 - Note each task's description
 - Note each task's acceptance criteria
 - Note expected micro acceptance (test name)
@@ -70,7 +70,7 @@ Each verifier receives:
 1. **Plan task** — the specific task with acceptance criteria
 2. **Specification path** — from the manifest (if available)
 3. **Plan path** — the full plan for phase context
-4. **Project skill paths** — from Step 2 discovery
+4. **Project skill paths** — from Step 3 discovery
 5. **Review checklist path** — `skills/technical-review/references/review-checklist.md`
 6. **Work unit** — the work unit name (for path construction)
 7. **Topic** — the plan topic name (used for output directory)

--- a/skills/technical-review/references/produce-review.md
+++ b/skills/technical-review/references/produce-review.md
@@ -8,7 +8,7 @@ Aggregate QA findings into a review document using the **[template.md](template.
 
 Write the review to `.workflows/{work_unit}/review/{topic}/review.md`. The review is always per-plan.
 
-**QA Verdict** (from Step 3):
+**QA Verdict** (from Step 4):
 - **Approve** — All acceptance criteria met, no blocking issues
 - **Request Changes** — Missing requirements, broken functionality, inadequate tests
 - **Comments Only** — Minor suggestions, non-blocking observations

--- a/skills/technical-review/references/review-actions-loop.md
+++ b/skills/technical-review/references/review-actions-loop.md
@@ -139,9 +139,9 @@ Invoke the workflow-bridge skill to enter plan mode with completion confirmation
 
 ## B. Dispatch Review Synthesizer
 
-Load **[invoke-review-synthesizer.md](invoke-review-synthesizer.md)** and follow its instructions.
+Load **[invoke-review-synthesizer.md](invoke-review-synthesizer.md)** and follow its instructions as written.
 
-**STOP.** Do not proceed until the synthesizer has returned.
+> **CHECKPOINT**: Do not proceed until the synthesizer has returned.
 
 #### If `STATUS` is `clean`
 
@@ -226,7 +226,7 @@ Approve this task?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user input.
+**STOP.** Wait for user response.
 
 #### If `gate_mode` is `auto`
 
@@ -302,10 +302,9 @@ Invoke the workflow-bridge skill to enter plan mode with continuation instructio
 For approved tasks in the staging file, invoke the task writer.
 
 1. Filter staging file to tasks with `status: approved`
-2. Load **[invoke-review-task-writer.md](invoke-review-task-writer.md)** and follow its instructions
-3. Wait for the task writer to return
+2. Load **[invoke-review-task-writer.md](invoke-review-task-writer.md)** and follow its instructions as written.
 
-**STOP.** Do not proceed until the task writer has returned.
+> **CHECKPOINT**: Do not proceed until the task writer has returned.
 
 Commit all changes (staging file, plan tasks, Plan Index Files):
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -19,7 +19,7 @@ Follows discussion (or investigation for bugfix). Transform prior-phase source m
 - **Source material** (required) - Prior-phase artifacts to synthesize (discussions, research, investigation findings)
 - **Topic name** (required) - Used for the output filename
 
-#### If source material seems incomplete or unclear
+**If source material seems incomplete or unclear:**
 
 > *Output the next fenced block as a code block:*
 
@@ -80,6 +80,8 @@ Read the specification status via manifest CLI (`node .claude/skills/workflow-ma
 Found existing specification for **{work_unit}**.
 
 · · · · · · · · · · · ·
+Continue or restart?
+
 - **`c`/`continue`** — Walk through the specification from its current state. You can review, amend, or navigate at any point.
 - **`r`/`restart`** — Delete the specification and all review tracking files. Start fresh.
 · · · · · · · · · · · ·

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -89,8 +89,6 @@ Found existing specification for **{work_unit}**.
 
 #### If `continue`
 
-Reset `finding_gate_mode` to `gated` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} finding_gate_mode gated`) (fresh invocation = fresh gates).
-
 → Proceed to **Step 3** (skipping Steps 1–2).
 
 #### If `restart`
@@ -136,39 +134,50 @@ Commit: `spec({work_unit}): initialize specification`
 
 ---
 
-## Step 3: Load Specification Principles
+## Step 3: Session Setup
 
-Load **[specification-principles.md](references/specification-principles.md)** and internalize the rules. These principles govern every subsequent step.
+Reset `finding_gate_mode` to `gated` via manifest CLI:
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} finding_gate_mode gated
+```
 
 → Proceed to **Step 4**.
 
 ---
 
-## Step 4: Spec Construction
+## Step 4: Load Specification Principles
 
-Load **[spec-construction.md](references/spec-construction.md)** and follow its instructions as written.
+Load **[specification-principles.md](references/specification-principles.md)** and internalize the rules. These principles govern every subsequent step.
 
 → Proceed to **Step 5**.
 
 ---
 
-## Step 5: Document Dependencies
+## Step 5: Spec Construction
 
-Load **[dependencies.md](references/dependencies.md)** and follow its instructions as written.
+Load **[spec-construction.md](references/spec-construction.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
 
 ---
 
-## Step 6: Specification Review
+## Step 6: Document Dependencies
 
-Load **[spec-review.md](references/spec-review.md)** and follow its instructions as written.
+Load **[dependencies.md](references/dependencies.md)** and follow its instructions as written.
 
 → Proceed to **Step 7**.
 
 ---
 
-## Step 7: Assess Type & Conclude
+## Step 7: Specification Review
+
+Load **[spec-review.md](references/spec-review.md)** and follow its instructions as written.
+
+→ Proceed to **Step 8**.
+
+---
+
+## Step 8: Assess Type & Conclude
 
 Load **[spec-completion.md](references/spec-completion.md)** and follow its instructions as written.
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -74,11 +74,15 @@ Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
 
 Read the specification status via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} status`).
 
+> *Output the next fenced block as a code block:*
+
+```
+Found existing specification for {work_unit}.
+```
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-Found existing specification for **{work_unit}**.
-
 · · · · · · · · · · · ·
 Continue or restart?
 

--- a/skills/technical-specification/SKILL.md
+++ b/skills/technical-specification/SKILL.md
@@ -112,7 +112,7 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 ## Step 2: Initialize Specification
 
-Load **[specification-format.md](references/specification-format.md)** for the template.
+Load **[specification-format.md](references/specification-format.md)** and follow its instructions as written.
 
 Create the specification file at `.workflows/{work_unit}/specification/{topic}/specification.md`:
 
@@ -149,7 +149,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phas
 
 ## Step 4: Load Specification Principles
 
-Load **[specification-principles.md](references/specification-principles.md)** and internalize the rules. These principles govern every subsequent step.
+Load **[specification-principles.md](references/specification-principles.md)** and follow its instructions as written. These principles govern every subsequent step.
 
 → Proceed to **Step 5**.
 

--- a/skills/technical-specification/references/spec-completion.md
+++ b/skills/technical-specification/references/spec-completion.md
@@ -39,6 +39,8 @@ of functionality to build."}
 
 ```
 · · · · · · · · · · · ·
+Confirm this type assessment?
+
 - **`y`/`yes`** — Confirm type assessment
 - **Comment** — Suggest a different classification
 · · · · · · · · · · · ·
@@ -46,7 +48,7 @@ of functionality to build."}
 
 **STOP.** Wait for user response.
 
-#### If `comment`
+#### If comment
 
 Discuss the user's suggested classification, re-assess, and re-present the assessment display and prompt above.
 
@@ -67,6 +69,8 @@ If any tracking file still shows `status: in-progress`, mark it complete now.
 
 > **CHECKPOINT**: Do not proceed to sign-off if any tracking files still show `status: in-progress`. They indicate incomplete review work.
 
+→ Proceed to **C. Sign-Off**.
+
 ---
 
 ## C. Sign-Off
@@ -75,6 +79,8 @@ If any tracking file still shows `status: in-progress`, mark it complete now.
 
 ```
 · · · · · · · · · · · ·
+Ready to conclude?
+
 - **`y`/`yes`** — Conclude specification and mark as completed
 - **Comment** — Add context before concluding
 · · · · · · · · · · · ·
@@ -82,7 +88,7 @@ If any tracking file still shows `status: in-progress`, mark it complete now.
 
 **STOP.** Wait for user response.
 
-#### If `comment`
+#### If comment
 
 Discuss the user's context, apply any changes, then re-present the sign-off prompt above.
 
@@ -113,6 +119,8 @@ Specification is complete when:
 
 Commit: `spec({work_unit}): conclude specification`
 
+→ Proceed to **E. Handle Source Specifications**.
+
 ---
 
 ## E. Handle Source Specifications
@@ -126,6 +134,8 @@ If any of your sources were **existing specifications** (as opposed to discussio
    ```
 2. Inform the user which topics were updated
 3. Commit: `spec({work_unit}): mark source specifications as superseded`
+
+→ Proceed to **F. Pipeline Continuation**.
 
 ---
 

--- a/skills/technical-specification/references/spec-construction.md
+++ b/skills/technical-specification/references/spec-construction.md
@@ -107,4 +107,4 @@ This is the end of this iteration.
 
 #### If all topics are covered
 
-→ Return to **[the skill](../SKILL.md)** for **Step 5**.
+→ Return to **[the skill](../SKILL.md)** for **Step 6**.

--- a/skills/technical-specification/references/spec-construction.md
+++ b/skills/technical-specification/references/spec-construction.md
@@ -19,7 +19,7 @@ F. Topic complete → loop back to A or exit
 
 ## A. Exhaustive Extraction
 
-Load **[exhaustive-extraction.md](exhaustive-extraction.md)** and follow its instructions for the current topic.
+Load **[exhaustive-extraction.md](exhaustive-extraction.md)** and follow its instructions as written.
 
 When working with multiple sources, search each one — information about a single topic may be scattered across documents.
 
@@ -103,7 +103,7 @@ This is the end of this iteration.
 
 #### If additional topics remain
 
-→ Proceed to **A. Exhaustive Extraction** and follow the instructions as written.
+→ Return to **A. Exhaustive Extraction**.
 
 #### If all topics are covered
 

--- a/skills/technical-specification/references/spec-review.md
+++ b/skills/technical-specification/references/spec-review.md
@@ -211,4 +211,4 @@ Run another review cycle?
 Specification review complete — {N} cycle(s), all tracking files finalised.
 ```
 
-→ Return to **[the skill](../SKILL.md)** for **Step 7**.
+→ Return to **[the skill](../SKILL.md)** for **Step 8**.

--- a/skills/technical-specification/references/spec-review.md
+++ b/skills/technical-specification/references/spec-review.md
@@ -170,7 +170,7 @@ Review cycle {N}
 Auto-review has not converged after 5 cycles — escalating for human review.
 ```
 
-→ Present the gated re-loop prompt below.
+Present the gated re-loop prompt below.
 
 #### If `finding_gate_mode: gated`
 

--- a/skills/technical-specification/references/spec-review.md
+++ b/skills/technical-specification/references/spec-review.md
@@ -68,7 +68,9 @@ Continue with review?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user choice. You MUST NOT choose on the user's behalf.
+You MUST NOT choose on the user's behalf.
+
+**STOP.** Wait for user response.
 
 #### If `proceed`
 

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -74,7 +74,7 @@ Epic Completed
 
 Load **[epic-display-and-menu.md](../../continue-epic/references/epic-display-and-menu.md)** and follow its instructions as written.
 
-**STOP.** Do not proceed until the above has returned with the user's selection.
+> **CHECKPOINT**: Do not proceed until the above has returned with the user's selection.
 
 → Proceed to **D. Enter Plan Mode**.
 

--- a/skills/workflow-discussion-entry/references/display-options.md
+++ b/skills/workflow-discussion-entry/references/display-options.md
@@ -93,4 +93,4 @@ How would you like to proceed?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.

--- a/skills/workflow-discussion-entry/references/gather-context-continue.md
+++ b/skills/workflow-discussion-entry/references/gather-context-continue.md
@@ -16,4 +16,4 @@ I've read the existing discussion.
 What would you like to focus on in this session?
 ```
 
-**STOP.** Wait for response before proceeding.
+**STOP.** Wait for user response.

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -18,7 +18,7 @@ New discussion: {topic}
 What's the core problem or decision we need to work through?
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.
 
 ---
 
@@ -30,7 +30,7 @@ What's the core problem or decision we need to work through?
 Any constraints or context I should know about?
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.
 
 ---
 
@@ -44,4 +44,4 @@ Are there specific files in the codebase I should review first?
 (Or "none" if not applicable)
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.

--- a/skills/workflow-discussion-entry/references/gather-context-research.md
+++ b/skills/workflow-discussion-entry/references/gather-context-research.md
@@ -26,4 +26,4 @@ research you'd like to include — drop them in now.
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.

--- a/skills/workflow-discussion-entry/references/handle-selection.md
+++ b/skills/workflow-discussion-entry/references/handle-selection.md
@@ -25,7 +25,7 @@ Set source="research".
 Which research topic would you like to discuss? (Enter a number or topic name)
 ```
 
-**STOP.** Wait for response.
+**STOP.** Wait for user response.
 
 #### If user chose `Continue discussion`
 
@@ -46,7 +46,7 @@ Set source="continue".
 Which discussion would you like to continue?
 ```
 
-**STOP.** Wait for response.
+**STOP.** Wait for user response.
 
 #### If user chose `Fresh topic`
 

--- a/skills/workflow-discussion-entry/references/name-topic.md
+++ b/skills/workflow-discussion-entry/references/name-topic.md
@@ -23,4 +23,4 @@ Is this name okay?
 · · · · · · · · · · · ·
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.

--- a/skills/workflow-research-entry/references/gather-context.md
+++ b/skills/workflow-research-entry/references/gather-context.md
@@ -62,7 +62,7 @@ What's on your mind?
 - What prompted this - a problem, opportunity, curiosity?
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.
 
 ---
 
@@ -77,7 +77,7 @@ What do you already know?
 - Constraints or context I should be aware of?
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.
 
 ---
 
@@ -92,7 +92,7 @@ Where should we start?
 - Or just talk it through and see where it goes?
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.
 
 ---
 
@@ -106,4 +106,4 @@ Any constraints or context I should know about upfront?
 (Or "none" if we're starting fresh)
 ```
 
-**STOP.** Wait for user response before proceeding.
+**STOP.** Wait for user response.

--- a/skills/workflow-review-entry/references/invoke-skill.md
+++ b/skills/workflow-review-entry/references/invoke-skill.md
@@ -4,26 +4,6 @@
 
 ---
 
-## Initialize Review Phase
-
-Only initialize if the review phase doesn't already exist:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
-```
-
-#### If `false`
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase review --topic {topic}
-```
-
-#### If `true`
-
-Phase already exists (validate-phase.md already handled status). Skip init-phase.
-
----
-
 ## Invoke the Skill
 
 Invoke the [technical-review](../../technical-review/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
@@ -44,8 +24,6 @@ Plans to review:
     plan: .workflows/{work_unit}/planning/{topic}/planning.md
     format: {format}
     specification: .workflows/{work_unit}/specification/{topic}/specification.md (exists: {true|false})
-    review_mode: {review_mode:[full|incremental]}
-    unreviewed_tasks: {unreviewed_tasks or "all"}
 
 Invoke the technical-review skill.
 ```

--- a/skills/workflow-review-entry/references/invoke-skill.md
+++ b/skills/workflow-review-entry/references/invoke-skill.md
@@ -4,8 +4,6 @@
 
 ---
 
-## Invoke the Skill
-
 Invoke the [technical-review](../../technical-review/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded - it contains the instructions for how to proceed.
 
 Query format from manifest:

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -64,8 +64,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --p
 
 **If not exists (`false`):**
 
-Store `review_mode = full`. This is a new review.
-
 → Return to **[the skill](../SKILL.md)**.
 
 **If exists (`true`):**
@@ -82,105 +80,8 @@ Reset to in-progress:
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status in-progress
 ```
 
-→ Proceed to **Detect Incremental Review**.
+→ Return to **[the skill](../SKILL.md)**.
 
 **If status is `in-progress`:**
-
-→ Proceed to **Detect Incremental Review**.
-
----
-
-## Detect Incremental Review
-
-The review phase exists from a prior session. Determine whether new tasks have been implemented since the last review.
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} completed_tasks
-```
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic} reviewed_tasks
-```
-
-#### If `reviewed_tasks` does not exist
-
-No prior review tracking. Store `review_mode = full`.
-
-→ Return to **[the skill](../SKILL.md)**.
-
-#### If `reviewed_tasks` exists
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} reviewed_tasks
-```
-
-Compare `completed_tasks` against `reviewed_tasks`. Any internal ID in `completed_tasks` but not in `reviewed_tasks` is unreviewed.
-
-**If no unreviewed tasks** (arrays match):
-
-> *Output the next fenced block as a code block:*
-
-```
-Reopening review: {topic:(titlecase)}
-
-All tasks have been reviewed. Starting a full re-review.
-```
-
-Store `review_mode = full`.
-
-Clear prior review data for a clean slate:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --phase review --topic {topic} reviewed_tasks
-```
-
-```bash
-rm .workflows/{work_unit}/review/{topic}/qa-task-*.md
-```
-
-→ Return to **[the skill](../SKILL.md)**.
-
-**If unreviewed tasks exist:**
-
-> *Output the next fenced block as a code block:*
-
-```
-New Implementation Detected
-
-Review covered {R} of {C} tasks. {U} task(s) not yet reviewed.
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Review mode?
-
-- **`i`/`incremental`** — Review only new tasks ({U} tasks)
-- **`f`/`full`** — Re-review all tasks
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-#### If `incremental`
-
-Store `review_mode = incremental` and `unreviewed_tasks = [{list of unreviewed internal IDs}]`.
-
-→ Return to **[the skill](../SKILL.md)**.
-
-#### If `full`
-
-Store `review_mode = full`.
-
-Clear prior review data for a clean slate:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --phase review --topic {topic} reviewed_tasks
-```
-
-```bash
-rm .workflows/{work_unit}/review/{topic}/qa-task-*.md
-```
 
 → Return to **[the skill](../SKILL.md)**.

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -66,13 +66,11 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --p
 
 → Return to **[the skill](../SKILL.md)**.
 
-**If exists (`true`):**
+**If exists and status is `completed`:**
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} status
 ```
-
-**If status is `completed`:**
 
 Reset to in-progress:
 
@@ -82,6 +80,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phas
 
 → Return to **[the skill](../SKILL.md)**.
 
-**If status is `in-progress`:**
+**If exists and status is `in-progress`:**
 
 → Return to **[the skill](../SKILL.md)**.

--- a/skills/workflow-specification-entry/references/analysis-flow.md
+++ b/skills/workflow-specification-entry/references/analysis-flow.md
@@ -20,7 +20,7 @@ For example:
 Your context (or 'none'):
 ```
 
-**STOP.** Wait for user response. Note their input for the analysis.
+**STOP.** Wait for user response.
 
 → Proceed to **B. Analyze Discussions**.
 


### PR DESCRIPTION
## Summary

- Every processing skill's Step 0 now follows a consistent **detect → prompt → route** pattern with no side effects
- Relocated setup logic (gate resets, spec_commit, format loading) into dedicated Session Setup steps
- Moved `init-phase` into processing skills (was in entry skill for review) and incremental review detection from entry skill to processing skill's Step 0

**Files changed:** 12 across planning, specification, review, implementation, and review-entry skills

## Test plan

- [ ] Trace new-plan path: Step 0 (no file) → Step 1 (format, init, create) → Step 2 (session setup) → Step 3+
- [ ] Trace continue-plan path: Step 0 (prompt) → Step 2 (session setup) → Step 3+
- [ ] Trace new-review path: Step 0 (no file, full mode) → Step 1 (init-phase) → Step 2+
- [ ] Trace resume-review with new tasks: Step 0 (incremental detection) → Step 2+
- [ ] Trace resume-implementation: Step 0 (announce, reset gates) → Step 1+
- [ ] Verify no stale step number references in any reference files

🤖 Generated with [Claude Code](https://claude.com/claude-code)