### PR TITLE
fix: enforce migrate skill STOP gate from calling skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .vscode/
 .claude/settings.local.json
+.claude/projects/

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .idea/
 .vscode/
 .claude/settings.local.json
-.claude/projects/

--- a/skills/continue-bugfix/SKILL.md
+++ b/skills/continue-bugfix/SKILL.md
@@ -23,7 +23,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -23,7 +23,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -23,7 +23,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -18,7 +18,7 @@ Use simple, individual commands. Never combine multiple operations into bash loo
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -20,17 +20,34 @@ Run the migration script with sandbox disabled (migrations may need to modify `.
 
 #### If files were updated
 
-The script will list which files were updated. Present this to the user:
+The script will list which files were updated. Present the list and a prompt:
 
 > *Output the next fenced block as a code block:*
 
 ```
 {list from script output}
-
-Review changes with `git diff`, then restart Claude to pick up the changes.
 ```
 
-The user needs to restart Claude before proceeding.
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Migrations applied. Review with `git diff` if needed.
+
+- **`c`/`continue`** — Proceed
+- **Ask** — Ask questions about the changes
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `continue`:**
+
+→ Return to the calling skill.
+
+**If ask:**
+
+Answer the user's question, then re-display the prompt above.
 
 **STOP.** Wait for user response.
 
@@ -42,7 +59,7 @@ The user needs to restart Claude before proceeding.
 All documents up to date.
 ```
 
-Return control silently - no user interaction needed.
+→ Return to the calling skill.
 
 ## Notes
 

--- a/skills/start-bugfix/SKILL.md
+++ b/skills/start-bugfix/SKILL.md
@@ -23,7 +23,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/start-epic/SKILL.md
+++ b/skills/start-epic/SKILL.md
@@ -23,7 +23,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -23,7 +23,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -10,7 +10,7 @@ Show the current state of the workflow for this project.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/view-plan/SKILL.md
+++ b/skills/view-plan/SKILL.md
@@ -10,7 +10,7 @@ Display a readable summary of a plan's phases, tasks, and status.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -24,7 +24,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 **This step is mandatory. You must complete it before proceeding.**
 
-Invoke the `/migrate` skill and assess its output.
+Invoke the `/migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
 ---
 


### PR DESCRIPTION
## Summary

- Model was blowing past the migrate skill's STOP gate when files were updated — it prioritised the parent skill's instructions and continued to Step 1
- Strengthened Step 0 wording in all 10 calling skills to explicitly defer to the migrate skill's instructions (including STOP gates)
- Replaced restart-required terminal stop with interactive continue/ask prompt, since migrations no longer require a Claude restart
- Fixed non-standard "Return control silently" to use `→ Return to` convention

## Test plan

- [ ] Trigger a migration (delete `.workflows/.state/migrations` log) and invoke `/workflow-start` — verify it stops after displaying migration results with the continue/ask prompt
- [ ] Press `c` to continue — verify it proceeds to the workflow overview
- [ ] Ask a question at the prompt — verify it answers and re-displays the prompt
- [ ] Run when no migrations needed — verify it proceeds silently with no pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)