### PR TITLE
Unify manifest structure + feature-to-epic pivot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Work-unit-first directory structure with uniform `{topic}` in all paths. For fea
 
 Discovery scripts filter by status — `workflow-start` and `continue-*` show active work by default, with menu options to view completed/cancelled items or manage lifecycle state. Completed/cancelled work units can be reactivated.
 
-**Feature-to-epic pivot**: Features can be converted to epics via the manage menu (`p`/`pivot`). Since all work types use the same `items` manifest structure, pivot just changes `work_type` — no data restructuring needed. After pivot, the user can continue immediately as an epic or return to the previous view.
+**Feature-to-epic pivot**: Features can be converted to epics via the manage menu (`p`/`pivot`). After pivot, the user can continue immediately as an epic or return to the previous view.
 
 **Epic soft gates**: When navigating forward between phases in an epic (via `continue-epic`), advisory gates warn if prerequisite phase items are still in-progress. These are informational, not blocking — the user can proceed anyway. Covers research→discussion, discussion→specification, specification→planning, and planning→implementation transitions. The system recovers gracefully via re-analysis if the user proceeds early.
 
@@ -244,7 +244,7 @@ The `/migrate` skill keeps workflow files in sync with the current system design
 Migration 016 converts phase-first directories to work-unit-first, creates `manifest.json` files from artifact frontmatter, renames `plan.md` to `planning.md` and `tracking.md` to `implementation.md`, and updates `work_type: greenfield` to `epic`. Frontmatter is preserved in migrated artifacts as a safety net — a follow-up migration will strip it once the manifest system is proven.
 
 **Migration 025 — Unified manifest items:**
-Migration 025 wraps flat feature/bugfix phase data into the `items[manifest.name]` structure, unifying all work types to use the same `phases.<phase>.items.<topic>` layout. Phase-level keys (`analysis_cache`) stay at phase level. Epics are skipped (already use items). This makes the manifest structure uniform and enables feature-to-epic pivot (just change `work_type`).
+Migration 025 ensures all work types use the `phases.<phase>.items.<topic>` layout. For feature/bugfix manifests with legacy flat phase data, it wraps fields into `items[manifest.name]`. Phase-level keys (`analysis_cache`) stay at phase level. Epics are unaffected.
 
 **Critical: Frontmatter extraction in bash scripts**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,12 +160,12 @@ Phase entry skills (`workflow-*-entry`) receive positional arguments: `$0` = wor
 
 **Work types and work units**: A *work type* is one of three pipeline shapes: epic, feature, or bugfix. A *work unit* is a named instance of a work type (e.g., "auth-flow" is a feature work unit, "payments-overhaul" is an epic work unit). Each work unit gets its own directory under `.workflows/` and its own `manifest.json`.
 
-**Topics**: A *topic* is the item within a phase. For feature/bugfix, the topic name equals the work unit name (single topic moving through the pipeline). For epic, topics are distinct from the work unit name (multiple topics per phase). All phases use per-topic items in the manifest for epic (including research). For feature/bugfix, research uses flat phase-level status. The discussion phase analyses all research files collectively to derive discussion topics.
+**Topics**: A *topic* is the item within a phase. For feature/bugfix, the topic name equals the work unit name (single topic moving through the pipeline). For epic, topics are distinct from the work unit name (multiple topics per phase). All work types use per-topic items in the manifest (unified structure). The discussion phase analyses all research files collectively to derive discussion topics.
 
 Work-unit-first directory structure with uniform `{topic}` in all paths. For feature/bugfix, `{topic}` equals `{work_unit}`. For epic, `{topic}` is the item within a phase.
 
 - Manifest: `.workflows/{work_unit}/manifest.json`
-- Research: `.workflows/{work_unit}/research/` (items for epic, flat for feature/bugfix)
+- Research: `.workflows/{work_unit}/research/`
 - Discussion: `.workflows/{work_unit}/discussion/{topic}.md` (flat file)
 - Investigation: `.workflows/{work_unit}/investigation/{topic}.md` (flat file)
 - Specification: `.workflows/{work_unit}/specification/{topic}/specification.md`
@@ -268,7 +268,7 @@ The manifest CLI at `skills/workflow-manifest/scripts/manifest.js` is the single
 Key properties:
 - JSON format, zero dependencies (Node handles JSON natively)
 - Domain-aware flag syntax: `--phase` and `--topic` flags route to correct internal path based on work_type
-- Skills never know manifest internal structure (flat for feature/bugfix, items for epic)
+- Skills never know manifest internal structure — all work types use items
 - File locking for concurrent session safety
 - Validation of structural values (work_type, phase names, statuses, gate modes)
 - Manifest location: `.workflows/{work_unit}/manifest.json`
@@ -289,7 +289,7 @@ $MANIFEST delete {work_unit} phases.research.analysis_cache             # delete
 $MANIFEST get {work_unit} --phase discussion --topic "*" status        # wildcard: collect from all topics
 ```
 
-**Wildcard topic**: `--topic "*"` collects values from all topics in a phase, abstracting away the epic items structure. Works with `get` and `exists` commands. For epic: iterates all items. For feature/bugfix: returns the single flat value.
+**Wildcard topic**: `--topic "*"` collects values from all topics in a phase. Works with `get` and `exists` commands. Iterates all items for any work type. For feature/bugfix: returns the single item (topic matches work unit name).
 
 See `skills/workflow-manifest/SKILL.md` for the full API.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ skills/
     scripts/discovery.js       #   All active work units grouped by type
     references/                #   Display, routing, lifecycle management
       active-work.md           #     Active work units display + selection
-      manage-work-unit.md      #     Complete/cancel work units
+      manage-work-unit.md      #     Complete/cancel/pivot work units
       view-completed.md        #     Browse completed/cancelled work units
   workflow-bridge/             # Pipeline continuation - discovers next phase, enters plan mode
     scripts/discovery.js       #   Topic-specific or phase-centric discovery
@@ -188,6 +188,8 @@ Work-unit-first directory structure with uniform `{topic}` in all paths. For fea
 
 Discovery scripts filter by status — `workflow-start` and `continue-*` show active work by default, with menu options to view completed/cancelled items or manage lifecycle state. Completed/cancelled work units can be reactivated.
 
+**Feature-to-epic pivot**: Features can be converted to epics via the manage menu (`p`/`pivot`). Since all work types use the same `items` manifest structure, pivot just changes `work_type` — no data restructuring needed. After pivot, the user can continue immediately as an epic or return to the previous view.
+
 **Epic soft gates**: When navigating forward between phases in an epic (via `continue-epic`), advisory gates warn if prerequisite phase items are still in-progress. These are informational, not blocking — the user can proceed anyway. Covers research→discussion, discussion→specification, specification→planning, and planning→implementation transitions. The system recovers gracefully via re-analysis if the user proceeds early.
 
 Commit docs frequently (natural breaks, before context refresh). Skills capture context, don't implement.
@@ -240,6 +242,9 @@ The `/migrate` skill keeps workflow files in sync with the current system design
 
 **Migration 016 — Work-unit restructure:**
 Migration 016 converts phase-first directories to work-unit-first, creates `manifest.json` files from artifact frontmatter, renames `plan.md` to `planning.md` and `tracking.md` to `implementation.md`, and updates `work_type: greenfield` to `epic`. Frontmatter is preserved in migrated artifacts as a safety net — a follow-up migration will strip it once the manifest system is proven.
+
+**Migration 025 — Unified manifest items:**
+Migration 025 wraps flat feature/bugfix phase data into the `items[manifest.name]` structure, unifying all work types to use the same `phases.<phase>.items.<topic>` layout. Phase-level keys (`analysis_cache`) stay at phase level. Epics are skipped (already use items). This makes the manifest structure uniform and enables feature-to-epic pivot (just change `work_type`).
 
 **Critical: Frontmatter extraction in bash scripts**
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Work units move through a simple lifecycle: **in-progress** → **completed** or
 
 Feature and bugfix pipelines offer an early completion option after implementation (skip review). Epic work units are completed when all topics have finished review.
 
-**Feature-to-epic pivot:** If a feature grows beyond its original scope, convert it to an epic via the manage menu. All existing progress is preserved — the unified manifest structure means no data migration is needed. After pivoting, continue immediately as an epic to add new topics.
+**Feature-to-epic pivot:** If a feature grows beyond its original scope, convert it to an epic via the manage menu. All existing progress is preserved. After pivoting, continue immediately as an epic to add new topics.
 
 ### Output Formats
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ Work units move through a simple lifecycle: **in-progress** → **completed** or
 
 Feature and bugfix pipelines offer an early completion option after implementation (skip review). Epic work units are completed when all topics have finished review.
 
+**Feature-to-epic pivot:** If a feature grows beyond its original scope, convert it to an epic via the manage menu. All existing progress is preserved — the unified manifest structure means no data migration is needed. After pivoting, continue immediately as an epic to add new topics.
+
 ### Output Formats
 
 Planning supports multiple output formats through an adapter pattern. Each format implements a 5-file contract — about, authoring, reading, updating, and graph — so the planning workflow works identically regardless of where tasks are stored.

--- a/skills/migrate/scripts/migrations/025-unify-manifest-items.sh
+++ b/skills/migrate/scripts/migrations/025-unify-manifest-items.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Migration 025: Unify manifest structure — items for all work types
+#
+# For each feature/bugfix manifest: wrap flat phase-level keys into
+# items[manifest.name]. Preserves phase-level keys: analysis_cache, items.
+# Skips phases that already have an items key.
+#
+# Idempotent. Direct node for JSON — never uses manifest CLI.
+#
+
+WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+
+[ -d "$WORKFLOWS_DIR" ] || return 0
+
+for manifest in "$WORKFLOWS_DIR"/*/manifest.json; do
+  [ -f "$manifest" ] || continue
+
+  dir=$(dirname "$manifest")
+  wu_name=$(basename "$dir")
+
+  # Skip dot-prefixed directories
+  case "$wu_name" in .*) continue ;; esac
+
+  result=$(node -e "
+    const fs = require('fs');
+    const m = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+
+    // Only migrate feature and bugfix
+    if (m.work_type !== 'feature' && m.work_type !== 'bugfix') process.exit(0);
+    if (!m.phases || typeof m.phases !== 'object') process.exit(0);
+
+    const topicName = m.name;
+    let changed = false;
+
+    // Phase-level keys to preserve at phase level (not wrap into items)
+    const PHASE_LEVEL_KEYS = new Set(['analysis_cache', 'items']);
+
+    for (const [phase, data] of Object.entries(m.phases)) {
+      if (!data || typeof data !== 'object') continue;
+      // Skip if already has items
+      if (data.items) continue;
+
+      // Collect keys to wrap
+      const itemData = {};
+      const keysToRemove = [];
+      for (const [key, val] of Object.entries(data)) {
+        if (!PHASE_LEVEL_KEYS.has(key)) {
+          itemData[key] = val;
+          keysToRemove.push(key);
+        }
+      }
+
+      // Only wrap if there's something to wrap
+      if (keysToRemove.length === 0) continue;
+
+      // Remove wrapped keys from phase level
+      for (const key of keysToRemove) {
+        delete data[key];
+      }
+
+      // Create items structure
+      data.items = { [topicName]: itemData };
+      changed = true;
+    }
+
+    if (changed) {
+      fs.writeFileSync(process.argv[1], JSON.stringify(m, null, 2) + '\n');
+      console.log('updated');
+    }
+  " "$manifest" 2>/dev/null) || true
+
+  if [ "$result" = "updated" ]; then
+    report_update "$manifest" "unified to items structure for $wu_name"
+  fi
+done

--- a/skills/status/scripts/discovery.js
+++ b/skills/status/scripts/discovery.js
@@ -176,9 +176,9 @@ function discover(cwd) {
       investigation: { status: invStatus },
       specification: {
         status: specStatus,
+        ...(singleSpec && singleSpec.superseded_by && { superseded_by: singleSpec.superseded_by }),
         ...(specStatus && {
           type: specItemCount > 1 ? 'mixed' : specType,
-          ...(singleSpec && singleSpec.superseded_by && { superseded_by: singleSpec.superseded_by }),
           ...(specItemCount <= 1 && { sources }),
           ...(specItemCount > 1 && { item_count: specItemCount }),
         }),

--- a/skills/status/scripts/discovery.js
+++ b/skills/status/scripts/discovery.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { loadActiveManifests, phaseData, phaseItems, countFiles } = require('../../workflow-shared/scripts/discovery-utils');
+const { loadActiveManifests, phaseItems, phaseStatus, countFiles } = require('../../workflow-shared/scripts/discovery-utils');
 
 function discover(cwd) {
   const manifests = loadActiveManifests(cwd);
@@ -38,8 +38,7 @@ function discover(cwd) {
     const baseDir = path.join(workflowsDir, m.name);
 
     // Research
-    const research = phaseData(m, 'research');
-    const researchStatus = research.status || null;
+    const researchStatus = phaseStatus(m, 'research');
     let fileCount = 0;
     if (researchStatus) {
       researchCount++;
@@ -60,65 +59,47 @@ function discover(cwd) {
     // Discussion
     let discStatus = null;
     let discItemCount = 0;
-    if (wt === 'epic') {
-      const items = phaseItems(m, 'discussion');
-      if (items.length > 0) {
-        discItemCount = items.length;
-        discStatus = aggregateStatus(items);
-        discTotal += items.length;
-        discCompleted += items.filter(i => i.status === 'completed').length;
-        discInProgress += items.filter(i => i.status === 'in-progress').length;
-      }
-    } else {
-      const disc = phaseData(m, 'discussion');
-      discStatus = disc.status || null;
-      if (discStatus) {
-        discTotal++;
-        if (discStatus === 'completed') discCompleted++;
-        if (discStatus === 'in-progress') discInProgress++;
-      }
+    const discItems = phaseItems(m, 'discussion');
+    if (discItems.length > 0) {
+      discItemCount = discItems.length;
+      discStatus = aggregateStatus(discItems);
+      discTotal += discItems.length;
+      discCompleted += discItems.filter(i => i.status === 'completed').length;
+      discInProgress += discItems.filter(i => i.status === 'in-progress').length;
     }
 
     // Investigation
-    const inv = phaseData(m, 'investigation');
-    const invStatus = inv.status || null;
+    const invStatus = phaseStatus(m, 'investigation');
 
     // Specification
     let specStatus = null;
     let specType = 'feature';
     let sources = [];
     let specItemCount = 0;
-    if (wt === 'epic') {
-      const items = phaseItems(m, 'specification');
-      if (items.length > 0) {
-        specItemCount = items.length;
-        const activeItems = items.filter(i => i.status !== 'superseded');
-        specStatus = aggregateStatus(activeItems);
-        for (const item of activeItems) {
-          specActive++;
-          const itemType = item.type || 'feature';
-          if (itemType === 'cross-cutting') specCrosscutting++;
-          else specFeature++;
-        }
-      }
-    } else {
-      const spec = phaseData(m, 'specification');
-      specStatus = spec.status || null;
-      specType = spec.type || 'feature';
-      if (specStatus && specStatus !== 'superseded') {
+    const specItems = phaseItems(m, 'specification');
+    if (specItems.length > 0) {
+      specItemCount = specItems.length;
+      const activeItems = specItems.filter(i => i.status !== 'superseded');
+      specStatus = aggregateStatus(activeItems);
+      for (const item of activeItems) {
         specActive++;
-        if (specType === 'cross-cutting') specCrosscutting++;
+        const itemType = item.type || 'feature';
+        if (itemType === 'cross-cutting') specCrosscutting++;
         else specFeature++;
       }
-      if (spec.sources && typeof spec.sources === 'object' && !Array.isArray(spec.sources)) {
-        sources = Object.entries(spec.sources).map(([name, data]) => ({
-          name,
-          status: (typeof data === 'object') ? (data.status || 'incorporated') : 'incorporated',
-        }));
-      } else if (Array.isArray(spec.sources)) {
-        sources = spec.sources;
+      // For single-item (feature/bugfix), extract item-level details
+      if (specItems.length === 1) {
+        const si = specItems[0];
+        specType = si.type || 'feature';
+        if (si.sources && typeof si.sources === 'object' && !Array.isArray(si.sources)) {
+          sources = Object.entries(si.sources).map(([name, data]) => ({
+            name,
+            status: (typeof data === 'object') ? (data.status || 'incorporated') : 'incorporated',
+          }));
+        } else if (Array.isArray(si.sources)) {
+          sources = si.sources;
+        }
       }
-      if (spec.superseded_by) specType = spec.type || 'feature'; // preserve for output
     }
 
     // Planning
@@ -127,36 +108,22 @@ function discover(cwd) {
     let externalDepsObj = {};
     let hasUnresolved = false;
     let planItemCount = 0;
-    if (wt === 'epic') {
-      const items = phaseItems(m, 'planning');
-      if (items.length > 0) {
-        planItemCount = items.length;
-        planStatus = aggregateStatus(items);
-        planTotal += items.length;
-        planCompleted += items.filter(i => i.status === 'completed').length;
-        planInProgress += items.filter(i => i.status === 'in-progress').length;
-        // Use format from first item that has one
-        const withFmt = items.find(i => i.format);
-        planFormat = withFmt ? withFmt.format : null;
-        // Aggregate external deps across all items
-        for (const item of items) {
-          const deps = (item.external_dependencies && typeof item.external_dependencies === 'object' && !Array.isArray(item.external_dependencies))
-            ? item.external_dependencies : {};
-          Object.assign(externalDepsObj, deps);
-        }
-        hasUnresolved = Object.values(externalDepsObj).some(d => d.state === 'unresolved');
+    const planItems = phaseItems(m, 'planning');
+    if (planItems.length > 0) {
+      planItemCount = planItems.length;
+      planStatus = aggregateStatus(planItems);
+      planTotal += planItems.length;
+      planCompleted += planItems.filter(i => i.status === 'completed').length;
+      planInProgress += planItems.filter(i => i.status === 'in-progress').length;
+      // Use format from first item that has one
+      const withFmt = planItems.find(i => i.format);
+      planFormat = withFmt ? withFmt.format : null;
+      // Aggregate external deps across all items
+      for (const item of planItems) {
+        const deps = (item.external_dependencies && typeof item.external_dependencies === 'object' && !Array.isArray(item.external_dependencies))
+          ? item.external_dependencies : {};
+        Object.assign(externalDepsObj, deps);
       }
-    } else {
-      const plan = phaseData(m, 'planning');
-      planStatus = plan.status || null;
-      planFormat = plan.format || null;
-      if (planStatus) {
-        planTotal++;
-        if (planStatus === 'completed') planCompleted++;
-        if (planStatus === 'in-progress') planInProgress++;
-      }
-      externalDepsObj = (plan.external_dependencies && typeof plan.external_dependencies === 'object' && !Array.isArray(plan.external_dependencies))
-        ? plan.external_dependencies : {};
       hasUnresolved = Object.values(externalDepsObj).some(d => d.state === 'unresolved');
     }
 
@@ -166,69 +133,54 @@ function discover(cwd) {
     let totalTasks = 0;
     let implCurrentPhase = null;
     let implItemCount = 0;
-    if (wt === 'epic') {
-      const items = phaseItems(m, 'implementation');
-      if (items.length > 0) {
-        implItemCount = items.length;
-        implStatus = aggregateStatus(items);
-        implTotal += items.length;
-        implCompleted += items.filter(i => i.status === 'completed').length;
-        implInProgressCount += items.filter(i => i.status === 'in-progress').length;
-        // Sum tasks across all items
-        for (const item of items) {
-          completedTasks += Array.isArray(item.completed_tasks) ? item.completed_tasks.length : 0;
-        }
-        // Sum task files across all topics
-        const planItems = phaseItems(m, 'planning');
-        for (const pi of planItems) {
-          const fmt = pi.format || planFormat;
-          if (fmt === 'local-markdown') {
-            totalTasks += countFiles(path.join(baseDir, 'planning', pi.name, 'tasks'), '.md');
-          }
+    const implItems = phaseItems(m, 'implementation');
+    if (implItems.length > 0) {
+      implItemCount = implItems.length;
+      implStatus = aggregateStatus(implItems);
+      implTotal += implItems.length;
+      implCompleted += implItems.filter(i => i.status === 'completed').length;
+      implInProgressCount += implItems.filter(i => i.status === 'in-progress').length;
+      // Sum tasks across all items
+      for (const item of implItems) {
+        completedTasks += Array.isArray(item.completed_tasks) ? item.completed_tasks.length : 0;
+      }
+      // Sum task files across all topics
+      for (const pi of planItems) {
+        const fmt = pi.format || planFormat;
+        if (fmt === 'local-markdown') {
+          totalTasks += countFiles(path.join(baseDir, 'planning', pi.name, 'tasks'), '.md');
         }
       }
-    } else {
-      const impl = phaseData(m, 'implementation');
-      implStatus = impl.status || null;
-      if (implStatus) {
-        implTotal++;
-        if (implStatus === 'completed') implCompleted++;
-        if (implStatus === 'in-progress') implInProgressCount++;
+      // For single-item, extract current_phase
+      if (implItems.length === 1) {
+        const ii = implItems[0];
+        if (ii.current_phase != null && ii.current_phase !== '~') implCurrentPhase = ii.current_phase;
       }
-      completedTasks = Array.isArray(impl.completed_tasks) ? impl.completed_tasks.length : 0;
-      const planFmt = planFormat || impl.format;
-      if (planFmt === 'local-markdown') {
-        totalTasks = countFiles(path.join(baseDir, 'planning', m.name, 'tasks'), '.md');
-      }
-      if (impl.current_phase != null && impl.current_phase !== '~') implCurrentPhase = impl.current_phase;
     }
 
     // Review
     let reviewStatus = null;
-    if (wt === 'epic') {
-      const items = phaseItems(m, 'review');
-      if (items.length > 0) {
-        reviewStatus = aggregateStatus(items);
-      }
-    } else {
-      const review = phaseData(m, 'review');
-      reviewStatus = review.status || null;
+    const reviewItems = phaseItems(m, 'review');
+    if (reviewItems.length > 0) {
+      reviewStatus = aggregateStatus(reviewItems);
     }
 
-    const specData = phaseData(m, 'specification');
+    // For single-item spec, extract superseded_by
+    const singleSpec = specItems.length === 1 ? specItems[0] : null;
+
     workUnits.push({
       name: m.name, work_type: wt,
       description: m.description || '',
       research: { status: researchStatus, ...(researchStatus && { file_count: fileCount }) },
-      discussion: { status: discStatus, ...(wt === 'epic' && discItemCount > 0 && { item_count: discItemCount }) },
+      discussion: { status: discStatus, ...(discItemCount > 1 && { item_count: discItemCount }) },
       investigation: { status: invStatus },
       specification: {
         status: specStatus,
         ...(specStatus && {
-          type: wt === 'epic' ? 'mixed' : specType,
-          ...(wt !== 'epic' && specData.superseded_by && { superseded_by: specData.superseded_by }),
-          ...(wt !== 'epic' && { sources }),
-          ...(wt === 'epic' && specItemCount > 0 && { item_count: specItemCount }),
+          type: specItemCount > 1 ? 'mixed' : specType,
+          ...(singleSpec && singleSpec.superseded_by && { superseded_by: singleSpec.superseded_by }),
+          ...(specItemCount <= 1 && { sources }),
+          ...(specItemCount > 1 && { item_count: specItemCount }),
         }),
       },
       planning: {
@@ -240,7 +192,7 @@ function discover(cwd) {
             ...(d.task_id && { task_id: d.task_id }),
           })),
           has_unresolved_deps: hasUnresolved,
-          ...(wt === 'epic' && planItemCount > 0 && { item_count: planItemCount }),
+          ...(planItemCount > 1 && { item_count: planItemCount }),
         }),
       },
       implementation: {
@@ -249,7 +201,7 @@ function discover(cwd) {
           ...(implCurrentPhase != null && { current_phase: implCurrentPhase }),
           completed_tasks: completedTasks,
           total_tasks: totalTasks,
-          ...(wt === 'epic' && implItemCount > 0 && { item_count: implItemCount }),
+          ...(implItemCount > 1 && { item_count: implItemCount }),
         }),
       },
       review: { status: reviewStatus },

--- a/skills/workflow-discussion-entry/scripts/discovery.js
+++ b/skills/workflow-discussion-entry/scripts/discovery.js
@@ -34,26 +34,11 @@ function discover(cwd, workUnit) {
   let completed = 0;
 
   for (const m of manifests) {
-    const dp = phaseData(m, 'discussion');
-    if (!dp) continue;
-
-    if (m.work_type === 'epic') {
-      const items = phaseItems(m, 'discussion');
-      if (items.length > 0) {
-        for (const item of items) {
-          discussions.push({ name: item.name, work_unit: m.name, status: item.status || 'unknown', work_type: m.work_type });
-          if (item.status === 'in-progress') inProgress++;
-          else if (item.status === 'completed') completed++;
-        }
-      } else if (dp.status) {
-        discussions.push({ name: m.name, work_unit: m.name, status: dp.status, work_type: m.work_type });
-        if (dp.status === 'in-progress') inProgress++;
-        else if (dp.status === 'completed') completed++;
-      }
-    } else if (dp.status) {
-      discussions.push({ name: m.name, work_unit: m.name, status: dp.status, work_type: m.work_type });
-      if (dp.status === 'in-progress') inProgress++;
-      else if (dp.status === 'completed') completed++;
+    const items = phaseItems(m, 'discussion');
+    for (const item of items) {
+      discussions.push({ name: item.name, work_unit: m.name, status: item.status || 'unknown', work_type: m.work_type });
+      if (item.status === 'in-progress') inProgress++;
+      else if (item.status === 'completed') completed++;
     }
   }
 

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -18,7 +18,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js <command> [args]
 
 ## Domain-Aware Flag Syntax
 
-Skills provide logical coordinates via `--phase` and `--topic` flags. The CLI routes to the correct JSON path internally based on work_type. Skills never know or care about the manifest's internal structure (flat for feature/bugfix, items for epic).
+Skills provide logical coordinates via `--phase` and `--topic` flags. The CLI routes to the correct JSON path internally. All work types use the same `items` structure — skills never need to know the manifest's internal layout.
 
 ```bash
 MANIFEST="node .claude/skills/workflow-manifest/scripts/manifest.js"
@@ -51,11 +51,10 @@ $MANIFEST get {work_unit} --phase discussion              # whole phase (for ite
 $MANIFEST get {work_unit} --phase discussion --topic {topic} status  # specific item field
 ```
 
-**`--topic "*"` (wildcard)** — collects values from all topics in a phase, abstracting away the epic items structure. Supported by `get` and `exists` only. For epic: iterates all items. For feature/bugfix: returns the single flat value.
+**`--topic "*"` (wildcard)** — collects values from all topics in a phase. Supported by `get` and `exists` only. For epic: iterates all items. For feature/bugfix: returns the single item (topic matches work unit name).
 
 **Internal routing (CLI handles, skills don't know):**
-- Feature/bugfix: `--phase discussion --topic auth-flow status` → `phases.discussion.status`
-- Epic: `--phase discussion --topic payment-processing status` → `phases.discussion.items.payment-processing.status`
+- All work types: `--phase discussion --topic auth-flow status` → `phases.discussion.items.auth-flow.status`
 
 ## Commands
 
@@ -111,7 +110,7 @@ Output is a JSON array of `{topic, value}` objects:
 ]
 ```
 
-For feature/bugfix, returns a single-element array (topic equals work unit name). Errors if the phase has no items.
+For feature/bugfix, returns a single-element array (topic matches work unit name). Errors if the phase has no items.
 
 Errors to stderr with non-zero exit if the path does not exist.
 
@@ -177,10 +176,7 @@ Output: JSON array of manifest objects.
 
 ### `init-phase`
 
-Register a topic within a phase. Behavior varies by work type:
-
-- **Epic**: creates `phases.<phase>.items.<topic>` with `{ "status": "in-progress" }`
-- **Feature/bugfix**: creates `phases.<phase>` with `{ "status": "in-progress" }` (flat — topic is implicit)
+Register a topic within a phase. All work types create `phases.<phase>.items.<topic>` with `{ "status": "in-progress" }`.
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js init-phase <name> --phase discussion --topic <topic>
@@ -258,4 +254,4 @@ Item-level statuses within epic phases follow the same phase-level rules.
 - **File locking**: `.lock` file next to manifest, exclusive create (`wx` flag), 30s stale detection. Prevents concurrent session conflicts.
 - **Atomic writes**: write to `.tmp` then `fs.renameSync`. No partial writes.
 - **Auto-creation**: `init` creates the work unit directory. Phase directories are created by skills when they enter that phase, not by the CLI.
-- **Domain routing**: `--phase` and `--topic` flags let skills use logical coordinates. The CLI resolves to the correct internal JSON path based on work_type (flat for feature/bugfix, items for epic).
+- **Domain routing**: `--phase` and `--topic` flags let skills use logical coordinates. The CLI resolves to the correct internal JSON path — all work types use `items` structure.

--- a/skills/workflow-manifest/scripts/manifest.js
+++ b/skills/workflow-manifest/scripts/manifest.js
@@ -154,9 +154,9 @@ function parseFlags(args) {
 
 /**
  * Resolve the internal JSON path segments for a phase+topic operation.
- * Routes based on work_type: feature/bugfix → flat, epic → items.
+ * All work types route through items when topic is provided.
  *
- * @param {string} workType - The work unit's work_type
+ * @param {string} workType - The work unit's work_type (kept for call-site compat)
  * @param {string} phase - The phase name
  * @param {string|null} topic - The topic name (null = whole phase)
  * @param {string[]} fieldSegments - Additional field path segments
@@ -164,24 +164,13 @@ function parseFlags(args) {
  */
 function resolvePhaseSegments(workType, phase, topic, fieldSegments) {
   const base = ['phases', phase];
-
-  if (!topic) {
-    // No topic — return the whole phase object (+ any field path)
-    return [...base, ...fieldSegments];
-  }
-
-  if (workType === 'epic') {
-    // Epic: phases.<phase>.items.<topic>[.field.path]
-    return [...base, 'items', topic, ...fieldSegments];
-  }
-
-  // Feature/bugfix: phases.<phase>[.field.path] (flat — topic is implicit)
-  return [...base, ...fieldSegments];
+  if (!topic) return [...base, ...fieldSegments];
+  return [...base, 'items', topic, ...fieldSegments];
 }
 
 /**
  * Resolve wildcard topic — collect field values from all topics in a phase.
- * For epic: iterates all items. For feature/bugfix: returns the single flat value.
+ * All work types use items structure.
  *
  * @param {object} manifest - The full manifest object
  * @param {string} phase - The phase name
@@ -192,20 +181,13 @@ function resolveWildcardTopic(manifest, phase, fieldSegments) {
   const phaseData = getByPath(manifest, ['phases', phase]);
   if (!phaseData) return [];
 
-  if (manifest.work_type === 'epic') {
-    const items = phaseData.items;
-    if (!items || typeof items !== 'object') return [];
+  const items = phaseData.items;
+  if (!items || typeof items !== 'object') return [];
 
-    return Object.keys(items).map(topic => ({
-      topic,
-      value: fieldSegments.length ? getByPath(items[topic], fieldSegments) : items[topic],
-    })).filter(entry => entry.value !== undefined);
-  }
-
-  // Feature/bugfix: single implicit topic
-  const value = fieldSegments.length ? getByPath(phaseData, fieldSegments) : phaseData;
-  if (value === undefined) return [];
-  return [{ topic: manifest.name, value }];
+  return Object.keys(items).map(topic => ({
+    topic,
+    value: fieldSegments.length ? getByPath(items[topic], fieldSegments) : items[topic],
+  })).filter(entry => entry.value !== undefined);
 }
 
 // ---------------------------------------------------------------------------
@@ -605,26 +587,14 @@ function cmdInitPhase(args) {
     const manifest = readManifest(name);
 
     if (!manifest.phases) manifest.phases = {};
+    if (!manifest.phases[phase]) manifest.phases[phase] = {};
+    if (!manifest.phases[phase].items) manifest.phases[phase].items = {};
 
-    if (manifest.work_type === 'epic') {
-      // Epic: create phases.<phase>.items.<topic> = { status: "in-progress" }
-      if (!manifest.phases[phase]) manifest.phases[phase] = {};
-      if (!manifest.phases[phase].items) manifest.phases[phase].items = {};
-
-      if (manifest.phases[phase].items[topic]) {
-        die(`Item "${topic}" already exists in phase "${phase}" of "${name}"`);
-      }
-
-      manifest.phases[phase].items[topic] = { status: 'in-progress' };
-    } else {
-      // Feature/bugfix: create phases.<phase> = { status: "in-progress" }
-      if (manifest.phases[phase] && manifest.phases[phase].status) {
-        die(`Phase "${phase}" already exists in "${name}"`);
-      }
-
-      if (!manifest.phases[phase]) manifest.phases[phase] = {};
-      manifest.phases[phase].status = 'in-progress';
+    if (manifest.phases[phase].items[topic]) {
+      die(`Item "${topic}" already exists in phase "${phase}" of "${name}"`);
     }
+
+    manifest.phases[phase].items[topic] = { status: 'in-progress' };
 
     writeManifestAtomic(name, manifest);
   });

--- a/skills/workflow-shared/scripts/discovery-utils.js
+++ b/skills/workflow-shared/scripts/discovery-utils.js
@@ -80,7 +80,18 @@ function loadAllManifests(cwd) {
 }
 
 function phaseStatus(manifest, phase) {
-  return ((manifest.phases || {})[phase] || {}).status || null;
+  const p = (manifest.phases || {})[phase] || {};
+  if (p.items && typeof p.items === 'object') {
+    const keys = Object.keys(p.items);
+    if (keys.length === 0) return null;
+    if (keys.length === 1) return (p.items[keys[0]] || {}).status || null;
+    const statuses = keys.map(k => (p.items[k] || {}).status).filter(Boolean);
+    if (statuses.length === 0) return null;
+    if (statuses.every(s => s === 'completed')) return 'completed';
+    if (statuses.some(s => s === 'in-progress')) return 'in-progress';
+    return statuses[0];
+  }
+  return p.status || null;
 }
 
 function phaseItems(manifest, phase) {
@@ -96,19 +107,7 @@ function phaseData(manifest, phase) {
 function computeNextPhase(manifest) {
   const wt = manifest.work_type;
 
-  // For epic, aggregate item statuses: all completed → 'completed', any in-progress → 'in-progress'
-  const ps = (phase) => {
-    if (wt === 'epic') {
-      const items = phaseItems(manifest, phase);
-      if (items.length === 0) return phaseStatus(manifest, phase); // fallback to flat if no items
-      const statuses = items.map(i => i.status).filter(Boolean);
-      if (statuses.length === 0) return null;
-      if (statuses.every(s => s === 'completed')) return 'completed';
-      if (statuses.some(s => s === 'in-progress')) return 'in-progress';
-      return statuses[0];
-    }
-    return phaseStatus(manifest, phase);
-  };
+  const ps = (phase) => phaseStatus(manifest, phase);
 
   if (ps('review') === 'completed') {
     return { next_phase: 'done', phase_label: 'pipeline complete' };

--- a/skills/workflow-specification-entry/scripts/discovery.js
+++ b/skills/workflow-specification-entry/scripts/discovery.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { loadActiveManifests, phaseStatus, phaseItems, phaseData, listFiles, listDirs, filesChecksum, fileExists } = require('../../workflow-shared/scripts/discovery-utils');
+const { loadActiveManifests, phaseItems, phaseData, listFiles, listDirs, filesChecksum, fileExists } = require('../../workflow-shared/scripts/discovery-utils');
 
 function discover(cwd, workUnit) {
   const allManifests = loadActiveManifests(cwd);
@@ -16,50 +16,27 @@ function discover(cwd, workUnit) {
   let discCount = 0, completedCount = 0, inProgressCount = 0;
 
   for (const m of manifests) {
-    const dp = phaseData(m, 'discussion');
-    if (!dp) continue;
-    const specPhase = phaseData(m, 'specification');
+    const discItemsList = phaseItems(m, 'discussion');
+    const specItemsList = phaseItems(m, 'specification');
 
-    if (m.work_type === 'epic') {
-      const items = phaseItems(m, 'discussion');
-      for (const item of items) {
-        discCount++;
-        if (item.status === 'completed') completedCount++;
-        else if (item.status === 'in-progress') inProgressCount++;
-
-        // Check if this discussion has an individual spec via sources
-        // For epic, sources are per spec item, not phase-level
-        let hasIndividualSpec = false;
-        let specStatus = '';
-        const specItems = phaseItems(m, 'specification');
-        for (const si of specItems) {
-          if (si.sources && si.sources[item.name]) {
-            hasIndividualSpec = true;
-            specStatus = si.status || '';
-            break;
-          }
-        }
-
-        discussions.push({
-          name: item.name, work_unit: m.name, status: item.status || 'unknown',
-          work_type: m.work_type, has_individual_spec: hasIndividualSpec,
-          ...(hasIndividualSpec && { spec_status: specStatus }),
-        });
-      }
-    } else if (dp.status) {
+    for (const item of discItemsList) {
       discCount++;
-      if (dp.status === 'completed') completedCount++;
-      else if (dp.status === 'in-progress') inProgressCount++;
+      if (item.status === 'completed') completedCount++;
+      else if (item.status === 'in-progress') inProgressCount++;
 
+      // Check if this discussion has an individual spec via sources
       let hasIndividualSpec = false;
       let specStatus = '';
-      if (specPhase.status) {
-        hasIndividualSpec = true;
-        specStatus = specPhase.status;
+      for (const si of specItemsList) {
+        if (si.sources && si.sources[item.name]) {
+          hasIndividualSpec = true;
+          specStatus = si.status || '';
+          break;
+        }
       }
 
       discussions.push({
-        name: m.name, work_unit: m.name, status: dp.status,
+        name: item.name, work_unit: m.name, status: item.status || 'unknown',
         work_type: m.work_type, has_individual_spec: hasIndividualSpec,
         ...(hasIndividualSpec && { spec_status: specStatus }),
       });
@@ -71,55 +48,29 @@ function discover(cwd, workUnit) {
   let specCount = 0;
 
   for (const m of manifests) {
-    if (m.work_type === 'epic') {
-      const specItems = phaseItems(m, 'specification');
-      for (const item of specItems) {
-        const specFile = path.join(workflowsDir, m.name, 'specification', item.name, 'specification.md');
-        if (!fileExists(specFile)) continue;
+    const specItemsList = phaseItems(m, 'specification');
+    const discItemsList = phaseItems(m, 'discussion');
 
-        const status = item.status || 'in-progress';
-        if (status === 'superseded') continue;
-
-        specCount++;
-        const spec = {
-          name: item.name, work_unit: m.name, status,
-          work_type: m.work_type,
-        };
-
-        if (item.superseded_by) spec.superseded_by = item.superseded_by;
-
-        if (item.sources && typeof item.sources === 'object') {
-          const discItems = phaseItems(m, 'discussion');
-          spec.sources = Object.entries(item.sources).map(([srcName, srcData]) => {
-            const srcStatus = (typeof srcData === 'object') ? (srcData.status || 'incorporated') : 'incorporated';
-            const match = discItems.find(i => i.name === srcName);
-            const discStatus = match ? (match.status || 'unknown') : 'unknown';
-            return { name: srcName, status: srcStatus, discussion_status: discStatus };
-          });
-        }
-
-        specifications.push(spec);
-      }
-    } else {
-      const specFile = path.join(workflowsDir, m.name, 'specification', m.name, 'specification.md');
+    for (const item of specItemsList) {
+      const specFile = path.join(workflowsDir, m.name, 'specification', item.name, 'specification.md');
       if (!fileExists(specFile)) continue;
 
-      const sp = phaseData(m, 'specification');
-      const status = sp.status || 'in-progress';
+      const status = item.status || 'in-progress';
       if (status === 'superseded') continue;
 
       specCount++;
       const spec = {
-        name: m.name, work_unit: m.name, status,
+        name: item.name, work_unit: m.name, status,
         work_type: m.work_type,
       };
 
-      if (sp.superseded_by) spec.superseded_by = sp.superseded_by;
+      if (item.superseded_by) spec.superseded_by = item.superseded_by;
 
-      if (sp.sources && typeof sp.sources === 'object') {
-        spec.sources = Object.entries(sp.sources).map(([srcName, srcData]) => {
+      if (item.sources && typeof item.sources === 'object') {
+        spec.sources = Object.entries(item.sources).map(([srcName, srcData]) => {
           const srcStatus = (typeof srcData === 'object') ? (srcData.status || 'incorporated') : 'incorporated';
-          const discStatus = phaseStatus(m, 'discussion') || 'unknown';
+          const match = discItemsList.find(i => i.name === srcName);
+          const discStatus = match ? (match.status || 'unknown') : 'unknown';
           return { name: srcName, status: srcStatus, discussion_status: discStatus };
         });
       }

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -106,12 +106,24 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} st
 node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} work_type epic
 ```
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-"{selected.name:(titlecase)}" converted from feature to epic.
-Continue it with /continue-epic.
+· · · · · · · · · · · ·
+**{selected.name:(titlecase)}** converted from feature to epic.
+
+- **`c`/`continue`** — Continue working on this epic now
+- **`b`/`back`** — Return to previous view
+· · · · · · · · · · · ·
 ```
+
+**STOP.** Wait for user response.
+
+**If user chose `c`/`continue`:**
+
+Invoke the `/continue-epic` skill. This is terminal — do not return to the caller.
+
+**If user chose `b`/`back`:**
 
 → Return to caller to redisplay main view (re-run discovery, re-render from top).
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -112,7 +112,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} wo
 · · · · · · · · · · · ·
 **{selected.name:(titlecase)}** converted from feature to epic.
 
-- **`c`/`continue`** — Continue working on this epic now
+- **`c`/`continue`** — Continue working on {selected.name:(titlecase)} as an epic
 - **`b`/`back`** — Return to previous view
 · · · · · · · · · · · ·
 ```

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -112,7 +112,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} wo
 · · · · · · · · · · · ·
 **{selected.name:(titlecase)}** converted from feature to epic.
 
-- **`c`/`continue`** — Continue working on {selected.name:(titlecase)} as an epic
+- **`c`/`continue`** — Continue {selected.name:(titlecase)} as epic
 - **`b`/`back`** — Return to previous view
 · · · · · · · · · · · ·
 ```

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -75,6 +75,9 @@ Set `implementation_completed` = true.
 @if(implementation_completed)
 - **`d`/`done`** — Mark as completed
 @endif
+@if(selected.work_type == 'feature')
+- **`p`/`pivot`** — Convert to epic (enables multiple topics)
+@endif
 - **`c`/`cancel`** — Mark as cancelled
 - **`b`/`back`** — Return
 - **Ask** — Ask a question about this work unit
@@ -93,6 +96,21 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} st
 
 ```
 "{selected.name:(titlecase)}" marked as completed.
+```
+
+→ Return to caller to redisplay main view (re-run discovery, re-render from top).
+
+#### If user chose `p`/`pivot`
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} work_type epic
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+"{selected.name:(titlecase)}" converted from feature to epic.
+Continue it with /continue-epic.
 ```
 
 → Return to caller to redisplay main view (re-run discovery, re-render from top).

--- a/tests/scripts/test-discovery-for-discussion.js
+++ b/tests/scripts/test-discovery-for-discussion.js
@@ -35,7 +35,7 @@ describe('workflow-discussion-entry discovery', () => {
   it('detects discussions from feature manifest', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'in-progress' } },
+      phases: { discussion: { items: { auth: { status: 'in-progress' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.state.scenario, 'discussions_only');
@@ -68,7 +68,7 @@ describe('workflow-discussion-entry discovery', () => {
       work_type: 'epic',
       phases: {
         research: { status: 'completed' },
-        discussion: { status: 'in-progress' },
+        discussion: { items: { v1: { status: 'in-progress' } } },
       },
     });
     createFile(dir, '.workflows/v1/research/notes.md', '# Notes');
@@ -120,15 +120,13 @@ describe('workflow-discussion-entry discovery', () => {
     assert.strictEqual(r.cache.entries.length, 0);
   });
 
-  it('epic with no items but with discussion status', () => {
+  it('epic with flat discussion status but no items returns no discussions', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
       phases: { discussion: { status: 'in-progress' } },
     });
     const r = discover(dir);
-    assert.strictEqual(r.discussions.files.length, 1);
-    assert.strictEqual(r.discussions.files[0].name, 'v1');
-    assert.strictEqual(r.discussions.files[0].work_type, 'epic');
+    assert.strictEqual(r.discussions.files.length, 0);
   });
 
   it('reads research_files from manifest analysis_cache', () => {

--- a/tests/scripts/test-discovery-for-specification.js
+++ b/tests/scripts/test-discovery-for-specification.js
@@ -22,8 +22,15 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'completed' },
-        specification: { status: 'in-progress' },
+        discussion: { items: { auth: { status: 'completed' } } },
+        specification: {
+          items: {
+            auth: {
+              status: 'in-progress',
+              sources: { auth: { status: 'extracted' } },
+            },
+          },
+        },
       },
     });
     const r = discover(dir);
@@ -37,11 +44,15 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'completed' },
+        discussion: { items: { auth: { status: 'completed' } } },
         specification: {
-          status: 'completed',
-          type: 'feature',
-          sources: { 'auth': { status: 'incorporated' } },
+          items: {
+            auth: {
+              status: 'completed',
+              type: 'feature',
+              sources: { 'auth': { status: 'incorporated' } },
+            },
+          },
         },
       },
     });
@@ -58,7 +69,7 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'old', {
       work_type: 'feature',
       phases: {
-        specification: { status: 'superseded', superseded_by: 'new-spec' },
+        specification: { items: { old: { status: 'superseded', superseded_by: 'new-spec' } } },
       },
     });
     createFile(dir, '.workflows/old/specification/old/specification.md', '# Old');
@@ -157,15 +168,15 @@ describe('workflow-specification-entry discovery', () => {
   it('computes discussion counts correctly', () => {
     createManifest(dir, 'a', {
       work_type: 'feature',
-      phases: { discussion: { status: 'completed' } },
+      phases: { discussion: { items: { a: { status: 'completed' } } } },
     });
     createManifest(dir, 'b', {
       work_type: 'feature',
-      phases: { discussion: { status: 'in-progress' } },
+      phases: { discussion: { items: { b: { status: 'in-progress' } } } },
     });
     createManifest(dir, 'c', {
       work_type: 'feature',
-      phases: { discussion: { status: 'completed' } },
+      phases: { discussion: { items: { c: { status: 'completed' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.current_state.discussion_count, 3);
@@ -180,8 +191,8 @@ describe('workflow-specification-entry discovery', () => {
       work_type: 'feature',
       phases: {
         discussion: {
-          status: 'completed',
           analysis_cache: { checksum: null, generated: '2026-01-01' },
+          items: { auth: { status: 'completed' } },
         },
       },
     });
@@ -194,8 +205,8 @@ describe('workflow-specification-entry discovery', () => {
       work_type: 'feature',
       phases: {
         discussion: {
-          status: 'completed',
           analysis_cache: { checksum, generated: '2026-01-01' },
+          items: { auth: { status: 'completed' } },
         },
       },
     });
@@ -219,7 +230,7 @@ describe('workflow-specification-entry discovery', () => {
   it('computes discussions checksum', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'completed' } },
+      phases: { discussion: { items: { auth: { status: 'completed' } } } },
     });
     createFile(dir, '.workflows/auth/discussion/auth.md', '# Auth discussion');
     const r = discover(dir);
@@ -229,7 +240,7 @@ describe('workflow-specification-entry discovery', () => {
   it('returns null checksum when no discussion files', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'completed' } },
+      phases: { discussion: { items: { auth: { status: 'completed' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.current_state.discussions_checksum, null);
@@ -239,7 +250,7 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'old', {
       work_type: 'feature',
       phases: {
-        specification: { status: 'superseded', superseded_by: 'new-spec' },
+        specification: { items: { old: { status: 'superseded', superseded_by: 'new-spec' } } },
       },
     });
     createFile(dir, '.workflows/old/specification/old/specification.md', '# Old');
@@ -251,7 +262,7 @@ describe('workflow-specification-entry discovery', () => {
   it('feature without spec shows has_individual_spec false', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { discussion: { status: 'completed' } },
+      phases: { discussion: { items: { auth: { status: 'completed' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.discussions[0].has_individual_spec, false);
@@ -261,8 +272,8 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
-        discussion: { status: 'completed' },
-        specification: { status: 'in-progress' },
+        discussion: { items: { auth: { status: 'completed' } } },
+        specification: { items: { auth: { status: 'in-progress' } } },
       },
     });
     createFile(dir, '.workflows/auth/specification/auth/specification.md', '# Spec');
@@ -276,8 +287,8 @@ describe('workflow-specification-entry discovery', () => {
       work_type: 'feature',
       phases: {
         discussion: {
-          status: 'completed',
           analysis_cache: { checksum: 'stale-hash', generated: '2026-01-01' },
+          items: { auth: { status: 'completed' } },
         },
       },
     });
@@ -290,8 +301,8 @@ describe('workflow-specification-entry discovery', () => {
     createManifest(dir, 'login-crash', {
       work_type: 'bugfix',
       phases: {
-        investigation: { status: 'completed' },
-        specification: { status: 'in-progress' },
+        investigation: { items: { 'login-crash': { status: 'completed' } } },
+        specification: { items: { 'login-crash': { status: 'in-progress' } } },
       },
     });
     createFile(dir, '.workflows/login-crash/specification/login-crash/specification.md', '# Spec');

--- a/tests/scripts/test-discovery-for-status.js
+++ b/tests/scripts/test-discovery-for-status.js
@@ -211,9 +211,9 @@ describe('status discovery', () => {
     });
     const r = discover(dir);
     // All items are superseded → activeItems is empty → specStatus is null
-    // superseded_by is only included when specStatus is truthy, so it's absent
+    // superseded_by is still included so consumers know where to look
     assert.strictEqual(r.work_units[0].specification.status, null);
-    assert.strictEqual(r.work_units[0].specification.superseded_by, undefined);
+    assert.strictEqual(r.work_units[0].specification.superseded_by, 'new-spec');
   });
 
   it('planning in-progress counted', () => {

--- a/tests/scripts/test-discovery-for-status.js
+++ b/tests/scripts/test-discovery-for-status.js
@@ -21,13 +21,15 @@ describe('status discovery', () => {
       work_type: 'feature',
       description: 'Auth flow',
       phases: {
-        discussion: { status: 'completed' },
-        specification: { status: 'completed', type: 'feature' },
-        planning: { status: 'completed', format: 'local-markdown' },
+        discussion: { items: { auth: { status: 'completed' } } },
+        specification: { items: { auth: { status: 'completed', type: 'feature' } } },
+        planning: { items: { auth: { status: 'completed', format: 'local-markdown' } } },
         implementation: {
-          status: 'in-progress',
-          current_phase: 1,
-          completed_tasks: ['auth-1-1'],
+          items: { auth: {
+            status: 'in-progress',
+            current_phase: 1,
+            completed_tasks: ['auth-1-1'],
+          } },
         },
       },
     });
@@ -75,11 +77,11 @@ describe('status discovery', () => {
   it('counts discussion statuses', () => {
     createManifest(dir, 'a', {
       work_type: 'feature',
-      phases: { discussion: { status: 'completed' } },
+      phases: { discussion: { items: { a: { status: 'completed' } } } },
     });
     createManifest(dir, 'b', {
       work_type: 'feature',
-      phases: { discussion: { status: 'in-progress' } },
+      phases: { discussion: { items: { b: { status: 'in-progress' } } } },
     });
 
     const r = discover(dir);
@@ -91,11 +93,11 @@ describe('status discovery', () => {
   it('separates feature and cross-cutting specs', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { specification: { status: 'completed', type: 'feature' } },
+      phases: { specification: { items: { auth: { status: 'completed', type: 'feature' } } } },
     });
     createManifest(dir, 'caching', {
       work_type: 'feature',
-      phases: { specification: { status: 'completed', type: 'cross-cutting' } },
+      phases: { specification: { items: { caching: { status: 'completed', type: 'cross-cutting' } } } },
     });
 
     const r = discover(dir);
@@ -107,7 +109,7 @@ describe('status discovery', () => {
   it('excludes superseded specs from counts', () => {
     createManifest(dir, 'old', {
       work_type: 'feature',
-      phases: { specification: { status: 'superseded', superseded_by: 'new' } },
+      phases: { specification: { items: { old: { status: 'superseded', superseded_by: 'new' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.counts.specification.active, 0);
@@ -118,11 +120,13 @@ describe('status discovery', () => {
       work_type: 'feature',
       phases: {
         planning: {
-          status: 'completed',
-          format: 'local-markdown',
-          external_dependencies: {
-            core: { state: 'unresolved', task_id: 'core-1' },
-          },
+          items: { auth: {
+            status: 'completed',
+            format: 'local-markdown',
+            external_dependencies: {
+              core: { state: 'unresolved', task_id: 'core-1' },
+            },
+          } },
         },
       },
     });
@@ -136,9 +140,11 @@ describe('status discovery', () => {
       work_type: 'feature',
       phases: {
         specification: {
-          status: 'completed',
-          type: 'feature',
-          sources: { 'auth-discussion': { status: 'incorporated' } },
+          items: { auth: {
+            status: 'completed',
+            type: 'feature',
+            sources: { 'auth-discussion': { status: 'incorporated' } },
+          } },
         },
       },
     });
@@ -163,7 +169,7 @@ describe('status discovery', () => {
   it('handles investigation status for bugfix', () => {
     createManifest(dir, 'crash', {
       work_type: 'bugfix',
-      phases: { investigation: { status: 'completed' } },
+      phases: { investigation: { items: { crash: { status: 'completed' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.work_units[0].investigation.status, 'completed');
@@ -172,7 +178,7 @@ describe('status discovery', () => {
   it('tracks review status', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { review: { status: 'completed' } },
+      phases: { review: { items: { auth: { status: 'completed' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.work_units[0].review.status, 'completed');
@@ -183,9 +189,11 @@ describe('status discovery', () => {
       work_type: 'feature',
       phases: {
         specification: {
-          status: 'completed',
-          type: 'feature',
-          sources: [{ name: 'auth-disc', status: 'incorporated' }],
+          items: { auth: {
+            status: 'completed',
+            type: 'feature',
+            sources: [{ name: 'auth-disc', status: 'incorporated' }],
+          } },
         },
       },
     });
@@ -198,17 +206,20 @@ describe('status discovery', () => {
     createManifest(dir, 'old', {
       work_type: 'feature',
       phases: {
-        specification: { status: 'superseded', superseded_by: 'new-spec' },
+        specification: { items: { old: { status: 'superseded', superseded_by: 'new-spec' } } },
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.work_units[0].specification.superseded_by, 'new-spec');
+    // All items are superseded → activeItems is empty → specStatus is null
+    // superseded_by is only included when specStatus is truthy, so it's absent
+    assert.strictEqual(r.work_units[0].specification.status, null);
+    assert.strictEqual(r.work_units[0].specification.superseded_by, undefined);
   });
 
   it('planning in-progress counted', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { planning: { status: 'in-progress', format: 'local-markdown' } },
+      phases: { planning: { items: { auth: { status: 'in-progress', format: 'local-markdown' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.counts.planning.in_progress, 1);
@@ -218,7 +229,7 @@ describe('status discovery', () => {
   it('implementation completed counted', () => {
     createManifest(dir, 'auth', {
       work_type: 'feature',
-      phases: { implementation: { status: 'completed' } },
+      phases: { implementation: { items: { auth: { status: 'completed' } } } },
     });
     const r = discover(dir);
     assert.strictEqual(r.counts.implementation.completed, 1);
@@ -245,12 +256,12 @@ describe('status discovery', () => {
     createFile(dir, '.workflows/v1/research/exploration.md', '# Exploration');
     const r = discover(dir);
     const wu = r.work_units[0];
-    // Research status comes from flat phase status, which is null here
-    assert.strictEqual(wu.research.status, null);
-    // No file_count because researchStatus is null
-    assert.strictEqual(wu.research.file_count, undefined);
-    // Research count only increments when flat status exists
-    assert.strictEqual(r.counts.research, 0);
+    // phaseStatus now reads items — status comes from the single item
+    assert.strictEqual(wu.research.status, 'completed');
+    // file_count is set because researchStatus is truthy
+    assert.strictEqual(wu.research.file_count, 1);
+    // Research count increments because status exists
+    assert.strictEqual(r.counts.research, 1);
   });
 
   it('epic research with both flat status and items', () => {
@@ -312,10 +323,10 @@ describe('status discovery', () => {
     // Specification: 2 items, 1 completed + 1 in-progress → aggregate 'in-progress'
     assert.strictEqual(wu.specification.status, 'in-progress');
     assert.strictEqual(wu.specification.item_count, 2);
-    // Planning: 1 item, completed
+    // Planning: 1 item, completed — no item_count (only set when > 1)
     assert.strictEqual(wu.planning.status, 'completed');
-    assert.strictEqual(wu.planning.item_count, 1);
-    // Implementation: 1 item, completed
+    assert.strictEqual(wu.planning.item_count, undefined);
+    // Implementation: 1 item, completed — no item_count (only set when > 1)
     assert.strictEqual(wu.implementation.status, 'completed');
     assert.strictEqual(wu.implementation.completed_tasks, 2);
     // Global counts

--- a/tests/scripts/test-discovery-utils.js
+++ b/tests/scripts/test-discovery-utils.js
@@ -152,7 +152,33 @@ describe('discovery-utils', () => {
   });
 
   describe('phaseStatus', () => {
-    it('extracts phase status', () => {
+    it('extracts status from single item', () => {
+      assert.strictEqual(phaseStatus({ phases: { discussion: { items: { test: { status: 'completed' } } } } }, 'discussion'), 'completed');
+    });
+
+    it('aggregates multiple items — all completed', () => {
+      assert.strictEqual(phaseStatus({
+        phases: { discussion: { items: { a: { status: 'completed' }, b: { status: 'completed' } } } },
+      }, 'discussion'), 'completed');
+    });
+
+    it('aggregates multiple items — some in-progress', () => {
+      assert.strictEqual(phaseStatus({
+        phases: { discussion: { items: { a: { status: 'completed' }, b: { status: 'in-progress' } } } },
+      }, 'discussion'), 'in-progress');
+    });
+
+    it('aggregates multiple items — no statuses returns null', () => {
+      assert.strictEqual(phaseStatus({
+        phases: { discussion: { items: { a: {}, b: {} } } },
+      }, 'discussion'), null);
+    });
+
+    it('returns null for empty items', () => {
+      assert.strictEqual(phaseStatus({ phases: { discussion: { items: {} } } }, 'discussion'), null);
+    });
+
+    it('falls back to flat status for uninitialised phases', () => {
       assert.strictEqual(phaseStatus({ phases: { discussion: { status: 'completed' } } }, 'discussion'), 'completed');
     });
 
@@ -208,27 +234,27 @@ describe('discovery-utils', () => {
 
   describe('computeNextPhase', () => {
     it('returns done when review completed', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { review: { status: 'completed' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { review: { items: { test: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'done');
     });
 
     it('returns review when implementation completed', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { implementation: { status: 'completed' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { implementation: { items: { test: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'review');
     });
 
     it('returns implementation when planning completed', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { planning: { status: 'completed' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { planning: { items: { test: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'implementation');
     });
 
     it('returns planning when spec completed', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { specification: { status: 'completed' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { specification: { items: { test: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'planning');
     });
 
     it('returns specification when discussion completed', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { discussion: { status: 'completed' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { discussion: { items: { test: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'specification');
     });
 
@@ -248,74 +274,75 @@ describe('discovery-utils', () => {
     });
 
     it('returns specification when investigation completed (bugfix)', () => {
-      const r = computeNextPhase({ work_type: 'bugfix', phases: { investigation: { status: 'completed' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'bugfix', phases: { investigation: { items: { test: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'specification');
     });
 
     it('returns discussion when research completed (epic)', () => {
-      const r = computeNextPhase({ work_type: 'epic', phases: { research: { status: 'completed' } } });
+      const r = computeNextPhase({ work_type: 'epic', phases: { research: { items: { explore: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'discussion');
     });
 
     it('returns in-progress planning', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { planning: { status: 'in-progress' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { planning: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'planning');
       assert.ok(r.phase_label.includes('in-progress'));
     });
 
     it('returns in-progress review', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { review: { status: 'in-progress' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { review: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'review');
       assert.strictEqual(r.phase_label, 'review (in-progress)');
     });
 
     it('returns in-progress implementation', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { implementation: { status: 'in-progress' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { implementation: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'implementation');
       assert.strictEqual(r.phase_label, 'implementation (in-progress)');
     });
 
     it('returns in-progress specification', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { specification: { status: 'in-progress' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { specification: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'specification');
       assert.strictEqual(r.phase_label, 'specification (in-progress)');
     });
 
     it('returns in-progress discussion', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { discussion: { status: 'in-progress' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { discussion: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'discussion');
       assert.strictEqual(r.phase_label, 'discussion (in-progress)');
     });
 
     it('returns in-progress investigation (bugfix)', () => {
-      const r = computeNextPhase({ work_type: 'bugfix', phases: { investigation: { status: 'in-progress' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'bugfix', phases: { investigation: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'investigation');
       assert.strictEqual(r.phase_label, 'investigation (in-progress)');
     });
 
     it('returns in-progress research (epic)', () => {
-      const r = computeNextPhase({ work_type: 'epic', phases: { research: { status: 'in-progress' } } });
+      const r = computeNextPhase({ work_type: 'epic', phases: { research: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'research');
       assert.strictEqual(r.phase_label, 'research (in-progress)');
     });
 
     it('returns in-progress research (feature)', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { research: { status: 'in-progress' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { research: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'research');
       assert.strictEqual(r.phase_label, 'research (in-progress)');
     });
 
     it('returns discussion when research completed (feature)', () => {
-      const r = computeNextPhase({ work_type: 'feature', phases: { research: { status: 'completed' } } });
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { research: { items: { test: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'discussion');
     });
 
     it('higher priority phase takes precedence', () => {
       const r = computeNextPhase({
+        name: 'test',
         work_type: 'feature',
         phases: {
-          implementation: { status: 'completed' },
-          review: { status: 'completed' },
+          implementation: { items: { test: { status: 'completed' } } },
+          review: { items: { test: { status: 'completed' } } },
         },
       });
       assert.strictEqual(r.next_phase, 'done');
@@ -377,7 +404,7 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.phase_label, 'specification (in-progress)');
     });
 
-    it('epic: falls back to flat status for research when no items', () => {
+    it('epic: falls back to flat status for uninitialised research', () => {
       const r = computeNextPhase({
         work_type: 'epic',
         phases: { research: { status: 'in-progress' } },

--- a/tests/scripts/test-migration-025.sh
+++ b/tests/scripts/test-migration-025.sh
@@ -1,0 +1,384 @@
+#!/bin/bash
+#
+# Tests migration 025-unify-manifest-items.sh
+# Validates wrapping flat feature/bugfix phase data into items[name].
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/migrate/scripts/migrations/025-unify-manifest-items.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Helper functions
+#
+
+setup_fixture() {
+    rm -rf "$TEST_DIR/.workflows"
+}
+
+create_manifest() {
+    local name="$1"
+    local content="$2"
+    mkdir -p "$TEST_DIR/.workflows/$name"
+    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+}
+
+# Stub report_update for migration script
+report_update() { echo "updated: $1 — $2"; }
+export -f report_update
+
+run_migration() {
+    cd "$TEST_DIR"
+    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+}
+
+get_field() {
+    local name="$1"
+    local field="$2"
+    node -e "
+      const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+      const parts = process.argv[2].split('.');
+      let v = m;
+      for (const p of parts) v = (v || {})[p];
+      console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
+    " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
+}
+
+assert_equals() {
+    local actual="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected: $expected"
+        echo -e "    Actual:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Should not find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    else
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+echo -e "${YELLOW}Test: feature flat discussion wrapped into items${NC}"
+setup_fixture
+
+create_manifest "my-feat" '{
+  "name": "my-feat",
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "discussion": { "status": "completed" }
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "my-feat" "phases.discussion.items.my-feat.status")" "completed" "Status moved into items"
+assert_contains "$output" "unified to items structure" "Reports update"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: feature planning with extra fields wrapped correctly${NC}"
+setup_fixture
+
+create_manifest "plan-feat" '{
+  "name": "plan-feat",
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "planning": { "status": "completed", "format": "local-markdown", "task_list_gate_mode": "gated" }
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "plan-feat" "phases.planning.items.plan-feat.status")" "completed" "Status in items"
+assert_equals "$(get_field "plan-feat" "phases.planning.items.plan-feat.format")" "local-markdown" "Format in items"
+assert_equals "$(get_field "plan-feat" "phases.planning.items.plan-feat.task_list_gate_mode")" "gated" "Gate mode in items"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: analysis_cache preserved at phase level${NC}"
+setup_fixture
+
+create_manifest "cached" '{
+  "name": "cached",
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "research": { "status": "completed", "analysis_cache": { "checksum": "abc123" } }
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "cached" "phases.research.analysis_cache.checksum")" "abc123" "analysis_cache stays at phase level"
+assert_equals "$(get_field "cached" "phases.research.items.cached.status")" "completed" "Status moved to items"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: bugfix investigation wrapped into items${NC}"
+setup_fixture
+
+create_manifest "my-bug" '{
+  "name": "my-bug",
+  "work_type": "bugfix",
+  "status": "in-progress",
+  "phases": {
+    "investigation": { "status": "in-progress" }
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "my-bug" "phases.investigation.items.my-bug.status")" "in-progress" "Bugfix investigation wrapped"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: epic manifests are skipped${NC}"
+setup_fixture
+
+create_manifest "my-epic" '{
+  "name": "my-epic",
+  "work_type": "epic",
+  "status": "in-progress",
+  "phases": {
+    "discussion": { "items": { "auth": { "status": "completed" } } }
+  }
+}'
+
+output=$(run_migration)
+
+assert_equals "$(get_field "my-epic" "phases.discussion.items.auth.status")" "completed" "Epic items unchanged"
+assert_not_contains "$output" "unified" "No update for epic"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: phases already with items are skipped${NC}"
+setup_fixture
+
+create_manifest "already-items" '{
+  "name": "already-items",
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "discussion": { "items": { "already-items": { "status": "completed" } } },
+    "specification": { "status": "in-progress" }
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "already-items" "phases.discussion.items.already-items.status")" "completed" "Existing items untouched"
+assert_equals "$(get_field "already-items" "phases.specification.items.already-items.status")" "in-progress" "Flat phase wrapped"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: multiple phases wrapped in one manifest${NC}"
+setup_fixture
+
+create_manifest "multi" '{
+  "name": "multi",
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "discussion": { "status": "completed" },
+    "specification": { "status": "completed" },
+    "planning": { "status": "in-progress", "format": "local-markdown" },
+    "implementation": { "status": "in-progress", "completed_tasks": ["multi-1-1"] }
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "multi" "phases.discussion.items.multi.status")" "completed" "Discussion wrapped"
+assert_equals "$(get_field "multi" "phases.specification.items.multi.status")" "completed" "Specification wrapped"
+assert_equals "$(get_field "multi" "phases.planning.items.multi.format")" "local-markdown" "Planning format in items"
+assert_equals "$(get_field "multi" "phases.implementation.items.multi.completed_tasks")" '["multi-1-1"]' "Implementation tasks in items"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
+setup_fixture
+
+create_manifest "idem" '{
+  "name": "idem",
+  "work_type": "feature",
+  "status": "in-progress",
+  "phases": {
+    "discussion": { "status": "completed" }
+  }
+}'
+
+run_migration > /dev/null
+output=$(run_migration)
+
+assert_equals "$(get_field "idem" "phases.discussion.items.idem.status")" "completed" "Items still correct"
+assert_not_contains "$output" "unified" "No update on second run"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state"
+echo '{"name":".state","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
+create_manifest "real" '{"name":"real","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "real" "phases.discussion.items.real.status")" "completed" "Real manifest migrated"
+# Dot-dir manifest should still have flat status
+dot_status=$(node -e "
+  const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+  console.log(m.phases.discussion.status || 'missing');
+" "$TEST_DIR/.workflows/.state/manifest.json")
+assert_equals "$dot_status" "completed" "Dot-dir manifest untouched"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: empty phases object unchanged${NC}"
+setup_fixture
+
+create_manifest "empty" '{"name":"empty","work_type":"feature","status":"in-progress","phases":{}}'
+
+output=$(run_migration)
+
+assert_not_contains "$output" "unified" "No update for empty phases"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
+setup_fixture
+
+output=$(run_migration)
+
+assert_not_contains "$output" "updated" "No updates without .workflows dir"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
+setup_fixture
+
+create_manifest "preserve" '{
+  "name": "preserve",
+  "work_type": "feature",
+  "status": "in-progress",
+  "created": "2026-03-01",
+  "description": "Test preservation",
+  "phases": {
+    "discussion": { "status": "completed" }
+  }
+}'
+
+run_migration > /dev/null
+
+assert_equals "$(get_field "preserve" "name")" "preserve" "Name preserved"
+assert_equals "$(get_field "preserve" "work_type")" "feature" "Work type preserved"
+assert_equals "$(get_field "preserve" "created")" "2026-03-01" "Created date preserved"
+assert_equals "$(get_field "preserve" "description")" "Test preservation" "Description preserved"
+
+echo ""
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "Tests run: $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "========================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -600,7 +600,7 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: init-phase for feature creates flat phase status${NC}"
+echo -e "${YELLOW}Test: init-phase for feature creates items structure${NC}"
 setup_fixture
 run_cli init my-feat --work-type feature --description "My Feature" >/dev/null 2>&1
 run_cli init-phase my-feat --phase discussion --topic my-feat >/dev/null 2>&1
@@ -608,15 +608,16 @@ output=$(run_cli_stdout get my-feat --phase discussion --topic my-feat status)
 
 assert_equals "$output" "in-progress" "Feature phase created with in-progress status"
 
-# Verify internal structure is flat (no items key)
+# Verify internal structure uses items (unified with epic)
 content=$(cat "$TEST_DIR/.workflows/my-feat/manifest.json")
-assert_not_contains "$content" '"items"' "Feature manifest has no items key"
+assert_contains "$content" '"items"' "Feature manifest has items key"
+assert_contains "$content" '"my-feat"' "Feature items key matches work unit name"
 
 echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: init-phase for bugfix creates flat phase status${NC}"
+echo -e "${YELLOW}Test: init-phase for bugfix creates items structure${NC}"
 setup_fixture
 run_cli init my-bug --work-type bugfix --description "My Bug" >/dev/null 2>&1
 run_cli init-phase my-bug --phase investigation --topic my-bug >/dev/null 2>&1
@@ -745,17 +746,18 @@ echo ""
 # DOMAIN ROUTING TESTS
 # ============================================================================
 
-echo -e "${YELLOW}Test: feature get/set routes to flat structure${NC}"
+echo -e "${YELLOW}Test: feature get/set routes through items (unified)${NC}"
 setup_fixture
 run_cli init routing-feat --work-type feature --description "Routing" >/dev/null 2>&1
 run_cli init-phase routing-feat --phase discussion --topic routing-feat >/dev/null 2>&1
 run_cli set routing-feat --phase discussion --topic routing-feat status completed >/dev/null 2>&1
 
-# Verify internal structure is flat
+# Verify internal structure uses items (same as epic)
 content=$(cat "$TEST_DIR/.workflows/routing-feat/manifest.json")
 assert_contains "$content" '"discussion"' "Discussion phase exists"
+assert_contains "$content" '"items"' "Feature manifest has items key"
+assert_contains "$content" '"routing-feat"' "Items key matches work unit name"
 assert_contains "$content" '"status": "completed"' "Status set to completed"
-assert_not_contains "$content" '"items"' "No items in feature manifest"
 
 echo ""
 


### PR DESCRIPTION
## Summary

- **Unified manifest items structure**: All work types (epic, feature, bugfix) now use the same `phases.<phase>.items.<topic>` structure in `manifest.json`. Previously feature/bugfix used flat `phases.<phase>.status` while epic used items — this divergence caused branching everywhere.
- **Migration 025**: Wraps existing flat feature/bugfix phase data into items, preserving phase-level keys like `analysis_cache`.
- **CLI simplification**: `resolvePhaseSegments`, `cmdInitPhase`, and `resolveWildcardTopic` no longer branch on work_type.
- **Discovery cleanup**: All discovery scripts use `phaseItems()`/`phaseStatus()` uniformly — removed ~110 lines of `wt === 'epic'` branching.
- **Feature-to-epic pivot**: New `p`/`pivot` option in the manage work unit menu converts a feature to an epic (just changes `work_type` — no restructuring needed since items are already in place).

## Test plan

- [x] All 125 manifest CLI tests pass
- [x] All 64 discovery-utils tests pass (5 new `phaseStatus` aggregation tests)
- [ ] Manual: create a feature, run migration 025, verify items structure
- [ ] Manual: pivot a feature to epic, verify `/continue-epic` picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)