### PR TITLE
rename review artifacts: qa-task → report, review.md → report.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ Work-unit-first directory structure with uniform `{topic}` in all paths. For fea
 - Specification: `.workflows/{work_unit}/specification/{topic}/specification.md`
 - Planning: `.workflows/{work_unit}/planning/{topic}/planning.md` + `tasks/`
 - Implementation: `.workflows/{work_unit}/implementation/{topic}/implementation.md`
-- Review: `.workflows/{work_unit}/review/{topic}/review.md`
+- Review: `.workflows/{work_unit}/review/{topic}/report.md`
 - State: `.workflows/{work_unit}/.state/` (per-work-unit analysis files)
 - Global state: `.workflows/.state/` (migrations, environment-setup.md)
 - Cache: `.workflows/.cache/` (planning scratch)

--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ Documents are stored in your project using a **work-unit-first** organisation. E
         implementation.md                #   Progress, gates, current task
     review/
       {topic}/
-        review.md                        #   Review summary and verdict
-        qa-task-{internal_id}.md             #   Per-task QA verification
+        report.md                        #   Review summary and verdict
+        report-{phase_id}-{task_id}.md   #   Per-task verification report
   .state/                                # Global state (migrations, env setup)
   .cache/                                # Ephemeral (planning scratch)
 ```

--- a/agents/planning-task-designer.md
+++ b/agents/planning-task-designer.md
@@ -59,6 +59,8 @@ Phase {N}: {Phase Name}
 
 Follow the **Task Table** template from plan-index-schema. Use placeholder IDs `{topic}-{phase_id}-{task_id}`. Set `Status` to `pending`. Leave `External ID` empty.
 
+**CRITICAL**: `{topic}` must be the **exact, full topic name** — never abbreviate or shorten it. The topic name is used for path construction and positional mapping across phases.
+
 The orchestrator will use the topic name from the Plan Index File.
 
 ## Rules

--- a/agents/review-findings-synthesizer.md
+++ b/agents/review-findings-synthesizer.md
@@ -21,8 +21,8 @@ You receive via the orchestrator's prompt:
 
 ## Your Process
 
-1. **Read review summary** — extract verdict, required changes, recommendations from `review.md`
-2. **Read all QA files** — read every `qa-task-*.md` in the review path. Extract BLOCKING ISSUES and significant NON-BLOCKING NOTES with their file:line references
+1. **Read review summary** — extract verdict, required changes, recommendations from `report.md`
+2. **Read all report files** — read every `report-*.md` in the review path. Extract BLOCKING ISSUES and significant NON-BLOCKING NOTES with their file:line references
 3. **Deduplicate** — same issue found across multiple QA files → one finding, note all sources
 4. **Group related findings** — multiple findings about the same concern become one task (e.g., 3 QA findings about missing error handling in the same module = 1 "add error handling" task)
 5. **Filter** — discard low-severity non-blocking findings unless they cluster into a pattern. Never discard high-severity or blocking findings.
@@ -69,7 +69,7 @@ gate_mode: gated
 ## Task 1: {title}
 status: pending
 severity: high
-sources: qa-task-3, qa-task-7
+sources: report-1-3, report-2-1
 
 **Problem**: {what the review found}
 **Solution**: {what to fix}

--- a/agents/review-task-verifier.md
+++ b/agents/review-task-verifier.md
@@ -19,7 +19,7 @@ You receive:
 5. **Review checklist path**: Path to the review checklist (`skills/technical-review/references/review-checklist.md`) — read this for detailed verification criteria
 6. **Work unit**: The work unit name (for path construction)
 7. **Topic**: The plan topic name (used for output directory)
-8. **Internal ID**: The internal ID (for output file naming, e.g., `{topic}-1-1`)
+8. **Task suffix**: The `{phase_id}-{task_id}` portion of the internal ID (for output file naming, e.g., `1-1`)
 
 ## Your Task
 
@@ -87,7 +87,7 @@ Review the implementation as a senior architect would:
 
 ## Output File Format
 
-Write to `.workflows/{work_unit}/review/{topic}/qa-task-{internal_id}.md`:
+Write to `.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md`:
 
 ```
 TASK: [Task name/description]

--- a/skills/migrate/scripts/migrations/026-rename-review-artifacts.sh
+++ b/skills/migrate/scripts/migrations/026-rename-review-artifacts.sh
@@ -6,8 +6,8 @@
 # - qa-task-{N}.md → report-{phase_id}-{task_id}.md (per-task, positional mapping from plan)
 #
 # Uses positional mapping: qa-task files are numbered sequentially (1, 2, 3...)
-# and map to plan tasks in table order. The internal ID ({topic}-{phase_id}-{task_id})
-# has its topic prefix stripped to produce the file suffix ({phase_id}-{task_id}).
+# and map to plan tasks in table order. The suffix ({phase_id}-{task_id}) is
+# extracted as the trailing two numeric segments of each internal ID.
 #
 # Idempotent. Direct file operations — never uses manifest CLI.
 #
@@ -54,14 +54,15 @@ for manifest in "$WORKFLOWS_DIR"/*/manifest.json; do
       continue
     fi
 
-    # Extract internal IDs from the plan task table
-    # Rows match: | {topic}-{N}-{N} | ... (internal ID in first column)
+    # Extract internal IDs from the plan task table.
+    # IDs may use an abbreviated prefix (e.g. acps-1-1 for topic auto-cascade-parent-status),
+    # so we match any row whose first column starts with a letter and ends with -{digit}-{digit}.
+    # The letter requirement excludes date rows (e.g. 2026-01-27) in changelog tables.
     internal_ids=()
     while IFS= read -r line; do
-      # Extract the internal ID from the first table column
       id=$(echo "$line" | sed -n 's/^| *\([^ |]*\) *|.*/\1/p')
       [ -n "$id" ] && internal_ids+=("$id")
-    done < <(grep "^| *${topic}-[0-9]" "$plan_file")
+    done < <(grep -E '^\| *[a-zA-Z][^ |]*-[0-9]+-[0-9]+ *\|' "$plan_file")
 
     if [ ${#internal_ids[@]} -eq 0 ]; then
       report_skip "$topic_dir" "no task IDs found in plan"
@@ -85,8 +86,9 @@ for manifest in "$WORKFLOWS_DIR"/*/manifest.json; do
       qa_file="${sorted_qa[$i]}"
       internal_id="${internal_ids[$i]}"
 
-      # Strip topic prefix to get phase_id-task_id suffix
-      suffix="${internal_id#"${topic}-"}"
+      # Extract trailing {phase_id}-{task_id} from internal ID
+      # Works regardless of prefix (full topic name or abbreviation)
+      suffix=$(echo "$internal_id" | grep -oE '[0-9]+-[0-9]+$')
       new_file="$topic_dir/report-${suffix}.md"
 
       if [ ! -f "$new_file" ]; then

--- a/skills/migrate/scripts/migrations/026-rename-review-artifacts.sh
+++ b/skills/migrate/scripts/migrations/026-rename-review-artifacts.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Migration 026: Rename review artifacts
+#
+# - review.md → report.md (final synthesis)
+# - qa-task-{N}.md → report-{phase_id}-{task_id}.md (per-task, positional mapping from plan)
+#
+# Uses positional mapping: qa-task files are numbered sequentially (1, 2, 3...)
+# and map to plan tasks in table order. The internal ID ({topic}-{phase_id}-{task_id})
+# has its topic prefix stripped to produce the file suffix ({phase_id}-{task_id}).
+#
+# Idempotent. Direct file operations — never uses manifest CLI.
+#
+
+WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+
+[ -d "$WORKFLOWS_DIR" ] || return 0
+
+for manifest in "$WORKFLOWS_DIR"/*/manifest.json; do
+  [ -f "$manifest" ] || continue
+
+  dir=$(dirname "$manifest")
+  wu_name=$(basename "$dir")
+
+  # Skip dot-prefixed directories
+  case "$wu_name" in .*) continue ;; esac
+
+  review_dir="$dir/review"
+  [ -d "$review_dir" ] || continue
+
+  # Process each topic directory under review/
+  for topic_dir in "$review_dir"/*/; do
+    [ -d "$topic_dir" ] || continue
+    topic=$(basename "$topic_dir")
+
+    # Step 1: Rename review.md → report.md
+    if [ -f "$topic_dir/review.md" ] && [ ! -f "$topic_dir/report.md" ]; then
+      mv "$topic_dir/review.md" "$topic_dir/report.md"
+      report_update "$topic_dir/report.md" "renamed review.md → report.md"
+    fi
+
+    # Step 2: Rename qa-task-{N}.md → report-{phase_id}-{task_id}.md
+    # Check if any qa-task files exist
+    qa_files=()
+    for f in "$topic_dir"/qa-task-*.md; do
+      [ -f "$f" ] && qa_files+=("$f")
+    done
+    [ ${#qa_files[@]} -eq 0 ] && continue
+
+    # Find the plan to build positional mapping
+    plan_file="$dir/planning/$topic/planning.md"
+    if [ ! -f "$plan_file" ]; then
+      report_skip "$topic_dir" "no plan found for positional mapping"
+      continue
+    fi
+
+    # Extract internal IDs from the plan task table
+    # Rows match: | {topic}-{N}-{N} | ... (internal ID in first column)
+    internal_ids=()
+    while IFS= read -r line; do
+      # Extract the internal ID from the first table column
+      id=$(echo "$line" | sed -n 's/^| *\([^ |]*\) *|.*/\1/p')
+      [ -n "$id" ] && internal_ids+=("$id")
+    done < <(grep "^| *${topic}-[0-9]" "$plan_file")
+
+    if [ ${#internal_ids[@]} -eq 0 ]; then
+      report_skip "$topic_dir" "no task IDs found in plan"
+      continue
+    fi
+
+    # Sort qa-task files numerically
+    sorted_qa=()
+    while IFS= read -r f; do
+      sorted_qa+=("$f")
+    done < <(printf '%s\n' "${qa_files[@]}" | sort -t- -k3 -n)
+
+    # Validate counts match
+    if [ ${#sorted_qa[@]} -ne ${#internal_ids[@]} ]; then
+      report_skip "$topic_dir" "qa-task count (${#sorted_qa[@]}) != plan task count (${#internal_ids[@]})"
+      continue
+    fi
+
+    # Rename each qa-task file using positional mapping
+    for i in "${!sorted_qa[@]}"; do
+      qa_file="${sorted_qa[$i]}"
+      internal_id="${internal_ids[$i]}"
+
+      # Strip topic prefix to get phase_id-task_id suffix
+      suffix="${internal_id#"${topic}-"}"
+      new_file="$topic_dir/report-${suffix}.md"
+
+      if [ ! -f "$new_file" ]; then
+        mv "$qa_file" "$new_file"
+        report_update "$new_file" "renamed $(basename "$qa_file") → report-${suffix}.md"
+      fi
+    done
+  done
+done

--- a/skills/technical-planning/references/plan-index-schema.md
+++ b/skills/technical-planning/references/plan-index-schema.md
@@ -54,7 +54,7 @@ approved_at: {YYYY-MM-DD}
 
 | Field | Set when |
 |-------|----------|
-| `Internal ID` | Task design -- format: `{topic}-{phase_id}-{task_id}` |
+| `Internal ID` | Task design -- format: `{topic}-{phase_id}-{task_id}` (full topic name, never abbreviated) |
 | `Name` | Task design -- descriptive task name |
 | `Edge Cases` | Task design -- curated list scoping which edge cases this task handles |
 | `Status` | Task design -> `pending`; authoring -> `authored` |

--- a/skills/technical-review/SKILL.md
+++ b/skills/technical-review/SKILL.md
@@ -25,7 +25,7 @@ Follows implementation. Verify plan tasks were implemented, tested adequately, a
 Context refresh (compaction) summarizes the conversation, losing procedural detail. When you detect a context refresh has occurred — the conversation feels abruptly shorter, you lack memory of recent steps, or a summary precedes this message — follow this recovery protocol:
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
-2. **Read review and synthesis files** for the current topic. Review documents are at `.workflows/{work_unit}/review/{topic}/review.md` with per-task QA files alongside (`qa-task-{internal_id}.md`). Synthesis staging files are at `.workflows/{work_unit}/implementation/{topic}/review-tasks-c{N}.md`. These are your source of truth for progress.
+2. **Read review and synthesis files** for the current topic. Review documents are at `.workflows/{work_unit}/review/{topic}/report.md` with per-task report files alongside (`report-{phase_id}-{task_id}.md`). Synthesis staging files are at `.workflows/{work_unit}/implementation/{topic}/review-tasks-c{N}.md`. These are your source of truth for progress.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 
@@ -51,7 +51,7 @@ When announcing a new step, output `── ── ── ── ──` on its o
 
 ## Step 0: Resume Detection
 
-Check if a review file exists at `.workflows/{work_unit}/review/{topic}/review.md`.
+Check if a review file exists at `.workflows/{work_unit}/review/{topic}/report.md`.
 
 #### If no review file exists
 
@@ -72,7 +72,7 @@ Found existing review for "{topic:(titlecase)}".
 Continue or restart?
 
 - **`c`/`continue`** — Continue the review from its current state
-- **`r`/`restart`** — Delete the review and all QA files. Start fresh.
+- **`r`/`restart`** — Delete the review and all report files. Start fresh.
 · · · · · · · · · · · ·
 ```
 
@@ -84,7 +84,7 @@ Continue or restart?
 
 #### If `restart`
 
-1. Delete the review file and all QA files (`qa-task-*.md`) in the review directory (`.workflows/{work_unit}/review/{topic}/`)
+1. Delete the review file and all report files (`report-*.md`) in the review directory (`.workflows/{work_unit}/review/{topic}/`)
 2. Commit: `review({work_unit}): restart review`
 
 → Proceed to **Step 1**.
@@ -109,7 +109,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}
 
 Phase already registered (e.g. reopened review). Skip init-phase.
 
-Now determine review mode. Check if the review file exists at `.workflows/{work_unit}/review/{topic}/review.md`.
+Now determine review mode. Check if the review file exists at `.workflows/{work_unit}/review/{topic}/report.md`.
 
 #### If no review file exists
 
@@ -160,7 +160,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --p
 ```
 
 ```bash
-rm .workflows/{work_unit}/review/{topic}/qa-task-*.md
+rm .workflows/{work_unit}/review/{topic}/report-*.md
 ```
 
 Commit: `review({work_unit}): clear review data for full re-review`
@@ -213,7 +213,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --p
 ```
 
 ```bash
-rm .workflows/{work_unit}/review/{topic}/qa-task-*.md
+rm .workflows/{work_unit}/review/{topic}/report-*.md
 ```
 
 Commit: `review({work_unit}): clear review data for full re-review`

--- a/skills/technical-review/references/invoke-task-verifiers.md
+++ b/skills/technical-review/references/invoke-task-verifiers.md
@@ -26,7 +26,7 @@ Using the format reading adapter loaded in Step 2, extract every task across all
 - Note each task's description
 - Note each task's acceptance criteria
 - Note expected micro acceptance (test name)
-- Note each task's **internal ID** (format: `{topic}-{phase_id}-{task_id}`) for file naming
+- Note each task's **internal ID** (format: `{topic}-{phase_id}-{task_id}`) — derive the **task suffix** by stripping the topic prefix (e.g., `auth-flow-1-1` → `1-1`)
 
 ---
 
@@ -74,7 +74,7 @@ Each verifier receives:
 5. **Review checklist path** — `skills/technical-review/references/review-checklist.md`
 6. **Work unit** — the work unit name (for path construction)
 7. **Topic** — the plan topic name (used for output directory)
-8. **Internal ID** — the internal ID (for output file naming, e.g., `{topic}-1-1`)
+8. **Task suffix** — the `{phase_id}-{task_id}` portion of the internal ID (for output file naming, e.g., `1-1`)
 
 If any verifier fails (error, timeout), record the failure and continue — aggregate what's available.
 
@@ -90,7 +90,7 @@ FINDINGS_COUNT: {N blocking issues}
 SUMMARY: {1 sentence}
 ```
 
-Full findings are written to `.workflows/{work_unit}/review/{topic}/qa-task-{internal_id}.md`.
+Full findings are written to `.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md`.
 
 ---
 
@@ -110,7 +110,7 @@ This enables incremental review detection on subsequent review sessions.
 
 Once all batches have completed:
 
-1. Read all `.workflows/{work_unit}/review/{topic}/qa-task-*.md` files
+1. Read all `.workflows/{work_unit}/review/{topic}/report-*.md` files
 2. Synthesize findings from file contents:
    - Collect all tasks with `STATUS: Incomplete` or `STATUS: Issues Found` as blocking issues
    - Collect all test issues (under/over-tested)

--- a/skills/technical-review/references/present-review.md
+++ b/skills/technical-review/references/present-review.md
@@ -4,7 +4,7 @@
 
 ---
 
-Read the review file at `.workflows/{work_unit}/review/{topic}/review.md`.
+Read the review file at `.workflows/{work_unit}/review/{topic}/report.md`.
 
 Present a structured summary to the user:
 

--- a/skills/technical-review/references/produce-review.md
+++ b/skills/technical-review/references/produce-review.md
@@ -6,7 +6,7 @@
 
 Aggregate QA findings into a review document using the **[template.md](template.md)**.
 
-Write the review to `.workflows/{work_unit}/review/{topic}/review.md`. The review is always per-plan.
+Write the review to `.workflows/{work_unit}/review/{topic}/report.md`. The review is always per-plan.
 
 **QA Verdict** (from Step 4):
 - **Approve** — All acceptance criteria met, no blocking issues

--- a/tests/scripts/test-migration-026.sh
+++ b/tests/scripts/test-migration-026.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+#
+# Tests migration 026-rename-review-artifacts.sh
+# Validates renaming review.md → report.md and qa-task-{N}.md → report-{phase_id}-{task_id}.md
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/migrate/scripts/migrations/026-rename-review-artifacts.sh"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Create a temporary directory for test fixtures
+TEST_DIR=$(mktemp -d)
+trap "rm -rf $TEST_DIR" EXIT
+
+echo "Test directory: $TEST_DIR"
+echo ""
+
+#
+# Helper functions
+#
+
+setup_fixture() {
+    rm -rf "$TEST_DIR/.workflows"
+}
+
+create_manifest() {
+    local name="$1"
+    local content="$2"
+    mkdir -p "$TEST_DIR/.workflows/$name"
+    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+}
+
+create_plan_with_tasks() {
+    local wu="$1"
+    local topic="$2"
+    shift 2
+    local ids=("$@")
+
+    mkdir -p "$TEST_DIR/.workflows/$wu/planning/$topic"
+    local plan="$TEST_DIR/.workflows/$wu/planning/$topic/planning.md"
+
+    echo "# Plan" > "$plan"
+    echo "" >> "$plan"
+    echo "| Internal ID | Task | Phase |" >> "$plan"
+    echo "|-------------|------|-------|" >> "$plan"
+    for id in "${ids[@]}"; do
+        echo "| $id | Task description | Phase 1 |" >> "$plan"
+    done
+}
+
+create_review_files() {
+    local wu="$1"
+    local topic="$2"
+    shift 2
+
+    mkdir -p "$TEST_DIR/.workflows/$wu/review/$topic"
+
+    # Create review.md
+    echo "# Review" > "$TEST_DIR/.workflows/$wu/review/$topic/review.md"
+
+    # Create qa-task files
+    local n=1
+    for _ in "$@"; do
+        echo "QA findings for task $n" > "$TEST_DIR/.workflows/$wu/review/$topic/qa-task-${n}.md"
+        n=$((n + 1))
+    done
+}
+
+# Stub report functions for migration script
+report_update() { echo "updated: $1 — $2"; }
+report_skip() { echo "skipped: $1 — $2"; }
+export -f report_update
+export -f report_skip
+
+run_migration() {
+    cd "$TEST_DIR"
+    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+}
+
+assert_file_exists() {
+    local path="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ -f "$path" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File not found: $path"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_file_not_exists() {
+    local path="$1"
+    local description="$2"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if [ ! -f "$path" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    File should not exist: $path"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected to find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
+assert_not_contains() {
+    local content="$1"
+    local expected="$2"
+    local description="$3"
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    if echo "$content" | grep -qF -- "$expected"; then
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Should not find: $expected"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    else
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    fi
+}
+
+# ============================================================================
+# TEST CASES
+# ============================================================================
+
+echo -e "${YELLOW}Test: feature — review.md renamed to report.md, qa-task files renamed${NC}"
+setup_fixture
+
+create_manifest "my-feat" '{"name":"my-feat","work_type":"feature","status":"in-progress","phases":{}}'
+create_plan_with_tasks "my-feat" "my-feat" "my-feat-1-1" "my-feat-1-2" "my-feat-2-1"
+create_review_files "my-feat" "my-feat" t1 t2 t3
+
+output=$(run_migration)
+
+assert_file_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/report.md" "review.md renamed to report.md"
+assert_file_not_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/review.md" "old review.md removed"
+assert_file_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/report-1-1.md" "qa-task-1.md → report-1-1.md"
+assert_file_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/report-1-2.md" "qa-task-2.md → report-1-2.md"
+assert_file_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/report-2-1.md" "qa-task-3.md → report-2-1.md"
+assert_file_not_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-1.md" "old qa-task-1.md removed"
+assert_file_not_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-2.md" "old qa-task-2.md removed"
+assert_file_not_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-3.md" "old qa-task-3.md removed"
+assert_contains "$output" "renamed review.md" "Reports review.md rename"
+assert_contains "$output" "report-1-1.md" "Reports qa-task rename"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: epic with multiple topics${NC}"
+setup_fixture
+
+create_manifest "my-epic" '{"name":"my-epic","work_type":"epic","status":"in-progress","phases":{}}'
+create_plan_with_tasks "my-epic" "auth" "auth-1-1" "auth-1-2"
+create_plan_with_tasks "my-epic" "billing" "billing-1-1"
+create_review_files "my-epic" "auth" t1 t2
+create_review_files "my-epic" "billing" t1
+
+run_migration > /dev/null
+
+assert_file_exists "$TEST_DIR/.workflows/my-epic/review/auth/report.md" "auth: review.md → report.md"
+assert_file_exists "$TEST_DIR/.workflows/my-epic/review/auth/report-1-1.md" "auth: qa-task-1 → report-1-1"
+assert_file_exists "$TEST_DIR/.workflows/my-epic/review/auth/report-1-2.md" "auth: qa-task-2 → report-1-2"
+assert_file_exists "$TEST_DIR/.workflows/my-epic/review/billing/report.md" "billing: review.md → report.md"
+assert_file_exists "$TEST_DIR/.workflows/my-epic/review/billing/report-1-1.md" "billing: qa-task-1 → report-1-1"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: already migrated — skip gracefully${NC}"
+setup_fixture
+
+create_manifest "done" '{"name":"done","work_type":"feature","status":"completed","phases":{}}'
+mkdir -p "$TEST_DIR/.workflows/done/review/done"
+echo "# Report" > "$TEST_DIR/.workflows/done/review/done/report.md"
+echo "findings" > "$TEST_DIR/.workflows/done/review/done/report-1-1.md"
+
+output=$(run_migration)
+
+assert_file_exists "$TEST_DIR/.workflows/done/review/done/report.md" "report.md still exists"
+assert_file_exists "$TEST_DIR/.workflows/done/review/done/report-1-1.md" "report-1-1.md still exists"
+assert_not_contains "$output" "renamed" "No renames reported"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: no plan exists — review.md renamed, qa-task files skipped${NC}"
+setup_fixture
+
+create_manifest "no-plan" '{"name":"no-plan","work_type":"feature","status":"in-progress","phases":{}}'
+mkdir -p "$TEST_DIR/.workflows/no-plan/review/no-plan"
+echo "# Review" > "$TEST_DIR/.workflows/no-plan/review/no-plan/review.md"
+echo "findings" > "$TEST_DIR/.workflows/no-plan/review/no-plan/qa-task-1.md"
+
+output=$(run_migration)
+
+assert_file_exists "$TEST_DIR/.workflows/no-plan/review/no-plan/report.md" "review.md still renamed"
+assert_file_exists "$TEST_DIR/.workflows/no-plan/review/no-plan/qa-task-1.md" "qa-task-1 preserved (no plan)"
+assert_contains "$output" "no plan found" "Reports skip reason"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: count mismatch — qa-task files skipped${NC}"
+setup_fixture
+
+create_manifest "mismatch" '{"name":"mismatch","work_type":"feature","status":"in-progress","phases":{}}'
+create_plan_with_tasks "mismatch" "mismatch" "mismatch-1-1" "mismatch-1-2"
+mkdir -p "$TEST_DIR/.workflows/mismatch/review/mismatch"
+echo "# Review" > "$TEST_DIR/.workflows/mismatch/review/mismatch/review.md"
+echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-1.md"
+echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-2.md"
+echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-3.md"
+
+output=$(run_migration)
+
+assert_file_exists "$TEST_DIR/.workflows/mismatch/review/mismatch/report.md" "review.md still renamed"
+assert_file_exists "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-1.md" "qa-task-1 preserved (mismatch)"
+assert_file_exists "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-2.md" "qa-task-2 preserved (mismatch)"
+assert_file_exists "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-3.md" "qa-task-3 preserved (mismatch)"
+assert_contains "$output" "qa-task count (3) != plan task count (2)" "Reports mismatch"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: topic with hyphens — suffix derived correctly${NC}"
+setup_fixture
+
+create_manifest "auto-cascade-parent-status" '{"name":"auto-cascade-parent-status","work_type":"feature","status":"in-progress","phases":{}}'
+create_plan_with_tasks "auto-cascade-parent-status" "auto-cascade-parent-status" \
+    "auto-cascade-parent-status-1-1" "auto-cascade-parent-status-1-2"
+create_review_files "auto-cascade-parent-status" "auto-cascade-parent-status" t1 t2
+
+run_migration > /dev/null
+
+assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-1.md" "Hyphenated topic: correct suffix 1-1"
+assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-2.md" "Hyphenated topic: correct suffix 1-2"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
+setup_fixture
+
+create_manifest "idem" '{"name":"idem","work_type":"feature","status":"in-progress","phases":{}}'
+create_plan_with_tasks "idem" "idem" "idem-1-1"
+create_review_files "idem" "idem" t1
+
+run_migration > /dev/null
+output=$(run_migration)
+
+assert_file_exists "$TEST_DIR/.workflows/idem/review/idem/report.md" "report.md still correct"
+assert_file_exists "$TEST_DIR/.workflows/idem/review/idem/report-1-1.md" "report-1-1.md still correct"
+assert_not_contains "$output" "renamed" "No renames on second run"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
+setup_fixture
+
+output=$(run_migration)
+
+assert_not_contains "$output" "updated" "No updates without .workflows dir"
+assert_not_contains "$output" "renamed" "No renames without .workflows dir"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: no review directory — skips work unit${NC}"
+setup_fixture
+
+create_manifest "no-review" '{"name":"no-review","work_type":"feature","status":"in-progress","phases":{}}'
+
+output=$(run_migration)
+
+assert_not_contains "$output" "renamed" "No renames without review dir"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: review.md only, no qa-task files — just renames review.md${NC}"
+setup_fixture
+
+create_manifest "review-only" '{"name":"review-only","work_type":"feature","status":"in-progress","phases":{}}'
+mkdir -p "$TEST_DIR/.workflows/review-only/review/review-only"
+echo "# Review" > "$TEST_DIR/.workflows/review-only/review/review-only/review.md"
+
+output=$(run_migration)
+
+assert_file_exists "$TEST_DIR/.workflows/review-only/review/review-only/report.md" "review.md renamed"
+assert_file_not_exists "$TEST_DIR/.workflows/review-only/review/review-only/review.md" "old review.md gone"
+assert_contains "$output" "renamed review.md" "Reports rename"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
+setup_fixture
+
+mkdir -p "$TEST_DIR/.workflows/.state/review/topic"
+echo '{"name":".state"}' > "$TEST_DIR/.workflows/.state/manifest.json"
+echo "# Review" > "$TEST_DIR/.workflows/.state/review/topic/review.md"
+
+output=$(run_migration)
+
+assert_file_exists "$TEST_DIR/.workflows/.state/review/topic/review.md" "Dot-dir review.md untouched"
+assert_not_contains "$output" "renamed" "No renames for dot dirs"
+
+echo ""
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+
+echo ""
+echo "========================================"
+echo -e "Tests run: $TESTS_RUN"
+echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
+echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
+echo "========================================"
+
+if [ $TESTS_FAILED -gt 0 ]; then
+    exit 1
+fi

--- a/tests/scripts/test-migration-026.sh
+++ b/tests/scripts/test-migration-026.sh
@@ -288,6 +288,60 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
+echo -e "${YELLOW}Test: abbreviated ID prefix — suffix still derived correctly${NC}"
+setup_fixture
+
+create_manifest "auto-cascade-parent-status" '{"name":"auto-cascade-parent-status","work_type":"feature","status":"in-progress","phases":{}}'
+# Plan uses abbreviated prefix "acps-" instead of full topic name
+create_plan_with_tasks "auto-cascade-parent-status" "auto-cascade-parent-status" \
+    "acps-1-1" "acps-1-2" "acps-2-1"
+create_review_files "auto-cascade-parent-status" "auto-cascade-parent-status" t1 t2 t3
+
+run_migration > /dev/null
+
+assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-1.md" "Abbreviated prefix: correct suffix 1-1"
+assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-2.md" "Abbreviated prefix: correct suffix 1-2"
+assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-2-1.md" "Abbreviated prefix: correct suffix 2-1"
+assert_file_not_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/qa-task-1.md" "Old qa-task-1 removed"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: plan with changelog dates — dates not mistaken for task IDs${NC}"
+setup_fixture
+
+create_manifest "with-log" '{"name":"with-log","work_type":"feature","status":"in-progress","phases":{}}'
+mkdir -p "$TEST_DIR/.workflows/with-log/planning/with-log"
+cat > "$TEST_DIR/.workflows/with-log/planning/with-log/planning.md" <<'PLAN'
+# Plan
+
+| Internal ID | Task | Phase |
+|-------------|------|-------|
+| with-log-1-1 | First task | Phase 1 |
+| with-log-1-2 | Second task | Phase 1 |
+
+## Changelog
+
+| Date | Note |
+|------|------|
+| 2026-01-27 | Created from specification |
+| 2026-01-30 | Migrated to updated plan format |
+| 2026-02-10 | Phase 2 added |
+PLAN
+
+create_review_files "with-log" "with-log" t1 t2
+
+run_migration > /dev/null
+
+assert_file_exists "$TEST_DIR/.workflows/with-log/review/with-log/report-1-1.md" "Task 1 renamed correctly"
+assert_file_exists "$TEST_DIR/.workflows/with-log/review/with-log/report-1-2.md" "Task 2 renamed correctly"
+assert_file_not_exists "$TEST_DIR/.workflows/with-log/review/with-log/qa-task-1.md" "Old file removed"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
 echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
 setup_fixture
 

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -2580,7 +2580,7 @@ const FLOWCHARTS = {
       { id: 'v1', label: 'Verify task 1', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'Check: implementation, acceptance criteria, tests, code quality.' },
       { id: 'v2', label: 'Verify task 2', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'Same checks, different task. Batches of 5 run in parallel.' },
       { id: 'vn', label: 'Verify task N', w: 140, h: 44, color: 'var(--action)', bg: 'rgba(56,189,248,0.08)', desc: 'One per task. All within a batch run simultaneously.' },
-      { id: 'aggregate', label: 'Aggregate QA findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 3: Read all qa-task-*.md files. Collect blocking issues, test issues, and code quality concerns.' },
+      { id: 'aggregate', label: 'Aggregate QA findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 3: Read all report-*.md files. Collect blocking issues, test issues, and code quality concerns.' },
       { id: 'produce', label: 'Produce review', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Aggregate QA findings into structured review document. Determine verdict (approve/changes/comments). Write to .workflows/{work_unit}/review/{topic}/.' },
       // Review Actions Loop (Step 5)
       { id: 'verdict', label: 'Verdict?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 5A: Route on QA verdict — approve (terminal), request-changes (synthesize recommended), comments-only (synthesize optional).' },
@@ -3017,8 +3017,8 @@ const FLOWCHARTS = {
   'review-findings-synthesizer': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-review skill during review actions loop.' },
-      { id: 'read-review', label: 'Read review summary', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read review.md — extract verdict, required changes, and recommendations.' },
-      { id: 'read-qa', label: 'Read all QA files', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read every qa-task-*.md in the review path. Extract BLOCKING ISSUES and significant NON-BLOCKING NOTES with file:line refs.' },
+      { id: 'read-review', label: 'Read review summary', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read report.md — extract verdict, required changes, and recommendations.' },
+      { id: 'read-qa', label: 'Read all QA files', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read every report-*.md in the review path. Extract BLOCKING ISSUES and significant NON-BLOCKING NOTES with file:line refs.' },
       { id: 'dedup', label: 'Deduplicate findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Same issue from multiple QA files → one finding, noting all sources.' },
       { id: 'group', label: 'Group related findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Multiple findings about the same concern become one task (e.g., 3 findings about missing error handling = 1 task).' },
       { id: 'filter', label: 'Filter by severity', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Discard low-severity non-blocking unless they cluster. Never discard high-severity or blocking.' },
@@ -3618,7 +3618,7 @@ const FLOWCHART_DESCS = {
   },
   'review-task-verifier': {
     summary: 'Verify a single task\'s implementation, tests, and code quality against the plan and spec.',
-    body: `<p>Dispatched <strong>in batches of 5</strong> by the technical-review skill during QA verification. Each verifier writes findings to <code>.workflows/{work_unit}/review/{topic}/qa-task-{index}.md</code>.</p>
+    body: `<p>Dispatched <strong>in batches of 5</strong> by the technical-review skill during QA verification. Each verifier writes findings to <code>.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md</code>.</p>
 <p>Three verification stages: <strong>implementation</strong> (exists, matches criteria, aligns with spec), <strong>tests</strong> (adequate coverage, edge cases, not over/under-tested), and <strong>code quality</strong> (conventions, SOLID, DRY, complexity, security, performance). Receives review checklist, topic name, and task index. Compiles a structured finding with blocking issues and non-blocking notes.</p>`,
     meta: { model: 'Opus', invokedBy: 'technical-review', complexity: 'Subagent' }
   },


### PR DESCRIPTION
## Summary

- Rename per-task QA files from `qa-task-{internal_id}.md` to `report-{phase_id}-{task_id}.md` — topic prefix dropped since the directory provides context
- Rename final synthesis file from `review.md` to `report.md` — everything in the review directory is now a "report"
- Add migration 026 with positional mapping from plan task tables to convert legacy incremental `qa-task-{N}.md` files, with safe fallbacks (skip when no plan or count mismatch)
- Enforce full topic name in internal IDs — add CRITICAL instruction to task designer agent and plan index schema to prevent abbreviations (e.g. `acps-` instead of `auto-cascade-parent-status-`)

## Test plan

- [x] Migration unit tests (`tests/scripts/test-migration-026.sh`) — 46 cases covering feature, epic, already-migrated, no plan, count mismatch, hyphenated topics, abbreviated prefixes, changelog date rows, idempotency, dot-dir exclusion
- [x] All 22 test suites pass on `/bin/bash` 3.2 (macOS default)
- [x] Real-world validation against Tick project: 169 files, zero data loss (MD5 checksum verified), idempotent on re-run
- [x] Grep for remaining `qa-task` references — only in old migrations/tests (008, 009, 024)

🤖 Generated with [Claude Code](https://claude.com/claude-code)