### PR TITLE
feat(migrate): stop gate signal + natural language summaries

### DIFF
--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -20,7 +20,7 @@ Run the migration script with sandbox disabled (migrations may need to modify `.
 
 #### If the output contains `---STOP_GATE: FILES_UPDATED---`
 
-**You MUST stop here.** Do not proceed to the next step. Do not return to the calling skill. Your response ends after displaying the prompt below.
+Files were updated. You MUST complete the steps below before returning to the calling skill.
 
 1. Run `git diff` to see what changed.
 2. Write a brief natural language summary of what the migrations did (e.g., "Restructured workflow directories, created manifest files, renamed tracking artifacts"). Focus on the nature of the changes, not individual file paths — these are internal workflow state files.

--- a/skills/migrate/SKILL.md
+++ b/skills/migrate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: migrate
 user-invocable: false
-allowed-tools: Bash(.claude/skills/migrate/scripts/migrate.sh)
+allowed-tools: Bash(.claude/skills/migrate/scripts/migrate.sh), Bash(git diff), Bash(git status), Bash(git add), Bash(git commit)
 ---
 
 # Migrate
@@ -18,21 +18,29 @@ Run the migration script with sandbox disabled (migrations may need to modify `.
 
 **CRITICAL**: Use `dangerouslyDisableSandbox: true` when calling the Bash tool for this command.
 
-#### If files were updated
+#### If the output contains `---STOP_GATE: FILES_UPDATED---`
 
-The script will list which files were updated. Present the list and a prompt:
+**You MUST stop here.** Do not proceed to the next step. Do not return to the calling skill. Your response ends after displaying the prompt below.
+
+1. Run `git diff` to see what changed.
+2. Write a brief natural language summary of what the migrations did (e.g., "Restructured workflow directories, created manifest files, renamed tracking artifacts"). Focus on the nature of the changes, not individual file paths — these are internal workflow state files.
+3. Display the summary and prompt:
 
 > *Output the next fenced block as a code block:*
 
 ```
-{list from script output}
+Migrations Applied
+
+{your natural language summary}
+
+{N} migration(s), {M} file(s) updated.
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Migrations applied. Review with `git diff` if needed.
+Ready to continue?
 
 - **`c`/`continue`** — Proceed
 - **Ask** — Ask questions about the changes
@@ -42,6 +50,8 @@ Migrations applied. Review with `git diff` if needed.
 **STOP.** Wait for user response.
 
 **If `continue`:**
+
+Check `git status`. If migration changes are uncommitted, stage and commit them with the message `chore: apply workflow migrations` before returning.
 
 → Return to the calling skill.
 

--- a/skills/migrate/scripts/migrate.sh
+++ b/skills/migrate/scripts/migrate.sh
@@ -90,7 +90,6 @@ MIGRATIONS_RUN=0
 report_update() {
     local filepath="$1"
     local description="$2"
-    echo "  ✓ $filepath ($description)"
     FILES_UPDATED=$((FILES_UPDATED + 1))
 }
 
@@ -153,7 +152,11 @@ done
 # Report results
 if [ "$FILES_UPDATED" -gt 0 ]; then
     echo ""
-    echo "$FILES_UPDATED file(s) migrated. Review with \`git diff\`, then proceed."
+    echo "$MIGRATIONS_RUN migration(s) applied, $FILES_UPDATED file(s) updated."
+    echo ""
+    echo "---STOP_GATE: FILES_UPDATED---"
+    echo "You MUST now follow the migration skill instructions to STOP and let the user review."
+    echo "Do NOT proceed to the next step. Do NOT return to the calling skill."
 else
     echo "[SKIP] No changes needed"
 fi

--- a/skills/migrate/scripts/migrate.sh
+++ b/skills/migrate/scripts/migrate.sh
@@ -155,6 +155,7 @@ if [ "$FILES_UPDATED" -gt 0 ]; then
     echo "$MIGRATIONS_RUN migration(s) applied, $FILES_UPDATED file(s) updated."
     echo ""
     echo "---STOP_GATE: FILES_UPDATED---"
+    echo "You MUST now follow the migration skill instructions to STOP and let the user review."
     echo "Follow the explicit instructions in the migration skill before proceeding."
 else
     echo "[SKIP] No changes needed"

--- a/skills/migrate/scripts/migrate.sh
+++ b/skills/migrate/scripts/migrate.sh
@@ -155,8 +155,7 @@ if [ "$FILES_UPDATED" -gt 0 ]; then
     echo "$MIGRATIONS_RUN migration(s) applied, $FILES_UPDATED file(s) updated."
     echo ""
     echo "---STOP_GATE: FILES_UPDATED---"
-    echo "You MUST now follow the migration skill instructions to STOP and let the user review."
-    echo "Do NOT proceed to the next step. Do NOT return to the calling skill."
+    echo "Follow the explicit instructions in the migration skill before proceeding."
 else
     echo "[SKIP] No changes needed"
 fi


### PR DESCRIPTION
## Summary

- Replace verbose per-file migration output with a compact summary line + structured `---STOP_GATE: FILES_UPDATED---` signal that reinforces the stop instruction directly in tool output
- Migrate skill now runs `git diff` itself and presents a natural language summary of changes instead of a raw file list — internal workflow state files are noise to the user
- On continue, uncommitted migration changes are auto-committed before returning to the calling skill

## Test plan

- [ ] Run workflows on a project with pending migrations — verify compact summary + stop gate appears
- [ ] Verify Claude stops at the gate and presents a natural language summary
- [ ] Verify continue path commits migration changes if uncommitted
- [ ] Run on a project with no pending migrations — verify `[SKIP] No changes needed` and no stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)