### PR TITLE
feat(tick): update output format refs with new CLI capabilities

### DIFF
--- a/skills/technical-planning/references/output-formats/linear/authoring.md
+++ b/skills/technical-planning/references/output-formats/linear/authoring.md
@@ -24,8 +24,8 @@ For each task, create a Linear issue via MCP:
 linear_createIssue(
   teamId: "{team_id}",
   projectId: "{project_id}",
-  title: "{Task title}",
-  description: "{Task description content}",
+  title: "{task:(titlecase)}",
+  description: "{description}",
   labelIds: ["{phase_label_id}", ...]
 )
 ```
@@ -70,7 +70,7 @@ When creating issues, if something is unclear:
 
 The official Linear MCP server does not support deletion. Ask the user to delete the Linear project manually via the Linear UI.
 
-> "The Linear project **{project name}** needs to be deleted before restarting. Please delete it in the Linear UI (Project Settings → Delete project), then confirm so I can proceed."
+> "The Linear project **{project:(titlecase)}** needs to be deleted before restarting. Please delete it in the Linear UI (Project Settings → Delete project), then confirm so I can proceed."
 
 **STOP.** Wait for user response.
 

--- a/skills/technical-planning/references/output-formats/local-markdown/authoring.md
+++ b/skills/technical-planning/references/output-formats/local-markdown/authoring.md
@@ -12,12 +12,12 @@ status: pending
 created: YYYY-MM-DD
 ---
 
-# {Task Title}
+# {task:(titlecase)}
 
-{Task description content}
+{description}
 ```
 
-**Required**: title (`# {Task Title}`) and description (body content). Everything else supports the format's storage mechanics.
+**Required**: title (`# {task:(titlecase)}`) and description (body content). Everything else supports the format's storage mechanics.
 
 ## Task Properties
 

--- a/skills/technical-planning/references/output-formats/local-markdown/updating.md
+++ b/skills/technical-planning/references/output-formats/local-markdown/updating.md
@@ -15,7 +15,7 @@ Update the `status` field in the task file frontmatter at `.workflows/{work_unit
 
 Edit the task file directly:
 
-- **Title**: Change the `# {Title}` heading in the body
+- **Title**: Change the `# {task:(titlecase)}` heading in the body
 - **Description**: Edit the body content below the title
 - **Priority**: Set or change the `priority:` field in frontmatter
 - **Tags**: Set or change the `tags:` field in frontmatter

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -115,9 +115,7 @@ tick ready --parent <parent-id> --tag security
 
 ### References
 
-Set via `--refs` to store the workflow's internal ID on each task. This links the tick task (external ID) back to the planning system's internal ID.
-
-The internal ID format is `{topic}-{phase_id}-{task_id}` (e.g., `auth-flow-1-1`, `auth-flow-2-3`). Set `--refs` on every task during authoring so that the internal-to-external ID mapping is stored directly in tick. For phase parent tasks, use the phase portion of the internal ID (e.g., `auth-flow-1`). References are comma-separated if multiple are needed.
+Set via `--refs` to store the internal ID on each tick task, linking it back to the planning system. Set at all levels: `{topic}` on the topic task, `{topic}-{phase_id}` on phase tasks, `{topic}-{phase_id}-{task_id}` on tasks. References are comma-separated if multiple are needed.
 
 ## Flagging
 

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -32,7 +32,7 @@ This returns the topic task ID (e.g., `tick-a1b2`).
 
 **2. Create phase tasks as children of the topic:**
 
-The `--refs` value is the topic name followed by the phase number (e.g., `{topic}-1`, `{topic}-2`).
+The `--refs` value follows the internal ID format: `{topic}-{phase_id}`.
 
 ```bash
 tick create "Phase 1: {phase:(titlecase)}" --parent tick-a1b2 --refs "{topic}-1"  # returns tick-c3d4
@@ -43,7 +43,7 @@ tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2 --refs "{topic}-2"
 
 ```bash
 tick create "{task:(titlecase)}" --parent tick-c3d4 \
-  --refs "{topic}-1-1" \
+  --refs "{topic}-{phase_id}-{task_id}" \
   --description "{description}
 
 Acceptance criteria, edge cases, and implementation

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -92,12 +92,12 @@ Tasks are created with `open` status by default.
 
 ### Phase Grouping
 
-Phases are represented as parent tasks. Each task belongs to a phase by being a child of that phase's task. Use `--parent <phase-id>` during creation.
+Phases are represented as parent tasks. Each task belongs to a phase by being a child of that phase's task. Use `--parent <phase-tick-id>` during creation.
 
 To list tasks within a phase:
 
 ```bash
-tick list --parent <phase-id>
+tick list --parent <phase-tick-id>
 ```
 
 ### Type
@@ -135,7 +135,7 @@ tick create "[NEEDS INFO] Rate limiting strategy" \
 Remove the topic task and all its descendants:
 
 ```bash
-tick remove <topic-id> --force
+tick remove <topic-tick-id> --force
 ```
 
 Removing a parent cascades to all children (phases and tasks). Dependency references to removed tasks are auto-cleaned from surviving tasks.

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -71,7 +71,7 @@ See **Task Properties** below for details on each flag.
 
 ## Post-Creation Verification
 
-After every `tick create`, run `tick show <task-tick-id>` and confirm that the title, description, and parent were all set correctly.
+After every `tick create`, run `tick show <tick-id>` and confirm that the title, description, and parent were all set correctly.
 
 #### If any field is empty or wrong
 

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -47,11 +47,14 @@ Acceptance criteria, edge cases, and implementation
 details go here. Supports multi-line text.}"
 ```
 
-Complete example — creating a task under a phase:
+Complete example — creating a task with all properties:
 
 ```bash
 tick create "Implement authentication middleware" \
   --parent tick-c3d4 \
+  --type task \
+  --tags "api,auth" \
+  --refs "auth-flow-1-1" \
   --description "Create Express middleware that validates JWT tokens on protected routes.
 
 Acceptance criteria:
@@ -60,6 +63,8 @@ Acceptance criteria:
 - Returns 401 for missing or invalid tokens
 - Passes user context to downstream handlers"
 ```
+
+See **Task Properties** below for details on each flag.
 
 ## Post-Creation Verification
 
@@ -94,51 +99,22 @@ tick list --parent <phase-id>
 
 ### Type
 
-Set the task type during creation to reflect the work type:
-
-```bash
-tick create "Fix null pointer in auth handler" --parent <phase-id> --type bug
-tick create "Add OAuth2 support" --parent <phase-id> --type feature
-tick create "Refactor database connection pool" --parent <phase-id> --type task
-tick create "Update CI pipeline config" --parent <phase-id> --type chore
-```
-
-Valid types: `bug`, `feature`, `task`, `chore`. Use `bug` for bugfix work types, `feature` for feature work types, and `task` or `chore` as appropriate for individual tasks within any work type.
+Set via `--type`. Valid types: `bug`, `feature`, `task`, `chore`. Use `bug` for bugfix work types, `feature` for feature work types, and `task` or `chore` as appropriate for individual tasks within any work type.
 
 ### Tags
 
-Tags provide additional categorisation beyond the parent/child hierarchy:
+Set via `--tags` with comma-separated, kebab-case values. Tags provide additional categorisation beyond the parent/child hierarchy. Filter tasks by tag:
 
 ```bash
-tick create "Add rate limiting" --parent <phase-id> --tags "api,security"
-```
-
-Tags are comma-separated, kebab-case. Filter tasks by tag:
-
-```bash
-tick list --parent <topic-id> --tag api
-tick ready --parent <phase-id> --tag security
+tick list --parent <parent-id> --tag api
+tick ready --parent <parent-id> --tag security
 ```
 
 ### References
 
-Use `--refs` to store the workflow's internal ID on each task. This links the tick task (external ID) back to the planning system's internal ID:
+Set via `--refs` to store the workflow's internal ID on each task. This links the tick task (external ID) back to the planning system's internal ID.
 
-```bash
-tick create "Implement authentication middleware" \
-  --parent <phase-id> \
-  --refs "auth-flow-1-1"
-```
-
-The internal ID format is `{topic}-{phase_id}-{task_id}` (e.g., `auth-flow-1-1`, `auth-flow-2-3`). Set `--refs` on every task during authoring so that the internal-to-external ID mapping is stored directly in tick.
-
-For phase parent tasks, use the phase portion of the internal ID:
-
-```bash
-tick create "Phase 1: Core Setup" --parent <topic-id> --refs "auth-flow-1"
-```
-
-References are comma-separated if multiple are needed.
+The internal ID format is `{topic}-{phase_id}-{task_id}` (e.g., `auth-flow-1-1`, `auth-flow-2-3`). Set `--refs` on every task during authoring so that the internal-to-external ID mapping is stored directly in tick. For phase parent tasks, use the phase portion of the internal ID (e.g., `auth-flow-1`). References are comma-separated if multiple are needed.
 
 ## Flagging
 

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -25,7 +25,7 @@ Tasks are created using the `tick create` command. Before creating individual ta
 **1. Create the topic task:**
 
 ```bash
-tick create "{Topic Name}"
+tick create "{topic:(titlecase)}"
 ```
 
 This returns the topic task ID (e.g., `tick-a1b2`).
@@ -33,14 +33,14 @@ This returns the topic task ID (e.g., `tick-a1b2`).
 **2. Create phase tasks as children of the topic:**
 
 ```bash
-tick create "Phase 1: {Phase Name}" --parent tick-a1b2
-tick create "Phase 2: {Phase Name}" --parent tick-a1b2
+tick create "Phase 1: {phase:(titlecase)}" --parent tick-a1b2
+tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2
 ```
 
 **3. Create tasks as children of their phase:**
 
 ```bash
-tick create "{Task Title}" --parent tick-c3d4 \
+tick create "{task:(titlecase)}" --parent tick-c3d4 \
   --description "{Task description content.
 
 Acceptance criteria, edge cases, and implementation

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -25,7 +25,7 @@ Tasks are created using the `tick create` command. Always set `--refs` to store 
 **1. Create the topic task:**
 
 ```bash
-tick create "{topic:(titlecase)}" --refs "{topic:(kebabcase)}"
+tick create "{topic:(titlecase)}" --refs "{topic}"
 ```
 
 This returns the topic task ID (e.g., `tick-a1b2`).

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -71,7 +71,7 @@ See **Task Properties** below for details on each flag.
 
 ## Post-Creation Verification
 
-After every `tick create`, run `tick show <task-id>` and confirm that the title, description, and parent were all set correctly.
+After every `tick create`, run `tick show <task-tick-id>` and confirm that the title, description, and parent were all set correctly.
 
 #### If any field is empty or wrong
 

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -122,13 +122,23 @@ tick ready --parent <phase-id> --tag security
 
 ### References
 
-Link tasks to external resources (spec sections, discussion topics, tickets):
+Use `--refs` to store the workflow's internal ID on each task. This links the tick task (external ID) back to the planning system's internal ID:
 
 ```bash
-tick create "Implement caching layer" --parent <phase-id> --refs "spec:caching,discussion:performance"
+tick create "Implement authentication middleware" \
+  --parent <phase-id> \
+  --refs "auth-flow-1-1"
 ```
 
-References are comma-separated free-form strings.
+The internal ID format is `{topic}-{phase_id}-{task_id}` (e.g., `auth-flow-1-1`, `auth-flow-2-3`). Set `--refs` on every task during authoring so that the internal-to-external ID mapping is stored directly in tick.
+
+For phase parent tasks, use the phase portion of the internal ID:
+
+```bash
+tick create "Phase 1: Core Setup" --parent <topic-id> --refs "auth-flow-1"
+```
+
+References are comma-separated if multiple are needed.
 
 ## Flagging
 

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -92,9 +92,43 @@ To list tasks within a phase:
 tick list --parent <phase-id>
 ```
 
-### Labels / Tags
+### Type
 
-Tick does not have a native label or tag system. Categorisation is handled through the parent/child hierarchy.
+Set the task type during creation to reflect the work type:
+
+```bash
+tick create "Fix null pointer in auth handler" --parent <phase-id> --type bug
+tick create "Add OAuth2 support" --parent <phase-id> --type feature
+tick create "Refactor database connection pool" --parent <phase-id> --type task
+tick create "Update CI pipeline config" --parent <phase-id> --type chore
+```
+
+Valid types: `bug`, `feature`, `task`, `chore`. Use `bug` for bugfix work types, `feature` for feature work types, and `task` or `chore` as appropriate for individual tasks within any work type.
+
+### Tags
+
+Tags provide additional categorisation beyond the parent/child hierarchy:
+
+```bash
+tick create "Add rate limiting" --parent <phase-id> --tags "api,security"
+```
+
+Tags are comma-separated, kebab-case. Filter tasks by tag:
+
+```bash
+tick list --parent <topic-id> --tag api
+tick ready --parent <phase-id> --tag security
+```
+
+### References
+
+Link tasks to external resources (spec sections, discussion topics, tickets):
+
+```bash
+tick create "Implement caching layer" --parent <phase-id> --refs "spec:caching,discussion:performance"
+```
+
+References are comma-separated free-form strings.
 
 ## Flagging
 

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -20,12 +20,12 @@ If a description contains double quotes, escape them with `\"`. That's it.
 
 ## Task Storage
 
-Tasks are created using the `tick create` command. Before creating individual tasks, establish the topic and phase parent tasks.
+Tasks are created using the `tick create` command. Always set `--refs` to store the workflow's internal ID — this links every tick task back to the planning system. Before creating individual tasks, establish the topic and phase parent tasks.
 
 **1. Create the topic task:**
 
 ```bash
-tick create "{topic:(titlecase)}"
+tick create "{topic:(titlecase)}" --refs "{topic:(kebabcase)}"
 ```
 
 This returns the topic task ID (e.g., `tick-a1b2`).
@@ -33,14 +33,15 @@ This returns the topic task ID (e.g., `tick-a1b2`).
 **2. Create phase tasks as children of the topic:**
 
 ```bash
-tick create "Phase 1: {phase:(titlecase)}" --parent tick-a1b2  # returns tick-c3d4
-tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2  # returns tick-e5f6
+tick create "Phase 1: {phase:(titlecase)}" --parent tick-a1b2 --refs "{topic}-1"  # returns tick-c3d4
+tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2 --refs "{topic}-2"  # returns tick-e5f6
 ```
 
 **3. Create tasks as children of their phase:**
 
 ```bash
 tick create "{task:(titlecase)}" --parent tick-c3d4 \
+  --refs "{topic}-1-1" \
   --description "{description}
 
 Acceptance criteria, edge cases, and implementation

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -41,7 +41,10 @@ tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2  # returns tick-e5
 
 ```bash
 tick create "{task:(titlecase)}" --parent tick-c3d4 \
-  --description "{description}"
+  --description "{description}
+
+Acceptance criteria, edge cases, and implementation
+details go here. Supports multi-line text."
 ```
 
 Complete example — creating a task under Phase 1:

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -10,11 +10,11 @@ tick create "Title" --parent <id> --description "Full description here.
 Multi-line content works fine inside double quotes."
 ```
 
-**Do NOT**:
-- Use heredocs (`<<'EOF'`) — sandbox blocks the temp files they create
-- Use the Write tool to create temp files — triggers approval prompts outside the project directory
-- Use Bash functions, variables, or subshells to construct the description
-- Write temp files anywhere (including `$TMPDIR`, `/tmp`, or the working directory)
+You should never do the following:
+- Do not use heredocs (`<<'EOF'`) — sandbox blocks the temp files they create
+- Do not use the Write tool to create temp files — triggers approval prompts outside the project directory
+- Do not use Bash functions, variables, or subshells to construct the description
+- Do not write temp files anywhere (including `$TMPDIR`, `/tmp`, or the working directory)
 
 If a description contains double quotes, escape them with `\"`. That's it.
 

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -5,7 +5,7 @@
 **CRITICAL**: Always pass descriptions directly as inline quoted strings. Never use workarounds.
 
 ```bash
-tick create "Title" --parent <id> --description "Full description here.
+tick create "Title" --parent <tick-id> --description "Full description here.
 
 Multi-line content works fine inside double quotes."
 ```
@@ -109,8 +109,8 @@ Optional. Set via `--type`. Valid types: `bug`, `feature`, `task`, `chore`. Use 
 Optional — not necessary in most cases, but available if needed. Set via `--tags` with comma-separated, kebab-case values. Tags provide additional categorisation beyond the parent/child hierarchy. Filter tasks by tag:
 
 ```bash
-tick list --parent <parent-id> --tag api
-tick ready --parent <parent-id> --tag security
+tick list --parent <tick-id> --tag api
+tick ready --parent <tick-id> --tag security
 ```
 
 ### References

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -32,6 +32,8 @@ This returns the topic task ID (e.g., `tick-a1b2`).
 
 **2. Create phase tasks as children of the topic:**
 
+The `--refs` value is the topic name followed by the phase number (e.g., `{topic}-1`, `{topic}-2`).
+
 ```bash
 tick create "Phase 1: {phase:(titlecase)}" --parent tick-a1b2 --refs "{topic}-1"  # returns tick-c3d4
 tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2 --refs "{topic}-2"  # returns tick-e5f6

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -33,21 +33,18 @@ This returns the topic task ID (e.g., `tick-a1b2`).
 **2. Create phase tasks as children of the topic:**
 
 ```bash
-tick create "Phase 1: {phase:(titlecase)}" --parent tick-a1b2
-tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2
+tick create "Phase 1: {phase:(titlecase)}" --parent tick-a1b2  # returns tick-c3d4
+tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2  # returns tick-e5f6
 ```
 
 **3. Create tasks as children of their phase:**
 
 ```bash
 tick create "{task:(titlecase)}" --parent tick-c3d4 \
-  --description "{Task description content.
-
-Acceptance criteria, edge cases, and implementation
-details go here. Supports multi-line text.}"
+  --description "{description}"
 ```
 
-Complete example — creating a task with all properties:
+Complete example — creating a task under Phase 1:
 
 ```bash
 tick create "Implement authentication middleware" \

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -115,7 +115,7 @@ tick ready --parent <parent-id> --tag security
 
 ### References
 
-Set via `--refs` to store the internal ID on each tick task, linking it back to the planning system. Set at all levels: `{topic}` on the topic task, `{topic}-{phase_id}` on phase tasks, `{topic}-{phase_id}-{task_id}` on tasks. References are comma-separated if multiple are needed.
+Set via `--refs` to store the internal ID on each tick task, linking it back to the planning system. Set at all levels — topic, phase, and task — as shown in the Task Storage examples above. References are comma-separated if multiple are needed.
 
 ## Flagging
 

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -43,7 +43,7 @@ tick create "Phase 2: {phase:(titlecase)}" --parent tick-a1b2 --refs "{topic}-2"
 
 ```bash
 tick create "{task:(titlecase)}" --parent tick-c3d4 \
-  --refs "{topic}-{phase_id}-{task_id}" \
+  --refs "{internal_id}" \
   --description "{description}
 
 Acceptance criteria, edge cases, and implementation

--- a/skills/technical-planning/references/output-formats/tick/authoring.md
+++ b/skills/technical-planning/references/output-formats/tick/authoring.md
@@ -99,11 +99,11 @@ tick list --parent <phase-id>
 
 ### Type
 
-Set via `--type`. Valid types: `bug`, `feature`, `task`, `chore`. Use `bug` for bugfix work types, `feature` for feature work types, and `task` or `chore` as appropriate for individual tasks within any work type.
+Optional. Set via `--type`. Valid types: `bug`, `feature`, `task`, `chore`. Use `bug` for bugfix work types, `feature` for feature work types, and `task` or `chore` as appropriate for individual tasks within any work type. Doesn't hurt to set — adds useful categorisation at no cost.
 
 ### Tags
 
-Set via `--tags` with comma-separated, kebab-case values. Tags provide additional categorisation beyond the parent/child hierarchy. Filter tasks by tag:
+Optional — not necessary in most cases, but available if needed. Set via `--tags` with comma-separated, kebab-case values. Tags provide additional categorisation beyond the parent/child hierarchy. Filter tasks by tag:
 
 ```bash
 tick list --parent <parent-id> --tag api

--- a/skills/technical-planning/references/output-formats/tick/graph.md
+++ b/skills/technical-planning/references/output-formats/tick/graph.md
@@ -19,7 +19,7 @@ Lower number = higher priority. Tasks are created with priority `2` (medium) by 
 ### Setting Priority
 
 ```bash
-tick update <task-id> --priority 1
+tick update <task-tick-id> --priority 1
 ```
 
 ### Removing Priority
@@ -27,7 +27,7 @@ tick update <task-id> --priority 1
 Reset to the default medium priority:
 
 ```bash
-tick update <task-id> --priority 2
+tick update <task-tick-id> --priority 2
 ```
 
 Tick does not support unsetting priority — every task has a priority level. Use `2` (medium) as the neutral default.
@@ -41,7 +41,7 @@ Tick validates all dependency changes: prevents cycles, self-references, and chi
 Declare that a task is blocked by another task:
 
 ```bash
-tick dep add <task-id> <blocked-by-id>
+tick dep add <task-tick-id> <blocked-by-id>
 ```
 
 Example — task `tick-e5f6` depends on `tick-a1b2`:
@@ -62,5 +62,5 @@ tick dep add tick-e5f6 tick-c3d4
 ### Removing a Dependency
 
 ```bash
-tick dep rm <task-id> <blocked-by-id>
+tick dep rm <task-tick-id> <blocked-by-id>
 ```

--- a/skills/technical-planning/references/output-formats/tick/graph.md
+++ b/skills/technical-planning/references/output-formats/tick/graph.md
@@ -57,6 +57,8 @@ tick dep add tick-e5f6 tick-a1b2
 tick dep add tick-e5f6 tick-c3d4
 ```
 
+**Note**: Dependencies can also be set at creation time via `--blocked-by <id,...>` and `--blocks <id,...>` on `tick create`. This is useful when the blocking relationship is known upfront, but the typical workflow authors all tasks first, then adds dependencies in a separate graphing pass.
+
 ### Removing a Dependency
 
 ```bash

--- a/skills/technical-planning/references/output-formats/tick/graph.md
+++ b/skills/technical-planning/references/output-formats/tick/graph.md
@@ -41,7 +41,7 @@ Tick validates all dependency changes: prevents cycles, self-references, and chi
 Declare that a task is blocked by another task:
 
 ```bash
-tick dep add <task-tick-id> <blocked-by-id>
+tick dep add <task-tick-id> <tick-id>
 ```
 
 Example — task `tick-e5f6` depends on `tick-a1b2`:
@@ -57,10 +57,10 @@ tick dep add tick-e5f6 tick-a1b2
 tick dep add tick-e5f6 tick-c3d4
 ```
 
-**Note**: Dependencies can also be set at creation time via `--blocked-by <id,...>` and `--blocks <id,...>` on `tick create`. This is useful when the blocking relationship is known upfront, but the typical workflow authors all tasks first, then adds dependencies in a separate graphing pass.
+**Note**: Dependencies can also be set at creation time via `--blocked-by <tick-id,...>` and `--blocks <tick-id,...>` on `tick create`. This is useful when the blocking relationship is known upfront, but the typical workflow authors all tasks first, then adds dependencies in a separate graphing pass.
 
 ### Removing a Dependency
 
 ```bash
-tick dep rm <task-tick-id> <blocked-by-id>
+tick dep rm <task-tick-id> <tick-id>
 ```

--- a/skills/technical-planning/references/output-formats/tick/graph.md
+++ b/skills/technical-planning/references/output-formats/tick/graph.md
@@ -19,7 +19,7 @@ Lower number = higher priority. Tasks are created with priority `2` (medium) by 
 ### Setting Priority
 
 ```bash
-tick update <task-tick-id> --priority 1
+tick update <tick-id> --priority 1
 ```
 
 ### Removing Priority
@@ -27,7 +27,7 @@ tick update <task-tick-id> --priority 1
 Reset to the default medium priority:
 
 ```bash
-tick update <task-tick-id> --priority 2
+tick update <tick-id> --priority 2
 ```
 
 Tick does not support unsetting priority — every task has a priority level. Use `2` (medium) as the neutral default.
@@ -41,7 +41,7 @@ Tick validates all dependency changes: prevents cycles, self-references, and chi
 Declare that a task is blocked by another task:
 
 ```bash
-tick dep add <task-tick-id> <tick-id>
+tick dep add <tick-id> <tick-id>
 ```
 
 Example — task `tick-e5f6` depends on `tick-a1b2`:
@@ -62,5 +62,5 @@ tick dep add tick-e5f6 tick-c3d4
 ### Removing a Dependency
 
 ```bash
-tick dep rm <task-tick-id> <tick-id>
+tick dep rm <tick-id> <tick-id>
 ```

--- a/skills/technical-planning/references/output-formats/tick/graph.md
+++ b/skills/technical-planning/references/output-formats/tick/graph.md
@@ -41,7 +41,7 @@ Tick validates all dependency changes: prevents cycles, self-references, and chi
 Declare that a task is blocked by another task:
 
 ```bash
-tick dep add <tick-id> <tick-id>
+tick dep add <tick-id> <blocked-by-tick-id>
 ```
 
 Example — task `tick-e5f6` depends on `tick-a1b2`:
@@ -62,5 +62,5 @@ tick dep add tick-e5f6 tick-c3d4
 ### Removing a Dependency
 
 ```bash
-tick dep rm <tick-id> <tick-id>
+tick dep rm <tick-id> <blocked-by-tick-id>
 ```

--- a/skills/technical-planning/references/output-formats/tick/reading.md
+++ b/skills/technical-planning/references/output-formats/tick/reading.md
@@ -23,6 +23,7 @@ tick list --parent <topic-id> --status open       # only open tasks
 tick list --parent <topic-id> --ready              # ready tasks only
 tick list --parent <topic-id> --blocked            # blocked tasks only
 tick list --parent <topic-id> --priority 0         # critical tasks only
+tick list --parent <topic-id> --count 5            # limit to 5 results
 ```
 
 ## Extracting a Task
@@ -40,22 +41,22 @@ Returns: id, title, status, priority, created/updated timestamps, parent, blocke
 To find the next task to implement:
 
 ```bash
-tick ready --parent <phase-id>
+tick ready --parent <phase-id> --count 1
 ```
 
-This returns tasks that are:
+This returns the single next task that is:
 
 1. Status is `open` (not started, not done, not cancelled)
 2. No unresolved blockers (all `blocked_by` tasks are `done`)
 3. No open children (leaf tasks, or parent tasks whose children are all complete)
 4. Within the specified phase (scoped by `--parent`)
 
-Results are sorted by priority (lower number = higher priority), then creation date. The first result is the next task.
+Results are sorted by priority (lower number = higher priority), then creation date. `--count 1` limits output to the first result.
 
 To find the next task across all phases of a topic:
 
 ```bash
-tick ready --parent <topic-id>
+tick ready --parent <topic-id> --count 1
 ```
 
 If `tick ready` returns no results, either all tasks are complete or remaining tasks are blocked.

--- a/skills/technical-planning/references/output-formats/tick/reading.md
+++ b/skills/technical-planning/references/output-formats/tick/reading.md
@@ -31,7 +31,7 @@ tick list --parent <topic-tick-id> --count 5            # limit to 5 results
 To read full task detail including description, blockers, and children:
 
 ```bash
-tick show <task-id>
+tick show <task-tick-id>
 ```
 
 Returns: id, title, status, priority, created/updated timestamps, parent, blocked_by list, children list, and full description.

--- a/skills/technical-planning/references/output-formats/tick/reading.md
+++ b/skills/technical-planning/references/output-formats/tick/reading.md
@@ -31,7 +31,7 @@ tick list --parent <topic-tick-id> --count 5            # limit to 5 results
 To read full task detail including description, blockers, and children:
 
 ```bash
-tick show <task-tick-id>
+tick show <tick-id>
 ```
 
 Returns: id, title, status, priority, created/updated timestamps, parent, blocked_by list, children list, and full description.

--- a/skills/technical-planning/references/output-formats/tick/reading.md
+++ b/skills/technical-planning/references/output-formats/tick/reading.md
@@ -5,7 +5,7 @@
 To retrieve all tasks for a topic:
 
 ```bash
-tick list --parent <topic-id>
+tick list --parent <topic-tick-id>
 ```
 
 This returns all descendants (phases and tasks) with summary-level data: id, title, status, priority, and parent. Results are sorted by priority (ascending), then creation date.
@@ -13,17 +13,17 @@ This returns all descendants (phases and tasks) with summary-level data: id, tit
 To list tasks within a specific phase:
 
 ```bash
-tick list --parent <phase-id>
+tick list --parent <phase-tick-id>
 ```
 
 Additional filtering:
 
 ```bash
-tick list --parent <topic-id> --status open       # only open tasks
-tick list --parent <topic-id> --ready              # ready tasks only
-tick list --parent <topic-id> --blocked            # blocked tasks only
-tick list --parent <topic-id> --priority 0         # critical tasks only
-tick list --parent <topic-id> --count 5            # limit to 5 results
+tick list --parent <topic-tick-id> --status open       # only open tasks
+tick list --parent <topic-tick-id> --ready              # ready tasks only
+tick list --parent <topic-tick-id> --blocked            # blocked tasks only
+tick list --parent <topic-tick-id> --priority 0         # critical tasks only
+tick list --parent <topic-tick-id> --count 5            # limit to 5 results
 ```
 
 ## Extracting a Task
@@ -41,7 +41,7 @@ Returns: id, title, status, priority, created/updated timestamps, parent, blocke
 To find the next task to implement:
 
 ```bash
-tick ready --parent <phase-id> --count 1
+tick ready --parent <phase-tick-id> --count 1
 ```
 
 This returns the single next task that is:
@@ -56,7 +56,7 @@ Results are sorted by priority (lower number = higher priority), then creation d
 To find the next task across all phases of a topic:
 
 ```bash
-tick ready --parent <topic-id> --count 1
+tick ready --parent <topic-tick-id> --count 1
 ```
 
 If `tick ready` returns no results, either all tasks are complete or remaining tasks are blocked.

--- a/skills/technical-planning/references/output-formats/tick/updating.md
+++ b/skills/technical-planning/references/output-formats/tick/updating.md
@@ -34,34 +34,21 @@ To update a task's properties:
 
 After every `tick update`, run `tick show <task-id>` and confirm that the updated fields were set correctly. If any field is empty or wrong, re-run the update.
 
-## Phase / Parent Status
+## Phase / Parent Status (Auto-Cascade)
 
-Phase tasks are parent tasks in the tick hierarchy. Update their status to reflect child task progress.
+Tick automatically cascades status changes through the parent/child hierarchy. **Do not manually update phase or topic parent status** — tick handles it.
 
-### Start Phase
+### How cascading works
 
-When the first task in a phase begins and the phase parent is still `open`:
+| Command | Downward cascade | Upward cascade |
+|---------|-----------------|----------------|
+| `tick start <id>` | — | Starts any `open` ancestors |
+| `tick done <id>` | Marks all non-terminal descendants as `done` | If all siblings are now terminal, auto-completes the parent (recursively upward) |
+| `tick cancel <id>` | Cancels all non-terminal descendants | If all siblings are now terminal, auto-completes the parent (`done` or `cancel` as appropriate) |
+| `tick reopen <id>` | — | Reopens any `done` ancestors (blocked if parent is `cancelled`) |
 
-```bash
-tick start <phase-id>
-```
-
-Check the phase parent's status with `tick show <phase-id>`. If status is `open`, start it.
-
-### Complete Phase
-
-When all child tasks in a phase are `done` or `cancelled` (none remain `open` or `in_progress`):
-
-```bash
-tick done <phase-id>
-```
-
-After completing a task, check: `tick list --parent <phase-id> --status open` and `tick list --parent <phase-id> --status in_progress`. If both return empty, the phase is complete.
-
-### Cancel Phase
-
-If all child tasks are `cancelled` (none `done`):
-
-```bash
-tick cancel <phase-id>
-```
+This means:
+- Starting a task automatically starts its phase and topic parents
+- Completing the last task in a phase automatically completes the phase
+- Cancelling a task may auto-complete the phase if all siblings are now terminal
+- Reopening a task reopens its completed ancestors so the hierarchy stays consistent

--- a/skills/technical-planning/references/output-formats/tick/updating.md
+++ b/skills/technical-planning/references/output-formats/tick/updating.md
@@ -23,11 +23,11 @@ To update a task's properties:
 - **Title**: `tick update <task-tick-id> --title "New title"`
 - **Description**: `tick update <task-tick-id> --description "New description"`
 - **Priority**: `tick update <task-tick-id> --priority 1`
-- **Parent**: `tick update <task-tick-id> --parent <new-parent-id>` (pass empty string to clear)
+- **Parent**: `tick update <task-tick-id> --parent <tick-id>` (pass empty string to clear)
 - **Type**: `tick update <task-tick-id> --type feature` (clear with `--clear-type`)
 - **Tags**: `tick update <task-tick-id> --tags "api,security"` (replaces all tags; clear with `--clear-tags`)
 - **Refs**: `tick update <task-tick-id> --refs "spec:caching"` (replaces all refs; clear with `--clear-refs`)
-- **Blocks**: `tick update <task-tick-id> --blocks <id,...>` (set task IDs this blocks)
+- **Blocks**: `tick update <task-tick-id> --blocks <tick-id,...>` (set task IDs this blocks)
 - **Dependencies**: See [graph.md](graph.md)
 
 ## Post-Update Verification
@@ -42,10 +42,10 @@ Tick automatically cascades status changes through the parent/child hierarchy. *
 
 | Command | Downward cascade | Upward cascade |
 |---------|-----------------|----------------|
-| `tick start <id>` | — | Starts any `open` ancestors |
-| `tick done <id>` | Marks all non-terminal descendants as `done` | If all siblings are now terminal, auto-completes the parent (recursively upward) |
-| `tick cancel <id>` | Cancels all non-terminal descendants | If all siblings are now terminal, auto-completes the parent (`done` or `cancel` as appropriate) |
-| `tick reopen <id>` | — | Reopens any `done` ancestors (blocked if parent is `cancelled`) |
+| `tick start <tick-id>` | — | Starts any `open` ancestors |
+| `tick done <tick-id>` | Marks all non-terminal descendants as `done` | If all siblings are now terminal, auto-completes the parent (recursively upward) |
+| `tick cancel <tick-id>` | Cancels all non-terminal descendants | If all siblings are now terminal, auto-completes the parent (`done` or `cancel` as appropriate) |
+| `tick reopen <tick-id>` | — | Reopens any `done` ancestors (blocked if parent is `cancelled`) |
 
 This means:
 - Starting a task automatically starts its phase and topic parents

--- a/skills/technical-planning/references/output-formats/tick/updating.md
+++ b/skills/technical-planning/references/output-formats/tick/updating.md
@@ -6,11 +6,11 @@ Tick uses dedicated commands for each status transition:
 
 | Transition | Command |
 |------------|---------|
-| Start | `tick start <task-tick-id>` (open → in_progress) |
-| Complete | `tick done <task-tick-id>` (in_progress → done) |
-| Cancelled | `tick cancel <task-tick-id>` (any → cancelled) |
-| Reopen | `tick reopen <task-tick-id>` (done/cancelled → open) |
-| Skipped | `tick cancel <task-tick-id>` (no separate skipped status — use cancel) |
+| Start | `tick start <tick-id>` (open → in_progress) |
+| Complete | `tick done <tick-id>` (in_progress → done) |
+| Cancelled | `tick cancel <tick-id>` (any → cancelled) |
+| Reopen | `tick reopen <tick-id>` (done/cancelled → open) |
+| Skipped | `tick cancel <tick-id>` (no separate skipped status — use cancel) |
 
 `done` and `cancel` set a closed timestamp. `reopen` clears it.
 
@@ -20,19 +20,19 @@ Tick uses dedicated commands for each status transition:
 
 To update a task's properties:
 
-- **Title**: `tick update <task-tick-id> --title "New title"`
-- **Description**: `tick update <task-tick-id> --description "New description"`
-- **Priority**: `tick update <task-tick-id> --priority 1`
-- **Parent**: `tick update <task-tick-id> --parent <tick-id>` (pass empty string to clear)
-- **Type**: `tick update <task-tick-id> --type feature` (clear with `--clear-type`)
-- **Tags**: `tick update <task-tick-id> --tags "api,security"` (replaces all tags; clear with `--clear-tags`)
-- **Refs**: `tick update <task-tick-id> --refs "spec:caching"` (replaces all refs; clear with `--clear-refs`)
-- **Blocks**: `tick update <task-tick-id> --blocks <tick-id,...>` (set task IDs this blocks)
+- **Title**: `tick update <tick-id> --title "New title"`
+- **Description**: `tick update <tick-id> --description "New description"`
+- **Priority**: `tick update <tick-id> --priority 1`
+- **Parent**: `tick update <tick-id> --parent <tick-id>` (pass empty string to clear)
+- **Type**: `tick update <tick-id> --type feature` (clear with `--clear-type`)
+- **Tags**: `tick update <tick-id> --tags "api,security"` (replaces all tags; clear with `--clear-tags`)
+- **Refs**: `tick update <tick-id> --refs "spec:caching"` (replaces all refs; clear with `--clear-refs`)
+- **Blocks**: `tick update <tick-id> --blocks <tick-id,...>` (set task IDs this blocks)
 - **Dependencies**: See [graph.md](graph.md)
 
 ## Post-Update Verification
 
-After every `tick update`, run `tick show <task-tick-id>` and confirm that the updated fields were set correctly. If any field is empty or wrong, re-run the update.
+After every `tick update`, run `tick show <tick-id>` and confirm that the updated fields were set correctly. If any field is empty or wrong, re-run the update.
 
 ## Phase / Parent Status (Auto-Cascade)
 

--- a/skills/technical-planning/references/output-formats/tick/updating.md
+++ b/skills/technical-planning/references/output-formats/tick/updating.md
@@ -6,11 +6,11 @@ Tick uses dedicated commands for each status transition:
 
 | Transition | Command |
 |------------|---------|
-| Start | `tick start <task-id>` (open → in_progress) |
-| Complete | `tick done <task-id>` (in_progress → done) |
-| Cancelled | `tick cancel <task-id>` (any → cancelled) |
-| Reopen | `tick reopen <task-id>` (done/cancelled → open) |
-| Skipped | `tick cancel <task-id>` (no separate skipped status — use cancel) |
+| Start | `tick start <task-tick-id>` (open → in_progress) |
+| Complete | `tick done <task-tick-id>` (in_progress → done) |
+| Cancelled | `tick cancel <task-tick-id>` (any → cancelled) |
+| Reopen | `tick reopen <task-tick-id>` (done/cancelled → open) |
+| Skipped | `tick cancel <task-tick-id>` (no separate skipped status — use cancel) |
 
 `done` and `cancel` set a closed timestamp. `reopen` clears it.
 
@@ -20,19 +20,19 @@ Tick uses dedicated commands for each status transition:
 
 To update a task's properties:
 
-- **Title**: `tick update <task-id> --title "New title"`
-- **Description**: `tick update <task-id> --description "New description"`
-- **Priority**: `tick update <task-id> --priority 1`
-- **Parent**: `tick update <task-id> --parent <new-parent-id>` (pass empty string to clear)
-- **Type**: `tick update <task-id> --type feature` (clear with `--clear-type`)
-- **Tags**: `tick update <task-id> --tags "api,security"` (replaces all tags; clear with `--clear-tags`)
-- **Refs**: `tick update <task-id> --refs "spec:caching"` (replaces all refs; clear with `--clear-refs`)
-- **Blocks**: `tick update <task-id> --blocks <id,...>` (set task IDs this blocks)
+- **Title**: `tick update <task-tick-id> --title "New title"`
+- **Description**: `tick update <task-tick-id> --description "New description"`
+- **Priority**: `tick update <task-tick-id> --priority 1`
+- **Parent**: `tick update <task-tick-id> --parent <new-parent-id>` (pass empty string to clear)
+- **Type**: `tick update <task-tick-id> --type feature` (clear with `--clear-type`)
+- **Tags**: `tick update <task-tick-id> --tags "api,security"` (replaces all tags; clear with `--clear-tags`)
+- **Refs**: `tick update <task-tick-id> --refs "spec:caching"` (replaces all refs; clear with `--clear-refs`)
+- **Blocks**: `tick update <task-tick-id> --blocks <id,...>` (set task IDs this blocks)
 - **Dependencies**: See [graph.md](graph.md)
 
 ## Post-Update Verification
 
-After every `tick update`, run `tick show <task-id>` and confirm that the updated fields were set correctly. If any field is empty or wrong, re-run the update.
+After every `tick update`, run `tick show <task-tick-id>` and confirm that the updated fields were set correctly. If any field is empty or wrong, re-run the update.
 
 ## Phase / Parent Status (Auto-Cascade)
 

--- a/skills/technical-planning/references/output-formats/tick/updating.md
+++ b/skills/technical-planning/references/output-formats/tick/updating.md
@@ -24,6 +24,10 @@ To update a task's properties:
 - **Description**: `tick update <task-id> --description "New description"`
 - **Priority**: `tick update <task-id> --priority 1`
 - **Parent**: `tick update <task-id> --parent <new-parent-id>` (pass empty string to clear)
+- **Type**: `tick update <task-id> --type feature` (clear with `--clear-type`)
+- **Tags**: `tick update <task-id> --tags "api,security"` (replaces all tags; clear with `--clear-tags`)
+- **Refs**: `tick update <task-id> --refs "spec:caching"` (replaces all refs; clear with `--clear-refs`)
+- **Blocks**: `tick update <task-id> --blocks <id,...>` (set task IDs this blocks)
 - **Dependencies**: See [graph.md](graph.md)
 
 ## Post-Update Verification


### PR DESCRIPTION
## Summary

- Add `--count 1` to `tick ready` for token-efficient next-task lookups, document `--count` on `tick list`
- Document `--type`, `--tags`, and `--refs` flags across authoring and updating refs; use `--refs` to store workflow internal IDs on tick tasks, bridging external/internal ID mapping
- Replace manual phase status management with auto-cascade documentation — tick handles parent status transitions automatically
- Consolidate authoring examples into a single complete `tick create` showing all flags; add creation-time `--blocked-by`/`--blocks` note to graph.md

## Test plan

- [ ] Review authoring.md complete example includes all flags (`--type`, `--tags`, `--refs`, `--description`)
- [ ] Verify reading.md uses `--count 1` on both `tick ready` commands
- [ ] Confirm updating.md auto-cascade table matches `tick help start/done/cancel/reopen` output
- [ ] Check graph.md note about creation-time deps doesn't conflict with two-phase authoring flow


🤖 Generated with [Claude Code](https://claude.com/claude-code)