### PR TITLE
fix: sync workflow-explorer with skill rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,23 @@
 
 A complete development workflow for Claude Code: explore ideas, capture decisions, build actionable plans, implement via strict TDD, and validate the result.
 
-A **six-phase workflow** where each phase feeds the next:
+**Three work types, each with its own pipeline:**
 
 ```
-Research → Discussion → Specification → Planning → Implementation → Review
+Epic:    Research → Discussion → Specification → Planning → Implementation → Review
+Feature:           Discussion → Specification → Planning → Implementation → Review
+Bugfix:          Investigation → Specification → Planning → Implementation → Review
 ```
 
-**Why this matters:** Complex features benefit from thorough discussion before implementation. This toolkit documents the *what* and *why* before diving into the *how*, preserving architectural decisions, edge cases, and the reasoning behind choices that would otherwise be lost.
+**Epics** are for multi-topic work spanning multiple sessions — new products, large initiatives, architectural overhauls. Topics move independently within phases: 10 discussions might yield 5 specifications, each planned and implemented separately.
 
-**Flexible entry points:** Start at Research for early exploration, or jump to Discussion when you know what you're building. `/start-feature` gathers context and pipelines through every phase automatically. Entry-point skills gather context and feed it to processing skills.
+**Features** are for adding functionality to an existing product. Single topic, linear pipeline. Optional research step if uncertainties exist.
 
-**Engineered like software.** This isn't a collection of prompts — it's built with the same discipline you'd apply to code. Entry-point skills gather context, phase entry skills validate and route, processing skills do the work. Output formats implement a [5-file adapter contract](#output-formats), so planning works identically regardless of where tasks end up. Agents handle isolated concerns. The result is a natural language workflow that's modular, extensible, and maintainable — software engineering principles applied to agentic workflows.
+**Bugfixes** are for fixing broken behavior. Investigation replaces discussion — it combines symptom gathering with code analysis to identify the root cause before specifying the fix.
+
+**Why this matters:** Complex work benefits from thorough discussion before implementation. This toolkit documents the *what* and *why* before diving into the *how*, preserving architectural decisions, edge cases, and the reasoning behind choices that would otherwise be lost.
+
+**Engineered like software.** This isn't a collection of prompts — it's built with the same discipline you'd apply to code. Entry-point skills gather context, phase entry skills validate and route, processing skills do the work. Output formats implement a [5-file adapter contract](#output-formats), so planning works identically regardless of where tasks end up. 17 specialized agents handle isolated concerns in parallel. The result is a natural language workflow that's modular, extensible, and maintainable.
 
 > [!NOTE]
 > **Work in progress.** The workflow is being refined through real-world usage. Expect updates as patterns evolve.
@@ -61,48 +67,23 @@ If you prefer to jump straight in:
 - `/start-epic` — multi-topic work spanning multiple sessions
 - `/start-bugfix` — fix broken behavior with investigation-first pipeline
 
-### The Workflow
+### The Phases
 
-```
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│   Research    │──▶│  Discussion   │──▶│ Specification │
-│   (Phase 1)   │   │   (Phase 2)   │   │   (Phase 3)   │
-├───────────────┤   ├───────────────┤   ├───────────────┤
-│ EXPLORING     │   │ WHAT & WHY    │   │ REFINING      │
-│               │   │               │   │               │
-│ • Ideas       │   │ • Architecture│   │ • Validate    │
-│ • Market      │   │ • Decisions   │   │ • Filter      │
-│ • Viability   │   │ • Edge cases  │   │ • Enrich      │
-│               │   │ • Rationale   │   │ • Standalone  │
-└───────────────┘   └───────────────┘   └───────────────┘
-                                                │
-                                                ▼
-┌───────────────┐   ┌───────────────┐   ┌───────────────┐
-│    Review     │◀──│Implementation │◀──│   Planning    │
-│   (Phase 6)   │   │   (Phase 5)   │   │   (Phase 4)   │
-├───────────────┤   ├───────────────┤   ├───────────────┤
-│ VALIDATING    │   │ DOING         │   │ HOW           │
-│               │   │               │   │               │
-│ • Plan check  │   │ • Tests first │   │ • Phases      │
-│ • Specs check │   │ • Then code   │   │ • Tasks       │
-│ • Test quality│   │ • Commit often│   │ • Criteria    │
-│ • Code quality│   │ • Task gates  │   │ • Outputs     │
-└───────────────┘   └───────────────┘   └───────────────┘
-```
+Each phase produces artifacts that feed the next. Here's what each phase does and why it exists:
 
-Each phase produces documents that feed the next. Here's the journey:
+**Research** — Free-form exploration. Investigate ideas, market fit, technical feasibility, business viability. The output is a research document capturing everything you've explored. When you move to discussion, the system analyses this document and breaks it into focused topics automatically. *(Epic always, feature optionally, bugfix never.)*
 
-**Research** — Free-form exploration. Investigate ideas, market fit, technical feasibility, business viability. The output is a research document capturing everything you've explored. The key benefit: when you move to discussion, the skill analyses this document and breaks it into focused topics automatically.
+**Discussion** — Per-topic deep dives into architecture, edge cases, competing approaches, and rationale. Each topic gets its own document. This captures not just decisions, but *why* you made them — the alternatives considered, the trade-offs weighed, the journey to the decision. *(Epic and feature.)*
 
-**Discussion** — Per-topic deep dives into architecture, edge cases, competing approaches, and rationale. Each topic gets its own document. This captures not just decisions, but *why* you made them — the alternatives considered, the trade-offs weighed, the journey to the decision. Conclude each topic when its decisions are made.
+**Investigation** — The bugfix alternative to discussion. Structured symptom gathering (environment, reproduction steps, expected vs actual behavior) combined with code analysis (scope, impact, patterns) to identify root cause. *(Bugfix only.)*
 
-**Specification** — This is where the magic happens. The skill analyses *all* your discussions and creates intelligent groupings — 10 discussions might become 3–5 specifications, or you can unify everything into one. It filters hallucinations, enriches gaps, and validates decisions against each other. The spec becomes the golden document: planning only references this, not earlier phases.
+**Specification** — Where the magic happens. The system analyses *all* your discussions (or investigation) and creates intelligent groupings — 10 discussions might become 3–5 specifications, or you can unify everything into one. It filters hallucinations, enriches gaps, and validates decisions against each other. The spec becomes the golden document: planning only references this, not earlier phases. *(All work types.)*
 
-**Planning** — Converts each specification into phased implementation plans with tasks, acceptance criteria, and dependency ordering. Supports [multiple output formats](#output-formats) — from local markdown files to CLI tools with native dependency graphs. Task authoring has per-item approval gates (with auto-mode for faster flow).
+**Planning** — Converts each specification into phased implementation plans with tasks, acceptance criteria, and dependency ordering. Supports [multiple output formats](#output-formats). Task authoring has per-item approval gates (with auto-mode for faster flow). *(All work types.)*
 
-**Implementation** — Executes plans via strict TDD. Tests first, then code, commit after each task. Per-task approval gates keep you in control, with auto-mode available when you trust the flow.
+**Implementation** — Executes plans via strict TDD. Tests first, then code, commit after each task. Per-task approval gates keep you in control, with auto-mode available when you trust the flow. Post-implementation analysis agents check architecture conformance, duplication, and coding standards — findings become remediation tasks. *(All work types.)*
 
-**Review** — Validates the implementation against spec and plan. Catches drift, missing requirements, and quality issues. Findings can be synthesized into remediation tasks that feed back into implementation, closing the review-implementation loop.
+**Review** — Validates the implementation against spec and plan. Parallel subagents verify each task independently. Catches drift, missing requirements, and quality issues. Findings can be synthesized into remediation tasks that feed back into implementation, closing the review-implementation loop. *(All work types.)*
 
 ### How It Fits Together
 
@@ -129,9 +110,10 @@ Each phase produces documents that feed the next. Here's the journey:
             ┌─────────────────────────────────────────────┐
             │          Processing Skills (do work)        │
             │                                             │
-            │  research → discussion → specification      │
-            │          → planning → implementation        │
-            │                    → review                 │
+            │  research ─┐                                │
+            │  discussion ├─▶ specification → planning    │
+            │  investigation┘        → implementation     │
+            │                              → review       │
             └──────────────────┬──────────────────────────┘
                                │
                                ▼
@@ -151,6 +133,26 @@ Each phase produces documents that feed the next. Here's the journey:
 
 **Workflow bridge** connects phases automatically. After each phase completes, it clears context and advances to the next phase. You approve each transition with "clear context and continue" — this keeps each phase in a clean context window.
 
+### Work Types in Detail
+
+#### Epic — Multi-Topic, Multi-Session
+
+Epics are phase-centric: topics move independently within each phase. Research produces a single document; the system analyses it to derive discussion topics. Discussions are grouped into specifications (many-to-many: 10 discussions might become 3–5 specs). Each spec is planned and implemented independently.
+
+**Soft gates** provide advisory warnings when navigating between phases if prerequisite items are still in-progress (e.g., discussions not yet complete when entering specification). These are informational, not blocking — proceed anyway and the system recovers via re-analysis.
+
+**Cross-topic dependencies** can be linked via `/link-dependencies` when plans reference work from other topics.
+
+#### Feature — Single Topic, Linear Pipeline
+
+A feature creates one topic that moves through every phase. Research is optional (gated at the start — skip it if you know what you're building). The topic name equals the work unit name throughout.
+
+**Feature-to-epic pivot:** If a feature grows beyond its original scope, convert it to an epic via the manage menu in `/workflow-start`. All existing progress is preserved — continue immediately as an epic to add new topics.
+
+#### Bugfix — Investigation-First
+
+Bugfixes replace discussion with investigation. The investigation phase combines structured symptom gathering with code analysis to identify the root cause. From specification onward, the pipeline is identical to feature.
+
 ### Work Unit Lifecycle
 
 Work units move through a simple lifecycle: **in-progress** → **completed** or **cancelled**.
@@ -160,8 +162,6 @@ Work units move through a simple lifecycle: **in-progress** → **completed** or
 - Completed and cancelled work units can be **reactivated** back to in-progress
 
 Feature and bugfix pipelines offer an early completion option after implementation (skip review). Epic work units are completed when all topics have finished review.
-
-**Feature-to-epic pivot:** If a feature grows beyond its original scope, convert it to an epic via the manage menu. All existing progress is preserved. After pivoting, continue immediately as an epic to add new topics.
 
 ### Output Formats
 
@@ -256,6 +256,9 @@ skills/
 ├── start-epic/                      # Pipeline: multi-topic, multi-session workflow
 ├── start-feature/                   # Pipeline: discussion → spec → plan → impl → review
 ├── start-bugfix/                    # Pipeline: investigation → spec → plan → impl → review
+├── continue-feature/                # Resume in-progress feature with phase routing
+├── continue-bugfix/                 # Resume in-progress bugfix with phase routing
+├── continue-epic/                   # Resume in-progress epic with full state display
 ├── link-dependencies/               # Wire cross-topic dependencies
 ├── status/                          # Show workflow status
 ├── view-plan/                       # View plan tasks
@@ -270,16 +273,30 @@ skills/
 └── workflow-review-entry/           # Review phase — validate impl + invoke
 
 agents/
-├── review-task-verifier.md           # Verifies single task implementation for review
-├── review-findings-synthesizer.md   # Synthesizes review findings into remediation tasks
-├── implementation-task-executor.md  # TDD executor for single plan tasks
-├── implementation-task-reviewer.md  # Post-task review for spec conformance
+├── # Planning (6 agents)
 ├── planning-phase-designer.md       # Design phases from specification
 ├── planning-task-designer.md        # Break phases into task lists
 ├── planning-task-author.md          # Write full task detail
 ├── planning-dependency-grapher.md   # Analyze task dependencies and priorities
 ├── planning-review-traceability.md  # Spec-to-plan traceability analysis
-└── planning-review-integrity.md     # Plan structural quality review
+├── planning-review-integrity.md     # Plan structural quality review
+│
+├── # Specification (2 agents)
+├── specification-review-input.md    # Review spec against source material
+├── specification-review-gap-analysis.md # Standalone spec gap analysis
+│
+├── # Implementation (7 agents)
+├── implementation-task-executor.md   # TDD executor for single plan tasks
+├── implementation-task-reviewer.md   # Post-task review for spec conformance
+├── implementation-analysis-architecture.md # Architecture conformance analysis
+├── implementation-analysis-duplication.md  # Duplication and DRY analysis
+├── implementation-analysis-standards.md    # Coding standards analysis
+├── implementation-analysis-synthesizer.md  # Synthesize analysis findings
+├── implementation-analysis-task-writer.md  # Write tasks from analysis findings
+│
+├── # Review (2 agents)
+├── review-task-verifier.md           # Verifies single task implementation
+└── review-findings-synthesizer.md    # Synthesizes findings into remediation tasks
 
 tests/
 └── scripts/                         # Tests for discovery scripts and migrations
@@ -291,19 +308,51 @@ tests/
 
 Processing skills assume pipeline context — work_type is set, prior phases are complete, artifacts are in expected locations. Phase entry skills validate and provide all required inputs before invoking them.
 
-| Skill                                                            | Description                                                                                                                                                                                                  |
-|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [**workflow-research-process**](skills/workflow-research-process/)             | Explore ideas from their earliest seed. Investigate market fit, technical feasibility, business viability. Free-flowing exploration across technical, business, and market domains.                          |
-| [**workflow-discussion-process**](skills/workflow-discussion-process/)         | Document technical discussions as expert architect and meeting assistant. Captures context, decisions, edge cases, competing solutions, debates, and rationale.                                              |
-| [**workflow-investigation-process**](skills/workflow-investigation-process/)   | Investigate bugs through symptom gathering and code analysis. Combines context collection with root cause identification for the bugfix pipeline.                                                            |
-| [**workflow-specification-process**](skills/workflow-specification-process/)   | Build validated specifications from source material through collaborative refinement. Filters hallucinations, enriches gaps, produces standalone spec.                                                       |
-| [**workflow-planning-process**](skills/workflow-planning-process/)             | Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats.                                                                 |
-| [**workflow-implementation-process**](skills/workflow-implementation-process/) | Execute implementation plans using strict TDD workflow. Writes tests first, implements to pass, commits frequently, and gates phases on user approval.                                                       |
-| [**workflow-review-process**](skills/workflow-review-process/)                 | Review completed implementation against specification requirements and plan acceptance criteria. Uses parallel subagents for efficient chain verification. Produces structured feedback without fixing code. |
+| Skill | Description |
+|-------|-------------|
+| [**workflow-research-process**](skills/workflow-research-process/) | Explore ideas from their earliest seed. Investigate market fit, technical feasibility, business viability. Free-flowing exploration across technical, business, and market domains. |
+| [**workflow-discussion-process**](skills/workflow-discussion-process/) | Document technical discussions as expert architect and meeting assistant. Captures context, decisions, edge cases, competing solutions, debates, and rationale. |
+| [**workflow-investigation-process**](skills/workflow-investigation-process/) | Investigate bugs through symptom gathering and code analysis. Combines context collection with root cause identification for the bugfix pipeline. |
+| [**workflow-specification-process**](skills/workflow-specification-process/) | Build validated specifications from source material through collaborative refinement. Filters hallucinations, enriches gaps, produces standalone spec. |
+| [**workflow-planning-process**](skills/workflow-planning-process/) | Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats. |
+| [**workflow-implementation-process**](skills/workflow-implementation-process/) | Execute implementation plans using strict TDD workflow. Writes tests first, implements to pass, commits frequently, and gates phases on user approval. |
+| [**workflow-review-process**](skills/workflow-review-process/) | Review completed implementation against specification requirements and plan acceptance criteria. Uses parallel subagents for efficient chain verification. Produces structured feedback without fixing code. |
 
 ### Entry-Point Skills
 
 Entry-point skills are the input layer: they gather context and pass it to processing skills.
+
+#### Start Skills
+
+Create new work units and pipeline through every phase automatically.
+
+| Skill | Description |
+|-------|-------------|
+| [**/start-feature**](skills/start-feature/) | Start a new feature through the full pipeline. Gathers context, creates a discussion, then bridges through specification → planning → implementation → review. |
+| [**/start-epic**](skills/start-epic/) | Start an epic — multi-topic, multi-session workflow. Gathers context, routes to research or discussion, then progresses phase by phase. |
+| [**/start-bugfix**](skills/start-bugfix/) | Start a bugfix through the pipeline. Gathers bug context, creates an investigation, then bridges through specification → planning → implementation → review. |
+
+#### Continue Skills
+
+Resume in-progress work with phase routing, backwards navigation, and lifecycle management.
+
+| Skill | Description |
+|-------|-------------|
+| [**/workflow-start**](skills/workflow-start/) | Unified dashboard — shows all active work, routes to start or continue skills, manages lifecycle (view completed/cancelled, mark done, pivot). |
+| [**/continue-feature**](skills/continue-feature/) | Resume an in-progress feature. Shows current phase state, routes to the next phase, and offers backwards navigation to revisit earlier phases. |
+| [**/continue-epic**](skills/continue-epic/) | Resume an in-progress epic. Full state display across all phases, interactive menu, and advisory soft gates for phase-forward navigation. |
+| [**/continue-bugfix**](skills/continue-bugfix/) | Resume an in-progress bugfix. Shows current phase state, routes to the next phase, and offers backwards navigation. |
+
+#### Utility Skills
+
+Helpers for navigating and maintaining the workflow.
+
+| Skill | Description |
+|-------|-------------|
+| [**/migrate**](skills/migrate/) | Keep workflow files in sync with the current system design. Runs automatically at the start of every workflow skill. |
+| [**/status**](skills/status/) | Show workflow status with relationship-aware display — specification sources, unlinked discussions, plan dependencies, and suggested next steps. |
+| [**/view-plan**](skills/view-plan/) | View a plan's tasks and progress, regardless of output format. |
+| [**/link-dependencies**](skills/link-dependencies/) | Link external dependencies across topics. Scans plans and wires up unresolved cross-topic dependencies. |
 
 #### Phase Entry Skills (Internal)
 
@@ -319,60 +368,45 @@ Phase entry skills are invoked automatically by start/continue/bridge skills. Th
 | **workflow-implementation-entry** | Implementation phase — validate plan, check deps/env + invoke |
 | **workflow-review-entry** | Review phase — validate impl, determine version + invoke |
 
-#### Utility Skills
-
-Helpers for navigating and maintaining the workflow.
-
-| Skill                                                                        | Description                                                                                                                                 |
-|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| [**/migrate**](skills/migrate/)                                              | Keep workflow files in sync with the current system design. Runs automatically at the start of every workflow skill.                        |
-| [**/status**](skills/status/)                                                | Show workflow status with relationship-aware display — specification sources, unlinked discussions, plan dependencies, and suggested next steps. |
-| [**/view-plan**](skills/view-plan/)                                          | View a plan's tasks and progress, regardless of output format.                                                                              |
-
-#### Start Skills
-
-Create new work units and pipeline through every phase automatically.
-
-| Skill                                                   | Description                                                                                                                                 |
-|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| [**/start-feature**](skills/start-feature/)              | Start a new feature through the full pipeline. Gathers context, creates a discussion, then bridges through specification → planning → implementation → review. |
-| [**/start-epic**](skills/start-epic/)                    | Start an epic — multi-topic, multi-session workflow. Gathers context, routes to research or discussion, then progresses phase by phase. |
-| [**/start-bugfix**](skills/start-bugfix/)                | Start a bugfix through the pipeline. Gathers bug context, creates an investigation, then bridges through specification → planning → implementation → review. |
-
-#### Continue Skills
-
-Resume in-progress work with phase routing, backwards navigation, and lifecycle management.
-
-| Skill                                                   | Description                                                                                                                                 |
-|---------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| [**/workflow-start**](skills/workflow-start/)             | Unified dashboard — shows all active work, routes to start or continue skills, manages lifecycle (view completed/cancelled, mark done). |
-| [**/continue-feature**](skills/continue-feature/)        | Resume an in-progress feature. Shows current phase state, routes to the next phase, and offers backwards navigation to revisit earlier phases. |
-| [**/continue-epic**](skills/continue-epic/)              | Resume an in-progress epic. Full state display across all phases, interactive menu, and advisory soft gates for phase-forward navigation. |
-| [**/continue-bugfix**](skills/continue-bugfix/)          | Resume an in-progress bugfix. Shows current phase state, routes to the next phase, and offers backwards navigation. |
-| [**/link-dependencies**](skills/link-dependencies/)      | Link external dependencies across topics. Scans plans and wires up unresolved cross-topic dependencies.                                    |
-
 ## Agents
 
 Subagents that skills can spawn for parallel task execution.
 
+### Planning Agents
+
 | Agent | Used By | Description |
 |-------|---------|-------------|
-| [**review-task-verifier**](agents/review-task-verifier.md) | workflow-review-process | Verifies a single plan task was implemented correctly. Checks implementation, tests, and code quality. Multiple run in parallel. |
-| [**implementation-task-executor**](agents/implementation-task-executor.md) | workflow-implementation-process | Implements a single plan task via strict TDD. |
-| [**implementation-task-reviewer**](agents/implementation-task-reviewer.md) | workflow-implementation-process | Reviews a completed task for spec conformance, acceptance criteria, and architectural quality. |
 | [**planning-phase-designer**](agents/planning-phase-designer.md) | workflow-planning-process | Designs implementation phases from a specification. |
 | [**planning-task-designer**](agents/planning-task-designer.md) | workflow-planning-process | Breaks a single phase into a task list with edge cases. |
 | [**planning-task-author**](agents/planning-task-author.md) | workflow-planning-process | Writes full detail for a single plan task. |
 | [**planning-dependency-grapher**](agents/planning-dependency-grapher.md) | workflow-planning-process | Analyzes authored tasks to establish internal dependencies and priorities. |
 | [**planning-review-traceability**](agents/planning-review-traceability.md) | workflow-planning-process | Spec-to-plan traceability analysis. |
 | [**planning-review-integrity**](agents/planning-review-integrity.md) | workflow-planning-process | Plan structural quality review. |
+
+### Specification Agents
+
+| Agent | Used By | Description |
+|-------|---------|-------------|
 | [**specification-review-input**](agents/specification-review-input.md) | workflow-specification-process | Reviews specification against source material for completeness and accuracy. |
 | [**specification-review-gap-analysis**](agents/specification-review-gap-analysis.md) | workflow-specification-process | Analyses specification as a standalone document for gaps, ambiguity, and missing detail. |
+
+### Implementation Agents
+
+| Agent | Used By | Description |
+|-------|---------|-------------|
+| [**implementation-task-executor**](agents/implementation-task-executor.md) | workflow-implementation-process | Implements a single plan task via strict TDD. |
+| [**implementation-task-reviewer**](agents/implementation-task-reviewer.md) | workflow-implementation-process | Reviews a completed task for spec conformance, acceptance criteria, and architectural quality. |
 | [**implementation-analysis-architecture**](agents/implementation-analysis-architecture.md) | workflow-implementation-process | Architecture conformance analysis of completed implementation. |
 | [**implementation-analysis-duplication**](agents/implementation-analysis-duplication.md) | workflow-implementation-process | Duplication and DRY analysis of completed implementation. |
 | [**implementation-analysis-standards**](agents/implementation-analysis-standards.md) | workflow-implementation-process | Coding standards analysis of completed implementation. |
 | [**implementation-analysis-synthesizer**](agents/implementation-analysis-synthesizer.md) | workflow-implementation-process | Synthesizes analysis findings from architecture, duplication, and standards agents. |
 | [**implementation-analysis-task-writer**](agents/implementation-analysis-task-writer.md) | workflow-implementation-process | Writes remediation tasks from synthesized analysis findings into the plan. |
+
+### Review Agents
+
+| Agent | Used By | Description |
+|-------|---------|-------------|
+| [**review-task-verifier**](agents/review-task-verifier.md) | workflow-review-process | Verifies a single plan task was implemented correctly. Checks implementation, tests, and code quality. Multiple run in parallel. |
 | [**review-findings-synthesizer**](agents/review-findings-synthesizer.md) | workflow-review-process | Synthesizes review findings into normalized remediation tasks for plan integration. |
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 <p align="center">
   <a href="#what-is-this">What is this?</a> •
-  <a href="#how-do-i-use-it">How to Use</a> •
-  <a href="#installation">Installation</a> •
-  <a href="#skills">Skills</a> •
-  <a href="#contributing">Contributing</a>
+  <a href="#getting-started">Getting Started</a> •
+  <a href="#the-workflow">The Workflow</a> •
+  <a href="#key-features">Key Features</a> •
+  <a href="#skills-reference">Skills Reference</a>
 </p>
 
 ---
@@ -18,170 +18,35 @@
   <a href="https://leeovery.github.io/claude-technical-workflows/"><strong>Open the Interactive Workflow Explorer</strong></a>
 </p>
 
-> **Workflow Explorer** — A visual, interactive guide to every phase and skill in this toolkit. Trace decision logic through flowcharts and understand the full pipeline at a glance. No install required — runs in your browser.
+> **Workflow Explorer** — A visual, interactive guide to every phase and skill in this toolkit. Trace decision logic through flowcharts and understand the full pipeline at a glance.
 
 ---
 
 ## What is this?
 
-A complete development workflow for Claude Code: explore ideas, capture decisions, build actionable plans, implement via strict TDD, and validate the result.
+A structured development workflow for Claude Code that turns conversations into working software. Instead of jumping straight to code, you discuss the *what* and *why* first — then the system builds specifications, plans implementation, writes code via strict TDD, and validates the result.
 
-**Three work types, each with its own pipeline:**
+**What you get:**
 
-```
-Epic:    Research → Discussion → Specification → Planning → Implementation → Review
-Feature:           Discussion → Specification → Planning → Implementation → Review
-Bugfix:          Investigation → Specification → Planning → Implementation → Review
-```
-
-**Epics** are for multi-topic work spanning multiple sessions — new products, large initiatives, architectural overhauls. Topics move independently within phases: 10 discussions might yield 5 specifications, each planned and implemented separately.
-
-**Features** are for adding functionality to an existing product. Single topic, linear pipeline. Optional research step if uncertainties exist.
-
-**Bugfixes** are for fixing broken behavior. Investigation replaces discussion — it combines symptom gathering with code analysis to identify the root cause before specifying the fix.
-
-**Why this matters:** Complex work benefits from thorough discussion before implementation. This toolkit documents the *what* and *why* before diving into the *how*, preserving architectural decisions, edge cases, and the reasoning behind choices that would otherwise be lost.
-
-**Engineered like software.** This isn't a collection of prompts — it's built with the same discipline you'd apply to code. Entry-point skills gather context, phase entry skills validate and route, processing skills do the work. Output formats implement a [5-file adapter contract](#output-formats), so planning works identically regardless of where tasks end up. 17 specialized agents handle isolated concerns in parallel. The result is a natural language workflow that's modular, extensible, and maintainable.
+- **Decisions that stick.** Architecture choices, edge cases, and trade-offs are captured in discussion documents — not lost to chat history. When you come back in a week, the context is there.
+- **Specifications that catch mistakes early.** The system analyses your discussions, filters hallucinations, fills gaps, and produces a validated spec before any code is written.
+- **Plans with real structure.** Specifications become phased implementation plans with tasks, acceptance criteria, and dependency ordering. Choose where tasks live — [local markdown files, Linear issues, or Tick CLI](#output-formats).
+- **Implementation via strict TDD.** Tests first, then code, commit after each task. Per-task approval gates keep you in control, or switch to auto-mode when you trust the flow.
+- **Built-in quality checks.** Post-implementation analysis checks architecture conformance, duplication, and coding standards. Review validates against spec and plan. Findings become remediation tasks automatically.
+- **Context that survives.** Each phase clears the context window and starts fresh, so you're never fighting token limits on large work. State lives in a manifest, not in conversation history.
 
 > [!NOTE]
 > **Work in progress.** The workflow is being refined through real-world usage. Expect updates as patterns evolve.
 
-### Quick Install
+## Getting Started
+
+### Install
 
 ```bash
 npx agntc add leeovery/claude-technical-workflows
 ```
 
-See [Installation](#installation) for details.
-
-## How do I use it?
-
-### Where to Start
-
-Run `/workflow-start`. It shows all active work, lets you continue where you left off, or start something new. When in doubt, this is your entry point — it routes you to the right place.
-
-If you prefer to jump straight in:
-
-- `/start-feature` — single feature through the full pipeline
-- `/start-epic` — multi-topic work spanning multiple sessions
-- `/start-bugfix` — fix broken behavior with investigation-first pipeline
-
-### The Phases
-
-Each phase produces artifacts that feed the next. Here's what each phase does and why it exists:
-
-**Research** — Free-form exploration. Investigate ideas, market fit, technical feasibility, business viability. The output is a research document capturing everything you've explored. When you move to discussion, the system analyses this document and breaks it into focused topics automatically. *(Epic always, feature optionally, bugfix never.)*
-
-**Discussion** — Per-topic deep dives into architecture, edge cases, competing approaches, and rationale. Each topic gets its own document. This captures not just decisions, but *why* you made them — the alternatives considered, the trade-offs weighed, the journey to the decision. *(Epic and feature.)*
-
-**Investigation** — The bugfix alternative to discussion. Structured symptom gathering (environment, reproduction steps, expected vs actual behavior) combined with code analysis (scope, impact, patterns) to identify root cause. *(Bugfix only.)*
-
-**Specification** — Where the magic happens. The system analyses *all* your discussions (or investigation) and creates intelligent groupings — 10 discussions might become 3–5 specifications, or you can unify everything into one. It filters hallucinations, enriches gaps, and validates decisions against each other. The spec becomes the golden document: planning only references this, not earlier phases. *(All work types.)*
-
-**Planning** — Converts each specification into phased implementation plans with tasks, acceptance criteria, and dependency ordering. Supports [multiple output formats](#output-formats). Task authoring has per-item approval gates (with auto-mode for faster flow). *(All work types.)*
-
-**Implementation** — Executes plans via strict TDD. Tests first, then code, commit after each task. Per-task approval gates keep you in control, with auto-mode available when you trust the flow. Post-implementation analysis agents check architecture conformance, duplication, and coding standards — findings become remediation tasks. *(All work types.)*
-
-**Review** — Validates the implementation against spec and plan. Parallel subagents verify each task independently. Catches drift, missing requirements, and quality issues. Findings can be synthesized into remediation tasks that feed back into implementation, closing the review-implementation loop. *(All work types.)*
-
-### How It Fits Together
-
-```
-                         ┌─────────────────────────────┐
-  User                   │       /workflow-start        │
-  Entry ────────────────▶│  Dashboard — shows all work  │
-                         └──────────┬──────────────────┘
-                                    │
-                    ┌───────────────┼───────────────┐
-                    ▼               ▼               ▼
-            ┌──────────────┐ ┌────────────┐ ┌─────────────┐
-            │/start-feature│ │/start-epic │ │/start-bugfix│
-            │/cont-feature │ │/cont-epic  │ │/cont-bugfix │
-            └──────┬───────┘ └─────┬──────┘ └──────┬──────┘
-                   │               │               │
-                   ▼               ▼               ▼
-            ┌─────────────────────────────────────────────┐
-            │         Phase Entry Skills (internal)       │
-            │  workflow-*-entry — validate + bootstrap     │
-            └──────────────────┬──────────────────────────┘
-                               │
-                               ▼
-            ┌─────────────────────────────────────────────┐
-            │          Processing Skills (do work)        │
-            │                                             │
-            │  research ─┐                                │
-            │  discussion ├─▶ specification → planning    │
-            │  investigation┘        → implementation     │
-            │                              → review       │
-            └──────────────────┬──────────────────────────┘
-                               │
-                               ▼
-            ┌─────────────────────────────────────────────┐
-            │         workflow-bridge (automatic)          │
-            │  Clears context, advances to next phase     │
-            └─────────────────────────────────────────────┘
-```
-
-**`/workflow-start`** is the main entry point. It discovers all active work, shows a dashboard, and routes to the right skill — whether that's starting something new or continuing where you left off. When in doubt, start here.
-
-**Start skills** (`/start-feature`, `/start-epic`, `/start-bugfix`) create new work units and gather initial context. **Continue skills** (`/continue-feature`, `/continue-epic`, `/continue-bugfix`) resume in-progress work with phase routing and backwards navigation.
-
-**Phase entry skills** (`workflow-*-entry`) are internal — invoked automatically to validate pipeline state and bootstrap each phase. You never call them directly.
-
-**Processing skills** (`workflow-*-process`) do the actual work for each phase. They assume pipeline context — prior phases are complete, artifacts are in expected locations.
-
-**Workflow bridge** connects phases automatically. After each phase completes, it clears context and advances to the next phase. You approve each transition with "clear context and continue" — this keeps each phase in a clean context window.
-
-### Work Types in Detail
-
-#### Epic — Multi-Topic, Multi-Session
-
-Epics are phase-centric: topics move independently within each phase. Research produces a single document; the system analyses it to derive discussion topics. Discussions are grouped into specifications (many-to-many: 10 discussions might become 3–5 specs). Each spec is planned and implemented independently.
-
-**Soft gates** provide advisory warnings when navigating between phases if prerequisite items are still in-progress (e.g., discussions not yet complete when entering specification). These are informational, not blocking — proceed anyway and the system recovers via re-analysis.
-
-**Cross-topic dependencies** can be linked via `/link-dependencies` when plans reference work from other topics.
-
-#### Feature — Single Topic, Linear Pipeline
-
-A feature creates one topic that moves through every phase. Research is optional (gated at the start — skip it if you know what you're building). The topic name equals the work unit name throughout.
-
-**Feature-to-epic pivot:** If a feature grows beyond its original scope, convert it to an epic via the manage menu in `/workflow-start`. All existing progress is preserved — continue immediately as an epic to add new topics.
-
-#### Bugfix — Investigation-First
-
-Bugfixes replace discussion with investigation. The investigation phase combines structured symptom gathering with code analysis to identify the root cause. From specification onward, the pipeline is identical to feature.
-
-### Work Unit Lifecycle
-
-Work units move through a simple lifecycle: **in-progress** → **completed** or **cancelled**.
-
-- **Completed** is set automatically when the pipeline finishes (review phase ends), or manually via the manage menu in `/workflow-start`
-- **Cancelled** is set manually for abandoned work
-- Completed and cancelled work units can be **reactivated** back to in-progress
-
-Feature and bugfix pipelines offer an early completion option after implementation (skip review). Epic work units are completed when all topics have finished review.
-
-### Output Formats
-
-Planning supports multiple output formats through an adapter pattern. Each format implements a 5-file contract — about, authoring, reading, updating, and graph — so the planning workflow works identically regardless of where tasks are stored.
-
-| Format | Best for | Setup | |
-|--------|----------|-------|-|
-| **Tick** | AI-driven workflows, native dependencies, token-efficient | `brew install leeovery/tools/tick` | Recommended |
-| **Local Markdown** | Simple features, offline, quick iterations | None | |
-| **Linear** | Team collaboration, visual tracking | Linear account + MCP server | |
-
-Choose a format when planning begins. New formats can be scaffolded with `/create-output-format`.
-
-## Installation
-
-```bash
-npx agntc add leeovery/claude-technical-workflows
-```
-
-Skills are copied to `.claude/` in your project and can be committed, giving you ownership and making them available everywhere including Claude Code for Web.
+Skills are copied to `.claude/` in your project. Commit them to make them available everywhere, including Claude Code for Web.
 
 <details>
 <summary>Removal</summary>
@@ -191,244 +56,134 @@ npx agntc remove leeovery/claude-technical-workflows
 ```
 </details>
 
-## Project Structure
-
-### Output Files
-
-Documents are stored in your project using a **work-unit-first** organisation. Each work unit (epic, feature, or bugfix) gets its own directory with phase subdirectories. A `manifest.json` in each work unit is the single source of truth for all workflow state — including the work unit's lifecycle status (`in-progress`, `completed`, `cancelled`) and per-phase progress.
-
-```
-.workflows/
-  {work_unit}/                           # One directory per work unit
-    manifest.json                        #   Single source of truth for state
-    .state/                              #   Per-work-unit analysis files
-      research-analysis.md
-    research/                            #   Flat, semantically named files
-      exploration.md
-    discussion/                          #   {topic}.md flat files
-      {topic}.md
-    investigation/                       #   {topic}.md flat files (bugfix)
-      {topic}.md
-    specification/
-      {topic}/
-        specification.md                 #   Spec + review tracking files
-    planning/
-      {topic}/
-        planning.md                      #   Plan index (phases, metadata)
-        tasks/                           #   Task files (local-markdown format)
-          {topic}-1-1.md
-    implementation/
-      {topic}/
-        implementation.md                #   Progress, gates, current task
-    review/
-      {topic}/
-        report.md                        #   Review summary and verdict
-        report-{phase_id}-{task_id}.md   #   Per-task verification report
-  .state/                                # Global state (migrations, env setup)
-  .cache/                                # Ephemeral (planning scratch)
-```
-
-For feature/bugfix, `{topic}` equals `{work_unit}`. For epic, `{topic}` is the item within a phase (e.g., `payment-processing` within the `payments-overhaul` epic).
-
-Each work unit starts with just a manifest. Phase directories are created as you enter each phase. Planning task storage varies by [output format](#output-formats) -- the tree above shows local-markdown; Tick and Linear store tasks externally.
-
-### Package Structure
-
-```
-skills/
-├── # Processing skills (model-invocable)
-├── workflow-research-process/              # Explore and validate ideas
-├── workflow-discussion-process/            # Document discussions
-├── workflow-investigation-process/         # Investigate bugs (bugfix pipeline)
-├── workflow-specification-process/         # Build validated specifications
-├── workflow-planning-process/              # Create implementation plans
-├── workflow-implementation-process/        # Execute via TDD
-├── workflow-review-process/                # Validate against artefacts
-│
-├── # Unified entry points
-├── workflow-start/                  # Discovers state, routes by work type + lifecycle management
-├── workflow-bridge/                 # Pipeline continuation — next phase routing
-├── workflow-shared/                 # Shared discovery utilities
-├── workflow-manifest/               # Manifest CLI — single source of truth for state
-│
-├── # Entry-point skills (user-invocable)
-├── migrate/                         # Keep workflow files in sync with system design
-├── start-epic/                      # Pipeline: multi-topic, multi-session workflow
-├── start-feature/                   # Pipeline: discussion → spec → plan → impl → review
-├── start-bugfix/                    # Pipeline: investigation → spec → plan → impl → review
-├── continue-feature/                # Resume in-progress feature with phase routing
-├── continue-bugfix/                 # Resume in-progress bugfix with phase routing
-├── continue-epic/                   # Resume in-progress epic with full state display
-├── link-dependencies/               # Wire cross-topic dependencies
-├── status/                          # Show workflow status
-├── view-plan/                       # View plan tasks
-│
-├── # Phase entry skills (internal — invoked by start/continue/bridge)
-├── workflow-research-entry/         # Research phase bootstrap + invoke
-├── workflow-discussion-entry/       # Discussion phase — scoped epic path or bridge
-├── workflow-investigation-entry/    # Investigation phase bootstrap + invoke
-├── workflow-specification-entry/    # Specification phase — scoped epic path or bridge
-├── workflow-planning-entry/         # Planning phase — validate spec + invoke
-├── workflow-implementation-entry/   # Implementation phase — validate plan + invoke
-└── workflow-review-entry/           # Review phase — validate impl + invoke
-
-agents/
-├── # Planning (6 agents)
-├── planning-phase-designer.md       # Design phases from specification
-├── planning-task-designer.md        # Break phases into task lists
-├── planning-task-author.md          # Write full task detail
-├── planning-dependency-grapher.md   # Analyze task dependencies and priorities
-├── planning-review-traceability.md  # Spec-to-plan traceability analysis
-├── planning-review-integrity.md     # Plan structural quality review
-│
-├── # Specification (2 agents)
-├── specification-review-input.md    # Review spec against source material
-├── specification-review-gap-analysis.md # Standalone spec gap analysis
-│
-├── # Implementation (7 agents)
-├── implementation-task-executor.md   # TDD executor for single plan tasks
-├── implementation-task-reviewer.md   # Post-task review for spec conformance
-├── implementation-analysis-architecture.md # Architecture conformance analysis
-├── implementation-analysis-duplication.md  # Duplication and DRY analysis
-├── implementation-analysis-standards.md    # Coding standards analysis
-├── implementation-analysis-synthesizer.md  # Synthesize analysis findings
-├── implementation-analysis-task-writer.md  # Write tasks from analysis findings
-│
-├── # Review (2 agents)
-├── review-task-verifier.md           # Verifies single task implementation
-└── review-findings-synthesizer.md    # Synthesizes findings into remediation tasks
-
-tests/
-└── scripts/                         # Tests for discovery scripts and migrations
-```
-
-## Skills
-
-### Processing Skills
-
-Processing skills assume pipeline context — work_type is set, prior phases are complete, artifacts are in expected locations. Phase entry skills validate and provide all required inputs before invoking them.
-
-| Skill | Description |
-|-------|-------------|
-| [**workflow-research-process**](skills/workflow-research-process/) | Explore ideas from their earliest seed. Investigate market fit, technical feasibility, business viability. Free-flowing exploration across technical, business, and market domains. |
-| [**workflow-discussion-process**](skills/workflow-discussion-process/) | Document technical discussions as expert architect and meeting assistant. Captures context, decisions, edge cases, competing solutions, debates, and rationale. |
-| [**workflow-investigation-process**](skills/workflow-investigation-process/) | Investigate bugs through symptom gathering and code analysis. Combines context collection with root cause identification for the bugfix pipeline. |
-| [**workflow-specification-process**](skills/workflow-specification-process/) | Build validated specifications from source material through collaborative refinement. Filters hallucinations, enriches gaps, produces standalone spec. |
-| [**workflow-planning-process**](skills/workflow-planning-process/) | Transform specifications into actionable implementation plans with phases, tasks, and acceptance criteria. Supports multiple output formats. |
-| [**workflow-implementation-process**](skills/workflow-implementation-process/) | Execute implementation plans using strict TDD workflow. Writes tests first, implements to pass, commits frequently, and gates phases on user approval. |
-| [**workflow-review-process**](skills/workflow-review-process/) | Review completed implementation against specification requirements and plan acceptance criteria. Uses parallel subagents for efficient chain verification. Produces structured feedback without fixing code. |
-
-### Entry-Point Skills
-
-Entry-point skills are the input layer: they gather context and pass it to processing skills.
-
-#### Start Skills
-
-Create new work units and pipeline through every phase automatically.
-
-| Skill | Description |
-|-------|-------------|
-| [**/start-feature**](skills/start-feature/) | Start a new feature through the full pipeline. Gathers context, creates a discussion, then bridges through specification → planning → implementation → review. |
-| [**/start-epic**](skills/start-epic/) | Start an epic — multi-topic, multi-session workflow. Gathers context, routes to research or discussion, then progresses phase by phase. |
-| [**/start-bugfix**](skills/start-bugfix/) | Start a bugfix through the pipeline. Gathers bug context, creates an investigation, then bridges through specification → planning → implementation → review. |
-
-#### Continue Skills
-
-Resume in-progress work with phase routing, backwards navigation, and lifecycle management.
-
-| Skill | Description |
-|-------|-------------|
-| [**/workflow-start**](skills/workflow-start/) | Unified dashboard — shows all active work, routes to start or continue skills, manages lifecycle (view completed/cancelled, mark done, pivot). |
-| [**/continue-feature**](skills/continue-feature/) | Resume an in-progress feature. Shows current phase state, routes to the next phase, and offers backwards navigation to revisit earlier phases. |
-| [**/continue-epic**](skills/continue-epic/) | Resume an in-progress epic. Full state display across all phases, interactive menu, and advisory soft gates for phase-forward navigation. |
-| [**/continue-bugfix**](skills/continue-bugfix/) | Resume an in-progress bugfix. Shows current phase state, routes to the next phase, and offers backwards navigation. |
-
-#### Utility Skills
-
-Helpers for navigating and maintaining the workflow.
-
-| Skill | Description |
-|-------|-------------|
-| [**/migrate**](skills/migrate/) | Keep workflow files in sync with the current system design. Runs automatically at the start of every workflow skill. |
-| [**/status**](skills/status/) | Show workflow status with relationship-aware display — specification sources, unlinked discussions, plan dependencies, and suggested next steps. |
-| [**/view-plan**](skills/view-plan/) | View a plan's tasks and progress, regardless of output format. |
-| [**/link-dependencies**](skills/link-dependencies/) | Link external dependencies across topics. Scans plans and wires up unresolved cross-topic dependencies. |
-
-#### Phase Entry Skills (Internal)
-
-Phase entry skills are invoked automatically by start/continue/bridge skills. They handle phase-specific validation, bootstrap questions, and processing skill invocation.
-
-| Skill | Description |
-|-------|-------------|
-| **workflow-research-entry** | Research phase bootstrap — seed questions + invoke processing skill |
-| **workflow-discussion-entry** | Discussion phase — scoped epic analysis or bridge mode context gathering |
-| **workflow-investigation-entry** | Investigation phase — bug context gathering + invoke processing skill |
-| **workflow-specification-entry** | Specification phase — scoped epic analysis flow or bridge mode validation |
-| **workflow-planning-entry** | Planning phase — validate spec, cross-cutting context + invoke |
-| **workflow-implementation-entry** | Implementation phase — validate plan, check deps/env + invoke |
-| **workflow-review-entry** | Review phase — validate impl, determine version + invoke |
-
-## Agents
-
-Subagents that skills can spawn for parallel task execution.
-
-### Planning Agents
-
-| Agent | Used By | Description |
-|-------|---------|-------------|
-| [**planning-phase-designer**](agents/planning-phase-designer.md) | workflow-planning-process | Designs implementation phases from a specification. |
-| [**planning-task-designer**](agents/planning-task-designer.md) | workflow-planning-process | Breaks a single phase into a task list with edge cases. |
-| [**planning-task-author**](agents/planning-task-author.md) | workflow-planning-process | Writes full detail for a single plan task. |
-| [**planning-dependency-grapher**](agents/planning-dependency-grapher.md) | workflow-planning-process | Analyzes authored tasks to establish internal dependencies and priorities. |
-| [**planning-review-traceability**](agents/planning-review-traceability.md) | workflow-planning-process | Spec-to-plan traceability analysis. |
-| [**planning-review-integrity**](agents/planning-review-integrity.md) | workflow-planning-process | Plan structural quality review. |
-
-### Specification Agents
-
-| Agent | Used By | Description |
-|-------|---------|-------------|
-| [**specification-review-input**](agents/specification-review-input.md) | workflow-specification-process | Reviews specification against source material for completeness and accuracy. |
-| [**specification-review-gap-analysis**](agents/specification-review-gap-analysis.md) | workflow-specification-process | Analyses specification as a standalone document for gaps, ambiguity, and missing detail. |
-
-### Implementation Agents
-
-| Agent | Used By | Description |
-|-------|---------|-------------|
-| [**implementation-task-executor**](agents/implementation-task-executor.md) | workflow-implementation-process | Implements a single plan task via strict TDD. |
-| [**implementation-task-reviewer**](agents/implementation-task-reviewer.md) | workflow-implementation-process | Reviews a completed task for spec conformance, acceptance criteria, and architectural quality. |
-| [**implementation-analysis-architecture**](agents/implementation-analysis-architecture.md) | workflow-implementation-process | Architecture conformance analysis of completed implementation. |
-| [**implementation-analysis-duplication**](agents/implementation-analysis-duplication.md) | workflow-implementation-process | Duplication and DRY analysis of completed implementation. |
-| [**implementation-analysis-standards**](agents/implementation-analysis-standards.md) | workflow-implementation-process | Coding standards analysis of completed implementation. |
-| [**implementation-analysis-synthesizer**](agents/implementation-analysis-synthesizer.md) | workflow-implementation-process | Synthesizes analysis findings from architecture, duplication, and standards agents. |
-| [**implementation-analysis-task-writer**](agents/implementation-analysis-task-writer.md) | workflow-implementation-process | Writes remediation tasks from synthesized analysis findings into the plan. |
-
-### Review Agents
-
-| Agent | Used By | Description |
-|-------|---------|-------------|
-| [**review-task-verifier**](agents/review-task-verifier.md) | workflow-review-process | Verifies a single plan task was implemented correctly. Checks implementation, tests, and code quality. Multiple run in parallel. |
-| [**review-findings-synthesizer**](agents/review-findings-synthesizer.md) | workflow-review-process | Synthesizes review findings into normalized remediation tasks for plan integration. |
-
-## Requirements
+### Requirements
 
 - Node.js 18+
 
+### Your First Workflow
+
+Run `/workflow-start` — it shows all active work, lets you continue where you left off, or start something new. When in doubt, this is your entry point.
+
+Or jump straight in:
+
+| Command | Use when... |
+|---------|-------------|
+| `/start-feature` | You're adding functionality to an existing product |
+| `/start-epic` | The work spans multiple topics and sessions |
+| `/start-bugfix` | Something is broken and needs fixing |
+
+Each command gathers context through a brief interview, then pipelines you through every phase automatically. Phase transitions clear context and start fresh — you approve each one.
+
+## The Workflow
+
+Three work types, each with its own pipeline:
+
+```
+Epic:    Research → Discussion → Specification → Planning → Implementation → Review
+Feature:           Discussion → Specification → Planning → Implementation → Review
+Bugfix:          Investigation → Specification → Planning → Implementation → Review
+```
+
+**Epics** are for large initiatives spanning multiple sessions. Topics move independently — 10 discussions might yield 5 specifications, each planned and implemented separately. Advisory soft gates warn when moving between phases if prerequisite items are still in progress.
+
+**Features** are for adding functionality. Single topic, linear pipeline. Research is optional — skip it if you know what you're building. If a feature grows beyond scope, pivot it to an epic without losing progress.
+
+**Bugfixes** replace discussion with investigation — structured symptom gathering combined with code analysis to find the root cause before specifying the fix.
+
+### The Phases
+
+| Phase | Purpose | Applies to |
+|-------|---------|------------|
+| **Research** | Explore ideas, market fit, technical feasibility. Output is analysed to derive discussion topics automatically. | Epic, Feature (optional) |
+| **Discussion** | Deep dives into architecture, edge cases, and rationale. Captures not just decisions, but *why* you made them. | Epic, Feature |
+| **Investigation** | Symptom gathering + code analysis to identify root cause. The bugfix alternative to discussion. | Bugfix |
+| **Specification** | Analyses all discussions/investigation, filters hallucinations, enriches gaps, validates decisions. The spec becomes the golden document — planning references only this. | All |
+| **Planning** | Converts specs into phased plans with tasks, acceptance criteria, and dependencies. Per-item approval gates with auto-mode. | All |
+| **Implementation** | Strict TDD — tests first, then code, commit per task. Post-implementation analysis agents check architecture, duplication, and standards. | All |
+| **Review** | Parallel subagents verify each task against spec and plan. Findings become remediation tasks that feed back into implementation. | All |
+
+### Lifecycle
+
+Work units are **in-progress**, **completed**, or **cancelled**. Completion happens automatically when the pipeline finishes, or manually via the manage menu in `/workflow-start`. Completed and cancelled work can be reactivated. Feature and bugfix pipelines offer early completion after implementation (skip review).
+
+## Key Features
+
+### 17 Specialized Agents
+
+Complex phases spawn parallel subagents for isolated concerns — planning uses 6 agents for phase design, task authoring, dependency graphing, and quality review. Implementation uses 7 for TDD execution, post-task review, and cross-cutting analysis. Specification and review each use 2 for input validation and gap analysis.
+
+### Output Formats
+
+Planning supports multiple output formats through an adapter pattern. Each format implements the same contract, so the workflow works identically regardless of where tasks are stored.
+
+| Format | Best for | Setup |
+|--------|----------|-------|
+| **Tick** (recommended) | AI-driven workflows, native dependency graphs, token-efficient | `brew install leeovery/tools/tick` |
+| **Local Markdown** | Simple features, offline, quick iterations | None |
+| **Linear** | Team collaboration, visual tracking | Linear account + MCP server |
+
+### Auto-Mode Gates
+
+Every approval gate (task authoring, implementation, review findings) can be switched to auto-mode. Choose `a`/`auto` at any gate to approve all remaining items automatically. Gates reset on fresh sessions for safety.
+
+### Cross-Topic Dependencies
+
+For epics with multiple plans, `/link-dependencies` scans for unresolved cross-topic references and wires them up.
+
+### Workflow Dashboard
+
+`/workflow-start` is a unified dashboard — view all active work, manage lifecycle (complete, cancel, reactivate), pivot features to epics, and route to the right skill.
+
+## Skills Reference
+
+<details>
+<summary><strong>Processing Skills</strong> — do the work for each phase</summary>
+
+| Skill | Description |
+|-------|-------------|
+| [workflow-research-process](skills/workflow-research-process/) | Free-form exploration across technical, business, and market domains |
+| [workflow-discussion-process](skills/workflow-discussion-process/) | Captures context, decisions, edge cases, competing solutions, and rationale |
+| [workflow-investigation-process](skills/workflow-investigation-process/) | Symptom gathering and code analysis for root cause identification |
+| [workflow-specification-process](skills/workflow-specification-process/) | Collaborative refinement into validated, standalone specifications |
+| [workflow-planning-process](skills/workflow-planning-process/) | Phased plans with tasks, acceptance criteria, and multiple output formats |
+| [workflow-implementation-process](skills/workflow-implementation-process/) | Strict TDD — tests first, implements to pass, commits frequently |
+| [workflow-review-process](skills/workflow-review-process/) | Parallel subagent verification against spec and plan |
+
+</details>
+
+<details>
+<summary><strong>Entry-Point Skills</strong> — user-facing commands</summary>
+
+**Start:** [`/start-feature`](skills/start-feature/) | [`/start-epic`](skills/start-epic/) | [`/start-bugfix`](skills/start-bugfix/)
+
+**Continue:** [`/workflow-start`](skills/workflow-start/) | [`/continue-feature`](skills/continue-feature/) | [`/continue-epic`](skills/continue-epic/) | [`/continue-bugfix`](skills/continue-bugfix/)
+
+**Utilities:** [`/status`](skills/status/) | [`/view-plan`](skills/view-plan/) | [`/link-dependencies`](skills/link-dependencies/) | [`/migrate`](skills/migrate/)
+
+</details>
+
+<details>
+<summary><strong>Agents</strong> — 17 subagents for parallel task execution</summary>
+
+**Planning:** [phase-designer](agents/planning-phase-designer.md) | [task-designer](agents/planning-task-designer.md) | [task-author](agents/planning-task-author.md) | [dependency-grapher](agents/planning-dependency-grapher.md) | [review-traceability](agents/planning-review-traceability.md) | [review-integrity](agents/planning-review-integrity.md)
+
+**Specification:** [review-input](agents/specification-review-input.md) | [review-gap-analysis](agents/specification-review-gap-analysis.md)
+
+**Implementation:** [task-executor](agents/implementation-task-executor.md) | [task-reviewer](agents/implementation-task-reviewer.md) | [analysis-architecture](agents/implementation-analysis-architecture.md) | [analysis-duplication](agents/implementation-analysis-duplication.md) | [analysis-standards](agents/implementation-analysis-standards.md) | [analysis-synthesizer](agents/implementation-analysis-synthesizer.md) | [analysis-task-writer](agents/implementation-analysis-task-writer.md)
+
+**Review:** [task-verifier](agents/review-task-verifier.md) | [findings-synthesizer](agents/review-findings-synthesizer.md)
+
+</details>
+
 ## Contributing
 
-Contributions are welcome! Whether it's:
-
-- **Bug fixes** in the documentation or skill definitions
-- **Improvements** to the workflow or templates
-- **Discussion** about approaches and trade-offs
-- **New skills** that complement the discuss-specify-plan-implement workflow
-
-Please open an issue first to discuss significant changes.
+Contributions are welcome! Whether it's bug fixes, workflow improvements, or new ideas — please open an issue first to discuss significant changes.
 
 ## Related Packages
 
-- [**Agntc**](https://github.com/leeovery/agntc) - The CLI that powers skill, agent, and hook installation
-- [**@leeovery/claude-laravel**](https://github.com/leeovery/claude-laravel) - Laravel development skills for Claude Code
-- [**@leeovery/claude-nuxt**](https://github.com/leeovery/claude-nuxt) - Nuxt.js development skills for Claude Code
+- [**Agntc**](https://github.com/leeovery/agntc) — The CLI that powers skill, agent, and hook installation
+- [**@leeovery/claude-laravel**](https://github.com/leeovery/claude-laravel) — Laravel development skills for Claude Code
+- [**@leeovery/claude-nuxt**](https://github.com/leeovery/claude-nuxt) — Nuxt.js development skills for Claude Code
 
 ## License
 

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -1063,31 +1063,31 @@
       <div class="tl-wrapper">
         <div class="tl-group"><div class="tl-dot" style="background:var(--research)"></div>
           <button class="nav-btn tl-cmd" onclick="selectPhase('research',this)" id="btn-research"><span class="name">1. Research</span><span class="badge badge-skl">skl</span></button>
-          <button class="nav-btn tl-skill" onclick="selectPhase('skill-research',this)" id="btn-skill-research"><span class="skill-label">technical-research</span><span class="badge badge-skl">skl</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-research',this)" id="btn-skill-research"><span class="skill-label">workflow-research-process</span><span class="badge badge-skl">skl</span></button>
         </div>
         <div class="tl-group"><div class="tl-dot" style="background:var(--discussion)"></div>
           <button class="nav-btn tl-cmd" onclick="selectPhase('discussion',this)" id="btn-discussion"><span class="name">2. Discussion</span><span class="badge badge-skl">skl</span></button>
-          <button class="nav-btn tl-skill" onclick="selectPhase('skill-discussion',this)" id="btn-skill-discussion"><span class="skill-label">technical-discussion</span><span class="badge badge-skl">skl</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-discussion',this)" id="btn-skill-discussion"><span class="skill-label">workflow-discussion-process</span><span class="badge badge-skl">skl</span></button>
         </div>
         <div class="tl-group"><div class="tl-dot" style="background:var(--investigation)"></div>
           <button class="nav-btn tl-cmd" onclick="selectPhase('investigation',this)" id="btn-investigation"><span class="name">3. Investigation</span><span class="badge badge-skl">skl</span></button>
-          <button class="nav-btn tl-skill" onclick="selectPhase('skill-investigation',this)" id="btn-skill-investigation"><span class="skill-label">technical-investigation</span><span class="badge badge-skl">skl</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-investigation',this)" id="btn-skill-investigation"><span class="skill-label">workflow-investigation-process</span><span class="badge badge-skl">skl</span></button>
         </div>
         <div class="tl-group"><div class="tl-dot" style="background:var(--specification)"></div>
           <button class="nav-btn tl-cmd" onclick="selectPhase('specification',this)" id="btn-specification"><span class="name">4. Specification</span><span class="badge badge-skl">skl</span></button>
-          <button class="nav-btn tl-skill" onclick="selectPhase('skill-specification',this)" id="btn-skill-specification"><span class="skill-label">technical-specification</span><span class="badge badge-skl">skl</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-specification',this)" id="btn-skill-specification"><span class="skill-label">workflow-specification-process</span><span class="badge badge-skl">skl</span></button>
         </div>
         <div class="tl-group"><div class="tl-dot" style="background:var(--planning)"></div>
           <button class="nav-btn tl-cmd" onclick="selectPhase('planning',this)" id="btn-planning"><span class="name">5. Planning</span><span class="badge badge-skl">skl</span></button>
-          <button class="nav-btn tl-skill" onclick="selectPhase('skill-planning',this)" id="btn-skill-planning"><span class="skill-label">technical-planning</span><span class="badge badge-skl">skl</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-planning',this)" id="btn-skill-planning"><span class="skill-label">workflow-planning-process</span><span class="badge badge-skl">skl</span></button>
         </div>
         <div class="tl-group"><div class="tl-dot" style="background:var(--implementation)"></div>
           <button class="nav-btn tl-cmd" onclick="selectPhase('implementation',this)" id="btn-implementation"><span class="name">6. Implementation</span><span class="badge badge-skl">skl</span></button>
-          <button class="nav-btn tl-skill" onclick="selectPhase('skill-implementation',this)" id="btn-skill-implementation"><span class="skill-label">technical-implementation</span><span class="badge badge-skl">skl</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-implementation',this)" id="btn-skill-implementation"><span class="skill-label">workflow-implementation-process</span><span class="badge badge-skl">skl</span></button>
         </div>
         <div class="tl-group"><div class="tl-dot" style="background:var(--review)"></div>
           <button class="nav-btn tl-cmd" onclick="selectPhase('review',this)" id="btn-review"><span class="name">7. Review</span><span class="badge badge-skl">skl</span></button>
-          <button class="nav-btn tl-skill" onclick="selectPhase('skill-review',this)" id="btn-skill-review"><span class="skill-label">technical-review</span><span class="badge badge-skl">skl</span></button>
+          <button class="nav-btn tl-skill" onclick="selectPhase('skill-review',this)" id="btn-skill-review"><span class="skill-label">workflow-review-process</span><span class="badge badge-skl">skl</span></button>
         </div>
       </div>
     </div>
@@ -1273,7 +1273,7 @@
             <div class="ov-phase-name">Specification</div>
             <div class="ov-phase-desc">Build validated specifications &mdash; filter hallucinations, enrich gaps</div>
             <div class="ov-badges">
-              <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-specification')"><span class="ov-badge-label">skill</span>technical-specification</span>
+              <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-specification')"><span class="ov-badge-label">skill</span>workflow-specification-process</span>
             </div>
           </div>
         </div>
@@ -1286,7 +1286,7 @@
             <div class="ov-phase-name">Planning</div>
             <div class="ov-phase-desc">Transform specs into phased plans with tasks and acceptance criteria</div>
             <div class="ov-badges">
-              <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-planning')"><span class="ov-badge-label">skill</span>technical-planning</span>
+              <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-planning')"><span class="ov-badge-label">skill</span>workflow-planning-process</span>
             </div>
           </div>
         </div>
@@ -1299,7 +1299,7 @@
             <div class="ov-phase-name">Implementation</div>
             <div class="ov-phase-desc">Execute plan via agent-based TDD &mdash; executor and reviewer per task</div>
             <div class="ov-badges">
-              <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-implementation')"><span class="ov-badge-label">skill</span>technical-implementation</span>
+              <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-implementation')"><span class="ov-badge-label">skill</span>workflow-implementation-process</span>
             </div>
           </div>
         </div>
@@ -1312,7 +1312,7 @@
             <div class="ov-phase-name">Review</div>
             <div class="ov-phase-desc">Verify implementation against plan using parallel verification agents</div>
             <div class="ov-badges">
-              <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-review')"><span class="ov-badge-label">skill</span>technical-review</span>
+              <span class="ov-badge ov-badge-skill ov-badge-link" onclick="event.stopPropagation(); selectPhase('skill-review')"><span class="ov-badge-label">skill</span>workflow-review-process</span>
             </div>
           </div>
         </div>
@@ -1434,19 +1434,19 @@ const phases = {
     label: 'Research Entry',
     complexity: 'Simple', steps: 4,
     output: '.workflows/{work_unit}/research/',
-    skill: 'technical-research',
+    skill: 'workflow-research-process',
     discovery: null,
     cache: null,
     prerequisites: 'None',
     scenarios: null,
-    desc: 'Parse args, check manifest status (new/resume/reopen), gather seed questions, invoke technical-research.',
+    desc: 'Parse args, check manifest status (new/resume/reopen), gather seed questions, invoke workflow-research-process.',
   },
   discussion: {
     color: '#60a5fa', bg: 'rgba(96,165,250,0.12)',
     label: 'Discussion Entry',
     complexity: 'Moderate', steps: 8,
     output: '.workflows/{work_unit}/discussion/{topic}.md',
-    skill: 'technical-discussion',
+    skill: 'workflow-discussion-process',
     discovery: 'discovery.js',
     cache: '{work_unit}/.state/research-analysis.md',
     prerequisites: 'None (but can consume research)',
@@ -1458,19 +1458,19 @@ const phases = {
     label: 'Investigation Entry',
     complexity: 'Simple', steps: 4,
     output: '.workflows/{work_unit}/investigation/{topic}.md',
-    skill: 'technical-investigation',
+    skill: 'workflow-investigation-process',
     discovery: null,
     cache: null,
     prerequisites: 'None (bugfix only)',
     scenarios: null,
-    desc: 'Bugfix-only phase entry. Parse args, check manifest (new/resume/reopen), gather bug context, invoke technical-investigation.',
+    desc: 'Bugfix-only phase entry. Parse args, check manifest (new/resume/reopen), gather bug context, invoke workflow-investigation-process.',
   },
   specification: {
     color: '#34d399', bg: 'rgba(52,211,153,0.12)',
     label: 'Specification Entry',
     complexity: 'Complex', steps: 6,
     output: '.workflows/{work_unit}/specification/{topic}/specification.md',
-    skill: 'technical-specification',
+    skill: 'workflow-specification-process',
     discovery: 'discovery.js',
     cache: '{work_unit}/.state/discussion-consolidation-analysis.md',
     prerequisites: 'Completed discussions required',
@@ -1482,36 +1482,36 @@ const phases = {
     label: 'Planning Entry',
     complexity: 'Moderate', steps: 5,
     output: '.workflows/{work_unit}/planning/{topic}/planning.md',
-    skill: 'technical-planning',
+    skill: 'workflow-planning-process',
     discovery: null,
     cache: null,
     prerequisites: 'Completed specification required',
     scenarios: null,
-    desc: 'Validate spec completed → validate plan state (new vs existing) → cross-cutting context (epic) → invoke technical-planning.',
+    desc: 'Validate spec completed → validate plan state (new vs existing) → cross-cutting context (epic) → invoke workflow-planning-process.',
   },
   implementation: {
     color: '#f97316', bg: 'rgba(249,115,22,0.12)',
     label: 'Implementation Entry',
     complexity: 'Moderate', steps: 5,
     output: 'Code changes (tracked in plan)',
-    skill: 'technical-implementation',
+    skill: 'workflow-implementation-process',
     discovery: null,
     cache: null,
     prerequisites: 'Completed plan required',
     scenarios: null,
-    desc: 'Validate plan completed → check external dependencies gate → environment setup gate → invoke technical-implementation.',
+    desc: 'Validate plan completed → check external dependencies gate → environment setup gate → invoke workflow-implementation-process.',
   },
   review: {
     color: '#f472b6', bg: 'rgba(244,114,182,0.12)',
     label: 'Review Entry',
     complexity: 'Moderate', steps: 4,
     output: 'Review feedback (approve/changes/comments)',
-    skill: 'technical-review',
+    skill: 'workflow-review-process',
     discovery: null,
     cache: null,
     prerequisites: 'Implementation of a plan',
     scenarios: null,
-    desc: 'Validate plan exists + implementation completed → determine review version (r1, r2, etc.) → invoke technical-review.',
+    desc: 'Validate plan exists + implementation completed → determine review version (r1, r2, etc.) → invoke workflow-review-process.',
   },
   // ── Unified entry (Layer 1) ──
   'workflow-start': {
@@ -1818,7 +1818,7 @@ const FLOWCHARTS = {
       { id: 'phase-exists', label: 'Phase exists?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Does a research phase entry exist in the manifest for this topic?' },
       { id: 'validate', label: 'Validate phase', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 2: Load validate-phase.md — handle in-progress/completed/reopened states.' },
       { id: 'gather', label: 'ASK: Gather context', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 3: Load gather-context.md — 4 questions: seed idea, current knowledge, starting point, constraints.' },
-      { id: 'skill', label: 'Invoke research skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Load invoke-skill.md — invoke technical-research with all gathered context.', skillLink: 'skill-research' },
+      { id: 'skill', label: 'Invoke research skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Load invoke-skill.md — invoke workflow-research-process with all gathered context.', skillLink: 'skill-research' },
     ],
     connections: [
       { from: 'start', to: 'parse' },
@@ -1867,7 +1867,7 @@ const FLOWCHARTS = {
       { id: 'gather-fresh', label: 'ASK: Gather fresh context', w: 210, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'gather-context-fresh.md — problem/decision, constraints, codebase files.' },
       { id: 'gather-research', label: 'ASK: Gather research ctx', w: 210, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'gather-context-research.md — context for starting from a research topic.' },
       { id: 'gather-continue', label: 'ASK: Gather continue ctx', w: 210, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'gather-context-continue.md — context for continuing an existing discussion.' },
-      { id: 'skill', label: 'Invoke discussion skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 8: Load invoke-skill.md — invoke technical-discussion with gathered context.', skillLink: 'skill-discussion' },
+      { id: 'skill', label: 'Invoke discussion skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 8: Load invoke-skill.md — invoke workflow-discussion-process with gathered context.', skillLink: 'skill-discussion' },
     ],
     connections: [
       { from: 'start', to: 'parse' },
@@ -1939,7 +1939,7 @@ const FLOWCHARTS = {
       { id: 'spec-status', label: 'Spec status?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Route by spec status: in-progress or completed.' },
       { id: 'ask-resume', label: 'ASK: Resume/fresh?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Spec is in-progress: ask whether to resume or start fresh.' },
       { id: 'reopen-spec', label: 'Reopen specification', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Spec is completed: reset status to in-progress. Verb = "Continuing".' },
-      { id: 'skill', label: 'Invoke specification skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Load invoke-skill.md — invoke technical-specification with sources and verb.', skillLink: 'skill-specification' },
+      { id: 'skill', label: 'Invoke specification skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Load invoke-skill.md — invoke workflow-specification-process with sources and verb.', skillLink: 'skill-specification' },
       // ── Epic scoped path (no topic) ──
       { id: 'discovery', label: 'Run discovery.js', w: 180, h: 44, color: 'var(--discovery)', bg: 'var(--discovery-bg)', desc: 'Run scoped discovery for this work_unit. Returns discussions, specifications, cache, and current_state counts.' },
       { id: 'has-disc', label: 'Discussions exist?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 5: check-prerequisites.md — do any discussions exist for this work unit?' },
@@ -2055,7 +2055,7 @@ const FLOWCHARTS = {
       { id: 'stop-xcut', label: 'STOP: Complete cross-cut', shape: 'stop', w: 200, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: User chose to stop and complete cross-cutting specs first.' },
       { id: 'summarize-xcut', label: 'Summarize cross-cutting', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Summarize completed cross-cutting specs for the handoff.' },
       // ── Invoke skill ──
-      { id: 'skill', label: 'Invoke planning skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 5: Load invoke-skill.md — invoke technical-planning with spec, context, and cross-cutting refs.', skillLink: 'skill-planning' },
+      { id: 'skill', label: 'Invoke planning skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 5: Load invoke-skill.md — invoke workflow-planning-process with spec, context, and cross-cutting refs.', skillLink: 'skill-planning' },
     ],
     connections: [
       { from: 'start', to: 'parse' },
@@ -2095,7 +2095,7 @@ const FLOWCHARTS = {
       { id: 'env-exists', label: 'Env setup?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Does environment-setup.md exist?' },
       { id: 'create-env', label: 'ASK: Setup instructions', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Setup file missing: Ask user for setup instructions, save to environment-setup.md.' },
       { id: 'env-ok', label: 'Environment noted', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Setup exists. Note for skill handoff.' },
-      { id: 'skill', label: 'Invoke implementation skill', w: 215, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 5: Load invoke-skill.md — invoke technical-implementation with plan, spec, env info.', skillLink: 'skill-implementation' },
+      { id: 'skill', label: 'Invoke implementation skill', w: 215, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 5: Load invoke-skill.md — invoke workflow-implementation-process with plan, spec, env info.', skillLink: 'skill-implementation' },
     ],
     connections: [
       { from: 'start', to: 'parse' },
@@ -2129,7 +2129,7 @@ const FLOWCHARTS = {
       { id: 'set-version', label: 'Set review version', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Set review_version = latest rN + 1, or 1 if none exist.' },
       // ── Invoke skill ──
       { id: 'init-phase', label: 'Init phase', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Initialize review phase in manifest.' },
-      { id: 'skill', label: 'Invoke review skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Load invoke-skill.md — invoke technical-review with plan, spec, format, and review version.', skillLink: 'skill-review' },
+      { id: 'skill', label: 'Invoke review skill', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Load invoke-skill.md — invoke workflow-review-process with plan, spec, format, and review version.', skillLink: 'skill-review' },
     ],
     connections: [
       { from: 'start', to: 'parse' },
@@ -2160,7 +2160,7 @@ const FLOWCHARTS = {
       { id: 'phase-exists', label: 'Phase exists?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Does an investigation phase entry exist for this topic?' },
       { id: 'validate', label: 'Validate phase', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 2: Load validate-phase.md — handle in-progress/completed states. Sets source=continue or source=reopen.' },
       { id: 'gather', label: 'ASK: Gather bug context', w: 210, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 3: Load gather-context.md — gather initial bug symptoms and reproduction context.' },
-      { id: 'skill', label: 'Invoke investigation skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Load invoke-skill.md — invoke technical-investigation with bug context.', skillLink: 'skill-investigation' },
+      { id: 'skill', label: 'Invoke investigation skill', w: 210, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', desc: 'Step 4: Load invoke-skill.md — invoke workflow-investigation-process with bug context.', skillLink: 'skill-investigation' },
     ],
     connections: [
       { from: 'start', to: 'parse' },
@@ -2236,7 +2236,7 @@ const FLOWCHARTS = {
   },
   'skill-research': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-research skill receives gathered context from entry skill.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: workflow-research-process skill receives gathered context from entry skill.' },
       { id: 'resume', label: 'Existing research?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if research file exists at the handoff output path.' },
       { id: 'resume-ask', label: 'ASK: Continue/restart?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Research exists: ask whether to continue or start fresh.' },
       { id: 'init', label: 'Initialize doc', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Create research file using template. Register in manifest. Commit.' },
@@ -2288,7 +2288,7 @@ const FLOWCHARTS = {
   },
   'skill-discussion': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-discussion skill receives context from entry skill.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: workflow-discussion-process skill receives context from entry skill.' },
       { id: 'resume', label: 'Existing discussion?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if discussion file exists at .workflows/{work_unit}/discussion/{topic}.md.' },
       { id: 'resume-ask', label: 'ASK: Continue/restart?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Discussion exists: announce current state, ask whether to continue or restart.' },
       { id: 'init', label: 'Initialize document', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Create {work_unit}/discussion/{topic}.md using template. Register in manifest. Commit.' },
@@ -2322,7 +2322,7 @@ const FLOWCHARTS = {
   },
   'skill-specification': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-specification skill receives source material and topic.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: workflow-specification-process skill receives source material and topic.' },
       // Resume detection
       { id: 'resume', label: 'Existing spec?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if specification file exists.' },
       { id: 'resume-ask', label: 'ASK: Continue/restart?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Specification exists: ask whether to continue (walk through from current state) or restart (delete and start fresh).' },
@@ -2389,7 +2389,7 @@ const FLOWCHARTS = {
   },
   'skill-planning': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-planning skill receives specification and context.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: workflow-planning-process skill receives specification and context.' },
       { id: 'resume', label: 'Existing plan?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if plan index file exists at .workflows/{work_unit}/planning/{topic}/planning.md.' },
       { id: 'spec-change', label: 'Spec changed?', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Load spec-change-detection.md — compare spec_commit in manifest against current HEAD to detect specification changes since planning started.' },
       { id: 'resume-choice', label: 'Continue / Restart?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'User chooses: continue from previous position (with spec change summary) or restart (deletes existing plan).' },
@@ -2476,7 +2476,7 @@ const FLOWCHARTS = {
   'skill-implementation': {
     nodes: [
       // Orchestrator setup (Steps 1-5)
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-implementation skill receives plan, env info, and tracking state.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: workflow-implementation-process skill receives plan, env info, and tracking state.' },
       { id: 'env-setup', label: '1. Environment setup', w: 195, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Run setup commands from environment-setup.md. Sequential, exactly as written.' },
       { id: 'read-plan', label: '2. Read plan + adapter', w: 195, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 2: Load plan, read format field, load output format adapters (reading, updating, authoring).' },
       { id: 'init-track', label: '3. Init tracking file', w: 195, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 3: Create/resume .workflows/{work_unit}/implementation/{topic}/implementation.md. Reset gate modes and cycles on fresh session.' },
@@ -2571,7 +2571,7 @@ const FLOWCHARTS = {
   },
   'skill-review': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-review skill receives plan(s), optional spec(s), and scope.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: workflow-review-process skill receives plan(s), optional spec(s), and scope.' },
       { id: 'read-plan', label: 'Read plan(s)', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Read all plan(s) for the selected scope — phases, tasks, and acceptance criteria.' },
       { id: 'read-spec', label: 'Read specification(s)', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 1: If available, read linked specification(s) for design context.' },
       { id: 'skills-disc', label: 'Project skills discovery', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 2: Scan .claude/skills/ for project-specific conventions, framework guidelines, and architecture patterns.' },
@@ -2704,6 +2704,7 @@ const FLOWCHARTS = {
   'view-plan': {
     nodes: [
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry point for /view-plan.' },
+      { id: 'migrate', label: 'Run /migrate', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Step 0: Run migrations.' },
       { id: 'gate-plans', label: 'Plans exist?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if any plan files exist in .workflows/{work_unit}/planning/{topic}/.' },
       { id: 'stop', label: 'STOP: No plans', shape: 'stop', w: 150, h: 40, color: 'var(--gate)', bg: 'var(--gate-bg)', desc: 'Terminal: No plans found. Run /start-planning first.' },
       { id: 'count', label: 'Single plan?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check if there is exactly one plan or multiple.' },
@@ -2716,7 +2717,8 @@ const FLOWCHARTS = {
       { id: 'end', label: 'Plan summary', shape: 'pill', w: 150, h: 40, color: '#94a3b8', bg: 'rgba(148,163,184,0.12)', desc: 'Final plan summary presented to the user.' },
     ],
     connections: [
-      { from: 'start', to: 'gate-plans' },
+      { from: 'start', to: 'migrate' },
+      { from: 'migrate', to: 'gate-plans' },
       { from: 'gate-plans', to: 'count', type: 'yes', label: 'exist', weight: 2 },
       { from: 'gate-plans', to: 'stop', type: 'no', label: 'none' },
       { from: 'count', to: 'auto', label: 'one' },
@@ -2749,7 +2751,7 @@ const FLOWCHARTS = {
   // ── Agent Flowcharts ──
   'planning-phase-designer': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning skill during plan construction.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-planning-process skill during plan construction.' },
       { id: 'read-refs', label: 'Read spec ingestion', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification ingestion protocol and full spec. Also reads cross-cutting specs if referenced.' },
       { id: 'read-principles', label: 'Read design principles', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read phase design principles and task design principles reference files.' },
       { id: 'design', label: 'Design phases', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Design implementation phase structure. Define goals, acceptance criteria, and sequencing.' },
@@ -2769,7 +2771,7 @@ const FLOWCHARTS = {
   },
   'planning-task-designer': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning skill during plan construction.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-planning-process skill during plan construction.' },
       { id: 'read-refs', label: 'Read spec ingestion', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification ingestion protocol, full spec, cross-cutting specs, and approved phases.' },
       { id: 'read-principles', label: 'Read task principles', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read task design principles reference file.' },
       { id: 'design', label: 'Design task list', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Break target phase into individual tasks with edge cases for each.' },
@@ -2789,7 +2791,7 @@ const FLOWCHARTS = {
   },
   'planning-task-author': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning skill during plan construction.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-planning-process skill during plan construction.' },
       { id: 'read-refs', label: 'Read spec ingestion', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification ingestion protocol, full spec, and cross-cutting specs.' },
       { id: 'read-template', label: 'Read task template', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read task design template, phases, and task list for context.' },
       { id: 'read-format', label: 'Read format adapter', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Load the output format adapter (authoring.md) for the plan\'s chosen format.' },
@@ -2811,7 +2813,7 @@ const FLOWCHARTS = {
   },
   'planning-dependency-grapher': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning skill after plan construction.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-planning-process skill after plan construction.' },
       { id: 'read-format', label: 'Read format refs', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read reading.md and graph.md format adapter references.' },
       { id: 'read-index', label: 'Read plan index', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the plan index file to understand plan structure.' },
       { id: 'list-tasks', label: 'List authored tasks', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Enumerate all authored task files from the plan.' },
@@ -2838,7 +2840,7 @@ const FLOWCHARTS = {
   },
   'implementation-task-executor': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-implementation skill for a single task.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-implementation-process skill for a single task.' },
       { id: 'read-refs', label: 'Read TDD + quality refs', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read TDD workflow reference and code quality standards. Read project skills and specification.' },
       { id: 'explore', label: 'Explore codebase', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Explore the codebase to understand existing patterns, conventions, and relevant code.' },
       { id: 'write-test', label: 'RED: Write failing test', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'TDD red phase: write a test for the next acceptance criterion. Test must fail for the right reason.' },
@@ -2864,7 +2866,7 @@ const FLOWCHARTS = {
   },
   'implementation-task-reviewer': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-implementation skill after each task.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-implementation-process skill after each task.' },
       { id: 'read-spec', label: 'Read specification', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the specification to understand the broader design intent and constraints.' },
       { id: 'check-diff', label: 'Check unstaged changes', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Run git diff/status to identify all changed files from the executor.' },
       { id: 'read-files', label: 'Read changed files', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the full content of all changed files — implementation and test code.' },
@@ -2887,7 +2889,7 @@ const FLOWCHARTS = {
   },
   'implementation-analysis-duplication': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked in parallel by technical-implementation during analysis cycle.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked in parallel by workflow-implementation-process during analysis cycle.' },
       { id: 'read-quality', label: 'Read code quality', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read code-quality.md to understand quality standards.' },
       { id: 'read-skills', label: 'Read project skills', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read project skills for framework conventions and existing patterns.' },
       { id: 'read-spec', label: 'Read specification', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification to understand design intent.' },
@@ -2908,7 +2910,7 @@ const FLOWCHARTS = {
   },
   'implementation-analysis-standards': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked in parallel by technical-implementation during analysis cycle.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked in parallel by workflow-implementation-process during analysis cycle.' },
       { id: 'read-quality', label: 'Read code quality', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read code-quality.md to understand quality standards.' },
       { id: 'read-skills', label: 'Read project skills', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read project skills — MUST DO/MUST NOT DO rules are primary targets.' },
       { id: 'read-spec', label: 'Read specification', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification — the specification advocate\'s primary reference.' },
@@ -2929,7 +2931,7 @@ const FLOWCHARTS = {
   },
   'implementation-analysis-architecture': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked in parallel by technical-implementation during analysis cycle.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked in parallel by workflow-implementation-process during analysis cycle.' },
       { id: 'read-quality', label: 'Read code quality', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read code-quality.md to understand quality standards.' },
       { id: 'read-skills', label: 'Read project skills', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read project skills for architectural patterns and conventions.' },
       { id: 'read-spec', label: 'Read specification', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read specification for intended architecture and design decisions.' },
@@ -2950,7 +2952,7 @@ const FLOWCHARTS = {
   },
   'implementation-analysis-synthesizer': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-implementation after all 3 analysis agents return.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-implementation-process after all 3 analysis agents return.' },
       { id: 'read-findings', label: 'Read all findings files', w: 210, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Locate and read analysis-duplication.md, analysis-standards.md, analysis-architecture.md from the topic directory.' },
       { id: 'dedup', label: 'Deduplicate findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Same issue from multiple agents → one finding, noting all sources.' },
       { id: 'group', label: 'Group related findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Multiple findings about the same pattern become one task (e.g., 3 duplication findings = 1 extract helper task).' },
@@ -2976,7 +2978,7 @@ const FLOWCHARTS = {
   },
   'implementation-analysis-task-writer': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-implementation after user approves analysis tasks.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-implementation-process after user approves analysis tasks.' },
       { id: 'read-staging', label: 'Read staging file', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Extract all tasks with status: approved from the staging file.' },
       { id: 'read-plan', label: 'Read plan (via adapter)', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Use reading adapter to determine max existing phase number.' },
       { id: 'calc-phase', label: 'Calculate next phase', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Next phase = max existing phase + 1.' },
@@ -2995,7 +2997,7 @@ const FLOWCHARTS = {
   },
   'review-task-verifier': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Dispatched in batches of 5 by technical-review skill during QA verification.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Dispatched in batches of 5 by workflow-review-process skill during QA verification.' },
       { id: 'read-task', label: 'Understand task', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the task: what it does, acceptance criteria, and expected tests.' },
       { id: 'load-spec', label: 'Load spec context', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Load the broader specification context: requirements, constraints, edge cases.' },
       { id: 'verify-impl', label: 'Verify implementation', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Check: implementation exists, matches acceptance criteria, aligns with spec.' },
@@ -3016,7 +3018,7 @@ const FLOWCHARTS = {
   },
   'review-findings-synthesizer': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-review skill during review actions loop.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-review-process skill during review actions loop.' },
       { id: 'read-review', label: 'Read review summary', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read report.md — extract verdict, required changes, and recommendations.' },
       { id: 'read-qa', label: 'Read all QA files', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read every report-*.md in the review path. Extract BLOCKING ISSUES and significant NON-BLOCKING NOTES with file:line refs.' },
       { id: 'dedup', label: 'Deduplicate findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Same issue from multiple QA files → one finding, noting all sources.' },
@@ -3272,7 +3274,7 @@ const FLOWCHARTS = {
   // ── Investigation Processing Skill ──
   'skill-investigation': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: technical-investigation skill receives bug context from entry skill.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: workflow-investigation-process skill receives bug context from entry skill.' },
       { id: 'resume', label: 'Existing investigation?', shape: 'diamond', w: 140, h: 140, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if investigation file exists at .workflows/{work_unit}/investigation/{topic}.md.' },
       { id: 'resume-ask', label: 'ASK: Continue/restart?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Investigation exists: announce findings so far, ask whether to continue or restart.' },
       { id: 'init', label: 'Initialize investigation', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Create investigation file from template. Register in manifest. Commit.' },
@@ -3302,7 +3304,7 @@ const FLOWCHARTS = {
   // ── New Agent Flowcharts ──
   'specification-review-input': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-specification during review cycle (Phase 1).' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-specification-process during review cycle (Phase 1).' },
       { id: 'read-format', label: 'Read tracking format', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read review-tracking-format.md to understand the output file structure.' },
       { id: 'read-spec', label: 'Read specification', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the specification to understand what is already captured.' },
       { id: 'read-sources', label: 'Read ALL sources', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Re-read every source document (discussions, research, references). Do not rely on memory.' },
@@ -3323,7 +3325,7 @@ const FLOWCHARTS = {
   },
   'specification-review-gap-analysis': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-specification during review cycle (Phase 2).' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-specification-process during review cycle (Phase 2).' },
       { id: 'read-format', label: 'Read tracking format', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read review-tracking-format.md to understand the output file structure.' },
       { id: 'read-spec', label: 'Read spec end-to-end', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the specification carefully as if about to implement it. Not scanning — full read.' },
       { id: 'assess', label: 'Assess per section', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'For each section: internal completeness, clarity, consistency, ambiguity, edge cases, planning readiness.' },
@@ -3342,7 +3344,7 @@ const FLOWCHARTS = {
   },
   'planning-review-traceability': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning during plan review.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-planning-process during plan review.' },
       { id: 'read-criteria', label: 'Read review criteria', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read review-traceability.md — absorb full analysis criteria before starting.' },
       { id: 'read-spec', label: 'Read specification', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read the specification in full. Do not rely on summaries.' },
       { id: 'read-plan', label: 'Read plan + all tasks', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read Plan Index File and all task files via format reading.md.' },
@@ -3365,7 +3367,7 @@ const FLOWCHARTS = {
   },
   'planning-review-integrity': {
     nodes: [
-      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by technical-planning during plan review.' },
+      { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Agent entry point. Invoked by workflow-planning-process during plan review.' },
       { id: 'read-criteria', label: 'Read review criteria', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read review-integrity.md — absorb all review dimensions before starting.' },
       { id: 'read-plan', label: 'Read plan + all tasks', w: 200, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Read Plan Index File and all task files via format reading.md.' },
       { id: 'evaluate', label: 'Evaluate all criteria', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Evaluate structural quality, implementation readiness, and standards adherence.' },
@@ -3400,40 +3402,40 @@ const FLOWCHART_DESCS = {
   research: {
     summary: 'Phase entry for research — parse args, check manifest, gather context, invoke processing skill.',
     body: `<p>The simplest phase entry. Parses arguments (work_type, work_unit, topic), checks the manifest for existing phase status. <strong>Topic resolved</strong>: routes to validate-phase (resume/reopen) or gather-context (4 seed questions). <strong>No topic</strong> (epic scoped): asks seed questions directly.</p>`,
-    meta: { output: '.workflows/{work_unit}/research/', skill: 'technical-research', complexity: 'Simple' }
+    meta: { output: '.workflows/{work_unit}/research/', skill: 'workflow-research-process', complexity: 'Simple' }
   },
   discussion: {
     summary: 'Phase entry for discussion — manifest routing or discovery-based scenario flow.',
     body: `<p>Two paths based on argument resolution. <strong>Topic resolved</strong> (feature/bugfix, or epic with topic): checks manifest → validate-phase or gather-context → invoke skill. <strong>No topic</strong> (epic scoped): runs <code>discovery.js</code> scoped to the work unit.</p>
-<p>Discovery classifies scenario: <strong>fresh</strong>, <strong>research_only</strong>, <strong>discussions_only</strong>, or <strong>research_and_discussions</strong>. Research analysis is <strong>cache-aware</strong> — checksums detect stale analysis. The options menu adapts based on what exists (2–4 options). After user selection, context is gathered and the <strong>technical-discussion</strong> skill is invoked.</p>`,
-    meta: { output: '.workflows/{work_unit}/discussion/{topic}.md', skill: 'technical-discussion', discovery: 'discovery.js', cache: '{work_unit}/.state/research-analysis.md' }
+<p>Discovery classifies scenario: <strong>fresh</strong>, <strong>research_only</strong>, <strong>discussions_only</strong>, or <strong>research_and_discussions</strong>. Research analysis is <strong>cache-aware</strong> — checksums detect stale analysis. The options menu adapts based on what exists (2–4 options). After user selection, context is gathered and the <strong>workflow-discussion-process</strong> skill is invoked.</p>`,
+    meta: { output: '.workflows/{work_unit}/discussion/{topic}.md', skill: 'workflow-discussion-process', discovery: 'discovery.js', cache: '{work_unit}/.state/research-analysis.md' }
   },
   investigation: {
     summary: 'Phase entry for investigation — bugfix-only, parse args, gather bug context, invoke processing skill.',
     body: `<p>Bugfix-only phase entry. Always has topic (topic = work_unit). Parses arguments, checks manifest for existing phase status.</p>
-<p><strong>New entry</strong>: gathers bug context (symptoms, error messages, reproduction steps). <strong>Existing</strong>: validate-phase (resume or reopen). Invokes the <strong>technical-investigation</strong> skill.</p>`,
-    meta: { output: '.workflows/{work_unit}/investigation/{topic}.md', skill: 'technical-investigation', complexity: 'Simple' }
+<p><strong>New entry</strong>: gathers bug context (symptoms, error messages, reproduction steps). <strong>Existing</strong>: validate-phase (resume or reopen). Invokes the <strong>workflow-investigation-process</strong> skill.</p>`,
+    meta: { output: '.workflows/{work_unit}/investigation/{topic}.md', skill: 'workflow-investigation-process', complexity: 'Simple' }
   },
   specification: {
     summary: 'Phase entry for specification — source validation or discovery-based state routing.',
     body: `<p>Two paths. <strong>Topic resolved</strong>: validates source material (discussion/investigation completed?), validates phase state, then invokes skill. <strong>No topic</strong> (epic scoped): runs <code>discovery.js</code>, checks prerequisites, routes by state.</p>
 <p>State routing handles: single completed discussion (auto-select), valid cache (show groupings), stale cache with/without specs, and multi-discussion analysis flow with coupling analysis and grouping menus.</p>`,
-    meta: { output: '.workflows/{work_unit}/specification/{topic}/specification.md', skill: 'technical-specification', discovery: 'discovery.js', cache: '{work_unit}/.state/discussion-consolidation-analysis.md' }
+    meta: { output: '.workflows/{work_unit}/specification/{topic}/specification.md', skill: 'workflow-specification-process', discovery: 'discovery.js', cache: '{work_unit}/.state/discussion-consolidation-analysis.md' }
   },
   planning: {
     summary: 'Phase entry for planning — validate spec, check plan state, surface cross-cutting context.',
     body: `<p>Validates specification is completed, then checks plan state (new vs existing). <strong>Fresh plans</strong>: loads cross-cutting spec context (epic only) before invoking. <strong>Existing plans</strong>: skips directly to skill invocation.</p>`,
-    meta: { output: '.workflows/{work_unit}/planning/{topic}/planning.md', skill: 'technical-planning' }
+    meta: { output: '.workflows/{work_unit}/planning/{topic}/planning.md', skill: 'workflow-planning-process' }
   },
   implementation: {
     summary: 'Phase entry for implementation — validate plan, check dependencies, check environment.',
-    body: `<p>Validates plan is completed, then runs two gates: <strong>external dependencies</strong> (confirms all resolved or satisfied) and <strong>environment setup</strong> (info gathering only — does not execute setup). Invokes the <strong>technical-implementation</strong> skill with plan, format, spec, and environment info.</p>`,
-    meta: { output: 'Code changes (tracked in plan)', skill: 'technical-implementation' }
+    body: `<p>Validates plan is completed, then runs two gates: <strong>external dependencies</strong> (confirms all resolved or satisfied) and <strong>environment setup</strong> (info gathering only — does not execute setup). Invokes the <strong>workflow-implementation-process</strong> skill with plan, format, spec, and environment info.</p>`,
+    meta: { output: 'Code changes (tracked in plan)', skill: 'workflow-implementation-process' }
   },
   review: {
     summary: 'Phase entry for review — validate plan + implementation, determine review version.',
-    body: `<p>Validates plan exists and implementation is completed. Determines review version (r1, r2, etc.) by scanning existing review directories. Invokes the <strong>technical-review</strong> skill with version and scope.</p>`,
-    meta: { output: 'Review feedback', skill: 'technical-review' }
+    body: `<p>Validates plan exists and implementation is completed. Determines review version (r1, r2, etc.) by scanning existing review directories. Invokes the <strong>workflow-review-process</strong> skill with version and scope.</p>`,
+    meta: { output: 'Review feedback', skill: 'workflow-review-process' }
   },
   // ── Entry point skills ──
   'workflow-start': {
@@ -3551,49 +3553,49 @@ const FLOWCHART_DESCS = {
     summary: 'Design implementation phases from a specification — goals, sequencing, and acceptance criteria.',
     body: `<p>Reads the specification via ingestion protocol, then loads phase and task design principles. Designs a phased implementation structure with clear goals and acceptance criteria for each phase.</p>
 <p>Supports <strong>amendment rounds</strong> — if prior output and feedback are provided, the agent revises its design rather than starting fresh. Output is a human-readable phase summary.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Subagent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-planning-process', complexity: 'Subagent' }
   },
   'planning-task-designer': {
     summary: 'Break a single phase into concrete tasks with edge cases and dependencies.',
     body: `<p>Reads the specification, approved phases, and task design principles. For the target phase, produces a detailed task list with edge cases identified per task.</p>
 <p>Supports <strong>amendment rounds</strong> — revises task list based on feedback when prior output exists. Output is a task table with IDs, names, edge cases, and status.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Subagent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-planning-process', complexity: 'Subagent' }
   },
   'planning-task-author': {
     summary: 'Author full task detail in the plan\'s output format — problem, solution, acceptance criteria, tests.',
     body: `<p>Reads specification, task template, phases, task list, and the <strong>output format adapter</strong> (authoring.md). Writes complete task detail in the exact format structure: problem, solution, outcome, do/don\'t, acceptance criteria, tests, and context.</p>
 <p>Supports <strong>amendment rounds</strong>. Format-aware — adapts to whichever output format the plan uses.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Subagent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-planning-process', complexity: 'Subagent' }
   },
   'planning-dependency-grapher': {
     summary: 'Analyze task dependencies, detect circular references, and assign priority classifications.',
     body: `<p>Reads format adapters (reading.md + graph.md), then the plan index and all authored task files. <strong>Clears existing graph data</strong> before re-analysis to ensure a clean state.</p>
 <p>For each task, extracts what it produces and requires, then matches across all tasks to build a dependency graph. Classifies tasks as <strong>bottleneck</strong>, <strong>foundation</strong>, or <strong>leaf</strong>. If <strong>cycles are detected</strong>, reports the cycle chain and does NOT apply changes — a hard stop. Otherwise, writes dependency and priority data back to tasks.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Subagent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-planning-process', complexity: 'Subagent' }
   },
   'planning-review-traceability': {
     summary: 'Verify spec→plan completeness and plan→spec fidelity (anti-hallucination).',
     body: `<p>Performs <strong>two-direction traceability</strong>. <strong>Spec→Plan</strong>: every decision, requirement, and edge case in the spec has plan coverage. <strong>Plan→Spec</strong>: everything in the plan traces back to the spec — the anti-hallucination gate.</p>
 <p>Creates a tracking file with findings containing full Current/Proposed content. Commits the tracking file. Returns status to the orchestrator for per-finding approval.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Review agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-planning-process', complexity: 'Review agent' }
   },
   'planning-review-integrity': {
     summary: 'Review plan structural quality, implementation readiness, and standards adherence.',
     body: `<p>Reviews the plan as a standalone document — structural quality without comparing to the spec. Evaluates: task template compliance, vertical slicing, phase structure, dependency ordering, task self-containment, granularity, and acceptance criteria quality.</p>
 <p>Creates a tracking file with findings. Commits. Returns status to the orchestrator. Proportional — prioritizes by impact, not cosmetics.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-planning', complexity: 'Review agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-planning-process', complexity: 'Review agent' }
   },
   'specification-review-input': {
     summary: 'Compare specification against all source material to catch missed content.',
     body: `<p>Reads the specification, then <strong>re-reads ALL source material</strong> (discussions, research, references). Compares systematically for each source: what topics does it cover? Are those fully captured? Are there details, edge cases, or decisions that didn't make it?</p>
 <p>Categorizes findings as <strong>enhancement to existing topic</strong> or <strong>new topic</strong>. Writes findings to a tracking file using the review tracking format.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-specification', complexity: 'Review agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-specification-process', complexity: 'Review agent' }
   },
   'specification-review-gap-analysis': {
     summary: 'Review specification as standalone document for completeness, clarity, and planning readiness.',
     body: `<p>Looks <strong>inward</strong> at the specification only — not outward at source material. Reads the spec end-to-end and assesses each section for internal completeness, clarity, consistency, and ambiguity.</p>
 <p>Analyzes: insufficient detail that would force implementers to guess, contradictions between sections, edge cases within scope boundaries, and planning readiness. Prioritizes findings as critical/important/minor.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-specification', complexity: 'Review agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-specification-process', complexity: 'Review agent' }
   },
   'skill-investigation': {
     summary: 'The investigation skill — symptom gathering, code analysis, and root cause identification for bugfixes.',
@@ -3607,61 +3609,61 @@ const FLOWCHART_DESCS = {
     body: `<p>Reads TDD workflow, code quality standards, project skills, and specification. Explores the codebase first to understand existing patterns.</p>
 <p>Executes a <strong>strict TDD loop</strong> per acceptance criterion: <strong>RED</strong> (write failing test) → <strong>GREEN</strong> (implement to pass) → <strong>REFACTOR</strong> (improve code, run tests) → <strong>LINT</strong> (run configured linters, fix issues, revert if tests break). Has hard stops for scope expansion, uncertainty, and untenable spec decisions — reports back rather than making autonomous choices.</p>
 <p>Returns a structured <strong>STATUS report</strong> (complete/blocked/failed) with files changed, tests written, and results.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-implementation', complexity: 'Subagent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-implementation-process', complexity: 'Subagent' }
   },
   'implementation-task-reviewer': {
     summary: 'Independently review a task across 5 dimensions with fix recommendations — no access to executor context.',
     body: `<p>Reads the specification, then checks unstaged changes via git diff/status and reads all changed files. Loads project skills for convention checking. <strong>Independent from the executor</strong> — no shared context.</p>
 <p>Evaluates across <strong>5 dimensions</strong>: spec conformance, acceptance criteria coverage, test adequacy, convention adherence, and architectural quality. Produces a structured verdict (<strong>approved</strong> or <strong>needs-changes</strong>) with file:line references.</p>
 <p>When returning <strong>needs-changes</strong>, each issue includes <strong>FIX</strong> (recommended approach), optional <strong>ALTERNATIVE</strong> (when multiple valid approaches exist), and <strong>CONFIDENCE</strong> (high/medium/low) — giving visibility into the fix strategy before re-execution.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-implementation', complexity: 'Subagent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-implementation-process', complexity: 'Subagent' }
   },
   'review-task-verifier': {
     summary: 'Verify a single task\'s implementation, tests, and code quality against the plan and spec.',
-    body: `<p>Dispatched <strong>in batches of 5</strong> by the technical-review skill during QA verification. Each verifier writes findings to <code>.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md</code>.</p>
+    body: `<p>Dispatched <strong>in batches of 5</strong> by the workflow-review-process skill during QA verification. Each verifier writes findings to <code>.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md</code>.</p>
 <p>Three verification stages: <strong>implementation</strong> (exists, matches criteria, aligns with spec), <strong>tests</strong> (adequate coverage, edge cases, not over/under-tested), and <strong>code quality</strong> (conventions, SOLID, DRY, complexity, security, performance). Receives review checklist, topic name, and task index. Compiles a structured finding with blocking issues and non-blocking notes.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-review', complexity: 'Subagent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-review-process', complexity: 'Subagent' }
   },
   'review-findings-synthesizer': {
     summary: 'Synthesize review findings into deduplicated, normalized remediation tasks for user approval.',
     body: `<p>Reads the review summary and all QA task verification files. Performs multi-step synthesis: <strong>deduplicate</strong> (same issue from multiple QA files → one finding) → <strong>group related findings</strong> into single tasks → <strong>filter by severity</strong> (never discard blocking) → <strong>normalize</strong> into canonical task template (Problem/Solution/Outcome/Do/AC/Tests).</p>
 <p>Writes two outputs: a <strong>review report</strong> (summary + discarded findings) and a <strong>staging file</strong> (proposed tasks with <code>status: pending</code>) for the orchestrator to present to the user.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-review', tools: 'Read, Write, Glob, Grep', complexity: 'Synthesis agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-review-process', tools: 'Read, Write, Glob, Grep', complexity: 'Synthesis agent' }
   },
   'implementation-analysis-duplication': {
     summary: 'Hunt for cross-file duplication, near-duplicate logic, and extraction candidates.',
     body: `<p>Analyses code that was independently written by separate task executors who couldn't see each other's work. Read-only — writes only a findings file.</p>
 <p>Focus areas: <strong>cross-file repeated patterns</strong>, <strong>near-duplicate logic</strong> (slightly different implementations of the same concept), <strong>helper extraction candidates</strong> (inline code that should be shared), and <strong>copy-paste drift</strong> across task boundaries.</p>
 <p>Proportional analysis — three similar lines is not worth flagging, but three similar 20-line blocks is. Plan scope only.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-implementation', tools: 'Read, Write, Glob, Grep, Bash', complexity: 'Analysis agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-implementation-process', tools: 'Read, Write, Glob, Grep, Bash', complexity: 'Analysis agent' }
   },
   'implementation-analysis-standards': {
     summary: 'The specification\'s advocate — find where implementation drifts from what was decided.',
     body: `<p>Analyses the implementation as the specification's advocate. Read-only — writes only a findings file.</p>
 <p>Focus areas: <strong>spec conformance</strong> (does the code match what was specified?), <strong>project skill compliance</strong> (MUST DO/MUST NOT DO rules), <strong>spec-vs-convention conflicts</strong> (when spec conflicts with language idiom, which won?), and <strong>missing validations/constraints</strong> from spec.</p>
 <p>Plan scope only — does not flag pre-existing drift in code that wasn't part of this implementation.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-implementation', tools: 'Read, Write, Glob, Grep, Bash', complexity: 'Analysis agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-implementation-process', tools: 'Read, Write, Glob, Grep, Bash', complexity: 'Analysis agent' }
   },
   'implementation-analysis-architecture': {
     summary: 'Review the completed implementation as an architect who didn\'t write it.',
     body: `<p>Reviews the implementation from an architectural perspective. Read-only — writes only a findings file.</p>
 <p>Focus areas: <strong>API surface quality</strong>, <strong>package/module structure</strong>, <strong>integration test gaps</strong> for cross-task workflows, <strong>seam quality</strong> between task boundaries, and <strong>over/under-engineering</strong>.</p>
 <p>Proportional and plan-scoped — focuses on high-impact issues, not cosmetic preferences.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-implementation', tools: 'Read, Write, Glob, Grep, Bash', complexity: 'Analysis agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-implementation-process', tools: 'Read, Write, Glob, Grep, Bash', complexity: 'Analysis agent' }
   },
   'implementation-analysis-synthesizer': {
     summary: 'Synthesize findings from 3 analysis agents into deduplicated, normalized tasks for user approval.',
     body: `<p>Locates findings files from the 3 analysis agents by convention (topic directory), reads them, then performs multi-step synthesis.</p>
 <p><strong>Process</strong>: deduplicate (same issue from multiple agents → one finding) → group related findings into single tasks → filter by severity (never discard high) → normalize into canonical task template (Problem/Solution/Outcome/Do/AC/Tests).</p>
 <p>Writes two outputs: an <strong>analysis report</strong> (summary + discarded findings) and a <strong>staging file</strong> (proposed tasks with <code>status: pending</code>) for the orchestrator to present to the user.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-implementation', tools: 'Read, Write, Glob, Grep', complexity: 'Synthesis agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-implementation-process', tools: 'Read, Write, Glob, Grep', complexity: 'Synthesis agent' }
   },
   'implementation-analysis-task-writer': {
     summary: 'Create plan tasks from approved analysis findings using the format\'s authoring adapter.',
     body: `<p>Invoked after the user approves analysis tasks. Reads the staging file, extracts tasks with <code>status: approved</code>, determines the next phase number, and creates tasks in the plan.</p>
 <p>Uses the plan format's <strong>authoring adapter</strong> to create tasks in the correct format (local-markdown file creation, Linear API calls, etc.). The topic name scopes tasks to the correct plan.</p>
 <p>Hard rules: approved only, no content modifications, no git writes (orchestrator commits), authoring adapter is authoritative.</p>`,
-    meta: { model: 'Opus', invokedBy: 'technical-implementation', tools: 'Read, Write, Edit, Glob, Grep, Bash', complexity: 'Task creation agent' }
+    meta: { model: 'Opus', invokedBy: 'workflow-implementation-process', tools: 'Read, Write, Edit, Glob, Grep, Bash', complexity: 'Task creation agent' }
   },
 };
 
@@ -3680,13 +3682,13 @@ const SOURCE_MAP = {
   // Bridge
   'workflow-bridge':      'skills/workflow-bridge/SKILL.md',
   // Processing skills (Layer 4)
-  'skill-research':       'skills/technical-research/SKILL.md',
-  'skill-discussion':     'skills/technical-discussion/SKILL.md',
-  'skill-investigation':  'skills/technical-investigation/SKILL.md',
-  'skill-specification':  'skills/technical-specification/SKILL.md',
-  'skill-planning':       'skills/technical-planning/SKILL.md',
-  'skill-implementation': 'skills/technical-implementation/SKILL.md',
-  'skill-review':         'skills/technical-review/SKILL.md',
+  'skill-research':       'skills/workflow-research-process/SKILL.md',
+  'skill-discussion':     'skills/workflow-discussion-process/SKILL.md',
+  'skill-investigation':  'skills/workflow-investigation-process/SKILL.md',
+  'skill-specification':  'skills/workflow-specification-process/SKILL.md',
+  'skill-planning':       'skills/workflow-planning-process/SKILL.md',
+  'skill-implementation': 'skills/workflow-implementation-process/SKILL.md',
+  'skill-review':         'skills/workflow-review-process/SKILL.md',
   // Unified entry (Layer 1)
   'workflow-start':       'skills/workflow-start/SKILL.md',
   // Work-type entry (Layer 2)


### PR DESCRIPTION
## Summary

- Updated ~70 stale `technical-*` references to `workflow-*-process` across SOURCE_MAP, phases metadata, sidebar labels, node descriptions, and FLOWCHART_DESCS
- Added missing `/migrate` step (Step 0) to the `view-plan` flowchart for consistency with all other entry-point skills

## Test plan

- [ ] Open `workflow-explorer.html` in browser — verify all sidebar skill labels show `workflow-*-process`
- [ ] Click each processing skill flowchart — verify START node desc uses new name
- [ ] Click info panel (ⓘ) on each phase entry — verify meta.skill field shows new name
- [ ] Click "Source" button on any processing skill — verify markdown viewer loads from correct path
- [ ] Check view-plan flowchart shows migrate step before plan existence check

🤖 Generated with [Claude Code](https://claude.com/claude-code)