### PR TITLE
feat: default plan format inheritance

### DIFF
--- a/roadmap/PR15-DEFAULT-PLAN-FORMAT.md
+++ b/roadmap/PR15-DEFAULT-PLAN-FORMAT.md
@@ -12,13 +12,13 @@ Add phase-level default format for planning. First topic's format choice is stor
 
 ### Write side
 
-When the planning process skill saves a format choice for a topic, also set it at phase level if no phase-level default exists yet:
+When the planning process skill saves a format choice for a topic, also set it at phase level (unconditional overwrite so the most recent choice becomes the new default):
 
 ```bash
 # Always set at topic level (existing behaviour)
 $MANIFEST set {work_unit} --phase planning --topic {topic} format {chosen-format}
 
-# Also set at phase level if not already set
+# Always set at phase level (overwrite — latest choice becomes the default)
 $MANIFEST set {work_unit} --phase planning format {chosen-format}
 ```
 
@@ -36,7 +36,7 @@ In the planning process skill, when determining format for a new topic:
 
 ### Override
 
-User can always choose a different format for a specific topic. The topic-level value takes precedence. Phase-level default is a recommendation, not a constraint.
+User can always choose a different format for a specific topic. The topic-level value takes precedence. Phase-level default is a recommendation, not a constraint. Choosing a different format updates the phase-level default so subsequent topics inherit the latest choice.
 
 ## Touch Points
 

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -174,6 +174,7 @@ Once selected:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase planning --topic {topic}
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} format {chosen-format}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning format {chosen-format}
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} spec_commit {commit-hash}
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task_list_gate_mode gated
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} author_gate_mode gated


### PR DESCRIPTION
## Summary

- Write plan format at phase level alongside topic level so subsequent topics inherit the most recent format choice
- The planning entry skill already queries phase-level format and passes it as a recommendation — this wires up the write side that was missing
- Phase-level default is unconditionally overwritten so the latest choice always becomes the new default

## Test plan

- [ ] Create an epic with multiple topics, plan the first topic choosing a format — verify phase-level format is set in manifest
- [ ] Plan a second topic — verify the recommendation prompt appears with the first topic's format
- [ ] Decline the recommendation and choose a different format — verify phase-level default updates to the new choice
- [ ] Plan a third topic — verify recommendation shows the updated format

🤖 Generated with [Claude Code](https://claude.com/claude-code)