### PR TITLE
refactor: manifest CLI dot-path syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Migration scripts are point-in-time snapshots. The manifest CLI validates values
 
 ## Manifest CLI
 
-The manifest CLI at `skills/workflow-manifest/scripts/manifest.js` is the single source of truth for all workflow state. See `skills/workflow-manifest/SKILL.md` for the full API.
+The manifest CLI at `skills/workflow-manifest/scripts/manifest.js` is the single source of truth for all workflow state. Uses dot-path syntax: `command <work-unit>[.<phase>[.<topic>]] [field] [value]`. Segment count determines access level (1 = work unit, 2 = phase, 3 = topic). See `skills/workflow-manifest/SKILL.md` for the full API.
 
 ## Display & Output Conventions (MANDATORY)
 

--- a/agents/workflow-implementation-analysis-task-writer.md
+++ b/agents/workflow-implementation-analysis-task-writer.md
@@ -47,11 +47,11 @@ Append at the end of the Plan Index File body, following the **Phase Entry** and
 - Internal IDs must match the IDs used in the created task files
 - Check the planning `external_id` via the manifest CLI:
   ```bash
-  node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} external_id
+  node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} external_id
   ```
   If the command errors (field doesn't exist) or returns empty, set it to the external identifier for the plan from the output format:
   ```bash
-  node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_id "{external_id_value}"
+  node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_id "{external_id_value}"
   ```
 
 ## Hard Rules

--- a/roadmap/IMPLEMENTATION-INDEX.md
+++ b/roadmap/IMPLEMENTATION-INDEX.md
@@ -20,7 +20,7 @@ Overview of remaining PRs for the work-type architecture. PR 1 (Big Bang) is the
 | ✅ | PR 12 | Research-to-Discussion Handoff | [PR12-FEATURE-RESEARCH-ANALYSIS.md](PR12-FEATURE-RESEARCH-ANALYSIS.md) |
 | ✅ | PR 13 | Manifest CLI — Wildcard Topic | [PR13-MANIFEST-WILDCARD-TOPIC.md](PR13-MANIFEST-WILDCARD-TOPIC.md) |
 | ✅ | PR 15 | Default Plan Format Inheritance | [PR15-DEFAULT-PLAN-FORMAT.md](PR15-DEFAULT-PLAN-FORMAT.md) |
-| | PR 14 | Manifest CLI — Dot-Path Syntax | [PR14-MANIFEST-DOT-PATH-SYNTAX.md](PR14-MANIFEST-DOT-PATH-SYNTAX.md) |
+| ✅ | PR 14 | Manifest CLI — Dot-Path Syntax | [PR14-MANIFEST-DOT-PATH-SYNTAX.md](PR14-MANIFEST-DOT-PATH-SYNTAX.md) |
 
 ## Why This Order
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -237,7 +237,7 @@ Blocking dependencies:
 Ask which dependency to mark as satisfied. Update via manifest CLI:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_dependencies.{dep_topic}.state satisfied_externally
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_dependencies.{dep_topic}.state satisfied_externally
 ```
 
 Commit the change. Then re-present the menu from **C. Menu** (the item may now be unblocked).

--- a/skills/link-dependencies/SKILL.md
+++ b/skills/link-dependencies/SKILL.md
@@ -82,7 +82,7 @@ Scan the selected work unit for existing plans:
    - Each subdirectory is a topic that may contain a `planning.md` file
 
 2. **Extract plan metadata**: For each topic with a plan
-   - Read the format via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format`
+   - Read the format via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format`
    - Note the format used by each plan
 
 #### If no plans exist
@@ -139,7 +139,7 @@ format. Consolidate your plans to a single format before linking.
 
 For each plan, read the `external_dependencies` from the manifest:
 
-1. **Read `external_dependencies`** via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} external_dependencies`
+1. **Read `external_dependencies`** via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} external_dependencies`
 2. **Categorize each dependency** by iterating the object's entries. Each key is a topic, each value has a `state` field:
    - **Unresolved**: `state: unresolved` (no task linked)
    - **Resolved**: `state: resolved` (has `task_id`)
@@ -192,8 +192,8 @@ For each unresolved dependency:
 For each resolved match:
 
 1. **Update the dependency in the manifest** via dot-path set:
-   - Set `state` to `resolved`: `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_dependencies.{dep-topic}.state resolved`
-   - Set `task_id`: `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_dependencies.{dep-topic}.task_id {internal_id}`
+   - Set `state` to `resolved`: `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_dependencies.{dep-topic}.state resolved`
+   - Set `task_id`: `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_dependencies.{dep-topic}.task_id {internal_id}`
 
 2. **Create dependency in output format**:
    - Load `../workflow-planning-process/references/output-formats/{format}/graph.md`

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -51,7 +51,7 @@ Store work_unit for the handoff.
 Check if discussion phase entry exists:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase discussion --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.discussion.{topic}
 ```
 
 **If exists (`true`):**

--- a/skills/workflow-discussion-entry/references/gather-context.md
+++ b/skills/workflow-discussion-entry/references/gather-context.md
@@ -13,7 +13,7 @@ New discussion entry: topic was provided by the caller.
 Check research status via manifest:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase research status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.research status
 ```
 
 **If research status is `completed`:**

--- a/skills/workflow-discussion-entry/references/handle-selection.md
+++ b/skills/workflow-discussion-entry/references/handle-selection.md
@@ -66,7 +66,7 @@ Refreshing analysis...
 
 Clear the cache metadata from the manifest and delete the cache file:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} phases.research.analysis_cache
+node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit}.research analysis_cache
 rm .workflows/{work_unit}/.state/research-analysis.md
 ```
 

--- a/skills/workflow-discussion-entry/references/research-analysis.md
+++ b/skills/workflow-discussion-entry/references/research-analysis.md
@@ -52,10 +52,10 @@ When naming themes:
 
 Write cache metadata to manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} phases.research.analysis_cache.checksum "{research.checksum from discovery}"
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} phases.research.analysis_cache.generated "{ISO timestamp}"
-node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} phases.research.analysis_cache.files "{filename1}.md"
-node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} phases.research.analysis_cache.files "{filename2}.md"
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.research analysis_cache.checksum "{research.checksum from discovery}"
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.research analysis_cache.generated "{ISO timestamp}"
+node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.research analysis_cache.files "{filename1}.md"
+node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.research analysis_cache.files "{filename2}.md"
 ```
 
 Ensure the cache directory exists:

--- a/skills/workflow-discussion-entry/references/validate-phase.md
+++ b/skills/workflow-discussion-entry/references/validate-phase.md
@@ -9,7 +9,7 @@ Check if a discussion already exists for this work unit and topic.
 Use the manifest CLI to check discussion phase state:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.discussion.{topic}
 ```
 
 #### If discussion exists and status is `in-progress`
@@ -29,7 +29,7 @@ Set source="continue".
 Reset to in-progress:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase discussion --topic {topic} status in-progress
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.discussion.{topic} status in-progress
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -92,7 +92,7 @@ Found existing discussion for **{topic:(titlecase)}**.
    Populate from handoff context and user input as before.
 4. Register discussion in manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase discussion --topic {topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}.discussion.{topic}
    ```
 5. Commit the initial file
 

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -25,7 +25,7 @@ Incorporate the user's context into the discussion, commit, then re-present the 
 
 1. Set discussion status to completed via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase discussion --topic {topic} status completed
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.discussion.{topic} status completed
    ```
 2. Final commit
 3. Invoke the bridge:

--- a/skills/workflow-implementation-entry/references/check-dependencies.md
+++ b/skills/workflow-implementation-entry/references/check-dependencies.md
@@ -7,7 +7,7 @@
 Query the planning manifest entry for external dependencies:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} external_dependencies
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} external_dependencies
 ```
 
 #### If no external dependencies (empty or not found)
@@ -25,7 +25,7 @@ External dependencies satisfied.
 For each dependency, check its state. If the dependency has a `task_id`, check whether that task is completed by querying the dependency's plan:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {dep_topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{dep_topic} status
 ```
 
 **If all dependencies are satisfied** (state is `satisfied` or `satisfied_externally`, and any referenced tasks are completed):
@@ -73,7 +73,7 @@ Incomplete (planned but not implemented):
 If the user says a dependency has been implemented outside the workflow:
 
 1. Ask which dependency to mark as satisfied
-2. Update the dependency's `state` to `satisfied_externally` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_dependencies.{dep-topic}.state satisfied_externally`)
+2. Update the dependency's `state` to `satisfied_externally` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_dependencies.{dep-topic}.state satisfied_externally`)
 3. Commit the change
 4. Re-check dependencies
 

--- a/skills/workflow-implementation-entry/references/invoke-skill.md
+++ b/skills/workflow-implementation-entry/references/invoke-skill.md
@@ -15,14 +15,14 @@ Invoke the [workflow-implementation-process](../../workflow-implementation-proce
 Query format and external_id from manifest:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} external_id
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} external_id
 ```
 
 Check implementation status:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status
 ```
 
 ```

--- a/skills/workflow-implementation-entry/references/validate-phase.md
+++ b/skills/workflow-implementation-entry/references/validate-phase.md
@@ -7,7 +7,7 @@
 Check if plan exists and is ready.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
 ```
 
 Also verify the plan file exists at `.workflows/{work_unit}/planning/{topic}/planning.md`.
@@ -43,13 +43,13 @@ The plan for "{topic:(titlecase)}" is not yet completed.
 Check if implementation phase entry exists:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase implementation --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
 ```
 
 **If exists (`true`):**
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status
 ```
 
 **If status is `completed`:**
@@ -57,7 +57,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 Reset to in-progress:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} status in-progress
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} status in-progress
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -34,7 +34,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 2. **Check task progress in the plan** — use the plan adapter's instructions to read the plan's current state. Also read the implementation file and any other working documents for additional context.
 3. **Check gate modes and progress** via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic}
    ```
    Check `task_gate_mode`, `fix_gate_mode`, `analysis_gate_mode`, `fix_attempts`, and `analysis_cycle` — if gates are `auto`, the user previously opted out. If `fix_attempts` > 0, you're mid-fix-loop for the current task. If `analysis_cycle` > 0, you've completed analysis cycles — check for findings files on disk (`analysis-*-c{cycle-number}.md` in the implementation directory) to determine mid-analysis state.
 4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
@@ -73,11 +73,11 @@ Found existing implementation for "{topic:(titlecase)}". Resuming from previous 
 
 Reset gate modes and counters via manifest CLI (fresh session = fresh gates/cycles):
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} task_gate_mode gated
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_gate_mode gated
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_gate_mode gated
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_attempts 0
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_cycle 0
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} task_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_attempts 0
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_cycle 0
 ```
 
 → Proceed to **Step 1**.
@@ -125,11 +125,11 @@ Save their instructions to `.workflows/.state/environment-setup.md` (or "No spec
 1. Read the plan from the provided location (typically `.workflows/{work_unit}/planning/{topic}/planning.md`)
 2. Plans can be stored in various formats. Read the `format` via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} format
+   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} format
    ```
    If not set in the implementation phase, check the planning phase:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format
+   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format
    ```
 3. Load the format's per-concern adapter files from `../workflow-planning-process/references/output-formats/{format}/`:
    - **reading.md** — how to read tasks from the plan
@@ -152,17 +152,17 @@ Save their instructions to `.workflows/.state/environment-setup.md` (or "No spec
 
 1. Set implementation state via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase implementation --topic {topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} format {format from plan}
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} task_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_attempts 0
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_cycle 0
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters []
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} project_skills []
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} current_phase 1
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} current_task ~
+   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}.implementation.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} format {format from plan}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} task_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_attempts 0
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_cycle 0
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters []
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills []
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_phase 1
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_task ~
    ```
 
 2. Create `.workflows/{work_unit}/implementation/{topic}/implementation.md`:
@@ -181,7 +181,7 @@ Save their instructions to `.workflows/.state/environment-setup.md` (or "No spec
 
 ## Step 4: Project Skills Discovery
 
-Check `project_skills` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} project_skills`).
+Check `project_skills` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} project_skills`).
 
 #### If `project_skills` is populated
 
@@ -247,8 +247,8 @@ Which project skills should be used?
 
 Store the selected skill paths via manifest CLI, pushing each path individually:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} --phase implementation --topic {topic} project_skills "{path1}"
-node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} --phase implementation --topic {topic} project_skills "{path2}"
+node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.implementation.{topic} project_skills "{path1}"
+node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.implementation.{topic} project_skills "{path2}"
 ```
 
 → Proceed to **Step 5**.
@@ -259,7 +259,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} --pha
 
 Load **[linter-setup.md](references/linter-setup.md)** and follow its instructions as written.
 
-Check `linters` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} linters`). If already populated, present the existing configuration for confirmation (same pattern as project skills in Step 4). If confirmed, skip discovery and proceed.
+Check `linters` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} linters`). If already populated, present the existing configuration for confirmation (same pattern as project skills in Step 4). If confirmed, skip discovery and proceed.
 
 Otherwise, present discovery findings to the user:
 
@@ -285,7 +285,7 @@ Approve these linters?
 
 #### If `yes`
 
-Store the approved linter commands via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters [...]`).
+Store the approved linter commands via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters [...]`).
 
 → Proceed to **Step 6**.
 
@@ -295,7 +295,7 @@ Adjust based on user input, re-present for confirmation.
 
 #### If `skip`
 
-Store empty linters array via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters []`).
+Store empty linters array via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters []`).
 
 → Proceed to **Step 6**.
 
@@ -364,9 +364,9 @@ Re-present the sign-off prompt above.
 
 Update implementation status via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} status completed
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_cycle 0
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_attempts 0
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_cycle 0
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_attempts 0
 ```
 
 Commit: `impl({work_unit}): complete implementation`

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -20,7 +20,7 @@ F. Create tasks in plan → invoke-task-writer.md
 
 ## A. Cycle Gate
 
-Increment `analysis_cycle` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_cycle {N}`).
+Increment `analysis_cycle` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_cycle {N}`).
 
 #### If `analysis_cycle` <= 3
 
@@ -150,7 +150,7 @@ impl({work_unit}): analysis cycle {N} — synthesis
 
 Read the staging file from `.workflows/{work_unit}/implementation/{topic}/analysis-tasks-c{cycle-number}.md`.
 
-Check `analysis_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} analysis_gate_mode`).
+Check `analysis_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} analysis_gate_mode`).
 
 Present an overview:
 

--- a/skills/workflow-implementation-process/references/invoke-analysis.md
+++ b/skills/workflow-implementation-process/references/invoke-analysis.md
@@ -26,10 +26,10 @@ Dispatch **all three in parallel** via the Task tool. Each agent receives the sa
 
 1. **Implementation files** — the file list from scope identification
 2. **Specification path** — from the specification (if available)
-3. **Project skill paths** — from `project_skills` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} project_skills`)
+3. **Project skill paths** — from `project_skills` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} project_skills`)
 4. **code-quality.md path** — `code-quality.md`
 5. **Topic name** — the implementation topic
-6. **Cycle number** — the current analysis cycle number (from `analysis_cycle` in the manifest: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} analysis_cycle`)
+6. **Cycle number** — the current analysis cycle number (from `analysis_cycle` in the manifest: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} analysis_cycle`)
 
 Each agent knows its own output path convention and writes findings independently.
 

--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -15,9 +15,9 @@ This step invokes the `workflow-implementation-task-executor` agent (`../../../a
 1. **tdd-workflow.md**: `tdd-workflow.md`
 2. **code-quality.md**: `code-quality.md`
 3. **Specification path**: from the specification (if available)
-4. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} project_skills`)
+4. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} project_skills`)
 5. **Task content**: normalised task content (see [task-normalisation.md](task-normalisation.md))
-6. **Linter commands**: from `linters` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} linters`) (if configured)
+6. **Linter commands**: from `linters` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} linters`) (if configured)
 
 **Re-attempts after review feedback** additionally include:
 7. **User-approved review notes**: verbatim or as modified by the user

--- a/skills/workflow-implementation-process/references/invoke-reviewer.md
+++ b/skills/workflow-implementation-process/references/invoke-reviewer.md
@@ -14,7 +14,7 @@ Invoke `workflow-implementation-task-reviewer` with:
 
 1. **Specification path**: same path given to the executor
 2. **Task content**: same normalised task content the executor received
-3. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} project_skills`)
+3. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} project_skills`)
 
 ---
 

--- a/skills/workflow-implementation-process/references/linter-setup.md
+++ b/skills/workflow-implementation-process/references/linter-setup.md
@@ -25,7 +25,7 @@ Discover and configure project linters for use during the TDD cycle's LINT step.
 Linter commands are stored in the manifest as a `linters` array:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters [{"name":"phpstan","command":"vendor/bin/phpstan analyse --memory-limit=512M"},{"name":"pint","command":"vendor/bin/pint --test"}]
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters [{"name":"phpstan","command":"vendor/bin/phpstan analyse --memory-limit=512M"},{"name":"pint","command":"vendor/bin/pint --test"}]
 ```
 
 Each entry has:
@@ -34,5 +34,5 @@ Each entry has:
 
 If the user skips linter setup, store an empty array:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} linters []
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters []
 ```

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -24,7 +24,7 @@ E. Update progress + phase check + commit
 1. Follow the format's **reading.md** instructions to determine the next available task.
 2. If no available tasks remain → skip to **When All Tasks Are Complete**.
 3. Normalise the task content following **[task-normalisation.md](task-normalisation.md)**.
-4. Reset `fix_attempts` to `0` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_attempts 0`).
+4. Reset `fix_attempts` to `0` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_attempts 0`).
 5. Mark the task as **in-progress** — follow the format's **updating.md** "In Progress" status transition.
 6. If the format's updating.md includes a **Phase / Parent Status** section: check whether the task's phase parent needs to be started. If so, follow the format's phase start instructions.
 
@@ -90,7 +90,7 @@ Task failed. How would you like to proceed?
 
 ### Review Changes
 
-Increment `fix_attempts` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_attempts {N}`).
+Increment `fix_attempts` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_attempts {N}`).
 
 > *Output the next fenced block as a code block:*
 
@@ -106,7 +106,7 @@ Notes (non-blocking):
 {NOTES from reviewer}
 ```
 
-Check `fix_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} fix_gate_mode`).
+Check `fix_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} fix_gate_mode`).
 
 #### If `fix_gate_mode: auto` and `fix_attempts < 3`
 
@@ -151,7 +151,7 @@ Phase: {phase number} — {phase name}
 {executor's SUMMARY — brief commentary, decisions, implementation notes}
 ```
 
-Check the `task_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} task_gate_mode`).
+Check the `task_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} task_gate_mode`).
 
 #### If `task_gate_mode: auto`
 
@@ -192,13 +192,13 @@ Approve this task?
 
 **Update implementation state via manifest CLI**:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} current_phase {N}
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} current_task {next_task_id or ~}
-node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} --phase implementation --topic {topic} completed_tasks "{internal_id}"
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_phase {N}
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_task {next_task_id or ~}
+node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.implementation.{topic} completed_tasks "{internal_id}"
 ```
-- If the current phase has no remaining open/in-progress tasks: `node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} --phase implementation --topic {topic} completed_phases {N}`
-- If user chose `auto` at the task gate this turn: `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} task_gate_mode auto`
-- If user chose `auto` at the fix gate this turn: `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} fix_gate_mode auto`
+- If the current phase has no remaining open/in-progress tasks: `node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.implementation.{topic} completed_phases {N}`
+- If user chose `auto` at the task gate this turn: `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} task_gate_mode auto`
+- If user chose `auto` at the fix gate this turn: `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_gate_mode auto`
 
 **Commit all changes** in a single commit:
 

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -46,7 +46,7 @@ Investigation is always bugfix work_type. Store work_unit for the handoff.
 Check if the investigation phase entry exists:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase investigation --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.investigation.{topic}
 ```
 
 **If exists (`true`):**

--- a/skills/workflow-investigation-entry/references/validate-phase.md
+++ b/skills/workflow-investigation-entry/references/validate-phase.md
@@ -7,7 +7,7 @@
 Check investigation status via manifest CLI:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase investigation --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.investigation.{topic}
 ```
 
 #### If status is `in-progress`
@@ -27,7 +27,7 @@ Set source="continue".
 Reset to in-progress:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase investigation --topic {topic} status in-progress
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.investigation.{topic} status in-progress
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -107,7 +107,7 @@ Found existing investigation for **{topic:(titlecase)}**.
 3. Populate the Symptoms section with any context already gathered
 4. Register investigation in manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase investigation --topic {topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}.investigation.{topic}
    ```
 5. Commit the initial file
 

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -27,7 +27,7 @@ Investigation complete. Ready to conclude?
 
 1. Set investigation status to completed via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase investigation --topic {topic} status completed
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.investigation.{topic} status completed
    ```
 2. Final commit
 3. Display conclusion:

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -16,45 +16,66 @@ CLI tool for reading and writing work unit manifest files. Single source of trut
 node .claude/skills/workflow-manifest/scripts/manifest.js <command> [args]
 ```
 
-## Domain-Aware Flag Syntax
+## Dot-Path Syntax
 
-Skills provide logical coordinates via `--phase` and `--topic` flags. The CLI routes to the correct JSON path internally. All work types use the same `items` structure — skills never need to know the manifest's internal layout.
+Every command follows: `command path [field] [value]`
+
+The path joins work unit, phase, and topic with dots. The field is always a separate argument. Segment count in the path determines the access level:
+
+| Segments | Level | Path | Field | Resolves to |
+|----------|-------|------|-------|-------------|
+| 1 | Work unit | `my-epic` | `work_type` | `work_type` |
+| 2 | Phase | `my-epic.planning` | `format` | `phases.planning.format` |
+| 3 | Topic | `my-epic.discussion.auth-flow` | `status` | `phases.discussion.items.auth-flow.status` |
 
 ```bash
 MANIFEST="node .claude/skills/workflow-manifest/scripts/manifest.js"
 
-# Phase operations (--phase and --topic flags):
-$MANIFEST get {work_unit} --phase discussion --topic {topic} [field.path]
-$MANIFEST get {work_unit} --phase discussion --topic "*" [field.path]   # wildcard: all topics
-$MANIFEST set {work_unit} --phase discussion --topic {topic} field.path value
-$MANIFEST init-phase {work_unit} --phase discussion --topic {topic}
-
-# Work-unit operations (no flags):
+# Work-unit level (1 segment):
 $MANIFEST get {work_unit} [field]
 $MANIFEST set {work_unit} field value
 $MANIFEST delete {work_unit} field.path
+$MANIFEST exists {work_unit} [field.path]
+
+# Phase level (2 segments):
+$MANIFEST get {work_unit}.{phase} [field]
+$MANIFEST set {work_unit}.{phase} field value
+$MANIFEST delete {work_unit}.{phase} field.path
+
+# Topic level (3 segments):
+$MANIFEST get {work_unit}.{phase}.{topic} [field.path]
+$MANIFEST set {work_unit}.{phase}.{topic} field.path value
+$MANIFEST delete {work_unit}.{phase}.{topic} field.path
+$MANIFEST init-phase {work_unit}.{phase}.{topic}
+
+# Wildcard (3 segments, * as topic):
+$MANIFEST get {work_unit}.{phase}.* [field.path]
+$MANIFEST exists {work_unit}.{phase}.* [field.path]
 
 # Existence checks (always exit 0, outputs true/false):
 $MANIFEST exists {work_unit}
 $MANIFEST exists {work_unit} [field.path]
-$MANIFEST exists {work_unit} --phase <phase> [--topic <topic>] [field.path]
-$MANIFEST exists {work_unit} --phase <phase> --topic "*" [field.path]   # wildcard: any topic
+$MANIFEST exists {work_unit}.{phase} [field.path]
+$MANIFEST exists {work_unit}.{phase}.{topic} [field.path]
 
 # Management (unchanged):
 $MANIFEST init name --work-type type --description "..."
 $MANIFEST list [--status s] [--work-type t]
 ```
 
-**`--topic` is optional for get** — if omitted, returns the whole phase object. Discovery scripts use this to iterate items:
-```bash
-$MANIFEST get {work_unit} --phase discussion              # whole phase (for iteration)
-$MANIFEST get {work_unit} --phase discussion --topic {topic} status  # specific item field
-```
+**Phase-level access** (2-segment path) — accesses fields directly on the phase object (`phases.{phase}.{field}`). Useful for phase-wide metadata like `format`, `analysis_cache`, etc.
 
-**`--topic "*"` (wildcard)** — collects values from all topics in a phase. Supported by `get` and `exists` only. For epic: iterates all items. For feature/bugfix: returns the single item (topic matches work unit name).
+**Topic-level access** (3-segment path) — routes through items: `phases.{phase}.items.{topic}.{field}`. Used for per-topic state like `status`, gate modes, etc.
+
+**Wildcard topic** (`*` as third segment) — collects values from all topics in a phase. Supported by `get` and `exists` only. For epic: iterates all items. For feature/bugfix: returns the single item.
 
 **Internal routing (CLI handles, skills don't know):**
-- All work types: `--phase discussion --topic auth-flow status` → `phases.discussion.items.auth-flow.status`
+- `my-epic.discussion.auth-flow status` → `phases.discussion.items.auth-flow.status`
+
+### Naming Constraints
+
+- **Work unit names must not contain dots** — dots are the path separator
+- **Work unit names must not match phase names** (`research`, `discussion`, `investigation`, `specification`, `planning`, `implementation`, `review`)
 
 ## Commands
 
@@ -66,13 +87,13 @@ Create a new work unit manifest.
 node .claude/skills/workflow-manifest/scripts/manifest.js init <name> --work-type <epic|feature|bugfix> --description "..."
 ```
 
-Creates `.workflows/<name>/manifest.json` with identity fields and empty phases. Errors if manifest already exists.
+Creates `.workflows/<name>/manifest.json` with identity fields and empty phases. Errors if manifest already exists. Rejects names containing dots or matching phase names.
 
 ### `get`
 
-Read a value or subtree. Three modes:
+Read a value or subtree. Three levels:
 
-**Work-unit level** (no flags):
+**Work-unit level** (1 segment):
 ```bash
 # Full manifest
 node .claude/skills/workflow-manifest/scripts/manifest.js get <name>
@@ -84,22 +105,28 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get <name> status
 node .claude/skills/workflow-manifest/scripts/manifest.js get <name> phases
 ```
 
-**Phase level** (with flags):
+**Phase level** (2 segments):
 ```bash
 # Whole phase object
-node .claude/skills/workflow-manifest/scripts/manifest.js get <name> --phase discussion
+node .claude/skills/workflow-manifest/scripts/manifest.js get <name>.discussion
 
-# Specific field within phase+topic context
-node .claude/skills/workflow-manifest/scripts/manifest.js get <name> --phase discussion --topic auth-flow status
-
-# Nested field path
-node .claude/skills/workflow-manifest/scripts/manifest.js get <name> --phase specification --topic auth-flow sources.auth-api.status
+# Specific field within phase
+node .claude/skills/workflow-manifest/scripts/manifest.js get <name>.planning format
 ```
 
-**Wildcard topic** (`--topic "*"`):
+**Topic level** (3 segments):
+```bash
+# Specific field within topic
+node .claude/skills/workflow-manifest/scripts/manifest.js get <name>.discussion.auth-flow status
+
+# Nested field path
+node .claude/skills/workflow-manifest/scripts/manifest.js get <name>.specification.auth-flow sources.auth-api.status
+```
+
+**Wildcard topic** (3 segments, `*` as topic):
 ```bash
 # Collect status from all topics in a phase
-node .claude/skills/workflow-manifest/scripts/manifest.js get <name> --phase discussion --topic "*" status
+node .claude/skills/workflow-manifest/scripts/manifest.js get <name>.discussion.* status
 ```
 
 Output is a JSON array of `{topic, value}` objects:
@@ -116,18 +143,24 @@ Errors to stderr with non-zero exit if the path does not exist.
 
 ### `set`
 
-Write a value. Two modes:
+Write a value. Three levels:
 
-**Work-unit level** (no flags):
+**Work-unit level** (1 segment):
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set <name> description "Updated description"
 node .claude/skills/workflow-manifest/scripts/manifest.js set <name> status completed
 ```
 
-**Phase level** (with flags):
+**Phase level** (2 segments):
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set <name> --phase discussion --topic auth-flow status completed
-node .claude/skills/workflow-manifest/scripts/manifest.js set <name> --phase planning --topic auth-flow task_list_gate_mode auto
+node .claude/skills/workflow-manifest/scripts/manifest.js set <name>.planning format local-markdown
+node .claude/skills/workflow-manifest/scripts/manifest.js set <name>.research analysis_cache '{"checksum":"..."}'
+```
+
+**Topic level** (3 segments):
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js set <name>.discussion.auth-flow status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set <name>.planning.auth-flow task_list_gate_mode auto
 ```
 
 Values are parsed as JSON first (for arrays, objects, numbers, booleans), falling back to string. Validates structural fields:
@@ -140,16 +173,21 @@ Values are parsed as JSON first (for arrays, objects, numbers, booleans), fallin
 
 ### `delete`
 
-Remove a key from the manifest. Two modes:
+Remove a key from the manifest. Three levels:
 
-**Work-unit level** (no flags):
+**Work-unit level** (1 segment):
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js delete <name> <field.path>
 ```
 
-**Phase level** (with flags):
+**Phase level** (2 segments):
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js delete <name> --phase research --topic <topic> analysis_cache
+node .claude/skills/workflow-manifest/scripts/manifest.js delete <name>.research analysis_cache
+```
+
+**Topic level** (3 segments):
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js delete <name>.implementation.auth completed_tasks
 ```
 
 Errors if the path does not exist. Deletes the key entirely (not just setting to null). Parent keys are preserved.
@@ -176,28 +214,33 @@ Output: JSON array of manifest objects.
 
 ### `init-phase`
 
-Register a topic within a phase. All work types create `phases.<phase>.items.<topic>` with `{ "status": "in-progress" }`.
+Register a topic within a phase. Creates `phases.<phase>.items.<topic>` with `{ "status": "in-progress" }`. Requires a 3-segment path.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js init-phase <name> --phase discussion --topic <topic>
+node .claude/skills/workflow-manifest/scripts/manifest.js init-phase <name>.discussion.<topic>
 ```
 
 Errors if item/phase already exists.
 
 ### `push`
 
-Append a value to an array field. Creates the array if it doesn't exist. Errors if the field exists but is not an array. Two modes:
+Append a value to an array field. Creates the array if it doesn't exist. Errors if the field exists but is not an array. Three levels:
 
-**Work-unit level** (no flags):
+**Work-unit level** (1 segment):
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js push <name> tags "v1"
 ```
 
-**Phase level** (with flags):
+**Phase level** (2 segments):
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js push <name> --phase implementation --topic <topic> completed_tasks "{topic}-1-1"
-node .claude/skills/workflow-manifest/scripts/manifest.js push <name> --phase implementation --topic <topic> completed_phases 1
-node .claude/skills/workflow-manifest/scripts/manifest.js push <name> --phase review --topic <topic> reviewed_tasks "{topic}-1-1"
+node .claude/skills/workflow-manifest/scripts/manifest.js push <name>.research analysis_cache.files "a.md"
+```
+
+**Topic level** (3 segments):
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js push <name>.implementation.{topic} completed_tasks "{topic}-1-1"
+node .claude/skills/workflow-manifest/scripts/manifest.js push <name>.implementation.{topic} completed_phases 1
+node .claude/skills/workflow-manifest/scripts/manifest.js push <name>.review.{topic} reviewed_tasks "{topic}-1-1"
 ```
 
 ### `exists`
@@ -208,21 +251,24 @@ Check whether a work unit, field, or phase entry exists. Always exits 0 — both
 # Does the work unit exist?
 node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>
 
-# Does a field path exist?
-node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> phases.discussion
+# Does a field path exist? (work-unit level)
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> work_type
 
-# Does a phase/topic entry exist?
-node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> --phase discussion --topic auth-flow
-node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> --phase discussion --topic auth-flow status
+# Does a phase-level field exist?
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussion
+
+# Does a topic entry exist?
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussion.auth-flow
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussion.auth-flow status
 
 # Wildcard: does any topic in the phase have this field?
-node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> --phase discussion --topic "*"
-node .claude/skills/workflow-manifest/scripts/manifest.js exists <name> --phase discussion --topic "*" status
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussion.*
+node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussion.* status
 ```
 
 If the work unit doesn't exist and a deeper path is requested, outputs `false` (no error). Actual usage errors (missing args, invalid phase name) still use `die()`.
 
-**Wildcard topic** (`--topic "*"`) — outputs `true` if any topic in the phase matches (has the field, or exists at all if no field specified), `false` otherwise. Always exits 0.
+**Wildcard topic** (`*` as third segment) — outputs `true` if any topic in the phase matches (has the field, or exists at all if no field specified), `false` otherwise. Always exits 0.
 
 ## Validation
 
@@ -254,4 +300,4 @@ Item-level statuses within epic phases follow the same phase-level rules.
 - **File locking**: `.lock` file next to manifest, exclusive create (`wx` flag), 30s stale detection. Prevents concurrent session conflicts.
 - **Atomic writes**: write to `.tmp` then `fs.renameSync`. No partial writes.
 - **Auto-creation**: `init` creates the work unit directory. Phase directories are created by skills when they enter that phase, not by the CLI.
-- **Domain routing**: `--phase` and `--topic` flags let skills use logical coordinates. The CLI resolves to the correct internal JSON path — all work types use `items` structure.
+- **Domain routing**: The dot-path syntax lets skills use logical coordinates. The CLI resolves to the correct internal JSON path — all work types use `items` structure.

--- a/skills/workflow-manifest/scripts/manifest.js
+++ b/skills/workflow-manifest/scripts/manifest.js
@@ -164,6 +164,21 @@ function resolvePhaseSegments(phase, topic, fieldSegments) {
 }
 
 /**
+ * Resolve field segments to full manifest path.
+ * At work-unit level (no phase), field maps directly to manifest root.
+ * At phase/topic level, field is prepended with the phase path.
+ */
+function resolveSegments(phase, topic, fieldSegments) {
+  return phase ? resolvePhaseSegments(phase, topic, fieldSegments) : fieldSegments;
+}
+
+function requireWorkUnit(workUnit) {
+  if (!fs.existsSync(manifestPath(workUnit))) {
+    die(`Work unit "${workUnit}" not found`);
+  }
+}
+
+/**
  * Resolve wildcard topic — collect field values from all topics in a phase.
  * All work types use items structure.
  *
@@ -415,14 +430,9 @@ function cmdSet(args) {
   const fieldSegments = args[1].split('.');
   const value = parseValue(args[2]);
 
-  if (!fs.existsSync(manifestPath(workUnit))) {
-    die(`Work unit "${workUnit}" not found`);
-  }
+  requireWorkUnit(workUnit);
 
-  // Resolve segments: work-unit level uses field directly, phase/topic level prepends phase path
-  const segments = phase
-    ? resolvePhaseSegments(phase, topic, fieldSegments)
-    : fieldSegments;
+  const segments = resolveSegments(phase, topic, fieldSegments);
 
   if (typeof value === 'string') {
     validateSet(segments, value);
@@ -441,13 +451,9 @@ function cmdDelete(args) {
   const { workUnit, phase, topic } = parsePath(args[0]);
   const fieldSegments = args[1].split('.');
 
-  if (!fs.existsSync(manifestPath(workUnit))) {
-    die(`Work unit "${workUnit}" not found`);
-  }
+  requireWorkUnit(workUnit);
 
-  const segments = phase
-    ? resolvePhaseSegments(phase, topic, fieldSegments)
-    : fieldSegments;
+  const segments = resolveSegments(phase, topic, fieldSegments);
 
   withLock(workUnit, () => {
     const manifest = readManifest(workUnit);
@@ -509,9 +515,7 @@ function cmdInitPhase(args) {
     die('Usage: init-phase <work-unit>.<phase>.<topic>');
   }
 
-  if (!fs.existsSync(manifestPath(workUnit))) {
-    die(`Work unit "${workUnit}" not found`);
-  }
+  requireWorkUnit(workUnit);
 
   withLock(workUnit, () => {
     const manifest = readManifest(workUnit);
@@ -539,13 +543,9 @@ function cmdPush(args) {
   const fieldSegments = args[1].split('.');
   const value = parseValue(args[2]);
 
-  if (!fs.existsSync(manifestPath(workUnit))) {
-    die(`Work unit "${workUnit}" not found`);
-  }
+  requireWorkUnit(workUnit);
 
-  const segments = phase
-    ? resolvePhaseSegments(phase, topic, fieldSegments)
-    : fieldSegments;
+  const segments = resolveSegments(phase, topic, fieldSegments);
 
   withLock(workUnit, () => {
     const manifest = readManifest(workUnit);

--- a/skills/workflow-manifest/scripts/manifest.js
+++ b/skills/workflow-manifest/scripts/manifest.js
@@ -18,9 +18,6 @@ const VALID_PHASES = [
   'review'
 ];
 
-// Phases that have no topics — --topic is not required for these
-const TOPICLESS_PHASES = [];
-
 const VALID_PHASE_STATUSES = {
   research:       ['in-progress', 'completed'],
   discussion:     ['in-progress', 'completed'],
@@ -127,42 +124,40 @@ function withLock(name, fn) {
 }
 
 // ---------------------------------------------------------------------------
-// Flag Parsing
+// Path Parsing
 // ---------------------------------------------------------------------------
 
 /**
- * Extract --phase and --topic flags from args.
- * Returns { phase, topic, positional } where positional is remaining args.
+ * Parse a dot-path argument into work unit, phase, and topic.
+ * Segment count determines the access level:
+ *   1 segment  → work-unit level
+ *   2 segments → phase level
+ *   3 segments → topic level
  */
-function parseFlags(args) {
-  let phase = null;
-  let topic = null;
-  const positional = [];
-
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--phase' && i + 1 < args.length) {
-      phase = args[++i];
-    } else if (args[i] === '--topic' && i + 1 < args.length) {
-      topic = args[++i];
-    } else {
-      positional.push(args[i]);
-    }
+function parsePath(pathArg) {
+  const parts = pathArg.split('.');
+  if (parts.length === 1) return { workUnit: parts[0], phase: null, topic: null };
+  if (parts.length === 2) {
+    validatePhase(parts[1]);
+    return { workUnit: parts[0], phase: parts[1], topic: null };
   }
-
-  return { phase, topic, positional };
+  if (parts.length === 3) {
+    validatePhase(parts[1]);
+    return { workUnit: parts[0], phase: parts[1], topic: parts[2] };
+  }
+  die(`Invalid path "${pathArg}". Expected: <work-unit>[.<phase>[.<topic>]]`);
 }
 
 /**
  * Resolve the internal JSON path segments for a phase+topic operation.
  * All work types route through items when topic is provided.
  *
- * @param {string} workType - The work unit's work_type (kept for call-site compat)
  * @param {string} phase - The phase name
  * @param {string|null} topic - The topic name (null = whole phase)
  * @param {string[]} fieldSegments - Additional field path segments
  * @returns {string[]} Full path segments from manifest root
  */
-function resolvePhaseSegments(workType, phase, topic, fieldSegments) {
+function resolvePhaseSegments(phase, topic, fieldSegments) {
   const base = ['phases', phase];
   if (!topic) return [...base, ...fieldSegments];
   return [...base, 'items', topic, ...fieldSegments];
@@ -344,6 +339,8 @@ function cmdInit(args) {
 
   if (!name) die('Usage: init <name> --work-type <type> --description "..."');
   if (!workType) die('--work-type is required');
+  if (name.includes('.')) die(`Work unit name "${name}" must not contain dots`);
+  if (VALID_PHASES.includes(name)) die(`Work unit name "${name}" conflicts with a phase name`);
 
   validateWorkType(workType);
 
@@ -370,160 +367,94 @@ function cmdInit(args) {
 }
 
 function cmdGet(args) {
-  const { phase, topic, positional } = parseFlags(args);
+  if (args.length < 1) die('Usage: get <path> [field.path]');
 
-  if (positional.length < 1) die('Usage: get <name> [--phase <phase>] [--topic <topic>] [field.path]');
-
-  const name = positional[0];
-  const manifest = readManifest(name);
+  const { workUnit, phase, topic } = parsePath(args[0]);
+  const manifest = readManifest(workUnit);
 
   if (!phase) {
-    // Work-unit-level: get <name> [field]
-    if (positional.length === 1) {
+    // Work-unit-level: get <wu> [field]
+    if (args.length === 1) {
       process.stdout.write(JSON.stringify(manifest, null, 2) + '\n');
       return;
     }
-
-    const segments = positional[1].split('.');
+    const segments = args[1].split('.');
     const value = getByPath(manifest, segments);
     if (value === undefined) {
-      die(`Path "${positional[1]}" not found in "${name}"`);
+      die(`Path "${args[1]}" not found in "${workUnit}"`);
     }
     outputValue(value);
     return;
   }
 
-  // Phase-level: get <name> --phase <phase> [--topic <topic>] [field.path]
-  validatePhase(phase);
-
-  const fieldSegments = positional.length > 1 ? positional[1].split('.') : [];
+  // Phase/topic level
+  const fieldSegments = args.length > 1 ? args[1].split('.') : [];
 
   // Wildcard topic: collect values from all topics
   if (topic === '*') {
     const results = resolveWildcardTopic(manifest, phase, fieldSegments);
     if (results.length === 0) {
-      die(`No items found in phase "${phase}" of "${name}"`);
+      die(`No items found in phase "${phase}" of "${workUnit}"`);
     }
     process.stdout.write(JSON.stringify(results, null, 2) + '\n');
     return;
   }
 
-  const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
-
+  const segments = resolvePhaseSegments(phase, topic, fieldSegments);
   const value = getByPath(manifest, segments);
   if (value === undefined) {
-    die(`Path "${segments.join('.')}" not found in "${name}"`);
+    die(`Path "${segments.join('.')}" not found in "${workUnit}"`);
   }
   outputValue(value);
 }
 
 function cmdSet(args) {
-  const { phase, topic, positional } = parseFlags(args);
+  if (args.length < 3) die('Usage: set <path> <field> <value>');
 
-  if (!phase) {
-    // Work-unit-level: set <name> <field> <value>
-    if (positional.length !== 3) die('Usage: set <name> <field> <value>');
+  const { workUnit, phase, topic } = parsePath(args[0]);
+  const fieldSegments = args[1].split('.');
+  const value = parseValue(args[2]);
 
-    const name = positional[0];
-    const segments = positional[1].split('.');
-    const value = parseValue(positional[2]);
-
-    if (typeof value === 'string') {
-      validateSet(segments, value);
-    }
-
-    if (!fs.existsSync(manifestPath(name))) {
-      die(`Work unit "${name}" not found`);
-    }
-
-    withLock(name, () => {
-      const manifest = readManifest(name);
-      setByPath(manifest, segments, value);
-      writeManifestAtomic(name, manifest);
-    });
-    return;
+  if (!fs.existsSync(manifestPath(workUnit))) {
+    die(`Work unit "${workUnit}" not found`);
   }
 
-  // Phase-level: set <name> --phase <phase> [--topic <topic>] <field.path> <value>
-  if (positional.length !== 3) {
-    die('Usage: set <name> --phase <phase> [--topic <topic>] <field.path> <value>');
-  }
-
-  const name = positional[0];
-  validatePhase(phase);
-  if (!topic && !TOPICLESS_PHASES.includes(phase)) {
-    die(`--topic is required for phase "${phase}"`);
-  }
-
-  const fieldSegments = positional[1].split('.');
-  const value = parseValue(positional[2]);
-
-  if (!fs.existsSync(manifestPath(name))) {
-    die(`Work unit "${name}" not found`);
-  }
-
-  const manifest = readManifest(name);
-  const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
+  // Resolve segments: work-unit level uses field directly, phase/topic level prepends phase path
+  const segments = phase
+    ? resolvePhaseSegments(phase, topic, fieldSegments)
+    : fieldSegments;
 
   if (typeof value === 'string') {
     validateSet(segments, value);
   }
 
-  withLock(name, () => {
-    const fresh = readManifest(name);
-    setByPath(fresh, segments, value);
-    writeManifestAtomic(name, fresh);
+  withLock(workUnit, () => {
+    const manifest = readManifest(workUnit);
+    setByPath(manifest, segments, value);
+    writeManifestAtomic(workUnit, manifest);
   });
 }
 
 function cmdDelete(args) {
-  const { phase, topic, positional } = parseFlags(args);
+  if (args.length < 2) die('Usage: delete <path> <field.path>');
 
-  if (!phase) {
-    // Work-unit-level: delete <name> <field.path>
-    if (positional.length !== 2) die('Usage: delete <name> <field.path>');
+  const { workUnit, phase, topic } = parsePath(args[0]);
+  const fieldSegments = args[1].split('.');
 
-    const name = positional[0];
-    const segments = positional[1].split('.');
-
-    if (!fs.existsSync(manifestPath(name))) {
-      die(`Work unit "${name}" not found`);
-    }
-
-    withLock(name, () => {
-      const manifest = readManifest(name);
-      if (!deleteByPath(manifest, segments)) {
-        die(`Path "${positional[1]}" not found in "${name}"`);
-      }
-      writeManifestAtomic(name, manifest);
-    });
-    return;
+  if (!fs.existsSync(manifestPath(workUnit))) {
+    die(`Work unit "${workUnit}" not found`);
   }
 
-  // Phase-level: delete <name> --phase <phase> [--topic <topic>] <field.path>
-  if (positional.length !== 2) {
-    die('Usage: delete <name> --phase <phase> [--topic <topic>] <field.path>');
-  }
+  const segments = phase
+    ? resolvePhaseSegments(phase, topic, fieldSegments)
+    : fieldSegments;
 
-  const name = positional[0];
-  validatePhase(phase);
-  if (!topic && !TOPICLESS_PHASES.includes(phase)) {
-    die(`--topic is required for phase "${phase}"`);
-  }
-
-  const fieldSegments = positional[1].split('.');
-
-  if (!fs.existsSync(manifestPath(name))) {
-    die(`Work unit "${name}" not found`);
-  }
-
-  withLock(name, () => {
-    const manifest = readManifest(name);
-    const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
+  withLock(workUnit, () => {
+    const manifest = readManifest(workUnit);
     if (!deleteByPath(manifest, segments)) {
-      die(`Path "${segments.join('.')}" not found in "${name}"`);
+      die(`Path "${segments.join('.')}" not found in "${workUnit}"`);
     }
-    writeManifestAtomic(name, manifest);
+    writeManifestAtomic(workUnit, manifest);
   });
 }
 
@@ -570,93 +501,54 @@ function cmdList(args) {
 }
 
 function cmdInitPhase(args) {
-  const { phase, topic, positional } = parseFlags(args);
+  if (args.length !== 1) die('Usage: init-phase <work-unit>.<phase>.<topic>');
 
-  if (positional.length !== 1 || !phase || !topic) {
-    die('Usage: init-phase <name> --phase <phase> --topic <topic>');
+  const { workUnit, phase, topic } = parsePath(args[0]);
+
+  if (!phase || !topic) {
+    die('Usage: init-phase <work-unit>.<phase>.<topic>');
   }
 
-  const name = positional[0];
-  validatePhase(phase);
-
-  if (!fs.existsSync(manifestPath(name))) {
-    die(`Work unit "${name}" not found`);
+  if (!fs.existsSync(manifestPath(workUnit))) {
+    die(`Work unit "${workUnit}" not found`);
   }
 
-  withLock(name, () => {
-    const manifest = readManifest(name);
+  withLock(workUnit, () => {
+    const manifest = readManifest(workUnit);
 
     if (!manifest.phases) manifest.phases = {};
     if (!manifest.phases[phase]) manifest.phases[phase] = {};
     if (!manifest.phases[phase].items) manifest.phases[phase].items = {};
 
     if (manifest.phases[phase].items[topic]) {
-      die(`Item "${topic}" already exists in phase "${phase}" of "${name}"`);
+      die(`Item "${topic}" already exists in phase "${phase}" of "${workUnit}"`);
     }
 
     manifest.phases[phase].items[topic] = { status: 'in-progress' };
 
-    writeManifestAtomic(name, manifest);
+    writeManifestAtomic(workUnit, manifest);
   });
 
-  process.stdout.write(`Initialized ${phase} phase for "${topic}" in "${name}"\n`);
+  process.stdout.write(`Initialized ${phase} phase for "${topic}" in "${workUnit}"\n`);
 }
 
 function cmdPush(args) {
-  const { phase, topic, positional } = parseFlags(args);
+  if (args.length < 3) die('Usage: push <path> <field> <value>');
 
-  if (!phase) {
-    // Work-unit-level: push <name> <field> <value>
-    if (positional.length !== 3) die('Usage: push <name> <field> <value>');
+  const { workUnit, phase, topic } = parsePath(args[0]);
+  const fieldSegments = args[1].split('.');
+  const value = parseValue(args[2]);
 
-    const name = positional[0];
-    const segments = positional[1].split('.');
-    const value = parseValue(positional[2]);
-
-    if (!fs.existsSync(manifestPath(name))) {
-      die(`Work unit "${name}" not found`);
-    }
-
-    withLock(name, () => {
-      const manifest = readManifest(name);
-      const current = getByPath(manifest, segments);
-
-      if (current !== undefined && !Array.isArray(current)) {
-        die(`Path "${positional[1]}" is not an array`);
-      }
-
-      if (current === undefined) {
-        setByPath(manifest, segments, [value]);
-      } else {
-        current.push(value);
-      }
-
-      writeManifestAtomic(name, manifest);
-    });
-    return;
+  if (!fs.existsSync(manifestPath(workUnit))) {
+    die(`Work unit "${workUnit}" not found`);
   }
 
-  // Phase-level: push <name> --phase <phase> [--topic <topic>] <field.path> <value>
-  if (positional.length !== 3) {
-    die('Usage: push <name> --phase <phase> [--topic <topic>] <field.path> <value>');
-  }
+  const segments = phase
+    ? resolvePhaseSegments(phase, topic, fieldSegments)
+    : fieldSegments;
 
-  const name = positional[0];
-  validatePhase(phase);
-  if (!topic && !TOPICLESS_PHASES.includes(phase)) {
-    die(`--topic is required for phase "${phase}"`);
-  }
-
-  const fieldSegments = positional[1].split('.');
-  const value = parseValue(positional[2]);
-
-  if (!fs.existsSync(manifestPath(name))) {
-    die(`Work unit "${name}" not found`);
-  }
-
-  withLock(name, () => {
-    const manifest = readManifest(name);
-    const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
+  withLock(workUnit, () => {
+    const manifest = readManifest(workUnit);
     const current = getByPath(manifest, segments);
 
     if (current !== undefined && !Array.isArray(current)) {
@@ -669,20 +561,18 @@ function cmdPush(args) {
       current.push(value);
     }
 
-    writeManifestAtomic(name, manifest);
+    writeManifestAtomic(workUnit, manifest);
   });
 }
 
 function cmdExists(args) {
-  const { phase, topic, positional } = parseFlags(args);
+  if (args.length < 1) die('Usage: exists <path> [field.path]');
 
-  if (positional.length < 1) die('Usage: exists <name> [--phase <phase>] [--topic <topic>] [field.path]');
-
-  const name = positional[0];
-  const mp = manifestPath(name);
+  const { workUnit, phase, topic } = parsePath(args[0]);
+  const mp = manifestPath(workUnit);
 
   // Work-unit level, no field path — just check if manifest file exists
-  if (!phase && positional.length === 1) {
+  if (!phase && args.length === 1) {
     process.stdout.write(fs.existsSync(mp) ? 'true\n' : 'false\n');
     return;
   }
@@ -697,15 +587,14 @@ function cmdExists(args) {
 
   if (!phase) {
     // Work-unit level with field path
-    const segments = positional[1].split('.');
+    const segments = args[1].split('.');
     const value = getByPath(manifest, segments);
     process.stdout.write(value !== undefined ? 'true\n' : 'false\n');
     return;
   }
 
-  // Phase-level
-  validatePhase(phase);
-  const fieldSegments = positional.length > 1 ? positional[1].split('.') : [];
+  // Phase/topic level
+  const fieldSegments = args.length > 1 ? args[1].split('.') : [];
 
   // Wildcard topic: check if any topic has the specified field
   if (topic === '*') {
@@ -714,7 +603,7 @@ function cmdExists(args) {
     return;
   }
 
-  const segments = resolvePhaseSegments(manifest.work_type, phase, topic, fieldSegments);
+  const segments = resolvePhaseSegments(phase, topic, fieldSegments);
   const value = getByPath(manifest, segments);
   process.stdout.write(value !== undefined ? 'true\n' : 'false\n');
 }

--- a/skills/workflow-planning-entry/references/invoke-skill.md
+++ b/skills/workflow-planning-entry/references/invoke-skill.md
@@ -19,7 +19,7 @@ Construct the handoff based on the plan state.
 Query the manifest for any existing plan format preference:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning format
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning format
 ```
 
 ```

--- a/skills/workflow-planning-entry/references/validate-phase.md
+++ b/skills/workflow-planning-entry/references/validate-phase.md
@@ -7,13 +7,13 @@
 Check whether a plan already exists for this topic.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase planning --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.planning.{topic}
 ```
 
 #### If exists (`true`)
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
 ```
 
 **If status is `completed`:**
@@ -21,7 +21,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 Reset to in-progress:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} status in-progress
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} status in-progress
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-planning-entry/references/validate-spec.md
+++ b/skills/workflow-planning-entry/references/validate-spec.md
@@ -7,7 +7,7 @@
 Check if specification exists and is ready using the manifest CLI.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic}
 ```
 
 #### If specification phase doesn't exist or has no status
@@ -45,7 +45,7 @@ The specification must be completed before planning can begin.
 Query all specification entries to identify cross-cutting specs:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification
 ```
 
 Parse the output to identify any items with `type: cross-cutting`. Store these for the cross-cutting context step.

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -34,9 +34,9 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 5. **Check gate modes** via manifest CLI — if `auto`, the user previously opted in during this session. Preserve these values.
-   - `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} task_list_gate_mode`
-   - `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} author_gate_mode`
-   - `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} finding_gate_mode`
+   - `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} task_list_gate_mode`
+   - `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} author_gate_mode`
+   - `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} finding_gate_mode`
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 
@@ -69,18 +69,18 @@ Check if a Plan Index File already exists at `.workflows/{work_unit}/planning/{t
 
 Check the planning status via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
 ```
 
 Note the current phase and task position from the manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} phase
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} task
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} phase
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} task
 ```
 
 Check `spec_commit` from the manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} spec_commit
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} spec_commit
 ```
 
 Load **[spec-change-detection.md](references/spec-change-detection.md)** and follow its instructions as written. Then present the user with an informed choice:
@@ -114,7 +114,7 @@ Continue or restart?
 
 1. Read the `format` from the manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format
+   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format
    ```
 2. Read **[output-formats.md](references/output-formats.md)**, find the entry matching the format, and load the format's **[authoring.md](references/output-formats/{format}/authoring.md)**
 3. Follow the authoring file's cleanup instructions to remove Authored Tasks for this topic
@@ -172,15 +172,15 @@ Once selected:
 2. Create the Plan Index File at `.workflows/{work_unit}/planning/{topic}/planning.md` using the **Title** template from **[plan-index-schema.md](references/plan-index-schema.md)**.
 3. Register planning and set metadata in the manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase planning --topic {topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} format {chosen-format}
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning format {chosen-format}
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} spec_commit {commit-hash}
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task_list_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} author_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} finding_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} phase 1
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task ~
+   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}.planning.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} format {chosen-format}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning format {chosen-format}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} spec_commit {commit-hash}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task_list_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} author_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} finding_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} phase 1
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task ~
    ```
 
 4. Commit: `planning({work_unit}): initialize plan`
@@ -193,18 +193,18 @@ Once selected:
 
 1. Read the `format` from the manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format
+   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format
    ```
 2. Read **[output-formats.md](references/output-formats.md)**, find the entry matching the format, and load the format's **[about.md](references/output-formats/{format}/about.md)** and **[authoring.md](references/output-formats/{format}/authoring.md)**
 3. Reset gate modes to `gated` in the manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task_list_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} author_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} finding_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task_list_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} author_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} finding_gate_mode gated
    ```
 4. Update `spec_commit` to current HEAD:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} spec_commit $(git rev-parse HEAD)
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} spec_commit $(git rev-parse HEAD)
    ```
 
 → Proceed to **Step 3**.
@@ -292,7 +292,7 @@ Re-present the sign-off prompt above.
 
 1. **Update plan status** via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} status completed
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} status completed
    ```
 2. **Final commit** — Commit the completed plan: `planning({work_unit}): complete plan`
 3. **Present completion summary**:

--- a/skills/workflow-planning-process/references/analyze-task-graph.md
+++ b/skills/workflow-planning-process/references/analyze-task-graph.md
@@ -19,7 +19,7 @@ priorities across the full plan.
 
 Read the `format` from the manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format
 ```
 
 Read **[output-formats.md](output-formats.md)**, find the entry matching the format, and load the format's **[reading.md](output-formats/{format}/reading.md)** and **[graph.md](output-formats/{format}/graph.md)**.

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -56,7 +56,7 @@ Re-invoke the agent with the same inputs.
 
 Check `author_gate_mode` via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} author_gate_mode
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} author_gate_mode
 ```
 
 #### If `author_gate_mode: auto`
@@ -118,7 +118,7 @@ Mark the task `approved` in the scratch file. Continue to the next task.
 
 Mark the task `approved` in the scratch file. Set all remaining `pending` tasks to `approved`. Update `author_gate_mode` in the manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} author_gate_mode auto
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} author_gate_mode auto
 ```
 
 → Proceed to **F. Write to Plan**.
@@ -175,12 +175,12 @@ For each approved task in the scratch file, in order:
 3. Update the task table in the Plan Index File: set `status: authored` and set `External ID` to the external identifier for the task as exposed by the output format
 4. If the manifest's `external_id` is empty, set it to the external identifier for the plan as exposed by the output format:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_id {external_id}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_id {external_id}
    ```
 5. If the current phase's `external_id` is empty, set it to the external identifier for the phase as exposed by the output format
 6. Advance the manifest planning position to the next pending task (or next phase if this was the last task):
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task {next_task_id}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task {next_task_id}
    ```
 7. Commit: `planning({work_unit}): author task {internal_id} ({task name})`
 

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -53,8 +53,8 @@ The agent returns a complete phase structure. Write it directly to the Plan Inde
 
 Update the manifest planning position:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} phase 1
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task ~
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} phase 1
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task ~
 ```
 
 Commit: `planning({work_unit}): draft phase structure`

--- a/skills/workflow-planning-process/references/define-tasks.md
+++ b/skills/workflow-planning-process/references/define-tasks.md
@@ -42,8 +42,8 @@ The agent returns a task overview and task table. Write the task table directly 
 
 Update the manifest planning position:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} phase {N}
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task ~
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} phase {N}
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task ~
 ```
 
 Commit: `planning({work_unit}): draft Phase {N} task list`
@@ -62,7 +62,7 @@ Then check the gate mode.
 
 Check `task_list_gate_mode` via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} task_list_gate_mode
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} task_list_gate_mode
 ```
 
 #### If `task_list_gate_mode: auto`
@@ -112,11 +112,11 @@ Note that `task_list_gate_mode` should be updated to `auto` in the manifest duri
 
 1. Advance the planning position in the manifest to the first task in this phase:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task {first_task_id}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task {first_task_id}
    ```
 2. If user chose `auto` at this gate: update the manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task_list_gate_mode auto
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task_list_gate_mode auto
    ```
 3. Commit: `planning({work_unit}): approve Phase {N} task list`
 

--- a/skills/workflow-planning-process/references/dependencies.md
+++ b/skills/workflow-planning-process/references/dependencies.md
@@ -18,7 +18,7 @@ External dependencies are things a feature needs from other topics or systems th
 
 ## Format
 
-External dependencies are stored in the **manifest** as `external_dependencies` (under `--phase planning --topic {topic}`), keyed by topic:
+External dependencies are stored in the **manifest** as `external_dependencies` (under `planning.{topic}`), keyed by topic:
 
 ```json
 {
@@ -41,14 +41,14 @@ External dependencies are stored in the **manifest** as `external_dependencies` 
 Set individual dependencies via dot-path:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_dependencies.billing-system.description "Invoice generation"
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_dependencies.billing-system.state unresolved
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_dependencies.billing-system.description "Invoice generation"
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_dependencies.billing-system.state unresolved
 ```
 
 If there are no external dependencies, use an empty object:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_dependencies '{}'
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_dependencies '{}'
 ```
 
 This makes it explicit for downstream stages that dependencies were considered and none exist.

--- a/skills/workflow-planning-process/references/invoke-review-integrity.md
+++ b/skills/workflow-planning-process/references/invoke-review-integrity.md
@@ -14,8 +14,8 @@ Invoke `workflow-planning-review-integrity` with:
 
 1. **Review criteria path**: `review-integrity.md` (in this directory)
 2. **Plan path**: `.workflows/{work_unit}/planning/{topic}/planning.md`
-3. **Format reading.md path**: read `format` from manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format`), load **[output-formats.md](output-formats.md)**, find the matching entry, and pass the format's `reading.md` path
-4. **Cycle number**: current `review_cycle` from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} review_cycle`)
+3. **Format reading.md path**: read `format` from manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format`), load **[output-formats.md](output-formats.md)**, find the matching entry, and pass the format's `reading.md` path
+4. **Cycle number**: current `review_cycle` from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} review_cycle`)
 5. **Topic name**: the topic/work-unit name
 6. **Task design path**: `task-design.md`
 

--- a/skills/workflow-planning-process/references/invoke-review-traceability.md
+++ b/skills/workflow-planning-process/references/invoke-review-traceability.md
@@ -15,8 +15,8 @@ Invoke `workflow-planning-review-traceability` with:
 1. **Review criteria path**: `review-traceability.md` (in this directory)
 2. **Specification path**: `.workflows/{work_unit}/specification/{topic}/specification.md`
 3. **Plan path**: `.workflows/{work_unit}/planning/{topic}/planning.md`
-4. **Format reading.md path**: read `format` from manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format`), load **[output-formats.md](output-formats.md)**, find the matching entry, and pass the format's `reading.md` path
-5. **Cycle number**: current `review_cycle` from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} review_cycle`)
+4. **Format reading.md path**: read `format` from manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format`), load **[output-formats.md](output-formats.md)**, find the matching entry, and pass the format's `reading.md` path
+5. **Cycle number**: current `review_cycle` from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} review_cycle`)
 6. **Topic name**: the topic/work-unit name
 7. **Task design path**: `task-design.md`
 

--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -12,7 +12,7 @@ This step constructs the complete plan — defining phases, designing task lists
 
 At any approval gate during plan construction, the user can navigate. They may describe where they want to go in their own words — a specific phase, a specific task, "the beginning", "the leading edge", or any point in the plan.
 
-The **leading edge** is where new work begins — the first phase, task list, or task that hasn't been completed yet. It is tracked by the manifest (`phase` and `task` fields under `--phase planning --topic {topic}`). To find the leading edge, read those values. If all phases and tasks are complete, the leading edge is the end of plan construction.
+The **leading edge** is where new work begins — the first phase, task list, or task that hasn't been completed yet. It is tracked by the manifest (`phase` and `task` fields under `planning.{topic}`). To find the leading edge, read those values. If all phases and tasks are complete, the leading edge is the end of plan construction.
 
 The manifest planning position always tracks the leading edge. It is only advanced when work is completed — never when the user navigates. Navigation moves the user's position, not the leading edge.
 
@@ -62,7 +62,7 @@ After **A. Define Tasks** returns with an approved task table, proceed to **Auth
 
 Check `task_list_gate_mode` via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} task_list_gate_mode
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} task_list_gate_mode
 ```
 
 **If `task_list_gate_mode` is `auto`:**
@@ -129,8 +129,8 @@ If the user navigates mid-approval, the scratch file preserves approval state. O
 
 Advance the manifest planning position to the next phase:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} phase {N+1}
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} task ~
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} phase {N+1}
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task ~
 ```
 
 Commit: `planning({work_unit}): complete Phase {N} tasks`

--- a/skills/workflow-planning-process/references/plan-index-schema.md
+++ b/skills/workflow-planning-process/references/plan-index-schema.md
@@ -66,7 +66,7 @@ approved_at: {YYYY-MM-DD}
 
 All metadata is managed via the manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js`). The following fields are set during planning:
 
-| Field (via `--phase planning --topic {topic}`) | Set when |
+| Field (via `planning.{topic}`) | Set when |
 |------------|----------|
 | `status` | Plan creation -> `in-progress`; completion -> `completed` |
 | `format` | Plan creation -- user-chosen output format |

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -12,21 +12,21 @@ Two-part review dispatched to sub-agents. Traceability runs first — its approv
 
 Check the `review_cycle` field in the manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} review_cycle
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} review_cycle
 ```
 
 #### If `review_cycle` is missing or not set
 
 Set `review_cycle: 1` in the manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} review_cycle 1
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} review_cycle 1
 ```
 
 #### If `review_cycle` is already set
 
 Increment `review_cycle` by 1:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} review_cycle {N+1}
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} review_cycle {N+1}
 ```
 
 Record the current cycle number — passed to both review agents for tracking file naming (`c{N}`).
@@ -69,8 +69,8 @@ Record the current cycle number — passed to both review agents for tracking fi
 
 Check `finding_gate_mode` and `review_cycle` in the manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} finding_gate_mode
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} review_cycle
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} finding_gate_mode
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} review_cycle
 ```
 
 #### If `finding_gate_mode: auto` and `review_cycle < 5`

--- a/skills/workflow-planning-process/references/process-review-findings.md
+++ b/skills/workflow-planning-process/references/process-review-findings.md
@@ -87,7 +87,7 @@ Show the finding with its full fix content, read directly from the tracking file
 
 Check `finding_gate_mode` via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} finding_gate_mode
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} finding_gate_mode
 ```
 
 #### If `finding_gate_mode: auto`
@@ -144,7 +144,7 @@ Incorporate feedback and re-present the proposed fix **in full**. Update the tra
 2. Update the tracking file: set resolution to "Fixed"
 3. Update `finding_gate_mode` in the manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} finding_gate_mode auto
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} finding_gate_mode auto
    ```
 4. Commit
 5. Process all remaining findings using the auto-mode flow above

--- a/skills/workflow-planning-process/references/resolve-dependencies.md
+++ b/skills/workflow-planning-process/references/resolve-dependencies.md
@@ -13,13 +13,13 @@ dependencies — things this plan needs from other topics or systems.
 
 Handle external dependencies — things this plan needs from other topics or systems.
 
-Dependencies are stored in the **manifest** as `external_dependencies` (under `--phase planning --topic {topic}`). See [dependencies.md](dependencies.md) for the format and states.
+Dependencies are stored in the **manifest** as `external_dependencies` (under `planning.{topic}`). See [dependencies.md](dependencies.md) for the format and states.
 
 #### If the specification has a Dependencies section
 
 The specification's Dependencies section lists what this feature needs from outside its own scope. These must be documented in the plan so implementation knows what is blocked and what is available.
 
-1. **Document each dependency** in the manifest's `external_dependencies` field (under `--phase planning --topic {topic}`) using the format described in [dependencies.md](dependencies.md). Initially, record each as `state: unresolved`.
+1. **Document each dependency** in the manifest's `external_dependencies` field (under `planning.{topic}`) using the format described in [dependencies.md](dependencies.md). Initially, record each as `state: unresolved`.
 
 2. **Resolve where possible** — For each dependency, check whether a plan already exists for that topic:
    - If a plan exists, identify the specific task(s) that satisfy the dependency. Query the output format to find relevant tasks. If ambiguous, ask the user which tasks apply. Update the dependency entry from `state: unresolved` → `state: resolved` with the `task_id`.
@@ -36,7 +36,7 @@ The specification's Dependencies section lists what this feature needs from outs
 Set the manifest field to an empty object:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase planning --topic {topic} external_dependencies '{}'
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} external_dependencies '{}'
 ```
 
 This makes it clear that dependencies were considered and none exist — not that they were overlooked.

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -67,7 +67,7 @@ Deferred — gather-context will resolve it.
 Check if the research phase entry exists:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase research --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.research.{topic}
 ```
 
 **If exists (`true`):**

--- a/skills/workflow-research-entry/references/validate-phase.md
+++ b/skills/workflow-research-entry/references/validate-phase.md
@@ -7,7 +7,7 @@
 Check research status via manifest CLI:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase research --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.research.{topic} status
 ```
 
 #### If status is `completed`
@@ -15,7 +15,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 Reset to in-progress:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase research --topic {topic} status in-progress
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.research.{topic} status in-progress
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -84,7 +84,7 @@ Found existing research for **{topic:(titlecase)}**.
 2. Populate the Starting Point section with context from the handoff. If restarting (no Context in handoff), create with a minimal Starting Point — the session will gather context naturally
 3. Register in manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase research --topic {topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}.research.{topic}
    ```
 4. Commit the initial file
 

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -6,7 +6,7 @@
 
 1. Set research status to completed:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase research --topic {topic} status completed
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.research.{topic} status completed
    ```
 2. Final commit: `research({work_unit}): complete {topic} research`
 3. Invoke the `/workflow-bridge` skill:

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -40,7 +40,7 @@ For each split topic:
 3. Remove the extracted content from the source file
 4. Init manifest item for the new topic:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase research --topic {topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}.research.{topic}
    ```
 
 Commit after splitting.

--- a/skills/workflow-review-entry/references/invoke-skill.md
+++ b/skills/workflow-review-entry/references/invoke-skill.md
@@ -9,7 +9,7 @@ Invoke the [workflow-review-process](../../workflow-review-process/SKILL.md) ski
 Query format from manifest:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format
 ```
 
 **Handoff:**

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -7,7 +7,7 @@
 Check if plan and implementation exist and are ready via manifest CLI.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
 ```
 
 #### If plan doesn't exist
@@ -25,7 +25,7 @@ A completed plan and completed implementation are required for review.
 **STOP.** Do not proceed — terminal condition.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status
 ```
 
 #### If implementation doesn't exist
@@ -59,7 +59,7 @@ The implementation for "{topic:(titlecase)}" is not yet completed.
 Check if review phase entry exists:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.review.{topic}
 ```
 
 **If not exists (`false`):**
@@ -69,13 +69,13 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --p
 **If exists and status is `completed`:**
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.review.{topic} status
 ```
 
 Reset to in-progress:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status in-progress
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review.{topic} status in-progress
 ```
 
 → Return to **[the skill](../SKILL.md)**.

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -96,13 +96,13 @@ Continue or restart?
 Check if review phase is registered in manifest:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.review.{topic}
 ```
 
 #### If `false`
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase review --topic {topic}
+node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}.review.{topic}
 ```
 
 #### If `true`
@@ -122,11 +122,11 @@ Store `review_mode = full`.
 Continuing from a previous session — determine scope.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase implementation --topic {topic} completed_tasks
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} completed_tasks
 ```
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit} --phase review --topic {topic} reviewed_tasks
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.review.{topic} reviewed_tasks
 ```
 
 **If `reviewed_tasks` does not exist:**
@@ -138,7 +138,7 @@ No prior review tracking. Store `review_mode = full`.
 **If `reviewed_tasks` exists and no unreviewed tasks (arrays match):**
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} reviewed_tasks
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.review.{topic} reviewed_tasks
 ```
 
 Compare `completed_tasks` against `reviewed_tasks`.
@@ -156,7 +156,7 @@ Store `review_mode = full`.
 Clear prior review data for a clean slate:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --phase review --topic {topic} reviewed_tasks
+node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit}.review.{topic} reviewed_tasks
 ```
 
 ```bash
@@ -170,7 +170,7 @@ Commit: `review({work_unit}): clear review data for full re-review`
 **If `reviewed_tasks` exists and unreviewed tasks exist:**
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase review --topic {topic} reviewed_tasks
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.review.{topic} reviewed_tasks
 ```
 
 Compare `completed_tasks` against `reviewed_tasks`. Any internal ID in `completed_tasks` but not in `reviewed_tasks` is unreviewed.
@@ -209,7 +209,7 @@ Store `review_mode = full`.
 Clear prior review data for a clean slate:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit} --phase review --topic {topic} reviewed_tasks
+node .claude/skills/workflow-manifest/scripts/manifest.js delete {work_unit}.review.{topic} reviewed_tasks
 ```
 
 ```bash

--- a/skills/workflow-review-process/references/invoke-review-task-writer.md
+++ b/skills/workflow-review-process/references/invoke-review-task-writer.md
@@ -10,7 +10,7 @@ This step invokes the task writer agent to create plan tasks from approved revie
 
 ## Determine Format
 
-Read the `format` field from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase planning --topic {topic} format`). This determines which output format adapters to pass to the agent.
+Read the `format` field from the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} format`). This determines which output format adapters to pass to the agent.
 
 ---
 

--- a/skills/workflow-review-process/references/invoke-task-verifiers.md
+++ b/skills/workflow-review-process/references/invoke-task-verifiers.md
@@ -99,7 +99,7 @@ Full findings are written to `.workflows/{work_unit}/review/{topic}/report-{phas
 After all verifiers complete, push each verified task's internal ID to the review manifest:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit} --phase review --topic {topic} reviewed_tasks "{internal_id}"
+node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.review.{topic} reviewed_tasks "{internal_id}"
 ```
 
 This enables incremental review detection on subsequent review sessions.

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -33,7 +33,7 @@ No actionable findings. All reviews passed with no required changes.
 Set the review phase status to completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review.{topic} status completed
 ```
 
 **Pipeline continuation** — Invoke the bridge:
@@ -78,7 +78,7 @@ Proceed with synthesis?
 User has chosen to skip synthesis. Set review status to completed — the review produced a verdict, even if the user declines to act on it now.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review.{topic} status completed
 ```
 
 **Pipeline continuation** — Invoke the bridge:
@@ -123,7 +123,7 @@ Synthesize non-blocking findings?
 Set review status to completed — the review produced a verdict, even if the user declines to act on non-blocking comments.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review.{topic} status completed
 ```
 
 **Pipeline continuation** — Invoke the bridge:
@@ -148,7 +148,7 @@ Load **[invoke-review-synthesizer.md](invoke-review-synthesizer.md)** and follow
 No actionable tasks from synthesis. Set review status to completed — the review produced a verdict and synthesis was attempted.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review.{topic} status completed
 ```
 
 > *Output the next fenced block as a code block:*
@@ -277,7 +277,7 @@ After all tasks processed:
 Set review status to completed — the review produced a verdict and synthesis tasks were offered, but the user chose to skip them all.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase review --topic {topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review.{topic} status completed
 ```
 
 Commit the staging file updates:
@@ -322,9 +322,9 @@ For each plan that received new tasks:
 
 1. Read the implementation tracking file at `.workflows/{work_unit}/implementation/{topic}/implementation.md`
 2. Update the manifest via CLI:
-   - `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} status in-progress`
-   - `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} updated {today's date}`
-   - `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase implementation --topic {topic} analysis_cycle 0`
+   - `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} status in-progress`
+   - `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} updated {today's date}`
+   - `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_cycle 0`
 3. Commit tracking changes:
 
 ```

--- a/skills/workflow-specification-entry/references/analysis-flow.md
+++ b/skills/workflow-specification-entry/references/analysis-flow.md
@@ -65,8 +65,8 @@ When forming groupings:
 
 Write cache metadata to manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} phases.discussion.analysis_cache.checksum "{checksum from current_state.discussions_checksum}"
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} phases.discussion.analysis_cache.generated "{ISO date}"
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.discussion analysis_cache.checksum "{checksum from current_state.discussions_checksum}"
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.discussion analysis_cache.generated "{ISO date}"
 ```
 
 Create the cache directory if needed:

--- a/skills/workflow-specification-entry/references/handoffs/continue-completed.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue-completed.md
@@ -6,7 +6,7 @@
 
 Before invoking the skill, reset `finding_gate_mode` to `gated` via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} finding_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} finding_gate_mode gated
 ```
 Commit if changed: `spec({work_unit}): reset gate mode`
 

--- a/skills/workflow-specification-entry/references/handoffs/continue.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue.md
@@ -6,7 +6,7 @@
 
 Before invoking the skill, reset `finding_gate_mode` to `gated` via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} finding_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} finding_gate_mode gated
 ```
 Commit if changed: `spec({work_unit}): reset gate mode`
 

--- a/skills/workflow-specification-entry/references/handoffs/create-with-incorporation.md
+++ b/skills/workflow-specification-entry/references/handoffs/create-with-incorporation.md
@@ -22,8 +22,8 @@ Context: This consolidates multiple sources. The existing specification should b
 
 After the specification is complete, mark the incorporated specs as superseded via manifest CLI:
 
-    set {source-work-unit} --phase specification --topic {source-topic} status superseded
-    set {source-work-unit} --phase specification --topic {source-topic} superseded_by {work_unit}
+    set {source-work-unit}.specification.{source-topic} status superseded
+    set {source-work-unit}.specification.{source-topic} superseded_by {work_unit}
 
 ---
 Invoke the workflow-specification-process skill.

--- a/skills/workflow-specification-entry/references/handoffs/unify-with-incorporation.md
+++ b/skills/workflow-specification-entry/references/handoffs/unify-with-incorporation.md
@@ -24,8 +24,8 @@ Context: This consolidates all discussions into a single unified specification. 
 
 After the unified specification is complete, mark the incorporated specs as superseded via manifest CLI:
 
-    set {source-work-unit} --phase specification --topic {source-topic} status superseded
-    set {source-work-unit} --phase specification --topic {source-topic} superseded_by unified
+    set {source-work-unit}.specification.{source-topic} status superseded
+    set {source-work-unit}.specification.{source-topic} superseded_by unified
 
 ---
 Invoke the workflow-specification-process skill.

--- a/skills/workflow-specification-entry/references/invoke-skill.md
+++ b/skills/workflow-specification-entry/references/invoke-skill.md
@@ -44,7 +44,7 @@ Invoke the workflow-specification-process skill.
 
 #### If `work_type` is `epic`
 
-Read the spec's source discussions from the manifest: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} sources`. List each source discussion file.
+Read the spec's source discussions from the manifest: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} sources`. List each source discussion file.
 
 ```
 Specification session for: {topic}

--- a/skills/workflow-specification-entry/references/validate-phase.md
+++ b/skills/workflow-specification-entry/references/validate-phase.md
@@ -48,7 +48,7 @@ Archive the existing spec.
 Reset to in-progress:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status in-progress
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} status in-progress
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -8,7 +8,7 @@ Check if source material exists and is ready.
 
 #### If `work_type` is `feature`
 
-Check if discussion exists and is completed. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion --topic {topic} status`.
+Check if discussion exists and is completed. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.discussion.{topic} status`.
 
 **If discussion doesn't exist:**
 
@@ -44,7 +44,7 @@ The discussion must be completed before specification can begin.
 
 #### If `work_type` is `bugfix`
 
-Check if investigation exists and is completed. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase investigation --topic {topic} status`.
+Check if investigation exists and is completed. Read status via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.investigation.{topic} status`.
 
 **If investigation doesn't exist:**
 
@@ -80,7 +80,7 @@ The investigation must be completed before specification can begin.
 
 #### If `work_type` is `epic`
 
-Check if at least one completed discussion exists for this work unit. Read discussion phase items via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase discussion`.
+Check if at least one completed discussion exists for this work unit. Read discussion phase items via manifest CLI: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.discussion`.
 
 **If no discussions exist:**
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -42,7 +42,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 2. **Read all tracking and state files** for the current topic — the specification file, review tracking files, or any working documents this skill creates. These are your source of truth for progress.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
-5. **Check `finding_gate_mode`** via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} finding_gate_mode`) — if `auto`, the user previously opted in during this session. Preserve this value.
+5. **Check `finding_gate_mode`** via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} finding_gate_mode`) — if `auto`, the user previously opted in during this session. Preserve this value.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 
@@ -72,7 +72,7 @@ Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
 
 #### If file exists
 
-Read the specification status via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} status`).
+Read the specification status via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} status`).
 
 > *Output the next fenced block as a code block:*
 
@@ -123,15 +123,15 @@ Create the specification file at `.workflows/{work_unit}/specification/{topic}/s
 1. Use the body template from specification-format.md (title + specification section + working notes section)
 2. Register specification and initialize state via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit} --phase specification --topic {topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} type feature
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} review_cycle 0
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} finding_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} date $(date +%Y-%m-%d)
+   node .claude/skills/workflow-manifest/scripts/manifest.js init-phase {work_unit}.specification.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} type feature
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} review_cycle 0
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} finding_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} date $(date +%Y-%m-%d)
    ```
 3. Add all sources with `status: pending` via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} sources.{source-name}.status pending
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} sources.{source-name}.status pending
    ```
 
 Commit: `spec({work_unit}): initialize specification`
@@ -144,7 +144,7 @@ Commit: `spec({work_unit}): initialize specification`
 
 Reset `finding_gate_mode` to `gated` via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} finding_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} finding_gate_mode gated
 ```
 
 → Proceed to **Step 4**.

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -81,7 +81,7 @@ Show the finding with its proposed content, read directly from the tracking file
 
 ### Check Gate Mode
 
-Check `finding_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} finding_gate_mode`).
+Check `finding_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} finding_gate_mode`).
 
 #### If `finding_gate_mode: auto`
 
@@ -136,7 +136,7 @@ Finding {N} of {total}: {brief_title:(titlecase)} — added.
 
 1. Log the content (same as "If approved" above)
 2. Update the tracking file: set resolution to "Approved"
-3. Update `finding_gate_mode` to `auto` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} finding_gate_mode auto`)
+3. Update `finding_gate_mode` to `auto` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} finding_gate_mode auto`)
 4. Commit
 5. Process all remaining findings using the auto-mode flow above
 

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -103,9 +103,9 @@ Discuss the user's context, apply any changes, then re-present the sign-off prom
 Update the specification metadata via manifest CLI:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status completed
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} type {type}  # feature or cross-cutting, as confirmed in Section A
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} date $(date +%Y-%m-%d)
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} type {type}  # feature or cross-cutting, as confirmed in Section A
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} date $(date +%Y-%m-%d)
 ```
 
 Specification is complete when:
@@ -129,8 +129,8 @@ If any of your sources were **existing specifications** (as opposed to discussio
 
 1. Mark each source specification as superseded via manifest CLI:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {source-topic} status superseded
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {source-topic} superseded_by {topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{source-topic} status superseded
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{source-topic} superseded_by {topic}
    ```
 2. Inform the user which topics were updated
 3. Commit: `spec({work_unit}): mark source specifications as superseded`
@@ -143,7 +143,7 @@ If any of your sources were **existing specifications** (as opposed to discussio
 
 Read the specification type from the manifest:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} type
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} type
 ```
 
 #### If `type` is `cross-cutting`

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -92,7 +92,7 @@ If you are uncertain whether the user approved, **ASK**: "Ready to log it, or do
 ## E. Log and Commit
 
 1. Write to the specification — **verbatim** as presented and approved. No silent modifications.
-2. After completing exhaustive extraction from a source (all relevant content presented and logged), update that source's status to `incorporated` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} sources.{source-name}.status incorporated`). See **[specification-format.md](specification-format.md)** for source status details.
+2. After completing exhaustive extraction from a source (all relevant content presented and logged), update that source's status to `incorporated` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} sources.{source-name}.status incorporated`). See **[specification-format.md](specification-format.md)** for source status details.
 3. Commit at natural breaks — after significant exchanges, after each major topic, and before any context refresh.
 
 ---

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -16,15 +16,15 @@ Load **[review-tracking-format.md](review-tracking-format.md)** — internalize 
 
 ## A. Cycle Management
 
-Check the `review_cycle` field via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} review_cycle`).
+Check the `review_cycle` field via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} review_cycle`).
 
 #### If `review_cycle` is 0 or not set
 
-Set `review_cycle` to 1 via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} review_cycle 1`).
+Set `review_cycle` to 1 via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} review_cycle 1`).
 
 #### If `review_cycle` is already set
 
-Increment `review_cycle` by 1 via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} review_cycle {N}`).
+Increment `review_cycle` by 1 via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} review_cycle {N}`).
 
 Record the current cycle number — used for tracking file naming (`c{N}`).
 
@@ -36,7 +36,7 @@ Commit the updated manifest.
 
 #### If `review_cycle` > 3
 
-Check `finding_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} finding_gate_mode`).
+Check `finding_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} finding_gate_mode`).
 
 **If `finding_gate_mode: auto`:**
 
@@ -90,7 +90,7 @@ Dispatch the `workflow-specification-review-input` agent via the Task tool:
 - **Specification path**: the specification file path
 - **Source material paths**: resolve source names to file paths. Read source names and work type from the manifest:
   ```bash
-  node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} sources
+  node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} sources
   node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} work_type
   ```
   Sources returns an object keyed by source name (e.g., `{"auth-design": {"status": "incorporated"}}`). For each source name, construct the source file path based on work type:
@@ -148,8 +148,8 @@ Load **[process-review-findings.md](process-review-findings.md)** and follow its
 
 Check `finding_gate_mode` and `review_cycle` via manifest CLI:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} finding_gate_mode
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} review_cycle
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} finding_gate_mode
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} review_cycle
 ```
 
 #### If `finding_gate_mode: auto` and `review_cycle < 5`

--- a/skills/workflow-specification-process/references/specification-format.md
+++ b/skills/workflow-specification-process/references/specification-format.md
@@ -18,15 +18,15 @@ Specification metadata is stored in the work-unit manifest, not in file frontmat
 
 ```bash
 # Read fields
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} status
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} type
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} review_cycle
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} finding_gate_mode
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} sources.{source-name}.status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} type
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} review_cycle
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} finding_gate_mode
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} sources.{source-name}.status
 
 # Write fields
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status completed
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} sources.{source-name}.status incorporated
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} sources.{source-name}.status incorporated
 ```
 
 | Field | Set when |
@@ -65,10 +65,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phas
 Track each source with its incorporation status via the manifest CLI:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} sources.auth-flow.status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} sources.auth-flow.status
 # → incorporated
 
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phase specification --topic {topic} sources.api-design.status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.specification.{topic} sources.api-design.status
 # → pending
 ```
 
@@ -78,8 +78,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit} --phas
 
 **When to update source status:**
 
-1. **When creating the specification**: All sources start as `pending` — `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} sources.{source-name}.status pending`
-2. **After completing exhaustive extraction from a source**: Mark that source as `incorporated` — `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} sources.{source-name}.status incorporated`
+1. **When creating the specification**: All sources start as `pending` — `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} sources.{source-name}.status pending`
+2. **After completing exhaustive extraction from a source**: Mark that source as `incorporated` — `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} sources.{source-name}.status incorporated`
 3. **When adding a new source to an existing spec**: Add it with `status: pending` via the same command
 
 **How to determine if a source is incorporated:**
@@ -89,7 +89,7 @@ A source is `incorporated` when you have:
 - Presented and logged all relevant content from that source
 - No more content from that source needs to be extracted
 
-**Important**: The specification's overall status should only be set to `completed` (via `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} --phase specification --topic {topic} status completed`) when:
+**Important**: The specification's overall status should only be set to `completed` (via `node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.specification.{topic} status completed`) when:
 - All sources are marked as `incorporated`
 - Both review phases are complete
 - User has signed off

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -35,7 +35,7 @@ Default `implementation_completed` = false, `has_plan` = false.
 Check whether the planning phase exists:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name} phases.planning
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name}.planning
 ```
 
 If the result is `true`, set `has_plan` = true.
@@ -43,7 +43,7 @@ If the result is `true`, set `has_plan` = true.
 Check whether the implementation phase exists:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name} phases.implementation
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name}.implementation
 ```
 
 #### If the result is `false`
@@ -57,7 +57,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name}
 ## C. Completion Check
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase implementation --topic "*" status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name}.implementation.* status
 ```
 
 This returns all topic statuses in the implementation phase.

--- a/skills/workflow-start/references/view-plan.md
+++ b/skills/workflow-start/references/view-plan.md
@@ -19,7 +19,7 @@ Set `topic` = `selected.name`.
 Query manifest for all planning topics:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase planning --topic "*" status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name}.planning.* status
 ```
 
 **If only one topic exists:**
@@ -61,7 +61,7 @@ Set `topic` to the selected topic.
 Read the `format` from the manifest:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name} --phase planning --topic {topic} format
+node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name}.planning.{topic} format
 ```
 
 Load **[reading.md](../../workflow-planning-process/references/output-formats/{format}/reading.md)** and follow its instructions as written.

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -2,7 +2,7 @@
 #
 # Tests for the workflow manifest CLI (manifest.js)
 # Validates init, get, set, list, init-phase, push, exists commands.
-# Uses domain-aware flag syntax (--phase, --topic).
+# Uses dot-path syntax: <work-unit>[.<phase>[.<topic>]]
 #
 
 set -eo pipefail
@@ -156,7 +156,7 @@ assert_dir_not_exists() {
 
     if [ ! -d "$dirpath" ]; then
         echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
+        TESTS_PASSES=$((TESTS_PASSED + 1))
         return 0
     else
         echo -e "  ${RED}✗${NC} $description"
@@ -231,6 +231,23 @@ assert_exit_nonzero "Missing work_type rejected" init no-type --description "No 
 
 echo ""
 
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: init rejects dots in work unit name${NC}"
+setup_fixture
+assert_exit_nonzero "Dot in name rejected" init foo.bar --work-type feature --description "Bad name"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: init rejects phase name as work unit name${NC}"
+setup_fixture
+assert_exit_nonzero "Phase name as work unit rejected" init discussion --work-type feature --description "Bad name"
+assert_exit_nonzero "Phase name as work unit rejected (research)" init research --work-type feature --description "Bad name"
+
+echo ""
+
 # ============================================================================
 # GET TESTS
 # ============================================================================
@@ -258,11 +275,11 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: get subtree at work-unit level${NC}"
+echo -e "${YELLOW}Test: get subtree at phase level (2-segment path)${NC}"
 setup_fixture
 run_cli init subtree-test --work-type feature --description "Subtree" >/dev/null 2>&1
-run_cli init-phase subtree-test --phase discussion --topic subtree-test >/dev/null 2>&1
-output=$(run_cli_stdout get subtree-test --phase discussion)
+run_cli init-phase subtree-test.discussion.subtree-test >/dev/null 2>&1
+output=$(run_cli_stdout get subtree-test.discussion)
 
 assert_contains "$output" '"status": "in-progress"' "Subtree output as JSON"
 
@@ -270,25 +287,25 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: get phase-level value for feature (flat routing)${NC}"
+echo -e "${YELLOW}Test: get topic-level value for feature${NC}"
 setup_fixture
 run_cli init feat-get --work-type feature --description "Get test" >/dev/null 2>&1
-run_cli init-phase feat-get --phase discussion --topic feat-get >/dev/null 2>&1
-output=$(run_cli_stdout get feat-get --phase discussion --topic feat-get status)
+run_cli init-phase feat-get.discussion.feat-get >/dev/null 2>&1
+output=$(run_cli_stdout get feat-get.discussion.feat-get status)
 
-assert_equals "$output" "in-progress" "Feature phase-level get returns flat status"
+assert_equals "$output" "in-progress" "Feature topic-level get returns status"
 
 echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: get phase-level value for epic (items routing)${NC}"
+echo -e "${YELLOW}Test: get topic-level value for epic${NC}"
 setup_fixture
 run_cli init epic-get --work-type epic --description "Get test" >/dev/null 2>&1
-run_cli init-phase epic-get --phase discussion --topic my-topic >/dev/null 2>&1
-output=$(run_cli_stdout get epic-get --phase discussion --topic my-topic status)
+run_cli init-phase epic-get.discussion.my-topic >/dev/null 2>&1
+output=$(run_cli_stdout get epic-get.discussion.my-topic status)
 
-assert_equals "$output" "in-progress" "Epic phase-level get routes through items"
+assert_equals "$output" "in-progress" "Epic topic-level get routes through items"
 
 echo ""
 
@@ -325,27 +342,27 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: set phase-level value for feature${NC}"
+echo -e "${YELLOW}Test: set topic-level value for feature${NC}"
 setup_fixture
 run_cli init feat-set --work-type feature --description "Set" >/dev/null 2>&1
-run_cli init-phase feat-set --phase discussion --topic feat-set >/dev/null 2>&1
-run_cli set feat-set --phase discussion --topic feat-set status completed >/dev/null 2>&1
-output=$(run_cli_stdout get feat-set --phase discussion --topic feat-set status)
+run_cli init-phase feat-set.discussion.feat-set >/dev/null 2>&1
+run_cli set feat-set.discussion.feat-set status completed >/dev/null 2>&1
+output=$(run_cli_stdout get feat-set.discussion.feat-set status)
 
-assert_equals "$output" "completed" "Feature phase-level set works (flat routing)"
+assert_equals "$output" "completed" "Feature topic-level set works"
 
 echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: set phase-level value for epic${NC}"
+echo -e "${YELLOW}Test: set topic-level value for epic${NC}"
 setup_fixture
 run_cli init epic-set --work-type epic --description "Set" >/dev/null 2>&1
-run_cli init-phase epic-set --phase discussion --topic my-topic >/dev/null 2>&1
-run_cli set epic-set --phase discussion --topic my-topic status completed >/dev/null 2>&1
-output=$(run_cli_stdout get epic-set --phase discussion --topic my-topic status)
+run_cli init-phase epic-set.discussion.my-topic >/dev/null 2>&1
+run_cli set epic-set.discussion.my-topic status completed >/dev/null 2>&1
+output=$(run_cli_stdout get epic-set.discussion.my-topic status)
 
-assert_equals "$output" "completed" "Epic phase-level set routes through items"
+assert_equals "$output" "completed" "Epic topic-level set routes through items"
 
 echo ""
 
@@ -354,8 +371,8 @@ echo ""
 echo -e "${YELLOW}Test: set auto-creates intermediate keys${NC}"
 setup_fixture
 run_cli init intermediate --work-type feature --description "Intermediate" >/dev/null 2>&1
-run_cli set intermediate --phase discussion --topic intermediate status in-progress >/dev/null 2>&1
-output=$(run_cli_stdout get intermediate --phase discussion --topic intermediate status)
+run_cli set intermediate.discussion.intermediate status in-progress >/dev/null 2>&1
+output=$(run_cli_stdout get intermediate.discussion.intermediate status)
 
 assert_equals "$output" "in-progress" "Intermediate keys auto-created"
 
@@ -363,11 +380,11 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: set --phase research with --topic works${NC}"
+echo -e "${YELLOW}Test: set topic-level research with topic works${NC}"
 setup_fixture
 run_cli init topicful --work-type feature --description "Topic research" >/dev/null 2>&1
-run_cli set topicful --phase research --topic exploration status in-progress >/dev/null 2>&1
-output=$(run_cli_stdout get topicful --phase research --topic exploration status)
+run_cli set topicful.research.exploration status in-progress >/dev/null 2>&1
+output=$(run_cli_stdout get topicful.research.exploration status)
 
 assert_equals "$output" "in-progress" "Set research with topic routes correctly"
 
@@ -375,12 +392,12 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: set --phase research with --topic for epic uses items${NC}"
+echo -e "${YELLOW}Test: set topic-level research for epic uses items${NC}"
 setup_fixture
 run_cli init topicful2 --work-type epic --description "Topic research epic" >/dev/null 2>&1
-run_cli init-phase topicful2 --phase research --topic exploration >/dev/null 2>&1
-run_cli set topicful2 --phase research --topic exploration status completed >/dev/null 2>&1
-output=$(run_cli_stdout get topicful2 --phase research --topic exploration status)
+run_cli init-phase topicful2.research.exploration >/dev/null 2>&1
+run_cli set topicful2.research.exploration status completed >/dev/null 2>&1
+output=$(run_cli_stdout get topicful2.research.exploration status)
 
 assert_equals "$output" "completed" "Epic research with topic uses items path"
 
@@ -388,28 +405,25 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: get --phase without --topic returns whole phase object${NC}"
+echo -e "${YELLOW}Test: get phase-level (2-segment) returns whole phase object${NC}"
 setup_fixture
 run_cli init topicful3 --work-type feature --description "Topic get" >/dev/null 2>&1
-run_cli set topicful3 --phase research --topic exploration status completed >/dev/null 2>&1
-output=$(run_cli_stdout get topicful3 --phase research)
+run_cli set topicful3.research.exploration status completed >/dev/null 2>&1
+output=$(run_cli_stdout get topicful3.research)
 
-assert_contains "$output" '"status": "completed"' "Get phase without topic returns phase object"
+assert_contains "$output" '"status": "completed"' "Get phase-level returns phase object"
 
 echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: set --phase without --topic fails for topic-required phases${NC}"
+echo -e "${YELLOW}Test: set phase-level field (2-segment path)${NC}"
 setup_fixture
-run_cli init topic-req --work-type feature --description "Topic required" >/dev/null 2>&1
-assert_exit_nonzero "Discussion requires --topic" set topic-req --phase discussion status in-progress
-assert_exit_nonzero "Specification requires --topic" set topic-req --phase specification status in-progress
-assert_exit_nonzero "Planning requires --topic" set topic-req --phase planning status in-progress
-assert_exit_nonzero "Implementation requires --topic" set topic-req --phase implementation status in-progress
-assert_exit_nonzero "Review requires --topic" set topic-req --phase review status in-progress
-assert_exit_nonzero "Investigation requires --topic" set topic-req --phase investigation status in-progress
-assert_exit_nonzero "Research requires --topic" set topic-req --phase research status in-progress
+run_cli init phase-set --work-type feature --description "Phase set" >/dev/null 2>&1
+run_cli set phase-set.planning format local-markdown >/dev/null 2>&1
+output=$(run_cli_stdout get phase-set.planning format)
+
+assert_equals "$output" "local-markdown" "Phase-level set works"
 
 echo ""
 
@@ -418,7 +432,7 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid phase names${NC}"
 setup_fixture
 run_cli init phase-check --work-type feature --description "Phase" >/dev/null 2>&1
-assert_exit_nonzero "Invalid phase rejected" set phase-check --phase cooking --topic phase-check status in-progress
+assert_exit_nonzero "Invalid phase rejected" set phase-check.cooking.phase-check status in-progress
 
 echo ""
 
@@ -427,8 +441,8 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid phase status${NC}"
 setup_fixture
 run_cli init status-check --work-type feature --description "Status" >/dev/null 2>&1
-assert_exit_nonzero "Invalid status for discussion rejected" set status-check --phase discussion --topic status-check status concluded
-assert_exit_nonzero "Invalid status for implementation rejected" set status-check --phase implementation --topic status-check status concluded
+assert_exit_nonzero "Invalid status for discussion rejected" set status-check.discussion.status-check status concluded
+assert_exit_nonzero "Invalid status for implementation rejected" set status-check.implementation.status-check status concluded
 
 echo ""
 
@@ -437,11 +451,11 @@ echo ""
 echo -e "${YELLOW}Test: set validates correct phase statuses${NC}"
 setup_fixture
 run_cli init valid-status --work-type feature --description "Valid" >/dev/null 2>&1
-run_cli set valid-status --phase discussion --topic valid-status status completed >/dev/null 2>&1
-run_cli set valid-status --phase implementation --topic valid-status status completed >/dev/null 2>&1
+run_cli set valid-status.discussion.valid-status status completed >/dev/null 2>&1
+run_cli set valid-status.implementation.valid-status status completed >/dev/null 2>&1
 
-disc_status=$(run_cli_stdout get valid-status --phase discussion --topic valid-status status)
-impl_status=$(run_cli_stdout get valid-status --phase implementation --topic valid-status status)
+disc_status=$(run_cli_stdout get valid-status.discussion.valid-status status)
+impl_status=$(run_cli_stdout get valid-status.implementation.valid-status status)
 
 assert_equals "$disc_status" "completed" "Discussion accepts completed"
 assert_equals "$impl_status" "completed" "Implementation accepts completed"
@@ -453,7 +467,7 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid gate modes${NC}"
 setup_fixture
 run_cli init gate-check --work-type feature --description "Gate" >/dev/null 2>&1
-assert_exit_nonzero "Invalid gate mode rejected" set gate-check --phase planning --topic gate-check task_gate_mode manual
+assert_exit_nonzero "Invalid gate mode rejected" set gate-check.planning.gate-check task_gate_mode manual
 
 echo ""
 
@@ -462,8 +476,8 @@ echo ""
 echo -e "${YELLOW}Test: set accepts valid gate modes${NC}"
 setup_fixture
 run_cli init gate-valid --work-type feature --description "Gate" >/dev/null 2>&1
-run_cli set gate-valid --phase planning --topic gate-valid task_gate_mode auto >/dev/null 2>&1
-output=$(run_cli_stdout get gate-valid --phase planning --topic gate-valid task_gate_mode)
+run_cli set gate-valid.planning.gate-valid task_gate_mode auto >/dev/null 2>&1
+output=$(run_cli_stdout get gate-valid.planning.gate-valid task_gate_mode)
 
 assert_equals "$output" "auto" "Gate mode set to auto"
 
@@ -492,8 +506,8 @@ echo ""
 echo -e "${YELLOW}Test: set parses JSON values${NC}"
 setup_fixture
 run_cli init json-parse --work-type feature --description "JSON" >/dev/null 2>&1
-run_cli set json-parse --phase specification --topic json-parse sources '[{"name":"auth","status":"pending"}]' >/dev/null 2>&1
-output=$(run_cli_stdout get json-parse --phase specification --topic json-parse sources)
+run_cli set json-parse.specification.json-parse sources '[{"name":"auth","status":"pending"}]' >/dev/null 2>&1
+output=$(run_cli_stdout get json-parse.specification.json-parse sources)
 
 assert_contains "$output" '"name": "auth"' "JSON array parsed and stored"
 
@@ -504,8 +518,8 @@ echo ""
 echo -e "${YELLOW}Test: set nested field path with dots${NC}"
 setup_fixture
 run_cli init dotpath --work-type feature --description "Dots" >/dev/null 2>&1
-run_cli set dotpath --phase specification --topic dotpath sources.auth-api.status incorporated >/dev/null 2>&1
-output=$(run_cli_stdout get dotpath --phase specification --topic dotpath sources.auth-api.status)
+run_cli set dotpath.specification.dotpath sources.auth-api.status incorporated >/dev/null 2>&1
+output=$(run_cli_stdout get dotpath.specification.dotpath sources.auth-api.status)
 
 assert_equals "$output" "incorporated" "Nested dot-path field set and get works"
 
@@ -591,8 +605,8 @@ echo ""
 echo -e "${YELLOW}Test: init-phase for epic creates item with in-progress status${NC}"
 setup_fixture
 run_cli init my-epic --work-type epic --description "My Epic" >/dev/null 2>&1
-run_cli init-phase my-epic --phase discussion --topic payment-processing >/dev/null 2>&1
-output=$(run_cli_stdout get my-epic --phase discussion --topic payment-processing status)
+run_cli init-phase my-epic.discussion.payment-processing >/dev/null 2>&1
+output=$(run_cli_stdout get my-epic.discussion.payment-processing status)
 
 assert_equals "$output" "in-progress" "Epic item created with in-progress status"
 
@@ -603,8 +617,8 @@ echo ""
 echo -e "${YELLOW}Test: init-phase for feature creates items structure${NC}"
 setup_fixture
 run_cli init my-feat --work-type feature --description "My Feature" >/dev/null 2>&1
-run_cli init-phase my-feat --phase discussion --topic my-feat >/dev/null 2>&1
-output=$(run_cli_stdout get my-feat --phase discussion --topic my-feat status)
+run_cli init-phase my-feat.discussion.my-feat >/dev/null 2>&1
+output=$(run_cli_stdout get my-feat.discussion.my-feat status)
 
 assert_equals "$output" "in-progress" "Feature phase created with in-progress status"
 
@@ -620,8 +634,8 @@ echo ""
 echo -e "${YELLOW}Test: init-phase for bugfix creates items structure${NC}"
 setup_fixture
 run_cli init my-bug --work-type bugfix --description "My Bug" >/dev/null 2>&1
-run_cli init-phase my-bug --phase investigation --topic my-bug >/dev/null 2>&1
-output=$(run_cli_stdout get my-bug --phase investigation --topic my-bug status)
+run_cli init-phase my-bug.investigation.my-bug >/dev/null 2>&1
+output=$(run_cli_stdout get my-bug.investigation.my-bug status)
 
 assert_equals "$output" "in-progress" "Bugfix phase created with in-progress status"
 
@@ -632,8 +646,8 @@ echo ""
 echo -e "${YELLOW}Test: init-phase rejects duplicate epic items${NC}"
 setup_fixture
 run_cli init dup-epic --work-type epic --description "Dup" >/dev/null 2>&1
-run_cli init-phase dup-epic --phase discussion --topic my-item >/dev/null 2>&1
-output=$(run_cli init-phase dup-epic --phase discussion --topic my-item || true)
+run_cli init-phase dup-epic.discussion.my-item >/dev/null 2>&1
+output=$(run_cli init-phase dup-epic.discussion.my-item || true)
 
 assert_contains "$output" "already exists" "Duplicate epic item rejected"
 
@@ -644,8 +658,8 @@ echo ""
 echo -e "${YELLOW}Test: init-phase rejects duplicate feature phase${NC}"
 setup_fixture
 run_cli init dup-feat --work-type feature --description "Dup" >/dev/null 2>&1
-run_cli init-phase dup-feat --phase discussion --topic dup-feat >/dev/null 2>&1
-output=$(run_cli init-phase dup-feat --phase discussion --topic dup-feat || true)
+run_cli init-phase dup-feat.discussion.dup-feat >/dev/null 2>&1
+output=$(run_cli init-phase dup-feat.discussion.dup-feat || true)
 
 assert_contains "$output" "already exists" "Duplicate feature phase rejected"
 
@@ -656,7 +670,7 @@ echo ""
 echo -e "${YELLOW}Test: init-phase rejects invalid phase${NC}"
 setup_fixture
 run_cli init bad-phase-epic --work-type epic --description "Bad" >/dev/null 2>&1
-assert_exit_nonzero "Invalid phase in init-phase rejected" init-phase bad-phase-epic --phase cooking --topic soup
+assert_exit_nonzero "Invalid phase in init-phase rejected" init-phase bad-phase-epic.cooking.soup
 
 echo ""
 
@@ -667,9 +681,9 @@ echo ""
 echo -e "${YELLOW}Test: push to non-existent field creates array${NC}"
 setup_fixture
 run_cli init push-new --work-type feature --description "Push new" >/dev/null 2>&1
-run_cli init-phase push-new --phase implementation --topic push-new >/dev/null 2>&1
-run_cli push push-new --phase implementation --topic push-new completed_tasks "task-1" >/dev/null 2>&1
-output=$(run_cli_stdout get push-new --phase implementation --topic push-new completed_tasks)
+run_cli init-phase push-new.implementation.push-new >/dev/null 2>&1
+run_cli push push-new.implementation.push-new completed_tasks "task-1" >/dev/null 2>&1
+output=$(run_cli_stdout get push-new.implementation.push-new completed_tasks)
 
 assert_contains "$output" '"task-1"' "Push creates array with value"
 
@@ -680,10 +694,10 @@ echo ""
 echo -e "${YELLOW}Test: push to existing array appends${NC}"
 setup_fixture
 run_cli init push-append --work-type feature --description "Push append" >/dev/null 2>&1
-run_cli init-phase push-append --phase implementation --topic push-append >/dev/null 2>&1
-run_cli push push-append --phase implementation --topic push-append completed_tasks "task-1" >/dev/null 2>&1
-run_cli push push-append --phase implementation --topic push-append completed_tasks "task-2" >/dev/null 2>&1
-output=$(run_cli_stdout get push-append --phase implementation --topic push-append completed_tasks)
+run_cli init-phase push-append.implementation.push-append >/dev/null 2>&1
+run_cli push push-append.implementation.push-append completed_tasks "task-1" >/dev/null 2>&1
+run_cli push push-append.implementation.push-append completed_tasks "task-2" >/dev/null 2>&1
+output=$(run_cli_stdout get push-append.implementation.push-append completed_tasks)
 
 assert_contains "$output" '"task-1"' "First value present"
 assert_contains "$output" '"task-2"' "Second value appended"
@@ -695,8 +709,8 @@ echo ""
 echo -e "${YELLOW}Test: push to non-array field errors${NC}"
 setup_fixture
 run_cli init push-bad --work-type feature --description "Push bad" >/dev/null 2>&1
-run_cli init-phase push-bad --phase implementation --topic push-bad >/dev/null 2>&1
-output=$(run_cli push push-bad --phase implementation --topic push-bad status "value" || true)
+run_cli init-phase push-bad.implementation.push-bad >/dev/null 2>&1
+output=$(run_cli push push-bad.implementation.push-bad status "value" || true)
 
 assert_contains "$output" "not an array" "Push to non-array errors"
 
@@ -704,12 +718,12 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: push with --phase/--topic for feature${NC}"
+echo -e "${YELLOW}Test: push topic-level for feature${NC}"
 setup_fixture
 run_cli init push-feat --work-type feature --description "Push feat" >/dev/null 2>&1
-run_cli init-phase push-feat --phase implementation --topic push-feat >/dev/null 2>&1
-run_cli push push-feat --phase implementation --topic push-feat completed_phases 1 >/dev/null 2>&1
-output=$(run_cli_stdout get push-feat --phase implementation --topic push-feat completed_phases)
+run_cli init-phase push-feat.implementation.push-feat >/dev/null 2>&1
+run_cli push push-feat.implementation.push-feat completed_phases 1 >/dev/null 2>&1
+output=$(run_cli_stdout get push-feat.implementation.push-feat completed_phases)
 
 assert_contains "$output" "1" "Push numeric value to feature"
 
@@ -717,12 +731,12 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: push with --phase/--topic for epic${NC}"
+echo -e "${YELLOW}Test: push topic-level for epic${NC}"
 setup_fixture
 run_cli init push-epic --work-type epic --description "Push epic" >/dev/null 2>&1
-run_cli init-phase push-epic --phase implementation --topic my-topic >/dev/null 2>&1
-run_cli push push-epic --phase implementation --topic my-topic completed_tasks "task-a" >/dev/null 2>&1
-output=$(run_cli_stdout get push-epic --phase implementation --topic my-topic completed_tasks)
+run_cli init-phase push-epic.implementation.my-topic >/dev/null 2>&1
+run_cli push push-epic.implementation.my-topic completed_tasks "task-a" >/dev/null 2>&1
+output=$(run_cli_stdout get push-epic.implementation.my-topic completed_tasks)
 
 assert_contains "$output" '"task-a"' "Push routes through items for epic"
 
@@ -749,8 +763,8 @@ echo ""
 echo -e "${YELLOW}Test: feature get/set routes through items (unified)${NC}"
 setup_fixture
 run_cli init routing-feat --work-type feature --description "Routing" >/dev/null 2>&1
-run_cli init-phase routing-feat --phase discussion --topic routing-feat >/dev/null 2>&1
-run_cli set routing-feat --phase discussion --topic routing-feat status completed >/dev/null 2>&1
+run_cli init-phase routing-feat.discussion.routing-feat >/dev/null 2>&1
+run_cli set routing-feat.discussion.routing-feat status completed >/dev/null 2>&1
 
 # Verify internal structure uses items (same as epic)
 content=$(cat "$TEST_DIR/.workflows/routing-feat/manifest.json")
@@ -766,9 +780,9 @@ echo ""
 echo -e "${YELLOW}Test: epic get/set routes through items${NC}"
 setup_fixture
 run_cli init routing-epic --work-type epic --description "Routing" >/dev/null 2>&1
-run_cli init-phase routing-epic --phase discussion --topic topic-a >/dev/null 2>&1
-run_cli init-phase routing-epic --phase discussion --topic topic-b >/dev/null 2>&1
-run_cli set routing-epic --phase discussion --topic topic-a status completed >/dev/null 2>&1
+run_cli init-phase routing-epic.discussion.topic-a >/dev/null 2>&1
+run_cli init-phase routing-epic.discussion.topic-b >/dev/null 2>&1
+run_cli set routing-epic.discussion.topic-a status completed >/dev/null 2>&1
 
 # Verify internal structure has items
 content=$(cat "$TEST_DIR/.workflows/routing-epic/manifest.json")
@@ -777,8 +791,8 @@ assert_contains "$content" '"topic-a"' "topic-a exists"
 assert_contains "$content" '"topic-b"' "topic-b exists"
 
 # Get specific item
-topic_a=$(run_cli_stdout get routing-epic --phase discussion --topic topic-a status)
-topic_b=$(run_cli_stdout get routing-epic --phase discussion --topic topic-b status)
+topic_a=$(run_cli_stdout get routing-epic.discussion.topic-a status)
+topic_b=$(run_cli_stdout get routing-epic.discussion.topic-b status)
 assert_equals "$topic_a" "completed" "topic-a status is completed"
 assert_equals "$topic_b" "in-progress" "topic-b status is in-progress"
 
@@ -786,11 +800,11 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: get phase without topic returns whole phase object${NC}"
+echo -e "${YELLOW}Test: get phase-level returns whole phase object${NC}"
 setup_fixture
 run_cli init phase-obj --work-type epic --description "Phase obj" >/dev/null 2>&1
-run_cli init-phase phase-obj --phase discussion --topic topic-x >/dev/null 2>&1
-output=$(run_cli_stdout get phase-obj --phase discussion)
+run_cli init-phase phase-obj.discussion.topic-x >/dev/null 2>&1
+output=$(run_cli_stdout get phase-obj.discussion)
 
 assert_contains "$output" '"items"' "Phase object contains items"
 assert_contains "$output" '"topic-x"' "Phase object contains topic-x"
@@ -829,12 +843,12 @@ echo ""
 echo -e "${YELLOW}Test: epic item-level status validation${NC}"
 setup_fixture
 run_cli init epic-validation --work-type epic --description "Validate items" >/dev/null 2>&1
-run_cli init-phase epic-validation --phase discussion --topic my-topic >/dev/null 2>&1
-assert_exit_nonzero "Invalid item status rejected" set epic-validation --phase discussion --topic my-topic status concluded
+run_cli init-phase epic-validation.discussion.my-topic >/dev/null 2>&1
+assert_exit_nonzero "Invalid item status rejected" set epic-validation.discussion.my-topic status concluded
 
 # Valid item status should work
-run_cli set epic-validation --phase discussion --topic my-topic status completed >/dev/null 2>&1
-output=$(run_cli_stdout get epic-validation --phase discussion --topic my-topic status)
+run_cli set epic-validation.discussion.my-topic status completed >/dev/null 2>&1
+output=$(run_cli_stdout get epic-validation.discussion.my-topic status)
 assert_equals "$output" "completed" "Valid item status accepted"
 
 echo ""
@@ -868,7 +882,7 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: exists with dot-path field that exists${NC}"
+echo -e "${YELLOW}Test: exists with field that exists${NC}"
 setup_fixture
 run_cli init exists-field --work-type feature --description "Field" >/dev/null 2>&1
 output=$(run_cli_stdout exists exists-field work_type)
@@ -881,7 +895,7 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: exists with dot-path field that does not exist${NC}"
+echo -e "${YELLOW}Test: exists with field that does not exist${NC}"
 setup_fixture
 run_cli init exists-nofield --work-type feature --description "No field" >/dev/null 2>&1
 output=$(run_cli_stdout exists exists-nofield nonexistent.deep.path)
@@ -894,12 +908,12 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: exists with --phase and --topic that exists${NC}"
+echo -e "${YELLOW}Test: exists with topic-level path that exists${NC}"
 setup_fixture
 run_cli init exists-phase --work-type epic --description "Phase" >/dev/null 2>&1
-run_cli init-phase exists-phase --phase discussion --topic my-topic >/dev/null 2>&1
-output=$(run_cli_stdout exists exists-phase --phase discussion --topic my-topic)
-exit_code=$(run_cli_exit_code exists exists-phase --phase discussion --topic my-topic)
+run_cli init-phase exists-phase.discussion.my-topic >/dev/null 2>&1
+output=$(run_cli_stdout exists exists-phase.discussion.my-topic)
+exit_code=$(run_cli_exit_code exists exists-phase.discussion.my-topic)
 
 assert_equals "$output" "true" "Existing phase/topic returns true"
 assert_equals "$exit_code" "0" "Existing phase/topic exits 0"
@@ -908,11 +922,11 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: exists with --phase and --topic that does not exist${NC}"
+echo -e "${YELLOW}Test: exists with topic-level path that does not exist${NC}"
 setup_fixture
 run_cli init exists-nophase --work-type epic --description "No phase" >/dev/null 2>&1
-output=$(run_cli_stdout exists exists-nophase --phase discussion --topic missing-topic)
-exit_code=$(run_cli_exit_code exists exists-nophase --phase discussion --topic missing-topic)
+output=$(run_cli_stdout exists exists-nophase.discussion.missing-topic)
+exit_code=$(run_cli_exit_code exists exists-nophase.discussion.missing-topic)
 
 assert_equals "$output" "false" "Non-existent phase/topic returns false"
 assert_equals "$exit_code" "0" "Non-existent phase/topic exits 0"
@@ -946,10 +960,10 @@ echo ""
 echo -e "${YELLOW}Test: get with wildcard topic on epic returns all items${NC}"
 setup_fixture
 run_cli init wc-epic --work-type epic --description "Wildcard" >/dev/null 2>&1
-run_cli init-phase wc-epic --phase implementation --topic auth-flow >/dev/null 2>&1
-run_cli init-phase wc-epic --phase implementation --topic billing >/dev/null 2>&1
-run_cli set wc-epic --phase implementation --topic auth-flow status completed >/dev/null 2>&1
-output=$(run_cli_stdout get wc-epic --phase implementation --topic "*" status)
+run_cli init-phase wc-epic.implementation.auth-flow >/dev/null 2>&1
+run_cli init-phase wc-epic.implementation.billing >/dev/null 2>&1
+run_cli set wc-epic.implementation.auth-flow status completed >/dev/null 2>&1
+output=$(run_cli_stdout get wc-epic.implementation.* status)
 assert_contains "$output" '"topic": "auth-flow"' "Wildcard get includes auth-flow"
 assert_contains "$output" '"value": "completed"' "Wildcard get shows completed value"
 assert_contains "$output" '"topic": "billing"' "Wildcard get includes billing"
@@ -962,9 +976,9 @@ echo ""
 echo -e "${YELLOW}Test: get with wildcard topic on feature returns single item${NC}"
 setup_fixture
 run_cli init wc-feat --work-type feature --description "Wildcard" >/dev/null 2>&1
-run_cli init-phase wc-feat --phase implementation --topic wc-feat >/dev/null 2>&1
-run_cli set wc-feat --phase implementation --topic wc-feat status completed >/dev/null 2>&1
-output=$(run_cli_stdout get wc-feat --phase implementation --topic "*" status)
+run_cli init-phase wc-feat.implementation.wc-feat >/dev/null 2>&1
+run_cli set wc-feat.implementation.wc-feat status completed >/dev/null 2>&1
+output=$(run_cli_stdout get wc-feat.implementation.* status)
 assert_contains "$output" '"topic": "wc-feat"' "Wildcard get on feature includes topic"
 assert_contains "$output" '"value": "completed"' "Wildcard get on feature shows value"
 
@@ -976,7 +990,7 @@ echo -e "${YELLOW}Test: get with wildcard topic on empty phase fails${NC}"
 setup_fixture
 run_cli init wc-empty --work-type epic --description "Empty" >/dev/null 2>&1
 run_cli set wc-empty phases.implementation '{}' >/dev/null 2>&1
-assert_exit_nonzero "Wildcard on empty phase returns error" get wc-empty --phase implementation --topic "*" status
+assert_exit_nonzero "Wildcard on empty phase returns error" get wc-empty.implementation.* status
 
 echo ""
 
@@ -985,8 +999,8 @@ echo ""
 echo -e "${YELLOW}Test: exists with wildcard topic returns true when items exist${NC}"
 setup_fixture
 run_cli init wc-exists --work-type epic --description "Exists" >/dev/null 2>&1
-run_cli init-phase wc-exists --phase implementation --topic topic-a >/dev/null 2>&1
-output=$(run_cli_stdout exists wc-exists --phase implementation --topic "*" status)
+run_cli init-phase wc-exists.implementation.topic-a >/dev/null 2>&1
+output=$(run_cli_stdout exists wc-exists.implementation.* status)
 exit_code=$?
 assert_equals "$output" "true" "Wildcard exists returns true when items have field"
 assert_equals "$exit_code" "0" "Wildcard exists exits 0"
@@ -998,7 +1012,7 @@ echo ""
 echo -e "${YELLOW}Test: exists with wildcard topic returns false when no items${NC}"
 setup_fixture
 run_cli init wc-noitems --work-type epic --description "No items" >/dev/null 2>&1
-output=$(run_cli_stdout exists wc-noitems --phase implementation --topic "*" status)
+output=$(run_cli_stdout exists wc-noitems.implementation.* status)
 exit_code=$?
 assert_equals "$output" "false" "Wildcard exists returns false when no items"
 assert_equals "$exit_code" "0" "Wildcard exists on empty exits 0"
@@ -1012,19 +1026,19 @@ echo ""
 echo -e "${YELLOW}Test: delete work-unit-level field${NC}"
 setup_fixture
 run_cli init del-wu --work-type feature --description "Delete WU" >/dev/null 2>&1
-run_cli set del-wu phases.research.analysis_cache '{"checksum":"abc","generated":"2026-01-01"}' >/dev/null 2>&1
-run_cli delete del-wu phases.research.analysis_cache >/dev/null 2>&1
-output=$(run_cli_stdout exists del-wu phases.research.analysis_cache)
+run_cli set del-wu.research analysis_cache '{"checksum":"abc","generated":"2026-01-01"}' >/dev/null 2>&1
+run_cli delete del-wu.research analysis_cache >/dev/null 2>&1
+output=$(run_cli_stdout exists del-wu.research analysis_cache)
 
 assert_equals "$output" "false" "Deleted field no longer exists"
 
 # Verify sibling fields preserved
-run_cli set del-wu phases.research.status completed >/dev/null 2>&1
+run_cli set del-wu.research status completed >/dev/null 2>&1
 
 # Re-create and delete to check siblings
-run_cli set del-wu phases.research.analysis_cache '{"checksum":"xyz"}' >/dev/null 2>&1
-run_cli delete del-wu phases.research.analysis_cache >/dev/null 2>&1
-research_status=$(run_cli_stdout get del-wu --phase research --topic del-wu status 2>/dev/null || run_cli_stdout get del-wu phases.research.status)
+run_cli set del-wu.research analysis_cache '{"checksum":"xyz"}' >/dev/null 2>&1
+run_cli delete del-wu.research analysis_cache >/dev/null 2>&1
+research_status=$(run_cli_stdout get del-wu.research status)
 
 assert_equals "$research_status" "completed" "Sibling fields preserved after delete"
 
@@ -1032,36 +1046,36 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: delete phase-level field for feature${NC}"
+echo -e "${YELLOW}Test: delete topic-level field for feature${NC}"
 setup_fixture
 run_cli init del-feat --work-type feature --description "Delete feat" >/dev/null 2>&1
-run_cli init-phase del-feat --phase planning --topic del-feat >/dev/null 2>&1
-run_cli set del-feat --phase planning --topic del-feat task_gate_mode auto >/dev/null 2>&1
-run_cli delete del-feat --phase planning --topic del-feat task_gate_mode >/dev/null 2>&1
-output=$(run_cli_stdout exists del-feat --phase planning --topic del-feat task_gate_mode)
+run_cli init-phase del-feat.planning.del-feat >/dev/null 2>&1
+run_cli set del-feat.planning.del-feat task_gate_mode auto >/dev/null 2>&1
+run_cli delete del-feat.planning.del-feat task_gate_mode >/dev/null 2>&1
+output=$(run_cli_stdout exists del-feat.planning.del-feat task_gate_mode)
 
-assert_equals "$output" "false" "Deleted phase-level field gone"
+assert_equals "$output" "false" "Deleted topic-level field gone"
 
 # Verify status preserved
-plan_status=$(run_cli_stdout get del-feat --phase planning --topic del-feat status)
+plan_status=$(run_cli_stdout get del-feat.planning.del-feat status)
 assert_equals "$plan_status" "in-progress" "Phase status preserved after delete"
 
 echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: delete phase-level field for epic${NC}"
+echo -e "${YELLOW}Test: delete topic-level field for epic${NC}"
 setup_fixture
 run_cli init del-epic --work-type epic --description "Delete epic" >/dev/null 2>&1
-run_cli init-phase del-epic --phase implementation --topic auth >/dev/null 2>&1
-run_cli push del-epic --phase implementation --topic auth completed_tasks "task-1" >/dev/null 2>&1
-run_cli delete del-epic --phase implementation --topic auth completed_tasks >/dev/null 2>&1
-output=$(run_cli_stdout exists del-epic --phase implementation --topic auth completed_tasks)
+run_cli init-phase del-epic.implementation.auth >/dev/null 2>&1
+run_cli push del-epic.implementation.auth completed_tasks "task-1" >/dev/null 2>&1
+run_cli delete del-epic.implementation.auth completed_tasks >/dev/null 2>&1
+output=$(run_cli_stdout exists del-epic.implementation.auth completed_tasks)
 
 assert_equals "$output" "false" "Deleted epic item field gone"
 
 # Verify status preserved
-impl_status=$(run_cli_stdout get del-epic --phase implementation --topic auth status)
+impl_status=$(run_cli_stdout get del-epic.implementation.auth status)
 assert_equals "$impl_status" "in-progress" "Epic item status preserved after delete"
 
 echo ""
@@ -1071,12 +1085,12 @@ echo ""
 echo -e "${YELLOW}Test: delete nested dot-path field${NC}"
 setup_fixture
 run_cli init del-nested --work-type feature --description "Nested" >/dev/null 2>&1
-run_cli set del-nested phases.research.analysis_cache.checksum "abc123" >/dev/null 2>&1
-run_cli set del-nested phases.research.analysis_cache.generated "2026-01-01" >/dev/null 2>&1
-run_cli delete del-nested phases.research.analysis_cache.checksum >/dev/null 2>&1
+run_cli set del-nested.research analysis_cache.checksum "abc123" >/dev/null 2>&1
+run_cli set del-nested.research analysis_cache.generated "2026-01-01" >/dev/null 2>&1
+run_cli delete del-nested.research analysis_cache.checksum >/dev/null 2>&1
 
-checksum_exists=$(run_cli_stdout exists del-nested phases.research.analysis_cache.checksum)
-generated_exists=$(run_cli_stdout exists del-nested phases.research.analysis_cache.generated)
+checksum_exists=$(run_cli_stdout exists del-nested.research analysis_cache.checksum)
+generated_exists=$(run_cli_stdout exists del-nested.research analysis_cache.generated)
 
 assert_equals "$checksum_exists" "false" "Nested field deleted"
 assert_equals "$generated_exists" "true" "Sibling nested field preserved"
@@ -1088,11 +1102,11 @@ echo ""
 echo -e "${YELLOW}Test: delete entire subtree${NC}"
 setup_fixture
 run_cli init del-tree --work-type feature --description "Tree" >/dev/null 2>&1
-run_cli set del-tree phases.research.analysis_cache '{"checksum":"abc","generated":"2026-01-01","files":["a.md","b.md"]}' >/dev/null 2>&1
-run_cli delete del-tree phases.research.analysis_cache >/dev/null 2>&1
+run_cli set del-tree.research analysis_cache '{"checksum":"abc","generated":"2026-01-01","files":["a.md","b.md"]}' >/dev/null 2>&1
+run_cli delete del-tree.research analysis_cache >/dev/null 2>&1
 
-cache_exists=$(run_cli_stdout exists del-tree phases.research.analysis_cache)
-research_exists=$(run_cli_stdout exists del-tree phases.research)
+cache_exists=$(run_cli_stdout exists del-tree.research analysis_cache)
+research_exists=$(run_cli_stdout exists del-tree.research)
 
 assert_equals "$cache_exists" "false" "Entire subtree deleted"
 assert_equals "$research_exists" "true" "Parent key preserved"
@@ -1118,10 +1132,14 @@ echo ""
 
 # ----------------------------------------------------------------------------
 
-echo -e "${YELLOW}Test: delete requires --topic for topic-required phases${NC}"
+echo -e "${YELLOW}Test: delete phase-level field (2-segment path)${NC}"
 setup_fixture
-run_cli init del-notopic --work-type feature --description "No topic" >/dev/null 2>&1
-assert_exit_nonzero "Delete without topic errors" delete del-notopic --phase discussion status
+run_cli init del-phase --work-type feature --description "Phase del" >/dev/null 2>&1
+run_cli set del-phase.research analysis_cache '{"checksum":"abc"}' >/dev/null 2>&1
+run_cli delete del-phase.research analysis_cache >/dev/null 2>&1
+output=$(run_cli_stdout exists del-phase.research analysis_cache)
+
+assert_equals "$output" "false" "Phase-level delete works"
 
 echo ""
 
@@ -1130,7 +1148,19 @@ echo ""
 echo -e "${YELLOW}Test: delete rejects invalid phase${NC}"
 setup_fixture
 run_cli init del-badphase --work-type feature --description "Bad phase" >/dev/null 2>&1
-assert_exit_nonzero "Delete invalid phase errors" delete del-badphase --phase cooking --topic del-badphase status
+assert_exit_nonzero "Delete invalid phase errors" delete del-badphase.cooking.del-badphase status
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: push phase-level (2-segment path)${NC}"
+setup_fixture
+run_cli init push-phase --work-type feature --description "Phase push" >/dev/null 2>&1
+run_cli push push-phase.research analysis_cache.files "a.md" >/dev/null 2>&1
+output=$(run_cli_stdout get push-phase.research analysis_cache.files)
+
+assert_contains "$output" '"a.md"' "Phase-level push works"
 
 echo ""
 


### PR DESCRIPTION
## Summary

- Replace `--phase`/`--topic` flags with unified dot-path syntax: `command <work-unit>[.<phase>[.<topic>]] [field] [value]` — segment count determines access level (1=work-unit, 2=phase, 3=topic)
- Migrate ~220 manifest CLI invocations across ~65 skill/agent files to new syntax
- Add name validation (no dots in work unit names, no phase names as work unit names), remove `TOPICLESS_PHASES`, rewrite tests (123 passing) and API docs

## Test plan

- [x] All 123 manifest CLI tests pass
- [x] Zero `--phase`/`--topic` references remain in skills/ and agents/
- [x] Zero raw `phases.` paths remain in skill manifest CLI calls
- [x] Migration scripts untouched (point-in-time snapshots)
- [ ] Manual smoke test: run a workflow end-to-end to verify skill invocations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)