### PR TITLE
fix: quote wildcard args in manifest CLI invocations

### DIFF
--- a/skills/workflow-discussion-entry/references/gather-context.md
+++ b/skills/workflow-discussion-entry/references/gather-context.md
@@ -41,7 +41,7 @@ New discussion entry: topic was provided by the caller.
 Check if any research items exist for this work unit:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.research.*
+node .claude/skills/workflow-manifest/scripts/manifest.js exists '{work_unit}.research.*'
 ```
 
 **If exists (`true`):**
@@ -59,7 +59,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.res
 ## C. Check Research Status
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.research.* status
+node .claude/skills/workflow-manifest/scripts/manifest.js get '{work_unit}.research.*' status
 ```
 
 **If any research item has status `completed`:**

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -126,7 +126,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get <name>.specificati
 **Wildcard topic** (3 segments, `*` as topic):
 ```bash
 # Collect status from all topics in a phase
-node .claude/skills/workflow-manifest/scripts/manifest.js get <name>.discussion.* status
+node .claude/skills/workflow-manifest/scripts/manifest.js get '<name>.discussion.*' status
 ```
 
 Output is a JSON array of `{topic, value}` objects:
@@ -262,8 +262,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussi
 node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussion.auth-flow status
 
 # Wildcard: does any topic in the phase have this field?
-node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussion.*
-node .claude/skills/workflow-manifest/scripts/manifest.js exists <name>.discussion.* status
+node .claude/skills/workflow-manifest/scripts/manifest.js exists '<name>.discussion.*'
+node .claude/skills/workflow-manifest/scripts/manifest.js exists '<name>.discussion.*' status
 ```
 
 If the work unit doesn't exist and a deeper path is requested, outputs `false` (no error). Actual usage errors (missing args, invalid phase name) still use `die()`.

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -57,7 +57,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {selected.name}
 ## C. Completion Check
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name}.implementation.* status
+node .claude/skills/workflow-manifest/scripts/manifest.js get '{selected.name}.implementation.*' status
 ```
 
 This returns all topic statuses in the implementation phase.

--- a/skills/workflow-start/references/view-plan.md
+++ b/skills/workflow-start/references/view-plan.md
@@ -19,7 +19,7 @@ Set `topic` = `selected.name`.
 Query manifest for all planning topics:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name}.planning.* status
+node .claude/skills/workflow-manifest/scripts/manifest.js get '{selected.name}.planning.*' status
 ```
 
 **If only one topic exists:**


### PR DESCRIPTION
## Summary

- zsh glob-expands unquoted `*` in manifest CLI dot-path args before node receives them, causing "no matches found" errors (exit code 1) instead of returning `false`
- Wrapped all 7 wildcard dot-path arguments across 4 files in single quotes to prevent shell expansion
- Fixes both skill invocations and manifest CLI documentation examples

## Test plan

- [ ] Run `node .claude/skills/workflow-manifest/scripts/manifest.js exists 'nonexistent.research.*'` — should return `false` (exit 0)
- [ ] Start a new feature discussion (`/start-feature`) for a work unit with no prior research — should cleanly return `false` at the research check instead of erroring

🤖 Generated with [Claude Code](https://claude.com/claude-code)