### PR TITLE
fix(view-plan): fetch external_id before loading format adapter

### DIFF
--- a/skills/workflow-start/references/view-plan.md
+++ b/skills/workflow-start/references/view-plan.md
@@ -58,11 +58,14 @@ Set `topic` to the selected topic.
 
 ## B. Read Plan
 
-Read the `format` from the manifest:
+Read the `format` and `external_id` from the manifest:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name}.planning.{topic} format
+node .claude/skills/workflow-manifest/scripts/manifest.js get {selected.name}.planning.{topic} external_id
 ```
+
+Use `external_id` as the plan-level parent identifier when following the format adapter's instructions below.
 
 → Load **[reading.md](../../workflow-planning-process/references/output-formats/{format}/reading.md)** and follow its instructions as written.
 


### PR DESCRIPTION
## Summary

- **Bug**: `view-plan` loaded the format adapter's `reading.md` without fetching `external_id` from the manifest, so Claude had no value for the adapter's parent identifier placeholder (e.g. tried guessing `tick_id` which doesn't exist)
- **Fix**: Fetch `external_id` alongside `format` in Step B and instruct its use as the plan-level parent identifier — format-agnostic, no format names referenced

## Test plan

- [ ] Use manage menu → view plan on a work unit with tick format — verify it fetches `external_id` and passes it to `tick list --parent`
- [ ] Verify no format-specific names appear in `view-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)