### PR TITLE
fix(workflow-start): show completed/cancelled option in empty state

### DIFF
--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -4,7 +4,7 @@
 
 ---
 
-No active work found. Offer to start something new.
+No active work found. Offer to start something new, with option to view completed/cancelled work if any exist.
 
 > *Output the next fenced block as a code block:*
 
@@ -12,6 +12,10 @@ No active work found. Offer to start something new.
 Workflow Overview
 
 No active work found.
+
+@if(completed_count > 0 || cancelled_count > 0)
+{completed_count} completed, {cancelled_count} cancelled.
+@endif
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -24,11 +28,17 @@ What would you like to start?
 2. **Epic** — large initiative, multi-topic, multi-session
 3. **Bugfix** — fix broken behavior
 
+@if(completed_count > 0 || cancelled_count > 0)
+4. **View completed & cancelled work units**
+@endif
+
 Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
+
+#### If user chose a start-new option
 
 Invoke the selected skill:
 
@@ -39,3 +49,11 @@ Invoke the selected skill:
 | Bugfix | `/start-bugfix` |
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
+
+#### If user chose "View completed & cancelled"
+
+→ Load **[view-completed.md](view-completed.md)** and follow its instructions as written.
+
+Re-run discovery to refresh state after potential changes.
+
+→ Return to caller.


### PR DESCRIPTION
## Summary

- When all work units are completed/cancelled, `empty-state.md` now conditionally shows the count and a menu option to view them
- Routes through `view-completed.md` then returns to caller (backbone Step 2) so routing re-evaluates with fresh discovery state

## Test plan

- [ ] Cancel or complete all active work units so no in-progress work remains
- [ ] Run `/workflow-start` — verify the overview shows completed/cancelled counts and menu option 4
- [ ] Select "View completed & cancelled" — verify it loads correctly and returns to the menu after

🤖 Generated with [Claude Code](https://claude.com/claude-code)