### PR TITLE
fix(workflow-start): emit completed/cancelled details in format

### DIFF
--- a/skills/workflow-start/references/view-completed.md
+++ b/skills/workflow-start/references/view-completed.md
@@ -4,7 +4,7 @@
 
 ---
 
-Display completed and cancelled work units. Self-contained — receives context from caller (completed/cancelled arrays, optional work_type filter).
+Display completed and cancelled work units from discovery output.
 
 ## A. Display List
 
@@ -44,7 +44,7 @@ Cancelled:
 @endif
 ```
 
-Build from the completed and cancelled arrays passed by the caller. Numbering is continuous across both sections. Blank line between each numbered item.
+Build from the completed and cancelled sections in the discovery output. Numbering is continuous across both sections. Blank line between each numbered item.
 
 → Proceed to **B. Select**.
 

--- a/skills/workflow-start/scripts/discovery.js
+++ b/skills/workflow-start/scripts/discovery.js
@@ -110,6 +110,22 @@ function format(result) {
   emitSection('features', result.features.work_units);
   emitSection('bugfixes', result.bugfixes.work_units);
 
+  if (result.completed.length > 0) {
+    lines.push('=== COMPLETED ===');
+    for (const u of result.completed) {
+      lines.push(`  ${u.name} (${u.work_type}, last phase: ${u.last_phase || 'none'})`);
+    }
+    lines.push('');
+  }
+
+  if (result.cancelled.length > 0) {
+    lines.push('=== CANCELLED ===');
+    for (const u of result.cancelled) {
+      lines.push(`  ${u.name} (${u.work_type}, last phase: ${u.last_phase || 'none'})`);
+    }
+    lines.push('');
+  }
+
   lines.push('=== STATE ===');
   lines.push(`has_any_work: ${result.state.has_any_work}`);
   lines.push(`counts: ${result.state.epic_count} epic, ${result.state.feature_count} feature, ${result.state.bugfix_count} bugfix`);

--- a/tests/scripts/test-discovery-for-start.js
+++ b/tests/scripts/test-discovery-for-start.js
@@ -267,4 +267,24 @@ describe('workflow-start format', () => {
     assert.ok(out.includes('completed_count: 0'));
     assert.ok(out.includes('cancelled_count: 0'));
   });
+
+  it('emits completed work unit details', () => {
+    createManifest(dir, 'done-feat', { work_type: 'feature', status: 'completed', phases: { review: { items: { 'done-feat': { status: 'completed' } } } } });
+    const out = format(discover(dir));
+    assert.ok(out.includes('=== COMPLETED ==='));
+    assert.ok(out.includes('  done-feat (feature, last phase: review)'));
+  });
+
+  it('emits cancelled work unit details', () => {
+    createManifest(dir, 'dropped', { work_type: 'bugfix', status: 'cancelled', phases: { investigation: { items: { dropped: { status: 'completed' } } } } });
+    const out = format(discover(dir));
+    assert.ok(out.includes('=== CANCELLED ==='));
+    assert.ok(out.includes('  dropped (bugfix, last phase: investigation)'));
+  });
+
+  it('omits completed/cancelled sections when empty', () => {
+    const out = format(discover(dir));
+    assert.ok(!out.includes('=== COMPLETED ==='));
+    assert.ok(!out.includes('=== CANCELLED ==='));
+  });
 });


### PR DESCRIPTION
## Summary

- **Bug fix**: `format()` emitted `completed_count`/`cancelled_count` but not the actual item details (name, work_type, last_phase), forcing the model to improvise when rendering `view-completed.md`
- **Adds `=== COMPLETED ===` and `=== CANCELLED ===` sections** to format output with full item details, only when items exist
- **Corrects `view-completed.md`** description to reference discovery output rather than "caller-passed arrays"

## Test plan

- [x] All 28 workflow-start discovery tests pass
- [ ] Run `/workflow-start` with only completed/cancelled work — select option 4, verify items render without re-running discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)