### PR TITLE
fix(workflow-start): use commands for non-numbered menu items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Claude Code skills package for structured technical discussion and planning work
 
 **This CLAUDE.md is development documentation for authoring the workflows — it does not ship with the product.** When installed, only the skills and agents are copied into the target project (which has its own CLAUDE.md). Skills and agents must be fully self-contained — never rely on this file for runtime behaviour, conventions, or formats that agents need to follow.
 
+## Git Workflow
+
+Always create a feature branch **before** the first commit. Never commit to main and move commits after. The only exception is when explicitly told to commit to main.
+
 ## Workflow Phases
 
 1. **Research** (`workflow-research-process` skill): EXPLORE - feasibility, market, viability, early ideas

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -66,7 +66,7 @@ Build from discovery output. Only show sections that have work units. Numbering 
 
 ## Menu
 
-Build a numbered menu with continue items first, then start-new options, then lifecycle options, separated by blank lines.
+Build the menu with numbered continue items first, then command options for start-new and lifecycle actions, separated by blank lines.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -78,26 +78,24 @@ What would you like to do?
 2. Continue "{bugfix.name:(titlecase)}" — bugfix, {bugfix.phase_label}
 3. Continue "{epic.name:(titlecase)}" — epic
 
-4. Start new feature
-5. Start new epic
-6. Start new bugfix
-
+- **`f`/`feature`** — Start new feature
+- **`e`/`epic`** — Start new epic
+- **`b`/`bugfix`** — Start new bugfix
 @if(has_inbox)
 - **`i`/`inbox`** — Start from an inbox item
 @endif
-
 @if(completed_count > 0 || cancelled_count > 0)
-7. View completed & cancelled work units
+- **`v`/`view`** — View completed & cancelled work units
 @endif
 - **`m`/`manage`** — Manage a work unit's lifecycle
 
-Select an option (enter number):
+Select an option (enter number or command):
 · · · · · · · · · · · ·
 ```
 
 **Continue items:** Feature/bugfix shows type + phase label. Epic just shows "epic" (detail is in continue-epic). No auto-select — always show the full menu. No "(recommended)" labels.
 
-**Start-new items:** Always show all three start options.
+**Command options:** Start-new, inbox, view, and manage are always command options (not numbered). Always show all three start options.
 
 Recreate with actual work units from discovery.
 
@@ -118,7 +116,7 @@ Invoke the selected skill:
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
 
-#### If user chose "View completed & cancelled"
+#### If user chose `v`/`view`
 
 → Load **[view-completed.md](view-completed.md)** and follow its instructions as written.
 

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -24,31 +24,29 @@ No active work found.
 · · · · · · · · · · · ·
 What would you like to start?
 
-1. **Feature** — add functionality to an existing product
-2. **Epic** — large initiative, multi-topic, multi-session
-3. **Bugfix** — fix broken behavior
-
+- **`f`/`feature`** — Add functionality to an existing product
+- **`e`/`epic`** — Large initiative, multi-topic, multi-session
+- **`b`/`bugfix`** — Fix broken behavior
 @if(has_inbox)
-4. **Start from inbox** ({inbox_count} items)
+- **`i`/`inbox`** — Start from an inbox item ({inbox_count} items)
 @endif
-
 @if(completed_count > 0 || cancelled_count > 0)
-5. **View completed & cancelled work units**
+- **`v`/`view`** — View completed & cancelled work units
 @endif
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-#### If user chose "Start from inbox"
+#### If user chose `i`/`inbox`
 
 → Load **[start-from-inbox.md](start-from-inbox.md)** and follow its instructions as written.
 
 → Return to caller.
 
-#### If user chose a start-new option
+#### If user chose `f`/`feature`, `e`/`epic`, or `b`/`bugfix`
 
 Invoke the selected skill:
 
@@ -60,7 +58,7 @@ Invoke the selected skill:
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
 
-#### If user chose "View completed & cancelled"
+#### If user chose `v`/`view`
 
 → Load **[view-completed.md](view-completed.md)** and follow its instructions as written.
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -19,12 +19,14 @@ Features:
   {N}. {unit.name:(titlecase)}
 @endforeach
 @endif
+
 @if(bugfix_count > 0)
 Bugfixes:
 @foreach(unit in bugfixes.work_units)
   {N}. {unit.name:(titlecase)}
 @endforeach
 @endif
+
 @if(epic_count > 0)
 Epics:
 @foreach(unit in epics.work_units)

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -4,15 +4,42 @@
 
 ---
 
-Manage an in-progress work unit's lifecycle. Self-contained four-step flow. Uses the numbered in-progress items already displayed by the caller.
+Manage an in-progress work unit's lifecycle. Self-contained four-step flow.
 
 ## A. Select
+
+> *Output the next fenced block as a code block:*
+
+```
+Manage
+
+@if(feature_count > 0)
+Features:
+@foreach(unit in features.work_units)
+  {N}. {unit.name:(titlecase)}
+@endforeach
+@endif
+@if(bugfix_count > 0)
+Bugfixes:
+@foreach(unit in bugfixes.work_units)
+  {N}. {unit.name:(titlecase)}
+@endforeach
+@endif
+@if(epic_count > 0)
+Epics:
+@foreach(unit in epics.work_units)
+  {N}. {unit.name:(titlecase)}
+@endforeach
+@endif
+```
+
+Build from discovery output. Only show sections that have work units. Numbering is continuous across sections — same numbers as the overview.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Which work unit would you like to manage? (enter number from list above, or **`b`/`back`** to return)
+Select a work unit (enter number, or **`b`/`back`** to return):
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-start/references/start-from-inbox.md
+++ b/skills/workflow-start/references/start-from-inbox.md
@@ -24,11 +24,17 @@ Build a numbered list combining all ideas and bugs, sorted by date (oldest first
 
 ```
 · · · · · · · · · · · ·
-Select an item (enter number):
+Select an item (enter number, or **`b`/`back`** to return):
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
+
+#### If user chose `b`/`back`
+
+→ Return to caller.
+
+#### If user chose a number
 
 → Proceed to **B. Load and Route**.
 


### PR DESCRIPTION
## Summary

- Numbers in the main menu now only map to continuable work units; start-new (`f/feature`, `e/epic`, `b/bugfix`), view completed (`v/view`), and inbox (`i/inbox`) are command options
- Manage menu re-displays a flat list of work units grouped by type instead of referencing "list above"
- Inbox menu gains `b/back` to return to overview; empty state updated for consistency

## Test plan

- [ ] Run `/workflow-start` with active work — verify numbers map to continue items only, commands work for start/view/manage
- [ ] Run `/workflow-start` with no active work — verify empty state uses commands
- [ ] Select `m/manage` — verify flat list re-displays with spacing between sections
- [ ] Select `i/inbox` — verify `b/back` returns to overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)