### PR TITLE
fix: strengthen agent scope boundaries and caller input lists

### DIFF
--- a/agents/workflow-planning-phase-designer.md
+++ b/agents/workflow-planning-phase-designer.md
@@ -79,3 +79,4 @@ Continue for all phases.
 5. **3-6 tasks per phase** — if you can't imagine 3+ tasks, merge; 8+ tasks, split
 6. **Specification is source of truth** — plan what the spec defines, nothing more
 7. **Cross-cutting specs inform, don't add scope** — they shape how you build, not what you build
+8. **Phases only — no task content** — your output is phase structure: goals, ordering, and acceptance criteria. Task tables and task lists are designed by a separate agent in a later step. Never include them.

--- a/agents/workflow-planning-task-designer.md
+++ b/agents/workflow-planning-task-designer.md
@@ -76,3 +76,4 @@ status: draft
 6. **Specification is source of truth** — tasks implement what the spec defines
 7. **Cross-cutting specs inform** — apply their decisions to task design without adding scope
 8. **Awareness of other phases** — avoid duplicating work planned in other phases; ensure proper ordering
+9. **Task tables only — no full task detail** — your output is a task overview and task table (Internal ID, Name, Edge Cases). Full task specifications (Problem, Solution, Do steps, Acceptance Criteria, Tests, etc.) are written by a separate authoring agent in a later step. Never include them.

--- a/roadmap/cross-cutting-work-type.md
+++ b/roadmap/cross-cutting-work-type.md
@@ -236,6 +236,16 @@ These are identified from codebase analysis — the files that need changes:
 | Epic displays | `continue-epic` | Show promoted topics as `(promoted)`, don't offer for continuation |
 | Migrations | New scripts | (A) build project manifest, (B) promote existing cc specs + strip type field |
 
+### Implementation Notes (from codebase review 2026-03-19)
+
+Recent changes that affect implementation approach (but not design):
+
+- **`→ Return to caller.` routing convention** — all skills now use this pattern. Files we plan to modify (`cross-cutting-context.md`, `validate-spec.md`) already updated. All new skills must follow this convention
+- **Bridge discovery uses manifest state** — `workflow-bridge/scripts/discovery.js` now reads manifest phase status instead of checking file existence. Aligns well with our approach — adding cc terminal logic fits naturally
+- **Planning internals refactored** — plan index file replaced by `task_map` in manifest. No impact on our work (we interact at planning entry level, not task storage)
+- **Discovery scripts have format tests** — all 7 discovery scripts now have tests. New `continue-cross-cutting` discovery script needs tests too
+- **Migration scripts use `report_update`/`report_skip`** — standardised, no-arg versions. Our new migration scripts should follow this pattern
+
 ### Edge Cases
 
 1. **Work unit name collision on promotion** — topic name may already exist as a work unit. Need collision handling (open question)

--- a/skills/workflow-implementation-process/references/invoke-analysis.md
+++ b/skills/workflow-implementation-process/references/invoke-analysis.md
@@ -28,8 +28,9 @@ Dispatch **all three in parallel** via the Task tool. Each agent receives the sa
 2. **Specification path** — from the specification (if available)
 3. **Project skill paths** — from `project_skills` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} project_skills`)
 4. **code-quality.md path** — `code-quality.md`
-5. **Topic name** — the implementation topic
-6. **Cycle number** — the current analysis cycle number (from `analysis_cycle` in the manifest: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} analysis_cycle`)
+5. **Work unit** — the work unit name (for path construction)
+6. **Topic name** — the implementation topic
+7. **Cycle number** — the current analysis cycle number (from `analysis_cycle` in the manifest: `node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} analysis_cycle`)
 
 Each agent knows its own output path convention and writes findings independently.
 

--- a/skills/workflow-implementation-process/references/invoke-synthesizer.md
+++ b/skills/workflow-implementation-process/references/invoke-synthesizer.md
@@ -15,11 +15,12 @@ This step invokes the synthesis agent to read analysis findings, deduplicate, an
 Pass via the orchestrator's prompt:
 
 1. **Task normalization reference path** — `task-normalisation.md`
-2. **Topic name** — the implementation topic
-3. **Cycle number** — the current analysis cycle number
-4. **Specification path** — from the specification (if available)
+2. **Work unit** — the work unit name (for path construction)
+3. **Topic name** — the implementation topic
+4. **Cycle number** — the current analysis cycle number
+5. **Specification path** — from the specification (if available)
 
-The agent knows its own file path conventions — it locates findings files and writes output files based on the topic name.
+The agent locates findings files and writes output files using the work unit and topic name.
 
 ---
 

--- a/skills/workflow-implementation-process/references/invoke-task-writer.md
+++ b/skills/workflow-implementation-process/references/invoke-task-writer.md
@@ -14,12 +14,13 @@ This step invokes the task writer agent to create plan tasks from approved analy
 
 Pass via the orchestrator's prompt:
 
-1. **Topic name** — the implementation topic
-2. **Staging file path** — `.workflows/{work_unit}/implementation/{topic}/analysis-tasks-c{cycle-number}.md`
-3. **Planning file path** — `.workflows/{work_unit}/planning/{topic}/planning.md`
-4. **Plan format reading adapter path** — `../../workflow-planning-process/references/output-formats/{format}/reading.md`
-5. **Plan format authoring adapter path** — `../../workflow-planning-process/references/output-formats/{format}/authoring.md`
-6. **Phase label** — `Analysis (Cycle {N})`
+1. **Work unit** — the work unit name (for path construction)
+2. **Topic name** — the implementation topic
+3. **Staging file path** — `.workflows/{work_unit}/implementation/{topic}/analysis-tasks-c{cycle-number}.md`
+4. **Planning file path** — `.workflows/{work_unit}/planning/{topic}/planning.md`
+5. **Plan format reading adapter path** — `../../workflow-planning-process/references/output-formats/{format}/reading.md`
+6. **Plan format authoring adapter path** — `../../workflow-planning-process/references/output-formats/{format}/authoring.md`
+7. **Phase label** — `Analysis (Cycle {N})`
 
 ---
 

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -44,9 +44,9 @@ Invoke `workflow-planning-phase-designer` with these file paths:
 3. **Cross-cutting specs**: cross-cutting spec paths if any
 4. **phase-design.md**: `phase-design.md`
 5. **Context guidance**: `phase-design/{work_type}.md` (default to `epic` if `work_type` is empty)
-6. **task-design.md**: `task-design.md`
+6. **task-design.md**: `task-design.md` *(for granularity awareness only — helps the agent judge whether a phase is too thin or too thick. The agent must NOT produce task tables or task lists.)*
 
-The agent returns a complete phase structure. Write it directly to the planning file body.
+The agent returns phases only — goals, ordering rationale, and acceptance criteria. **Task lists are designed separately in a later step; do not request or include them.** Write the phase structure directly to the planning file body.
 
 Update the manifest planning position:
 ```bash

--- a/skills/workflow-review-process/references/invoke-review-synthesizer.md
+++ b/skills/workflow-review-process/references/invoke-review-synthesizer.md
@@ -26,10 +26,11 @@ Dispatch **one agent** via the Task tool.
 
 The synthesizer receives:
 
-1. **Plan topic** — the plan being synthesized
-2. **Review path** — path to `review/{topic}/` directory (review summary + QA files)
-3. **Specification path** — from the manifest
-4. **Cycle number** — the review remediation cycle number
+1. **Work unit** — the work unit name (for path construction)
+2. **Plan topic** — the plan being synthesized
+3. **Review path** — path to `review/{topic}/` directory (review summary + QA files)
+4. **Specification path** — from the manifest
+5. **Cycle number** — the review remediation cycle number
 
 ---
 


### PR DESCRIPTION
## Summary

- **Phase designer scope boundary**: Added explicit guards preventing the phase designer agent from producing task tables — the root cause of it overstepping into task list design during planning. Defence in depth across both the caller (`define-phases.md`) and the agent itself.
- **Missing `work_unit` inputs**: Four caller reference files (`invoke-analysis.md`, `invoke-synthesizer.md`, `invoke-task-writer.md`, `invoke-review-synthesizer.md`) were missing `work_unit` from their explicit input lists despite agents needing it for path construction. Now matches agent expectations.
- **Task designer scope boundary**: Added rule preventing the task designer from writing full task detail (same pattern as phase designer fix).

## Test plan

- [ ] Run a feature planning session — verify phase designer produces phases only (no task tables)
- [ ] Run through task design step — verify task designer produces table only (no full detail)
- [ ] Verify implementation analysis agents receive `work_unit` correctly
- [ ] Verify review synthesis agent receives `work_unit` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)