### PR TITLE
fix(planning): reduce multi-phase bias in phase designer

### DIFF
--- a/agents/workflow-planning-phase-designer.md
+++ b/agents/workflow-planning-phase-designer.md
@@ -72,11 +72,12 @@ Continue for all phases.
 
 ## Rules
 
-1. **Strongest foundation first** — Phase 1 establishes the pattern for subsequent phases. Follow the Phase 1 strategy from the loaded context guidance.
-2. **Vertical phases** — each phase delivers working functionality, not technical layers
-3. **Clear acceptance** — every criterion is pass/fail verifiable
-4. **No forward references** — no phase depends on something not yet built
-5. **3-6 tasks per phase** — if you can't imagine 3+ tasks, merge; 8+ tasks, split
-6. **Specification is source of truth** — plan what the spec defines, nothing more
-7. **Cross-cutting specs inform, don't add scope** — they shape how you build, not what you build
-8. **Phases only — no task content** — your output is phase structure: goals, ordering, and acceptance criteria. Task tables and task lists are designed by a separate agent in a later step. Never include them.
+1. **Right-size to the specification** — a single phase is a valid plan. Don't create phases to fill a template; create them because the work has genuinely distinct stages. A focused spec might be one phase with 4 tasks. A large spec might be 10 phases. Both are correct.
+2. **Strongest foundation first** — Phase 1 establishes the pattern for subsequent phases. Follow the Phase 1 strategy from the loaded context guidance.
+3. **Vertical phases** — each phase delivers working functionality, not technical layers
+4. **Clear acceptance** — every criterion is pass/fail verifiable
+5. **No forward references** — no phase depends on something not yet built
+6. **3-6 tasks per phase** — if you can't imagine 3+ tasks, merge; 8+ tasks, split
+7. **Specification is source of truth** — plan what the spec defines, nothing more
+8. **Cross-cutting specs inform, don't add scope** — they shape how you build, not what you build
+9. **Phases only — no task content** — your output is phase structure: goals, ordering, and acceptance criteria. Task tables and task lists are designed by a separate agent in a later step. Never include them.

--- a/skills/workflow-planning-process/references/phase-design.md
+++ b/skills/workflow-planning-process/references/phase-design.md
@@ -8,6 +8,14 @@ This reference defines generic principles for breaking specifications into imple
 
 A work-type context file (epic, feature, or bugfix) is always loaded alongside this file. The context file provides the Phase 1 strategy, progression model, examples, and work-type-specific guidance. These generic principles apply across all work types.
 
+## Right-Size the Plan
+
+**A single phase is a valid plan.** Not every feature needs multiple phases, and not every epic specification needs a multi-phase breakdown. Phase overhead has a cost — don't pay it unless the work genuinely has distinct stages that benefit from separate checkpoints.
+
+The right number of phases is whatever the specification demands — no more, no less. A focused feature might be one phase with 4 tasks. A large system might be 12 phases. Both are correct if they match the scope. Judge by the specification's complexity, not by an expectation of what a plan "should" look like.
+
+Before adding a phase, ask: **does this phase exist because the work genuinely needs a checkpoint here, or because multi-phase plans feel more thorough?** If the latter, merge it.
+
 ## What Makes a Good Phase
 
 Each phase should:

--- a/skills/workflow-planning-process/references/phase-design/epic.md
+++ b/skills/workflow-planning-process/references/phase-design/epic.md
@@ -57,6 +57,8 @@ Each phase delivers something a user or test suite can validate independently.
 
 This ordering means each phase builds on a working system. The skeleton establishes the pattern; core features flesh it out; edge cases harden it; refinement polishes it.
 
+These are conceptual stages, not a phase count requirement. A tightly scoped plan might combine core features and edge cases into a single phase after the skeleton. Only create separate phases for work that genuinely benefits from a checkpoint between them.
+
 ---
 
 ## Cross-Phase Coupling (Epic)

--- a/skills/workflow-planning-process/references/phase-design/feature.md
+++ b/skills/workflow-planning-process/references/phase-design/feature.md
@@ -19,7 +19,22 @@ Phase 1 should:
 
 ## Feature Vertical Phases
 
-Each phase adds a complete slice of the new feature, building on the existing system.
+Each phase adds a complete slice of the new feature, building on the existing system. The number of phases depends entirely on the specification's scope — a focused feature may be a single phase, a larger feature may need several.
+
+**Example** (Adding a configuration toggle with validation):
+
+```
+Phase 1: Configuration toggle — setting storage, validation rules, API endpoint, UI control
+```
+
+One phase is sufficient when the feature is cohesive and doesn't have distinct stages that benefit from separate checkpoints.
+
+**Example** (Adding webhook support to existing API):
+
+```
+Phase 1: Core webhook delivery — event registration, payload construction, HTTP dispatch, retry on failure
+Phase 2: Management and observability — webhook CRUD endpoints, delivery logs, manual retry UI
+```
 
 **Example** (Adding OAuth to existing Express API):
 
@@ -28,14 +43,6 @@ Phase 1: Basic OAuth flow — provider registration, callback, token exchange, s
 Phase 2: Permission scoping — granular permissions, role mapping, scope enforcement
 Phase 3: Token lifecycle — refresh tokens, expiry handling, revocation
 Phase 4: Edge cases — concurrent sessions, provider downtime, account linking
-```
-
-**Example** (Adding search to existing e-commerce app):
-
-```
-Phase 1: Basic keyword search — index products, query endpoint, display results
-Phase 2: Filtering and facets — category filters, price ranges, attribute facets
-Phase 3: Relevance tuning — boosting, synonyms, typo tolerance
 ```
 
 Each phase delivers functionality that users or tests can validate against the existing system.
@@ -48,6 +55,8 @@ Each phase delivers functionality that users or tests can validate against the e
 - **Extended capability**: Richer variations, additional options, deeper integration
 - **Edge cases**: Boundary conditions, failure modes, interaction with existing features
 - **Refinement**: Performance, UX polish, hardening
+
+Not every feature passes through all stages. A focused feature might cover core functionality and edge cases together in a single phase. Only create separate phases for stages that represent genuinely distinct work with meaningful checkpoints between them.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add "Right-Size the Plan" section to generic phase design principles — explicitly states single phase is valid, phase count should match spec complexity
- Add 1-phase and 2-phase examples to feature.md (config toggle, webhooks) alongside existing 3-4 phase examples, breaking the anchoring effect
- Add qualifier to progression models in both feature.md and epic.md — stages are conceptual, not a phase count requirement
- Add "Right-size to the specification" as Rule 1 in the phase designer agent

## Test plan

- [ ] Run planning on a small feature spec and verify the phase designer produces 1-2 phases rather than defaulting to 3-4
- [ ] Run planning on a larger spec and verify it still produces appropriate multi-phase plans
- [ ] Verify phase designer agent still respects all other rules (vertical phases, no task content, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)