### PR TITLE
fix(planning): initialize task_map during phase registration

### DIFF
--- a/skills/workflow-planning-process/references/initialize-plan.md
+++ b/skills/workflow-planning-process/references/initialize-plan.md
@@ -70,6 +70,7 @@ Existing plans use **{format}**. Use the same format?
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} finding_gate_mode gated
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} phase 1
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task ~
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task_map '{}'
    ```
 
 4. Commit: `planning({work_unit}): initialize plan`


### PR DESCRIPTION
## Summary

- Initialize `task_map` as empty object `{}` during planning phase registration in `initialize-plan.md`
- Prevents manifest CLI exit code 1 when reading `task_map` before any tasks are authored
- Eliminates need for exists checks at every read site — `get` now returns `{}` instead of erroring

## Test plan

- [ ] Start a new planning phase and verify `task_map` is set to `{}` in the manifest after initialization
- [ ] Confirm `get task_map` returns `{}` before any tasks are authored (no exit code 1)
- [ ] Author tasks and verify `task_map.{id}` dot-path sets still work correctly on the initialized object