### PR TITLE
fix: rename inbox/ to .inbox/ for internal directory consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Skills are organised in two tiers:
 
 **Processing skills** (`workflow-*-process`) are model-invocable. They assume pipeline context — work_type is set, prior phases are complete, artifacts are in expected locations. Phase entry skills provide all required inputs before invoking them.
 
-**Capture skills** (`workflow-log-idea`, `workflow-log-bug`) are model-invocable, lightweight skills outside the pipeline. They capture ideas or bugs as markdown files in the inbox (`.workflows/inbox/`). No manifest, no migrations, no step/reference structure — just natural language instructions with capture-only constraints. They can be invoked directly by the user or discovered by the model when the user wants to log something.
+**Capture skills** (`workflow-log-idea`, `workflow-log-bug`) are model-invocable, lightweight skills outside the pipeline. They capture ideas or bugs as markdown files in the inbox (`.workflows/.inbox/`). No manifest, no migrations, no step/reference structure — just natural language instructions with capture-only constraints. They can be invoked directly by the user or discovered by the model when the user wants to log something.
 
 ### Phase Entry Skill Routing
 
@@ -72,8 +72,8 @@ Work-unit-first directory structure with uniform `{topic}` in all paths. For fea
 - State: `.workflows/{work_unit}/.state/` (per-work-unit analysis files)
 - Global state: `.workflows/.state/` (migrations, environment-setup.md)
 - Cache: `.workflows/.cache/{work_unit}/{phase}/{topic}/` (scratch files for any phase)
-- Inbox: `.workflows/inbox/ideas/`, `.workflows/inbox/bugs/` (pre-pipeline capture, plain markdown)
-- Inbox archive: `.workflows/inbox/.archived/{ideas,bugs}/` (moved here when an inbox item enters the pipeline)
+- Inbox: `.workflows/.inbox/ideas/`, `.workflows/.inbox/bugs/` (pre-pipeline capture, plain markdown)
+- Inbox archive: `.workflows/.inbox/.archived/{ideas,bugs}/` (moved here when an inbox item enters the pipeline)
 
 **Work unit lifecycle**: Each work unit has a `status` field in its manifest tracking its lifecycle state:
 - `in-progress` — actively being worked on (default on creation)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Revisit any completed phase before moving forward — refine a discussion, updat
 
 ### Inbox Capture
 
-Log ideas and bugs as you go — mid-conversation or from scratch. Say "log that as an idea" during any conversation, or invoke `/workflow-log-idea` or `/workflow-log-bug` directly. Captured items land in the inbox as plain markdown files. When you're ready, `/workflow-start` shows your inbox and lets you promote items into the pipeline — pre-filling context and skipping the gather-context interview.
+Log ideas and bugs as you go — mid-conversation or from scratch. Say "log that as an idea" during any conversation, or invoke `/workflow-log-idea` or `/workflow-log-bug` directly. Captured items land in `.inbox` as plain markdown files. When you're ready, `/workflow-start` shows your inbox and lets you promote items into the pipeline — pre-filling context and skipping the gather-context interview.
 
 ### Workflow Dashboard
 

--- a/skills/start-bugfix/SKILL.md
+++ b/skills/start-bugfix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-bugfix
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.js), Bash(ls .workflows/), Bash(mkdir -p .workflows/inbox/.archived/), Bash(mv .workflows/inbox/)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.js), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 
 Start a new bugfix. Gather a brief description, create the work unit, and route to investigation.

--- a/skills/start-bugfix/references/name-check.md
+++ b/skills/start-bugfix/references/name-check.md
@@ -72,8 +72,8 @@ Where `{description}` is a concise one-line summary compiled from the bug contex
 **If this work unit was started from an inbox file**, archive it:
 
 ```bash
-mkdir -p .workflows/inbox/.archived/bugs
-mv .workflows/inbox/bugs/{file} .workflows/inbox/.archived/bugs/{file}
+mkdir -p .workflows/.inbox/.archived/bugs
+mv .workflows/.inbox/bugs/{file} .workflows/.inbox/.archived/bugs/{file}
 ```
 
 → Return to caller.

--- a/skills/start-cross-cutting/SKILL.md
+++ b/skills/start-cross-cutting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-cross-cutting
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.js), Bash(ls .workflows/), Bash(mkdir -p .workflows/inbox/.archived/), Bash(mv .workflows/inbox/)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.js), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 
 Start a new cross-cutting concern. Gather a brief description, create the work unit, and route to the first phase.

--- a/skills/start-cross-cutting/references/name-check.md
+++ b/skills/start-cross-cutting/references/name-check.md
@@ -74,8 +74,8 @@ Where `{description}` is a concise one-line summary compiled from the context ga
 **If this work unit was started from an inbox file**, archive it:
 
 ```bash
-mkdir -p .workflows/inbox/.archived/ideas
-mv .workflows/inbox/ideas/{file} .workflows/inbox/.archived/ideas/{file}
+mkdir -p .workflows/.inbox/.archived/ideas
+mv .workflows/.inbox/ideas/{file} .workflows/.inbox/.archived/ideas/{file}
 ```
 
 → Return to caller.

--- a/skills/start-epic/SKILL.md
+++ b/skills/start-epic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-epic
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.js), Bash(ls .workflows/), Bash(mkdir -p .workflows/inbox/.archived/), Bash(mv .workflows/inbox/)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.js), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 
 Start a new epic. Gather a brief description, create the work unit, and route to the first phase.

--- a/skills/start-epic/references/name-check.md
+++ b/skills/start-epic/references/name-check.md
@@ -72,8 +72,8 @@ Where `{description}` is a concise one-line summary compiled from the epic conte
 **If this work unit was started from an inbox file**, archive it:
 
 ```bash
-mkdir -p .workflows/inbox/.archived/ideas
-mv .workflows/inbox/ideas/{file} .workflows/inbox/.archived/ideas/{file}
+mkdir -p .workflows/.inbox/.archived/ideas
+mv .workflows/.inbox/ideas/{file} .workflows/.inbox/.archived/ideas/{file}
 ```
 
 → Return to caller.

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-feature
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.js), Bash(ls .workflows/), Bash(mkdir -p .workflows/inbox/.archived/), Bash(mv .workflows/inbox/)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.js), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 
 Start a new feature. Gather a brief description, create the work unit, and route to the first phase.

--- a/skills/start-feature/references/name-check.md
+++ b/skills/start-feature/references/name-check.md
@@ -72,8 +72,8 @@ Where `{description}` is a concise one-line summary compiled from the feature co
 **If this work unit was started from an inbox file**, archive it:
 
 ```bash
-mkdir -p .workflows/inbox/.archived/ideas
-mv .workflows/inbox/ideas/{file} .workflows/inbox/.archived/ideas/{file}
+mkdir -p .workflows/.inbox/.archived/ideas
+mv .workflows/.inbox/ideas/{file} .workflows/.inbox/.archived/ideas/{file}
 ```
 
 → Return to caller.

--- a/skills/workflow-log-bug/SKILL.md
+++ b/skills/workflow-log-bug/SKILL.md
@@ -19,10 +19,10 @@ If there's already conversation context about something broken, synthesise it st
 When ready, generate a short kebab-case slug from the core symptom (e.g., `stale-cache-on-deploy`, `login-timeout`) and write the file:
 
 ```bash
-mkdir -p .workflows/inbox/bugs
+mkdir -p .workflows/.inbox/bugs
 ```
 
-**File:** `.workflows/inbox/bugs/{YYYY-MM-DD}--{slug}.md` (use today's actual date)
+**File:** `.workflows/.inbox/bugs/{YYYY-MM-DD}--{slug}.md` (use today's actual date)
 - H1 title, prose body, 200-500 words
 - No forced headings — let the content flow naturally
 - Naturally cover symptoms, conditions, and impact as discussed

--- a/skills/workflow-log-idea/SKILL.md
+++ b/skills/workflow-log-idea/SKILL.md
@@ -19,10 +19,10 @@ If there's already conversation context about an idea, synthesise it straight in
 When ready, generate a short kebab-case slug from the core concept (e.g., `smart-retry-logic`, `unified-search`) and write the file:
 
 ```bash
-mkdir -p .workflows/inbox/ideas
+mkdir -p .workflows/.inbox/ideas
 ```
 
-**File:** `.workflows/inbox/ideas/{YYYY-MM-DD}--{slug}.md` (use today's actual date)
+**File:** `.workflows/.inbox/ideas/{YYYY-MM-DD}--{slug}.md` (use today's actual date)
 - H1 title, prose body, 200-500 words
 - No forced headings — let the content flow naturally
 - Mention relevant codebase files, constraints, or goals if they came up

--- a/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh
+++ b/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Migration 033: Rename inbox/ to .inbox/
+#
+# Moves .workflows/inbox/ to .workflows/.inbox/ so the inbox directory
+# follows the dot-prefix convention used by .cache/ and .state/.
+#
+# Idempotent: skips if .workflows/inbox/ does not exist.
+# If both exist, merges inbox/ contents into .inbox/ then removes inbox/.
+#
+
+WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+OLD_INBOX="$WORKFLOWS_DIR/inbox"
+NEW_INBOX="$WORKFLOWS_DIR/.inbox"
+
+[ -d "$OLD_INBOX" ] || return 0
+
+if [ -d "$NEW_INBOX" ]; then
+  # Both exist — merge old into new
+  cp -rn "$OLD_INBOX/"* "$NEW_INBOX/" 2>/dev/null
+  cp -rn "$OLD_INBOX/".* "$NEW_INBOX/" 2>/dev/null
+  rm -rf "$OLD_INBOX"
+  report_update "merged inbox/ into .inbox/"
+else
+  mv "$OLD_INBOX" "$NEW_INBOX"
+  report_update "renamed inbox/ to .inbox/"
+fi

--- a/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh
+++ b/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh
@@ -20,8 +20,8 @@ if [ -d "$NEW_INBOX" ]; then
   cp -rn "$OLD_INBOX/"* "$NEW_INBOX/" 2>/dev/null || true
   cp -rn "$OLD_INBOX/".* "$NEW_INBOX/" 2>/dev/null || true
   rm -rf "$OLD_INBOX"
-  report_update "merged inbox/ into .inbox/"
+  report_update
 else
   mv "$OLD_INBOX" "$NEW_INBOX"
-  report_update "renamed inbox/ to .inbox/"
+  report_update
 fi

--- a/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh
+++ b/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh
@@ -17,8 +17,8 @@ NEW_INBOX="$WORKFLOWS_DIR/.inbox"
 
 if [ -d "$NEW_INBOX" ]; then
   # Both exist — merge old into new
-  cp -rn "$OLD_INBOX/"* "$NEW_INBOX/" 2>/dev/null
-  cp -rn "$OLD_INBOX/".* "$NEW_INBOX/" 2>/dev/null
+  cp -rn "$OLD_INBOX/"* "$NEW_INBOX/" 2>/dev/null || true
+  cp -rn "$OLD_INBOX/".* "$NEW_INBOX/" 2>/dev/null || true
   rm -rf "$OLD_INBOX"
   report_update "merged inbox/ into .inbox/"
 else

--- a/skills/workflow-start/references/start-from-inbox.md
+++ b/skills/workflow-start/references/start-from-inbox.md
@@ -46,7 +46,7 @@ Read the full content of the selected inbox file.
 
 Invoke `/start-bugfix` with the inbox file path as positional argument:
 
-`/start-bugfix .workflows/inbox/bugs/{file}`
+`/start-bugfix .workflows/.inbox/bugs/{file}`
 
 This skill ends. The invoked skill handles archival. Terminal.
 
@@ -68,18 +68,18 @@ What type of work unit?
 
 **If `f`/`feature`:**
 
-Invoke `/start-feature .workflows/inbox/ideas/{file}`.
+Invoke `/start-feature .workflows/.inbox/ideas/{file}`.
 
 This skill ends. The invoked skill handles archival. Terminal.
 
 **If `e`/`epic`:**
 
-Invoke `/start-epic .workflows/inbox/ideas/{file}`.
+Invoke `/start-epic .workflows/.inbox/ideas/{file}`.
 
 This skill ends. The invoked skill handles archival. Terminal.
 
 **If `c`/`cross-cutting`:**
 
-Invoke `/start-cross-cutting .workflows/inbox/ideas/{file}`.
+Invoke `/start-cross-cutting .workflows/.inbox/ideas/{file}`.
 
 This skill ends. The invoked skill handles archival. Terminal.

--- a/skills/workflow-start/scripts/discovery.js
+++ b/skills/workflow-start/scripts/discovery.js
@@ -43,7 +43,7 @@ function parseInboxFile(filename) {
 }
 
 function discoverInbox(cwd) {
-  const inboxDir = path.join(cwd, '.workflows', 'inbox');
+  const inboxDir = path.join(cwd, '.workflows', '.inbox');
   const ideas = [];
   const bugs = [];
 

--- a/tests/scripts/test-discovery-for-start.js
+++ b/tests/scripts/test-discovery-for-start.js
@@ -242,7 +242,7 @@ describe('workflow-start discovery', () => {
   });
 
   it('discovers inbox ideas', () => {
-    createFile(dir, '.workflows/inbox/ideas/2026-03-19--smart-retry.md', '# Smart Retry Logic\n\nSome idea content.');
+    createFile(dir, '.workflows/.inbox/ideas/2026-03-19--smart-retry.md', '# Smart Retry Logic\n\nSome idea content.');
     const r = discover(dir);
     assert.strictEqual(r.inbox.idea_count, 1);
     assert.strictEqual(r.inbox.ideas[0].slug, 'smart-retry');
@@ -253,7 +253,7 @@ describe('workflow-start discovery', () => {
   });
 
   it('discovers inbox bugs', () => {
-    createFile(dir, '.workflows/inbox/bugs/2026-03-18--login-timeout.md', '# Login Timeout\n\nBug details.');
+    createFile(dir, '.workflows/.inbox/bugs/2026-03-18--login-timeout.md', '# Login Timeout\n\nBug details.');
     const r = discover(dir);
     assert.strictEqual(r.inbox.bug_count, 1);
     assert.strictEqual(r.inbox.bugs[0].slug, 'login-timeout');
@@ -263,9 +263,9 @@ describe('workflow-start discovery', () => {
   });
 
   it('discovers mixed inbox ideas and bugs', () => {
-    createFile(dir, '.workflows/inbox/ideas/2026-03-19--idea-one.md', '# Idea One\n\nContent.');
-    createFile(dir, '.workflows/inbox/ideas/2026-03-20--idea-two.md', '# Idea Two\n\nContent.');
-    createFile(dir, '.workflows/inbox/bugs/2026-03-18--bug-one.md', '# Bug One\n\nContent.');
+    createFile(dir, '.workflows/.inbox/ideas/2026-03-19--idea-one.md', '# Idea One\n\nContent.');
+    createFile(dir, '.workflows/.inbox/ideas/2026-03-20--idea-two.md', '# Idea Two\n\nContent.');
+    createFile(dir, '.workflows/.inbox/bugs/2026-03-18--bug-one.md', '# Bug One\n\nContent.');
     const r = discover(dir);
     assert.strictEqual(r.inbox.idea_count, 2);
     assert.strictEqual(r.inbox.bug_count, 1);
@@ -283,15 +283,15 @@ describe('workflow-start discovery', () => {
   });
 
   it('skips inbox files that do not match expected filename format', () => {
-    createFile(dir, '.workflows/inbox/ideas/random-notes.md', '# Random\n\nContent.');
-    createFile(dir, '.workflows/inbox/ideas/2026-03-19--valid-idea.md', '# Valid Idea\n\nContent.');
+    createFile(dir, '.workflows/.inbox/ideas/random-notes.md', '# Random\n\nContent.');
+    createFile(dir, '.workflows/.inbox/ideas/2026-03-19--valid-idea.md', '# Valid Idea\n\nContent.');
     const r = discover(dir);
     assert.strictEqual(r.inbox.idea_count, 1);
     assert.strictEqual(r.inbox.ideas[0].slug, 'valid-idea');
   });
 
   it('falls back to slug when file has no H1 title', () => {
-    createFile(dir, '.workflows/inbox/ideas/2026-03-19--no-title.md', 'Just some content without a heading.');
+    createFile(dir, '.workflows/.inbox/ideas/2026-03-19--no-title.md', 'Just some content without a heading.');
     const r = discover(dir);
     assert.strictEqual(r.inbox.ideas[0].title, 'no-title');
   });
@@ -383,8 +383,8 @@ describe('workflow-start format', () => {
   });
 
   it('emits inbox section with ideas and bugs', () => {
-    createFile(dir, '.workflows/inbox/ideas/2026-03-19--smart-retry.md', '# Smart Retry\n\nContent.');
-    createFile(dir, '.workflows/inbox/bugs/2026-03-18--login-timeout.md', '# Login Timeout\n\nContent.');
+    createFile(dir, '.workflows/.inbox/ideas/2026-03-19--smart-retry.md', '# Smart Retry\n\nContent.');
+    createFile(dir, '.workflows/.inbox/bugs/2026-03-18--login-timeout.md', '# Login Timeout\n\nContent.');
     const out = format(discover(dir));
     assert.ok(out.includes('=== INBOX ==='));
     assert.ok(out.includes('  ideas: 1'));
@@ -399,7 +399,7 @@ describe('workflow-start format', () => {
   });
 
   it('includes has_inbox and inbox_count in state output', () => {
-    createFile(dir, '.workflows/inbox/ideas/2026-03-19--idea.md', '# Idea\n\nContent.');
+    createFile(dir, '.workflows/.inbox/ideas/2026-03-19--idea.md', '# Idea\n\nContent.');
     const out = format(discover(dir));
     assert.ok(out.includes('has_inbox: true'));
     assert.ok(out.includes('inbox_count: 1'));

--- a/tests/scripts/test-migration-033.sh
+++ b/tests/scripts/test-migration-033.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+#
+# Tests for migration 033: rename-inbox-to-dotinbox
+#
+# Run: bash tests/scripts/test-migration-033.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-033-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Test 1: Renames inbox/ to .inbox/ ---
+test_simple_rename() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/inbox/ideas"
+  mkdir -p "$TEST_DIR/.workflows/inbox/bugs"
+  echo "# Smart Retry" > "$TEST_DIR/.workflows/inbox/ideas/2026-03-19--smart-retry.md"
+  echo "# Login Bug" > "$TEST_DIR/.workflows/inbox/bugs/2026-03-18--login-timeout.md"
+
+  source "$MIGRATION"
+
+  assert_eq "old inbox removed" "false" "$([ -d "$TEST_DIR/.workflows/inbox" ] && echo true || echo false)"
+  assert_eq ".inbox exists" "true" "$([ -d "$TEST_DIR/.workflows/.inbox" ] && echo true || echo false)"
+  assert_eq "idea file moved" "true" "$([ -f "$TEST_DIR/.workflows/.inbox/ideas/2026-03-19--smart-retry.md" ] && echo true || echo false)"
+  assert_eq "bug file moved" "true" "$([ -f "$TEST_DIR/.workflows/.inbox/bugs/2026-03-18--login-timeout.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 2: Skips when no inbox/ exists ---
+test_no_inbox() {
+  setup
+
+  source "$MIGRATION"
+
+  assert_eq "no .inbox created" "false" "$([ -d "$TEST_DIR/.workflows/.inbox" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 3: Skips when only .inbox/ exists (already migrated) ---
+test_already_migrated() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.inbox/ideas"
+  echo "# Existing" > "$TEST_DIR/.workflows/.inbox/ideas/2026-03-20--existing.md"
+
+  source "$MIGRATION"
+
+  assert_eq ".inbox still exists" "true" "$([ -d "$TEST_DIR/.workflows/.inbox" ] && echo true || echo false)"
+  assert_eq "existing file intact" "true" "$([ -f "$TEST_DIR/.workflows/.inbox/ideas/2026-03-20--existing.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 4: Merges when both inbox/ and .inbox/ exist ---
+test_merge() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/inbox/ideas"
+  mkdir -p "$TEST_DIR/.workflows/.inbox/ideas"
+  echo "# Old Idea" > "$TEST_DIR/.workflows/inbox/ideas/2026-03-18--old-idea.md"
+  echo "# New Idea" > "$TEST_DIR/.workflows/.inbox/ideas/2026-03-19--new-idea.md"
+
+  source "$MIGRATION"
+
+  assert_eq "old inbox removed" "false" "$([ -d "$TEST_DIR/.workflows/inbox" ] && echo true || echo false)"
+  assert_eq "old idea merged" "true" "$([ -f "$TEST_DIR/.workflows/.inbox/ideas/2026-03-18--old-idea.md" ] && echo true || echo false)"
+  assert_eq "new idea preserved" "true" "$([ -f "$TEST_DIR/.workflows/.inbox/ideas/2026-03-19--new-idea.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 5: Merge does not overwrite existing files in .inbox/ ---
+test_merge_no_overwrite() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/inbox/ideas"
+  mkdir -p "$TEST_DIR/.workflows/.inbox/ideas"
+  echo "# Old Version" > "$TEST_DIR/.workflows/inbox/ideas/2026-03-18--same-name.md"
+  echo "# New Version" > "$TEST_DIR/.workflows/.inbox/ideas/2026-03-18--same-name.md"
+
+  source "$MIGRATION"
+
+  local content
+  content=$(cat "$TEST_DIR/.workflows/.inbox/ideas/2026-03-18--same-name.md")
+  assert_eq "existing file not overwritten" "# New Version" "$content"
+
+  teardown
+}
+
+# --- Test 6: Archived subdirectory is moved too ---
+test_archived_moved() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/inbox/.archived/ideas"
+  echo "# Archived" > "$TEST_DIR/.workflows/inbox/.archived/ideas/2026-03-17--archived-idea.md"
+
+  source "$MIGRATION"
+
+  assert_eq "archived dir moved" "true" "$([ -f "$TEST_DIR/.workflows/.inbox/.archived/ideas/2026-03-17--archived-idea.md" ] && echo true || echo false)"
+  assert_eq "old inbox removed" "false" "$([ -d "$TEST_DIR/.workflows/inbox" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 033 tests..."
+echo ""
+
+test_simple_rename
+test_no_inbox
+test_already_migrated
+test_merge
+test_merge_no_overwrite
+test_archived_moved
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- Renames `.workflows/inbox/` to `.workflows/.inbox/` so it follows the dot-prefix convention used by `.cache/` and `.state/` — preventing it from appearing as a work unit in directory listings
- Updates all 15 files referencing inbox paths: discovery script, capture skills, start skills, name-check references, start-from-inbox routing, tests, CLAUDE.md, and README
- Adds migration 033 to automatically move existing user data from `inbox/` to `.inbox/` (with merge handling if both exist)

## Test plan

- [x] All 42 discovery tests pass
- [x] Grep confirms no stale `.workflows/inbox` references remain (only migration script references old path intentionally)
- [ ] Manual: run `/workflow-log-idea` and verify file lands in `.workflows/.inbox/ideas/`
- [ ] Manual: run `/workflow-start` with inbox items and verify display + routing works


🤖 Generated with [Claude Code](https://claude.com/claude-code)