### PR TITLE
fix: quote zsh-unsafe manifest CLI args in skill files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,8 @@ Migration scripts are point-in-time snapshots. The manifest CLI validates values
 
 The manifest CLI at `skills/workflow-manifest/scripts/manifest.js` is the single source of truth for all workflow state. Uses dot-path syntax: `command <work-unit>[.<phase>[.<topic>]] [field] [value]`. Segment count determines access level (1 = work unit, 2 = phase, 3 = topic). See `skills/workflow-manifest/SKILL.md` for the full API.
 
+**Shell quoting**: Always single-quote values that zsh would interpret — `'[]'`, `'[...]'`, `'{}'`, `'~'`. Bare `[]` is a glob pattern (causes `no matches found` errors) and bare `~` expands to the home directory.
+
 ## Display & Output Conventions (MANDATORY)
 
 These are hard rules, not suggestions. All entry-point skills that present discovery state, menus, or interactive choices MUST follow these conventions exactly. When writing or editing skill files, read existing skills and references as working examples — they are the authoritative demonstration of these rules in practice.

--- a/skills/workflow-implementation-process/references/initialize-tracking.md
+++ b/skills/workflow-implementation-process/references/initialize-tracking.md
@@ -23,10 +23,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.imp
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_gate_mode gated
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} fix_attempts 0
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} analysis_cycle 0
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters []
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills []
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters '[]'
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills '[]'
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_phase 1
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_task ~
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_task '~'
    ```
 
 2. Commit: `impl({work_unit}): start implementation`

--- a/skills/workflow-implementation-process/references/linter-setup.md
+++ b/skills/workflow-implementation-process/references/linter-setup.md
@@ -111,7 +111,7 @@ Use these linters?
 
 Copy to topic level:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters [{phase-level values}]
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters '[{phase-level values}]'
 ```
 
 → Return to caller.
@@ -124,7 +124,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implem
 
 Clear topic-level `linters` before re-discovery:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters []
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters '[]'
 ```
 
 → Proceed to **C. Discovery**.
@@ -170,8 +170,8 @@ Approve these linters?
 
 Store at both levels:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters [...]
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation linters [...]
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters '[...]'
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation linters '[...]'
 ```
 
 → Return to caller.
@@ -186,8 +186,8 @@ Adjust based on user input.
 
 Store empty array at both levels:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters []
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation linters []
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} linters '[]'
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation linters '[]'
 ```
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/project-skills-discovery.md
+++ b/skills/workflow-implementation-process/references/project-skills-discovery.md
@@ -107,7 +107,7 @@ Use these project skills?
 
 Copy to topic level:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills [{phase-level values}]
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills '[{phase-level values}]'
 ```
 
 → Return to caller.
@@ -120,7 +120,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implem
 
 Clear topic-level `project_skills` before re-discovery:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills []
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills '[]'
 ```
 
 → Proceed to **C. Discovery**.
@@ -139,8 +139,8 @@ No project skills found. Proceeding without project-specific conventions.
 
 Store empty array at both levels:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills []
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation project_skills []
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills '[]'
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation project_skills '[]'
 ```
 
 → Return to caller.
@@ -177,8 +177,8 @@ Which project skills should be used?
 
 Store empty array at both levels:
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills []
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation project_skills []
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} project_skills '[]'
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation project_skills '[]'
 ```
 
 → Return to caller.
@@ -189,7 +189,7 @@ Store the selected skill paths via manifest CLI, pushing each path individually 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.implementation.{topic} project_skills "{path1}"
 node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.implementation.{topic} project_skills "{path2}"
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation project_skills ["{path1}","{path2}"]
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation project_skills '["{path1}","{path2}"]'
 ```
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -262,7 +262,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js key-of {work_unit}.pla
 **Update implementation state via manifest CLI**:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_phase {N}
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_task {next_task_id or ~}
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.implementation.{topic} current_task '{next_task_id or ~}'
 node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.implementation.{topic} completed_tasks "{internal_id}"
 ```
 If the current phase has no remaining open/in-progress tasks: `node .claude/skills/workflow-manifest/scripts/manifest.js push {work_unit}.implementation.{topic} completed_phases {N}`

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -51,7 +51,7 @@ The agent returns phases only — goals, ordering rationale, and acceptance crit
 Update the manifest planning position:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} phase 1
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task ~
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task '~'
 ```
 
 Commit: `planning({work_unit}): draft phase structure`

--- a/skills/workflow-planning-process/references/define-tasks.md
+++ b/skills/workflow-planning-process/references/define-tasks.md
@@ -42,7 +42,7 @@ The agent returns a task overview and task table. Write the task table to the pl
 Update the manifest planning position:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} phase {N}
-node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task ~
+node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task '~'
 ```
 
 Commit: `planning({work_unit}): draft Phase {N} task list`

--- a/skills/workflow-planning-process/references/initialize-plan.md
+++ b/skills/workflow-planning-process/references/initialize-plan.md
@@ -69,7 +69,7 @@ Existing plans use **{format}**. Use the same format?
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} author_gate_mode gated
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} finding_gate_mode gated
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} phase 1
-   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task ~
+   node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task '~'
    node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.planning.{topic} task_map '{}'
    ```
 


### PR DESCRIPTION
## Summary

- Single-quote `[]`, `[...]`, and `~` values in all manifest CLI bash blocks across implementation and planning skill references
- Prevents zsh glob expansion (`no matches found: []`) and tilde expansion when Claude executes these commands
- Consistent with existing `'{}'` quoting already used in `initialize-plan.md`

## Test plan

- [ ] Run implementation skill on a fresh work unit in zsh — verify `init-phase` + `set linters '[]'` succeeds without exit code 1
- [ ] Run planning skill — verify `task '~'` sets literal tilde, not home directory path

🤖 Generated with [Claude Code](https://claude.com/claude-code)