### PR TITLE
fix: use exists check before get in phase validation

### DIFF
--- a/skills/workflow-implementation-entry/references/invoke-skill.md
+++ b/skills/workflow-implementation-entry/references/invoke-skill.md
@@ -17,22 +17,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planni
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} external_id
 ```
 
-Check implementation state:
+Check if implementation already exists:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
-```
-
-#### If implementation does not exist (`false`)
-
-Set `status` = `not-started`.
-
-#### If implementation exists (`true`)
-
-Check status:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status
 ```
 
 ```
@@ -42,7 +30,7 @@ Work unit: {work_unit}
 Format: {format}
 External ID: {external_id} (if applicable)
 Specification: .workflows/{work_unit}/specification/{topic}/specification.md (exists: {true|false})
-Implementation: {exists | new} (status: {in-progress | not-started | completed})
+Implementation: {exists:[true|false]}
 
 Dependencies: {All satisfied | List any notes}
 Environment: {Setup required | No special setup required}

--- a/skills/workflow-implementation-entry/references/invoke-skill.md
+++ b/skills/workflow-implementation-entry/references/invoke-skill.md
@@ -25,7 +25,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.imp
 
 #### If implementation does not exist (`false`)
 
-Implementation is new — status is `not-started`.
+Set `status` = `not-started`.
 
 #### If implementation exists (`true`)
 

--- a/skills/workflow-implementation-entry/references/invoke-skill.md
+++ b/skills/workflow-implementation-entry/references/invoke-skill.md
@@ -23,7 +23,13 @@ Check implementation state:
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
 ```
 
-If implementation exists (`true`), check status:
+#### If implementation does not exist (`false`)
+
+Implementation is new — status is `not-started`.
+
+#### If implementation exists (`true`)
+
+Check status:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status

--- a/skills/workflow-implementation-entry/references/invoke-skill.md
+++ b/skills/workflow-implementation-entry/references/invoke-skill.md
@@ -17,7 +17,13 @@ node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planni
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} external_id
 ```
 
-Check implementation status:
+Check implementation state:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
+```
+
+If implementation exists (`true`), check status:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status

--- a/skills/workflow-implementation-entry/references/validate-phase.md
+++ b/skills/workflow-implementation-entry/references/validate-phase.md
@@ -34,7 +34,7 @@ Check status:
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
 ```
 
-#### If plan status is not `completed`
+**If plan status is not `completed`:**
 
 > *Output the next fenced block as a code block:*
 
@@ -46,7 +46,7 @@ The plan for "{topic:(titlecase)}" is not yet completed.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan status is `completed`
+**If plan status is `completed`:**
 
 → Proceed to **B. Implementation Check**.
 

--- a/skills/workflow-implementation-entry/references/validate-phase.md
+++ b/skills/workflow-implementation-entry/references/validate-phase.md
@@ -42,12 +42,27 @@ The plan for "{topic:(titlecase)}" is not yet completed.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan exists (`true`) and status is `completed` and implementation exists and status is `completed`
+Check if implementation exists:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
+```
+
+#### If implementation does not exist
+
+Proceed normally (new entry).
+
+→ Return to caller.
+
+#### If implementation exists
+
+Check status:
+
+```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status
 ```
+
+**If status is `completed`:**
 
 Reset to in-progress:
 
@@ -63,14 +78,8 @@ Reopening implementation: {topic:(titlecase)}
 
 → Return to caller.
 
-#### If plan exists (`true`) and status is `completed` and implementation exists and status is `in-progress`
+**If status is `in-progress`:**
 
 Proceed normally.
-
-→ Return to caller.
-
-#### If plan exists (`true`) and status is `completed` and implementation does not exist
-
-Proceed normally (new entry).
 
 → Return to caller.

--- a/skills/workflow-implementation-entry/references/validate-phase.md
+++ b/skills/workflow-implementation-entry/references/validate-phase.md
@@ -6,6 +6,8 @@
 
 Check if plan exists and is ready.
 
+## A. Plan Check
+
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.planning.{topic}
 ```
@@ -24,13 +26,15 @@ A completed plan is required for implementation.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan exists (`true`) and status is not `completed`
+#### If plan exists (`true`)
 
 Check status:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
 ```
+
+#### If plan status is not `completed`
 
 > *Output the next fenced block as a code block:*
 
@@ -42,7 +46,11 @@ The plan for "{topic:(titlecase)}" is not yet completed.
 
 **STOP.** Do not proceed — terminal condition.
 
-Check if implementation exists:
+#### If plan status is `completed`
+
+→ Proceed to **B. Implementation Check**.
+
+## B. Implementation Check
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -84,15 +84,11 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.rev
 
 → Return to caller.
 
-**If exists (`true`):**
-
-Check status:
+**If exists (`true`) and status is `completed`:**
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.review.{topic} status
 ```
-
-**If status is `completed`:**
 
 Reset to in-progress:
 
@@ -102,6 +98,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review
 
 → Return to caller.
 
-**If status is `in-progress`:**
+**If exists (`true`) and status is `in-progress`:**
 
 → Return to caller.

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -6,6 +6,8 @@
 
 Check if plan and implementation exist and are ready via manifest CLI.
 
+## A. Existence Checks
+
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.planning.{topic}
 ```
@@ -25,14 +27,6 @@ A completed plan and completed implementation are required for review.
 **STOP.** Do not proceed — terminal condition.
 
 #### If plan exists (`true`)
-
-Check plan status:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
-```
-
-Check if implementation exists:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
@@ -54,7 +48,9 @@ A completed implementation is required for review.
 
 #### If implementation exists (`true`)
 
-Check implementation status:
+→ Proceed to **B. Implementation Status**.
+
+## B. Implementation Status
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status
@@ -72,9 +68,11 @@ The implementation for "{topic:(titlecase)}" is not yet completed.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan and implementation are both ready
+#### If implementation status is `completed`
 
-Check if review phase entry exists:
+→ Proceed to **C. Review State**.
+
+## C. Review State
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.review.{topic}

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -28,13 +28,11 @@ A completed plan and completed implementation are required for review.
 
 #### If plan exists (`true`)
 
-→ Proceed to check implementation.
-
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
 ```
 
-#### If implementation doesn't exist (`false`)
+**If implementation doesn't exist (`false`):**
 
 > *Output the next fenced block as a code block:*
 
@@ -48,7 +46,7 @@ A completed implementation is required for review.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If implementation exists (`true`)
+**If implementation exists (`true`):**
 
 → Proceed to **B. Implementation Status**.
 

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -7,10 +7,10 @@
 Check if plan and implementation exist and are ready via manifest CLI.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.planning.{topic}
 ```
 
-#### If plan doesn't exist
+#### If plan doesn't exist (`false`)
 
 > *Output the next fenced block as a code block:*
 
@@ -24,11 +24,21 @@ A completed plan and completed implementation are required for review.
 
 **STOP.** Do not proceed — terminal condition.
 
+#### If plan exists (`true`)
+
+Check plan status:
+
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.planning.{topic} status
 ```
 
-#### If implementation doesn't exist
+Check if implementation exists:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
+```
+
+#### If implementation doesn't exist (`false`)
 
 > *Output the next fenced block as a code block:*
 
@@ -41,6 +51,14 @@ A completed implementation is required for review.
 ```
 
 **STOP.** Do not proceed — terminal condition.
+
+#### If implementation exists (`true`)
+
+Check implementation status:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.implementation.{topic} status
+```
 
 #### If implementation status is not `completed`
 
@@ -66,11 +84,15 @@ node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.rev
 
 → Return to caller.
 
-**If exists and status is `completed`:**
+**If exists (`true`):**
+
+Check status:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.review.{topic} status
 ```
+
+**If status is `completed`:**
 
 Reset to in-progress:
 
@@ -80,6 +102,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review
 
 → Return to caller.
 
-**If exists and status is `in-progress`:**
+**If status is `in-progress`:**
 
 → Return to caller.

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -28,6 +28,8 @@ A completed plan and completed implementation are required for review.
 
 #### If plan exists (`true`)
 
+→ Proceed to check implementation.
+
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.implementation.{topic}
 ```
@@ -78,15 +80,17 @@ The implementation for "{topic:(titlecase)}" is not yet completed.
 node .claude/skills/workflow-manifest/scripts/manifest.js exists {work_unit}.review.{topic}
 ```
 
-**If not exists (`false`):**
+#### If review does not exist
 
 → Return to caller.
 
-**If exists (`true`) and status is `completed`:**
+#### If review exists
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js get {work_unit}.review.{topic} status
 ```
+
+**If status is `completed`:**
 
 Reset to in-progress:
 
@@ -96,6 +100,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit}.review
 
 → Return to caller.
 
-**If exists (`true`) and status is `in-progress`:**
+**If status is `in-progress`:**
 
 → Return to caller.


### PR DESCRIPTION
## Summary

- Manifest CLI's `get` command errors when a topic item doesn't exist — three files were calling `get` on implementation status without first checking `exists`, causing failures when entering implementation for the first time
- Added `exists` gate before `get` in implementation-entry's validate-phase and invoke-skill references
- Applied same fix to review-entry's validate-phase for both planning and implementation checks

## Test plan

- [ ] Start implementation on a work unit that has never had implementation started — should no longer error
- [ ] Resume implementation on an existing in-progress work unit — should proceed normally
- [ ] Re-enter implementation on a completed work unit — should reopen correctly
- [ ] Enter review on a work unit with completed plan and implementation — should validate without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)