### PR TITLE
fix: commit manifest when setting terminal work unit status

### DIFF
--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -31,6 +31,8 @@ Set the work unit status to completed:
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
+Commit: `workflow({work_unit}): complete bugfix pipeline`
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -74,6 +76,8 @@ Set the work unit status to completed:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
+
+Commit: `workflow({work_unit}): complete bugfix pipeline (review skipped)`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -29,6 +29,8 @@ Set the work unit status to completed:
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
+Commit: `workflow({work_unit}): complete cross-cutting pipeline`
+
 > *Output the next fenced block as a code block:*
 
 ```

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -48,6 +48,8 @@ Set the work unit status to completed:
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
+Commit: `workflow({work_unit}): complete epic pipeline`
+
 > *Output the next fenced block as a code block:*
 
 ```

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -32,6 +32,8 @@ Set the work unit status to completed:
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
 
+Commit: `workflow({work_unit}): complete feature pipeline`
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -75,6 +77,8 @@ Set the work unit status to completed:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {work_unit} status completed
 ```
+
+Commit: `workflow({work_unit}): complete feature pipeline (review skipped)`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -139,6 +139,8 @@ Set `implementation_completed` = true.
 node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status completed
 ```
 
+Commit: `workflow({selected.name}): mark as completed`
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -185,6 +187,8 @@ Invoke the `/continue-epic` skill. This is terminal — do not return to the cal
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.js set {selected.name} status cancelled
 ```
+
+Commit: `workflow({selected.name}): mark as cancelled`
 
 > *Output the next fenced block as a code block:*
 


### PR DESCRIPTION
## Summary

- Bridge continuation files (feature, bugfix, epic, cross-cutting) were setting work unit status to `completed` without committing — leaving a dirty manifest after pipeline completion
- Manage menu was setting status to `completed`/`cancelled` without committing
- Added `Commit:` instructions to all 8 affected locations across 5 files

## Test plan

- [ ] Complete a feature pipeline through review → verify manifest is committed at terminal condition
- [ ] Skip review via `d`/`done` at bridge prompt → verify commit
- [ ] Mark a work unit as completed/cancelled via manage menu → verify commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)