### PR TITLE
fix: skip redundant gather-context in entry skills

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -142,6 +142,14 @@ Load **[display-options.md](references/display-options.md)** and follow its inst
 
 ## Step 6: Gather Context
 
+#### If discussion context is already available in conversation
+
+The caller already gathered context (problem description, motivation, constraints). Do not re-ask.
+
+→ Proceed to **Step 7**.
+
+#### Otherwise
+
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 7**.

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -77,6 +77,20 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ## Step 3: Gather Bug Context
 
+#### If bug context is already available in conversation
+
+The caller already gathered bug context (expected/actual behavior, initial context). Do not re-ask.
+
+> *Output the next fenced block as a code block:*
+
+```
+Starting investigation: {work_unit:(titlecase)}
+```
+
+→ Proceed to **Step 4**.
+
+#### Otherwise
+
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -96,6 +96,14 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ## Step 4: Gather Context
 
+#### If research context is already available in conversation
+
+The caller already gathered context (idea description, motivation, constraints). Do not re-ask.
+
+→ Proceed to **Step 5**.
+
+#### Otherwise
+
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.


### PR DESCRIPTION
## Summary

- Entry skills (investigation, research, discussion) re-asked for context even when the caller had already gathered it from an inbox item or its own prompt
- Added conditional bypass: if context is already in conversation, skip the gather-context step and proceed directly to skill invocation
- Applies to `workflow-investigation-entry`, `workflow-research-entry`, and `workflow-discussion-entry`

## Test plan

- [ ] Start a bugfix from an inbox item → verify investigation entry does not re-ask "What bug are you investigating?"
- [ ] Start a bugfix directly via `/start-bugfix` (no inbox) → verify investigation entry still asks for bug context
- [ ] Start a feature from an inbox item → verify discussion entry does not re-ask core problem/constraints
- [ ] Start a feature directly → verify discussion entry still asks gather-context questions
- [ ] Start an epic from an inbox idea → verify research entry skips seed questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)