### PR TITLE
feat: add migration 034 and normalise all migration tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,67 @@ The `/workflow-migrate` skill keeps workflow files in sync with the current syst
 
 Migration scripts are point-in-time snapshots. The manifest CLI validates values against the current schema, which changes over time (e.g., valid statuses). A migration that uses the CLI today may break silently when validation rules change in a later release. Always read and write `manifest.json` directly using `node` (or `jq`) — never via the manifest CLI. This ensures migrations remain stable regardless of future schema changes.
 
+**Bash 3.2 compatibility**: Migration scripts must be compatible with Bash 3.2 (macOS default). Avoid `mapfile`/`readarray` (bash 4+), associative arrays `declare -A` (bash 4+), and `local -n` namerefs (bash 4.3+).
+
+**Testing migrations:**
+
+Every migration must have a corresponding test file at `tests/scripts/test-migration-NNN.sh`. The test harness follows this structure:
+
+```bash
+#!/bin/bash
+#
+# Tests for migration NNN: description
+#
+# Run: bash tests/scripts/test-migration-NNN.sh
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/NNN-description.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-NNN-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+```
+
+Conventions:
+- **Invocation**: Use `source "$MIGRATION"` for migrations that use `return 0`. Use `bash "$MIGRATION"` with `export -f report_update report_skip` for migrations that use `exit 0`.
+- **Isolation**: Each test function calls `setup` at the start and `teardown` at the end. No shared state between tests.
+- **Assertions**: Use only `assert_eq`. Parameter order: `label`, `expected`, `actual`. Convert other checks inline:
+  - File exists: `assert_eq "desc" "true" "$([ -f "$path" ] && echo true || echo false)"`
+  - Content match: `assert_eq "desc" "true" "$(echo "$content" | grep -q 'pattern' && echo true || echo false)"`
+  - Fixed-string match: `assert_eq "desc" "true" "$(echo "$content" | grep -qF 'text' && echo true || echo false)"`
+- **grep with leading dashes**: Always use `--` before patterns starting with `-` (e.g., `grep -qF -- '- item'`).
+- **Test naming**: Functions prefixed `test_`, comments `# --- Test N: Description ---`.
+- **Summary**: `echo "Results: $PASS passed, $FAIL failed"` then `[ "$FAIL" -eq 0 ] || exit 1`.
+- **Coverage**: Every migration test must cover at minimum: happy path, skip/no-op conditions, idempotency (run twice, same result), and content preservation where applicable.
+
 ## Manifest CLI
 
 The manifest CLI at `skills/workflow-manifest/scripts/manifest.cjs` is the single source of truth for all workflow state. Uses dot-path syntax: `command <work-unit>[.<phase>[.<topic>]] [field] [value]`. Segment count determines access level (1 = work unit, 2 = phase, 3 = topic). See `skills/workflow-manifest/SKILL.md` for the full API.

--- a/skills/workflow-migrate/scripts/migrations/034-show-clear-context-on-plan-accept.sh
+++ b/skills/workflow-migrate/scripts/migrations/034-show-clear-context-on-plan-accept.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Migration 034: Enable showClearContextOnPlanAccept
+#
+# Claude Code 2.1.81 hides the "clear context and approve" plan-mode button
+# by default. The workflows rely on this button to clear context between
+# phases via the bridge skill. This migration ensures the setting is present
+# in the consumer project's .claude/settings.json.
+#
+# Idempotent: skips if the setting already exists with value true.
+#
+
+SETTINGS_DIR="${PROJECT_DIR:-.}/.claude"
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+
+if [ -f "$SETTINGS_FILE" ] && node -e "
+  const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+  process.exit(s.showClearContextOnPlanAccept === true ? 0 : 1);
+" "$SETTINGS_FILE" 2>/dev/null; then
+  return 0
+fi
+
+mkdir -p "$SETTINGS_DIR"
+
+if [ -f "$SETTINGS_FILE" ]; then
+  node -e "
+    const fs = require('fs');
+    const settings = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+    settings.showClearContextOnPlanAccept = true;
+    fs.writeFileSync(process.argv[1], JSON.stringify(settings, null, 2) + '\n');
+  " "$SETTINGS_FILE"
+else
+  printf '{\n  "showClearContextOnPlanAccept": true\n}\n' > "$SETTINGS_FILE"
+fi
+
+report_update

--- a/tests/scripts/test-migration-001.sh
+++ b/tests/scripts/test-migration-001.sh
@@ -1,150 +1,52 @@
 #!/bin/bash
-#
-# Tests migration 001-discussion-frontmatter.sh
-# Validates conversion from legacy markdown header format to YAML frontmatter.
-#
+# Tests for migration 001: discussion-frontmatter
+# Run: bash tests/scripts/test-migration-001.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/001-discussion-frontmatter.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/001-discussion-frontmatter.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-001-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/discussion"
+  DISCUSSION_DIR="$TEST_DIR/docs/workflow/discussion"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    DISCUSSION_DIR="$TEST_DIR/docs/workflow/discussion"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
 run_migration() {
-    cd "$TEST_DIR"
-    # Source the migration script (it uses DISCUSSION_DIR variable)
-    DISCUSSION_DIR="$TEST_DIR/docs/workflow/discussion"
-    source "$MIGRATION_SCRIPT"
+  cd "$TEST_DIR"
+  DISCUSSION_DIR="$TEST_DIR/docs/workflow/discussion"
+  source "$MIGRATION"
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: Legacy format with Exploring status ---
+test_legacy_exploring() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-assert_file_starts_with() {
-    local file="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    local first_line=$(head -1 "$file")
-    if [ "$first_line" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected first line: $expected"
-        echo -e "    Actual first line:   $first_line"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Legacy format with Exploring status${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/api-design.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/api-design.md" << 'EOF'
 # Discussion: API Design
 
 **Date**: 2024-01-15
@@ -155,24 +57,24 @@ cat > "$DISCUSSION_DIR/api-design.md" << 'EOF'
 We need to design the API.
 EOF
 
-output=$(run_migration 2>&1)
-content=$(cat "$DISCUSSION_DIR/api-design.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/api-design.md")
 
-assert_file_starts_with "$DISCUSSION_DIR/api-design.md" "---" "File starts with frontmatter delimiter"
-assert_contains "$content" "^topic: api-design$" "Topic extracted from filename"
-assert_contains "$content" "^status: in-progress$" "Exploring status mapped to in-progress"
-assert_contains "$content" "^date: 2024-01-15$" "Date extracted"
-assert_contains "$content" "^# Discussion: API Design$" "H1 heading preserved"
-assert_contains "$content" "^## Context$" "Content sections preserved"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "File starts with frontmatter delimiter" "---" "$(head -1 "$DISCUSSION_DIR/api-design.md")"
+  assert_eq "Topic extracted from filename" "true" "$(echo "$content" | grep -q '^topic: api-design$' && echo true || echo false)"
+  assert_eq "Exploring status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
+  assert_eq "Date extracted" "true" "$(echo "$content" | grep -q '^date: 2024-01-15$' && echo true || echo false)"
+  assert_eq "H1 heading preserved" "true" "$(echo "$content" | grep -q '^# Discussion: API Design$' && echo true || echo false)"
+  assert_eq "Content sections preserved" "true" "$(echo "$content" | grep -q '^## Context$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Legacy format with Deciding status ---
+test_legacy_deciding() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Deciding status${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/auth-flow.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/auth-flow.md" << 'EOF'
 # Discussion: Auth Flow
 
 **Date**: 2024-02-20
@@ -183,18 +85,19 @@ cat > "$DISCUSSION_DIR/auth-flow.md" << 'EOF'
 Option A or B.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/auth-flow.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/auth-flow.md")
 
-assert_contains "$content" "^status: in-progress$" "Deciding status mapped to in-progress"
+  assert_eq "Deciding status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Legacy format with Concluded status ---
+test_legacy_concluded() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Concluded status${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/caching.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/caching.md" << 'EOF'
 # Discussion: Caching Strategy
 
 **Date**: 2024-03-10
@@ -205,18 +108,19 @@ cat > "$DISCUSSION_DIR/caching.md" << 'EOF'
 We chose Redis.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/caching.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/caching.md")
 
-assert_contains "$content" "^status: concluded$" "Concluded status mapped to concluded"
+  assert_eq "Concluded status mapped to concluded" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Legacy format with Complete status ---
+test_legacy_complete() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Complete status${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/database.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/database.md" << 'EOF'
 # Discussion: Database Choice
 
 **Date**: 2024-04-01
@@ -227,18 +131,19 @@ cat > "$DISCUSSION_DIR/database.md" << 'EOF'
 PostgreSQL selected.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/database.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/database.md")
 
-assert_contains "$content" "^status: concluded$" "Complete status mapped to concluded"
+  assert_eq "Complete status mapped to concluded" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Legacy format with emoji status ---
+test_legacy_emoji_status() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with emoji status (✅ Complete)${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/logging.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/logging.md" << 'EOF'
 # Discussion: Logging
 
 **Date**: 2024-05-15
@@ -249,18 +154,19 @@ cat > "$DISCUSSION_DIR/logging.md" << 'EOF'
 Structured logging with JSON.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/logging.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/logging.md")
 
-assert_contains "$content" "^status: concluded$" "✅ Complete status mapped to concluded"
+  assert_eq "Emoji Complete status mapped to concluded" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: Legacy format with alternate colon placement ---
+test_alternate_colon() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with alternate colon placement (Status:)${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/testing.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/testing.md" << 'EOF'
 # Discussion: Testing Strategy
 
 **Date**: 2024-06-01
@@ -271,18 +177,19 @@ cat > "$DISCUSSION_DIR/testing.md" << 'EOF'
 TDD approach.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/testing.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/testing.md")
 
-assert_contains "$content" "^status: concluded$" "Alternate colon format handled"
+  assert_eq "Alternate colon format handled" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Legacy format with Started field instead of Date ---
+test_started_field() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Started field instead of Date${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/deployment.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/deployment.md" << 'EOF'
 # Discussion: Deployment
 
 **Started:** 2024-07-01
@@ -293,18 +200,19 @@ cat > "$DISCUSSION_DIR/deployment.md" << 'EOF'
 Deployment options.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/deployment.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/deployment.md")
 
-assert_contains "$content" "^date: 2024-07-01$" "Date extracted from Started field"
+  assert_eq "Date extracted from Started field" "true" "$(echo "$content" | grep -q '^date: 2024-07-01$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Legacy format without date field ---
+test_no_date() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format without date field${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/no-date.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/no-date.md" << 'EOF'
 # Discussion: No Date
 
 **Status**: Exploring
@@ -314,19 +222,20 @@ cat > "$DISCUSSION_DIR/no-date.md" << 'EOF'
 Missing date.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/no-date.md")
-today=$(date +%Y-%m-%d)
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/no-date.md")
+  today=$(date +%Y-%m-%d)
 
-assert_contains "$content" "^date: $today$" "Date defaults to today when not found"
+  assert_eq "Date defaults to today when not found" "true" "$(echo "$content" | grep -q "^date: $today$" && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: File already has frontmatter (should skip) ---
+test_already_has_frontmatter() {
+  setup
 
-echo -e "${YELLOW}Test: File already has frontmatter (should skip)${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/existing.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/existing.md" << 'EOF'
 ---
 topic: existing
 status: concluded
@@ -340,20 +249,20 @@ date: 2024-01-01
 Already migrated content.
 EOF
 
-original_content=$(cat "$DISCUSSION_DIR/existing.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$DISCUSSION_DIR/existing.md")
+  original_content=$(cat "$DISCUSSION_DIR/existing.md")
+  run_migration
+  new_content=$(cat "$DISCUSSION_DIR/existing.md")
 
-assert_equals "$new_content" "$original_content" "File with frontmatter unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File with frontmatter unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: File without legacy format (should skip) ---
+test_no_legacy_format() {
+  setup
 
-echo -e "${YELLOW}Test: File without legacy format (should skip)${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/weird.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/weird.md" << 'EOF'
 # Some Random Document
 
 This has no status or date fields.
@@ -363,20 +272,20 @@ This has no status or date fields.
 Content here.
 EOF
 
-original_content=$(cat "$DISCUSSION_DIR/weird.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$DISCUSSION_DIR/weird.md")
+  original_content=$(cat "$DISCUSSION_DIR/weird.md")
+  run_migration
+  new_content=$(cat "$DISCUSSION_DIR/weird.md")
 
-assert_equals "$new_content" "$original_content" "File without legacy format unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File without legacy format unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 11: Idempotency (running migration twice) ---
+test_idempotency() {
+  setup
 
-echo -e "${YELLOW}Test: Idempotency (running migration twice)${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/idempotent.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/idempotent.md" << 'EOF'
 # Discussion: Idempotent Test
 
 **Date**: 2024-08-01
@@ -387,23 +296,22 @@ cat > "$DISCUSSION_DIR/idempotent.md" << 'EOF'
 Content.
 EOF
 
-run_migration
-first_run=$(cat "$DISCUSSION_DIR/idempotent.md")
+  run_migration
+  first_run=$(cat "$DISCUSSION_DIR/idempotent.md")
 
-# Run again
-output=$(run_migration 2>&1)
-second_run=$(cat "$DISCUSSION_DIR/idempotent.md")
+  run_migration
+  second_run=$(cat "$DISCUSSION_DIR/idempotent.md")
 
-assert_equals "$second_run" "$first_run" "Second migration run produces same result"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "Second migration run produces same result" "$first_run" "$second_run"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: Content preservation (multiple sections) ---
+test_content_preservation() {
+  setup
 
-echo -e "${YELLOW}Test: Content preservation (multiple sections)${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/full-discussion.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/full-discussion.md" << 'EOF'
 # Discussion: Full Discussion
 
 **Date**: 2024-09-01
@@ -427,22 +335,23 @@ We chose Option A.
 Some impacts.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/full-discussion.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/full-discussion.md")
 
-assert_contains "$content" "^## Context$" "Context section preserved"
-assert_contains "$content" "^## Options$" "Options section preserved"
-assert_contains "$content" "^## Decision$" "Decision section preserved"
-assert_contains "$content" "^## Consequences$" "Consequences section preserved"
-assert_contains "$content" "Option A" "List content preserved"
+  assert_eq "Context section preserved" "true" "$(echo "$content" | grep -q '^## Context$' && echo true || echo false)"
+  assert_eq "Options section preserved" "true" "$(echo "$content" | grep -q '^## Options$' && echo true || echo false)"
+  assert_eq "Decision section preserved" "true" "$(echo "$content" | grep -q '^## Decision$' && echo true || echo false)"
+  assert_eq "Consequences section preserved" "true" "$(echo "$content" | grep -q '^## Consequences$' && echo true || echo false)"
+  assert_eq "List content preserved" "true" "$(echo "$content" | grep -qF 'Option A' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 13: Kebab-case topic from filename ---
+test_kebab_case_topic() {
+  setup
 
-echo -e "${YELLOW}Test: Kebab-case topic from filename${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/user-authentication-flow.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/user-authentication-flow.md" << 'EOF'
 # Discussion: User Authentication Flow
 
 **Date**: 2024-10-01
@@ -453,18 +362,19 @@ cat > "$DISCUSSION_DIR/user-authentication-flow.md" << 'EOF'
 Content.
 EOF
 
-run_migration
-content=$(cat "$DISCUSSION_DIR/user-authentication-flow.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/user-authentication-flow.md")
 
-assert_contains "$content" "^topic: user-authentication-flow$" "Topic uses kebab-case from filename"
+  assert_eq "Topic uses kebab-case from filename" "true" "$(echo "$content" | grep -q '^topic: user-authentication-flow$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 14: Body with multiple --- horizontal rules preserved ---
+test_body_horizontal_rules() {
+  setup
 
-echo -e "${YELLOW}Test: Body with multiple --- horizontal rules preserved${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/multi-hr.md" << 'TESTEOF'
+  cat > "$DISCUSSION_DIR/multi-hr.md" << 'TESTEOF'
 # Discussion: Multi HR
 
 **Date**: 2024-11-01
@@ -493,22 +403,23 @@ More questions here.
 Wrap up.
 TESTEOF
 
-body_before=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/multi-hr.md")
-run_migration
-content=$(cat "$DISCUSSION_DIR/multi-hr.md")
-body_after=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/multi-hr.md")
+  body_before=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/multi-hr.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/multi-hr.md")
+  body_after=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/multi-hr.md")
 
-assert_contains "$content" "^status: in-progress$" "Frontmatter status is correct"
-assert_contains "$content" "^topic: multi-hr$" "Frontmatter topic is correct"
-assert_equals "$body_after" "$body_before" "All body --- horizontal rules preserved exactly"
+  assert_eq "Frontmatter status is correct" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
+  assert_eq "Frontmatter topic is correct" "true" "$(echo "$content" | grep -q '^topic: multi-hr$' && echo true || echo false)"
+  assert_eq "All body --- horizontal rules preserved exactly" "$body_before" "$body_after"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 15: Body with code blocks, tables, and special characters ---
+test_special_chars() {
+  setup
 
-echo -e "${YELLOW}Test: Body with code blocks, tables, and special characters${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/special-chars.md" << 'TESTEOF'
+  cat > "$DISCUSSION_DIR/special-chars.md" << 'TESTEOF'
 # Discussion: Special Chars
 
 **Date**: 2024-11-02
@@ -538,21 +449,22 @@ Use `grep -E "pattern|other"` to search.
 Also check `$HOME/.config` for settings.
 TESTEOF
 
-body_before=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/special-chars.md")
-run_migration
-content=$(cat "$DISCUSSION_DIR/special-chars.md")
-body_after=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/special-chars.md")
+  body_before=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/special-chars.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/special-chars.md")
+  body_after=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/special-chars.md")
 
-assert_contains "$content" "^status: in-progress$" "Frontmatter status correct"
-assert_equals "$body_after" "$body_before" "Body with code blocks, tables, and special chars preserved exactly"
+  assert_eq "Frontmatter status correct" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
+  assert_eq "Body with code blocks, tables, and special chars preserved exactly" "$body_before" "$body_after"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 16: Exact body content preservation after migration ---
+test_exact_body_preservation() {
+  setup
 
-echo -e "${YELLOW}Test: Exact body content preservation after migration${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/exact-body.md" << 'TESTEOF'
+  cat > "$DISCUSSION_DIR/exact-body.md" << 'TESTEOF'
 # Discussion: Exact Body
 
 **Date**: 2024-11-03
@@ -597,28 +509,39 @@ VAR2="double \"escaped\" quotes"
 Final paragraph with apostrophes: don't, won't, can't.
 TESTEOF
 
-body_before=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/exact-body.md")
-run_migration
-content=$(cat "$DISCUSSION_DIR/exact-body.md")
-body_after=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/exact-body.md")
+  body_before=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/exact-body.md")
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/exact-body.md")
+  body_after=$(sed -n '/^## /,$p' "$DISCUSSION_DIR/exact-body.md")
 
-assert_contains "$content" "^status: concluded$" "Frontmatter status correct"
-assert_contains "$content" "^topic: exact-body$" "Frontmatter topic correct"
-assert_equals "$body_after" "$body_before" "Complex body content preserved exactly after migration"
+  assert_eq "Frontmatter status correct" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
+  assert_eq "Frontmatter topic correct" "true" "$(echo "$content" | grep -q '^topic: exact-body$' && echo true || echo false)"
+  assert_eq "Complex body content preserved exactly after migration" "$body_before" "$body_after"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 001 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_legacy_exploring
+test_legacy_deciding
+test_legacy_concluded
+test_legacy_complete
+test_legacy_emoji_status
+test_alternate_colon
+test_started_field
+test_no_date
+test_already_has_frontmatter
+test_no_legacy_format
+test_idempotency
+test_content_preservation
+test_kebab_case_topic
+test_body_horizontal_rules
+test_special_chars
+test_exact_body_preservation
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-002.sh
+++ b/tests/scripts/test-migration-002.sh
@@ -1,157 +1,52 @@
 #!/bin/bash
-#
-# Tests migration 002-specification-frontmatter.sh
-# Validates conversion from legacy markdown header format to YAML frontmatter.
-#
+# Tests for migration 002: specification-frontmatter
+# Run: bash tests/scripts/test-migration-002.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/002-specification-frontmatter.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/002-specification-frontmatter.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-002-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/specification"
+  SPEC_DIR="$TEST_DIR/docs/workflow/specification"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/specification"
-    SPEC_DIR="$TEST_DIR/docs/workflow/specification"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
 run_migration() {
-    cd "$TEST_DIR"
-    # Source the migration script (it uses SPEC_DIR variable)
-    SPEC_DIR="$TEST_DIR/docs/workflow/specification"
-    source "$MIGRATION_SCRIPT"
+  cd "$TEST_DIR"
+  SPEC_DIR="$TEST_DIR/docs/workflow/specification"
+  source "$MIGRATION"
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: Legacy format with Building specification status ---
+test_building_specification() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-assert_file_starts_with() {
-    local file="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    local first_line=$(head -1 "$file")
-    if [ "$first_line" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected first line: $expected"
-        echo -e "    Actual first line:   $first_line"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-get_frontmatter_value() {
-    local file="$1"
-    local key="$2"
-    # Extract value from frontmatter (between first --- and second ---)
-    sed -n '/^---$/,/^---$/p' "$file" | grep "^$key:" | sed "s/^$key:[[:space:]]*//"
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Legacy format with Building specification status${NC}"
-setup_fixture
-cat > "$SPEC_DIR/user-auth.md" << 'EOF'
+  cat > "$SPEC_DIR/user-auth.md" << 'EOF'
 # Specification: User Authentication
 
 **Status**: Building specification
@@ -163,25 +58,25 @@ cat > "$SPEC_DIR/user-auth.md" << 'EOF'
 This is the spec content.
 EOF
 
-output=$(run_migration 2>&1)
-content=$(cat "$SPEC_DIR/user-auth.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/user-auth.md")
 
-assert_file_starts_with "$SPEC_DIR/user-auth.md" "---" "File starts with frontmatter delimiter"
-assert_contains "$content" "^topic: user-auth$" "Topic extracted from filename"
-assert_contains "$content" "^status: in-progress$" "Status mapped to in-progress"
-assert_contains "$content" "^type: feature$" "Type preserved as feature"
-assert_contains "$content" "^date: 2024-01-15$" "Date extracted from Last Updated"
-assert_contains "$content" "^# Specification: User Authentication$" "H1 heading preserved"
-assert_contains "$content" "^## Overview$" "Content sections preserved"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "File starts with frontmatter delimiter" "---" "$(head -1 "$SPEC_DIR/user-auth.md")"
+  assert_eq "Topic extracted from filename" "true" "$(echo "$content" | grep -q '^topic: user-auth$' && echo true || echo false)"
+  assert_eq "Status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
+  assert_eq "Type preserved as feature" "true" "$(echo "$content" | grep -q '^type: feature$' && echo true || echo false)"
+  assert_eq "Date extracted from Last Updated" "true" "$(echo "$content" | grep -q '^date: 2024-01-15$' && echo true || echo false)"
+  assert_eq "H1 heading preserved" "true" "$(echo "$content" | grep -q '^# Specification: User Authentication$' && echo true || echo false)"
+  assert_eq "Content sections preserved" "true" "$(echo "$content" | grep -q '^## Overview$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Legacy format with Complete status ---
+test_complete_status() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Complete status${NC}"
-setup_fixture
-cat > "$SPEC_DIR/billing-system.md" << 'EOF'
+  cat > "$SPEC_DIR/billing-system.md" << 'EOF'
 # Specification: Billing System
 
 **Status**: Complete
@@ -193,19 +88,20 @@ cat > "$SPEC_DIR/billing-system.md" << 'EOF'
 Billing content here.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/billing-system.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/billing-system.md")
 
-assert_contains "$content" "^status: concluded$" "Complete status mapped to concluded"
-assert_contains "$content" "^type: cross-cutting$" "Type preserved as cross-cutting"
+  assert_eq "Complete status mapped to concluded" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
+  assert_eq "Type preserved as cross-cutting" "true" "$(echo "$content" | grep -q '^type: cross-cutting$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Legacy format with Completed status (variant) ---
+test_completed_status() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Completed status (variant)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/api-design.md" << 'EOF'
+  cat > "$SPEC_DIR/api-design.md" << 'EOF'
 # Specification: API Design
 
 **Status**: Completed
@@ -217,19 +113,20 @@ cat > "$SPEC_DIR/api-design.md" << 'EOF'
 API content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/api-design.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/api-design.md")
 
-assert_contains "$content" "^status: concluded$" "Completed status mapped to concluded"
-assert_contains "$content" "^date: 2024-03-10$" "Date extracted from Date field"
+  assert_eq "Completed status mapped to concluded" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
+  assert_eq "Date extracted from Date field" "true" "$(echo "$content" | grep -q '^date: 2024-03-10$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Legacy format with Building status (short form) ---
+test_building_short() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Building status (short form)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/caching.md" << 'EOF'
+  cat > "$SPEC_DIR/caching.md" << 'EOF'
 # Specification: Caching Strategy
 
 **Status**: Building
@@ -241,18 +138,19 @@ cat > "$SPEC_DIR/caching.md" << 'EOF'
 Caching content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/caching.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/caching.md")
 
-assert_contains "$content" "^status: in-progress$" "Building status mapped to in-progress"
+  assert_eq "Building status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Legacy format without Type field ---
+test_no_type_field() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format without Type field${NC}"
-setup_fixture
-cat > "$SPEC_DIR/notifications.md" << 'EOF'
+  cat > "$SPEC_DIR/notifications.md" << 'EOF'
 # Specification: Notifications
 
 **Status**: Building specification
@@ -263,18 +161,19 @@ cat > "$SPEC_DIR/notifications.md" << 'EOF'
 Notification content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/notifications.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/notifications.md")
 
-assert_contains "$content" "^type: *$" "Type left empty when not found (requires manual review)"
+  assert_eq "Type left empty when not found" "true" "$(echo "$content" | grep -q '^type: *$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: Legacy format without date field ---
+test_no_date_field() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format without date field${NC}"
-setup_fixture
-cat > "$SPEC_DIR/logging.md" << 'EOF'
+  cat > "$SPEC_DIR/logging.md" << 'EOF'
 # Specification: Logging
 
 **Status**: Building specification
@@ -285,19 +184,20 @@ cat > "$SPEC_DIR/logging.md" << 'EOF'
 Logging content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/logging.md")
-today=$(date +%Y-%m-%d)
+  run_migration
+  content=$(cat "$SPEC_DIR/logging.md")
+  today=$(date +%Y-%m-%d)
 
-assert_contains "$content" "^date: $today$" "Date defaults to today when not found"
+  assert_eq "Date defaults to today when not found" "true" "$(echo "$content" | grep -q "^date: $today$" && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: File already has frontmatter (should skip) ---
+test_already_has_frontmatter() {
+  setup
 
-echo -e "${YELLOW}Test: File already has frontmatter (should skip)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/existing.md" << 'EOF'
+  cat > "$SPEC_DIR/existing.md" << 'EOF'
 ---
 topic: existing
 status: concluded
@@ -312,20 +212,20 @@ date: 2024-01-01
 Already migrated content.
 EOF
 
-original_content=$(cat "$SPEC_DIR/existing.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$SPEC_DIR/existing.md")
+  original_content=$(cat "$SPEC_DIR/existing.md")
+  run_migration
+  new_content=$(cat "$SPEC_DIR/existing.md")
 
-assert_equals "$new_content" "$original_content" "File with frontmatter unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File with frontmatter unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: File without legacy format (should skip) ---
+test_no_legacy_format() {
+  setup
 
-echo -e "${YELLOW}Test: File without legacy format (should skip)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/weird.md" << 'EOF'
+  cat > "$SPEC_DIR/weird.md" << 'EOF'
 # Some Random Document
 
 This has no status or type fields.
@@ -335,20 +235,20 @@ This has no status or type fields.
 Content here.
 EOF
 
-original_content=$(cat "$SPEC_DIR/weird.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$SPEC_DIR/weird.md")
+  original_content=$(cat "$SPEC_DIR/weird.md")
+  run_migration
+  new_content=$(cat "$SPEC_DIR/weird.md")
 
-assert_equals "$new_content" "$original_content" "File without legacy format unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File without legacy format unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Idempotency (running migration twice) ---
+test_idempotency() {
+  setup
 
-echo -e "${YELLOW}Test: Idempotency (running migration twice)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/idempotent.md" << 'EOF'
+  cat > "$SPEC_DIR/idempotent.md" << 'EOF'
 # Specification: Idempotent Test
 
 **Status**: Building specification
@@ -360,23 +260,22 @@ cat > "$SPEC_DIR/idempotent.md" << 'EOF'
 Content.
 EOF
 
-run_migration
-first_run=$(cat "$SPEC_DIR/idempotent.md")
+  run_migration
+  first_run=$(cat "$SPEC_DIR/idempotent.md")
 
-# Run again
-output=$(run_migration 2>&1)
-second_run=$(cat "$SPEC_DIR/idempotent.md")
+  run_migration
+  second_run=$(cat "$SPEC_DIR/idempotent.md")
 
-assert_equals "$second_run" "$first_run" "Second migration run produces same result"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "Second migration run produces same result" "$first_run" "$second_run"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: Status variation - Draft ---
+test_draft_status() {
+  setup
 
-echo -e "${YELLOW}Test: Status variation - Draft${NC}"
-setup_fixture
-cat > "$SPEC_DIR/draft-spec.md" << 'EOF'
+  cat > "$SPEC_DIR/draft-spec.md" << 'EOF'
 # Specification: Draft Spec
 
 **Status**: Draft
@@ -388,18 +287,19 @@ cat > "$SPEC_DIR/draft-spec.md" << 'EOF'
 Draft content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/draft-spec.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/draft-spec.md")
 
-assert_contains "$content" "^status: in-progress$" "Draft status mapped to in-progress"
+  assert_eq "Draft status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 11: Status variation - Done ---
+test_done_status() {
+  setup
 
-echo -e "${YELLOW}Test: Status variation - Done${NC}"
-setup_fixture
-cat > "$SPEC_DIR/done-spec.md" << 'EOF'
+  cat > "$SPEC_DIR/done-spec.md" << 'EOF'
 # Specification: Done Spec
 
 **Status**: Done
@@ -411,18 +311,19 @@ cat > "$SPEC_DIR/done-spec.md" << 'EOF'
 Done content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/done-spec.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/done-spec.md")
 
-assert_contains "$content" "^status: concluded$" "Done status mapped to concluded"
+  assert_eq "Done status mapped to concluded" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: Content preservation (multiple sections) ---
+test_content_preservation() {
+  setup
 
-echo -e "${YELLOW}Test: Content preservation (multiple sections)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/full-spec.md" << 'EOF'
+  cat > "$SPEC_DIR/full-spec.md" << 'EOF'
 # Specification: Full Spec
 
 **Status**: Complete
@@ -447,22 +348,23 @@ Architecture details.
 None.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/full-spec.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/full-spec.md")
 
-assert_contains "$content" "^## Overview$" "Overview section preserved"
-assert_contains "$content" "^## Architecture$" "Architecture section preserved"
-assert_contains "$content" "^## Edge Cases$" "Edge Cases section preserved"
-assert_contains "$content" "- Case 1" "List content preserved"
-assert_contains "$content" "^## Dependencies$" "Dependencies section preserved"
+  assert_eq "Overview section preserved" "true" "$(echo "$content" | grep -q '^## Overview$' && echo true || echo false)"
+  assert_eq "Architecture section preserved" "true" "$(echo "$content" | grep -q '^## Architecture$' && echo true || echo false)"
+  assert_eq "Edge Cases section preserved" "true" "$(echo "$content" | grep -q '^## Edge Cases$' && echo true || echo false)"
+  assert_eq "List content preserved" "true" "$(echo "$content" | grep -qF -- '- Case 1' && echo true || echo false)"
+  assert_eq "Dependencies section preserved" "true" "$(echo "$content" | grep -q '^## Dependencies$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 13: Kebab-case topic from filename ---
+test_kebab_case_topic() {
+  setup
 
-echo -e "${YELLOW}Test: Kebab-case topic from filename${NC}"
-setup_fixture
-cat > "$SPEC_DIR/user-profile-settings.md" << 'EOF'
+  cat > "$SPEC_DIR/user-profile-settings.md" << 'EOF'
 # Specification: User Profile Settings
 
 **Status**: Building specification
@@ -474,18 +376,19 @@ cat > "$SPEC_DIR/user-profile-settings.md" << 'EOF'
 Content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/user-profile-settings.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/user-profile-settings.md")
 
-assert_contains "$content" "^topic: user-profile-settings$" "Topic uses kebab-case from filename"
+  assert_eq "Topic uses kebab-case from filename" "true" "$(echo "$content" | grep -q '^topic: user-profile-settings$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 14: Sources field with single source ---
+test_single_source() {
+  setup
 
-echo -e "${YELLOW}Test: Sources field with single source${NC}"
-setup_fixture
-cat > "$SPEC_DIR/migration-spec.md" << 'EOF'
+  cat > "$SPEC_DIR/migration-spec.md" << 'EOF'
 # Specification: Migration
 
 **Status**: Complete
@@ -502,19 +405,20 @@ cat > "$SPEC_DIR/migration-spec.md" << 'EOF'
 The migration command imports task data.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/migration-spec.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/migration-spec.md")
 
-assert_contains "$content" "^sources:$" "Sources field present in frontmatter"
-assert_contains "$content" "^  - migration-subcommand$" "Single source preserved as YAML list item"
+  assert_eq "Sources field present in frontmatter" "true" "$(echo "$content" | grep -q '^sources:$' && echo true || echo false)"
+  assert_eq "Single source preserved as YAML list item" "true" "$(echo "$content" | grep -q '^  - migration-subcommand$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 15: Sources field with multiple sources ---
+test_multiple_sources() {
+  setup
 
-echo -e "${YELLOW}Test: Sources field with multiple sources (tick-core pattern)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/tick-core.md" << 'EOF'
+  cat > "$SPEC_DIR/tick-core.md" << 'EOF'
 # Specification: Tick Core
 
 **Status**: Complete
@@ -531,21 +435,22 @@ cat > "$SPEC_DIR/tick-core.md" << 'EOF'
 Tick is a minimal task tracker.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/tick-core.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/tick-core.md")
 
-assert_contains "$content" "^sources:$" "Sources field present in frontmatter"
-assert_contains "$content" "^  - project-fundamentals$" "First source preserved"
-assert_contains "$content" "^  - data-schema-design$" "Second source preserved"
-assert_contains "$content" "^  - tui$" "Last source preserved"
+  assert_eq "Sources field present in frontmatter" "true" "$(echo "$content" | grep -q '^sources:$' && echo true || echo false)"
+  assert_eq "First source preserved" "true" "$(echo "$content" | grep -q '^  - project-fundamentals$' && echo true || echo false)"
+  assert_eq "Second source preserved" "true" "$(echo "$content" | grep -q '^  - data-schema-design$' && echo true || echo false)"
+  assert_eq "Last source preserved" "true" "$(echo "$content" | grep -q '^  - tui$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 16: Specification without Sources field ---
+test_no_sources_field() {
+  setup
 
-echo -e "${YELLOW}Test: Specification without Sources field${NC}"
-setup_fixture
-cat > "$SPEC_DIR/no-sources.md" << 'EOF'
+  cat > "$SPEC_DIR/no-sources.md" << 'EOF'
 # Specification: No Sources
 
 **Status**: Complete
@@ -559,27 +464,19 @@ cat > "$SPEC_DIR/no-sources.md" << 'EOF'
 This spec has no sources.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/no-sources.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/no-sources.md")
 
-# Should NOT have a sources field
-TESTS_RUN=$((TESTS_RUN + 1))
-if ! echo "$content" | grep -q "^sources:"; then
-    echo -e "  ${GREEN}✓${NC} No sources field when source not present"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-else
-    echo -e "  ${RED}✗${NC} No sources field when source not present"
-    echo -e "    Found sources field when it shouldn't exist"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-fi
+  assert_eq "No sources field when source not present" "false" "$(echo "$content" | grep -q '^sources:' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 17: Body with --- horizontal rules preserved ---
+test_body_horizontal_rules() {
+  setup
 
-echo -e "${YELLOW}Test: Body with --- horizontal rules preserved${NC}"
-setup_fixture
-cat > "$SPEC_DIR/hr-body.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/hr-body.md" << 'TESTEOF'
 # Specification: Test
 
 **Status**: Complete
@@ -604,24 +501,25 @@ More content.
 End content.
 TESTEOF
 
-run_migration
-content=$(cat "$SPEC_DIR/hr-body.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/hr-body.md")
 
-assert_contains "$content" "^status: concluded$" "Frontmatter status correct"
-assert_contains "$content" "^date: 2024-01-01$" "Frontmatter date correct"
+  assert_eq "Frontmatter status correct" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
+  assert_eq "Frontmatter date correct" "true" "$(echo "$content" | grep -q '^date: 2024-01-01$' && echo true || echo false)"
 
-body=$(sed -n '/^## /,$p' "$SPEC_DIR/hr-body.md")
-assert_contains "$body" "^## Overview$" "Overview section preserved"
-assert_contains "$body" "^## Dependencies$" "Dependencies section preserved"
-assert_contains "$body" "^## Final Section$" "Final Section preserved"
+  body=$(sed -n '/^## /,$p' "$SPEC_DIR/hr-body.md")
+  assert_eq "Overview section preserved" "true" "$(echo "$body" | grep -q '^## Overview$' && echo true || echo false)"
+  assert_eq "Dependencies section preserved" "true" "$(echo "$body" | grep -q '^## Dependencies$' && echo true || echo false)"
+  assert_eq "Final Section preserved" "true" "$(echo "$body" | grep -q '^## Final Section$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 18: Exact body content preservation ---
+test_exact_body_preservation() {
+  setup
 
-echo -e "${YELLOW}Test: Exact body content preservation${NC}"
-setup_fixture
-cat > "$SPEC_DIR/exact-body.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/exact-body.md" << 'TESTEOF'
 # Specification: Exact Body
 
 **Status**: Complete
@@ -663,19 +561,20 @@ echo $value;
 Done.
 TESTEOF
 
-body_before=$(sed -n '/^## /,$p' "$SPEC_DIR/exact-body.md")
-run_migration
-body_after=$(sed -n '/^## /,$p' "$SPEC_DIR/exact-body.md")
+  body_before=$(sed -n '/^## /,$p' "$SPEC_DIR/exact-body.md")
+  run_migration
+  body_after=$(sed -n '/^## /,$p' "$SPEC_DIR/exact-body.md")
 
-assert_equals "$body_after" "$body_before" "Body content exactly preserved after migration"
+  assert_eq "Body content exactly preserved after migration" "$body_before" "$body_after"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 19: Building specification status with complex body ---
+test_building_complex_body() {
+  setup
 
-echo -e "${YELLOW}Test: Building specification status with complex body${NC}"
-setup_fixture
-cat > "$SPEC_DIR/building-complex.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/building-complex.md" << 'TESTEOF'
 # Specification: Building Complex
 
 **Status**: Building specification
@@ -706,30 +605,44 @@ Content about watchers.
 Final integration notes.
 TESTEOF
 
-run_migration
-content=$(cat "$SPEC_DIR/building-complex.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/building-complex.md")
 
-assert_contains "$content" "^status: in-progress$" "Building specification maps to in-progress"
+  assert_eq "Building specification maps to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
 
-body=$(sed -n '/^## /,$p' "$SPEC_DIR/building-complex.md")
-assert_contains "$body" "^## Overview$" "Overview section preserved"
-assert_contains "$body" "^## Watchers$" "Watchers section preserved"
-assert_contains "$body" "^## Integration$" "Integration section preserved"
-assert_contains "$body" "| create | onCreate | high |" "Table content preserved"
+  body=$(sed -n '/^## /,$p' "$SPEC_DIR/building-complex.md")
+  assert_eq "Overview section preserved" "true" "$(echo "$body" | grep -q '^## Overview$' && echo true || echo false)"
+  assert_eq "Watchers section preserved" "true" "$(echo "$body" | grep -q '^## Watchers$' && echo true || echo false)"
+  assert_eq "Integration section preserved" "true" "$(echo "$body" | grep -q '^## Integration$' && echo true || echo false)"
+  assert_eq "Table content preserved" "true" "$(echo "$body" | grep -qF '| create | onCreate | high |' && echo true || echo false)"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 002 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_building_specification
+test_complete_status
+test_completed_status
+test_building_short
+test_no_type_field
+test_no_date_field
+test_already_has_frontmatter
+test_no_legacy_format
+test_idempotency
+test_draft_status
+test_done_status
+test_content_preservation
+test_kebab_case_topic
+test_single_source
+test_multiple_sources
+test_no_sources_field
+test_body_horizontal_rules
+test_exact_body_preservation
+test_building_complex_body
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-003.sh
+++ b/tests/scripts/test-migration-003.sh
@@ -1,150 +1,52 @@
 #!/bin/bash
-#
-# Tests migration 003-planning-frontmatter.sh
-# Validates conversion from legacy plan format to full YAML frontmatter.
-#
+# Tests for migration 003: planning-frontmatter
+# Run: bash tests/scripts/test-migration-003.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/003-planning-frontmatter.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/003-planning-frontmatter.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-003-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/planning"
+  PLAN_DIR="$TEST_DIR/docs/workflow/planning"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/planning"
-    PLAN_DIR="$TEST_DIR/docs/workflow/planning"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
 run_migration() {
-    cd "$TEST_DIR"
-    # Source the migration script (it uses PLAN_DIR variable)
-    PLAN_DIR="$TEST_DIR/docs/workflow/planning"
-    source "$MIGRATION_SCRIPT"
+  cd "$TEST_DIR"
+  PLAN_DIR="$TEST_DIR/docs/workflow/planning"
+  source "$MIGRATION"
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: Legacy format with partial frontmatter and Draft status ---
+test_draft_with_partial_frontmatter() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-assert_file_starts_with() {
-    local file="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    local first_line=$(head -1 "$file")
-    if [ "$first_line" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected first line: $expected"
-        echo -e "    Actual first line:   $first_line"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Legacy format with partial frontmatter and Draft status${NC}"
-setup_fixture
-cat > "$PLAN_DIR/user-auth.md" << 'EOF'
+  cat > "$PLAN_DIR/user-auth.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -160,26 +62,26 @@ format: local-markdown
 Plan content here.
 EOF
 
-output=$(run_migration 2>&1)
-content=$(cat "$PLAN_DIR/user-auth.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/user-auth.md")
 
-assert_file_starts_with "$PLAN_DIR/user-auth.md" "---" "File starts with frontmatter delimiter"
-assert_contains "$content" "^topic: user-auth$" "Topic extracted from filename"
-assert_contains "$content" "^status: in-progress$" "Draft status mapped to in-progress"
-assert_contains "$content" "^date: 2024-01-15$" "Date extracted"
-assert_contains "$content" "^format: local-markdown$" "Format preserved"
-assert_contains "$content" "^specification: user-auth.md$" "Specification filename extracted"
-assert_contains "$content" "^# Implementation Plan: User Authentication$" "H1 heading preserved"
-assert_contains "$content" "^## Overview$" "Content sections preserved"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "File starts with frontmatter delimiter" "---" "$(head -1 "$PLAN_DIR/user-auth.md")"
+  assert_eq "Topic extracted from filename" "true" "$(echo "$content" | grep -q '^topic: user-auth$' && echo true || echo false)"
+  assert_eq "Draft status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
+  assert_eq "Date extracted" "true" "$(echo "$content" | grep -q '^date: 2024-01-15$' && echo true || echo false)"
+  assert_eq "Format preserved" "true" "$(echo "$content" | grep -q '^format: local-markdown$' && echo true || echo false)"
+  assert_eq "Specification filename extracted" "true" "$(echo "$content" | grep -q '^specification: user-auth.md$' && echo true || echo false)"
+  assert_eq "H1 heading preserved" "true" "$(echo "$content" | grep -q '^# Implementation Plan: User Authentication$' && echo true || echo false)"
+  assert_eq "Content sections preserved" "true" "$(echo "$content" | grep -q '^## Overview$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Legacy format with Ready status ---
+test_ready_status() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Ready status${NC}"
-setup_fixture
-cat > "$PLAN_DIR/api-endpoints.md" << 'EOF'
+  cat > "$PLAN_DIR/api-endpoints.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -195,18 +97,19 @@ format: local-markdown
 Ready to implement.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/api-endpoints.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/api-endpoints.md")
 
-assert_contains "$content" "^status: in-progress$" "Ready status mapped to in-progress"
+  assert_eq "Ready status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Legacy format with In Progress status ---
+test_in_progress_status() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with In Progress status${NC}"
-setup_fixture
-cat > "$PLAN_DIR/caching.md" << 'EOF'
+  cat > "$PLAN_DIR/caching.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -222,18 +125,19 @@ format: local-markdown
 Work in progress.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/caching.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/caching.md")
 
-assert_contains "$content" "^status: in-progress$" "In Progress status mapped to in-progress"
+  assert_eq "In Progress status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Legacy format with Completed status ---
+test_completed_status() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format with Completed status${NC}"
-setup_fixture
-cat > "$PLAN_DIR/database.md" << 'EOF'
+  cat > "$PLAN_DIR/database.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -249,18 +153,19 @@ format: local-markdown
 Implementation complete.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/database.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/database.md")
 
-assert_contains "$content" "^status: concluded$" "Completed status mapped to concluded"
+  assert_eq "Completed status mapped to concluded" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Legacy format without partial frontmatter (inline only) ---
+test_no_partial_frontmatter() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format without partial frontmatter (inline only)${NC}"
-setup_fixture
-cat > "$PLAN_DIR/no-frontmatter.md" << 'EOF'
+  cat > "$PLAN_DIR/no-frontmatter.md" << 'EOF'
 # Implementation Plan: No Frontmatter
 
 **Date**: 2024-05-15
@@ -272,20 +177,21 @@ cat > "$PLAN_DIR/no-frontmatter.md" << 'EOF'
 No frontmatter at all.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/no-frontmatter.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/no-frontmatter.md")
 
-assert_file_starts_with "$PLAN_DIR/no-frontmatter.md" "---" "Frontmatter added"
-assert_contains "$content" "^topic: no-frontmatter$" "Topic extracted from filename"
-assert_contains "$content" "^format: MISSING$" "Missing format flagged"
+  assert_eq "Frontmatter added" "---" "$(head -1 "$PLAN_DIR/no-frontmatter.md")"
+  assert_eq "Topic extracted from filename" "true" "$(echo "$content" | grep -q '^topic: no-frontmatter$' && echo true || echo false)"
+  assert_eq "Missing format flagged" "true" "$(echo "$content" | grep -q '^format: MISSING$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: Legacy format without date field ---
+test_no_date_field() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format without date field${NC}"
-setup_fixture
-cat > "$PLAN_DIR/no-date.md" << 'EOF'
+  cat > "$PLAN_DIR/no-date.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -300,19 +206,20 @@ format: local-markdown
 Missing date.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/no-date.md")
-today=$(date +%Y-%m-%d)
+  run_migration
+  content=$(cat "$PLAN_DIR/no-date.md")
+  today=$(date +%Y-%m-%d)
 
-assert_contains "$content" "^date: $today$" "Date defaults to today when not found"
+  assert_eq "Date defaults to today when not found" "true" "$(echo "$content" | grep -q "^date: $today$" && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Legacy format without specification field ---
+test_no_spec_field() {
+  setup
 
-echo -e "${YELLOW}Test: Legacy format without specification field${NC}"
-setup_fixture
-cat > "$PLAN_DIR/no-spec.md" << 'EOF'
+  cat > "$PLAN_DIR/no-spec.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -327,18 +234,19 @@ format: local-markdown
 Missing specification.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/no-spec.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/no-spec.md")
 
-assert_contains "$content" "^specification: no-spec.md$" "Specification defaults to topic.md"
+  assert_eq "Specification defaults to topic.md" "true" "$(echo "$content" | grep -q '^specification: no-spec.md$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Specification path extraction (full path to filename) ---
+test_spec_path_extraction() {
+  setup
 
-echo -e "${YELLOW}Test: Specification path extraction (full path to filename)${NC}"
-setup_fixture
-cat > "$PLAN_DIR/billing.md" << 'EOF'
+  cat > "$PLAN_DIR/billing.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -354,18 +262,19 @@ format: local-markdown
 Billing plan.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/billing.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/billing.md")
 
-assert_contains "$content" "^specification: billing-system.md$" "Specification filename extracted from path"
+  assert_eq "Specification filename extracted from path" "true" "$(echo "$content" | grep -q '^specification: billing-system.md$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Different format value (beads) ---
+test_beads_format() {
+  setup
 
-echo -e "${YELLOW}Test: Different format value (beads)${NC}"
-setup_fixture
-cat > "$PLAN_DIR/beads-plan.md" << 'EOF'
+  cat > "$PLAN_DIR/beads-plan.md" << 'EOF'
 ---
 format: beads
 ---
@@ -381,18 +290,19 @@ format: beads
 Using beads format.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/beads-plan.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/beads-plan.md")
 
-assert_contains "$content" "^format: beads$" "Non-default format preserved"
+  assert_eq "Non-default format preserved" "true" "$(echo "$content" | grep -q '^format: beads$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: File already has full frontmatter (should skip) ---
+test_already_has_full_frontmatter() {
+  setup
 
-echo -e "${YELLOW}Test: File already has full frontmatter (should skip)${NC}"
-setup_fixture
-cat > "$PLAN_DIR/existing.md" << 'EOF'
+  cat > "$PLAN_DIR/existing.md" << 'EOF'
 ---
 topic: existing
 status: concluded
@@ -408,20 +318,20 @@ specification: existing.md
 Already migrated content.
 EOF
 
-original_content=$(cat "$PLAN_DIR/existing.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$PLAN_DIR/existing.md")
+  original_content=$(cat "$PLAN_DIR/existing.md")
+  run_migration
+  new_content=$(cat "$PLAN_DIR/existing.md")
 
-assert_equals "$new_content" "$original_content" "File with full frontmatter unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File with full frontmatter unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 11: File without legacy format (should skip) ---
+test_no_legacy_format() {
+  setup
 
-echo -e "${YELLOW}Test: File without legacy format (should skip)${NC}"
-setup_fixture
-cat > "$PLAN_DIR/weird.md" << 'EOF'
+  cat > "$PLAN_DIR/weird.md" << 'EOF'
 # Some Random Document
 
 This has no status, date, or specification fields.
@@ -431,20 +341,20 @@ This has no status, date, or specification fields.
 Content here.
 EOF
 
-original_content=$(cat "$PLAN_DIR/weird.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$PLAN_DIR/weird.md")
+  original_content=$(cat "$PLAN_DIR/weird.md")
+  run_migration
+  new_content=$(cat "$PLAN_DIR/weird.md")
 
-assert_equals "$new_content" "$original_content" "File without legacy format unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File without legacy format unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: Idempotency (running migration twice) ---
+test_idempotency() {
+  setup
 
-echo -e "${YELLOW}Test: Idempotency (running migration twice)${NC}"
-setup_fixture
-cat > "$PLAN_DIR/idempotent.md" << 'EOF'
+  cat > "$PLAN_DIR/idempotent.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -460,23 +370,22 @@ format: local-markdown
 Content.
 EOF
 
-run_migration
-first_run=$(cat "$PLAN_DIR/idempotent.md")
+  run_migration
+  first_run=$(cat "$PLAN_DIR/idempotent.md")
 
-# Run again
-output=$(run_migration 2>&1)
-second_run=$(cat "$PLAN_DIR/idempotent.md")
+  run_migration
+  second_run=$(cat "$PLAN_DIR/idempotent.md")
 
-assert_equals "$second_run" "$first_run" "Second migration run produces same result"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "Second migration run produces same result" "$first_run" "$second_run"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 13: Content preservation (multiple phases) ---
+test_content_preservation() {
+  setup
 
-echo -e "${YELLOW}Test: Content preservation (multiple phases)${NC}"
-setup_fixture
-cat > "$PLAN_DIR/full-plan.md" << 'EOF'
+  cat > "$PLAN_DIR/full-plan.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -504,21 +413,22 @@ Phase 2 tasks.
 Phase 3 tasks.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/full-plan.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/full-plan.md")
 
-assert_contains "$content" "^## Overview$" "Overview section preserved"
-assert_contains "$content" "^## Phase 1: Setup$" "Phase 1 section preserved"
-assert_contains "$content" "^## Phase 2: Core$" "Phase 2 section preserved"
-assert_contains "$content" "^## Phase 3: Polish$" "Phase 3 section preserved"
+  assert_eq "Overview section preserved" "true" "$(echo "$content" | grep -q '^## Overview$' && echo true || echo false)"
+  assert_eq "Phase 1 section preserved" "true" "$(echo "$content" | grep -q '^## Phase 1: Setup$' && echo true || echo false)"
+  assert_eq "Phase 2 section preserved" "true" "$(echo "$content" | grep -q '^## Phase 2: Core$' && echo true || echo false)"
+  assert_eq "Phase 3 section preserved" "true" "$(echo "$content" | grep -q '^## Phase 3: Polish$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 14: Kebab-case topic from filename ---
+test_kebab_case_topic() {
+  setup
 
-echo -e "${YELLOW}Test: Kebab-case topic from filename${NC}"
-setup_fixture
-cat > "$PLAN_DIR/user-profile-settings.md" << 'EOF'
+  cat > "$PLAN_DIR/user-profile-settings.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -534,18 +444,19 @@ format: local-markdown
 Content.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/user-profile-settings.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/user-profile-settings.md")
 
-assert_contains "$content" "^topic: user-profile-settings$" "Topic uses kebab-case from filename"
+  assert_eq "Topic uses kebab-case from filename" "true" "$(echo "$content" | grep -q '^topic: user-profile-settings$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 15: Beads format with epic -> plan_id ---
+test_epic_to_plan_id() {
+  setup
 
-echo -e "${YELLOW}Test: Beads format with epic → plan_id${NC}"
-setup_fixture
-cat > "$PLAN_DIR/docman-python-sdk.md" << 'EOF'
+  cat > "$PLAN_DIR/docman-python-sdk.md" << 'EOF'
 ---
 format: beads
 epic: docman-api-python-0c8
@@ -561,31 +472,22 @@ epic: docman-api-python-0c8
 This plan is managed via Beads.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/docman-python-sdk.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/docman-python-sdk.md")
 
-assert_contains "$content" "^format: beads$" "Beads format preserved"
-assert_contains "$content" "^plan_id: docman-api-python-0c8$" "Epic migrated to plan_id"
-assert_contains "$content" "^date: 2026-01-12$" "Date extracted from Created field"
+  assert_eq "Beads format preserved" "true" "$(echo "$content" | grep -q '^format: beads$' && echo true || echo false)"
+  assert_eq "Epic migrated to plan_id" "true" "$(echo "$content" | grep -q '^plan_id: docman-api-python-0c8$' && echo true || echo false)"
+  assert_eq "Date extracted from Created field" "true" "$(echo "$content" | grep -q '^date: 2026-01-12$' && echo true || echo false)"
+  assert_eq "Epic field removed" "false" "$(echo "$content" | grep -q '^epic:' && echo true || echo false)"
 
-# Should NOT have epic field anymore
-TESTS_RUN=$((TESTS_RUN + 1))
-if ! echo "$content" | grep -q "^epic:"; then
-    echo -e "  ${GREEN}✓${NC} Epic field removed (migrated to plan_id)"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-else
-    echo -e "  ${RED}✗${NC} Epic field removed (migrated to plan_id)"
-    echo -e "    Found epic field when it should be plan_id"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-fi
+  teardown
+}
 
-echo ""
+# --- Test 16: Linear format with project -> plan_id ---
+test_project_to_plan_id() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Linear/Backlog format with project → plan_id${NC}"
-setup_fixture
-cat > "$PLAN_DIR/linear-plan.md" << 'EOF'
+  cat > "$PLAN_DIR/linear-plan.md" << 'EOF'
 ---
 format: linear
 project: my-linear-project
@@ -601,30 +503,21 @@ project: my-linear-project
 This plan is managed via Linear.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/linear-plan.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/linear-plan.md")
 
-assert_contains "$content" "^format: linear$" "Linear format preserved"
-assert_contains "$content" "^plan_id: my-linear-project$" "Project migrated to plan_id"
+  assert_eq "Linear format preserved" "true" "$(echo "$content" | grep -q '^format: linear$' && echo true || echo false)"
+  assert_eq "Project migrated to plan_id" "true" "$(echo "$content" | grep -q '^plan_id: my-linear-project$' && echo true || echo false)"
+  assert_eq "Project field removed" "false" "$(echo "$content" | grep -q '^project:' && echo true || echo false)"
 
-# Should NOT have project field anymore
-TESTS_RUN=$((TESTS_RUN + 1))
-if ! echo "$content" | grep -q "^project:"; then
-    echo -e "  ${GREEN}✓${NC} Project field removed (migrated to plan_id)"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-else
-    echo -e "  ${RED}✗${NC} Project field removed (migrated to plan_id)"
-    echo -e "    Found project field when it should be plan_id"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-fi
+  teardown
+}
 
-echo ""
+# --- Test 17: Created field as alternative to Date ---
+test_created_field() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Created field as alternative to Date${NC}"
-setup_fixture
-cat > "$PLAN_DIR/created-field.md" << 'EOF'
+  cat > "$PLAN_DIR/created-field.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -640,18 +533,19 @@ format: local-markdown
 Uses Created instead of Date.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/created-field.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/created-field.md")
 
-assert_contains "$content" "^date: 2026-01-15$" "Date extracted from Created field (alternative)"
+  assert_eq "Date extracted from Created field" "true" "$(echo "$content" | grep -q '^date: 2026-01-15$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 18: No plan_id when original has no epic/project ---
+test_no_plan_id() {
+  setup
 
-echo -e "${YELLOW}Test: No plan_id when original has no epic/project${NC}"
-setup_fixture
-cat > "$PLAN_DIR/no-plan-id.md" << 'EOF'
+  cat > "$PLAN_DIR/no-plan-id.md" << 'EOF'
 ---
 format: local-markdown
 ---
@@ -666,25 +560,19 @@ format: local-markdown
 Local markdown format, no external ID.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/no-plan-id.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/no-plan-id.md")
 
-# Should NOT have a plan_id field since original didn't have epic/project
-TESTS_RUN=$((TESTS_RUN + 1))
-if ! echo "$content" | grep -q "^plan_id:"; then
-    echo -e "  ${GREEN}✓${NC} No plan_id when original had no epic/project"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-else
-    echo -e "  ${RED}✗${NC} No plan_id when original had no epic/project"
-    echo -e "    Found plan_id field when it shouldn't exist"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-fi
+  assert_eq "No plan_id when original had no epic/project" "false" "$(echo "$content" | grep -q '^plan_id:' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-echo -e "${YELLOW}Test: Body with --- horizontal rules preserved${NC}"
-setup_fixture
-cat > "$PLAN_DIR/hr-rules.md" << 'TESTEOF'
+# --- Test 19: Body with --- horizontal rules preserved ---
+test_body_horizontal_rules() {
+  setup
+
+  cat > "$PLAN_DIR/hr-rules.md" << 'TESTEOF'
 ---
 format: local-markdown
 ---
@@ -712,26 +600,27 @@ Core tasks here.
 Cleanup tasks here.
 TESTEOF
 
-run_migration
-content=$(cat "$PLAN_DIR/hr-rules.md")
+  run_migration
+  content=$(cat "$PLAN_DIR/hr-rules.md")
 
-assert_contains "$content" "^format: local-markdown$" "Format preserved in frontmatter"
-assert_contains "$content" "^topic: hr-rules$" "Topic extracted from filename"
-assert_contains "$content" "^status: in-progress$" "Status mapped correctly"
+  assert_eq "Format preserved in frontmatter" "true" "$(echo "$content" | grep -q '^format: local-markdown$' && echo true || echo false)"
+  assert_eq "Topic extracted from filename" "true" "$(echo "$content" | grep -q '^topic: hr-rules$' && echo true || echo false)"
+  assert_eq "Status mapped correctly" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
 
-body_after=$(sed -n '/^## /,$p' "$PLAN_DIR/hr-rules.md")
-assert_contains "$body_after" "^## Phase 1: Setup$" "Phase 1 section preserved"
-assert_contains "$body_after" "^## Phase 2: Core$" "Phase 2 section preserved"
-assert_contains "$body_after" "^## Phase 3: Cleanup$" "Phase 3 section preserved"
-assert_contains "$body_after" "^---$" "Horizontal rules preserved in body"
+  body_after=$(sed -n '/^## /,$p' "$PLAN_DIR/hr-rules.md")
+  assert_eq "Phase 1 section preserved" "true" "$(echo "$body_after" | grep -q '^## Phase 1: Setup$' && echo true || echo false)"
+  assert_eq "Phase 2 section preserved" "true" "$(echo "$body_after" | grep -q '^## Phase 2: Core$' && echo true || echo false)"
+  assert_eq "Phase 3 section preserved" "true" "$(echo "$body_after" | grep -q '^## Phase 3: Cleanup$' && echo true || echo false)"
+  assert_eq "Horizontal rules preserved in body" "true" "$(echo "$body_after" | grep -q '^---$' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 20: Exact body content preservation ---
+test_exact_body_preservation() {
+  setup
 
-echo -e "${YELLOW}Test: Exact body content preservation${NC}"
-setup_fixture
-cat > "$PLAN_DIR/exact-body.md" << 'TESTEOF'
+  cat > "$PLAN_DIR/exact-body.md" << 'TESTEOF'
 ---
 format: beads
 epic: PROJ-123
@@ -771,33 +660,44 @@ Schema::create('users', function (Blueprint $table) {
 | Auth middleware | pending | JWT |
 TESTEOF
 
-body_before=$(sed -n '/^## /,$p' "$PLAN_DIR/exact-body.md")
+  body_before=$(sed -n '/^## /,$p' "$PLAN_DIR/exact-body.md")
+  run_migration
+  body_after=$(sed -n '/^## /,$p' "$PLAN_DIR/exact-body.md")
 
-run_migration
+  assert_eq "Body content exactly preserved after migration" "$body_before" "$body_after"
 
-body_after=$(sed -n '/^## /,$p' "$PLAN_DIR/exact-body.md")
+  content=$(cat "$PLAN_DIR/exact-body.md")
+  assert_eq "Format preserved" "true" "$(echo "$content" | grep -q '^format: beads$' && echo true || echo false)"
+  assert_eq "Epic migrated to plan_id" "true" "$(echo "$content" | grep -q '^plan_id: PROJ-123$' && echo true || echo false)"
 
-assert_equals "$body_after" "$body_before" "Body content exactly preserved after migration"
+  teardown
+}
 
-content=$(cat "$PLAN_DIR/exact-body.md")
-assert_contains "$content" "^format: beads$" "Format preserved"
-assert_contains "$content" "^plan_id: PROJ-123$" "Epic migrated to plan_id"
-
+# --- Run all tests ---
+echo "Running migration 003 tests..."
 echo ""
 
-# ----------------------------------------------------------------------------
-
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_draft_with_partial_frontmatter
+test_ready_status
+test_in_progress_status
+test_completed_status
+test_no_partial_frontmatter
+test_no_date_field
+test_no_spec_field
+test_spec_path_extraction
+test_beads_format
+test_already_has_full_frontmatter
+test_no_legacy_format
+test_idempotency
+test_content_preservation
+test_kebab_case_topic
+test_epic_to_plan_id
+test_project_to_plan_id
+test_created_field
+test_no_plan_id
+test_body_horizontal_rules
+test_exact_body_preservation
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-004.sh
+++ b/tests/scripts/test-migration-004.sh
@@ -1,132 +1,55 @@
 #!/bin/bash
-#
-# Tests migration 004-sources-object-format.sh
-# Validates conversion from simple sources array to object format with status.
-#
+# Tests for migration 004: sources-object-format
+# Run: bash tests/scripts/test-migration-004.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/004-sources-object-format.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/004-sources-object-format.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-004-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/specification"
+  mkdir -p "$TEST_DIR/docs/workflow/discussion"
+  SPEC_DIR="$TEST_DIR/docs/workflow/specification"
+  DISCUSSION_DIR="$TEST_DIR/docs/workflow/discussion"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/specification"
-    mkdir -p "$TEST_DIR/docs/workflow/discussion"
-    SPEC_DIR="$TEST_DIR/docs/workflow/specification"
-    DISCUSSION_DIR="$TEST_DIR/docs/workflow/discussion"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
 run_migration() {
-    cd "$TEST_DIR"
-    # Source the migration script (it uses SPEC_DIR and DISCUSSION_DIR variables)
-    SPEC_DIR="$TEST_DIR/docs/workflow/specification"
-    DISCUSSION_DIR="$TEST_DIR/docs/workflow/discussion"
-    source "$MIGRATION_SCRIPT"
+  cd "$TEST_DIR"
+  SPEC_DIR="$TEST_DIR/docs/workflow/specification"
+  DISCUSSION_DIR="$TEST_DIR/docs/workflow/discussion"
+  source "$MIGRATION"
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: Single source conversion ---
+test_single_source() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local unexpected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if ! echo "$content" | grep -q -- "$unexpected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should NOT find: $unexpected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Single source conversion${NC}"
-setup_fixture
-cat > "$SPEC_DIR/single-source.md" << 'EOF'
+  cat > "$SPEC_DIR/single-source.md" << 'EOF'
 ---
 topic: single-source
 status: concluded
@@ -143,20 +66,20 @@ sources:
 Content here.
 EOF
 
-output=$(run_migration 2>&1)
-content=$(cat "$SPEC_DIR/single-source.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/single-source.md")
 
-assert_contains "$content" "- name: auth-flow" "Source name converted to object"
-assert_contains "$content" "status: incorporated" "Status set to incorporated"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "Source name converted to object" "true" "$(echo "$content" | grep -qF -- '- name: auth-flow' && echo true || echo false)"
+  assert_eq "Status set to incorporated" "true" "$(echo "$content" | grep -qF 'status: incorporated' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Multiple sources conversion ---
+test_multiple_sources() {
+  setup
 
-echo -e "${YELLOW}Test: Multiple sources conversion${NC}"
-setup_fixture
-cat > "$SPEC_DIR/multi-source.md" << 'EOF'
+  cat > "$SPEC_DIR/multi-source.md" << 'EOF'
 ---
 topic: multi-source
 status: in-progress
@@ -175,22 +98,22 @@ sources:
 Content here.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/multi-source.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/multi-source.md")
 
-assert_contains "$content" "- name: topic-a" "First source converted"
-assert_contains "$content" "- name: topic-b" "Second source converted"
-assert_contains "$content" "- name: topic-c" "Third source converted"
-# All should have incorporated status
-assert_contains "$content" "status: incorporated" "Status set to incorporated"
+  assert_eq "First source converted" "true" "$(echo "$content" | grep -qF -- '- name: topic-a' && echo true || echo false)"
+  assert_eq "Second source converted" "true" "$(echo "$content" | grep -qF -- '- name: topic-b' && echo true || echo false)"
+  assert_eq "Third source converted" "true" "$(echo "$content" | grep -qF -- '- name: topic-c' && echo true || echo false)"
+  assert_eq "Status set to incorporated" "true" "$(echo "$content" | grep -qF 'status: incorporated' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Sources with quotes ---
+test_quoted_sources() {
+  setup
 
-echo -e "${YELLOW}Test: Sources with quotes${NC}"
-setup_fixture
-cat > "$SPEC_DIR/quoted-sources.md" << 'EOF'
+  cat > "$SPEC_DIR/quoted-sources.md" << 'EOF'
 ---
 topic: quoted-sources
 status: concluded
@@ -208,19 +131,20 @@ sources:
 Content here.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/quoted-sources.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/quoted-sources.md")
 
-assert_contains "$content" "- name: quoted-topic" "Quoted source name extracted"
-assert_contains "$content" "- name: another-topic" "Second quoted source extracted"
+  assert_eq "Quoted source name extracted" "true" "$(echo "$content" | grep -qF -- '- name: quoted-topic' && echo true || echo false)"
+  assert_eq "Second quoted source extracted" "true" "$(echo "$content" | grep -qF -- '- name: another-topic' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Already migrated (object format) - should skip ---
+test_already_migrated() {
+  setup
 
-echo -e "${YELLOW}Test: Already migrated (object format) - should skip${NC}"
-setup_fixture
-cat > "$SPEC_DIR/already-migrated.md" << 'EOF'
+  cat > "$SPEC_DIR/already-migrated.md" << 'EOF'
 ---
 topic: already-migrated
 status: concluded
@@ -240,22 +164,20 @@ sources:
 Content here.
 EOF
 
-original_content=$(cat "$SPEC_DIR/already-migrated.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$SPEC_DIR/already-migrated.md")
+  original_content=$(cat "$SPEC_DIR/already-migrated.md")
+  run_migration
+  new_content=$(cat "$SPEC_DIR/already-migrated.md")
 
-assert_equals "$new_content" "$original_content" "File with object format unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File with object format unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: No sources field WITH matching discussion ---
+test_no_sources_with_discussion() {
+  setup
 
-echo -e "${YELLOW}Test: No sources field WITH matching discussion${NC}"
-setup_fixture
-
-# Create a matching discussion file
-cat > "$DISCUSSION_DIR/has-discussion.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/has-discussion.md" << 'EOF'
 ---
 topic: has-discussion
 status: concluded
@@ -267,8 +189,7 @@ date: 2024-05-15
 Some discussion content.
 EOF
 
-# Create spec without sources field
-cat > "$SPEC_DIR/has-discussion.md" << 'EOF'
+  cat > "$SPEC_DIR/has-discussion.md" << 'EOF'
 ---
 topic: has-discussion
 status: in-progress
@@ -283,22 +204,21 @@ date: 2024-05-15
 Content here.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/has-discussion.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/has-discussion.md")
 
-assert_contains "$content" "sources:" "Sources field added"
-assert_contains "$content" "- name: has-discussion" "Matching discussion added as source"
-assert_contains "$content" "status: incorporated" "Status set to incorporated"
+  assert_eq "Sources field added" "true" "$(echo "$content" | grep -qF 'sources:' && echo true || echo false)"
+  assert_eq "Matching discussion added as source" "true" "$(echo "$content" | grep -qF -- '- name: has-discussion' && echo true || echo false)"
+  assert_eq "Status set to incorporated" "true" "$(echo "$content" | grep -qF 'status: incorporated' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: No sources field WITHOUT matching discussion ---
+test_no_sources_no_discussion() {
+  setup
 
-echo -e "${YELLOW}Test: No sources field WITHOUT matching discussion${NC}"
-setup_fixture
-
-# Create spec without sources field and no matching discussion
-cat > "$SPEC_DIR/no-discussion.md" << 'EOF'
+  cat > "$SPEC_DIR/no-discussion.md" << 'EOF'
 ---
 topic: no-discussion
 status: in-progress
@@ -313,18 +233,19 @@ date: 2024-05-15
 Content here.
 EOF
 
-output=$(run_migration 2>&1)
-content=$(cat "$SPEC_DIR/no-discussion.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/no-discussion.md")
 
-assert_contains "$content" "sources: \[\]" "Empty sources array added"
+  assert_eq "Empty sources array added" "true" "$(echo "$content" | grep -qF 'sources: []' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: No frontmatter - should skip ---
+test_no_frontmatter() {
+  setup
 
-echo -e "${YELLOW}Test: No frontmatter - should skip${NC}"
-setup_fixture
-cat > "$SPEC_DIR/no-frontmatter.md" << 'EOF'
+  cat > "$SPEC_DIR/no-frontmatter.md" << 'EOF'
 # Specification: No Frontmatter
 
 ## Overview
@@ -332,20 +253,20 @@ cat > "$SPEC_DIR/no-frontmatter.md" << 'EOF'
 This file has no YAML frontmatter.
 EOF
 
-original_content=$(cat "$SPEC_DIR/no-frontmatter.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$SPEC_DIR/no-frontmatter.md")
+  original_content=$(cat "$SPEC_DIR/no-frontmatter.md")
+  run_migration
+  new_content=$(cat "$SPEC_DIR/no-frontmatter.md")
 
-assert_equals "$new_content" "$original_content" "File without frontmatter unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File without frontmatter unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Idempotency (running migration twice) ---
+test_idempotency() {
+  setup
 
-echo -e "${YELLOW}Test: Idempotency (running migration twice)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/idempotent.md" << 'EOF'
+  cat > "$SPEC_DIR/idempotent.md" << 'EOF'
 ---
 topic: idempotent
 status: concluded
@@ -363,23 +284,22 @@ sources:
 Content.
 EOF
 
-run_migration
-first_run=$(cat "$SPEC_DIR/idempotent.md")
+  run_migration
+  first_run=$(cat "$SPEC_DIR/idempotent.md")
 
-# Run again
-output=$(run_migration 2>&1)
-second_run=$(cat "$SPEC_DIR/idempotent.md")
+  run_migration
+  second_run=$(cat "$SPEC_DIR/idempotent.md")
 
-assert_equals "$second_run" "$first_run" "Second migration run produces same result"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "Second migration run produces same result" "$first_run" "$second_run"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Content preservation after migration ---
+test_content_preservation() {
+  setup
 
-echo -e "${YELLOW}Test: Content preservation after migration${NC}"
-setup_fixture
-cat > "$SPEC_DIR/preserve-content.md" << 'EOF'
+  cat > "$SPEC_DIR/preserve-content.md" << 'EOF'
 ---
 topic: preserve-content
 status: concluded
@@ -417,24 +337,25 @@ Details about component B.
 None.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/preserve-content.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/preserve-content.md")
 
-assert_contains "$content" "# Specification: Preserve Content" "H1 heading preserved"
-assert_contains "$content" "## Overview" "Overview section preserved"
-assert_contains "$content" "## Architecture" "Architecture section preserved"
-assert_contains "$content" "### Component A" "Nested heading preserved"
-assert_contains "$content" "## Edge Cases" "Edge Cases section preserved"
-assert_contains "$content" "- Edge case 1" "List content preserved"
-assert_contains "$content" "## Dependencies" "Dependencies section preserved"
+  assert_eq "H1 heading preserved" "true" "$(echo "$content" | grep -qF '# Specification: Preserve Content' && echo true || echo false)"
+  assert_eq "Overview section preserved" "true" "$(echo "$content" | grep -qF '## Overview' && echo true || echo false)"
+  assert_eq "Architecture section preserved" "true" "$(echo "$content" | grep -qF '## Architecture' && echo true || echo false)"
+  assert_eq "Nested heading preserved" "true" "$(echo "$content" | grep -qF '### Component A' && echo true || echo false)"
+  assert_eq "Edge Cases section preserved" "true" "$(echo "$content" | grep -qF '## Edge Cases' && echo true || echo false)"
+  assert_eq "List content preserved" "true" "$(echo "$content" | grep -qF -- '- Edge case 1' && echo true || echo false)"
+  assert_eq "Dependencies section preserved" "true" "$(echo "$content" | grep -qF '## Dependencies' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: Other frontmatter fields preserved ---
+test_other_fields_preserved() {
+  setup
 
-echo -e "${YELLOW}Test: Other frontmatter fields preserved${NC}"
-setup_fixture
-cat > "$SPEC_DIR/other-fields.md" << 'EOF'
+  cat > "$SPEC_DIR/other-fields.md" << 'EOF'
 ---
 topic: other-fields
 status: concluded
@@ -452,23 +373,24 @@ superseded_by: newer-spec
 Content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/other-fields.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/other-fields.md")
 
-assert_contains "$content" "topic: other-fields" "Topic field preserved"
-assert_contains "$content" "status: concluded" "Status field preserved"
-assert_contains "$content" "type: feature" "Type field preserved"
-assert_contains "$content" "date: 2024-08-01" "Date field preserved"
-assert_contains "$content" "superseded_by: newer-spec" "Superseded_by field preserved"
-assert_contains "$content" "- name: topic-x" "Source converted to object"
+  assert_eq "Topic field preserved" "true" "$(echo "$content" | grep -qF 'topic: other-fields' && echo true || echo false)"
+  assert_eq "Status field preserved" "true" "$(echo "$content" | grep -qF 'status: concluded' && echo true || echo false)"
+  assert_eq "Type field preserved" "true" "$(echo "$content" | grep -qF 'type: feature' && echo true || echo false)"
+  assert_eq "Date field preserved" "true" "$(echo "$content" | grep -qF 'date: 2024-08-01' && echo true || echo false)"
+  assert_eq "Superseded_by field preserved" "true" "$(echo "$content" | grep -qF 'superseded_by: newer-spec' && echo true || echo false)"
+  assert_eq "Source converted to object" "true" "$(echo "$content" | grep -qF -- '- name: topic-x' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 11: Empty sources array - should skip ---
+test_empty_sources() {
+  setup
 
-echo -e "${YELLOW}Test: Empty sources array - should skip${NC}"
-setup_fixture
-cat > "$SPEC_DIR/empty-sources.md" << 'EOF'
+  cat > "$SPEC_DIR/empty-sources.md" << 'EOF'
 ---
 topic: empty-sources
 status: in-progress
@@ -484,22 +406,20 @@ sources:
 Content.
 EOF
 
-# This is a bit tricky - file has sources: but no actual items
-# Migration should recognize this and not break the file
-run_migration
-content=$(cat "$SPEC_DIR/empty-sources.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/empty-sources.md")
 
-# File should still be valid YAML
-assert_contains "$content" "^---$" "Frontmatter delimiters present"
-assert_contains "$content" "topic: empty-sources" "Topic preserved"
+  assert_eq "Frontmatter delimiters present" "true" "$(echo "$content" | grep -q '^---$' && echo true || echo false)"
+  assert_eq "Topic preserved" "true" "$(echo "$content" | grep -qF 'topic: empty-sources' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: Sources is last field in frontmatter ---
+test_sources_last() {
+  setup
 
-echo -e "${YELLOW}Test: Sources is last field in frontmatter${NC}"
-setup_fixture
-cat > "$SPEC_DIR/sources-last.md" << 'EOF'
+  cat > "$SPEC_DIR/sources-last.md" << 'EOF'
 ---
 topic: sources-last
 status: concluded
@@ -516,19 +436,20 @@ sources:
 Content.
 EOF
 
-run_migration
-content=$(cat "$SPEC_DIR/sources-last.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/sources-last.md")
 
-assert_contains "$content" "- name: final-topic" "Source converted when last in frontmatter"
-assert_contains "$content" "status: incorporated" "Status added"
+  assert_eq "Source converted when last in frontmatter" "true" "$(echo "$content" | grep -qF -- '- name: final-topic' && echo true || echo false)"
+  assert_eq "Status added" "true" "$(echo "$content" | grep -qF 'status: incorporated' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 13: Sources last with --- horizontal rules in body ---
+test_sources_last_with_hr_body() {
+  setup
 
-echo -e "${YELLOW}Test: Sources last with --- horizontal rules in body${NC}"
-setup_fixture
-cat > "$SPEC_DIR/body-with-hr.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/body-with-hr.md" << 'TESTEOF'
 ---
 topic: body-with-hr
 status: concluded
@@ -564,24 +485,25 @@ Some content here.
 Final paragraph.
 TESTEOF
 
-run_migration
-content=$(cat "$SPEC_DIR/body-with-hr.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/body-with-hr.md")
 
-assert_contains "$content" "- name: my-discussion" "Source converted with HR in body"
-assert_contains "$content" "status: incorporated" "Status added with HR in body"
-assert_contains "$content" "## Overview" "Overview section preserved"
-assert_contains "$content" "## Dependencies" "Dependencies section preserved"
-assert_contains "$content" "## More content after second HR" "Content after second HR preserved"
-assert_contains "$content" "Final paragraph." "Final paragraph preserved"
-assert_contains "$content" "The plugin architecture" "List item in body preserved"
+  assert_eq "Source converted with HR in body" "true" "$(echo "$content" | grep -qF -- '- name: my-discussion' && echo true || echo false)"
+  assert_eq "Status added with HR in body" "true" "$(echo "$content" | grep -qF 'status: incorporated' && echo true || echo false)"
+  assert_eq "Overview section preserved" "true" "$(echo "$content" | grep -qF '## Overview' && echo true || echo false)"
+  assert_eq "Dependencies section preserved" "true" "$(echo "$content" | grep -qF '## Dependencies' && echo true || echo false)"
+  assert_eq "Content after second HR preserved" "true" "$(echo "$content" | grep -qF '## More content after second HR' && echo true || echo false)"
+  assert_eq "Final paragraph preserved" "true" "$(echo "$content" | grep -qF 'Final paragraph.' && echo true || echo false)"
+  assert_eq "List item in body preserved" "true" "$(echo "$content" | grep -qF 'The plugin architecture' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 14: Multiple sources last with rich body content ---
+test_rich_body() {
+  setup
 
-echo -e "${YELLOW}Test: Multiple sources last with rich body content${NC}"
-setup_fixture
-cat > "$SPEC_DIR/rich-body.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/rich-body.md" << 'TESTEOF'
 ---
 topic: rich-body
 status: concluded
@@ -620,24 +542,25 @@ tick create "Task with quotes" --priority 1
 | value    | other    |
 TESTEOF
 
-run_migration
-content=$(cat "$SPEC_DIR/rich-body.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/rich-body.md")
 
-assert_contains "$content" "- name: topic-one" "First source converted"
-assert_contains "$content" "- name: topic-two" "Second source converted"
-assert_contains "$content" "- name: topic-three" "Third source converted"
-assert_contains "$content" "## Overview" "Overview preserved"
-assert_contains "$content" 'tick create "Task with quotes"' "Code block with quotes preserved"
-assert_contains "$content" "## Another Section" "Section after HR preserved"
-assert_contains "$content" "Column A" "Table preserved"
+  assert_eq "First source converted" "true" "$(echo "$content" | grep -qF -- '- name: topic-one' && echo true || echo false)"
+  assert_eq "Second source converted" "true" "$(echo "$content" | grep -qF -- '- name: topic-two' && echo true || echo false)"
+  assert_eq "Third source converted" "true" "$(echo "$content" | grep -qF -- '- name: topic-three' && echo true || echo false)"
+  assert_eq "Overview preserved" "true" "$(echo "$content" | grep -qF '## Overview' && echo true || echo false)"
+  assert_eq "Code block with quotes preserved" "true" "$(echo "$content" | grep -qF 'tick create "Task with quotes"' && echo true || echo false)"
+  assert_eq "Section after HR preserved" "true" "$(echo "$content" | grep -qF '## Another Section' && echo true || echo false)"
+  assert_eq "Table preserved" "true" "$(echo "$content" | grep -qF 'Column A' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 15: No sources with matching discussion and --- in body ---
+test_no_sources_with_discussion_and_hr() {
+  setup
 
-echo -e "${YELLOW}Test: No sources with matching discussion and --- in body${NC}"
-setup_fixture
-cat > "$DISCUSSION_DIR/has-hr-body.md" << 'EOF'
+  cat > "$DISCUSSION_DIR/has-hr-body.md" << 'EOF'
 ---
 topic: has-hr-body
 status: concluded
@@ -649,7 +572,7 @@ date: 2024-11-01
 ## Content
 EOF
 
-cat > "$SPEC_DIR/has-hr-body.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/has-hr-body.md" << 'TESTEOF'
 ---
 topic: has-hr-body
 status: in-progress
@@ -670,22 +593,23 @@ Content here.
 More content here.
 TESTEOF
 
-run_migration
-content=$(cat "$SPEC_DIR/has-hr-body.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/has-hr-body.md")
 
-assert_contains "$content" "- name: has-hr-body" "Matching discussion added"
-assert_contains "$content" "status: incorporated" "Status set"
-assert_contains "$content" "## Overview" "Overview preserved"
-assert_contains "$content" "## Dependencies" "Dependencies preserved"
-assert_contains "$content" "More content here." "Content after HR preserved"
+  assert_eq "Matching discussion added" "true" "$(echo "$content" | grep -qF -- '- name: has-hr-body' && echo true || echo false)"
+  assert_eq "Status set" "true" "$(echo "$content" | grep -qF 'status: incorporated' && echo true || echo false)"
+  assert_eq "Overview preserved" "true" "$(echo "$content" | grep -qF '## Overview' && echo true || echo false)"
+  assert_eq "Dependencies preserved" "true" "$(echo "$content" | grep -qF '## Dependencies' && echo true || echo false)"
+  assert_eq "Content after HR preserved" "true" "$(echo "$content" | grep -qF 'More content here.' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 16: Real-world pattern - many sources + body with lists, tables, code, HR ---
+test_real_world_many_sources() {
+  setup
 
-echo -e "${YELLOW}Test: Real-world pattern - many sources + body with lists, tables, code, HR${NC}"
-setup_fixture
-cat > "$SPEC_DIR/tick-core-pattern.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/tick-core-pattern.md" << 'TESTEOF'
 ---
 topic: tick-core-pattern
 status: concluded
@@ -760,26 +684,27 @@ Prerequisites:
 Final section with content.
 TESTEOF
 
-run_migration
-content=$(cat "$SPEC_DIR/tick-core-pattern.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/tick-core-pattern.md")
 
-assert_contains "$content" "- name: project-fundamentals" "First of 8 sources converted"
-assert_contains "$content" "- name: tui" "Last of 8 sources converted"
-assert_contains "$content" "## Overview" "Overview preserved"
-assert_contains "$content" '`tasks.jsonl`' "Inline code preserved"
-assert_contains "$content" "| Field | Type | Required |" "Table preserved"
-assert_contains "$content" 'tick create "Setup authentication"' "Code block with quotes preserved"
-assert_contains "$content" "## Dependencies" "Dependencies after HR preserved"
-assert_contains "$content" "## More Content" "Content after second HR preserved"
-assert_contains "$content" "Final section with content." "Final paragraph preserved"
+  assert_eq "First of 8 sources converted" "true" "$(echo "$content" | grep -qF -- '- name: project-fundamentals' && echo true || echo false)"
+  assert_eq "Last of 8 sources converted" "true" "$(echo "$content" | grep -qF -- '- name: tui' && echo true || echo false)"
+  assert_eq "Overview preserved" "true" "$(echo "$content" | grep -qF '## Overview' && echo true || echo false)"
+  assert_eq "Inline code preserved" "true" "$(echo "$content" | grep -qF '`tasks.jsonl`' && echo true || echo false)"
+  assert_eq "Table preserved" "true" "$(echo "$content" | grep -qF '| Field | Type | Required |' && echo true || echo false)"
+  assert_eq "Code block with quotes preserved" "true" "$(echo "$content" | grep -qF 'tick create "Setup authentication"' && echo true || echo false)"
+  assert_eq "Dependencies after HR preserved" "true" "$(echo "$content" | grep -qF '## Dependencies' && echo true || echo false)"
+  assert_eq "Content after second HR preserved" "true" "$(echo "$content" | grep -qF '## More Content' && echo true || echo false)"
+  assert_eq "Final paragraph preserved" "true" "$(echo "$content" | grep -qF 'Final section with content.' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 17: Real-world pattern - legacy spec without frontmatter (should skip) ---
+test_legacy_no_frontmatter() {
+  setup
 
-echo -e "${YELLOW}Test: Real-world pattern - legacy spec without frontmatter (should skip)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/evvi-pattern.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/evvi-pattern.md" << 'TESTEOF'
 # Specification: API Design
 
 **Status**: Complete
@@ -798,28 +723,39 @@ Content here with **bold** and `code`.
 Final content.
 TESTEOF
 
-run_migration
-content=$(cat "$SPEC_DIR/evvi-pattern.md")
+  run_migration
+  content=$(cat "$SPEC_DIR/evvi-pattern.md")
 
-# Should be unchanged (no frontmatter = skip)
-assert_contains "$content" "# Specification: API Design" "Legacy H1 unchanged"
-assert_contains "$content" "Status" "Legacy status line present"
-assert_contains "$content" "## API Philosophy" "Body unchanged"
-assert_contains "$content" "## More Content" "More content unchanged"
+  assert_eq "Legacy H1 unchanged" "true" "$(echo "$content" | grep -qF '# Specification: API Design' && echo true || echo false)"
+  assert_eq "Legacy status line present" "true" "$(echo "$content" | grep -qF 'Status' && echo true || echo false)"
+  assert_eq "Body unchanged" "true" "$(echo "$content" | grep -qF '## API Philosophy' && echo true || echo false)"
+  assert_eq "More content unchanged" "true" "$(echo "$content" | grep -qF '## More Content' && echo true || echo false)"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 004 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_single_source
+test_multiple_sources
+test_quoted_sources
+test_already_migrated
+test_no_sources_with_discussion
+test_no_sources_no_discussion
+test_no_frontmatter
+test_idempotency
+test_content_preservation
+test_other_fields_preserved
+test_empty_sources
+test_sources_last
+test_sources_last_with_hr_body
+test_rich_body
+test_no_sources_with_discussion_and_hr
+test_real_world_many_sources
+test_legacy_no_frontmatter
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-005.sh
+++ b/tests/scripts/test-migration-005.sh
@@ -1,128 +1,46 @@
 #!/bin/bash
-#
-# Tests migration 005-plan-external-deps-frontmatter.sh
-# Validates migration of external dependencies from body section to frontmatter.
-#
+# Tests for migration 005: plan-external-deps-frontmatter
+# Run: bash tests/scripts/test-migration-005.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/005-plan-external-deps-frontmatter.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/005-plan-external-deps-frontmatter.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-005-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/planning"
+  PLAN_DIR="$TEST_DIR/docs/workflow/planning"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/planning"
-    PLAN_DIR="$TEST_DIR/docs/workflow/planning"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-run_migration() {
-    cd "$TEST_DIR"
-    PLAN_DIR="$TEST_DIR/docs/workflow/planning"
-    source "$MIGRATION_SCRIPT"
-}
+# --- Test 1: Unresolved dependency ---
+test_unresolved_dep() {
+  setup
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local unexpected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if ! echo "$content" | grep -q -- "$unexpected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should NOT find: $unexpected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Unresolved dependency${NC}"
-setup_fixture
-cat > "$PLAN_DIR/billing.md" << 'EOF'
+  cat > "$PLAN_DIR/billing.md" << 'EOF'
 ---
 topic: billing
 status: in-progress
@@ -146,24 +64,25 @@ Plan content here.
 Setup tasks.
 EOF
 
-output=$(run_migration 2>&1)
-content=$(cat "$PLAN_DIR/billing.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/billing.md")
 
-assert_contains "$content" "external_dependencies:" "external_dependencies added to frontmatter"
-assert_contains "$content" "topic: payment-gateway" "Dep topic extracted"
-assert_contains "$content" "description: Payment processing for checkout" "Dep description extracted"
-assert_contains "$content" "state: unresolved" "State set to unresolved"
-assert_not_contains "$content" "## External Dependencies" "Body section removed"
-assert_contains "$content" "## Phase 1: Setup" "Other body sections preserved"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "external_dependencies added to frontmatter" "true" "$(echo "$content" | grep -q 'external_dependencies:' && echo true || echo false)"
+  assert_eq "Dep topic extracted" "true" "$(echo "$content" | grep -q 'topic: payment-gateway' && echo true || echo false)"
+  assert_eq "Dep description extracted" "true" "$(echo "$content" | grep -q 'description: Payment processing for checkout' && echo true || echo false)"
+  assert_eq "State set to unresolved" "true" "$(echo "$content" | grep -q 'state: unresolved' && echo true || echo false)"
+  assert_eq "Body section removed" "false" "$(echo "$content" | grep -qF '## External Dependencies' && echo true || echo false)"
+  assert_eq "Other body sections preserved" "true" "$(echo "$content" | grep -qF '## Phase 1: Setup' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Resolved dependency with arrow and task_id ---
+test_resolved_dep() {
+  setup
 
-echo -e "${YELLOW}Test: Resolved dependency with arrow and task_id${NC}"
-setup_fixture
-cat > "$PLAN_DIR/auth.md" << 'EOF'
+  cat > "$PLAN_DIR/auth.md" << 'EOF'
 ---
 topic: auth
 status: in-progress
@@ -187,21 +106,23 @@ Auth plan.
 Core tasks.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/auth.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/auth.md")
 
-assert_contains "$content" "topic: user-service" "Resolved dep topic extracted"
-assert_contains "$content" "description: User context for permissions" "Resolved dep description extracted"
-assert_contains "$content" "state: resolved" "State set to resolved"
-assert_contains "$content" "task_id: auth-1-3" "Task ID extracted"
+  assert_eq "Resolved dep topic extracted" "true" "$(echo "$content" | grep -q 'topic: user-service' && echo true || echo false)"
+  assert_eq "Resolved dep description extracted" "true" "$(echo "$content" | grep -q 'description: User context for permissions' && echo true || echo false)"
+  assert_eq "State set to resolved" "true" "$(echo "$content" | grep -q 'state: resolved' && echo true || echo false)"
+  assert_eq "Task ID extracted" "true" "$(echo "$content" | grep -q 'task_id: auth-1-3' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Resolved dependency with (resolved) suffix ---
+test_resolved_suffix() {
+  setup
 
-echo -e "${YELLOW}Test: Resolved dependency with (resolved) suffix${NC}"
-setup_fixture
-cat > "$PLAN_DIR/api.md" << 'EOF'
+  cat > "$PLAN_DIR/api.md" << 'EOF'
 ---
 topic: api
 status: in-progress
@@ -225,19 +146,21 @@ API plan.
 Tasks.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/api.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/api.md")
 
-assert_contains "$content" "state: resolved" "Resolved state detected"
-assert_contains "$content" "task_id: db-2-1" "Task ID extracted with (resolved) suffix stripped"
+  assert_eq "Resolved state detected" "true" "$(echo "$content" | grep -q 'state: resolved' && echo true || echo false)"
+  assert_eq "Task ID extracted with (resolved) suffix stripped" "true" "$(echo "$content" | grep -q 'task_id: db-2-1' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Satisfied externally dependency ---
+test_satisfied_externally() {
+  setup
 
-echo -e "${YELLOW}Test: Satisfied externally dependency${NC}"
-setup_fixture
-cat > "$PLAN_DIR/checkout.md" << 'EOF'
+  cat > "$PLAN_DIR/checkout.md" << 'EOF'
 ---
 topic: checkout
 status: in-progress
@@ -261,20 +184,22 @@ Checkout plan.
 Cart tasks.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/checkout.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/checkout.md")
 
-assert_contains "$content" "topic: payment-gateway" "Satisfied dep topic extracted"
-assert_contains "$content" "description: Payment processing" "Satisfied dep description extracted"
-assert_contains "$content" "state: satisfied_externally" "State set to satisfied_externally"
+  assert_eq "Satisfied dep topic extracted" "true" "$(echo "$content" | grep -q 'topic: payment-gateway' && echo true || echo false)"
+  assert_eq "Satisfied dep description extracted" "true" "$(echo "$content" | grep -q 'description: Payment processing' && echo true || echo false)"
+  assert_eq "State set to satisfied_externally" "true" "$(echo "$content" | grep -q 'state: satisfied_externally' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Mixed dependency types ---
+test_mixed_deps() {
+  setup
 
-echo -e "${YELLOW}Test: Mixed dependency types${NC}"
-setup_fixture
-cat > "$PLAN_DIR/mixed.md" << 'EOF'
+  cat > "$PLAN_DIR/mixed.md" << 'EOF'
 ---
 topic: mixed
 status: in-progress
@@ -300,26 +225,28 @@ Mixed plan.
 Core tasks.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/mixed.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/mixed.md")
 
-assert_contains "$content" "topic: billing-system" "Unresolved dep present"
-assert_contains "$content" "state: unresolved" "Unresolved state present"
-assert_contains "$content" "topic: user-authentication" "Resolved dep present"
-assert_contains "$content" "state: resolved" "Resolved state present"
-assert_contains "$content" "task_id: auth-1-3" "Task ID present"
-assert_contains "$content" "topic: payment-gateway" "Satisfied dep present"
-assert_contains "$content" "state: satisfied_externally" "Satisfied state present"
-assert_not_contains "$content" "## External Dependencies" "Body section removed"
-assert_contains "$content" "## Phase 1: Core" "Other sections preserved"
+  assert_eq "Unresolved dep present" "true" "$(echo "$content" | grep -q 'topic: billing-system' && echo true || echo false)"
+  assert_eq "Unresolved state present" "true" "$(echo "$content" | grep -q 'state: unresolved' && echo true || echo false)"
+  assert_eq "Resolved dep present" "true" "$(echo "$content" | grep -q 'topic: user-authentication' && echo true || echo false)"
+  assert_eq "Resolved state present" "true" "$(echo "$content" | grep -q 'state: resolved' && echo true || echo false)"
+  assert_eq "Task ID present" "true" "$(echo "$content" | grep -q 'task_id: auth-1-3' && echo true || echo false)"
+  assert_eq "Satisfied dep present" "true" "$(echo "$content" | grep -q 'topic: payment-gateway' && echo true || echo false)"
+  assert_eq "Satisfied state present" "true" "$(echo "$content" | grep -q 'state: satisfied_externally' && echo true || echo false)"
+  assert_eq "Body section removed" "false" "$(echo "$content" | grep -qF '## External Dependencies' && echo true || echo false)"
+  assert_eq "Other sections preserved" "true" "$(echo "$content" | grep -qF '## Phase 1: Core' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: No External Dependencies section — empty array ---
+test_no_deps_section() {
+  setup
 
-echo -e "${YELLOW}Test: No External Dependencies section — empty array${NC}"
-setup_fixture
-cat > "$PLAN_DIR/no-deps.md" << 'EOF'
+  cat > "$PLAN_DIR/no-deps.md" << 'EOF'
 ---
 topic: no-deps
 status: in-progress
@@ -339,19 +266,21 @@ No deps plan.
 Core tasks.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/no-deps.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/no-deps.md")
 
-assert_contains "$content" "external_dependencies: \[\]" "Empty array added when no section"
-assert_contains "$content" "## Phase 1: Core" "Body preserved"
+  assert_eq "Empty array added when no section" "true" "$(echo "$content" | grep -q 'external_dependencies: \[\]' && echo true || echo false)"
+  assert_eq "Body preserved" "true" "$(echo "$content" | grep -qF '## Phase 1: Core' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Already has external_dependencies in frontmatter — skip ---
+test_already_has_deps() {
+  setup
 
-echo -e "${YELLOW}Test: Already has external_dependencies in frontmatter — skip${NC}"
-setup_fixture
-cat > "$PLAN_DIR/already-done.md" << 'EOF'
+  cat > "$PLAN_DIR/already-done.md" << 'EOF'
 ---
 topic: already-done
 status: in-progress
@@ -371,20 +300,21 @@ external_dependencies:
 Already done.
 EOF
 
-original_content=$(cat "$PLAN_DIR/already-done.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$PLAN_DIR/already-done.md")
+  original_content=$(cat "$PLAN_DIR/already-done.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  new_content=$(cat "$PLAN_DIR/already-done.md")
 
-assert_equals "$new_content" "$original_content" "File with existing external_dependencies unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File with existing external_dependencies unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: No frontmatter — skip ---
+test_no_frontmatter() {
+  setup
 
-echo -e "${YELLOW}Test: No frontmatter — skip${NC}"
-setup_fixture
-cat > "$PLAN_DIR/no-frontmatter.md" << 'EOF'
+  cat > "$PLAN_DIR/no-frontmatter.md" << 'EOF'
 # Implementation Plan: No Frontmatter
 
 ## External Dependencies
@@ -396,20 +326,21 @@ cat > "$PLAN_DIR/no-frontmatter.md" << 'EOF'
 Tasks.
 EOF
 
-original_content=$(cat "$PLAN_DIR/no-frontmatter.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$PLAN_DIR/no-frontmatter.md")
+  original_content=$(cat "$PLAN_DIR/no-frontmatter.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  new_content=$(cat "$PLAN_DIR/no-frontmatter.md")
 
-assert_equals "$new_content" "$original_content" "File without frontmatter unchanged"
-assert_contains "$output" "skipped" "Reports skip"
+  assert_eq "File without frontmatter unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Idempotency (running migration twice) ---
+test_idempotency() {
+  setup
 
-echo -e "${YELLOW}Test: Idempotency (running migration twice)${NC}"
-setup_fixture
-cat > "$PLAN_DIR/idempotent.md" << 'EOF'
+  cat > "$PLAN_DIR/idempotent.md" << 'EOF'
 ---
 topic: idempotent
 status: in-progress
@@ -433,23 +364,24 @@ Content.
 Tasks.
 EOF
 
-run_migration
-first_run=$(cat "$PLAN_DIR/idempotent.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  first_run=$(cat "$PLAN_DIR/idempotent.md")
 
-# Run again
-output=$(run_migration 2>&1)
-second_run=$(cat "$PLAN_DIR/idempotent.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  second_run=$(cat "$PLAN_DIR/idempotent.md")
 
-assert_equals "$second_run" "$first_run" "Second migration run produces same result"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "Second migration run produces same result" "$first_run" "$second_run"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: Body with --- horizontal rules preserved ---
+test_hr_body() {
+  setup
 
-echo -e "${YELLOW}Test: Body with --- horizontal rules preserved${NC}"
-setup_fixture
-cat > "$PLAN_DIR/hr-body.md" << 'TESTEOF'
+  cat > "$PLAN_DIR/hr-body.md" << 'TESTEOF'
 ---
 topic: hr-body
 status: in-progress
@@ -483,22 +415,24 @@ Setup tasks.
 Core tasks.
 TESTEOF
 
-run_migration
-content=$(cat "$PLAN_DIR/hr-body.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/hr-body.md")
 
-assert_contains "$content" "topic: some-dep" "Dep extracted from body"
-assert_not_contains "$content" "## External Dependencies" "Deps section removed"
-assert_contains "$content" "## Overview" "Overview preserved"
-assert_contains "$content" "## Phase 1: Setup" "Phase 1 preserved"
-assert_contains "$content" "## Phase 2: Core" "Phase 2 preserved"
+  assert_eq "Dep extracted from body" "true" "$(echo "$content" | grep -q 'topic: some-dep' && echo true || echo false)"
+  assert_eq "Deps section removed" "false" "$(echo "$content" | grep -qF '## External Dependencies' && echo true || echo false)"
+  assert_eq "Overview preserved" "true" "$(echo "$content" | grep -qF '## Overview' && echo true || echo false)"
+  assert_eq "Phase 1 preserved" "true" "$(echo "$content" | grep -qF '## Phase 1: Setup' && echo true || echo false)"
+  assert_eq "Phase 2 preserved" "true" "$(echo "$content" | grep -qF '## Phase 2: Core' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 11: Review/tracking files skipped ---
+test_review_files_skipped() {
+  setup
 
-echo -e "${YELLOW}Test: Review/tracking files skipped${NC}"
-setup_fixture
-cat > "$PLAN_DIR/topic-review-traceability.md" << 'EOF'
+  cat > "$PLAN_DIR/topic-review-traceability.md" << 'EOF'
 ---
 topic: topic
 review: true
@@ -509,20 +443,21 @@ review: true
 Content.
 EOF
 
-original_content=$(cat "$PLAN_DIR/topic-review-traceability.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$PLAN_DIR/topic-review-traceability.md")
+  original_content=$(cat "$PLAN_DIR/topic-review-traceability.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  new_content=$(cat "$PLAN_DIR/topic-review-traceability.md")
 
-assert_equals "$new_content" "$original_content" "Review file unchanged"
-assert_not_contains "$output" "updated" "No update for review file"
+  assert_eq "Review file unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: Arrow with -> syntax ---
+test_arrow_alt_syntax() {
+  setup
 
-echo -e "${YELLOW}Test: Arrow with -> syntax${NC}"
-setup_fixture
-cat > "$PLAN_DIR/arrow-alt.md" << 'EOF'
+  cat > "$PLAN_DIR/arrow-alt.md" << 'EOF'
 ---
 topic: arrow-alt
 status: in-progress
@@ -546,25 +481,33 @@ Content.
 Tasks.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/arrow-alt.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/arrow-alt.md")
 
-assert_contains "$content" "state: resolved" "Resolved with -> syntax"
-assert_contains "$content" "task_id: data-1-2" "Task ID extracted with -> syntax"
+  assert_eq "Resolved with -> syntax" "true" "$(echo "$content" | grep -q 'state: resolved' && echo true || echo false)"
+  assert_eq "Task ID extracted with -> syntax" "true" "$(echo "$content" | grep -q 'task_id: data-1-2' && echo true || echo false)"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 005 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_unresolved_dep
+test_resolved_dep
+test_resolved_suffix
+test_satisfied_externally
+test_mixed_deps
+test_no_deps_section
+test_already_has_deps
+test_no_frontmatter
+test_idempotency
+test_hr_body
+test_review_files_skipped
+test_arrow_alt_syntax
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-006.sh
+++ b/tests/scripts/test-migration-006.sh
@@ -1,185 +1,48 @@
 #!/bin/bash
-#
-# Tests migration 006-directory-restructure.sh
-# Validates restructuring from flat files to topic directories.
-#
+# Tests for migration 006: directory-restructure
+# Run: bash tests/scripts/test-migration-006.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/006-directory-restructure.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/006-directory-restructure.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-006-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/specification"
+  mkdir -p "$TEST_DIR/docs/workflow/planning"
+  SPEC_DIR="$TEST_DIR/docs/workflow/specification"
+  PLAN_DIR="$TEST_DIR/docs/workflow/planning"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/specification"
-    mkdir -p "$TEST_DIR/docs/workflow/planning"
-    SPEC_DIR="$TEST_DIR/docs/workflow/specification"
-    PLAN_DIR="$TEST_DIR/docs/workflow/planning"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-run_migration() {
-    cd "$TEST_DIR"
-    SPEC_DIR="$TEST_DIR/docs/workflow/specification"
-    PLAN_DIR="$TEST_DIR/docs/workflow/planning"
-    source "$MIGRATION_SCRIPT"
-}
+# --- Test 1: Specification flat file to topic directory ---
+test_spec_restructure() {
+  setup
 
-assert_file_exists() {
-    local file="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$file" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $file"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local file="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$file" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $file"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_exists() {
-    local dir="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -d "$dir" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory not found: $dir"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Specification flat file → topic directory${NC}"
-setup_fixture
-cat > "$SPEC_DIR/user-auth.md" << 'EOF'
+  cat > "$SPEC_DIR/user-auth.md" << 'EOF'
 ---
 topic: user-auth
 status: concluded
@@ -194,23 +57,24 @@ date: 2024-01-15
 Content.
 EOF
 
-output=$(run_migration 2>&1)
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_dir_exists "$SPEC_DIR/user-auth" "Topic directory created"
-assert_file_exists "$SPEC_DIR/user-auth/specification.md" "Spec moved to specification.md"
-assert_file_not_exists "$SPEC_DIR/user-auth.md" "Original flat file removed"
+  assert_eq "Topic directory created" "true" "$([ -d "$SPEC_DIR/user-auth" ] && echo true || echo false)"
+  assert_eq "Spec moved to specification.md" "true" "$([ -f "$SPEC_DIR/user-auth/specification.md" ] && echo true || echo false)"
+  assert_eq "Original flat file removed" "false" "$([ -f "$SPEC_DIR/user-auth.md" ] && echo true || echo false)"
 
-content=$(cat "$SPEC_DIR/user-auth/specification.md")
-assert_contains "$content" "topic: user-auth" "Content preserved after move"
-assert_contains "$output" "updated" "Reports update"
+  content=$(cat "$SPEC_DIR/user-auth/specification.md")
+  assert_eq "Content preserved after move" "true" "$(echo "$content" | grep -q 'topic: user-auth' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Planning flat file to topic directory ---
+test_plan_restructure() {
+  setup
 
-echo -e "${YELLOW}Test: Planning flat file → topic directory${NC}"
-setup_fixture
-cat > "$PLAN_DIR/billing.md" << 'EOF'
+  cat > "$PLAN_DIR/billing.md" << 'EOF'
 ---
 topic: billing
 status: in-progress
@@ -226,22 +90,24 @@ specification: billing.md
 Plan content.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_dir_exists "$PLAN_DIR/billing" "Topic directory created"
-assert_file_exists "$PLAN_DIR/billing/plan.md" "Plan moved to plan.md"
-assert_file_not_exists "$PLAN_DIR/billing.md" "Original flat file removed"
+  assert_eq "Topic directory created" "true" "$([ -d "$PLAN_DIR/billing" ] && echo true || echo false)"
+  assert_eq "Plan moved to plan.md" "true" "$([ -f "$PLAN_DIR/billing/plan.md" ] && echo true || echo false)"
+  assert_eq "Original flat file removed" "false" "$([ -f "$PLAN_DIR/billing.md" ] && echo true || echo false)"
 
-content=$(cat "$PLAN_DIR/billing/plan.md")
-assert_contains "$content" "topic: billing" "Content preserved after move"
+  content=$(cat "$PLAN_DIR/billing/plan.md")
+  assert_eq "Content preserved after move" "true" "$(echo "$content" | grep -q 'topic: billing' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Content preserved through spec restructure ---
+test_spec_content_preserved() {
+  setup
 
-echo -e "${YELLOW}Test: Content preserved through spec restructure${NC}"
-setup_fixture
-cat > "$SPEC_DIR/api-design.md" << 'TESTEOF'
+  cat > "$SPEC_DIR/api-design.md" << 'TESTEOF'
 ---
 topic: api-design
 status: concluded
@@ -264,19 +130,21 @@ Content with **bold** and `code`.
 | core | Needed first |
 TESTEOF
 
-original_content=$(cat "$SPEC_DIR/api-design.md")
-run_migration
-moved_content=$(cat "$SPEC_DIR/api-design/specification.md")
+  original_content=$(cat "$SPEC_DIR/api-design.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  moved_content=$(cat "$SPEC_DIR/api-design/specification.md")
 
-assert_equals "$moved_content" "$original_content" "Spec content exactly preserved through restructure"
+  assert_eq "Spec content exactly preserved through restructure" "$original_content" "$moved_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Content preserved through plan restructure ---
+test_plan_content_preserved() {
+  setup
 
-echo -e "${YELLOW}Test: Content preserved through plan restructure${NC}"
-setup_fixture
-cat > "$PLAN_DIR/caching.md" << 'TESTEOF'
+  cat > "$PLAN_DIR/caching.md" << 'TESTEOF'
 ---
 topic: caching
 status: in-progress
@@ -297,22 +165,22 @@ Plan content.
 - Task 2
 TESTEOF
 
-original_content=$(cat "$PLAN_DIR/caching.md")
-run_migration
-moved_content=$(cat "$PLAN_DIR/caching/plan.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  moved_content=$(cat "$PLAN_DIR/caching/plan.md")
 
-# Content same except specification field gets updated by Phase 3
-assert_contains "$moved_content" "topic: caching" "Topic preserved"
-assert_contains "$moved_content" "## Phase 1: Setup" "Body preserved"
+  assert_eq "Topic preserved" "true" "$(echo "$moved_content" | grep -q 'topic: caching' && echo true || echo false)"
+  assert_eq "Body preserved" "true" "$(echo "$moved_content" | grep -qF '## Phase 1: Setup' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Already restructured spec — skip ---
+test_already_restructured_spec() {
+  setup
 
-echo -e "${YELLOW}Test: Already restructured spec — skip${NC}"
-setup_fixture
-mkdir -p "$SPEC_DIR/existing"
-cat > "$SPEC_DIR/existing/specification.md" << 'EOF'
+  mkdir -p "$SPEC_DIR/existing"
+  cat > "$SPEC_DIR/existing/specification.md" << 'EOF'
 ---
 topic: existing
 status: concluded
@@ -327,21 +195,22 @@ date: 2024-05-15
 Already restructured.
 EOF
 
-original_content=$(cat "$SPEC_DIR/existing/specification.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$SPEC_DIR/existing/specification.md")
+  original_content=$(cat "$SPEC_DIR/existing/specification.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  new_content=$(cat "$SPEC_DIR/existing/specification.md")
 
-assert_equals "$new_content" "$original_content" "Already restructured spec unchanged"
-assert_not_contains "$output" "updated" "No update for already restructured spec"
+  assert_eq "Already restructured spec unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: Already restructured plan — skip ---
+test_already_restructured_plan() {
+  setup
 
-echo -e "${YELLOW}Test: Already restructured plan — skip${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/existing"
-cat > "$PLAN_DIR/existing/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/existing"
+  cat > "$PLAN_DIR/existing/plan.md" << 'EOF'
 ---
 topic: existing
 status: concluded
@@ -357,21 +226,22 @@ specification: existing/specification.md
 Already restructured.
 EOF
 
-original_content=$(cat "$PLAN_DIR/existing/plan.md")
-output=$(run_migration 2>&1)
-new_content=$(cat "$PLAN_DIR/existing/plan.md")
+  original_content=$(cat "$PLAN_DIR/existing/plan.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  new_content=$(cat "$PLAN_DIR/existing/plan.md")
 
-assert_equals "$new_content" "$original_content" "Already restructured plan unchanged"
-assert_not_contains "$output" "updated" "No update for already restructured plan"
+  assert_eq "Already restructured plan unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Plan frontmatter specification field updated ---
+test_spec_field_updated() {
+  setup
 
-echo -e "${YELLOW}Test: Plan frontmatter specification field updated${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/user-auth"
-cat > "$PLAN_DIR/user-auth/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/user-auth"
+  cat > "$PLAN_DIR/user-auth/plan.md" << 'EOF'
 ---
 topic: user-auth
 status: in-progress
@@ -387,19 +257,21 @@ specification: user-auth.md
 Content.
 EOF
 
-run_migration
-content=$(cat "$PLAN_DIR/user-auth/plan.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  content=$(cat "$PLAN_DIR/user-auth/plan.md")
 
-assert_contains "$content" "specification: user-auth/specification.md" "Specification field updated to directory path"
+  assert_eq "Specification field updated to directory path" "true" "$(echo "$content" | grep -q 'specification: user-auth/specification.md' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Specification field already updated — no change ---
+test_spec_field_already_updated() {
+  setup
 
-echo -e "${YELLOW}Test: Specification field already updated — no change${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/already-updated"
-cat > "$PLAN_DIR/already-updated/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/already-updated"
+  cat > "$PLAN_DIR/already-updated/plan.md" << 'EOF'
 ---
 topic: already-updated
 status: in-progress
@@ -415,20 +287,21 @@ specification: already-updated/specification.md
 Content.
 EOF
 
-original_content=$(cat "$PLAN_DIR/already-updated/plan.md")
-run_migration
-new_content=$(cat "$PLAN_DIR/already-updated/plan.md")
+  original_content=$(cat "$PLAN_DIR/already-updated/plan.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  new_content=$(cat "$PLAN_DIR/already-updated/plan.md")
 
-assert_equals "$new_content" "$original_content" "Already-updated specification field unchanged"
+  assert_eq "Already-updated specification field unchanged" "$original_content" "$new_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Multiple specs and plans restructured together ---
+test_multiple_restructured() {
+  setup
 
-echo -e "${YELLOW}Test: Multiple specs and plans restructured together${NC}"
-setup_fixture
-
-cat > "$SPEC_DIR/topic-a.md" << 'EOF'
+  cat > "$SPEC_DIR/topic-a.md" << 'EOF'
 ---
 topic: topic-a
 status: concluded
@@ -439,7 +312,7 @@ date: 2024-09-01
 # Spec A
 EOF
 
-cat > "$SPEC_DIR/topic-b.md" << 'EOF'
+  cat > "$SPEC_DIR/topic-b.md" << 'EOF'
 ---
 topic: topic-b
 status: in-progress
@@ -450,7 +323,7 @@ date: 2024-09-02
 # Spec B
 EOF
 
-cat > "$PLAN_DIR/topic-a.md" << 'EOF'
+  cat > "$PLAN_DIR/topic-a.md" << 'EOF'
 ---
 topic: topic-a
 status: in-progress
@@ -462,26 +335,27 @@ specification: topic-a.md
 # Plan A
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$SPEC_DIR/topic-a/specification.md" "Spec A restructured"
-assert_file_exists "$SPEC_DIR/topic-b/specification.md" "Spec B restructured"
-assert_file_exists "$PLAN_DIR/topic-a/plan.md" "Plan A restructured"
-assert_file_not_exists "$SPEC_DIR/topic-a.md" "Spec A flat file removed"
-assert_file_not_exists "$SPEC_DIR/topic-b.md" "Spec B flat file removed"
-assert_file_not_exists "$PLAN_DIR/topic-a.md" "Plan A flat file removed"
+  assert_eq "Spec A restructured" "true" "$([ -f "$SPEC_DIR/topic-a/specification.md" ] && echo true || echo false)"
+  assert_eq "Spec B restructured" "true" "$([ -f "$SPEC_DIR/topic-b/specification.md" ] && echo true || echo false)"
+  assert_eq "Plan A restructured" "true" "$([ -f "$PLAN_DIR/topic-a/plan.md" ] && echo true || echo false)"
+  assert_eq "Spec A flat file removed" "false" "$([ -f "$SPEC_DIR/topic-a.md" ] && echo true || echo false)"
+  assert_eq "Spec B flat file removed" "false" "$([ -f "$SPEC_DIR/topic-b.md" ] && echo true || echo false)"
+  assert_eq "Plan A flat file removed" "false" "$([ -f "$PLAN_DIR/topic-a.md" ] && echo true || echo false)"
 
-# Verify the plan's spec field was updated
-content=$(cat "$PLAN_DIR/topic-a/plan.md")
-assert_contains "$content" "specification: topic-a/specification.md" "Plan A spec field updated"
+  content=$(cat "$PLAN_DIR/topic-a/plan.md")
+  assert_eq "Plan A spec field updated" "true" "$(echo "$content" | grep -q 'specification: topic-a/specification.md' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: Idempotency (running migration twice) ---
+test_idempotency() {
+  setup
 
-echo -e "${YELLOW}Test: Idempotency (running migration twice)${NC}"
-setup_fixture
-cat > "$SPEC_DIR/idempotent.md" << 'EOF'
+  cat > "$SPEC_DIR/idempotent.md" << 'EOF'
 ---
 topic: idempotent
 status: concluded
@@ -492,29 +366,34 @@ date: 2024-10-01
 # Spec: Idempotent
 EOF
 
-run_migration
-first_content=$(cat "$SPEC_DIR/idempotent/specification.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  first_content=$(cat "$SPEC_DIR/idempotent/specification.md")
 
-# Run again — should skip since directory already exists
-output=$(run_migration 2>&1)
-second_content=$(cat "$SPEC_DIR/idempotent/specification.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  second_content=$(cat "$SPEC_DIR/idempotent/specification.md")
 
-assert_equals "$second_content" "$first_content" "Second run produces same result"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "Second run produces same result" "$first_content" "$second_content"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 006 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_spec_restructure
+test_plan_restructure
+test_spec_content_preserved
+test_plan_content_preserved
+test_already_restructured_spec
+test_already_restructured_plan
+test_spec_field_updated
+test_spec_field_already_updated
+test_multiple_restructured
+test_idempotency
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-007.sh
+++ b/tests/scripts/test-migration-007.sh
@@ -1,164 +1,47 @@
 #!/bin/bash
-#
-# Tests migration 007-tasks-subdirectory.sh
-# Validates moving task files into tasks/ subdirectory within plan topics.
-#
+# Tests for migration 007: tasks-subdirectory
+# Run: bash tests/scripts/test-migration-007.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/007-tasks-subdirectory.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/007-tasks-subdirectory.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-007-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/planning"
+  PLAN_DIR="$TEST_DIR/docs/workflow/planning"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/planning"
-    PLAN_DIR="$TEST_DIR/docs/workflow/planning"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-run_migration() {
-    cd "$TEST_DIR"
-    PLAN_DIR="$TEST_DIR/docs/workflow/planning"
-    source "$MIGRATION_SCRIPT"
-}
+# --- Test 1: Single task file moved to tasks/ ---
+test_single_task_moved() {
+  setup
 
-assert_file_exists() {
-    local file="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$file" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $file"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local file="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$file" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $file"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_exists() {
-    local dir="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -d "$dir" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory not found: $dir"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Single task file moved to tasks/${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/user-auth"
-cat > "$PLAN_DIR/user-auth/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/user-auth"
+  cat > "$PLAN_DIR/user-auth/plan.md" << 'EOF'
 ---
 topic: user-auth
 status: in-progress
@@ -168,27 +51,29 @@ format: local-markdown
 # Plan: User Auth
 EOF
 
-cat > "$PLAN_DIR/user-auth/user-auth-1-1.md" << 'EOF'
+  cat > "$PLAN_DIR/user-auth/user-auth-1-1.md" << 'EOF'
 # Task 1-1
 
 Task content.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_dir_exists "$PLAN_DIR/user-auth/tasks" "tasks/ subdirectory created"
-assert_file_exists "$PLAN_DIR/user-auth/tasks/user-auth-1-1.md" "Task file moved to tasks/"
-assert_file_not_exists "$PLAN_DIR/user-auth/user-auth-1-1.md" "Original task file removed"
-assert_file_exists "$PLAN_DIR/user-auth/plan.md" "plan.md untouched"
+  assert_eq "tasks/ subdirectory created" "true" "$([ -d "$PLAN_DIR/user-auth/tasks" ] && echo true || echo false)"
+  assert_eq "Task file moved to tasks/" "true" "$([ -f "$PLAN_DIR/user-auth/tasks/user-auth-1-1.md" ] && echo true || echo false)"
+  assert_eq "Original task file removed" "false" "$([ -f "$PLAN_DIR/user-auth/user-auth-1-1.md" ] && echo true || echo false)"
+  assert_eq "plan.md untouched" "true" "$([ -f "$PLAN_DIR/user-auth/plan.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Multiple task files moved ---
+test_multiple_tasks_moved() {
+  setup
 
-echo -e "${YELLOW}Test: Multiple task files moved${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/billing"
-cat > "$PLAN_DIR/billing/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/billing"
+  cat > "$PLAN_DIR/billing/plan.md" << 'EOF'
 ---
 topic: billing
 status: in-progress
@@ -198,35 +83,37 @@ format: local-markdown
 # Plan: Billing
 EOF
 
-cat > "$PLAN_DIR/billing/billing-1-1.md" << 'EOF'
+  cat > "$PLAN_DIR/billing/billing-1-1.md" << 'EOF'
 # Task 1-1
 EOF
 
-cat > "$PLAN_DIR/billing/billing-1-2.md" << 'EOF'
+  cat > "$PLAN_DIR/billing/billing-1-2.md" << 'EOF'
 # Task 1-2
 EOF
 
-cat > "$PLAN_DIR/billing/billing-2-1.md" << 'EOF'
+  cat > "$PLAN_DIR/billing/billing-2-1.md" << 'EOF'
 # Task 2-1
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$PLAN_DIR/billing/tasks/billing-1-1.md" "First task moved"
-assert_file_exists "$PLAN_DIR/billing/tasks/billing-1-2.md" "Second task moved"
-assert_file_exists "$PLAN_DIR/billing/tasks/billing-2-1.md" "Third task moved"
-assert_file_not_exists "$PLAN_DIR/billing/billing-1-1.md" "First original removed"
-assert_file_not_exists "$PLAN_DIR/billing/billing-1-2.md" "Second original removed"
-assert_file_not_exists "$PLAN_DIR/billing/billing-2-1.md" "Third original removed"
+  assert_eq "First task moved" "true" "$([ -f "$PLAN_DIR/billing/tasks/billing-1-1.md" ] && echo true || echo false)"
+  assert_eq "Second task moved" "true" "$([ -f "$PLAN_DIR/billing/tasks/billing-1-2.md" ] && echo true || echo false)"
+  assert_eq "Third task moved" "true" "$([ -f "$PLAN_DIR/billing/tasks/billing-2-1.md" ] && echo true || echo false)"
+  assert_eq "First original removed" "false" "$([ -f "$PLAN_DIR/billing/billing-1-1.md" ] && echo true || echo false)"
+  assert_eq "Second original removed" "false" "$([ -f "$PLAN_DIR/billing/billing-1-2.md" ] && echo true || echo false)"
+  assert_eq "Third original removed" "false" "$([ -f "$PLAN_DIR/billing/billing-2-1.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Review/tracking files NOT moved ---
+test_review_files_not_moved() {
+  setup
 
-echo -e "${YELLOW}Test: Review/tracking files NOT moved${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/api"
-cat > "$PLAN_DIR/api/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/api"
+  cat > "$PLAN_DIR/api/plan.md" << 'EOF'
 ---
 topic: api
 status: in-progress
@@ -236,29 +123,31 @@ format: local-markdown
 # Plan: API
 EOF
 
-cat > "$PLAN_DIR/api/api-1-1.md" << 'EOF'
+  cat > "$PLAN_DIR/api/api-1-1.md" << 'EOF'
 # Task 1-1
 EOF
 
-cat > "$PLAN_DIR/api/review-traceability-tracking-c1.md" << 'EOF'
+  cat > "$PLAN_DIR/api/review-traceability-tracking-c1.md" << 'EOF'
 # Review Tracking
 
 Tracking content.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$PLAN_DIR/api/tasks/api-1-1.md" "Task file moved"
-assert_file_exists "$PLAN_DIR/api/review-traceability-tracking-c1.md" "Review file stays in place"
+  assert_eq "Task file moved" "true" "$([ -f "$PLAN_DIR/api/tasks/api-1-1.md" ] && echo true || echo false)"
+  assert_eq "Review file stays in place" "true" "$([ -f "$PLAN_DIR/api/review-traceability-tracking-c1.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: No task files — skip ---
+test_no_task_files() {
+  setup
 
-echo -e "${YELLOW}Test: No task files — skip${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/beads-plan"
-cat > "$PLAN_DIR/beads-plan/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/beads-plan"
+  cat > "$PLAN_DIR/beads-plan/plan.md" << 'EOF'
 ---
 topic: beads-plan
 status: in-progress
@@ -268,35 +157,37 @@ format: beads
 # Plan: Beads Plan
 EOF
 
-output=$(run_migration 2>&1)
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_contains "$output" "skipped" "Skipped when no task files"
-assert_file_exists "$PLAN_DIR/beads-plan/plan.md" "plan.md untouched"
+  assert_eq "plan.md untouched" "true" "$([ -f "$PLAN_DIR/beads-plan/plan.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: No plan.md — skip entirely ---
+test_no_plan_md() {
+  setup
 
-echo -e "${YELLOW}Test: No plan.md — skip entirely${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/orphan"
-cat > "$PLAN_DIR/orphan/orphan-1-1.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/orphan"
+  cat > "$PLAN_DIR/orphan/orphan-1-1.md" << 'EOF'
 # Orphan task
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# Task file should NOT be moved since there's no plan.md
-assert_file_exists "$PLAN_DIR/orphan/orphan-1-1.md" "Task file stays when no plan.md"
+  assert_eq "Task file stays when no plan.md" "true" "$([ -f "$PLAN_DIR/orphan/orphan-1-1.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: Tasks already in tasks/ — idempotent skip ---
+test_already_moved() {
+  setup
 
-echo -e "${YELLOW}Test: Tasks already in tasks/ — idempotent skip${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/done/tasks"
-cat > "$PLAN_DIR/done/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/done/tasks"
+  cat > "$PLAN_DIR/done/plan.md" << 'EOF'
 ---
 topic: done
 status: concluded
@@ -306,23 +197,24 @@ format: local-markdown
 # Plan: Done
 EOF
 
-cat > "$PLAN_DIR/done/tasks/done-1-1.md" << 'EOF'
+  cat > "$PLAN_DIR/done/tasks/done-1-1.md" << 'EOF'
 # Task 1-1
 EOF
 
-output=$(run_migration 2>&1)
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_contains "$output" "skipped" "Skipped when tasks already moved"
-assert_file_exists "$PLAN_DIR/done/tasks/done-1-1.md" "Existing task file untouched"
+  assert_eq "Existing task file untouched" "true" "$([ -f "$PLAN_DIR/done/tasks/done-1-1.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Task content preserved after move ---
+test_content_preserved() {
+  setup
 
-echo -e "${YELLOW}Test: Task content preserved after move${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/preserve"
-cat > "$PLAN_DIR/preserve/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/preserve"
+  cat > "$PLAN_DIR/preserve/plan.md" << 'EOF'
 ---
 topic: preserve
 status: in-progress
@@ -332,7 +224,7 @@ format: local-markdown
 # Plan: Preserve
 EOF
 
-cat > "$PLAN_DIR/preserve/preserve-1-1.md" << 'TESTEOF'
+  cat > "$PLAN_DIR/preserve/preserve-1-1.md" << 'TESTEOF'
 ---
 task_id: preserve-1-1
 title: Setup Database
@@ -366,20 +258,22 @@ CREATE TABLE users (
 ```
 TESTEOF
 
-original_content=$(cat "$PLAN_DIR/preserve/preserve-1-1.md")
-run_migration
-moved_content=$(cat "$PLAN_DIR/preserve/tasks/preserve-1-1.md")
+  original_content=$(cat "$PLAN_DIR/preserve/preserve-1-1.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  moved_content=$(cat "$PLAN_DIR/preserve/tasks/preserve-1-1.md")
 
-assert_equals "$moved_content" "$original_content" "Task file content exactly preserved after move"
+  assert_eq "Task file content exactly preserved after move" "$original_content" "$moved_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Idempotency (running migration twice) ---
+test_idempotency() {
+  setup
 
-echo -e "${YELLOW}Test: Idempotency (running migration twice)${NC}"
-setup_fixture
-mkdir -p "$PLAN_DIR/idem"
-cat > "$PLAN_DIR/idem/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/idem"
+  cat > "$PLAN_DIR/idem/plan.md" << 'EOF'
 ---
 topic: idem
 status: in-progress
@@ -389,72 +283,78 @@ format: local-markdown
 # Plan: Idem
 EOF
 
-cat > "$PLAN_DIR/idem/idem-1-1.md" << 'EOF'
+  cat > "$PLAN_DIR/idem/idem-1-1.md" << 'EOF'
 # Task 1-1
 EOF
 
-run_migration
-first_content=$(cat "$PLAN_DIR/idem/tasks/idem-1-1.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  first_content=$(cat "$PLAN_DIR/idem/tasks/idem-1-1.md")
 
-# Run again — should skip
-run_migration
-second_content=$(cat "$PLAN_DIR/idem/tasks/idem-1-1.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  second_content=$(cat "$PLAN_DIR/idem/tasks/idem-1-1.md")
 
-assert_equals "$second_content" "$first_content" "Second run produces same result"
+  assert_eq "Second run produces same result" "$first_content" "$second_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Multiple topics processed independently ---
+test_multiple_topics() {
+  setup
 
-echo -e "${YELLOW}Test: Multiple topics processed independently${NC}"
-setup_fixture
-
-mkdir -p "$PLAN_DIR/topic-a"
-cat > "$PLAN_DIR/topic-a/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/topic-a"
+  cat > "$PLAN_DIR/topic-a/plan.md" << 'EOF'
 ---
 topic: topic-a
 format: local-markdown
 ---
 # Plan A
 EOF
-cat > "$PLAN_DIR/topic-a/topic-a-1-1.md" << 'EOF'
+  cat > "$PLAN_DIR/topic-a/topic-a-1-1.md" << 'EOF'
 # Task A-1-1
 EOF
 
-mkdir -p "$PLAN_DIR/topic-b"
-cat > "$PLAN_DIR/topic-b/plan.md" << 'EOF'
+  mkdir -p "$PLAN_DIR/topic-b"
+  cat > "$PLAN_DIR/topic-b/plan.md" << 'EOF'
 ---
 topic: topic-b
 format: local-markdown
 ---
 # Plan B
 EOF
-cat > "$PLAN_DIR/topic-b/topic-b-1-1.md" << 'EOF'
+  cat > "$PLAN_DIR/topic-b/topic-b-1-1.md" << 'EOF'
 # Task B-1-1
 EOF
-cat > "$PLAN_DIR/topic-b/topic-b-1-2.md" << 'EOF'
+  cat > "$PLAN_DIR/topic-b/topic-b-1-2.md" << 'EOF'
 # Task B-1-2
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$PLAN_DIR/topic-a/tasks/topic-a-1-1.md" "Topic A task moved"
-assert_file_exists "$PLAN_DIR/topic-b/tasks/topic-b-1-1.md" "Topic B first task moved"
-assert_file_exists "$PLAN_DIR/topic-b/tasks/topic-b-1-2.md" "Topic B second task moved"
+  assert_eq "Topic A task moved" "true" "$([ -f "$PLAN_DIR/topic-a/tasks/topic-a-1-1.md" ] && echo true || echo false)"
+  assert_eq "Topic B first task moved" "true" "$([ -f "$PLAN_DIR/topic-b/tasks/topic-b-1-1.md" ] && echo true || echo false)"
+  assert_eq "Topic B second task moved" "true" "$([ -f "$PLAN_DIR/topic-b/tasks/topic-b-1-2.md" ] && echo true || echo false)"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 007 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_single_task_moved
+test_multiple_tasks_moved
+test_review_files_not_moved
+test_no_task_files
+test_no_plan_md
+test_already_moved
+test_content_preserved
+test_idempotency
+test_multiple_topics
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-008.sh
+++ b/tests/scripts/test-migration-008.sh
@@ -1,383 +1,263 @@
 #!/bin/bash
-#
-# Tests migration 008-review-directory-structure.sh
-# Validates moving flat review files into versioned r1/ directory structure.
-#
+# Tests for migration 008: review-directory-structure
+# Run: bash tests/scripts/test-migration-008.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/008-review-directory-structure.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/008-review-directory-structure.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-008-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/review"
+  REVIEW_DIR="$TEST_DIR/docs/workflow/review"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/review"
-    REVIEW_DIR="$TEST_DIR/docs/workflow/review"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-run_migration() {
-    cd "$TEST_DIR"
-    REVIEW_DIR="$TEST_DIR/docs/workflow/review"
-    source "$MIGRATION_SCRIPT"
-}
+# --- Test 1: Simple review — summary + QA files moved to r1/ ---
+test_simple_review() {
+  setup
 
-assert_file_exists() {
-    local file="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$file" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $file"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local file="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$file" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $file"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_exists() {
-    local dir="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -d "$dir" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory not found: $dir"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Simple review — summary + QA files moved to r1/${NC}"
-setup_fixture
-
-cat > "$REVIEW_DIR/tick-core.md" << 'EOF'
+  cat > "$REVIEW_DIR/tick-core.md" << 'EOF'
 # Review: Tick Core
 
 Summary of the review.
 EOF
 
-mkdir -p "$REVIEW_DIR/tick-core"
-cat > "$REVIEW_DIR/tick-core/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/tick-core"
+  cat > "$REVIEW_DIR/tick-core/qa-task-1.md" << 'EOF'
 # QA Task 1
 Findings.
 EOF
-cat > "$REVIEW_DIR/tick-core/qa-task-2.md" << 'EOF'
+  cat > "$REVIEW_DIR/tick-core/qa-task-2.md" << 'EOF'
 # QA Task 2
 More findings.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_dir_exists "$REVIEW_DIR/tick-core/r1" "r1/ directory created"
-assert_file_exists "$REVIEW_DIR/tick-core/r1/review.md" "Summary moved to r1/review.md"
-assert_file_exists "$REVIEW_DIR/tick-core/r1/qa-task-1.md" "QA task 1 moved to r1/"
-assert_file_exists "$REVIEW_DIR/tick-core/r1/qa-task-2.md" "QA task 2 moved to r1/"
-assert_file_not_exists "$REVIEW_DIR/tick-core.md" "Original summary removed"
+  assert_eq "r1/ directory created" "true" "$([ -d "$REVIEW_DIR/tick-core/r1" ] && echo true || echo false)"
+  assert_eq "Summary moved to r1/review.md" "true" "$([ -f "$REVIEW_DIR/tick-core/r1/review.md" ] && echo true || echo false)"
+  assert_eq "QA task 1 moved to r1/" "true" "$([ -f "$REVIEW_DIR/tick-core/r1/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "QA task 2 moved to r1/" "true" "$([ -f "$REVIEW_DIR/tick-core/r1/qa-task-2.md" ] && echo true || echo false)"
+  assert_eq "Original summary removed" "false" "$([ -f "$REVIEW_DIR/tick-core.md" ] && echo true || echo false)"
 
-# Content preserved
-content=$(cat "$REVIEW_DIR/tick-core/r1/review.md")
-assert_contains "$content" "Summary of the review" "Summary content preserved"
+  content=$(cat "$REVIEW_DIR/tick-core/r1/review.md")
+  assert_eq "Summary content preserved" "true" "$(echo "$content" | grep -qF 'Summary of the review' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Review with product-assessment.md ---
+test_product_assessment() {
+  setup
 
-echo -e "${YELLOW}Test: Review with product-assessment.md${NC}"
-setup_fixture
-
-cat > "$REVIEW_DIR/installation.md" << 'EOF'
+  cat > "$REVIEW_DIR/installation.md" << 'EOF'
 # Review: Installation
 Summary.
 EOF
 
-mkdir -p "$REVIEW_DIR/installation"
-cat > "$REVIEW_DIR/installation/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/installation"
+  cat > "$REVIEW_DIR/installation/qa-task-1.md" << 'EOF'
 # QA 1
 EOF
-cat > "$REVIEW_DIR/installation/product-assessment.md" << 'EOF'
+  cat > "$REVIEW_DIR/installation/product-assessment.md" << 'EOF'
 # Product Assessment
 Assessment content.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$REVIEW_DIR/installation/r1/review.md" "Summary moved"
-assert_file_exists "$REVIEW_DIR/installation/r1/qa-task-1.md" "QA task moved"
-assert_file_exists "$REVIEW_DIR/installation/r1/product-assessment.md" "Product assessment moved to r1/"
+  assert_eq "Summary moved" "true" "$([ -f "$REVIEW_DIR/installation/r1/review.md" ] && echo true || echo false)"
+  assert_eq "QA task moved" "true" "$([ -f "$REVIEW_DIR/installation/r1/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "Product assessment moved to r1/" "true" "$([ -f "$REVIEW_DIR/installation/r1/product-assessment.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Multi-plan review — per-plan QA subdirectories moved ---
+test_multi_plan_review() {
+  setup
 
-echo -e "${YELLOW}Test: Multi-plan review — per-plan QA subdirectories moved${NC}"
-setup_fixture
-
-cat > "$REVIEW_DIR/doctor-installation-migration.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-installation-migration.md" << 'EOF'
 # Review: Doctor + Installation + Migration
 Multi-plan summary.
 EOF
 
-mkdir -p "$REVIEW_DIR/doctor-installation-migration"
-cat > "$REVIEW_DIR/doctor-installation-migration/product-assessment.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/doctor-installation-migration"
+  cat > "$REVIEW_DIR/doctor-installation-migration/product-assessment.md" << 'EOF'
 # Product Assessment
 EOF
 
-mkdir -p "$REVIEW_DIR/doctor-installation-migration/installation"
-cat > "$REVIEW_DIR/doctor-installation-migration/installation/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/doctor-installation-migration/installation"
+  cat > "$REVIEW_DIR/doctor-installation-migration/installation/qa-task-1.md" << 'EOF'
 # Installation QA 1
 EOF
-cat > "$REVIEW_DIR/doctor-installation-migration/installation/qa-task-2.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-installation-migration/installation/qa-task-2.md" << 'EOF'
 # Installation QA 2
 EOF
 
-mkdir -p "$REVIEW_DIR/doctor-installation-migration/migration"
-cat > "$REVIEW_DIR/doctor-installation-migration/migration/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/doctor-installation-migration/migration"
+  cat > "$REVIEW_DIR/doctor-installation-migration/migration/qa-task-1.md" << 'EOF'
 # Migration QA 1
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$REVIEW_DIR/doctor-installation-migration/r1/review.md" "Summary moved"
-assert_file_exists "$REVIEW_DIR/doctor-installation-migration/r1/product-assessment.md" "Product assessment moved"
-assert_dir_exists "$REVIEW_DIR/doctor-installation-migration/r1/installation" "Per-plan subdir moved to r1/"
-assert_file_exists "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-1.md" "Subdir QA file preserved"
-assert_file_exists "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-2.md" "Subdir QA file 2 preserved"
-assert_dir_exists "$REVIEW_DIR/doctor-installation-migration/r1/migration" "Second per-plan subdir moved"
-assert_file_exists "$REVIEW_DIR/doctor-installation-migration/r1/migration/qa-task-1.md" "Second subdir QA preserved"
+  assert_eq "Summary moved" "true" "$([ -f "$REVIEW_DIR/doctor-installation-migration/r1/review.md" ] && echo true || echo false)"
+  assert_eq "Product assessment moved" "true" "$([ -f "$REVIEW_DIR/doctor-installation-migration/r1/product-assessment.md" ] && echo true || echo false)"
+  assert_eq "Per-plan subdir moved to r1/" "true" "$([ -d "$REVIEW_DIR/doctor-installation-migration/r1/installation" ] && echo true || echo false)"
+  assert_eq "Subdir QA file preserved" "true" "$([ -f "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "Subdir QA file 2 preserved" "true" "$([ -f "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-2.md" ] && echo true || echo false)"
+  assert_eq "Second per-plan subdir moved" "true" "$([ -d "$REVIEW_DIR/doctor-installation-migration/r1/migration" ] && echo true || echo false)"
+  assert_eq "Second subdir QA preserved" "true" "$([ -f "$REVIEW_DIR/doctor-installation-migration/r1/migration/qa-task-1.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Summary file without matching directory ---
+test_standalone_summary() {
+  setup
 
-echo -e "${YELLOW}Test: Summary file without matching directory${NC}"
-setup_fixture
-
-cat > "$REVIEW_DIR/standalone.md" << 'EOF'
+  cat > "$REVIEW_DIR/standalone.md" << 'EOF'
 # Review: Standalone
 Just a summary, no QA directory.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_dir_exists "$REVIEW_DIR/standalone/r1" "r1/ created even without pre-existing dir"
-assert_file_exists "$REVIEW_DIR/standalone/r1/review.md" "Summary moved to r1/review.md"
-assert_file_not_exists "$REVIEW_DIR/standalone.md" "Original summary removed"
+  assert_eq "r1/ created even without pre-existing dir" "true" "$([ -d "$REVIEW_DIR/standalone/r1" ] && echo true || echo false)"
+  assert_eq "Summary moved to r1/review.md" "true" "$([ -f "$REVIEW_DIR/standalone/r1/review.md" ] && echo true || echo false)"
+  assert_eq "Original summary removed" "false" "$([ -f "$REVIEW_DIR/standalone.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: r1/ already exists — idempotent skip ---
+test_already_migrated() {
+  setup
 
-echo -e "${YELLOW}Test: r1/ already exists — idempotent skip${NC}"
-setup_fixture
-
-mkdir -p "$REVIEW_DIR/done/r1"
-cat > "$REVIEW_DIR/done/r1/review.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/done/r1"
+  cat > "$REVIEW_DIR/done/r1/review.md" << 'EOF'
 # Review: Done
 Already migrated.
 EOF
 
-# Put a stale .md at root level — should be ignored since r1/ exists
-cat > "$REVIEW_DIR/done.md" << 'EOF'
+  cat > "$REVIEW_DIR/done.md" << 'EOF'
 # Stale summary
 EOF
 
-original_r1=$(cat "$REVIEW_DIR/done/r1/review.md")
-output=$(run_migration 2>&1)
+  original_r1=$(cat "$REVIEW_DIR/done/r1/review.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  new_r1=$(cat "$REVIEW_DIR/done/r1/review.md")
 
-new_r1=$(cat "$REVIEW_DIR/done/r1/review.md")
-assert_equals "$new_r1" "$original_r1" "Existing r1/ content unchanged"
-assert_contains "$output" "skipped" "Skipped when r1/ exists"
+  assert_eq "Existing r1/ content unchanged" "$original_r1" "$new_r1"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: No review directory — early return ---
+test_no_review_dir() {
+  setup
+  rm -rf "$TEST_DIR/docs/workflow/review"
 
-echo -e "${YELLOW}Test: No review directory — early return${NC}"
-rm -rf "$TEST_DIR/docs"
-mkdir -p "$TEST_DIR/docs/workflow"
-# No review dir at all
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-REVIEW_DIR="$TEST_DIR/docs/workflow/review"
-cd "$TEST_DIR"
-source "$MIGRATION_SCRIPT"
-# Should not error — early return 0
+  assert_eq "No error when review directory missing" "true" "true"
 
-TESTS_RUN=$((TESTS_RUN + 1))
-echo -e "  ${GREEN}✓${NC} No error when review directory missing"
-TESTS_PASSED=$((TESTS_PASSED + 1))
+  teardown
+}
 
-echo ""
+# --- Test 7: Idempotency — running migration twice ---
+test_idempotency() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Idempotency — running migration twice${NC}"
-setup_fixture
-
-cat > "$REVIEW_DIR/idem.md" << 'EOF'
+  cat > "$REVIEW_DIR/idem.md" << 'EOF'
 # Review: Idempotent Test
 Summary content.
 EOF
 
-mkdir -p "$REVIEW_DIR/idem"
-cat > "$REVIEW_DIR/idem/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/idem"
+  cat > "$REVIEW_DIR/idem/qa-task-1.md" << 'EOF'
 # QA 1
 EOF
 
-run_migration
-first_content=$(cat "$REVIEW_DIR/idem/r1/review.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  first_content=$(cat "$REVIEW_DIR/idem/r1/review.md")
 
-# Run again
-run_migration
-second_content=$(cat "$REVIEW_DIR/idem/r1/review.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  second_content=$(cat "$REVIEW_DIR/idem/r1/review.md")
 
-assert_equals "$second_content" "$first_content" "Second run produces same result"
+  assert_eq "Second run produces same result" "$first_content" "$second_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Many QA files moved correctly ---
+test_many_qa_files() {
+  setup
 
-echo -e "${YELLOW}Test: Many QA files moved correctly${NC}"
-setup_fixture
-
-cat > "$REVIEW_DIR/big-review.md" << 'EOF'
+  cat > "$REVIEW_DIR/big-review.md" << 'EOF'
 # Review: Big Review
 Many tasks.
 EOF
 
-mkdir -p "$REVIEW_DIR/big-review"
-for i in $(seq 1 20); do
+  mkdir -p "$REVIEW_DIR/big-review"
+  for i in $(seq 1 20); do
     cat > "$REVIEW_DIR/big-review/qa-task-${i}.md" << EOF
 # QA Task $i
 Finding $i.
 EOF
-done
+  done
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-for i in $(seq 1 20); do
-    assert_file_exists "$REVIEW_DIR/big-review/r1/qa-task-${i}.md" "QA task $i moved to r1/"
-done
+  for i in $(seq 1 20); do
+    assert_eq "QA task $i moved to r1/" "true" "$([ -f "$REVIEW_DIR/big-review/r1/qa-task-${i}.md" ] && echo true || echo false)"
+  done
 
-# Verify content of a sample
-content=$(cat "$REVIEW_DIR/big-review/r1/qa-task-15.md")
-assert_contains "$content" "Finding 15" "QA task 15 content preserved"
+  content=$(cat "$REVIEW_DIR/big-review/r1/qa-task-15.md")
+  assert_eq "QA task 15 content preserved" "true" "$(echo "$content" | grep -qF 'Finding 15' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Content preservation — complex review file ---
+test_complex_content_preserved() {
+  setup
 
-echo -e "${YELLOW}Test: Content preservation — complex review file${NC}"
-setup_fixture
-
-cat > "$REVIEW_DIR/complex.md" << 'TESTEOF'
+  cat > "$REVIEW_DIR/complex.md" << 'TESTEOF'
 # Review: Complex
 
 ## Summary
@@ -401,57 +281,64 @@ tick create "test task" --priority 1
 - Finding with special chars: @#$%
 TESTEOF
 
-mkdir -p "$REVIEW_DIR/complex"
-original=$(cat "$REVIEW_DIR/complex.md")
+  mkdir -p "$REVIEW_DIR/complex"
+  original=$(cat "$REVIEW_DIR/complex.md")
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  moved=$(cat "$REVIEW_DIR/complex/r1/review.md")
 
-moved=$(cat "$REVIEW_DIR/complex/r1/review.md")
-assert_equals "$moved" "$original" "Complex content exactly preserved"
+  assert_eq "Complex content exactly preserved" "$original" "$moved"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: Multiple reviews processed in one run ---
+test_multiple_reviews() {
+  setup
 
-echo -e "${YELLOW}Test: Multiple reviews processed in one run${NC}"
-setup_fixture
-
-cat > "$REVIEW_DIR/review-a.md" << 'EOF'
+  cat > "$REVIEW_DIR/review-a.md" << 'EOF'
 # Review A
 EOF
-mkdir -p "$REVIEW_DIR/review-a"
-cat > "$REVIEW_DIR/review-a/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/review-a"
+  cat > "$REVIEW_DIR/review-a/qa-task-1.md" << 'EOF'
 # QA A-1
 EOF
 
-cat > "$REVIEW_DIR/review-b.md" << 'EOF'
+  cat > "$REVIEW_DIR/review-b.md" << 'EOF'
 # Review B
 EOF
-mkdir -p "$REVIEW_DIR/review-b"
-cat > "$REVIEW_DIR/review-b/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/review-b"
+  cat > "$REVIEW_DIR/review-b/qa-task-1.md" << 'EOF'
 # QA B-1
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$REVIEW_DIR/review-a/r1/review.md" "Review A migrated"
-assert_file_exists "$REVIEW_DIR/review-a/r1/qa-task-1.md" "Review A QA moved"
-assert_file_exists "$REVIEW_DIR/review-b/r1/review.md" "Review B migrated"
-assert_file_exists "$REVIEW_DIR/review-b/r1/qa-task-1.md" "Review B QA moved"
+  assert_eq "Review A migrated" "true" "$([ -f "$REVIEW_DIR/review-a/r1/review.md" ] && echo true || echo false)"
+  assert_eq "Review A QA moved" "true" "$([ -f "$REVIEW_DIR/review-a/r1/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "Review B migrated" "true" "$([ -f "$REVIEW_DIR/review-b/r1/review.md" ] && echo true || echo false)"
+  assert_eq "Review B QA moved" "true" "$([ -f "$REVIEW_DIR/review-b/r1/qa-task-1.md" ] && echo true || echo false)"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 008 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_simple_review
+test_product_assessment
+test_multi_plan_review
+test_standalone_summary
+test_already_migrated
+test_no_review_dir
+test_idempotency
+test_many_qa_files
+test_complex_content_preserved
+test_multiple_reviews
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-009.sh
+++ b/tests/scripts/test-migration-009.sh
@@ -1,407 +1,273 @@
 #!/bin/bash
-#
-# Tests migration 009-review-per-plan-storage.sh
-# Validates restructuring of review directories to per-plan storage.
-#
+# Tests for migration 009: review-per-plan-storage
+# Run: bash tests/scripts/test-migration-009.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/009-review-per-plan-storage.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/009-review-per-plan-storage.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-009-test.XXXXXX)
+  mkdir -p "$TEST_DIR/docs/workflow/review"
+  REVIEW_DIR="$TEST_DIR/docs/workflow/review"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    mkdir -p "$TEST_DIR/docs/workflow/review"
-    REVIEW_DIR="$TEST_DIR/docs/workflow/review"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-run_migration() {
-    cd "$TEST_DIR"
-    REVIEW_DIR="$TEST_DIR/docs/workflow/review"
-    source "$MIGRATION_SCRIPT"
-}
+# --- Test 1: Product assessment files deleted ---
+test_product_assessment_deleted() {
+  setup
 
-assert_file_exists() {
-    local file="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$file" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $file"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local file="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$file" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $file"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_exists() {
-    local dir="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -d "$dir" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory not found: $dir"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Phase 1 — Product assessment files deleted${NC}"
-setup_fixture
-
-mkdir -p "$REVIEW_DIR/tick-core/r1"
-cat > "$REVIEW_DIR/tick-core/r1/review.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/tick-core/r1"
+  cat > "$REVIEW_DIR/tick-core/r1/review.md" << 'EOF'
 # Review
 EOF
-cat > "$REVIEW_DIR/tick-core/r1/product-assessment.md" << 'EOF'
+  cat > "$REVIEW_DIR/tick-core/r1/product-assessment.md" << 'EOF'
 PLANS_REVIEWED: tick-core
 ROBUSTNESS: Good
 EOF
 
-output=$(run_migration 2>&1)
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_not_exists "$REVIEW_DIR/tick-core/r1/product-assessment.md" "Product assessment deleted"
-assert_file_exists "$REVIEW_DIR/tick-core/r1/review.md" "review.md preserved"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "product assessment deleted" "false" "$([ -f "$REVIEW_DIR/tick-core/r1/product-assessment.md" ] && echo true || echo false)"
+  assert_eq "review.md preserved" "true" "$([ -f "$REVIEW_DIR/tick-core/r1/review.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Multiple product assessments all deleted ---
+test_multiple_product_assessments() {
+  setup
 
-echo -e "${YELLOW}Test: Phase 1 — Multiple product assessments all deleted${NC}"
-setup_fixture
-
-mkdir -p "$REVIEW_DIR/plan-a/r1"
-cat > "$REVIEW_DIR/plan-a/r1/product-assessment.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/plan-a/r1"
+  cat > "$REVIEW_DIR/plan-a/r1/product-assessment.md" << 'EOF'
 PLANS_REVIEWED: plan-a
 EOF
 
-mkdir -p "$REVIEW_DIR/plan-b/r1"
-cat > "$REVIEW_DIR/plan-b/r1/product-assessment.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/plan-b/r1"
+  cat > "$REVIEW_DIR/plan-b/r1/product-assessment.md" << 'EOF'
 PLANS_REVIEWED: plan-b
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_not_exists "$REVIEW_DIR/plan-a/r1/product-assessment.md" "plan-a PA deleted"
-assert_file_not_exists "$REVIEW_DIR/plan-b/r1/product-assessment.md" "plan-b PA deleted"
+  assert_eq "plan-a PA deleted" "false" "$([ -f "$REVIEW_DIR/plan-a/r1/product-assessment.md" ] && echo true || echo false)"
+  assert_eq "plan-b PA deleted" "false" "$([ -f "$REVIEW_DIR/plan-b/r1/product-assessment.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Multi-plan QA subdirs moved to per-plan dirs ---
+test_multi_plan_qa_moved() {
+  setup
 
-echo -e "${YELLOW}Test: Phase 2 — Multi-plan QA subdirs moved to per-plan dirs${NC}"
-setup_fixture
-
-# Simulate: review/doctor-installation-migration/r1/{plan}/qa-task-*.md
-mkdir -p "$REVIEW_DIR/doctor-installation-migration/r1/installation"
-cat > "$REVIEW_DIR/doctor-installation-migration/r1/review.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/doctor-installation-migration/r1/installation"
+  cat > "$REVIEW_DIR/doctor-installation-migration/r1/review.md" << 'EOF'
 # Aggregate Review
 EOF
-cat > "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-1.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-1.md" << 'EOF'
 # QA 1
 EOF
-cat > "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-2.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-2.md" << 'EOF'
 # QA 2
 EOF
 
-mkdir -p "$REVIEW_DIR/doctor-installation-migration/r1/migration"
-cat > "$REVIEW_DIR/doctor-installation-migration/r1/migration/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/doctor-installation-migration/r1/migration"
+  cat > "$REVIEW_DIR/doctor-installation-migration/r1/migration/qa-task-1.md" << 'EOF'
 # Migration QA 1
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$REVIEW_DIR/installation/r1/qa-task-1.md" "installation QA 1 moved to per-plan dir"
-assert_file_exists "$REVIEW_DIR/installation/r1/qa-task-2.md" "installation QA 2 moved to per-plan dir"
-assert_file_exists "$REVIEW_DIR/migration/r1/qa-task-1.md" "migration QA 1 moved to per-plan dir"
-assert_file_not_exists "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-1.md" "Source QA removed"
-# Aggregate review.md stays (historical artifact)
-assert_file_exists "$REVIEW_DIR/doctor-installation-migration/r1/review.md" "Aggregate review.md preserved"
+  assert_eq "installation QA 1 moved to per-plan dir" "true" "$([ -f "$REVIEW_DIR/installation/r1/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "installation QA 2 moved to per-plan dir" "true" "$([ -f "$REVIEW_DIR/installation/r1/qa-task-2.md" ] && echo true || echo false)"
+  assert_eq "migration QA 1 moved to per-plan dir" "true" "$([ -f "$REVIEW_DIR/migration/r1/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "source QA removed" "false" "$([ -f "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "aggregate review.md preserved" "true" "$([ -f "$REVIEW_DIR/doctor-installation-migration/r1/review.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Orphaned QA files at topic root moved into r1/ ---
+test_orphaned_qa_moved() {
+  setup
 
-echo -e "${YELLOW}Test: Phase 3 — Orphaned QA files at topic root moved into r1/${NC}"
-setup_fixture
-
-# Simulate: review/doctor-validation/qa-task-*.md (no r1/)
-mkdir -p "$REVIEW_DIR/doctor-validation"
-cat > "$REVIEW_DIR/doctor-validation/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/doctor-validation"
+  cat > "$REVIEW_DIR/doctor-validation/qa-task-1.md" << 'EOF'
 # QA 1
 EOF
-cat > "$REVIEW_DIR/doctor-validation/qa-task-2.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-validation/qa-task-2.md" << 'EOF'
 # QA 2
 EOF
-cat > "$REVIEW_DIR/doctor-validation/qa-task-3.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-validation/qa-task-3.md" << 'EOF'
 # QA 3
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_dir_exists "$REVIEW_DIR/doctor-validation/r1" "r1/ created"
-assert_file_exists "$REVIEW_DIR/doctor-validation/r1/qa-task-1.md" "QA 1 moved to r1/"
-assert_file_exists "$REVIEW_DIR/doctor-validation/r1/qa-task-2.md" "QA 2 moved to r1/"
-assert_file_exists "$REVIEW_DIR/doctor-validation/r1/qa-task-3.md" "QA 3 moved to r1/"
-assert_file_not_exists "$REVIEW_DIR/doctor-validation/qa-task-1.md" "Original QA removed"
+  assert_eq "r1/ created" "true" "$([ -d "$REVIEW_DIR/doctor-validation/r1" ] && echo true || echo false)"
+  assert_eq "QA 1 moved to r1/" "true" "$([ -f "$REVIEW_DIR/doctor-validation/r1/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "QA 2 moved to r1/" "true" "$([ -f "$REVIEW_DIR/doctor-validation/r1/qa-task-2.md" ] && echo true || echo false)"
+  assert_eq "QA 3 moved to r1/" "true" "$([ -f "$REVIEW_DIR/doctor-validation/r1/qa-task-3.md" ] && echo true || echo false)"
+  assert_eq "original QA removed" "false" "$([ -f "$REVIEW_DIR/doctor-validation/qa-task-1.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Skip if r1/ already exists ---
+test_skip_existing_r1() {
+  setup
 
-echo -e "${YELLOW}Test: Phase 3 — Skip if r1/ already exists${NC}"
-setup_fixture
-
-mkdir -p "$REVIEW_DIR/already-done/r1"
-cat > "$REVIEW_DIR/already-done/r1/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/already-done/r1"
+  cat > "$REVIEW_DIR/already-done/r1/qa-task-1.md" << 'EOF'
 # Already in r1
 EOF
 
-# Stale QA file at root — should NOT be touched since r1/ exists
-cat > "$REVIEW_DIR/already-done/qa-task-99.md" << 'EOF'
+  cat > "$REVIEW_DIR/already-done/qa-task-99.md" << 'EOF'
 # Stale
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# r1 content unchanged
-content=$(cat "$REVIEW_DIR/already-done/r1/qa-task-1.md")
-assert_equals "$content" "# Already in r1" "Existing r1/ content unchanged"
-# Stale file stays (r1/ exists, so phase 3 skips)
-assert_file_exists "$REVIEW_DIR/already-done/qa-task-99.md" "Stale file untouched when r1/ exists"
+  local content
+  content=$(cat "$REVIEW_DIR/already-done/r1/qa-task-1.md")
+  assert_eq "existing r1/ content unchanged" "# Already in r1" "$content"
+  assert_eq "stale file untouched when r1/ exists" "true" "$([ -f "$REVIEW_DIR/already-done/qa-task-99.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: No review directory — early return ---
+test_no_review_dir() {
+  setup
+  rm -rf "$TEST_DIR/docs"
+  mkdir -p "$TEST_DIR/docs/workflow"
 
-echo -e "${YELLOW}Test: No review directory — early return${NC}"
-rm -rf "$TEST_DIR/docs"
-mkdir -p "$TEST_DIR/docs/workflow"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-REVIEW_DIR="$TEST_DIR/docs/workflow/review"
-cd "$TEST_DIR"
-output=$(source "$MIGRATION_SCRIPT" 2>&1)
+  # If we get here without error, migration handled missing dir gracefully
+  assert_eq "no error when review directory missing" "true" "true"
 
-TESTS_RUN=$((TESTS_RUN + 1))
-echo -e "  ${GREEN}✓${NC} No error when review directory missing"
-TESTS_PASSED=$((TESTS_PASSED + 1))
-assert_not_contains "$output" "updated" "No updates without review dir"
+  teardown
+}
 
-echo ""
+# --- Test 7: Idempotency — running migration twice ---
+test_idempotency() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Idempotency — running migration twice${NC}"
-setup_fixture
-
-mkdir -p "$REVIEW_DIR/idem"
-cat > "$REVIEW_DIR/idem/qa-task-1.md" << 'EOF'
+  mkdir -p "$REVIEW_DIR/idem"
+  cat > "$REVIEW_DIR/idem/qa-task-1.md" << 'EOF'
 # QA 1
 EOF
 
-run_migration
-first_content=$(cat "$REVIEW_DIR/idem/r1/qa-task-1.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local first_content
+  first_content=$(cat "$REVIEW_DIR/idem/r1/qa-task-1.md")
 
-# Run again — r1/ exists now, should skip
-output=$(run_migration 2>&1)
-second_content=$(cat "$REVIEW_DIR/idem/r1/qa-task-1.md")
+  source "$MIGRATION"
+  local second_content
+  second_content=$(cat "$REVIEW_DIR/idem/r1/qa-task-1.md")
 
-assert_equals "$second_content" "$first_content" "Second run produces same result"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "second run produces same result" "$first_content" "$second_content"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: All three phases together ---
+test_all_phases() {
+  setup
 
-echo -e "${YELLOW}Test: Tick-like scenario — all three phases together${NC}"
-setup_fixture
-
-# Multi-plan review with aggregate + per-plan subdirs
-mkdir -p "$REVIEW_DIR/doctor-installation-migration/r1/installation"
-mkdir -p "$REVIEW_DIR/doctor-installation-migration/r1/migration"
-cat > "$REVIEW_DIR/doctor-installation-migration/r1/review.md" << 'EOF'
+  # Multi-plan review with aggregate + per-plan subdirs
+  mkdir -p "$REVIEW_DIR/doctor-installation-migration/r1/installation"
+  mkdir -p "$REVIEW_DIR/doctor-installation-migration/r1/migration"
+  cat > "$REVIEW_DIR/doctor-installation-migration/r1/review.md" << 'EOF'
 # Aggregate
 EOF
-cat > "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-1.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-installation-migration/r1/installation/qa-task-1.md" << 'EOF'
 # Install QA 1
 EOF
-cat > "$REVIEW_DIR/doctor-installation-migration/r1/migration/qa-task-1.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-installation-migration/r1/migration/qa-task-1.md" << 'EOF'
 # Migration QA 1
 EOF
 
-# Single-plan review (already correct structure)
-mkdir -p "$REVIEW_DIR/tick-core/r1"
-cat > "$REVIEW_DIR/tick-core/r1/review.md" << 'EOF'
+  # Single-plan review (already correct structure)
+  mkdir -p "$REVIEW_DIR/tick-core/r1"
+  cat > "$REVIEW_DIR/tick-core/r1/review.md" << 'EOF'
 # Tick Core Review
 EOF
-cat > "$REVIEW_DIR/tick-core/r1/qa-task-1.md" << 'EOF'
+  cat > "$REVIEW_DIR/tick-core/r1/qa-task-1.md" << 'EOF'
 # TC QA 1
 EOF
-# Orphaned per-plan dirs
-mkdir -p "$REVIEW_DIR/doctor-validation"
-cat > "$REVIEW_DIR/doctor-validation/qa-task-1.md" << 'EOF'
+
+  # Orphaned per-plan dirs
+  mkdir -p "$REVIEW_DIR/doctor-validation"
+  cat > "$REVIEW_DIR/doctor-validation/qa-task-1.md" << 'EOF'
 # DV QA 1
 EOF
-cat > "$REVIEW_DIR/doctor-validation/qa-task-2.md" << 'EOF'
+  cat > "$REVIEW_DIR/doctor-validation/qa-task-2.md" << 'EOF'
 # DV QA 2
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# Phase 2: multi-plan QA moved to per-plan
-assert_file_exists "$REVIEW_DIR/installation/r1/qa-task-1.md" "installation QA moved"
-assert_file_exists "$REVIEW_DIR/migration/r1/qa-task-1.md" "migration QA moved"
+  # Phase 2: multi-plan QA moved to per-plan
+  assert_eq "installation QA moved" "true" "$([ -f "$REVIEW_DIR/installation/r1/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "migration QA moved" "true" "$([ -f "$REVIEW_DIR/migration/r1/qa-task-1.md" ] && echo true || echo false)"
 
-# Phase 3: orphaned QA moved into r1/
-assert_file_exists "$REVIEW_DIR/doctor-validation/r1/qa-task-1.md" "orphaned DV QA 1 moved to r1/"
-assert_file_exists "$REVIEW_DIR/doctor-validation/r1/qa-task-2.md" "orphaned DV QA 2 moved to r1/"
+  # Phase 3: orphaned QA moved into r1/
+  assert_eq "orphaned DV QA 1 moved to r1/" "true" "$([ -f "$REVIEW_DIR/doctor-validation/r1/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "orphaned DV QA 2 moved to r1/" "true" "$([ -f "$REVIEW_DIR/doctor-validation/r1/qa-task-2.md" ] && echo true || echo false)"
 
-# Already-correct single-plan review untouched
-assert_file_exists "$REVIEW_DIR/tick-core/r1/review.md" "tick-core review.md preserved"
-assert_file_exists "$REVIEW_DIR/tick-core/r1/qa-task-1.md" "tick-core QA preserved"
+  # Already-correct single-plan review untouched
+  assert_eq "tick-core review.md preserved" "true" "$([ -f "$REVIEW_DIR/tick-core/r1/review.md" ] && echo true || echo false)"
+  assert_eq "tick-core QA preserved" "true" "$([ -f "$REVIEW_DIR/tick-core/r1/qa-task-1.md" ] && echo true || echo false)"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 009 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_product_assessment_deleted
+test_multiple_product_assessments
+test_multi_plan_qa_moved
+test_orphaned_qa_moved
+test_skip_existing_r1
+test_no_review_dir
+test_idempotency
+test_all_phases
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-010.sh
+++ b/tests/scripts/test-migration-010.sh
@@ -1,349 +1,234 @@
 #!/bin/bash
-#
-# Tests migration 010-cache-state-restructure.sh
-# Validates the full .cache/ → .state/ + .cache/ restructure.
-#
+# Tests for migration 010: gitignore-sessions
+# Run: bash tests/scripts/test-migration-010.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/010-gitignore-sessions.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/010-gitignore-sessions.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-010-test.XXXXXX)
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    rm -rf "$TEST_DIR/.gitignore"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-run_migration() {
-    cd "$TEST_DIR"
-    source "$MIGRATION_SCRIPT"
+# --- Test 1: Move analysis files from .cache/ to .state/ ---
+test_move_analysis_files() {
+  setup
+
+  mkdir -p "$TEST_DIR/docs/workflow/.cache"
+  echo "analysis content" > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md"
+  echo "research content" > "$TEST_DIR/docs/workflow/.cache/research-analysis.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "discussion-consolidation-analysis.md moved to .state/" "true" "$([ -f "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" ] && echo true || echo false)"
+  assert_eq "research-analysis.md moved to .state/" "true" "$([ -f "$TEST_DIR/docs/workflow/.state/research-analysis.md" ] && echo true || echo false)"
+  assert_eq "discussion-consolidation-analysis.md removed from .cache/" "false" "$([ -f "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md" ] && echo true || echo false)"
+  assert_eq "research-analysis.md removed from .cache/" "false" "$([ -f "$TEST_DIR/docs/workflow/.cache/research-analysis.md" ] && echo true || echo false)"
+  assert_eq "discussion content preserved" "analysis content" "$(cat "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md")"
+  assert_eq "research content preserved" "research content" "$(cat "$TEST_DIR/docs/workflow/.state/research-analysis.md")"
+
+  teardown
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 2: Clean up orphaned migration tracking in .cache/ ---
+test_cleanup_migration_tracking() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  mkdir -p "$TEST_DIR/docs/workflow/.cache"
+  echo "001" > "$TEST_DIR/docs/workflow/.cache/migrations"
+  echo "001" > "$TEST_DIR/docs/workflow/.cache/migrations.log"
 
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "migrations file removed from .cache/" "false" "$([ -f "$TEST_DIR/docs/workflow/.cache/migrations" ] && echo true || echo false)"
+  assert_eq "migrations.log file removed from .cache/" "false" "$([ -f "$TEST_DIR/docs/workflow/.cache/migrations.log" ] && echo true || echo false)"
+
+  teardown
 }
 
-assert_not_contains() {
-    local content="$1"
-    local unexpected="$2"
-    local description="$3"
+# --- Test 3: Add docs/workflow/.cache/ to .gitignore ---
+test_add_gitignore_entry() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$unexpected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Did not expect to find: $unexpected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_line_count() {
-    local content="$1"
-    local pattern="$2"
-    local expected_count="$3"
-    local description="$4"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    local actual_count
-    actual_count=$(echo "$content" | grep -cF -- "$pattern" || true)
-
-    if [ "$actual_count" = "$expected_count" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected count: $expected_count"
-        echo -e "    Actual count:   $actual_count"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Move analysis files from .cache/ to .state/${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/docs/workflow/.cache"
-echo "analysis content" > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md"
-echo "research content" > "$TEST_DIR/docs/workflow/.cache/research-analysis.md"
-
-run_migration
-
-assert_file_exists "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" "discussion-consolidation-analysis.md moved to .state/"
-assert_file_exists "$TEST_DIR/docs/workflow/.state/research-analysis.md" "research-analysis.md moved to .state/"
-assert_file_not_exists "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md" "discussion-consolidation-analysis.md removed from .cache/"
-assert_file_not_exists "$TEST_DIR/docs/workflow/.cache/research-analysis.md" "research-analysis.md removed from .cache/"
-assert_equals "$(cat "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md")" "analysis content" "Content preserved after move"
-assert_equals "$(cat "$TEST_DIR/docs/workflow/.state/research-analysis.md")" "research content" "Content preserved after move"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Clean up orphaned migration tracking in .cache/${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/docs/workflow/.cache"
-echo "001" > "$TEST_DIR/docs/workflow/.cache/migrations"
-echo "001" > "$TEST_DIR/docs/workflow/.cache/migrations.log"
-
-run_migration
-
-assert_file_not_exists "$TEST_DIR/docs/workflow/.cache/migrations" "migrations file removed from .cache/"
-assert_file_not_exists "$TEST_DIR/docs/workflow/.cache/migrations.log" "migrations.log file removed from .cache/"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Add docs/workflow/.cache/ to .gitignore${NC}"
-setup_fixture
-cat > "$TEST_DIR/.gitignore" << 'EOF'
+  cat > "$TEST_DIR/.gitignore" << 'EOF'
 node_modules/
 .env
 EOF
 
-run_migration
-content=$(cat "$TEST_DIR/.gitignore")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local content
+  content=$(cat "$TEST_DIR/.gitignore")
 
-assert_contains "$content" "node_modules/" "Existing entry preserved"
-assert_contains "$content" ".env" "Existing entry preserved"
-assert_contains "$content" "docs/workflow/.cache/" ".cache/ entry appended"
+  assert_eq "existing node_modules/ preserved" "true" "$(echo "$content" | grep -qF 'node_modules/' && echo true || echo false)"
+  assert_eq "existing .env preserved" "true" "$(echo "$content" | grep -qF '.env' && echo true || echo false)"
+  assert_eq ".cache/ entry appended" "true" "$(echo "$content" | grep -qF 'docs/workflow/.cache/' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Remove old sessions/ entry from .gitignore ---
+test_remove_old_sessions_entry() {
+  setup
 
-echo -e "${YELLOW}Test: Remove old sessions/ entry from .gitignore${NC}"
-setup_fixture
-cat > "$TEST_DIR/.gitignore" << 'EOF'
+  cat > "$TEST_DIR/.gitignore" << 'EOF'
 node_modules/
 docs/workflow/.cache/sessions/
 .env
 EOF
 
-run_migration
-content=$(cat "$TEST_DIR/.gitignore")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local content
+  content=$(cat "$TEST_DIR/.gitignore")
 
-assert_not_contains "$content" "docs/workflow/.cache/sessions/" "Old sessions/ entry removed"
-assert_contains "$content" "docs/workflow/.cache/" "New .cache/ entry added"
-assert_contains "$content" "node_modules/" "Other entries preserved"
-assert_contains "$content" ".env" "Other entries preserved"
+  assert_eq "old sessions/ entry removed" "false" "$(echo "$content" | grep -qF 'docs/workflow/.cache/sessions/' && echo true || echo false)"
+  assert_eq "new .cache/ entry added" "true" "$(echo "$content" | grep -qF 'docs/workflow/.cache/' && echo true || echo false)"
+  assert_eq "node_modules/ preserved" "true" "$(echo "$content" | grep -qF 'node_modules/' && echo true || echo false)"
+  assert_eq ".env preserved" "true" "$(echo "$content" | grep -qF '.env' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: No .gitignore exists — creates and adds entry ---
+test_no_gitignore() {
+  setup
 
-echo -e "${YELLOW}Test: No .gitignore exists — creates and adds entry${NC}"
-setup_fixture
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local content
+  content=$(cat "$TEST_DIR/.gitignore")
 
-run_migration
-content=$(cat "$TEST_DIR/.gitignore")
+  assert_eq ".cache/ entry added to new .gitignore" "true" "$(echo "$content" | grep -qF 'docs/workflow/.cache/' && echo true || echo false)"
 
-assert_contains "$content" "docs/workflow/.cache/" ".cache/ entry added to new .gitignore"
+  teardown
+}
 
-echo ""
+# --- Test 6: Idempotent — .cache/ already in .gitignore, no files to move ---
+test_already_correct() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Idempotent — .cache/ already in .gitignore, no files to move${NC}"
-setup_fixture
-cat > "$TEST_DIR/.gitignore" << 'EOF'
+  cat > "$TEST_DIR/.gitignore" << 'EOF'
 node_modules/
 docs/workflow/.cache/
 .env
 EOF
 
-original=$(cat "$TEST_DIR/.gitignore")
-output=$(run_migration 2>&1)
-new_content=$(cat "$TEST_DIR/.gitignore")
+  local original
+  original=$(cat "$TEST_DIR/.gitignore")
 
-assert_equals "$new_content" "$original" "File unchanged when already correct"
-assert_contains "$output" "skipped" "Reported skip for .gitignore"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
+  local new_content
+  new_content=$(cat "$TEST_DIR/.gitignore")
+
+  assert_eq "file unchanged when already correct" "$original" "$new_content"
+
+  teardown
+}
+
+# --- Test 7: Idempotency — running migration twice ---
+test_idempotency() {
+  setup
+
+  mkdir -p "$TEST_DIR/docs/workflow/.cache"
+  echo "analysis" > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local first_gitignore
+  first_gitignore=$(cat "$TEST_DIR/.gitignore")
+
+  source "$MIGRATION"
+  local second_gitignore
+  second_gitignore=$(cat "$TEST_DIR/.gitignore")
+
+  assert_eq "second run produces same .gitignore" "$first_gitignore" "$second_gitignore"
+  local cache_count
+  cache_count=$(echo "$second_gitignore" | grep -cF "docs/workflow/.cache/" || true)
+  assert_eq ".cache/ entry appears exactly once" "1" "$cache_count"
+  assert_eq "file still in .state/ after second run" "true" "$([ -f "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 8: Files already in .state/ — no double move ---
+test_no_double_move() {
+  setup
+
+  mkdir -p "$TEST_DIR/docs/workflow/.state"
+  echo "existing state content" > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "existing .state/ file not overwritten" "existing state content" "$(cat "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md")"
+
+  teardown
+}
+
+# --- Test 9: .gitignore with no trailing newline — entry on its own line ---
+test_no_trailing_newline() {
+  setup
+
+  printf 'node_modules/\n.claude/settings.local.json' > "$TEST_DIR/.gitignore"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local content
+  content=$(cat "$TEST_DIR/.gitignore")
+
+  assert_eq "original last line preserved intact" "true" "$(echo "$content" | grep -qF '.claude/settings.local.json' && echo true || echo false)"
+  assert_eq "no concatenation with appended entry" "false" "$(echo "$content" | grep -qF '.claude/settings.local.jsondocs' && echo true || echo false)"
+  assert_eq ".cache/ entry present" "true" "$(echo "$content" | grep -qF 'docs/workflow/.cache/' && echo true || echo false)"
+  local line_count
+  line_count=$(wc -l < "$TEST_DIR/.gitignore" | tr -d ' ')
+  assert_eq "entry appended as separate line (3 lines total)" "3" "$line_count"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 010 tests..."
 echo ""
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Idempotency — running migration twice${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/docs/workflow/.cache"
-echo "analysis" > "$TEST_DIR/docs/workflow/.cache/discussion-consolidation-analysis.md"
-
-run_migration
-first_gitignore=$(cat "$TEST_DIR/.gitignore")
-
-run_migration
-second_gitignore=$(cat "$TEST_DIR/.gitignore")
-
-assert_equals "$second_gitignore" "$first_gitignore" "Second run produces same .gitignore"
-assert_line_count "$second_gitignore" "docs/workflow/.cache/" "1" ".cache/ entry appears exactly once"
-assert_file_exists "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md" "File still in .state/ after second run"
+test_move_analysis_files
+test_cleanup_migration_tracking
+test_add_gitignore_entry
+test_remove_old_sessions_entry
+test_no_gitignore
+test_already_correct
+test_idempotency
+test_no_double_move
+test_no_trailing_newline
 
 echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Files already in .state/ — no double move${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/docs/workflow/.state"
-echo "existing state content" > "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md"
-
-run_migration
-
-assert_equals "$(cat "$TEST_DIR/docs/workflow/.state/discussion-consolidation-analysis.md")" "existing state content" "Existing .state/ file not overwritten"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: .gitignore with no trailing newline — entry on its own line${NC}"
-setup_fixture
-printf 'node_modules/\n.claude/settings.local.json' > "$TEST_DIR/.gitignore"
-
-run_migration
-content=$(cat "$TEST_DIR/.gitignore")
-
-assert_contains "$content" ".claude/settings.local.json" "Original last line preserved intact"
-assert_not_contains "$content" ".claude/settings.local.jsondocs" "No concatenation with appended entry"
-assert_contains "$content" "docs/workflow/.cache/" ".cache/ entry present"
-# Verify each entry is on its own line
-line_count=$(wc -l < "$TEST_DIR/.gitignore" | tr -d ' ')
-assert_equals "$line_count" "3" "Entry appended as separate line (3 lines total)"
-
-echo ""
-
-# ============================================================================
-# SUMMARY
-# ============================================================================
-
-echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-011.sh
+++ b/tests/scripts/test-migration-011.sh
@@ -1,386 +1,246 @@
 #!/bin/bash
-#
-# Tests migration 011-rename-workflow-directory.sh
-# Validates moving docs/workflow/ → .workflows/
-#
+# Tests for migration 011: rename-workflow-directory
+# Run: bash tests/scripts/test-migration-011.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/011-rename-workflow-directory.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/011-rename-workflow-directory.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-011-test.XXXXXX)
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/docs"
-    rm -rf "$TEST_DIR/.workflows"
-    rm -rf "$TEST_DIR/.gitignore"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-run_migration() {
-    cd "$TEST_DIR"
-    source "$MIGRATION_SCRIPT"
+# --- Test 1: Full migration — docs/workflow/ to .workflows/ ---
+test_full_migration() {
+  setup
+
+  mkdir -p "$TEST_DIR/docs/workflow/discussion"
+  mkdir -p "$TEST_DIR/docs/workflow/specification/auth"
+  mkdir -p "$TEST_DIR/docs/workflow/.state"
+  mkdir -p "$TEST_DIR/docs/workflow/.cache/sessions"
+  echo "discussion content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+  echo "spec content" > "$TEST_DIR/docs/workflow/specification/auth/specification.md"
+  echo "state data" > "$TEST_DIR/docs/workflow/.state/migrations"
+  echo "cache data" > "$TEST_DIR/docs/workflow/.cache/sessions/abc.yaml"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "discussion file moved" "true" "$([ -f "$TEST_DIR/.workflows/discussion/auth.md" ] && echo true || echo false)"
+  assert_eq "discussion content preserved" "discussion content" "$(cat "$TEST_DIR/.workflows/discussion/auth.md")"
+  assert_eq "spec file moved" "true" "$([ -f "$TEST_DIR/.workflows/specification/auth/specification.md" ] && echo true || echo false)"
+  assert_eq "spec content preserved" "spec content" "$(cat "$TEST_DIR/.workflows/specification/auth/specification.md")"
+  assert_eq "hidden .state/ dir moved" "true" "$([ -f "$TEST_DIR/.workflows/.state/migrations" ] && echo true || echo false)"
+  assert_eq ".state content preserved" "state data" "$(cat "$TEST_DIR/.workflows/.state/migrations")"
+  assert_eq "hidden .cache/ dir moved" "true" "$([ -f "$TEST_DIR/.workflows/.cache/sessions/abc.yaml" ] && echo true || echo false)"
+  assert_eq "old directory removed" "false" "$([ -d "$TEST_DIR/docs/workflow" ] && echo true || echo false)"
+  assert_eq "empty docs/ removed" "false" "$([ -d "$TEST_DIR/docs" ] && echo true || echo false)"
+
+  teardown
 }
 
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 2: Already migrated — only .workflows/ exists ---
+test_already_migrated() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  echo "existing" > "$TEST_DIR/.workflows/discussion/auth.md"
 
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "existing files untouched" "true" "$([ -f "$TEST_DIR/.workflows/discussion/auth.md" ] && echo true || echo false)"
+  assert_eq "content unchanged" "existing" "$(cat "$TEST_DIR/.workflows/discussion/auth.md")"
+
+  teardown
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 3: Fresh install — neither directory exists ---
+test_fresh_install() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+  assert_eq ".workflows/ not created unnecessarily" "false" "$([ -d "$TEST_DIR/.workflows" ] && echo true || echo false)"
+
+  teardown
 }
 
-assert_not_contains() {
-    local content="$1"
-    local unexpected="$2"
-    local description="$3"
+# --- Test 4: Gitignore updated — docs/workflow/.cache/ to .workflows/.cache/ ---
+test_gitignore_updated() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$unexpected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Did not expect to find: $unexpected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-assert_file_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_exists() {
-    local dirpath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -d "$dirpath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory not found: $dirpath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_not_exists() {
-    local dirpath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -d "$dirpath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory should not exist: $dirpath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Full migration — docs/workflow/ → .workflows/${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/docs/workflow/discussion"
-mkdir -p "$TEST_DIR/docs/workflow/specification/auth"
-mkdir -p "$TEST_DIR/docs/workflow/.state"
-mkdir -p "$TEST_DIR/docs/workflow/.cache/sessions"
-echo "discussion content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
-echo "spec content" > "$TEST_DIR/docs/workflow/specification/auth/specification.md"
-echo "state data" > "$TEST_DIR/docs/workflow/.state/migrations"
-echo "cache data" > "$TEST_DIR/docs/workflow/.cache/sessions/abc.yaml"
-
-run_migration
-
-assert_file_exists "$TEST_DIR/.workflows/discussion/auth.md" "Discussion file moved"
-assert_equals "$(cat "$TEST_DIR/.workflows/discussion/auth.md")" "discussion content" "Discussion content preserved"
-assert_file_exists "$TEST_DIR/.workflows/specification/auth/specification.md" "Spec file moved"
-assert_equals "$(cat "$TEST_DIR/.workflows/specification/auth/specification.md")" "spec content" "Spec content preserved"
-assert_file_exists "$TEST_DIR/.workflows/.state/migrations" "Hidden .state/ dir moved"
-assert_equals "$(cat "$TEST_DIR/.workflows/.state/migrations")" "state data" ".state content preserved"
-assert_file_exists "$TEST_DIR/.workflows/.cache/sessions/abc.yaml" "Hidden .cache/ dir moved"
-assert_dir_not_exists "$TEST_DIR/docs/workflow" "Old directory removed"
-assert_dir_not_exists "$TEST_DIR/docs" "Empty docs/ removed"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Already migrated — only .workflows/ exists${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/discussion"
-echo "existing" > "$TEST_DIR/.workflows/discussion/auth.md"
-
-output=$(run_migration 2>&1)
-
-assert_contains "$output" "skipped" "Reports skip when nothing to migrate"
-assert_file_exists "$TEST_DIR/.workflows/discussion/auth.md" "Existing files untouched"
-assert_equals "$(cat "$TEST_DIR/.workflows/discussion/auth.md")" "existing" "Content unchanged"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Fresh install — neither directory exists${NC}"
-setup_fixture
-
-output=$(run_migration 2>&1)
-
-assert_contains "$output" "skipped" "Reports skip for fresh install"
-assert_dir_not_exists "$TEST_DIR/.workflows" ".workflows/ not created unnecessarily"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Gitignore updated — docs/workflow/.cache/ → .workflows/.cache/${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/docs/workflow/discussion"
-echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
-cat > "$TEST_DIR/.gitignore" << 'EOF'
+  mkdir -p "$TEST_DIR/docs/workflow/discussion"
+  echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+  cat > "$TEST_DIR/.gitignore" << 'EOF'
 node_modules/
 docs/workflow/.cache/
 .env
 EOF
 
-run_migration
-content=$(cat "$TEST_DIR/.gitignore")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local content
+  content=$(cat "$TEST_DIR/.gitignore")
 
-assert_contains "$content" ".workflows/.cache/" "New gitignore entry present"
-assert_not_contains "$content" "docs/workflow/.cache/" "Old gitignore entry removed"
-assert_contains "$content" "node_modules/" "Other entries preserved"
-assert_contains "$content" ".env" "Other entries preserved"
+  assert_eq "new gitignore entry present" "true" "$(echo "$content" | grep -qF '.workflows/.cache/' && echo true || echo false)"
+  assert_eq "old gitignore entry removed" "false" "$(echo "$content" | grep -qF 'docs/workflow/.cache/' && echo true || echo false)"
+  assert_eq "node_modules/ preserved" "true" "$(echo "$content" | grep -qF 'node_modules/' && echo true || echo false)"
+  assert_eq ".env preserved" "true" "$(echo "$content" | grep -qF '.env' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Gitignore already has .workflows/.cache/ — no-op ---
+test_gitignore_already_correct() {
+  setup
 
-echo -e "${YELLOW}Test: Gitignore already has .workflows/.cache/ — no-op${NC}"
-setup_fixture
-
-cat > "$TEST_DIR/.gitignore" << 'EOF'
+  cat > "$TEST_DIR/.gitignore" << 'EOF'
 node_modules/
 .workflows/.cache/
 .env
 EOF
 
-original=$(cat "$TEST_DIR/.gitignore")
-output=$(run_migration 2>&1)
-new_content=$(cat "$TEST_DIR/.gitignore")
+  local original
+  original=$(cat "$TEST_DIR/.gitignore")
 
-assert_equals "$new_content" "$original" "Gitignore unchanged"
-assert_contains "$output" "skipped" "Reports skip for gitignore"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-echo ""
+  local new_content
+  new_content=$(cat "$TEST_DIR/.gitignore")
 
-# ----------------------------------------------------------------------------
+  assert_eq "gitignore unchanged" "$original" "$new_content"
 
-echo -e "${YELLOW}Test: docs/ preserved if has other contents${NC}"
-setup_fixture
+  teardown
+}
 
-mkdir -p "$TEST_DIR/docs/workflow/discussion"
-mkdir -p "$TEST_DIR/docs/api"
-echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
-echo "api docs" > "$TEST_DIR/docs/api/readme.md"
+# --- Test 6: docs/ preserved if has other contents ---
+test_docs_preserved() {
+  setup
 
-run_migration
+  mkdir -p "$TEST_DIR/docs/workflow/discussion"
+  mkdir -p "$TEST_DIR/docs/api"
+  echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+  echo "api docs" > "$TEST_DIR/docs/api/readme.md"
 
-assert_dir_not_exists "$TEST_DIR/docs/workflow" "Old workflow dir removed"
-assert_dir_exists "$TEST_DIR/docs/api" "Other docs/ contents preserved"
-assert_file_exists "$TEST_DIR/docs/api/readme.md" "Non-workflow file preserved"
-assert_file_exists "$TEST_DIR/.workflows/discussion/auth.md" "Workflow files moved"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-echo ""
+  assert_eq "old workflow dir removed" "false" "$([ -d "$TEST_DIR/docs/workflow" ] && echo true || echo false)"
+  assert_eq "other docs/ contents preserved" "true" "$([ -d "$TEST_DIR/docs/api" ] && echo true || echo false)"
+  assert_eq "non-workflow file preserved" "true" "$([ -f "$TEST_DIR/docs/api/readme.md" ] && echo true || echo false)"
+  assert_eq "workflow files moved" "true" "$([ -f "$TEST_DIR/.workflows/discussion/auth.md" ] && echo true || echo false)"
 
-# ----------------------------------------------------------------------------
+  teardown
+}
 
-echo -e "${YELLOW}Test: Hidden directories (.state/, .cache/) moved correctly${NC}"
-setup_fixture
+# --- Test 7: Hidden directories (.state/, .cache/) moved correctly ---
+test_hidden_dirs_moved() {
+  setup
 
-mkdir -p "$TEST_DIR/docs/workflow/.state"
-mkdir -p "$TEST_DIR/docs/workflow/.cache"
-echo "state" > "$TEST_DIR/docs/workflow/.state/migrations"
-echo "cache" > "$TEST_DIR/docs/workflow/.cache/data"
+  mkdir -p "$TEST_DIR/docs/workflow/.state"
+  mkdir -p "$TEST_DIR/docs/workflow/.cache"
+  echo "state" > "$TEST_DIR/docs/workflow/.state/migrations"
+  echo "cache" > "$TEST_DIR/docs/workflow/.cache/data"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_dir_exists "$TEST_DIR/.workflows/.state" ".state/ directory moved"
-assert_dir_exists "$TEST_DIR/.workflows/.cache" ".cache/ directory moved"
-assert_file_exists "$TEST_DIR/.workflows/.state/migrations" ".state file moved"
-assert_file_exists "$TEST_DIR/.workflows/.cache/data" ".cache file moved"
-assert_equals "$(cat "$TEST_DIR/.workflows/.state/migrations")" "state" ".state content preserved"
-assert_equals "$(cat "$TEST_DIR/.workflows/.cache/data")" "cache" ".cache content preserved"
+  assert_eq ".state/ directory moved" "true" "$([ -d "$TEST_DIR/.workflows/.state" ] && echo true || echo false)"
+  assert_eq ".cache/ directory moved" "true" "$([ -d "$TEST_DIR/.workflows/.cache" ] && echo true || echo false)"
+  assert_eq ".state file moved" "true" "$([ -f "$TEST_DIR/.workflows/.state/migrations" ] && echo true || echo false)"
+  assert_eq ".cache file moved" "true" "$([ -f "$TEST_DIR/.workflows/.cache/data" ] && echo true || echo false)"
+  assert_eq ".state content preserved" "state" "$(cat "$TEST_DIR/.workflows/.state/migrations")"
+  assert_eq ".cache content preserved" "cache" "$(cat "$TEST_DIR/.workflows/.cache/data")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Partial migration — item already at destination is skipped ---
+test_partial_migration() {
+  setup
 
-echo -e "${YELLOW}Test: Partial migration — item already at destination is skipped${NC}"
-setup_fixture
+  mkdir -p "$TEST_DIR/docs/workflow/discussion"
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  echo "old" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+  echo "new" > "$TEST_DIR/.workflows/discussion/auth.md"
+  echo "other" > "$TEST_DIR/docs/workflow/discussion/billing.md"
 
-mkdir -p "$TEST_DIR/docs/workflow/discussion"
-mkdir -p "$TEST_DIR/.workflows/discussion"
-echo "old" > "$TEST_DIR/docs/workflow/discussion/auth.md"
-echo "new" > "$TEST_DIR/.workflows/discussion/auth.md"
-echo "other" > "$TEST_DIR/docs/workflow/discussion/billing.md"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-output=$(run_migration 2>&1)
+  assert_eq "existing destination not overwritten" "new" "$(cat "$TEST_DIR/.workflows/discussion/auth.md")"
 
-assert_contains "$output" "skipped" "Reports skip for existing item"
-assert_equals "$(cat "$TEST_DIR/.workflows/discussion/auth.md")" "new" "Existing destination not overwritten"
+  teardown
+}
 
-echo ""
+# --- Test 9: Idempotency — running twice produces same result ---
+test_idempotency() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Idempotency — running twice produces same result${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/docs/workflow/discussion"
-echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
-cat > "$TEST_DIR/.gitignore" << 'EOF'
+  mkdir -p "$TEST_DIR/docs/workflow/discussion"
+  echo "content" > "$TEST_DIR/docs/workflow/discussion/auth.md"
+  cat > "$TEST_DIR/.gitignore" << 'EOF'
 docs/workflow/.cache/
 EOF
 
-run_migration
-first_content=$(cat "$TEST_DIR/.workflows/discussion/auth.md")
-first_gitignore=$(cat "$TEST_DIR/.gitignore")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local first_content first_gitignore
+  first_content=$(cat "$TEST_DIR/.workflows/discussion/auth.md")
+  first_gitignore=$(cat "$TEST_DIR/.gitignore")
 
-run_migration
-second_content=$(cat "$TEST_DIR/.workflows/discussion/auth.md")
-second_gitignore=$(cat "$TEST_DIR/.gitignore")
+  source "$MIGRATION"
+  local second_content second_gitignore
+  second_content=$(cat "$TEST_DIR/.workflows/discussion/auth.md")
+  second_gitignore=$(cat "$TEST_DIR/.gitignore")
 
-assert_equals "$second_content" "$first_content" "File content same after second run"
-assert_equals "$second_gitignore" "$first_gitignore" "Gitignore same after second run"
+  assert_eq "file content same after second run" "$first_content" "$second_content"
+  assert_eq "gitignore same after second run" "$first_gitignore" "$second_gitignore"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 011 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_full_migration
+test_already_migrated
+test_fresh_install
+test_gitignore_updated
+test_gitignore_already_correct
+test_docs_preserved
+test_hidden_dirs_moved
+test_partial_migration
+test_idempotency
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-012.sh
+++ b/tests/scripts/test-migration-012.sh
@@ -1,214 +1,118 @@
 #!/bin/bash
-#
-# Tests migration 012-environment-setup-to-state.sh
-# Validates moving environment-setup.md to .state/ directory.
-#
+# Tests for migration 012: environment-setup-to-state
+# Run: bash tests/scripts/test-migration-012.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/012-environment-setup-to-state.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/012-environment-setup-to-state.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
 
-echo "Test directory: $TEST_DIR"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-012-test.XXXXXX)
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Test 1: Move environment-setup.md to .state/ ---
+test_move_to_state() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo "environment content" > "$TEST_DIR/.workflows/environment-setup.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "file moved to .state/" "true" "$([ -f "$TEST_DIR/.workflows/.state/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "file removed from root" "false" "$([ -f "$TEST_DIR/.workflows/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "content preserved" "environment content" "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")"
+
+  teardown
+}
+
+# --- Test 2: Already in .state/ — no-op ---
+test_already_in_state() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo "already there" > "$TEST_DIR/.workflows/.state/environment-setup.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "file still in .state/" "true" "$([ -f "$TEST_DIR/.workflows/.state/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "content unchanged" "already there" "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")"
+
+  teardown
+}
+
+# --- Test 3: No environment-setup.md — no-op ---
+test_no_file() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "no file created at root" "false" "$([ -f "$TEST_DIR/.workflows/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "no file created in .state/" "false" "$([ -f "$TEST_DIR/.workflows/.state/environment-setup.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 4: Idempotency — running twice ---
+test_idempotency() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo "content" > "$TEST_DIR/.workflows/environment-setup.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  local first_content
+  first_content=$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")
+
+  source "$MIGRATION"
+  local second_content
+  second_content=$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")
+
+  assert_eq "content same after second run" "$first_content" "$second_content"
+  assert_eq "root file still gone" "false" "$([ -f "$TEST_DIR/.workflows/environment-setup.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 012 tests..."
 echo ""
 
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
-}
-
-report_skip() {
-    echo "skipped"
-}
-
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
-    rm -rf "$TEST_DIR/docs"
-}
-
-run_migration() {
-    cd "$TEST_DIR"
-    source "$MIGRATION_SCRIPT"
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Move environment-setup.md to .state/${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo "environment content" > "$TEST_DIR/.workflows/environment-setup.md"
-
-run_migration
-
-assert_file_exists "$TEST_DIR/.workflows/.state/environment-setup.md" "File moved to .state/"
-assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "File removed from root"
-assert_equals "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")" "environment content" "Content preserved"
+test_move_to_state
+test_already_in_state
+test_no_file
+test_idempotency
 
 echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Already in .state/ — no-op${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo "already there" > "$TEST_DIR/.workflows/.state/environment-setup.md"
-
-output=$(run_migration 2>&1)
-
-assert_file_exists "$TEST_DIR/.workflows/.state/environment-setup.md" "File still in .state/"
-assert_equals "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")" "already there" "Content unchanged"
-assert_contains "$output" "skipped" "Reports skip"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: No environment-setup.md — no-op${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/.state"
-
-run_migration
-
-assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "No file created at root"
-assert_file_not_exists "$TEST_DIR/.workflows/.state/environment-setup.md" "No file created in .state/"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Idempotency — running twice${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo "content" > "$TEST_DIR/.workflows/environment-setup.md"
-
-run_migration
-first_content=$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")
-
-run_migration
-second_content=$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")
-
-assert_equals "$second_content" "$first_content" "Content same after second run"
-assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "Root file still gone"
-
-echo ""
-
-# ============================================================================
-# SUMMARY
-# ============================================================================
-
-echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-013.sh
+++ b/tests/scripts/test-migration-013.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+#
+# Tests for migration 013: discussion-work-type
+#
+# Run: bash tests/scripts/test-migration-013.sh
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/013-discussion-work-type.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-013-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+run() {
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+}
+
+# --- Test 1: Adds work_type after status ---
+test_adds_work_type() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" <<'EOF'
+---
+topic: auth-flow
+status: completed
+---
+
+# Auth Flow Discussion
+EOF
+
+  run
+
+  assert_eq "work_type added" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/discussion/auth-flow.md" && echo true || echo false)"
+  assert_eq "status preserved" "true" "$(grep -q '^status: completed' "$TEST_DIR/.workflows/discussion/auth-flow.md" && echo true || echo false)"
+  assert_eq "topic preserved" "true" "$(grep -q '^topic: auth-flow' "$TEST_DIR/.workflows/discussion/auth-flow.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 2: Skips when work_type already present ---
+test_skips_existing() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/discussion/billing.md" <<'EOF'
+---
+topic: billing
+status: in-progress
+work_type: greenfield
+---
+
+# Billing
+EOF
+
+  run
+
+  local count
+  count=$(grep -c '^work_type:' "$TEST_DIR/.workflows/discussion/billing.md")
+  assert_eq "no duplicate work_type" "1" "$count"
+
+  teardown
+}
+
+# --- Test 3: Skips files without frontmatter ---
+test_skips_no_frontmatter() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/discussion/plain.md" <<'EOF'
+# Plain file without frontmatter
+EOF
+
+  run
+
+  assert_eq "no work_type added" "false" "$(grep -q 'work_type' "$TEST_DIR/.workflows/discussion/plain.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 4: Skips when no discussion directory ---
+test_no_discussion_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows/discussion"
+
+  run
+
+  assert_eq "no error" "true" "true"
+
+  teardown
+}
+
+# --- Test 5: Adds work_type at end if no status field ---
+test_no_status_field() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/discussion/minimal.md" <<'EOF'
+---
+topic: minimal
+---
+
+# Minimal
+EOF
+
+  run
+
+  assert_eq "work_type added" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/discussion/minimal.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 6: Body content with --- preserved ---
+test_body_preserved() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/discussion/complex.md" <<'EOF'
+---
+topic: complex
+status: completed
+---
+
+# Complex
+
+Some content here.
+
+---
+
+More content after horizontal rule.
+EOF
+
+  run
+
+  assert_eq "body preserved" "true" "$(grep -q 'More content after horizontal rule.' "$TEST_DIR/.workflows/discussion/complex.md" && echo true || echo false)"
+  assert_eq "work_type added" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/discussion/complex.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 013 tests..."
+echo ""
+
+test_adds_work_type
+test_skips_existing
+test_skips_no_frontmatter
+test_no_discussion_dir
+test_no_status_field
+test_body_preserved
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-014.sh
+++ b/tests/scripts/test-migration-014.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+#
+# Tests for migration 014: specification-work-type
+#
+# Run: bash tests/scripts/test-migration-014.sh
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/014-specification-work-type.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-014-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+run() {
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+}
+
+# --- Test 1: Adds work_type after type ---
+test_adds_work_type() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" <<'EOF'
+---
+topic: auth-flow
+type: feature
+status: completed
+---
+
+# Auth Flow Specification
+EOF
+
+  run
+
+  assert_eq "work_type added" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/specification/auth-flow/specification.md" && echo true || echo false)"
+  assert_eq "type preserved" "true" "$(grep -q '^type: feature' "$TEST_DIR/.workflows/specification/auth-flow/specification.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 2: Skips when work_type already present ---
+test_skips_existing() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" <<'EOF'
+---
+topic: auth-flow
+type: feature
+work_type: greenfield
+status: completed
+---
+
+# Auth Flow
+EOF
+
+  run
+
+  local count
+  count=$(grep -c '^work_type:' "$TEST_DIR/.workflows/specification/auth-flow/specification.md")
+  assert_eq "no duplicate work_type" "1" "$count"
+
+  teardown
+}
+
+# --- Test 3: Skips files without frontmatter ---
+test_skips_no_frontmatter() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" <<'EOF'
+# Plain file without frontmatter
+EOF
+
+  run
+
+  assert_eq "no work_type added" "false" "$(grep -q 'work_type' "$TEST_DIR/.workflows/specification/auth-flow/specification.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 4: Skips when no specification directory ---
+test_no_spec_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows/specification"
+
+  run
+
+  assert_eq "no error" "true" "true"
+
+  teardown
+}
+
+# --- Test 5: Adds work_type at end if no type field ---
+test_no_type_field() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" <<'EOF'
+---
+topic: auth-flow
+status: completed
+---
+
+# Auth Flow
+EOF
+
+  run
+
+  assert_eq "work_type added" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/specification/auth-flow/specification.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 6: Multiple specs processed ---
+test_multiple_specs() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/specification/billing"
+
+  cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" <<'EOF'
+---
+topic: auth-flow
+type: feature
+status: completed
+---
+
+# Auth Flow
+EOF
+
+  cat > "$TEST_DIR/.workflows/specification/billing/specification.md" <<'EOF'
+---
+topic: billing
+type: feature
+status: in-progress
+---
+
+# Billing
+EOF
+
+  run
+
+  assert_eq "auth-flow has work_type" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/specification/auth-flow/specification.md" && echo true || echo false)"
+  assert_eq "billing has work_type" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/specification/billing/specification.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 014 tests..."
+echo ""
+
+test_adds_work_type
+test_skips_existing
+test_skips_no_frontmatter
+test_no_spec_dir
+test_no_type_field
+test_multiple_specs
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-015.sh
+++ b/tests/scripts/test-migration-015.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+#
+# Tests for migration 015: plan-work-type
+#
+# Run: bash tests/scripts/test-migration-015.sh
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/015-plan-work-type.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-015-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows/planning/auth-flow"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+run() {
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+}
+
+# --- Test 1: Adds work_type after status ---
+test_adds_work_type() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" <<'EOF'
+---
+topic: auth-flow
+status: completed
+---
+
+# Auth Flow Plan
+EOF
+
+  run
+
+  assert_eq "work_type added" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/planning/auth-flow/plan.md" && echo true || echo false)"
+  assert_eq "status preserved" "true" "$(grep -q '^status: completed' "$TEST_DIR/.workflows/planning/auth-flow/plan.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 2: Skips when work_type already present ---
+test_skips_existing() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" <<'EOF'
+---
+topic: auth-flow
+status: completed
+work_type: greenfield
+---
+
+# Auth Flow
+EOF
+
+  run
+
+  local count
+  count=$(grep -c '^work_type:' "$TEST_DIR/.workflows/planning/auth-flow/plan.md")
+  assert_eq "no duplicate work_type" "1" "$count"
+
+  teardown
+}
+
+# --- Test 3: Skips files without frontmatter ---
+test_skips_no_frontmatter() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" <<'EOF'
+# Plain file without frontmatter
+EOF
+
+  run
+
+  assert_eq "no work_type added" "false" "$(grep -q 'work_type' "$TEST_DIR/.workflows/planning/auth-flow/plan.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 4: Skips when no planning directory ---
+test_no_plan_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows/planning"
+
+  run
+
+  assert_eq "no error" "true" "true"
+
+  teardown
+}
+
+# --- Test 5: Adds work_type at end if no status field ---
+test_no_status_field() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" <<'EOF'
+---
+topic: auth-flow
+---
+
+# Auth Flow
+EOF
+
+  run
+
+  assert_eq "work_type added" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/planning/auth-flow/plan.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 6: Multiple plans processed ---
+test_multiple_plans() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/planning/billing"
+
+  cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" <<'EOF'
+---
+topic: auth-flow
+status: completed
+---
+
+# Auth Flow
+EOF
+
+  cat > "$TEST_DIR/.workflows/planning/billing/plan.md" <<'EOF'
+---
+topic: billing
+status: in-progress
+---
+
+# Billing
+EOF
+
+  run
+
+  assert_eq "auth-flow has work_type" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/planning/auth-flow/plan.md" && echo true || echo false)"
+  assert_eq "billing has work_type" "true" "$(grep -q '^work_type: greenfield' "$TEST_DIR/.workflows/planning/billing/plan.md" && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 015 tests..."
+echo ""
+
+test_adds_work_type
+test_skips_existing
+test_skips_no_frontmatter
+test_no_plan_dir
+test_no_status_field
+test_multiple_plans
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-016.sh
+++ b/tests/scripts/test-migration-016.sh
@@ -1,218 +1,61 @@
 #!/bin/bash
-#
-# Tests migration 016-work-unit-restructure.sh
-# Validates phase-first → work-unit-first directory restructuring.
-#
+# Tests for migration 016: work-unit-restructure
+# Run: bash tests/scripts/test-migration-016.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/016-work-unit-restructure.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/016-work-unit-restructure.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-FILES_UPDATED=0
-FILES_SKIPPED=0
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-016-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows"
 }
 
-# No export needed — migration is sourced in the same shell
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
-    FILES_UPDATED=0
-    FILES_SKIPPED=0
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-run_migration() {
-    cd "$TEST_DIR"
-    source "$MIGRATION_SCRIPT"
+# --- Test 1: No .workflows directory — skip cleanly ---
+test_no_workflows_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "no updates without .workflows dir" "false" "$([ -d "$TEST_DIR/.workflows" ] && echo true || echo false)"
+
+  teardown
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 2: Single feature — artifacts grouped correctly ---
+test_single_feature() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/dark-mode"
+  mkdir -p "$TEST_DIR/.workflows/planning/dark-mode"
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local unexpected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$unexpected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Unexpectedly found: $unexpected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_exists() {
-    local dirpath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -d "$dirpath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory not found: $dirpath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_not_exists() {
-    local dirpath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -d "$dirpath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory should not exist: $dirpath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test 1: No .workflows directory — skip cleanly${NC}"
-setup_fixture
-# Don't create .workflows
-output=$(run_migration 2>&1)
-
-assert_equals "$FILES_UPDATED" "0" "No files updated"
-assert_equals "$FILES_SKIPPED" "0" "No files skipped"
-assert_not_contains "$output" "updated" "No updates without .workflows dir"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test 2: Single feature — artifacts grouped correctly${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/dark-mode"
-mkdir -p "$TEST_DIR/.workflows/planning/dark-mode"
-
-cat > "$TEST_DIR/.workflows/discussion/dark-mode.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/dark-mode.md" << 'EOF'
 ---
 topic: dark-mode
 status: concluded
@@ -227,7 +70,7 @@ date: 2026-01-15
 We need dark mode.
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/dark-mode/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/dark-mode/specification.md" << 'EOF'
 ---
 topic: dark-mode
 status: concluded
@@ -243,7 +86,7 @@ review_cycle: 1
 Dark mode everywhere.
 EOF
 
-cat > "$TEST_DIR/.workflows/planning/dark-mode/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/dark-mode/plan.md" << 'EOF'
 ---
 topic: dark-mode
 status: in-progress
@@ -258,38 +101,36 @@ format: local-markdown
 Phase 1 here.
 EOF
 
-mkdir -p "$TEST_DIR/.workflows/planning/dark-mode/tasks"
-echo "task 1" > "$TEST_DIR/.workflows/planning/dark-mode/tasks/task-1.md"
+  mkdir -p "$TEST_DIR/.workflows/planning/dark-mode/tasks"
+  echo "task 1" > "$TEST_DIR/.workflows/planning/dark-mode/tasks/task-1.md"
 
-output=$(run_migration 2>&1)
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/manifest.json" "manifest.json created"
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/discussion/dark-mode.md" "discussion moved as {name}.md"
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/specification/dark-mode/specification.md" "specification in topic subdir"
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/planning/dark-mode/planning.md" "plan.md renamed to planning.md in topic subdir"
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/planning/dark-mode/tasks/task-1.md" "tasks directory in topic subdir"
+  assert_eq "manifest.json created" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/manifest.json" ] && echo true || echo false)"
+  assert_eq "discussion moved as {name}.md" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/discussion/dark-mode.md" ] && echo true || echo false)"
+  assert_eq "specification in topic subdir" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/specification/dark-mode/specification.md" ] && echo true || echo false)"
+  assert_eq "plan.md renamed to planning.md in topic subdir" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/planning/dark-mode/planning.md" ] && echo true || echo false)"
+  assert_eq "tasks directory in topic subdir" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/planning/dark-mode/tasks/task-1.md" ] && echo true || echo false)"
 
-# Verify manifest content
-manifest=$(cat "$TEST_DIR/.workflows/dark-mode/manifest.json")
-assert_contains "$manifest" '"work_type": "feature"' "manifest has correct work_type"
-assert_contains "$manifest" '"name": "dark-mode"' "manifest has correct name"
-assert_contains "$manifest" '"status": "active"' "manifest has active status"
+  manifest=$(cat "$TEST_DIR/.workflows/dark-mode/manifest.json")
+  assert_eq "manifest has correct work_type" "true" "$(echo "$manifest" | grep -qF '"work_type": "feature"' && echo true || echo false)"
+  assert_eq "manifest has correct name" "true" "$(echo "$manifest" | grep -qF '"name": "dark-mode"' && echo true || echo false)"
+  assert_eq "manifest has active status" "true" "$(echo "$manifest" | grep -qF '"status": "active"' && echo true || echo false)"
 
-# Verify empty phase dirs cleaned up
-assert_dir_not_exists "$TEST_DIR/.workflows/discussion" "discussion phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/specification" "specification phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/planning" "planning phase dir cleaned up"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "discussion phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/discussion" ] && echo true || echo false)"
+  assert_eq "specification phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/specification" ] && echo true || echo false)"
+  assert_eq "planning phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/planning" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Single bugfix — investigation path handled ---
+test_single_bugfix() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/investigation/login-timeout"
 
-echo -e "${YELLOW}Test 3: Single bugfix — investigation path handled${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/investigation/login-timeout"
-
-cat > "$TEST_DIR/.workflows/investigation/login-timeout/investigation.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/investigation/login-timeout/investigation.md" << 'EOF'
 ---
 topic: login-timeout
 status: concluded
@@ -304,24 +145,25 @@ date: 2026-02-01
 Session expiry.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/login-timeout/manifest.json" "manifest.json created"
-assert_file_exists "$TEST_DIR/.workflows/login-timeout/investigation/login-timeout.md" "investigation moved as {name}.md"
+  assert_eq "manifest.json created" "true" "$([ -f "$TEST_DIR/.workflows/login-timeout/manifest.json" ] && echo true || echo false)"
+  assert_eq "investigation moved as {name}.md" "true" "$([ -f "$TEST_DIR/.workflows/login-timeout/investigation/login-timeout.md" ] && echo true || echo false)"
 
-manifest=$(cat "$TEST_DIR/.workflows/login-timeout/manifest.json")
-assert_contains "$manifest" '"work_type": "bugfix"' "manifest has bugfix work_type"
-assert_contains "$manifest" '"investigation"' "manifest has investigation phase"
+  manifest=$(cat "$TEST_DIR/.workflows/login-timeout/manifest.json")
+  assert_eq "manifest has bugfix work_type" "true" "$(echo "$manifest" | grep -qF '"work_type": "bugfix"' && echo true || echo false)"
+  assert_eq "manifest has investigation phase" "true" "$(echo "$manifest" | grep -qF '"investigation"' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Multiple features — each gets own work unit ---
+test_multiple_features() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
 
-echo -e "${YELLOW}Test 4: Multiple features — each gets own work unit${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-
-for topic in auth-flow dark-mode api-keys; do
+  for topic in auth-flow dark-mode api-keys; do
     cat > "$TEST_DIR/.workflows/discussion/$topic.md" << EOF
 ---
 topic: $topic
@@ -332,27 +174,28 @@ date: 2026-01-01
 
 # Discussion: $topic
 EOF
-done
+  done
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/auth-flow/manifest.json" "auth-flow manifest created"
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/manifest.json" "dark-mode manifest created"
-assert_file_exists "$TEST_DIR/.workflows/api-keys/manifest.json" "api-keys manifest created"
+  assert_eq "auth-flow manifest created" "true" "$([ -f "$TEST_DIR/.workflows/auth-flow/manifest.json" ] && echo true || echo false)"
+  assert_eq "dark-mode manifest created" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/manifest.json" ] && echo true || echo false)"
+  assert_eq "api-keys manifest created" "true" "$([ -f "$TEST_DIR/.workflows/api-keys/manifest.json" ] && echo true || echo false)"
 
-assert_file_exists "$TEST_DIR/.workflows/auth-flow/discussion/auth-flow.md" "auth-flow discussion moved"
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/discussion/dark-mode.md" "dark-mode discussion moved"
-assert_file_exists "$TEST_DIR/.workflows/api-keys/discussion/api-keys.md" "api-keys discussion moved"
+  assert_eq "auth-flow discussion moved" "true" "$([ -f "$TEST_DIR/.workflows/auth-flow/discussion/auth-flow.md" ] && echo true || echo false)"
+  assert_eq "dark-mode discussion moved" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/discussion/dark-mode.md" ] && echo true || echo false)"
+  assert_eq "api-keys discussion moved" "true" "$([ -f "$TEST_DIR/.workflows/api-keys/discussion/api-keys.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Greenfield with multiple discussions — creates v1 epic ---
+test_greenfield_epic() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
 
-echo -e "${YELLOW}Test 5: Greenfield with multiple discussions — creates v1 epic${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-
-cat > "$TEST_DIR/.workflows/discussion/payment-processing.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/payment-processing.md" << 'EOF'
 ---
 topic: payment-processing
 status: concluded
@@ -363,7 +206,7 @@ date: 2026-01-10
 # Discussion: Payment Processing
 EOF
 
-cat > "$TEST_DIR/.workflows/discussion/refund-handling.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/refund-handling.md" << 'EOF'
 ---
 topic: refund-handling
 status: in-progress
@@ -374,26 +217,26 @@ date: 2026-01-12
 # Discussion: Refund Handling
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/v1/manifest.json" "v1 epic manifest created"
-assert_file_exists "$TEST_DIR/.workflows/v1/discussion/payment-processing.md" "epic discussion preserved name"
-assert_file_exists "$TEST_DIR/.workflows/v1/discussion/refund-handling.md" "second epic discussion preserved"
+  assert_eq "v1 epic manifest created" "true" "$([ -f "$TEST_DIR/.workflows/v1/manifest.json" ] && echo true || echo false)"
+  assert_eq "epic discussion preserved name" "true" "$([ -f "$TEST_DIR/.workflows/v1/discussion/payment-processing.md" ] && echo true || echo false)"
+  assert_eq "second epic discussion preserved" "true" "$([ -f "$TEST_DIR/.workflows/v1/discussion/refund-handling.md" ] && echo true || echo false)"
 
-manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
-assert_contains "$manifest" '"work_type": "epic"' "greenfield mapped to epic"
+  manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
+  assert_eq "greenfield mapped to epic" "true" "$(echo "$manifest" | grep -qF '"work_type": "epic"' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: Mixed (features + bugfix + greenfield) — correct classification ---
+test_mixed_types() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/investigation/crash-fix"
 
-echo -e "${YELLOW}Test 6: Mixed (features + bugfix + greenfield) — correct classification${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/investigation/crash-fix"
-
-# Feature
-cat > "$TEST_DIR/.workflows/discussion/notifications.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/notifications.md" << 'EOF'
 ---
 topic: notifications
 status: in-progress
@@ -404,8 +247,7 @@ date: 2026-01-01
 # Discussion: Notifications
 EOF
 
-# Greenfield (goes to v1 epic)
-cat > "$TEST_DIR/.workflows/discussion/data-model.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/data-model.md" << 'EOF'
 ---
 topic: data-model
 status: concluded
@@ -416,8 +258,7 @@ date: 2026-01-05
 # Discussion: Data Model
 EOF
 
-# Bugfix
-cat > "$TEST_DIR/.workflows/investigation/crash-fix/investigation.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/investigation/crash-fix/investigation.md" << 'EOF'
 ---
 topic: crash-fix
 status: in-progress
@@ -428,29 +269,30 @@ date: 2026-02-01
 # Investigation: Crash Fix
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/notifications/manifest.json" "feature work unit created"
-assert_file_exists "$TEST_DIR/.workflows/v1/manifest.json" "epic work unit created"
-assert_file_exists "$TEST_DIR/.workflows/crash-fix/manifest.json" "bugfix work unit created"
+  assert_eq "feature work unit created" "true" "$([ -f "$TEST_DIR/.workflows/notifications/manifest.json" ] && echo true || echo false)"
+  assert_eq "epic work unit created" "true" "$([ -f "$TEST_DIR/.workflows/v1/manifest.json" ] && echo true || echo false)"
+  assert_eq "bugfix work unit created" "true" "$([ -f "$TEST_DIR/.workflows/crash-fix/manifest.json" ] && echo true || echo false)"
 
-feat_manifest=$(cat "$TEST_DIR/.workflows/notifications/manifest.json")
-epic_manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
-bug_manifest=$(cat "$TEST_DIR/.workflows/crash-fix/manifest.json")
+  feat_manifest=$(cat "$TEST_DIR/.workflows/notifications/manifest.json")
+  epic_manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
+  bug_manifest=$(cat "$TEST_DIR/.workflows/crash-fix/manifest.json")
 
-assert_contains "$feat_manifest" '"work_type": "feature"' "notifications is feature"
-assert_contains "$epic_manifest" '"work_type": "epic"' "v1 is epic"
-assert_contains "$bug_manifest" '"work_type": "bugfix"' "crash-fix is bugfix"
+  assert_eq "notifications is feature" "true" "$(echo "$feat_manifest" | grep -qF '"work_type": "feature"' && echo true || echo false)"
+  assert_eq "v1 is epic" "true" "$(echo "$epic_manifest" | grep -qF '"work_type": "epic"' && echo true || echo false)"
+  assert_eq "crash-fix is bugfix" "true" "$(echo "$bug_manifest" | grep -qF '"work_type": "bugfix"' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Idempotency — running twice produces same result ---
+test_idempotency() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
 
-echo -e "${YELLOW}Test 7: Idempotency — running twice produces same result${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-
-cat > "$TEST_DIR/.workflows/discussion/idempotent-test.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/idempotent-test.md" << 'EOF'
 ---
 topic: idempotent-test
 status: concluded
@@ -461,34 +303,28 @@ date: 2026-01-01
 # Discussion: Idempotent Test
 EOF
 
-run_migration
-first_manifest=$(cat "$TEST_DIR/.workflows/idempotent-test/manifest.json")
-first_discussion=$(cat "$TEST_DIR/.workflows/idempotent-test/discussion/idempotent-test.md")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  first_manifest=$(cat "$TEST_DIR/.workflows/idempotent-test/manifest.json")
+  first_discussion=$(cat "$TEST_DIR/.workflows/idempotent-test/discussion/idempotent-test.md")
 
-# Reset counters and run again
-FILES_UPDATED=0
-FILES_SKIPPED=0
-output=$(run_migration 2>&1)
+  source "$MIGRATION"
 
-second_manifest=$(cat "$TEST_DIR/.workflows/idempotent-test/manifest.json")
-second_discussion=$(cat "$TEST_DIR/.workflows/idempotent-test/discussion/idempotent-test.md")
+  second_manifest=$(cat "$TEST_DIR/.workflows/idempotent-test/manifest.json")
+  second_discussion=$(cat "$TEST_DIR/.workflows/idempotent-test/discussion/idempotent-test.md")
 
-assert_equals "$second_manifest" "$first_manifest" "Manifest unchanged on second run"
-assert_equals "$second_discussion" "$first_discussion" "Discussion unchanged on second run"
-# Second run exits early — no phase dirs remain, manifest exists
-# Either skips at the early exit or report_skip runs in the loop
-assert_equals "$FILES_UPDATED" "0" "No files updated on second run"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "Manifest unchanged on second run" "$first_manifest" "$second_manifest"
+  assert_eq "Discussion unchanged on second run" "$first_discussion" "$second_discussion"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Frontmatter preserved intact in migrated artifacts ---
+test_frontmatter_preserved() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
 
-echo -e "${YELLOW}Test 8: Frontmatter preserved intact in migrated artifacts${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-
-cat > "$TEST_DIR/.workflows/discussion/preserved.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/preserved.md" << 'EOF'
 ---
 topic: preserved
 status: concluded
@@ -510,28 +346,29 @@ Content with special chars: "quotes", 'apostrophes', $variables.
 More content.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-content=$(cat "$TEST_DIR/.workflows/preserved/discussion/preserved.md")
-assert_contains "$content" "^---$" "Frontmatter delimiters preserved"
-assert_contains "$content" "^topic: preserved$" "topic field preserved"
-assert_contains "$content" "^status: concluded$" "status field preserved"
-assert_contains "$content" "^work_type: feature$" "work_type field preserved"
-assert_contains "$content" "Content with special chars" "Body content preserved"
-assert_contains "$content" "## Section Two" "Sections after --- preserved"
+  content=$(cat "$TEST_DIR/.workflows/preserved/discussion/preserved.md")
+  assert_eq "Frontmatter delimiters preserved" "true" "$(echo "$content" | grep -q '^---$' && echo true || echo false)"
+  assert_eq "topic field preserved" "true" "$(echo "$content" | grep -q '^topic: preserved$' && echo true || echo false)"
+  assert_eq "status field preserved" "true" "$(echo "$content" | grep -q '^status: concluded$' && echo true || echo false)"
+  assert_eq "work_type field preserved" "true" "$(echo "$content" | grep -q '^work_type: feature$' && echo true || echo false)"
+  assert_eq "Body content preserved" "true" "$(echo "$content" | grep -qF 'Content with special chars' && echo true || echo false)"
+  assert_eq "Sections after --- preserved" "true" "$(echo "$content" | grep -qF '## Section Two' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: Manifest contains expected fields from frontmatter ---
+test_manifest_fields() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/full-test"
+  mkdir -p "$TEST_DIR/.workflows/planning/full-test"
+  mkdir -p "$TEST_DIR/.workflows/planning/full-test/tasks"
 
-echo -e "${YELLOW}Test 10: Manifest contains expected fields from frontmatter${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/full-test"
-mkdir -p "$TEST_DIR/.workflows/planning/full-test"
-mkdir -p "$TEST_DIR/.workflows/planning/full-test/tasks"
-
-cat > "$TEST_DIR/.workflows/discussion/full-test.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/full-test.md" << 'EOF'
 ---
 topic: full-test
 status: concluded
@@ -543,7 +380,7 @@ research_source: exploration.md
 # Discussion: Full Test
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/full-test/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/full-test/specification.md" << 'EOF'
 ---
 topic: full-test
 status: concluded
@@ -556,7 +393,7 @@ finding_gate_mode: auto
 # Specification: Full Test
 EOF
 
-cat > "$TEST_DIR/.workflows/planning/full-test/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/full-test/plan.md" << 'EOF'
 ---
 topic: full-test
 status: in-progress
@@ -570,35 +407,30 @@ author_gate_mode: auto
 # Plan: Full Test
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-manifest=$(cat "$TEST_DIR/.workflows/full-test/manifest.json")
+  manifest=$(cat "$TEST_DIR/.workflows/full-test/manifest.json")
 
-# Discussion fields
-assert_contains "$manifest" '"status": "concluded"' "discussion status in manifest"
-assert_contains "$manifest" '"research_source": "exploration.md"' "research_source in manifest"
+  assert_eq "discussion status in manifest" "true" "$(echo "$manifest" | grep -qF '"status": "concluded"' && echo true || echo false)"
+  assert_eq "research_source in manifest" "true" "$(echo "$manifest" | grep -qF '"research_source": "exploration.md"' && echo true || echo false)"
+  assert_eq "spec type in manifest" "true" "$(echo "$manifest" | grep -qF '"type": "feature"' && echo true || echo false)"
+  assert_eq "review_cycle in manifest" "true" "$(echo "$manifest" | grep -qF '"review_cycle": 2' && echo true || echo false)"
+  assert_eq "plan format in manifest" "true" "$(echo "$manifest" | grep -qF '"format": "local-markdown"' && echo true || echo false)"
+  assert_eq "task_gate_mode in manifest" "true" "$(echo "$manifest" | grep -qF '"task_gate_mode": "gated"' && echo true || echo false)"
+  assert_eq "author_gate_mode in manifest" "true" "$(echo "$manifest" | grep -qF '"author_gate_mode": "auto"' && echo true || echo false)"
 
-# Specification fields
-assert_contains "$manifest" '"type": "feature"' "spec type in manifest"
-assert_contains "$manifest" '"review_cycle": 2' "review_cycle in manifest"
+  teardown
+}
 
-# Planning fields
-assert_contains "$manifest" '"format": "local-markdown"' "plan format in manifest"
-assert_contains "$manifest" '"task_gate_mode": "gated"' "task_gate_mode in manifest"
-assert_contains "$manifest" '"author_gate_mode": "auto"' "author_gate_mode in manifest"
+# --- Test 11: Empty phase directories cleaned up ---
+test_empty_phase_dirs() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification"
+  mkdir -p "$TEST_DIR/.workflows/planning"
 
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test 11: Empty phase directories cleaned up${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification"
-mkdir -p "$TEST_DIR/.workflows/planning"
-
-# Only one discussion, spec/plan dirs are empty
-cat > "$TEST_DIR/.workflows/discussion/cleanup-test.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/cleanup-test.md" << 'EOF'
 ---
 topic: cleanup-test
 status: in-progress
@@ -609,21 +441,22 @@ date: 2026-01-01
 # Discussion: Cleanup Test
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_dir_not_exists "$TEST_DIR/.workflows/discussion" "empty discussion dir removed"
-assert_dir_not_exists "$TEST_DIR/.workflows/specification" "empty specification dir removed"
-assert_dir_not_exists "$TEST_DIR/.workflows/planning" "empty planning dir removed"
+  assert_eq "empty discussion dir removed" "false" "$([ -d "$TEST_DIR/.workflows/discussion" ] && echo true || echo false)"
+  assert_eq "empty specification dir removed" "false" "$([ -d "$TEST_DIR/.workflows/specification" ] && echo true || echo false)"
+  assert_eq "empty planning dir removed" "false" "$([ -d "$TEST_DIR/.workflows/planning" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: greenfield to epic mapping in manifest ---
+test_greenfield_to_epic() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
 
-echo -e "${YELLOW}Test 12: greenfield → epic mapping in manifest${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-
-cat > "$TEST_DIR/.workflows/discussion/epic-mapping.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/epic-mapping.md" << 'EOF'
 ---
 topic: epic-mapping
 status: in-progress
@@ -634,22 +467,23 @@ date: 2026-01-01
 # Discussion: Epic Mapping
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
-assert_contains "$manifest" '"work_type": "epic"' "greenfield mapped to epic in manifest"
-assert_not_contains "$manifest" '"greenfield"' "no greenfield reference in manifest"
+  manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
+  assert_eq "greenfield mapped to epic in manifest" "true" "$(echo "$manifest" | grep -qF '"work_type": "epic"' && echo true || echo false)"
+  assert_eq "no greenfield reference in manifest" "false" "$(echo "$manifest" | grep -qF '"greenfield"' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 13: Implementation tracking.md to implementation.md rename ---
+test_tracking_rename() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/implementation/impl-rename"
 
-echo -e "${YELLOW}Test 13: Implementation tracking.md → implementation.md rename${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/implementation/impl-rename"
-
-cat > "$TEST_DIR/.workflows/discussion/impl-rename.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/impl-rename.md" << 'EOF'
 ---
 topic: impl-rename
 status: concluded
@@ -660,7 +494,7 @@ date: 2026-01-01
 # Discussion
 EOF
 
-cat > "$TEST_DIR/.workflows/implementation/impl-rename/tracking.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/implementation/impl-rename/tracking.md" << 'EOF'
 ---
 topic: impl-rename
 status: in-progress
@@ -677,23 +511,25 @@ fix_gate_mode: gated
 Some progress here.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/impl-rename/implementation/impl-rename/implementation.md" "tracking.md renamed to implementation.md in topic subdir"
-assert_file_not_exists "$TEST_DIR/.workflows/impl-rename/implementation/impl-rename/tracking.md" "old tracking.md not present"
+  assert_eq "tracking.md renamed to implementation.md in topic subdir" "true" "$([ -f "$TEST_DIR/.workflows/impl-rename/implementation/impl-rename/implementation.md" ] && echo true || echo false)"
+  assert_eq "old tracking.md not present" "false" "$([ -f "$TEST_DIR/.workflows/impl-rename/implementation/impl-rename/tracking.md" ] && echo true || echo false)"
 
-# Verify content preserved
-content=$(cat "$TEST_DIR/.workflows/impl-rename/implementation/impl-rename/implementation.md")
-assert_contains "$content" "Some progress here" "implementation content preserved"
+  content=$(cat "$TEST_DIR/.workflows/impl-rename/implementation/impl-rename/implementation.md")
+  assert_eq "implementation content preserved" "true" "$(echo "$content" | grep -qF 'Some progress here' && echo true || echo false)"
 
-# ----------------------------------------------------------------------------
+  teardown
+}
 
-echo -e "${YELLOW}Test: Research with Discussion-ready marker → concluded status${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/research"
+# --- Test 14: Research with Discussion-ready marker ---
+test_research_discussion_ready() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/research"
 
-cat > "$TEST_DIR/.workflows/discussion/data-model.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/data-model.md" << 'EOF'
 ---
 topic: data-model
 status: concluded
@@ -704,7 +540,7 @@ date: 2026-01-05
 # Discussion: Data Model
 EOF
 
-cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 # Research: Exploration
 
 Some research content here.
@@ -714,21 +550,22 @@ Some research content here.
 More content after the marker.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-research_status=$(node -e "var m = JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.research ? m.phases.research.status : 'missing')")
-assert_equals "$research_status" "concluded" "research with Discussion-ready marker gets concluded status"
+  research_status=$(node -e "var m = JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.research ? m.phases.research.status : 'missing')")
+  assert_eq "research with Discussion-ready marker gets concluded status" "concluded" "$research_status"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 15: Research without Discussion-ready marker ---
+test_research_no_marker() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/research"
 
-echo -e "${YELLOW}Test: Research without Discussion-ready marker → in-progress status${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/research"
-
-cat > "$TEST_DIR/.workflows/discussion/api-design.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/api-design.md" << 'EOF'
 ---
 topic: api-design
 status: in-progress
@@ -739,31 +576,32 @@ date: 2026-01-08
 # Discussion: API Design
 EOF
 
-cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 # Research: Exploration
 
 Some research content here. Still exploring options.
 No discussion-ready marker in this file.
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-research_status=$(node -e "var m = JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.research ? m.phases.research.status : 'missing')")
-assert_equals "$research_status" "concluded" "research concluded when later phases (discussion) exist"
+  research_status=$(node -e "var m = JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.research ? m.phases.research.status : 'missing')")
+  assert_eq "research concluded when later phases (discussion) exist" "concluded" "$research_status"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 16: Epic with spec/plan/impl/review — all phases migrated ---
+test_epic_all_phases() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/payment-processing"
+  mkdir -p "$TEST_DIR/.workflows/planning/payment-processing/tasks"
+  mkdir -p "$TEST_DIR/.workflows/implementation/payment-processing"
+  mkdir -p "$TEST_DIR/.workflows/review/payment-processing/r1"
 
-echo -e "${YELLOW}Test: Epic with spec/plan/impl/review — all phases migrated${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/payment-processing"
-mkdir -p "$TEST_DIR/.workflows/planning/payment-processing/tasks"
-mkdir -p "$TEST_DIR/.workflows/implementation/payment-processing"
-mkdir -p "$TEST_DIR/.workflows/review/payment-processing/r1"
-
-cat > "$TEST_DIR/.workflows/discussion/payment-processing.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/payment-processing.md" << 'EOF'
 ---
 topic: payment-processing
 status: concluded
@@ -774,7 +612,7 @@ date: 2026-01-10
 # Discussion: Payment Processing
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/payment-processing/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/payment-processing/specification.md" << 'EOF'
 ---
 topic: payment-processing
 status: concluded
@@ -787,7 +625,7 @@ finding_gate_mode: gated
 # Specification: Payment Processing
 EOF
 
-cat > "$TEST_DIR/.workflows/planning/payment-processing/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/payment-processing/plan.md" << 'EOF'
 ---
 topic: payment-processing
 status: concluded
@@ -800,9 +638,9 @@ author_gate_mode: auto
 # Plan: Payment Processing
 EOF
 
-echo "task content" > "$TEST_DIR/.workflows/planning/payment-processing/tasks/task-1.md"
+  echo "task content" > "$TEST_DIR/.workflows/planning/payment-processing/tasks/task-1.md"
 
-cat > "$TEST_DIR/.workflows/implementation/payment-processing/tracking.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/implementation/payment-processing/tracking.md" << 'EOF'
 ---
 topic: payment-processing
 status: in-progress
@@ -818,64 +656,59 @@ current_task: task-3
 # Implementation: Payment Processing
 EOF
 
-echo "review content" > "$TEST_DIR/.workflows/review/payment-processing/r1/review.md"
+  echo "review content" > "$TEST_DIR/.workflows/review/payment-processing/r1/review.md"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/v1/manifest.json" "v1 manifest created"
-assert_file_exists "$TEST_DIR/.workflows/v1/discussion/payment-processing.md" "epic discussion moved"
-assert_file_exists "$TEST_DIR/.workflows/v1/specification/payment-processing/specification.md" "epic spec moved to topic subdir"
-assert_file_exists "$TEST_DIR/.workflows/v1/planning/payment-processing/planning.md" "epic plan.md renamed to planning.md"
-assert_file_exists "$TEST_DIR/.workflows/v1/planning/payment-processing/tasks/task-1.md" "epic tasks dir moved"
-assert_file_exists "$TEST_DIR/.workflows/v1/implementation/payment-processing/implementation.md" "epic tracking.md renamed to implementation.md"
-assert_file_exists "$TEST_DIR/.workflows/v1/review/payment-processing/r1/review.md" "epic review moved"
+  assert_eq "v1 manifest created" "true" "$([ -f "$TEST_DIR/.workflows/v1/manifest.json" ] && echo true || echo false)"
+  assert_eq "epic discussion moved" "true" "$([ -f "$TEST_DIR/.workflows/v1/discussion/payment-processing.md" ] && echo true || echo false)"
+  assert_eq "epic spec moved to topic subdir" "true" "$([ -f "$TEST_DIR/.workflows/v1/specification/payment-processing/specification.md" ] && echo true || echo false)"
+  assert_eq "epic plan.md renamed to planning.md" "true" "$([ -f "$TEST_DIR/.workflows/v1/planning/payment-processing/planning.md" ] && echo true || echo false)"
+  assert_eq "epic tasks dir moved" "true" "$([ -f "$TEST_DIR/.workflows/v1/planning/payment-processing/tasks/task-1.md" ] && echo true || echo false)"
+  assert_eq "epic tracking.md renamed to implementation.md" "true" "$([ -f "$TEST_DIR/.workflows/v1/implementation/payment-processing/implementation.md" ] && echo true || echo false)"
+  assert_eq "epic review moved" "true" "$([ -f "$TEST_DIR/.workflows/v1/review/payment-processing/r1/review.md" ] && echo true || echo false)"
 
-# Verify manifest items structure
-manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
-assert_contains "$manifest" '"work_type": "epic"' "manifest has epic work_type"
+  manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
+  assert_eq "manifest has epic work_type" "true" "$(echo "$manifest" | grep -qF '"work_type": "epic"' && echo true || echo false)"
 
-# Spec items
-spec_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var s=m.phases.specification; console.log(s && s.items && s.items['payment-processing'] ? s.items['payment-processing'].status : 'missing')")
-assert_equals "$spec_status" "concluded" "manifest spec items has correct status"
+  spec_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var s=m.phases.specification; console.log(s && s.items && s.items['payment-processing'] ? s.items['payment-processing'].status : 'missing')")
+  assert_eq "manifest spec items has correct status" "concluded" "$spec_status"
 
-spec_type=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var s=m.phases.specification; console.log(s && s.items && s.items['payment-processing'] ? s.items['payment-processing'].type : 'missing')")
-assert_equals "$spec_type" "feature" "manifest spec items has type field"
+  spec_type=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var s=m.phases.specification; console.log(s && s.items && s.items['payment-processing'] ? s.items['payment-processing'].type : 'missing')")
+  assert_eq "manifest spec items has type field" "feature" "$spec_type"
 
-# Plan items
-plan_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var p=m.phases.planning; console.log(p && p.items && p.items['payment-processing'] ? p.items['payment-processing'].status : 'missing')")
-assert_equals "$plan_status" "concluded" "manifest plan items has correct status"
+  plan_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var p=m.phases.planning; console.log(p && p.items && p.items['payment-processing'] ? p.items['payment-processing'].status : 'missing')")
+  assert_eq "manifest plan items has correct status" "concluded" "$plan_status"
 
-plan_format=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var p=m.phases.planning; console.log(p && p.items && p.items['payment-processing'] ? p.items['payment-processing'].format : 'missing')")
-assert_equals "$plan_format" "local-markdown" "manifest plan items has format field"
+  plan_format=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var p=m.phases.planning; console.log(p && p.items && p.items['payment-processing'] ? p.items['payment-processing'].format : 'missing')")
+  assert_eq "manifest plan items has format field" "local-markdown" "$plan_format"
 
-# Impl items
-impl_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var i=m.phases.implementation; console.log(i && i.items && i.items['payment-processing'] ? i.items['payment-processing'].status : 'missing')")
-assert_equals "$impl_status" "in-progress" "manifest impl items has correct status"
+  impl_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var i=m.phases.implementation; console.log(i && i.items && i.items['payment-processing'] ? i.items['payment-processing'].status : 'missing')")
+  assert_eq "manifest impl items has correct status" "in-progress" "$impl_status"
 
-impl_cycle=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var i=m.phases.implementation; console.log(i && i.items && i.items['payment-processing'] ? i.items['payment-processing'].analysis_cycle : 'missing')")
-assert_equals "$impl_cycle" "2" "manifest impl items has analysis_cycle field"
+  impl_cycle=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var i=m.phases.implementation; console.log(i && i.items && i.items['payment-processing'] ? i.items['payment-processing'].analysis_cycle : 'missing')")
+  assert_eq "manifest impl items has analysis_cycle field" "2" "$impl_cycle"
 
-# Review items
-review_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var r=m.phases.review; console.log(r && r.items && r.items['payment-processing'] ? r.items['payment-processing'].status : 'missing')")
-assert_equals "$review_status" "completed" "manifest review items has completed status"
+  review_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var r=m.phases.review; console.log(r && r.items && r.items['payment-processing'] ? r.items['payment-processing'].status : 'missing')")
+  assert_eq "manifest review items has completed status" "completed" "$review_status"
 
-# Source dirs cleaned up
-assert_dir_not_exists "$TEST_DIR/.workflows/discussion" "discussion phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/specification" "spec phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/planning" "planning phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/implementation" "impl phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/review" "review phase dir cleaned up"
+  assert_eq "discussion phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/discussion" ] && echo true || echo false)"
+  assert_eq "spec phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/specification" ] && echo true || echo false)"
+  assert_eq "planning phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/planning" ] && echo true || echo false)"
+  assert_eq "impl phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/implementation" ] && echo true || echo false)"
+  assert_eq "review phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/review" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 17: discussion-consolidation-analysis.md moved to v1/.state/ ---
+test_state_file_moved() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/.state"
 
-echo -e "${YELLOW}Test: discussion-consolidation-analysis.md moved to v1/.state/${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/.state"
-
-cat > "$TEST_DIR/.workflows/discussion/some-topic.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/some-topic.md" << 'EOF'
 ---
 topic: some-topic
 status: concluded
@@ -886,28 +719,27 @@ date: 2026-01-10
 # Discussion: Some Topic
 EOF
 
-echo "consolidation analysis content" > "$TEST_DIR/.workflows/.state/discussion-consolidation-analysis.md"
+  echo "consolidation analysis content" > "$TEST_DIR/.workflows/.state/discussion-consolidation-analysis.md"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/v1/.state/discussion-consolidation-analysis.md" "discussion-consolidation-analysis.md moved to v1/.state/"
-assert_file_not_exists "$TEST_DIR/.workflows/.state/discussion-consolidation-analysis.md" "original state file removed"
+  assert_eq "discussion-consolidation-analysis.md moved to v1/.state/" "true" "$([ -f "$TEST_DIR/.workflows/v1/.state/discussion-consolidation-analysis.md" ] && echo true || echo false)"
+  assert_eq "original state file removed" "false" "$([ -f "$TEST_DIR/.workflows/.state/discussion-consolidation-analysis.md" ] && echo true || echo false)"
 
-# Verify content preserved
-content=$(cat "$TEST_DIR/.workflows/v1/.state/discussion-consolidation-analysis.md")
-assert_contains "$content" "consolidation analysis content" "state file content preserved"
+  content=$(cat "$TEST_DIR/.workflows/v1/.state/discussion-consolidation-analysis.md")
+  assert_eq "state file content preserved" "true" "$(echo "$content" | grep -qF 'consolidation analysis content' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 18: Unmatched review topic routes to v1 ---
+test_unmatched_review() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/review/doctor-installation-migration/r1"
 
-echo -e "${YELLOW}Test: Unmatched review topic routes to v1${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/review/doctor-installation-migration/r1"
-
-# Epic discussion to trigger v1 creation
-cat > "$TEST_DIR/.workflows/discussion/data-model.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/data-model.md" << 'EOF'
 ---
 topic: data-model
 status: concluded
@@ -918,27 +750,26 @@ date: 2026-01-05
 # Discussion: Data Model
 EOF
 
-# Review dir with no matching topic in other phases
-echo "review findings" > "$TEST_DIR/.workflows/review/doctor-installation-migration/r1/review.md"
+  echo "review findings" > "$TEST_DIR/.workflows/review/doctor-installation-migration/r1/review.md"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/v1/review/doctor-installation-migration/r1/review.md" "unmatched review topic moved to v1"
-assert_dir_not_exists "$TEST_DIR/.workflows/review" "review phase dir cleaned up"
+  assert_eq "unmatched review topic moved to v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/review/doctor-installation-migration/r1/review.md" ] && echo true || echo false)"
+  assert_eq "review phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/review" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 19: Mixed feature + epic with all phases ---
+test_mixed_feature_epic() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/dark-mode"
+  mkdir -p "$TEST_DIR/.workflows/specification/payment-processing"
+  mkdir -p "$TEST_DIR/.workflows/planning/payment-processing/tasks"
 
-echo -e "${YELLOW}Test: Mixed feature + epic with all phases${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/dark-mode"
-mkdir -p "$TEST_DIR/.workflows/specification/payment-processing"
-mkdir -p "$TEST_DIR/.workflows/planning/payment-processing/tasks"
-
-# Feature
-cat > "$TEST_DIR/.workflows/discussion/dark-mode.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/dark-mode.md" << 'EOF'
 ---
 topic: dark-mode
 status: concluded
@@ -949,7 +780,7 @@ date: 2026-01-15
 # Discussion: Dark Mode
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/dark-mode/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/dark-mode/specification.md" << 'EOF'
 ---
 topic: dark-mode
 status: concluded
@@ -960,8 +791,7 @@ type: feature
 # Specification: Dark Mode
 EOF
 
-# Epic
-cat > "$TEST_DIR/.workflows/discussion/payment-processing.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/payment-processing.md" << 'EOF'
 ---
 topic: payment-processing
 status: concluded
@@ -972,7 +802,7 @@ date: 2026-01-10
 # Discussion: Payment Processing
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/payment-processing/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/payment-processing/specification.md" << 'EOF'
 ---
 topic: payment-processing
 status: concluded
@@ -983,7 +813,7 @@ type: feature
 # Specification: Payment Processing
 EOF
 
-cat > "$TEST_DIR/.workflows/planning/payment-processing/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/payment-processing/plan.md" << 'EOF'
 ---
 topic: payment-processing
 status: in-progress
@@ -994,45 +824,40 @@ format: local-markdown
 # Plan: Payment Processing
 EOF
 
-echo "task content" > "$TEST_DIR/.workflows/planning/payment-processing/tasks/task-1.md"
+  echo "task content" > "$TEST_DIR/.workflows/planning/payment-processing/tasks/task-1.md"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# Feature goes to its own work unit
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/manifest.json" "feature manifest created"
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/specification/dark-mode/specification.md" "feature spec in own work unit"
+  assert_eq "feature manifest created" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/manifest.json" ] && echo true || echo false)"
+  assert_eq "feature spec in own work unit" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/specification/dark-mode/specification.md" ] && echo true || echo false)"
+  assert_eq "v1 epic manifest created" "true" "$([ -f "$TEST_DIR/.workflows/v1/manifest.json" ] && echo true || echo false)"
+  assert_eq "epic spec in v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/specification/payment-processing/specification.md" ] && echo true || echo false)"
+  assert_eq "epic plan in v1 (renamed)" "true" "$([ -f "$TEST_DIR/.workflows/v1/planning/payment-processing/planning.md" ] && echo true || echo false)"
+  assert_eq "epic tasks in v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/planning/payment-processing/tasks/task-1.md" ] && echo true || echo false)"
 
-# Epic goes to v1
-assert_file_exists "$TEST_DIR/.workflows/v1/manifest.json" "v1 epic manifest created"
-assert_file_exists "$TEST_DIR/.workflows/v1/specification/payment-processing/specification.md" "epic spec in v1"
-assert_file_exists "$TEST_DIR/.workflows/v1/planning/payment-processing/planning.md" "epic plan in v1 (renamed)"
-assert_file_exists "$TEST_DIR/.workflows/v1/planning/payment-processing/tasks/task-1.md" "epic tasks in v1"
+  feat_manifest=$(cat "$TEST_DIR/.workflows/dark-mode/manifest.json")
+  epic_manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
+  assert_eq "dark-mode is feature" "true" "$(echo "$feat_manifest" | grep -qF '"work_type": "feature"' && echo true || echo false)"
+  assert_eq "v1 is epic" "true" "$(echo "$epic_manifest" | grep -qF '"work_type": "epic"' && echo true || echo false)"
 
-# Manifests correct
-feat_manifest=$(cat "$TEST_DIR/.workflows/dark-mode/manifest.json")
-epic_manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
-assert_contains "$feat_manifest" '"work_type": "feature"' "dark-mode is feature"
-assert_contains "$epic_manifest" '"work_type": "epic"' "v1 is epic"
+  assert_eq "discussion phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/discussion" ] && echo true || echo false)"
+  assert_eq "spec phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/specification" ] && echo true || echo false)"
+  assert_eq "planning phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/planning" ] && echo true || echo false)"
 
-# Source phase dirs cleaned up
-assert_dir_not_exists "$TEST_DIR/.workflows/discussion" "discussion phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/specification" "spec phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/planning" "planning phase dir cleaned up"
+  teardown
+}
 
-echo ""
+# --- Test 20: Epic with multiple topics across phases ---
+test_epic_multiple_topics() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+  mkdir -p "$TEST_DIR/.workflows/specification/billing"
+  mkdir -p "$TEST_DIR/.workflows/planning/auth-flow/tasks"
+  mkdir -p "$TEST_DIR/.workflows/implementation/auth-flow"
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Epic with multiple topics across phases${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
-mkdir -p "$TEST_DIR/.workflows/specification/billing"
-mkdir -p "$TEST_DIR/.workflows/planning/auth-flow/tasks"
-mkdir -p "$TEST_DIR/.workflows/implementation/auth-flow"
-
-# Two epic discussions
-cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -1043,7 +868,7 @@ date: 2026-01-10
 # Discussion: Auth Flow
 EOF
 
-cat > "$TEST_DIR/.workflows/discussion/billing.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/billing.md" << 'EOF'
 ---
 topic: billing
 status: in-progress
@@ -1054,8 +879,7 @@ date: 2026-01-12
 # Discussion: Billing
 EOF
 
-# Both have specs
-cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -1067,7 +891,7 @@ review_cycle: 2
 # Specification: Auth Flow
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: in-progress
@@ -1078,8 +902,7 @@ type: feature
 # Specification: Billing
 EOF
 
-# Only auth-flow has plan + impl
-cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -1090,9 +913,9 @@ format: local-markdown
 # Plan: Auth Flow
 EOF
 
-echo "task content" > "$TEST_DIR/.workflows/planning/auth-flow/tasks/task-1.md"
+  echo "task content" > "$TEST_DIR/.workflows/planning/auth-flow/tasks/task-1.md"
 
-cat > "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" << 'EOF'
 ---
 topic: auth-flow
 status: in-progress
@@ -1104,44 +927,39 @@ current_phase: phase-1
 # Implementation: Auth Flow
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# Both specs moved to v1
-assert_file_exists "$TEST_DIR/.workflows/v1/specification/auth-flow/specification.md" "auth-flow spec in v1"
-assert_file_exists "$TEST_DIR/.workflows/v1/specification/billing/specification.md" "billing spec in v1"
+  assert_eq "auth-flow spec in v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/specification/auth-flow/specification.md" ] && echo true || echo false)"
+  assert_eq "billing spec in v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/specification/billing/specification.md" ] && echo true || echo false)"
+  assert_eq "auth-flow plan renamed in v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/planning/auth-flow/planning.md" ] && echo true || echo false)"
+  assert_eq "auth-flow tasks in v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/planning/auth-flow/tasks/task-1.md" ] && echo true || echo false)"
+  assert_eq "auth-flow impl renamed in v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/implementation/auth-flow/implementation.md" ] && echo true || echo false)"
 
-# Only auth-flow has plan+impl
-assert_file_exists "$TEST_DIR/.workflows/v1/planning/auth-flow/planning.md" "auth-flow plan renamed in v1"
-assert_file_exists "$TEST_DIR/.workflows/v1/planning/auth-flow/tasks/task-1.md" "auth-flow tasks in v1"
-assert_file_exists "$TEST_DIR/.workflows/v1/implementation/auth-flow/implementation.md" "auth-flow impl renamed in v1"
+  auth_spec=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.specification && m.phases.specification.items && m.phases.specification.items['auth-flow'] ? m.phases.specification.items['auth-flow'].status : 'missing')")
+  billing_spec=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.specification && m.phases.specification.items && m.phases.specification.items['billing'] ? m.phases.specification.items['billing'].status : 'missing')")
+  auth_plan=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.planning && m.phases.planning.items && m.phases.planning.items['auth-flow'] ? m.phases.planning.items['auth-flow'].status : 'missing')")
+  billing_plan=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.planning && m.phases.planning.items ? (m.phases.planning.items['billing'] ? 'found' : 'absent') : 'no-items')")
 
-# Manifest has items for both spec topics but only auth-flow in plan/impl
-manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
-auth_spec=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.specification && m.phases.specification.items && m.phases.specification.items['auth-flow'] ? m.phases.specification.items['auth-flow'].status : 'missing')")
-billing_spec=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.specification && m.phases.specification.items && m.phases.specification.items['billing'] ? m.phases.specification.items['billing'].status : 'missing')")
-auth_plan=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.planning && m.phases.planning.items && m.phases.planning.items['auth-flow'] ? m.phases.planning.items['auth-flow'].status : 'missing')")
-billing_plan=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.planning && m.phases.planning.items ? (m.phases.planning.items['billing'] ? 'found' : 'absent') : 'no-items')")
+  assert_eq "manifest spec items: auth-flow concluded" "concluded" "$auth_spec"
+  assert_eq "manifest spec items: billing in-progress" "in-progress" "$billing_spec"
+  assert_eq "manifest plan items: auth-flow concluded" "concluded" "$auth_plan"
+  assert_eq "manifest plan items: billing absent (no plan)" "absent" "$billing_plan"
 
-assert_equals "$auth_spec" "concluded" "manifest spec items: auth-flow concluded"
-assert_equals "$billing_spec" "in-progress" "manifest spec items: billing in-progress"
-assert_equals "$auth_plan" "concluded" "manifest plan items: auth-flow concluded"
-assert_equals "$billing_plan" "absent" "manifest plan items: billing absent (no plan)"
+  assert_eq "spec phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/specification" ] && echo true || echo false)"
+  assert_eq "planning phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/planning" ] && echo true || echo false)"
+  assert_eq "impl phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/implementation" ] && echo true || echo false)"
 
-# Source dirs cleaned up
-assert_dir_not_exists "$TEST_DIR/.workflows/specification" "spec phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/planning" "planning phase dir cleaned up"
-assert_dir_not_exists "$TEST_DIR/.workflows/implementation" "impl phase dir cleaned up"
+  teardown
+}
 
-echo ""
+# --- Test 21: Feature with review — manifest has review phase ---
+test_feature_with_review() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/review/dark-mode/r1"
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Feature with review — manifest has review phase${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/review/dark-mode/r1"
-
-cat > "$TEST_DIR/.workflows/discussion/dark-mode.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/dark-mode.md" << 'EOF'
 ---
 topic: dark-mode
 status: concluded
@@ -1152,26 +970,27 @@ date: 2026-01-15
 # Discussion: Dark Mode
 EOF
 
-echo "review findings" > "$TEST_DIR/.workflows/review/dark-mode/r1/review.md"
+  echo "review findings" > "$TEST_DIR/.workflows/review/dark-mode/r1/review.md"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/dark-mode/review/dark-mode/r1/review.md" "feature review moved"
+  assert_eq "feature review moved" "true" "$([ -f "$TEST_DIR/.workflows/dark-mode/review/dark-mode/r1/review.md" ] && echo true || echo false)"
 
-manifest=$(cat "$TEST_DIR/.workflows/dark-mode/manifest.json")
-assert_contains "$manifest" '"review"' "manifest has review phase"
-assert_contains "$manifest" '"status": "completed"' "manifest review status is completed"
+  manifest=$(cat "$TEST_DIR/.workflows/dark-mode/manifest.json")
+  assert_eq "manifest has review phase" "true" "$(echo "$manifest" | grep -qF '"review"' && echo true || echo false)"
+  assert_eq "manifest review status is completed" "true" "$(echo "$manifest" | grep -qF '"status": "completed"' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 22: research-analysis.md moves to v1/.state/ (regression) ---
+test_research_analysis_state() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/.state"
 
-echo -e "${YELLOW}Test: research-analysis.md moves to v1/.state/ (regression)${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/.state"
-
-cat > "$TEST_DIR/.workflows/discussion/some-topic.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/some-topic.md" << 'EOF'
 ---
 topic: some-topic
 status: concluded
@@ -1182,51 +1001,53 @@ date: 2026-01-10
 # Discussion: Some Topic
 EOF
 
-echo "research analysis content" > "$TEST_DIR/.workflows/.state/research-analysis.md"
+  echo "research analysis content" > "$TEST_DIR/.workflows/.state/research-analysis.md"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/v1/.state/research-analysis.md" "research-analysis.md moved to v1/.state/"
-assert_file_not_exists "$TEST_DIR/.workflows/.state/research-analysis.md" "original research-analysis.md removed"
+  assert_eq "research-analysis.md moved to v1/.state/" "true" "$([ -f "$TEST_DIR/.workflows/v1/.state/research-analysis.md" ] && echo true || echo false)"
+  assert_eq "original research-analysis.md removed" "false" "$([ -f "$TEST_DIR/.workflows/.state/research-analysis.md" ] && echo true || echo false)"
 
-content=$(cat "$TEST_DIR/.workflows/v1/.state/research-analysis.md")
-assert_contains "$content" "research analysis content" "research-analysis.md content preserved"
+  content=$(cat "$TEST_DIR/.workflows/v1/.state/research-analysis.md")
+  assert_eq "research-analysis.md content preserved" "true" "$(echo "$content" | grep -qF 'research analysis content' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 23: Review-only triggers v1 (no discussion needed) ---
+test_review_only_v1() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/review/orphan-topic/r1"
 
-echo -e "${YELLOW}Test: Review-only triggers v1 (no discussion needed)${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/review/orphan-topic/r1"
+  echo "review findings" > "$TEST_DIR/.workflows/review/orphan-topic/r1/review.md"
 
-echo "review findings" > "$TEST_DIR/.workflows/review/orphan-topic/r1/review.md"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-run_migration
+  assert_eq "v1 created from review-only" "true" "$([ -f "$TEST_DIR/.workflows/v1/manifest.json" ] && echo true || echo false)"
+  assert_eq "review-only topic moved to v1" "true" "$([ -f "$TEST_DIR/.workflows/v1/review/orphan-topic/r1/review.md" ] && echo true || echo false)"
 
-assert_file_exists "$TEST_DIR/.workflows/v1/manifest.json" "v1 created from review-only"
-assert_file_exists "$TEST_DIR/.workflows/v1/review/orphan-topic/r1/review.md" "review-only topic moved to v1"
+  manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
+  assert_eq "v1 is epic" "true" "$(echo "$manifest" | grep -qF '"work_type": "epic"' && echo true || echo false)"
 
-manifest=$(cat "$TEST_DIR/.workflows/v1/manifest.json")
-assert_contains "$manifest" '"work_type": "epic"' "v1 is epic"
+  review_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var r=m.phases.review; console.log(r && r.items && r.items['orphan-topic'] ? r.items['orphan-topic'].status : 'missing')")
+  assert_eq "review-only topic in manifest items" "completed" "$review_status"
 
-review_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); var r=m.phases.review; console.log(r && r.items && r.items['orphan-topic'] ? r.items['orphan-topic'].status : 'missing')")
-assert_equals "$review_status" "completed" "review-only topic in manifest items"
+  assert_eq "review phase dir cleaned up" "false" "$([ -d "$TEST_DIR/.workflows/review" ] && echo true || echo false)"
 
-assert_dir_not_exists "$TEST_DIR/.workflows/review" "review phase dir cleaned up"
+  teardown
+}
 
-echo ""
+# --- Test 24: Implementation without work_type falls back to prior registration ---
+test_impl_no_worktype_feature() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
+  mkdir -p "$TEST_DIR/.workflows/planning/auth-flow"
+  mkdir -p "$TEST_DIR/.workflows/implementation/auth-flow"
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Implementation without work_type falls back to prior registration${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/auth-flow"
-mkdir -p "$TEST_DIR/.workflows/planning/auth-flow"
-mkdir -p "$TEST_DIR/.workflows/implementation/auth-flow"
-
-cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/auth-flow.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -1237,7 +1058,7 @@ date: 2026-01-15
 # Discussion: Auth Flow
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/auth-flow/specification.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -1248,7 +1069,7 @@ type: feature
 # Specification: Auth Flow
 EOF
 
-cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/auth-flow/plan.md" << 'EOF'
 ---
 topic: auth-flow
 status: concluded
@@ -1260,8 +1081,7 @@ ext_id: tick-abc123
 # Plan: Auth Flow
 EOF
 
-# Implementation has frontmatter but NO work_type (the gap 013-015 missed)
-cat > "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" << 'EOF'
 ---
 topic: auth-flow
 status: completed
@@ -1277,33 +1097,33 @@ current_task: ~
 # Implementation: Auth Flow
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/auth-flow/manifest.json" "manifest created"
-assert_file_exists "$TEST_DIR/.workflows/auth-flow/implementation/auth-flow/implementation.md" "implementation moved to feature work unit"
-assert_file_not_exists "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" "old implementation file removed"
+  assert_eq "manifest created" "true" "$([ -f "$TEST_DIR/.workflows/auth-flow/manifest.json" ] && echo true || echo false)"
+  assert_eq "implementation moved to feature work unit" "true" "$([ -f "$TEST_DIR/.workflows/auth-flow/implementation/auth-flow/implementation.md" ] && echo true || echo false)"
+  assert_eq "old implementation file removed" "false" "$([ -f "$TEST_DIR/.workflows/implementation/auth-flow/tracking.md" ] && echo true || echo false)"
 
-manifest=$(cat "$TEST_DIR/.workflows/auth-flow/manifest.json")
-assert_contains "$manifest" '"work_type": "feature"' "work unit is feature"
+  manifest=$(cat "$TEST_DIR/.workflows/auth-flow/manifest.json")
+  assert_eq "work unit is feature" "true" "$(echo "$manifest" | grep -qF '"work_type": "feature"' && echo true || echo false)"
 
-impl_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/auth-flow/manifest.json','utf8')); console.log(m.phases.implementation ? m.phases.implementation.status : 'missing')")
-assert_equals "$impl_status" "completed" "implementation status in manifest"
+  impl_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/auth-flow/manifest.json','utf8')); console.log(m.phases.implementation ? m.phases.implementation.status : 'missing')")
+  assert_eq "implementation status in manifest" "completed" "$impl_status"
 
-# Verify no v1 epic was created (all artifacts belong to the feature)
-assert_file_not_exists "$TEST_DIR/.workflows/v1/manifest.json" "no v1 epic created"
+  assert_eq "no v1 epic created" "false" "$([ -f "$TEST_DIR/.workflows/v1/manifest.json" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 25: Implementation without work_type — bugfix falls back correctly ---
+test_impl_no_worktype_bugfix() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/investigation/fix-crash"
+  mkdir -p "$TEST_DIR/.workflows/specification/fix-crash"
+  mkdir -p "$TEST_DIR/.workflows/planning/fix-crash"
+  mkdir -p "$TEST_DIR/.workflows/implementation/fix-crash"
 
-echo -e "${YELLOW}Test: Implementation without work_type — bugfix falls back correctly${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/investigation/fix-crash"
-mkdir -p "$TEST_DIR/.workflows/specification/fix-crash"
-mkdir -p "$TEST_DIR/.workflows/planning/fix-crash"
-mkdir -p "$TEST_DIR/.workflows/implementation/fix-crash"
-
-cat > "$TEST_DIR/.workflows/investigation/fix-crash/investigation.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/investigation/fix-crash/investigation.md" << 'EOF'
 ---
 topic: fix-crash
 status: concluded
@@ -1313,7 +1133,7 @@ work_type: bugfix
 # Investigation: Fix Crash
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/fix-crash/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/fix-crash/specification.md" << 'EOF'
 ---
 topic: fix-crash
 status: concluded
@@ -1324,7 +1144,7 @@ type: feature
 # Specification: Fix Crash
 EOF
 
-cat > "$TEST_DIR/.workflows/planning/fix-crash/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/fix-crash/plan.md" << 'EOF'
 ---
 topic: fix-crash
 status: concluded
@@ -1335,8 +1155,7 @@ format: local-markdown
 # Plan: Fix Crash
 EOF
 
-# No work_type in implementation
-cat > "$TEST_DIR/.workflows/implementation/fix-crash/tracking.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/implementation/fix-crash/tracking.md" << 'EOF'
 ---
 topic: fix-crash
 status: completed
@@ -1347,27 +1166,28 @@ task_gate_mode: auto
 # Implementation: Fix Crash
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_file_exists "$TEST_DIR/.workflows/fix-crash/implementation/fix-crash/implementation.md" "bugfix implementation moved to own work unit"
+  assert_eq "bugfix implementation moved to own work unit" "true" "$([ -f "$TEST_DIR/.workflows/fix-crash/implementation/fix-crash/implementation.md" ] && echo true || echo false)"
 
-manifest=$(cat "$TEST_DIR/.workflows/fix-crash/manifest.json")
-assert_contains "$manifest" '"work_type": "bugfix"' "work unit is bugfix"
+  manifest=$(cat "$TEST_DIR/.workflows/fix-crash/manifest.json")
+  assert_eq "work unit is bugfix" "true" "$(echo "$manifest" | grep -qF '"work_type": "bugfix"' && echo true || echo false)"
 
-impl_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/fix-crash/manifest.json','utf8')); console.log(m.phases.implementation ? m.phases.implementation.status : 'missing')")
-assert_equals "$impl_status" "completed" "implementation status in bugfix manifest"
+  impl_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/fix-crash/manifest.json','utf8')); console.log(m.phases.implementation ? m.phases.implementation.status : 'missing')")
+  assert_eq "implementation status in bugfix manifest" "completed" "$impl_status"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 26: Non-standard status values are normalized ---
+test_status_normalization() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/widget"
+  mkdir -p "$TEST_DIR/.workflows/planning/widget"
 
-echo -e "${YELLOW}Test: Non-standard status values are normalized${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/widget"
-mkdir -p "$TEST_DIR/.workflows/planning/widget"
-
-cat > "$TEST_DIR/.workflows/discussion/widget.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/widget.md" << 'EOF'
 ---
 topic: widget
 status: concluded
@@ -1377,7 +1197,7 @@ work_type: feature
 # Discussion: Widget
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/widget/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/widget/specification.md" << 'EOF'
 ---
 topic: widget
 status: concluded
@@ -1388,8 +1208,7 @@ type: feature
 # Specification: Widget
 EOF
 
-# Non-standard status: "planning" instead of "in-progress"
-cat > "$TEST_DIR/.workflows/planning/widget/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/widget/plan.md" << 'EOF'
 ---
 topic: widget
 status: planning
@@ -1400,21 +1219,22 @@ format: tick
 # Plan: Widget
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-plan_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/widget/manifest.json','utf8')); console.log(m.phases.planning.status)")
-assert_equals "$plan_status" "in-progress" "non-standard 'planning' status normalized to 'in-progress'"
+  plan_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/widget/manifest.json','utf8')); console.log(m.phases.planning.status)")
+  assert_eq "non-standard 'planning' status normalized to 'in-progress'" "in-progress" "$plan_status"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 27: Status normalization — completed/concluded crossover ---
+test_status_crossover() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/crossover"
 
-echo -e "${YELLOW}Test: Status normalization — completed/concluded crossover${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/crossover"
-
-cat > "$TEST_DIR/.workflows/discussion/crossover.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/crossover.md" << 'EOF'
 ---
 topic: crossover
 status: completed
@@ -1424,7 +1244,7 @@ work_type: feature
 # Discussion: Crossover
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/crossover/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/crossover/specification.md" << 'EOF'
 ---
 topic: crossover
 status: completed
@@ -1435,32 +1255,31 @@ type: feature
 # Specification: Crossover
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-disc_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/crossover/manifest.json','utf8')); console.log(m.phases.discussion.status)")
-assert_equals "$disc_status" "concluded" "discussion 'completed' normalized to 'concluded'"
+  disc_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/crossover/manifest.json','utf8')); console.log(m.phases.discussion.status)")
+  assert_eq "discussion 'completed' normalized to 'concluded'" "concluded" "$disc_status"
 
-spec_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/crossover/manifest.json','utf8')); console.log(m.phases.specification.status)")
-assert_equals "$spec_status" "concluded" "specification 'completed' normalized to 'concluded'"
+  spec_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/crossover/manifest.json','utf8')); console.log(m.phases.specification.status)")
+  assert_eq "specification 'completed' normalized to 'concluded'" "concluded" "$spec_status"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 28: Research status inferred from later phases ---
+test_research_inferred() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/research"
 
-echo -e "${YELLOW}Test: Research status inferred from later phases${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/research"
-
-# Research with no Discussion-ready marker
-cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 # Research Exploration
 
 Some research content without any Discussion-ready marker.
 EOF
 
-# Greenfield discussion exists — proves research was concluded
-cat > "$TEST_DIR/.workflows/discussion/topic-a.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/topic-a.md" << 'EOF'
 ---
 topic: topic-a
 status: concluded
@@ -1470,50 +1289,46 @@ work_type: greenfield
 # Discussion: Topic A
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-research_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.research ? m.phases.research.status : 'missing')")
-assert_equals "$research_status" "concluded" "research concluded when later phases exist"
+  research_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.research ? m.phases.research.status : 'missing')")
+  assert_eq "research concluded when later phases exist" "concluded" "$research_status"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 29: Research status stays in-progress when no later phases ---
+test_research_in_progress() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/research"
 
-echo -e "${YELLOW}Test: Research status stays in-progress when no later phases${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/research"
-
-# Research only — no other phases, no Discussion-ready marker
-cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/research/exploration.md" << 'EOF'
 # Research Exploration
 
 Early research, nothing else exists yet.
 EOF
 
-# Need a greenfield discussion to trigger v1 epic creation... but we want ONLY research.
-# Research without any other phase and without a marker: the file is greenfield (no work_type),
-# so it triggers V1_EPIC_NEEDED. The v1 manifest should have only research, in-progress.
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# v1 should exist with research only
-research_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.research ? m.phases.research.status : 'missing')")
-assert_equals "$research_status" "in-progress" "research stays in-progress when no later phases"
+  research_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.research ? m.phases.research.status : 'missing')")
+  assert_eq "research stays in-progress when no later phases" "in-progress" "$research_status"
 
-# No other phases should exist
-phase_count=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(Object.keys(m.phases).length)")
-assert_equals "$phase_count" "1" "only research phase in manifest"
+  phase_count=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(Object.keys(m.phases).length)")
+  assert_eq "only research phase in manifest" "1" "$phase_count"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 30: Specification path references updated for new directory depth ---
+test_spec_path_references() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/my-feature"
+  mkdir -p "$TEST_DIR/.workflows/planning/my-feature"
 
-echo -e "${YELLOW}Test: Specification path references updated for new directory depth${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/my-feature"
-mkdir -p "$TEST_DIR/.workflows/planning/my-feature"
-
-cat > "$TEST_DIR/.workflows/discussion/my-feature.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/my-feature.md" << 'EOF'
 ---
 topic: my-feature
 status: concluded
@@ -1523,7 +1338,7 @@ work_type: feature
 # Discussion: My Feature
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/my-feature/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/my-feature/specification.md" << 'EOF'
 ---
 topic: my-feature
 status: concluded
@@ -1534,7 +1349,7 @@ type: feature
 # Specification: My Feature
 EOF
 
-cat > "$TEST_DIR/.workflows/planning/my-feature/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/my-feature/plan.md" << 'EOF'
 ---
 topic: my-feature
 status: concluded
@@ -1547,26 +1362,26 @@ spec_commit: abc123
 # Plan: My Feature
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-spec_ref=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/my-feature/manifest.json','utf8')); console.log(m.phases.planning.specification)")
-assert_equals "$spec_ref" "../../specification/my-feature/specification.md" "spec path gets extra ../ for new directory depth"
+  spec_ref=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/my-feature/manifest.json','utf8')); console.log(m.phases.planning.specification)")
+  assert_eq "spec path gets extra ../ for new directory depth" "../../specification/my-feature/specification.md" "$spec_ref"
 
-# Verify the path actually resolves
-resolved="$TEST_DIR/.workflows/my-feature/planning/my-feature/$spec_ref"
-assert_file_exists "$(cd "$(dirname "$resolved")" && pwd)/$(basename "$resolved")" "spec path resolves to actual file"
+  resolved="$TEST_DIR/.workflows/my-feature/planning/my-feature/$spec_ref"
+  assert_eq "spec path resolves to actual file" "true" "$([ -f "$(cd "$(dirname "$resolved")" && pwd)/$(basename "$resolved")" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 31: Epic spec path references also updated ---
+test_epic_spec_path() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/billing"
+  mkdir -p "$TEST_DIR/.workflows/planning/billing"
 
-echo -e "${YELLOW}Test: Epic spec path references also updated${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/billing"
-mkdir -p "$TEST_DIR/.workflows/planning/billing"
-
-cat > "$TEST_DIR/.workflows/discussion/billing.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/billing.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -1576,7 +1391,7 @@ work_type: greenfield
 # Discussion: Billing
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/billing/specification.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -1587,7 +1402,7 @@ type: feature
 # Specification: Billing
 EOF
 
-cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/planning/billing/plan.md" << 'EOF'
 ---
 topic: billing
 status: concluded
@@ -1601,22 +1416,23 @@ spec_commit: def456
 # Plan: Billing
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-epic_spec_ref=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.planning.items.billing.specification)")
-assert_equals "$epic_spec_ref" "../../specification/billing/specification.md" "epic spec path gets extra ../"
+  epic_spec_ref=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.planning.items.billing.specification)")
+  assert_eq "epic spec path gets extra ../" "../../specification/billing/specification.md" "$epic_spec_ref"
 
-# ============================================================================
-echo -e "${YELLOW}TEST: Superseded specification status preserved${NC}"
-# ============================================================================
+  teardown
+}
 
-setup_fixture
+# --- Test 32: Superseded specification status preserved ---
+test_superseded_spec() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/specification/payments"
+  mkdir -p "$TEST_DIR/.workflows/specification/payments-v2"
 
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/specification/payments"
-mkdir -p "$TEST_DIR/.workflows/specification/payments-v2"
-
-cat > "$TEST_DIR/.workflows/discussion/payments.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/payments.md" << 'EOF'
 ---
 topic: payments
 status: concluded
@@ -1626,7 +1442,7 @@ work_type: greenfield
 # Discussion: Payments
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/payments/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/payments/specification.md" << 'EOF'
 ---
 topic: payments
 status: superseded
@@ -1638,7 +1454,7 @@ work_type: greenfield
 # Specification: Payments (superseded)
 EOF
 
-cat > "$TEST_DIR/.workflows/specification/payments-v2/specification.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/specification/payments-v2/specification.md" << 'EOF'
 ---
 topic: payments-v2
 status: concluded
@@ -1649,25 +1465,26 @@ work_type: greenfield
 # Specification: Payments v2
 EOF
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-superseded_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.specification.items.payments.status)")
-assert_equals "$superseded_status" "superseded" "superseded spec status preserved"
+  superseded_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.specification.items.payments.status)")
+  assert_eq "superseded spec status preserved" "superseded" "$superseded_status"
 
-v2_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.specification.items['payments-v2'].status)")
-assert_equals "$v2_status" "concluded" "non-superseded spec status preserved"
+  v2_status=$(node -e "var m=JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/v1/manifest.json','utf8')); console.log(m.phases.specification.items['payments-v2'].status)")
+  assert_eq "non-superseded spec status preserved" "concluded" "$v2_status"
 
-# ============================================================================
-echo -e "${YELLOW}TEST: Research subdirectories migrated to v1 epic${NC}"
-# ============================================================================
+  teardown
+}
 
-setup_fixture
+# --- Test 33: Research subdirectories migrated to v1 epic ---
+test_research_subdirs() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/research/sync-engine"
+  mkdir -p "$TEST_DIR/.workflows/research/multi-tenancy"
 
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/research/sync-engine"
-mkdir -p "$TEST_DIR/.workflows/research/multi-tenancy"
-
-cat > "$TEST_DIR/.workflows/discussion/core.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/core.md" << 'EOF'
 ---
 topic: core
 status: concluded
@@ -1677,7 +1494,7 @@ work_type: greenfield
 # Discussion: Core
 EOF
 
-cat > "$TEST_DIR/.workflows/research/overview.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/research/overview.md" << 'EOF'
 ---
 topic: overview
 ---
@@ -1685,30 +1502,29 @@ topic: overview
 # Research overview
 EOF
 
-echo "# Sync architecture" > "$TEST_DIR/.workflows/research/sync-engine/architecture.md"
-echo "# Sync API design" > "$TEST_DIR/.workflows/research/sync-engine/api-design.md"
-echo "# MT overview" > "$TEST_DIR/.workflows/research/multi-tenancy/overview.md"
+  echo "# Sync architecture" > "$TEST_DIR/.workflows/research/sync-engine/architecture.md"
+  echo "# Sync API design" > "$TEST_DIR/.workflows/research/sync-engine/api-design.md"
+  echo "# MT overview" > "$TEST_DIR/.workflows/research/multi-tenancy/overview.md"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_equals "$([ -d "$TEST_DIR/.workflows/v1/research/sync-engine" ] && echo yes)" "yes" "research subdir sync-engine migrated"
-assert_equals "$([ -f "$TEST_DIR/.workflows/v1/research/sync-engine/architecture.md" ] && echo yes)" "yes" "research subdir file migrated"
-assert_equals "$([ -d "$TEST_DIR/.workflows/v1/research/multi-tenancy" ] && echo yes)" "yes" "research subdir multi-tenancy migrated"
-assert_equals "$([ -f "$TEST_DIR/.workflows/v1/research/overview.md" ] && echo yes)" "yes" "flat research file also migrated"
-assert_equals "$([ -d "$TEST_DIR/.workflows/research" ] && echo yes || echo no)" "no" "old research dir removed"
+  assert_eq "research subdir sync-engine migrated" "true" "$([ -d "$TEST_DIR/.workflows/v1/research/sync-engine" ] && echo true || echo false)"
+  assert_eq "research subdir file migrated" "true" "$([ -f "$TEST_DIR/.workflows/v1/research/sync-engine/architecture.md" ] && echo true || echo false)"
+  assert_eq "research subdir multi-tenancy migrated" "true" "$([ -d "$TEST_DIR/.workflows/v1/research/multi-tenancy" ] && echo true || echo false)"
+  assert_eq "flat research file also migrated" "true" "$([ -f "$TEST_DIR/.workflows/v1/research/overview.md" ] && echo true || echo false)"
+  assert_eq "old research dir removed" "false" "$([ -d "$TEST_DIR/.workflows/research" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ============================================================================
-echo -e "${YELLOW}TEST: .gitkeep-only directories treated as empty${NC}"
-# ============================================================================
+# --- Test 34: .gitkeep-only directories treated as empty ---
+test_gitkeep_empty() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  mkdir -p "$TEST_DIR/.workflows/planning"
 
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/discussion"
-mkdir -p "$TEST_DIR/.workflows/planning"
-
-cat > "$TEST_DIR/.workflows/discussion/widget.md" << 'EOF'
+  cat > "$TEST_DIR/.workflows/discussion/widget.md" << 'EOF'
 ---
 topic: widget
 status: concluded
@@ -1718,26 +1534,55 @@ work_type: greenfield
 # Discussion: Widget
 EOF
 
-touch "$TEST_DIR/.workflows/planning/.gitkeep"
+  touch "$TEST_DIR/.workflows/planning/.gitkeep"
 
-run_migration
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-assert_equals "$([ -d "$TEST_DIR/.workflows/planning" ] && echo yes || echo no)" "no" ".gitkeep-only planning dir removed"
-assert_equals "$([ -d "$TEST_DIR/.workflows/v1/discussion" ] && echo yes)" "yes" "discussion still migrated correctly"
+  assert_eq ".gitkeep-only planning dir removed" "false" "$([ -d "$TEST_DIR/.workflows/planning" ] && echo true || echo false)"
+  assert_eq "discussion still migrated correctly" "true" "$([ -d "$TEST_DIR/.workflows/v1/discussion" ] && echo true || echo false)"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 016 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_no_workflows_dir
+test_single_feature
+test_single_bugfix
+test_multiple_features
+test_greenfield_epic
+test_mixed_types
+test_idempotency
+test_frontmatter_preserved
+test_manifest_fields
+test_empty_phase_dirs
+test_greenfield_to_epic
+test_tracking_rename
+test_research_discussion_ready
+test_research_no_marker
+test_epic_all_phases
+test_state_file_moved
+test_unmatched_review
+test_mixed_feature_epic
+test_epic_multiple_topics
+test_feature_with_review
+test_research_analysis_state
+test_review_only_v1
+test_impl_no_worktype_feature
+test_impl_no_worktype_bugfix
+test_status_normalization
+test_status_crossover
+test_research_inferred
+test_research_in_progress
+test_spec_path_references
+test_epic_spec_path
+test_superseded_spec
+test_research_subdirs
+test_gitkeep_empty
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-017.sh
+++ b/tests/scripts/test-migration-017.sh
@@ -1,122 +1,46 @@
 #!/bin/bash
-#
-# Tests migration 017-external-deps-object.sh
-# Validates conversion of external_dependencies from array to object format.
-#
+# Tests for migration 017: external-deps-object
+# Run: bash tests/scripts/test-migration-017.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/017-external-deps-object.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/017-external-deps-object.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-017-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: Converts array to object for feature ---
+test_array_to_object_feature() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        echo -e "    In: $content"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local unexpected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$unexpected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Unexpectedly found: $unexpected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    fi
-}
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
-    mkdir -p "$TEST_DIR/.workflows"
-}
-
-run_migration() {
-    cd "$TEST_DIR"
-    source "$MIGRATION_SCRIPT"
-}
-
-# ============================================================================
-# TESTS
-# ============================================================================
-
-echo -e "${YELLOW}Test: converts array to object for feature${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/auth"
-cat > "$TEST_DIR/.workflows/auth/manifest.json" << 'EOF'
+  mkdir -p "$TEST_DIR/.workflows/auth"
+  cat > "$TEST_DIR/.workflows/auth/manifest.json" << 'EOF'
 {
   "name": "auth",
   "work_type": "feature",
@@ -132,25 +56,28 @@ cat > "$TEST_DIR/.workflows/auth/manifest.json" << 'EOF'
   }
 }
 EOF
-output=$(run_migration 2>&1)
-content=$(cat "$TEST_DIR/.workflows/auth/manifest.json")
 
-assert_contains "$content" '"billing"' "billing key exists"
-assert_contains "$content" '"state": "unresolved"' "billing state preserved"
-assert_contains "$content" '"description": "Invoice API"' "billing description preserved"
-assert_contains "$content" '"payments"' "payments key exists"
-assert_contains "$content" '"task_id": "pay-1"' "payments task_id preserved"
-assert_not_contains "$content" '"topic"' "topic field removed from values"
-assert_contains "$output" "skipped" "Reports skip after conversion"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-echo ""
+  content=$(cat "$TEST_DIR/.workflows/auth/manifest.json")
 
-# ----------------------------------------------------------------------------
+  assert_eq "billing key exists" "true" "$(echo "$content" | grep -qF '"billing"' && echo true || echo false)"
+  assert_eq "billing state preserved" "true" "$(echo "$content" | grep -qF '"state": "unresolved"' && echo true || echo false)"
+  assert_eq "billing description preserved" "true" "$(echo "$content" | grep -qF '"description": "Invoice API"' && echo true || echo false)"
+  assert_eq "payments key exists" "true" "$(echo "$content" | grep -qF '"payments"' && echo true || echo false)"
+  assert_eq "payments task_id preserved" "true" "$(echo "$content" | grep -qF '"task_id": "pay-1"' && echo true || echo false)"
+  assert_eq "topic field removed from values" "false" "$(echo "$content" | grep -qF '"topic"' && echo true || echo false)"
 
-echo -e "${YELLOW}Test: converts empty array to empty object${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/simple"
-cat > "$TEST_DIR/.workflows/simple/manifest.json" << 'EOF'
+  teardown
+}
+
+# --- Test 2: Converts empty array to empty object ---
+test_empty_array_to_object() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/simple"
+  cat > "$TEST_DIR/.workflows/simple/manifest.json" << 'EOF'
 {
   "name": "simple",
   "work_type": "feature",
@@ -163,25 +90,26 @@ cat > "$TEST_DIR/.workflows/simple/manifest.json" << 'EOF'
   }
 }
 EOF
-run_migration
-content=$(cat "$TEST_DIR/.workflows/simple/manifest.json")
 
-# Empty array should become empty object
-result=$(node -e "
-  const d = JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/simple/manifest.json','utf8'));
-  const deps = d.phases.planning.external_dependencies;
-  console.log(typeof deps === 'object' && !Array.isArray(deps) ? 'object' : 'not_object');
-")
-assert_equals "$result" "object" "Empty array converted to object"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-echo ""
+  result=$(node -e "
+    const d = JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/simple/manifest.json','utf8'));
+    const deps = d.phases.planning.external_dependencies;
+    console.log(typeof deps === 'object' && !Array.isArray(deps) ? 'object' : 'not_object');
+  ")
+  assert_eq "Empty array converted to object" "object" "$result"
 
-# ----------------------------------------------------------------------------
+  teardown
+}
 
-echo -e "${YELLOW}Test: converts array in epic items${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/my-epic"
-cat > "$TEST_DIR/.workflows/my-epic/manifest.json" << 'EOF'
+# --- Test 3: Converts array in epic items ---
+test_epic_items() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/my-epic"
+  cat > "$TEST_DIR/.workflows/my-epic/manifest.json" << 'EOF'
 {
   "name": "my-epic",
   "work_type": "epic",
@@ -200,21 +128,25 @@ cat > "$TEST_DIR/.workflows/my-epic/manifest.json" << 'EOF'
   }
 }
 EOF
-run_migration
-content=$(cat "$TEST_DIR/.workflows/my-epic/manifest.json")
 
-assert_contains "$content" '"auth"' "auth key exists in epic item"
-assert_contains "$content" '"state": "resolved"' "state preserved"
-assert_not_contains "$content" '"topic"' "topic field removed"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-echo ""
+  content=$(cat "$TEST_DIR/.workflows/my-epic/manifest.json")
 
-# ----------------------------------------------------------------------------
+  assert_eq "auth key exists in epic item" "true" "$(echo "$content" | grep -qF '"auth"' && echo true || echo false)"
+  assert_eq "state preserved" "true" "$(echo "$content" | grep -qF '"state": "resolved"' && echo true || echo false)"
+  assert_eq "topic field removed" "false" "$(echo "$content" | grep -qF '"topic"' && echo true || echo false)"
 
-echo -e "${YELLOW}Test: idempotent — already object format unchanged${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/already-done"
-cat > "$TEST_DIR/.workflows/already-done/manifest.json" << 'EOF'
+  teardown
+}
+
+# --- Test 4: Idempotent — already object format unchanged ---
+test_idempotent() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/already-done"
+  cat > "$TEST_DIR/.workflows/already-done/manifest.json" << 'EOF'
 {
   "name": "already-done",
   "work_type": "feature",
@@ -229,22 +161,24 @@ cat > "$TEST_DIR/.workflows/already-done/manifest.json" << 'EOF'
   }
 }
 EOF
-# Save content before migration
-before=$(cat "$TEST_DIR/.workflows/already-done/manifest.json")
-output=$(run_migration 2>&1)
-after=$(cat "$TEST_DIR/.workflows/already-done/manifest.json")
 
-assert_equals "$after" "$before" "Already-object format unchanged"
-assert_contains "$output" "skipped" "Reports skip for already-object format"
+  before=$(cat "$TEST_DIR/.workflows/already-done/manifest.json")
 
-echo ""
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# ----------------------------------------------------------------------------
+  after=$(cat "$TEST_DIR/.workflows/already-done/manifest.json")
+  assert_eq "Already-object format unchanged" "$before" "$after"
 
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/.archive/old"
-cat > "$TEST_DIR/.workflows/.archive/old/manifest.json" << 'EOF'
+  teardown
+}
+
+# --- Test 5: Skips dot-prefixed directories ---
+test_skip_dot_dirs() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.archive/old"
+  cat > "$TEST_DIR/.workflows/.archive/old/manifest.json" << 'EOF'
 {
   "name": "old",
   "work_type": "feature",
@@ -258,21 +192,24 @@ cat > "$TEST_DIR/.workflows/.archive/old/manifest.json" << 'EOF'
   }
 }
 EOF
-before=$(cat "$TEST_DIR/.workflows/.archive/old/manifest.json")
-output=$(run_migration 2>&1)
-after=$(cat "$TEST_DIR/.workflows/.archive/old/manifest.json")
 
-assert_equals "$after" "$before" "Dot-prefixed directory skipped"
-assert_not_contains "$output" "updated" "No update for dot-prefixed directory"
+  before=$(cat "$TEST_DIR/.workflows/.archive/old/manifest.json")
 
-echo ""
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# ----------------------------------------------------------------------------
+  after=$(cat "$TEST_DIR/.workflows/.archive/old/manifest.json")
+  assert_eq "Dot-prefixed directory skipped" "$before" "$after"
 
-echo -e "${YELLOW}Test: no external_dependencies field left unchanged${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/no-deps"
-cat > "$TEST_DIR/.workflows/no-deps/manifest.json" << 'EOF'
+  teardown
+}
+
+# --- Test 6: No external_dependencies field left unchanged ---
+test_no_deps_unchanged() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/no-deps"
+  cat > "$TEST_DIR/.workflows/no-deps/manifest.json" << 'EOF'
 {
   "name": "no-deps",
   "work_type": "feature",
@@ -284,26 +221,29 @@ cat > "$TEST_DIR/.workflows/no-deps/manifest.json" << 'EOF'
   }
 }
 EOF
-before=$(cat "$TEST_DIR/.workflows/no-deps/manifest.json")
-output=$(run_migration 2>&1)
-after=$(cat "$TEST_DIR/.workflows/no-deps/manifest.json")
 
-assert_equals "$after" "$before" "No external_dependencies field left unchanged"
-assert_contains "$output" "skipped" "Reports skip for no deps"
+  before=$(cat "$TEST_DIR/.workflows/no-deps/manifest.json")
 
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  after=$(cat "$TEST_DIR/.workflows/no-deps/manifest.json")
+  assert_eq "No external_dependencies field left unchanged" "$before" "$after"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 017 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_array_to_object_feature
+test_empty_array_to_object
+test_epic_items
+test_idempotent
+test_skip_dot_dirs
+test_no_deps_unchanged
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-018.sh
+++ b/tests/scripts/test-migration-018.sh
@@ -1,233 +1,133 @@
 #!/bin/bash
-#
-# Tests migration 018-remove-stale-environment-setup.sh
-# Validates cleanup of stale environment-setup.md from workflows root.
-#
+# Tests for migration 018: remove-stale-environment-setup
+# Run: bash tests/scripts/test-migration-018.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/018-remove-stale-environment-setup.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/018-remove-stale-environment-setup.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
 
-echo "Test directory: $TEST_DIR"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-018-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Test 1: Both exist — removes stale root copy, keeps .state/ ---
+test_both_exist() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo "stale content" > "$TEST_DIR/.workflows/environment-setup.md"
+  echo "real content" > "$TEST_DIR/.workflows/.state/environment-setup.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "Stale root file removed" "false" "$([ -f "$TEST_DIR/.workflows/environment-setup.md" ] && echo true || echo false)"
+  assert_eq ".state/ copy preserved" "true" "$([ -f "$TEST_DIR/.workflows/.state/environment-setup.md" ] && echo true || echo false)"
+  assert_eq ".state/ content unchanged" "real content" "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")"
+
+  teardown
+}
+
+# --- Test 2: Only root exists — moves to .state/ ---
+test_only_root() {
+  setup
+
+  echo "needs moving" > "$TEST_DIR/.workflows/environment-setup.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "Root file removed" "false" "$([ -f "$TEST_DIR/.workflows/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "File moved to .state/" "true" "$([ -f "$TEST_DIR/.workflows/.state/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "Content preserved" "needs moving" "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")"
+
+  teardown
+}
+
+# --- Test 3: Only .state/ exists — no-op ---
+test_only_state() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo "already correct" > "$TEST_DIR/.workflows/.state/environment-setup.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq ".state/ copy still exists" "true" "$([ -f "$TEST_DIR/.workflows/.state/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "No root file created" "false" "$([ -f "$TEST_DIR/.workflows/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "Content unchanged" "already correct" "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")"
+
+  teardown
+}
+
+# --- Test 4: Neither exists — no-op ---
+test_neither_exists() {
+  setup
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "No root file created" "false" "$([ -f "$TEST_DIR/.workflows/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "No .state/ file created" "false" "$([ -f "$TEST_DIR/.workflows/.state/environment-setup.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 5: Idempotency — running twice with both files ---
+test_idempotency() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo "stale" > "$TEST_DIR/.workflows/environment-setup.md"
+  echo "canonical" > "$TEST_DIR/.workflows/.state/environment-setup.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  source "$MIGRATION"
+
+  assert_eq "Root file still gone after second run" "false" "$([ -f "$TEST_DIR/.workflows/environment-setup.md" ] && echo true || echo false)"
+  assert_eq ".state/ copy still exists" "true" "$([ -f "$TEST_DIR/.workflows/.state/environment-setup.md" ] && echo true || echo false)"
+  assert_eq "Content unchanged after second run" "canonical" "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 018 tests..."
 echo ""
 
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
-}
-
-report_skip() {
-    echo "skipped"
-}
-
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
-}
-
-run_migration() {
-    cd "$TEST_DIR"
-    source "$MIGRATION_SCRIPT"
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local filepath="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$filepath" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $filepath"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: Both exist — removes stale root copy, keeps .state/${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo "stale content" > "$TEST_DIR/.workflows/environment-setup.md"
-echo "real content" > "$TEST_DIR/.workflows/.state/environment-setup.md"
-
-output=$(run_migration 2>&1)
-
-assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "Stale root file removed"
-assert_file_exists "$TEST_DIR/.workflows/.state/environment-setup.md" ".state/ copy preserved"
-assert_equals "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")" "real content" ".state/ content unchanged"
-assert_contains "$output" "updated" "Reports update"
+test_both_exist
+test_only_root
+test_only_state
+test_neither_exists
+test_idempotency
 
 echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Only root exists — moves to .state/${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows"
-echo "needs moving" > "$TEST_DIR/.workflows/environment-setup.md"
-
-output=$(run_migration 2>&1)
-
-assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "Root file removed"
-assert_file_exists "$TEST_DIR/.workflows/.state/environment-setup.md" "File moved to .state/"
-assert_equals "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")" "needs moving" "Content preserved"
-assert_contains "$output" "updated" "Reports update"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Only .state/ exists — no-op${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo "already correct" > "$TEST_DIR/.workflows/.state/environment-setup.md"
-
-output=$(run_migration 2>&1)
-
-assert_file_exists "$TEST_DIR/.workflows/.state/environment-setup.md" ".state/ copy still exists"
-assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "No root file created"
-assert_equals "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")" "already correct" "Content unchanged"
-assert_contains "$output" "skipped" "Reports skip"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Neither exists — no-op${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows"
-
-output=$(run_migration 2>&1)
-
-assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "No root file created"
-assert_file_not_exists "$TEST_DIR/.workflows/.state/environment-setup.md" "No .state/ file created"
-assert_contains "$output" "skipped" "Reports skip"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: Idempotency — running twice with both files${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo "stale" > "$TEST_DIR/.workflows/environment-setup.md"
-echo "canonical" > "$TEST_DIR/.workflows/.state/environment-setup.md"
-
-run_migration
-run_migration
-
-assert_file_not_exists "$TEST_DIR/.workflows/environment-setup.md" "Root file still gone after second run"
-assert_file_exists "$TEST_DIR/.workflows/.state/environment-setup.md" ".state/ copy still exists"
-assert_equals "$(cat "$TEST_DIR/.workflows/.state/environment-setup.md")" "canonical" "Content unchanged after second run"
-
-echo ""
-
-# ============================================================================
-# SUMMARY
-# ============================================================================
-
-echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-019.sh
+++ b/tests/scripts/test-migration-019.sh
@@ -1,209 +1,130 @@
 #!/bin/bash
-#
-# Tests migration 019-status-rename.sh
-# Validates renaming of work unit statuses: active → in-progress, archived → cancelled.
-# Also validates auto-detection of completed pipelines → concluded.
-#
+# Tests for migration 019: status-rename
+# Run: bash tests/scripts/test-migration-019.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/019-status-rename.sh"
-
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
-
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
-
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Helper functions
-#
-
 REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/019-status-rename.sh"
 
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows" "$TEST_DIR/.claude"
-    # Symlink .claude/skills → repo skills/ so the migration can find the manifest CLI
-    mkdir -p "$TEST_DIR/.claude"
-    ln -sfn "$REPO_DIR/skills" "$TEST_DIR/.claude/skills"
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+export -f report_update report_skip
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
 create_manifest() {
-    local name="$1"
-    local content="$2"
-    mkdir -p "$TEST_DIR/.workflows/$name"
-    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
-}
-
-# Stub report_update for migration script
-report_update() { echo "updated"; }
-export -f report_update
-
-run_migration() {
-    cd "$TEST_DIR"
-    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+  local name="$1"
+  local content="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name"
+  echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
 get_status() {
-    local name="$1"
-    node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/$name/manifest.json"
+  local name="$1"
+  node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
 get_json() {
-    local name="$1"
-    cat "$TEST_DIR/.workflows/$name/manifest.json"
+  local name="$1"
+  cat "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-019-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows"
+  mkdir -p "$TEST_DIR/.claude"
+  ln -sfn "$REPO_DIR/skills" "$TEST_DIR/.claude/skills"
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: active to in-progress ---
+test_active_to_in_progress() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  create_manifest "my-feature" '{"work_type":"feature","status":"active","phases":{}}'
 
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
+
+  assert_eq "Status changed to in-progress" "in-progress" "$(get_status "my-feature")"
+
+  teardown
 }
 
-# ============================================================================
-# TEST CASES
-# ============================================================================
+# --- Test 2: archived to cancelled ---
+test_archived_to_cancelled() {
+  setup
 
-echo -e "${YELLOW}Test: active → in-progress${NC}"
-setup_fixture
+  create_manifest "old-feature" '{"work_type":"feature","status":"archived","phases":{}}'
 
-create_manifest "my-feature" '{"work_type":"feature","status":"active","phases":{}}'
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-output=$(run_migration)
+  assert_eq "Status changed to cancelled" "cancelled" "$(get_status "old-feature")"
 
-assert_equals "$(get_status "my-feature")" "in-progress" "Status changed to in-progress"
-assert_contains "$output" "updated" "Reports update"
+  teardown
+}
 
-echo ""
+# --- Test 3: in-progress unchanged (already correct) ---
+test_in_progress_unchanged() {
+  setup
 
-# ----------------------------------------------------------------------------
+  create_manifest "current" '{"work_type":"feature","status":"in-progress","phases":{}}'
 
-echo -e "${YELLOW}Test: archived → cancelled${NC}"
-setup_fixture
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-create_manifest "old-feature" '{"work_type":"feature","status":"archived","phases":{}}'
+  assert_eq "Status remains in-progress" "in-progress" "$(get_status "current")"
 
-output=$(run_migration)
+  teardown
+}
 
-assert_equals "$(get_status "old-feature")" "cancelled" "Status changed to cancelled"
-assert_contains "$output" "updated" "Reports update"
+# --- Test 4: concluded unchanged ---
+test_concluded_unchanged() {
+  setup
 
-echo ""
+  create_manifest "done-feature" '{"work_type":"feature","status":"concluded","phases":{}}'
 
-# ----------------------------------------------------------------------------
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-echo -e "${YELLOW}Test: in-progress unchanged (already correct)${NC}"
-setup_fixture
+  assert_eq "Status remains concluded" "concluded" "$(get_status "done-feature")"
 
-create_manifest "current" '{"work_type":"feature","status":"in-progress","phases":{}}'
+  teardown
+}
 
-output=$(run_migration)
-status=$(get_status "current")
+# --- Test 5: cancelled unchanged ---
+test_cancelled_unchanged() {
+  setup
 
-assert_equals "$status" "in-progress" "Status remains in-progress"
-assert_not_contains "$output" "updated" "No update reported"
+  create_manifest "dead-feature" '{"work_type":"feature","status":"cancelled","phases":{}}'
 
-echo ""
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-# ----------------------------------------------------------------------------
+  assert_eq "Status remains cancelled" "cancelled" "$(get_status "dead-feature")"
 
-echo -e "${YELLOW}Test: concluded unchanged${NC}"
-setup_fixture
+  teardown
+}
 
-create_manifest "done-feature" '{"work_type":"feature","status":"concluded","phases":{}}'
+# --- Test 6: feature with completed review to concluded ---
+test_feature_completed_review() {
+  setup
 
-output=$(run_migration)
-
-assert_equals "$(get_status "done-feature")" "concluded" "Status remains concluded"
-assert_not_contains "$output" "updated" "No update reported"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: cancelled unchanged${NC}"
-setup_fixture
-
-create_manifest "dead-feature" '{"work_type":"feature","status":"cancelled","phases":{}}'
-
-output=$(run_migration)
-
-assert_equals "$(get_status "dead-feature")" "cancelled" "Status remains cancelled"
-assert_not_contains "$output" "updated" "No update reported"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: feature with completed review → concluded${NC}"
-setup_fixture
-
-create_manifest "done-but-active" '{
+  create_manifest "done-but-active" '{
   "work_type": "feature",
   "status": "active",
   "phases": {
@@ -215,19 +136,18 @@ create_manifest "done-but-active" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_status "done-but-active")" "concluded" "Completed pipeline detected and set to concluded"
-assert_contains "$output" "updated" "Reports concluded update"
+  assert_eq "Completed pipeline detected and set to concluded" "concluded" "$(get_status "done-but-active")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: feature in-progress with completed review to concluded ---
+test_in_progress_completed_review() {
+  setup
 
-echo -e "${YELLOW}Test: feature in-progress with completed review → concluded${NC}"
-setup_fixture
-
-create_manifest "done-in-progress" '{
+  create_manifest "done-in-progress" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -235,18 +155,18 @@ create_manifest "done-in-progress" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_status "done-in-progress")" "concluded" "In-progress with completed review set to concluded"
+  assert_eq "In-progress with completed review set to concluded" "concluded" "$(get_status "done-in-progress")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: feature with incomplete review stays in-progress ---
+test_incomplete_review() {
+  setup
 
-echo -e "${YELLOW}Test: feature with incomplete review stays in-progress${NC}"
-setup_fixture
-
-create_manifest "mid-review" '{
+  create_manifest "mid-review" '{
   "work_type": "feature",
   "status": "active",
   "phases": {
@@ -254,18 +174,18 @@ create_manifest "mid-review" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_status "mid-review")" "in-progress" "Incomplete review stays in-progress (not concluded)"
+  assert_eq "Incomplete review stays in-progress (not concluded)" "in-progress" "$(get_status "mid-review")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: feature with no review phase stays in-progress ---
+test_no_review_phase() {
+  setup
 
-echo -e "${YELLOW}Test: feature with no review phase stays in-progress${NC}"
-setup_fixture
-
-create_manifest "no-review" '{
+  create_manifest "no-review" '{
   "work_type": "feature",
   "status": "active",
   "phases": {
@@ -273,18 +193,18 @@ create_manifest "no-review" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_status "no-review")" "in-progress" "No review phase stays in-progress"
+  assert_eq "No review phase stays in-progress" "in-progress" "$(get_status "no-review")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: epic with all review items completed to concluded ---
+test_epic_all_review_completed() {
+  setup
 
-echo -e "${YELLOW}Test: epic with all review items completed → concluded${NC}"
-setup_fixture
-
-create_manifest "done-epic" '{
+  create_manifest "done-epic" '{
   "work_type": "epic",
   "status": "active",
   "phases": {
@@ -297,18 +217,18 @@ create_manifest "done-epic" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_status "done-epic")" "concluded" "Epic with all review items completed set to concluded"
+  assert_eq "Epic with all review items completed set to concluded" "concluded" "$(get_status "done-epic")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 11: epic with some review items incomplete stays in-progress ---
+test_epic_partial_review() {
+  setup
 
-echo -e "${YELLOW}Test: epic with some review items incomplete stays in-progress${NC}"
-setup_fixture
-
-create_manifest "partial-epic" '{
+  create_manifest "partial-epic" '{
   "work_type": "epic",
   "status": "active",
   "phases": {
@@ -321,18 +241,18 @@ create_manifest "partial-epic" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_status "partial-epic")" "in-progress" "Epic with incomplete review items stays in-progress"
+  assert_eq "Epic with incomplete review items stays in-progress" "in-progress" "$(get_status "partial-epic")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: epic with no review items stays in-progress ---
+test_epic_no_review() {
+  setup
 
-echo -e "${YELLOW}Test: epic with no review items stays in-progress${NC}"
-setup_fixture
-
-create_manifest "no-review-epic" '{
+  create_manifest "no-review-epic" '{
   "work_type": "epic",
   "status": "active",
   "phases": {
@@ -344,18 +264,18 @@ create_manifest "no-review-epic" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_status "no-review-epic")" "in-progress" "Epic with no review items stays in-progress"
+  assert_eq "Epic with no review items stays in-progress" "in-progress" "$(get_status "no-review-epic")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 13: bugfix with completed review to concluded ---
+test_bugfix_completed_review() {
+  setup
 
-echo -e "${YELLOW}Test: bugfix with completed review → concluded${NC}"
-setup_fixture
-
-create_manifest "fixed-bug" '{
+  create_manifest "fixed-bug" '{
   "work_type": "bugfix",
   "status": "active",
   "phases": {
@@ -363,79 +283,79 @@ create_manifest "fixed-bug" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_status "fixed-bug")" "concluded" "Bugfix with completed review set to concluded"
+  assert_eq "Bugfix with completed review set to concluded" "concluded" "$(get_status "fixed-bug")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 14: multiple work units processed ---
+test_multiple_work_units() {
+  setup
 
-echo -e "${YELLOW}Test: multiple work units processed${NC}"
-setup_fixture
+  create_manifest "feat-a" '{"work_type":"feature","status":"active","phases":{}}'
+  create_manifest "feat-b" '{"work_type":"feature","status":"archived","phases":{}}'
+  create_manifest "feat-c" '{"work_type":"feature","status":"in-progress","phases":{}}'
 
-create_manifest "feat-a" '{"work_type":"feature","status":"active","phases":{}}'
-create_manifest "feat-b" '{"work_type":"feature","status":"archived","phases":{}}'
-create_manifest "feat-c" '{"work_type":"feature","status":"in-progress","phases":{}}'
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-output=$(run_migration)
+  assert_eq "First work unit: active to in-progress" "in-progress" "$(get_status "feat-a")"
+  assert_eq "Second work unit: archived to cancelled" "cancelled" "$(get_status "feat-b")"
+  assert_eq "Third work unit: in-progress unchanged" "in-progress" "$(get_status "feat-c")"
 
-assert_equals "$(get_status "feat-a")" "in-progress" "First work unit: active → in-progress"
-assert_equals "$(get_status "feat-b")" "cancelled" "Second work unit: archived → cancelled"
-assert_equals "$(get_status "feat-c")" "in-progress" "Third work unit: in-progress unchanged"
+  teardown
+}
 
-echo ""
+# --- Test 15: skips dot-prefixed directories ---
+test_skip_dot_dirs() {
+  setup
 
-# ----------------------------------------------------------------------------
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo '{"status":"active"}' > "$TEST_DIR/.workflows/.state/manifest.json"
+  create_manifest "real" '{"work_type":"feature","status":"active","phases":{}}'
 
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo '{"status":"active"}' > "$TEST_DIR/.workflows/.state/manifest.json"
-create_manifest "real" '{"work_type":"feature","status":"active","phases":{}}'
+  assert_eq "Real work unit updated" "in-progress" "$(get_status "real")"
+  assert_eq "Dot-dir manifest not touched" "active" "$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/.state/manifest.json")"
 
-output=$(run_migration)
+  teardown
+}
 
-assert_equals "$(get_status "real")" "in-progress" "Real work unit updated"
-assert_equals "$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/.state/manifest.json")" "active" "Dot-dir manifest not touched"
+# --- Test 16: idempotent — running twice produces same result ---
+test_idempotent() {
+  setup
 
-echo ""
+  create_manifest "idem" '{"work_type":"feature","status":"active","phases":{}}'
 
-# ----------------------------------------------------------------------------
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
+  before=$(get_json "idem")
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
+  after=$(get_json "idem")
 
-echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
-setup_fixture
+  assert_eq "JSON unchanged after second run" "$before" "$after"
 
-create_manifest "idem" '{"work_type":"feature","status":"active","phases":{}}'
+  teardown
+}
 
-run_migration > /dev/null
-before=$(get_json "idem")
-output=$(run_migration)
-after=$(get_json "idem")
+# --- Test 17: no .workflows directory — exits cleanly ---
+test_no_workflows() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
 
-assert_equals "$after" "$before" "JSON unchanged after second run"
-assert_not_contains "$output" "updated" "No update on second run"
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-echo ""
+  assert_eq "exits cleanly" "true" "true"
 
-# ----------------------------------------------------------------------------
+  teardown
+}
 
-echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
-setup_fixture
+# --- Test 18: preserves other manifest fields ---
+test_preserves_fields() {
+  setup
 
-output=$(run_migration)
-
-assert_not_contains "$output" "updated" "No updates without .workflows dir"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
-setup_fixture
-
-create_manifest "preserve" '{
+  create_manifest "preserve" '{
   "name": "preserve",
   "work_type": "feature",
   "status": "active",
@@ -446,29 +366,42 @@ create_manifest "preserve" '{
   }
 }'
 
-run_migration > /dev/null
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
 
-json=$(get_json "preserve")
+  json=$(get_json "preserve")
 
-assert_contains "$json" '"name": "preserve"' "Name preserved"
-assert_contains "$json" '"work_type": "feature"' "Work type preserved"
-assert_contains "$json" '"created": "2026-01-15"' "Created date preserved"
-assert_contains "$json" '"description": "test feature"' "Description preserved"
-assert_contains "$json" '"status": "concluded"' "Discussion phase status preserved"
+  assert_eq "Name preserved" "true" "$(echo "$json" | grep -qF '"name": "preserve"' && echo true || echo false)"
+  assert_eq "Work type preserved" "true" "$(echo "$json" | grep -qF '"work_type": "feature"' && echo true || echo false)"
+  assert_eq "Created date preserved" "true" "$(echo "$json" | grep -qF '"created": "2026-01-15"' && echo true || echo false)"
+  assert_eq "Description preserved" "true" "$(echo "$json" | grep -qF '"description": "test feature"' && echo true || echo false)"
+  assert_eq "Discussion phase status preserved" "true" "$(echo "$json" | grep -qF '"status": "concluded"' && echo true || echo false)"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 019 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_active_to_in_progress
+test_archived_to_cancelled
+test_in_progress_unchanged
+test_concluded_unchanged
+test_cancelled_unchanged
+test_feature_completed_review
+test_in_progress_completed_review
+test_incomplete_review
+test_no_review_phase
+test_epic_all_review_completed
+test_epic_partial_review
+test_epic_no_review
+test_bugfix_completed_review
+test_multiple_work_units
+test_skip_dot_dirs
+test_idempotent
+test_no_workflows
+test_preserves_fields
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-020.sh
+++ b/tests/scripts/test-migration-020.sh
@@ -1,195 +1,122 @@
 #!/bin/bash
-#
-# Tests migration 020-normalise-terminal-status.sh
-# Validates concluded → completed for phase statuses and work unit status.
-#
+# Tests for migration 020: normalise-terminal-status
+# Run: bash tests/scripts/test-migration-020.sh
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/020-normalise-terminal-status.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/020-normalise-terminal-status.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
+export -f report_update report_skip
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
 create_manifest() {
-    local name="$1"
-    local content="$2"
-    mkdir -p "$TEST_DIR/.workflows/$name"
-    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
-}
-
-# Stub report_update for migration script
-report_update() { echo "updated"; }
-export -f report_update
-
-run_migration() {
-    cd "$TEST_DIR"
-    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+  local name="$1"
+  local content="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name"
+  echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
 get_field() {
-    local name="$1"
-    local field="$2"
-    node -e "
-      const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
-      const parts = process.argv[2].split('.');
-      let v = m;
-      for (const p of parts) v = (v || {})[p];
-      console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
-    " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
+  local name="$1"
+  local field="$2"
+  node -e "
+    const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    const parts = process.argv[2].split('.');
+    let v = m;
+    for (const p of parts) v = (v || {})[p];
+    console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
+  " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
 }
 
 get_json() {
-    local name="$1"
-    cat "$TEST_DIR/.workflows/$name/manifest.json"
+  local name="$1"
+  cat "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-020-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows"
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: work unit status concluded to completed ---
+test_wu_concluded_to_completed() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  create_manifest "done-feat" '{"work_type":"feature","status":"concluded","phases":{}}'
 
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
+
+  assert_eq "Work unit status changed to completed" "completed" "$(get_field "done-feat" "status")"
+
+  teardown
 }
 
-# ============================================================================
-# TEST CASES
-# ============================================================================
+# --- Test 2: in-progress work unit unchanged ---
+test_in_progress_unchanged() {
+  setup
 
-echo -e "${YELLOW}Test: work unit status concluded → completed${NC}"
-setup_fixture
+  create_manifest "active-feat" '{"work_type":"feature","status":"in-progress","phases":{}}'
 
-create_manifest "done-feat" '{"work_type":"feature","status":"concluded","phases":{}}'
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-output=$(run_migration)
+  assert_eq "Status remains in-progress" "in-progress" "$(get_field "active-feat" "status")"
 
-assert_equals "$(get_field "done-feat" "status")" "completed" "Work unit status changed to completed"
-assert_contains "$output" "updated" "Reports update"
+  teardown
+}
 
-echo ""
+# --- Test 3: cancelled work unit unchanged ---
+test_cancelled_unchanged() {
+  setup
 
-# ----------------------------------------------------------------------------
+  create_manifest "dead-feat" '{"work_type":"feature","status":"cancelled","phases":{}}'
 
-echo -e "${YELLOW}Test: in-progress work unit unchanged${NC}"
-setup_fixture
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-create_manifest "active-feat" '{"work_type":"feature","status":"in-progress","phases":{}}'
+  assert_eq "Status remains cancelled" "cancelled" "$(get_field "dead-feat" "status")"
 
-output=$(run_migration)
+  teardown
+}
 
-assert_equals "$(get_field "active-feat" "status")" "in-progress" "Status remains in-progress"
-assert_not_contains "$output" "updated" "No update reported"
+# --- Test 4: completed work unit unchanged ---
+test_completed_unchanged() {
+  setup
 
-echo ""
+  create_manifest "already-done" '{"work_type":"feature","status":"completed","phases":{}}'
 
-# ----------------------------------------------------------------------------
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-echo -e "${YELLOW}Test: cancelled work unit unchanged${NC}"
-setup_fixture
+  assert_eq "Status remains completed" "completed" "$(get_field "already-done" "status")"
 
-create_manifest "dead-feat" '{"work_type":"feature","status":"cancelled","phases":{}}'
+  teardown
+}
 
-output=$(run_migration)
+# --- Test 5: flat phase statuses concluded to completed ---
+test_flat_phase_statuses() {
+  setup
 
-assert_equals "$(get_field "dead-feat" "status")" "cancelled" "Status remains cancelled"
-assert_not_contains "$output" "updated" "No update reported"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: completed work unit unchanged${NC}"
-setup_fixture
-
-create_manifest "already-done" '{"work_type":"feature","status":"completed","phases":{}}'
-
-output=$(run_migration)
-
-assert_equals "$(get_field "already-done" "status")" "completed" "Status remains completed"
-assert_not_contains "$output" "updated" "No update reported"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: flat phase statuses concluded → completed${NC}"
-setup_fixture
-
-create_manifest "phases-feat" '{
+  create_manifest "phases-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -202,23 +129,23 @@ create_manifest "phases-feat" '{
   }
 }'
 
-run_migration > /dev/null
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
 
-assert_equals "$(get_field "phases-feat" "phases.research.status")" "completed" "Research status → completed"
-assert_equals "$(get_field "phases-feat" "phases.discussion.status")" "completed" "Discussion status → completed"
-assert_equals "$(get_field "phases-feat" "phases.specification.status")" "completed" "Specification status → completed"
-assert_equals "$(get_field "phases-feat" "phases.planning.status")" "completed" "Planning status → completed"
-assert_equals "$(get_field "phases-feat" "phases.implementation.status")" "completed" "Implementation status unchanged"
-assert_equals "$(get_field "phases-feat" "phases.review.status")" "in-progress" "Review in-progress unchanged"
+  assert_eq "Research status to completed" "completed" "$(get_field "phases-feat" "phases.research.status")"
+  assert_eq "Discussion status to completed" "completed" "$(get_field "phases-feat" "phases.discussion.status")"
+  assert_eq "Specification status to completed" "completed" "$(get_field "phases-feat" "phases.specification.status")"
+  assert_eq "Planning status to completed" "completed" "$(get_field "phases-feat" "phases.planning.status")"
+  assert_eq "Implementation status unchanged" "completed" "$(get_field "phases-feat" "phases.implementation.status")"
+  assert_eq "Review in-progress unchanged" "in-progress" "$(get_field "phases-feat" "phases.review.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: in-progress phase statuses unchanged ---
+test_in_progress_phase() {
+  setup
 
-echo -e "${YELLOW}Test: in-progress phase statuses unchanged${NC}"
-setup_fixture
-
-create_manifest "ip-feat" '{
+  create_manifest "ip-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -226,19 +153,18 @@ create_manifest "ip-feat" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_field "ip-feat" "phases.discussion.status")" "in-progress" "In-progress stays in-progress"
-assert_not_contains "$output" "updated" "No update reported"
+  assert_eq "In-progress stays in-progress" "in-progress" "$(get_field "ip-feat" "phases.discussion.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: superseded specification unchanged ---
+test_superseded_unchanged() {
+  setup
 
-echo -e "${YELLOW}Test: superseded specification unchanged${NC}"
-setup_fixture
-
-create_manifest "super-feat" '{
+  create_manifest "super-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -246,19 +172,18 @@ create_manifest "super-feat" '{
   }
 }'
 
-output=$(run_migration)
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-assert_equals "$(get_field "super-feat" "phases.specification.status")" "superseded" "Superseded stays superseded"
-assert_not_contains "$output" "updated" "No update reported"
+  assert_eq "Superseded stays superseded" "superseded" "$(get_field "super-feat" "phases.specification.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: epic item-level statuses concluded to completed ---
+test_epic_item_statuses() {
+  setup
 
-echo -e "${YELLOW}Test: epic item-level statuses concluded → completed${NC}"
-setup_fixture
-
-create_manifest "my-epic" '{
+  create_manifest "my-epic" '{
   "work_type": "epic",
   "status": "in-progress",
   "phases": {
@@ -286,22 +211,22 @@ create_manifest "my-epic" '{
   }
 }'
 
-run_migration > /dev/null
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
 
-assert_equals "$(get_field "my-epic" "phases.discussion.items.auth.status")" "completed" "Epic discussion item → completed"
-assert_equals "$(get_field "my-epic" "phases.discussion.items.billing.status")" "in-progress" "In-progress item unchanged"
-assert_equals "$(get_field "my-epic" "phases.specification.items.auth.status")" "completed" "Epic spec item → completed"
-assert_equals "$(get_field "my-epic" "phases.planning.items.auth.status")" "completed" "Epic planning item → completed"
-assert_equals "$(get_field "my-epic" "phases.implementation.items.auth.status")" "completed" "Implementation item unchanged"
+  assert_eq "Epic discussion item to completed" "completed" "$(get_field "my-epic" "phases.discussion.items.auth.status")"
+  assert_eq "In-progress item unchanged" "in-progress" "$(get_field "my-epic" "phases.discussion.items.billing.status")"
+  assert_eq "Epic spec item to completed" "completed" "$(get_field "my-epic" "phases.specification.items.auth.status")"
+  assert_eq "Epic planning item to completed" "completed" "$(get_field "my-epic" "phases.planning.items.auth.status")"
+  assert_eq "Implementation item unchanged" "completed" "$(get_field "my-epic" "phases.implementation.items.auth.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: bugfix phases concluded to completed ---
+test_bugfix_phases() {
+  setup
 
-echo -e "${YELLOW}Test: bugfix phases concluded → completed${NC}"
-setup_fixture
-
-create_manifest "my-bug" '{
+  create_manifest "my-bug" '{
   "work_type": "bugfix",
   "status": "concluded",
   "phases": {
@@ -313,40 +238,40 @@ create_manifest "my-bug" '{
   }
 }'
 
-run_migration > /dev/null
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
 
-assert_equals "$(get_field "my-bug" "status")" "completed" "Bugfix work unit status → completed"
-assert_equals "$(get_field "my-bug" "phases.investigation.status")" "completed" "Investigation → completed"
-assert_equals "$(get_field "my-bug" "phases.specification.status")" "completed" "Specification → completed"
-assert_equals "$(get_field "my-bug" "phases.planning.status")" "completed" "Planning → completed"
-assert_equals "$(get_field "my-bug" "phases.implementation.status")" "completed" "Implementation unchanged"
-assert_equals "$(get_field "my-bug" "phases.review.status")" "completed" "Review unchanged"
+  assert_eq "Bugfix work unit status to completed" "completed" "$(get_field "my-bug" "status")"
+  assert_eq "Investigation to completed" "completed" "$(get_field "my-bug" "phases.investigation.status")"
+  assert_eq "Specification to completed" "completed" "$(get_field "my-bug" "phases.specification.status")"
+  assert_eq "Planning to completed" "completed" "$(get_field "my-bug" "phases.planning.status")"
+  assert_eq "Implementation unchanged" "completed" "$(get_field "my-bug" "phases.implementation.status")"
+  assert_eq "Review unchanged" "completed" "$(get_field "my-bug" "phases.review.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: skips dot-prefixed directories ---
+test_skip_dot_dirs() {
+  setup
 
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo '{"status":"concluded"}' > "$TEST_DIR/.workflows/.state/manifest.json"
+  create_manifest "real" '{"work_type":"feature","status":"concluded","phases":{}}'
 
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo '{"status":"concluded"}' > "$TEST_DIR/.workflows/.state/manifest.json"
-create_manifest "real" '{"work_type":"feature","status":"concluded","phases":{}}'
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
 
-run_migration > /dev/null
+  assert_eq "Real work unit updated" "completed" "$(get_field "real" "status")"
+  dot_status=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/.state/manifest.json")
+  assert_eq "Dot-dir manifest not touched" "concluded" "$dot_status"
 
-assert_equals "$(get_field "real" "status")" "completed" "Real work unit updated"
-dot_status=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/.workflows/.state/manifest.json")
-assert_equals "$dot_status" "concluded" "Dot-dir manifest not touched"
+  teardown
+}
 
-echo ""
+# --- Test 11: idempotent — running twice produces same result ---
+test_idempotent() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
-setup_fixture
-
-create_manifest "idem" '{
+  create_manifest "idem" '{
   "work_type": "feature",
   "status": "concluded",
   "phases": {
@@ -355,22 +280,21 @@ create_manifest "idem" '{
   }
 }'
 
-run_migration > /dev/null
-before=$(get_json "idem")
-output=$(run_migration)
-after=$(get_json "idem")
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
+  before=$(get_json "idem")
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
+  after=$(get_json "idem")
 
-assert_equals "$after" "$before" "JSON unchanged after second run"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "JSON unchanged after second run" "$before" "$after"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: preserves other manifest fields ---
+test_preserves_fields() {
+  setup
 
-echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
-setup_fixture
-
-create_manifest "preserve" '{
+  create_manifest "preserve" '{
   "name": "preserve",
   "work_type": "feature",
   "status": "concluded",
@@ -381,55 +305,56 @@ create_manifest "preserve" '{
   }
 }'
 
-run_migration > /dev/null
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
 
-json=$(get_json "preserve")
+  json=$(get_json "preserve")
 
-assert_contains "$json" '"name": "preserve"' "Name preserved"
-assert_contains "$json" '"work_type": "feature"' "Work type preserved"
-assert_contains "$json" '"created": "2026-01-15"' "Created date preserved"
-assert_contains "$json" '"description": "test feature"' "Description preserved"
-assert_contains "$json" '"checksum": "abc123"' "Analysis cache preserved"
-assert_equals "$(get_field "preserve" "phases.discussion.status")" "completed" "Phase status updated"
+  assert_eq "Name preserved" "true" "$(echo "$json" | grep -qF '"name": "preserve"' && echo true || echo false)"
+  assert_eq "Work type preserved" "true" "$(echo "$json" | grep -qF '"work_type": "feature"' && echo true || echo false)"
+  assert_eq "Created date preserved" "true" "$(echo "$json" | grep -qF '"created": "2026-01-15"' && echo true || echo false)"
+  assert_eq "Description preserved" "true" "$(echo "$json" | grep -qF '"description": "test feature"' && echo true || echo false)"
+  assert_eq "Analysis cache preserved" "true" "$(echo "$json" | grep -qF '"checksum": "abc123"' && echo true || echo false)"
+  assert_eq "Phase status updated" "completed" "$(get_field "preserve" "phases.discussion.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 13: no .workflows directory — exits cleanly ---
+test_no_workflows() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
 
-echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
-setup_fixture
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
 
-output=$(run_migration)
+  assert_eq "exits cleanly" "true" "true"
 
-assert_not_contains "$output" "updated" "No updates without .workflows dir"
+  teardown
+}
 
-echo ""
+# --- Test 14: multiple work units processed ---
+test_multiple_work_units() {
+  setup
 
-# ----------------------------------------------------------------------------
+  create_manifest "feat-a" '{"work_type":"feature","status":"concluded","phases":{"discussion":{"status":"concluded"}}}'
+  create_manifest "feat-b" '{"work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"concluded"}}}'
+  create_manifest "feat-c" '{"work_type":"feature","status":"cancelled","phases":{}}'
 
-echo -e "${YELLOW}Test: multiple work units processed${NC}"
-setup_fixture
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
 
-create_manifest "feat-a" '{"work_type":"feature","status":"concluded","phases":{"discussion":{"status":"concluded"}}}'
-create_manifest "feat-b" '{"work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"concluded"}}}'
-create_manifest "feat-c" '{"work_type":"feature","status":"cancelled","phases":{}}'
+  assert_eq "First: work unit concluded to completed" "completed" "$(get_field "feat-a" "status")"
+  assert_eq "First: phase concluded to completed" "completed" "$(get_field "feat-a" "phases.discussion.status")"
+  assert_eq "Second: in-progress unchanged" "in-progress" "$(get_field "feat-b" "status")"
+  assert_eq "Second: phase concluded to completed" "completed" "$(get_field "feat-b" "phases.discussion.status")"
+  assert_eq "Third: cancelled unchanged" "cancelled" "$(get_field "feat-c" "status")"
 
-run_migration > /dev/null
+  teardown
+}
 
-assert_equals "$(get_field "feat-a" "status")" "completed" "First: work unit concluded → completed"
-assert_equals "$(get_field "feat-a" "phases.discussion.status")" "completed" "First: phase concluded → completed"
-assert_equals "$(get_field "feat-b" "status")" "in-progress" "Second: in-progress unchanged"
-assert_equals "$(get_field "feat-b" "phases.discussion.status")" "completed" "Second: phase concluded → completed"
-assert_equals "$(get_field "feat-c" "status")" "cancelled" "Third: cancelled unchanged"
+# --- Test 15: mixed epic with concluded and completed items ---
+test_mixed_epic() {
+  setup
 
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: mixed epic with concluded and completed items${NC}"
-setup_fixture
-
-create_manifest "mixed-epic" '{
+  create_manifest "mixed-epic" '{
   "work_type": "epic",
   "status": "in-progress",
   "phases": {
@@ -452,26 +377,36 @@ create_manifest "mixed-epic" '{
   }
 }'
 
-run_migration > /dev/null
+  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION" > /dev/null
 
-assert_equals "$(get_field "mixed-epic" "phases.discussion.items.auth.status")" "completed" "Discussion auth → completed"
-assert_equals "$(get_field "mixed-epic" "phases.discussion.items.billing.status")" "completed" "Discussion billing → completed"
-assert_equals "$(get_field "mixed-epic" "phases.implementation.items.auth.status")" "completed" "Impl auth unchanged"
-assert_equals "$(get_field "mixed-epic" "phases.review.items.auth.status")" "completed" "Review auth unchanged"
+  assert_eq "Discussion auth to completed" "completed" "$(get_field "mixed-epic" "phases.discussion.items.auth.status")"
+  assert_eq "Discussion billing to completed" "completed" "$(get_field "mixed-epic" "phases.discussion.items.billing.status")"
+  assert_eq "Impl auth unchanged" "completed" "$(get_field "mixed-epic" "phases.implementation.items.auth.status")"
+  assert_eq "Review auth unchanged" "completed" "$(get_field "mixed-epic" "phases.review.items.auth.status")"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 020 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_wu_concluded_to_completed
+test_in_progress_unchanged
+test_cancelled_unchanged
+test_completed_unchanged
+test_flat_phase_statuses
+test_in_progress_phase
+test_superseded_unchanged
+test_epic_item_statuses
+test_bugfix_phases
+test_skip_dot_dirs
+test_idempotent
+test_preserves_fields
+test_no_workflows
+test_multiple_work_units
+test_mixed_epic
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-021.sh
+++ b/tests/scripts/test-migration-021.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+#
+# Tests for migration 021: research-filename-rename
+#
+# Run: bash tests/scripts/test-migration-021.sh
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/021-research-filename-rename.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+export -f report_update report_skip
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-021-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+create_work_unit() {
+  local name="$1" work_type="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name/research"
+  cat > "$TEST_DIR/.workflows/$name/manifest.json" <<EOF
+{"name":"$name","work_type":"$work_type","status":"in-progress","phases":{}}
+EOF
+}
+
+# --- Test 1: Renames exploration.md to {work_unit}.md for features ---
+test_feature_rename() {
+  setup
+
+  create_work_unit "auth-flow" "feature"
+  echo "# Research" > "$TEST_DIR/.workflows/auth-flow/research/exploration.md"
+
+  bash "$MIGRATION"
+
+  assert_eq "renamed" "true" "$([ -f "$TEST_DIR/.workflows/auth-flow/research/auth-flow.md" ] && echo true || echo false)"
+  assert_eq "old removed" "false" "$([ -f "$TEST_DIR/.workflows/auth-flow/research/exploration.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 2: Skips epic work units ---
+test_skips_epic() {
+  setup
+
+  create_work_unit "payments" "epic"
+  echo "# Research" > "$TEST_DIR/.workflows/payments/research/exploration.md"
+
+  bash "$MIGRATION"
+
+  assert_eq "exploration untouched" "true" "$([ -f "$TEST_DIR/.workflows/payments/research/exploration.md" ] && echo true || echo false)"
+  assert_eq "no renamed file" "false" "$([ -f "$TEST_DIR/.workflows/payments/research/payments.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 3: Skips when exploration.md doesn't exist ---
+test_no_exploration() {
+  setup
+
+  create_work_unit "billing" "feature"
+
+  bash "$MIGRATION"
+
+  assert_eq "no file created" "false" "$([ -f "$TEST_DIR/.workflows/billing/research/billing.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 4: Skips when target already exists ---
+test_target_exists() {
+  setup
+
+  create_work_unit "data-sync" "feature"
+  echo "# Old" > "$TEST_DIR/.workflows/data-sync/research/exploration.md"
+  echo "# New" > "$TEST_DIR/.workflows/data-sync/research/data-sync.md"
+
+  bash "$MIGRATION"
+
+  local content
+  content=$(cat "$TEST_DIR/.workflows/data-sync/research/data-sync.md")
+  assert_eq "target not overwritten" "# New" "$content"
+  assert_eq "exploration still exists" "true" "$([ -f "$TEST_DIR/.workflows/data-sync/research/exploration.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 5: Skips dot-prefixed directories ---
+test_skips_dot_dirs() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.cache/research"
+  cat > "$TEST_DIR/.workflows/.cache/manifest.json" <<'EOF'
+{"name":".cache","work_type":"feature","status":"in-progress","phases":{}}
+EOF
+  echo "# Scratch" > "$TEST_DIR/.workflows/.cache/research/exploration.md"
+
+  bash "$MIGRATION"
+
+  assert_eq "dot dir untouched" "true" "$([ -f "$TEST_DIR/.workflows/.cache/research/exploration.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 6: No .workflows directory ---
+test_no_workflows_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
+
+  bash "$MIGRATION"
+
+  assert_eq "no error" "true" "true"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 021 tests..."
+echo ""
+
+test_feature_rename
+test_skips_epic
+test_no_exploration
+test_target_exists
+test_skips_dot_dirs
+test_no_workflows_dir
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-022.sh
+++ b/tests/scripts/test-migration-022.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+#
+# Tests for migration 022: remove-session-state
+#
+# Run: bash tests/scripts/test-migration-022.sh
+#
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/022-remove-session-state.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-022-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Test 1: Removes sessions directory ---
+test_removes_sessions() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.cache/sessions"
+  echo "session: 1" > "$TEST_DIR/.workflows/.cache/sessions/sess-001.yml"
+
+  source "$MIGRATION"
+
+  assert_eq "sessions dir removed" "false" "$([ -d "$TEST_DIR/.workflows/.cache/sessions" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 2: Cleans hook entries from settings.json ---
+test_cleans_hooks() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "command": "bash .workflows/session-env.sh" },
+          { "command": "bash .workflows/compact-recovery.sh" }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          { "command": "bash .workflows/session-cleanup.sh" }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": ["Bash(git status:*)"]
+  }
+}
+EOF
+
+  source "$MIGRATION"
+
+  assert_eq "hooks removed" "false" "$(node -e "
+    const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(s.hooks ? 'true' : 'false');
+  " "$TEST_DIR/.claude/settings.json")"
+  assert_eq "permissions preserved" "true" "$(node -e "
+    const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(s.permissions ? 'true' : 'false');
+  " "$TEST_DIR/.claude/settings.json")"
+
+  teardown
+}
+
+# --- Test 3: Removes settings.json entirely if empty after cleanup ---
+test_removes_empty_settings() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "command": "bash .workflows/session-env.sh" }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+  source "$MIGRATION"
+
+  assert_eq "settings.json removed" "false" "$([ -f "$TEST_DIR/.claude/settings.json" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 4: Skips when no sessions dir and no hook entries ---
+test_nothing_to_clean() {
+  setup
+
+  source "$MIGRATION"
+
+  assert_eq "no error" "true" "true"
+
+  teardown
+}
+
+# --- Test 5: Skips settings.json without workflow hooks ---
+test_unrelated_hooks() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "command": "echo hello" }
+        ]
+      }
+    ]
+  }
+}
+EOF
+
+  source "$MIGRATION"
+
+  assert_eq "unrelated hooks preserved" "true" "$(node -e "
+    const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(s.hooks && s.hooks.SessionStart ? 'true' : 'false');
+  " "$TEST_DIR/.claude/settings.json")"
+
+  teardown
+}
+
+# --- Test 6: Handles both sessions dir and hooks together ---
+test_both_cleanups() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.cache/sessions"
+  echo "data" > "$TEST_DIR/.workflows/.cache/sessions/sess.yml"
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "command": "bash .workflows/session-env.sh" }
+        ]
+      }
+    ]
+  },
+  "other": "kept"
+}
+EOF
+
+  source "$MIGRATION"
+
+  assert_eq "sessions dir removed" "false" "$([ -d "$TEST_DIR/.workflows/.cache/sessions" ] && echo true || echo false)"
+  assert_eq "other setting preserved" "kept" "$(node -e "
+    const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(s.other || 'missing');
+  " "$TEST_DIR/.claude/settings.json")"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 022 tests..."
+echo ""
+
+test_removes_sessions
+test_cleans_hooks
+test_removes_empty_settings
+test_nothing_to_clean
+test_unrelated_hooks
+test_both_cleanups
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-023.sh
+++ b/tests/scripts/test-migration-023.sh
@@ -1,193 +1,95 @@
 #!/bin/bash
 #
-# Tests migration 023-clear-research-analysis-cache.sh
-# Validates removal of old-format analysis caches and manifest cleanup.
+# Tests for migration 023: clear-research-analysis-cache
+#
+# Run: bash tests/scripts/test-migration-023.sh
 #
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/023-clear-research-analysis-cache.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/023-clear-research-analysis-cache.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
+export -f report_update report_skip
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
 
-echo "Test directory: $TEST_DIR"
-echo ""
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-023-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
 
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
 create_manifest() {
-    local name="$1"
-    local content="$2"
-    mkdir -p "$TEST_DIR/.workflows/$name"
-    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+  local name="$1"
+  local content="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name"
+  echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
 create_state_file() {
-    local name="$1"
-    local content="$2"
-    mkdir -p "$TEST_DIR/.workflows/$name/.state"
-    echo "$content" > "$TEST_DIR/.workflows/$name/.state/research-analysis.md"
-}
-
-# Stub report_update for migration script
-export -f report_update 2>/dev/null || true
-report_update() { echo "updated"; }
-export -f report_update
-
-run_migration() {
-    cd "$TEST_DIR"
-    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+  local name="$1"
+  local content="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name/.state"
+  echo "$content" > "$TEST_DIR/.workflows/$name/.state/research-analysis.md"
 }
 
 get_field() {
-    local name="$1"
-    local field="$2"
-    node -e "
-      const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
-      const parts = process.argv[2].split('.');
-      let v = m;
-      for (const p of parts) v = (v || {})[p];
-      console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
-    " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
+  local name="$1"
+  local field="$2"
+  node -e "
+    const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    const parts = process.argv[2].split('.');
+    let v = m;
+    for (const p of parts) v = (v || {})[p];
+    console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
+  " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
 }
 
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+run_migration() {
+  cd "$TEST_DIR"
+  bash "$MIGRATION" 2>&1
 }
 
-assert_file_exists() {
-    local path="$1"
-    local description="$2"
+# --- Test 1: Deletes .state/research-analysis.md ---
+test_deletes_state_file() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  create_manifest "my-feat" '{"work_type":"feature","status":"in-progress","phases":{"research":{}}}'
+  create_state_file "my-feat" "# Research Analysis Cache\n\n## Topics\n\n### Theme\n- old format"
 
-    if [ -f "$path" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $path"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+  run_migration > /dev/null
+
+  assert_eq "state file deleted" "false" "$([ -f "$TEST_DIR/.workflows/my-feat/.state/research-analysis.md" ] && echo true || echo false)"
+
+  teardown
 }
 
-assert_file_not_exists() {
-    local path="$1"
-    local description="$2"
+# --- Test 2: Clears analysis_cache from manifest ---
+test_clears_analysis_cache() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$path" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $path"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: deletes .state/research-analysis.md${NC}"
-setup_fixture
-
-create_manifest "my-feat" '{"work_type":"feature","status":"in-progress","phases":{"research":{}}}'
-create_state_file "my-feat" "# Research Analysis Cache\n\n## Topics\n\n### Theme\n- old format"
-
-output=$(run_migration)
-
-assert_file_not_exists "$TEST_DIR/.workflows/my-feat/.state/research-analysis.md" "State file deleted"
-assert_contains "$output" "updated" "Reports file removal"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: clears analysis_cache from manifest${NC}"
-setup_fixture
-
-create_manifest "cached-feat" '{
+  create_manifest "cached-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -202,20 +104,19 @@ create_manifest "cached-feat" '{
   }
 }'
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_equals "$(get_field "cached-feat" "phases.research.analysis_cache")" "undefined" "analysis_cache removed from manifest"
-assert_equals "$(get_field "cached-feat" "phases.research.status")" "completed" "Research status preserved"
-assert_contains "$output" "updated" "Reports manifest cleanup"
+  assert_eq "analysis_cache removed from manifest" "undefined" "$(get_field "cached-feat" "phases.research.analysis_cache")"
+  assert_eq "research status preserved" "completed" "$(get_field "cached-feat" "phases.research.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Both file and manifest cleaned together ---
+test_both_cleaned() {
+  setup
 
-echo -e "${YELLOW}Test: both file and manifest cleaned together${NC}"
-setup_fixture
-
-create_manifest "both" '{
+  create_manifest "both" '{
   "work_type": "epic",
   "status": "in-progress",
   "phases": {
@@ -225,22 +126,22 @@ create_manifest "both" '{
     }
   }
 }'
-create_state_file "both" "# old cache content"
+  create_state_file "both" "# old cache content"
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_file_not_exists "$TEST_DIR/.workflows/both/.state/research-analysis.md" "State file deleted"
-assert_equals "$(get_field "both" "phases.research.analysis_cache")" "undefined" "analysis_cache removed"
-assert_equals "$(get_field "both" "phases.research.status")" "completed" "Research status preserved"
+  assert_eq "state file deleted" "false" "$([ -f "$TEST_DIR/.workflows/both/.state/research-analysis.md" ] && echo true || echo false)"
+  assert_eq "analysis_cache removed" "undefined" "$(get_field "both" "phases.research.analysis_cache")"
+  assert_eq "research status preserved" "completed" "$(get_field "both" "phases.research.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Manifest without analysis_cache unchanged ---
+test_no_cache_unchanged() {
+  setup
 
-echo -e "${YELLOW}Test: manifest without analysis_cache unchanged${NC}"
-setup_fixture
-
-create_manifest "no-cache" '{
+  create_manifest "no-cache" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -249,54 +150,53 @@ create_manifest "no-cache" '{
   }
 }'
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_equals "$(get_field "no-cache" "phases.research.status")" "completed" "Research status unchanged"
-assert_equals "$(get_field "no-cache" "phases.discussion.status")" "in-progress" "Discussion status unchanged"
-assert_not_contains "$output" "updated" "No manifest update reported"
+  assert_eq "research status unchanged" "completed" "$(get_field "no-cache" "phases.research.status")"
+  assert_eq "discussion status unchanged" "in-progress" "$(get_field "no-cache" "phases.discussion.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Manifest without research phase unchanged ---
+test_no_research_phase() {
+  setup
 
-echo -e "${YELLOW}Test: manifest without research phase unchanged${NC}"
-setup_fixture
+  create_manifest "no-research" '{"work_type":"bugfix","status":"in-progress","phases":{"investigation":{"status":"in-progress"}}}'
 
-create_manifest "no-research" '{"work_type":"bugfix","status":"in-progress","phases":{"investigation":{"status":"in-progress"}}}'
+  run_migration > /dev/null
 
-output=$(run_migration)
+  assert_eq "investigation unchanged" "in-progress" "$(get_field "no-research" "phases.investigation.status")"
 
-assert_equals "$(get_field "no-research" "phases.investigation.status")" "in-progress" "Investigation unchanged"
-assert_not_contains "$output" "updated" "No update reported"
+  teardown
+}
 
-echo ""
+# --- Test 6: Skips dot-prefixed directories ---
+test_skips_dot_dirs() {
+  setup
 
-# ----------------------------------------------------------------------------
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo '{"phases":{"research":{"analysis_cache":{"checksum":"old"}}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
+  create_manifest "real" '{"work_type":"feature","status":"in-progress","phases":{"research":{"analysis_cache":{"checksum":"old"}}}}'
 
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
+  run_migration > /dev/null
 
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo '{"phases":{"research":{"analysis_cache":{"checksum":"old"}}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
-create_manifest "real" '{"work_type":"feature","status":"in-progress","phases":{"research":{"analysis_cache":{"checksum":"old"}}}}'
+  assert_eq "real manifest cleaned" "undefined" "$(get_field "real" "phases.research.analysis_cache")"
+  local dot_cache
+  dot_cache=$(node -e "
+    const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(m.phases.research.analysis_cache ? 'present' : 'absent');
+  " "$TEST_DIR/.workflows/.state/manifest.json")
+  assert_eq "dot-dir manifest not touched" "present" "$dot_cache"
 
-run_migration > /dev/null
+  teardown
+}
 
-assert_equals "$(get_field "real" "phases.research.analysis_cache")" "undefined" "Real manifest cleaned"
-dot_cache=$(node -e "
-  const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
-  console.log(m.phases.research.analysis_cache ? 'present' : 'absent');
-" "$TEST_DIR/.workflows/.state/manifest.json")
-assert_equals "$dot_cache" "present" "Dot-dir manifest not touched"
+# --- Test 7: Idempotent — running twice produces same result ---
+test_idempotent() {
+  setup
 
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
-setup_fixture
-
-create_manifest "idem" '{
+  create_manifest "idem" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -306,23 +206,22 @@ create_manifest "idem" '{
     }
   }
 }'
-create_state_file "idem" "# old cache"
+  create_state_file "idem" "# old cache"
 
-run_migration > /dev/null
-output=$(run_migration)
+  run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_file_not_exists "$TEST_DIR/.workflows/idem/.state/research-analysis.md" "State file still gone"
-assert_equals "$(get_field "idem" "phases.research.analysis_cache")" "undefined" "analysis_cache still gone"
-assert_not_contains "$output" "updated" "No updates on second run"
+  assert_eq "state file still gone" "false" "$([ -f "$TEST_DIR/.workflows/idem/.state/research-analysis.md" ] && echo true || echo false)"
+  assert_eq "analysis_cache still gone" "undefined" "$(get_field "idem" "phases.research.analysis_cache")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Preserves other manifest fields ---
+test_preserves_fields() {
+  setup
 
-echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
-setup_fixture
-
-create_manifest "preserve" '{
+  create_manifest "preserve" '{
   "name": "preserve",
   "work_type": "feature",
   "status": "in-progress",
@@ -336,72 +235,76 @@ create_manifest "preserve" '{
   }
 }'
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "preserve" "name")" "preserve" "Name preserved"
-assert_equals "$(get_field "preserve" "work_type")" "feature" "Work type preserved"
-assert_equals "$(get_field "preserve" "created")" "2026-01-15" "Created date preserved"
-assert_equals "$(get_field "preserve" "phases.research.status")" "completed" "Research status preserved"
-assert_equals "$(get_field "preserve" "phases.discussion.status")" "in-progress" "Discussion status preserved"
-assert_equals "$(get_field "preserve" "phases.research.analysis_cache")" "undefined" "analysis_cache removed"
+  assert_eq "name preserved" "preserve" "$(get_field "preserve" "name")"
+  assert_eq "work type preserved" "feature" "$(get_field "preserve" "work_type")"
+  assert_eq "created date preserved" "2026-01-15" "$(get_field "preserve" "created")"
+  assert_eq "research status preserved" "completed" "$(get_field "preserve" "phases.research.status")"
+  assert_eq "discussion status preserved" "in-progress" "$(get_field "preserve" "phases.discussion.status")"
+  assert_eq "analysis_cache removed" "undefined" "$(get_field "preserve" "phases.research.analysis_cache")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Multiple work units processed ---
+test_multiple_work_units() {
+  setup
 
-echo -e "${YELLOW}Test: multiple work units processed${NC}"
-setup_fixture
-
-create_manifest "feat-a" '{
+  create_manifest "feat-a" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"research": {"status": "completed", "analysis_cache": {"checksum": "a1"}}}
 }'
-create_state_file "feat-a" "# cache a"
+  create_state_file "feat-a" "# cache a"
 
-create_manifest "feat-b" '{
+  create_manifest "feat-b" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"research": {"status": "completed", "analysis_cache": {"checksum": "b2"}}}
 }'
 
-create_manifest "feat-c" '{
+  create_manifest "feat-c" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"research": {"status": "completed"}}
 }'
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_file_not_exists "$TEST_DIR/.workflows/feat-a/.state/research-analysis.md" "feat-a state file deleted"
-assert_equals "$(get_field "feat-a" "phases.research.analysis_cache")" "undefined" "feat-a cache cleared"
-assert_equals "$(get_field "feat-b" "phases.research.analysis_cache")" "undefined" "feat-b cache cleared"
-assert_equals "$(get_field "feat-c" "phases.research.analysis_cache")" "undefined" "feat-c had no cache, still none"
+  assert_eq "feat-a state file deleted" "false" "$([ -f "$TEST_DIR/.workflows/feat-a/.state/research-analysis.md" ] && echo true || echo false)"
+  assert_eq "feat-a cache cleared" "undefined" "$(get_field "feat-a" "phases.research.analysis_cache")"
+  assert_eq "feat-b cache cleared" "undefined" "$(get_field "feat-b" "phases.research.analysis_cache")"
+  assert_eq "feat-c had no cache, still none" "undefined" "$(get_field "feat-c" "phases.research.analysis_cache")"
 
+  teardown
+}
+
+# --- Test 10: No .workflows directory — exits cleanly ---
+test_no_workflows_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
+
+  run_migration > /dev/null
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 023 tests..."
 echo ""
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
-setup_fixture
-
-output=$(run_migration)
-
-assert_not_contains "$output" "updated" "No updates without .workflows dir"
-
-echo ""
-
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_deletes_state_file
+test_clears_analysis_cache
+test_both_cleaned
+test_no_cache_unchanged
+test_no_research_phase
+test_skips_dot_dirs
+test_idempotent
+test_preserves_fields
+test_multiple_work_units
+test_no_workflows_dir
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-024.sh
+++ b/tests/scripts/test-migration-024.sh
@@ -1,263 +1,138 @@
 #!/bin/bash
 #
-# Tests migration 024-backfill-and-flatten-review.sh
-# Validates:
-#   Step 1: Backfill completed_tasks / completed_phases from frontmatter
-#   Step 2: Normalise external IDs to internal IDs via plan table mapping
-#   Step 3: Flatten review/{topic}/r{N}/ directories
-#   Step 4: Rename ext_id → external_id in manifests and plan files
-#   Step 5: Rename ID → Internal ID in plan index task table headers
+# Tests for migration 024: backfill-and-flatten-review
+#
+# Run: bash tests/scripts/test-migration-024.sh
 #
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/024-backfill-and-flatten-review.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/024-backfill-and-flatten-review.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
+export -f report_update report_skip
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
 
-echo "Test directory: $TEST_DIR"
-echo ""
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-024-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
 
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
 create_manifest() {
-    local name="$1"
-    local content="$2"
-    mkdir -p "$TEST_DIR/.workflows/$name"
-    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+  local name="$1"
+  local content="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name"
+  echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
 create_implementation_file() {
-    local wu="$1"
-    local topic="$2"
-    local content="$3"
-    mkdir -p "$TEST_DIR/.workflows/$wu/implementation/$topic"
-    printf '%s' "$content" > "$TEST_DIR/.workflows/$wu/implementation/$topic/implementation.md"
+  local wu="$1"
+  local topic="$2"
+  local content="$3"
+  mkdir -p "$TEST_DIR/.workflows/$wu/implementation/$topic"
+  printf '%s' "$content" > "$TEST_DIR/.workflows/$wu/implementation/$topic/implementation.md"
 }
 
 create_plan_file() {
-    local wu="$1"
-    local topic="$2"
-    local content="$3"
-    mkdir -p "$TEST_DIR/.workflows/$wu/planning/$topic"
-    printf '%s' "$content" > "$TEST_DIR/.workflows/$wu/planning/$topic/planning.md"
+  local wu="$1"
+  local topic="$2"
+  local content="$3"
+  mkdir -p "$TEST_DIR/.workflows/$wu/planning/$topic"
+  printf '%s' "$content" > "$TEST_DIR/.workflows/$wu/planning/$topic/planning.md"
 }
 
 create_review_file() {
-    local wu="$1"
-    local topic="$2"
-    local subdir="$3"
-    local filename="$4"
-    local content="${5:-# review content}"
-    mkdir -p "$TEST_DIR/.workflows/$wu/review/$topic/$subdir"
-    echo "$content" > "$TEST_DIR/.workflows/$wu/review/$topic/$subdir/$filename"
-}
-
-# Stub report_update for migration script
-export -f report_update 2>/dev/null || true
-report_update() { echo "updated"; }
-export -f report_update
-report_skip() { echo "skipped"; }
-export -f report_skip
-
-run_migration() {
-    cd "$TEST_DIR"
-    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+  local wu="$1"
+  local topic="$2"
+  local subdir="$3"
+  local filename="$4"
+  local content="${5:-# review content}"
+  mkdir -p "$TEST_DIR/.workflows/$wu/review/$topic/$subdir"
+  echo "$content" > "$TEST_DIR/.workflows/$wu/review/$topic/$subdir/$filename"
 }
 
 get_field() {
-    local name="$1"
-    local field="$2"
-    node -e "
-      const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
-      const parts = process.argv[2].split('.');
-      let v = m;
-      for (const p of parts) v = (v || {})[p];
-      console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
-    " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
+  local name="$1"
+  local field="$2"
+  node -e "
+    const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    const parts = process.argv[2].split('.');
+    let v = m;
+    for (const p of parts) v = (v || {})[p];
+    console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
+  " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
 }
 
 get_json() {
-    local name="$1"
-    cat "$TEST_DIR/.workflows/$name/manifest.json"
+  local name="$1"
+  cat "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+run_migration() {
+  cd "$TEST_DIR"
+  bash "$MIGRATION" 2>&1
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: Backfills completed_tasks from inline YAML array ---
+test_backfill_inline_array() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-assert_file_exists() {
-    local path="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ -f "$path" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $path"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_file_not_exists() {
-    local path="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -f "$path" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $path"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_dir_not_exists() {
-    local path="$1"
-    local description="$2"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ ! -d "$path" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Directory should not exist: $path"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-# ============================================================================
-# STEP 1: Backfill completed_tasks / completed_phases
-# ============================================================================
-
-echo -e "${YELLOW}=== Step 1: Backfill from frontmatter ===${NC}"
-echo ""
-
-echo -e "${YELLOW}Test: backfills completed_tasks from inline YAML array${NC}"
-setup_fixture
-
-create_manifest "my-feat" '{
+  create_manifest "my-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
     "implementation": {}
   }
 }'
-create_implementation_file "my-feat" "my-feat" '---
+  create_implementation_file "my-feat" "my-feat" '---
 completed_tasks: [my-feat-1-1, my-feat-1-2, my-feat-2-1]
 completed_phases: [1, 2]
 ---
 # Implementation
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "my-feat" "phases.implementation.completed_tasks")" '["my-feat-1-1","my-feat-1-2","my-feat-2-1"]' "completed_tasks backfilled from inline array"
-assert_equals "$(get_field "my-feat" "phases.implementation.completed_phases")" '[1,2]' "completed_phases backfilled"
+  assert_eq "completed_tasks backfilled from inline array" '["my-feat-1-1","my-feat-1-2","my-feat-2-1"]' "$(get_field "my-feat" "phases.implementation.completed_tasks")"
+  assert_eq "completed_phases backfilled" '[1,2]' "$(get_field "my-feat" "phases.implementation.completed_phases")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Backfills completed_tasks from multi-line YAML list ---
+test_backfill_multiline() {
+  setup
 
-echo -e "${YELLOW}Test: backfills completed_tasks from multi-line YAML list${NC}"
-setup_fixture
-
-create_manifest "ml-feat" '{
+  create_manifest "ml-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
     "implementation": {}
   }
 }'
-create_implementation_file "ml-feat" "ml-feat" '---
+  create_implementation_file "ml-feat" "ml-feat" '---
 completed_tasks:
   - ml-feat-1-1
   - ml-feat-1-2
@@ -269,19 +144,19 @@ completed_phases:
 # Implementation
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "ml-feat" "phases.implementation.completed_tasks")" '["ml-feat-1-1","ml-feat-1-2","ml-feat-2-1"]' "completed_tasks backfilled from multi-line list"
-assert_equals "$(get_field "ml-feat" "phases.implementation.completed_phases")" '[1,2]' "completed_phases backfilled from multi-line list"
+  assert_eq "completed_tasks backfilled from multi-line list" '["ml-feat-1-1","ml-feat-1-2","ml-feat-2-1"]' "$(get_field "ml-feat" "phases.implementation.completed_tasks")"
+  assert_eq "completed_phases backfilled from multi-line list" '[1,2]' "$(get_field "ml-feat" "phases.implementation.completed_phases")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: Does not overwrite existing completed_tasks ---
+test_no_overwrite_existing() {
+  setup
 
-echo -e "${YELLOW}Test: does not overwrite existing completed_tasks${NC}"
-setup_fixture
-
-create_manifest "existing" '{
+  create_manifest "existing" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -291,26 +166,26 @@ create_manifest "existing" '{
     }
   }
 }'
-create_implementation_file "existing" "existing" '---
+  create_implementation_file "existing" "existing" '---
 completed_tasks: [existing-1-1, existing-1-2, existing-2-1]
 completed_phases: [1, 2]
 ---
 # Implementation
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "existing" "phases.implementation.completed_tasks")" '["existing-1-1"]' "Existing completed_tasks not overwritten"
-assert_equals "$(get_field "existing" "phases.implementation.completed_phases")" '[1]' "Existing completed_phases not overwritten"
+  assert_eq "existing completed_tasks not overwritten" '["existing-1-1"]' "$(get_field "existing" "phases.implementation.completed_tasks")"
+  assert_eq "existing completed_phases not overwritten" '[1]' "$(get_field "existing" "phases.implementation.completed_phases")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Backfills epic items separately ---
+test_backfill_epic_items() {
+  setup
 
-echo -e "${YELLOW}Test: backfills epic items separately${NC}"
-setup_fixture
-
-create_manifest "my-epic" '{
+  create_manifest "my-epic" '{
   "work_type": "epic",
   "status": "in-progress",
   "phases": {
@@ -322,33 +197,33 @@ create_manifest "my-epic" '{
     }
   }
 }'
-create_implementation_file "my-epic" "auth" '---
+  create_implementation_file "my-epic" "auth" '---
 completed_tasks: [auth-1-1, auth-1-2]
 completed_phases: [1]
 ---
 # Auth Implementation
 '
-create_implementation_file "my-epic" "billing" '---
+  create_implementation_file "my-epic" "billing" '---
 completed_tasks: [billing-1-1]
 completed_phases: [1]
 ---
 # Billing Implementation
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "my-epic" "phases.implementation.items.auth.completed_tasks")" '["auth-1-1","auth-1-2"]' "Epic auth item backfilled"
-assert_equals "$(get_field "my-epic" "phases.implementation.items.auth.completed_phases")" '[1]' "Epic auth phases backfilled"
-assert_equals "$(get_field "my-epic" "phases.implementation.items.billing.completed_tasks")" '["billing-1-1"]' "Epic billing item backfilled"
+  assert_eq "epic auth item backfilled" '["auth-1-1","auth-1-2"]' "$(get_field "my-epic" "phases.implementation.items.auth.completed_tasks")"
+  assert_eq "epic auth phases backfilled" '[1]' "$(get_field "my-epic" "phases.implementation.items.auth.completed_phases")"
+  assert_eq "epic billing item backfilled" '["billing-1-1"]' "$(get_field "my-epic" "phases.implementation.items.billing.completed_tasks")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Skips work units with no implementation phase ---
+test_skips_no_implementation() {
+  setup
 
-echo -e "${YELLOW}Test: skips work units with no implementation phase${NC}"
-setup_fixture
-
-create_manifest "no-impl" '{
+  create_manifest "no-impl" '{
   "work_type": "bugfix",
   "status": "in-progress",
   "phases": {
@@ -356,36 +231,29 @@ create_manifest "no-impl" '{
   }
 }'
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_not_contains "$output" "updated" "No backfill reported for work unit without implementation"
+  teardown
+}
 
-echo ""
+# --- Test 6: Normalises tick IDs to internal IDs via plan table ---
+test_normalise_tick_ids() {
+  setup
 
-# ============================================================================
-# STEP 2: Normalise external IDs to internal IDs
-# ============================================================================
-
-echo -e "${YELLOW}=== Step 2: Normalise external IDs ===${NC}"
-echo ""
-
-echo -e "${YELLOW}Test: normalises tick IDs to internal IDs via plan table${NC}"
-setup_fixture
-
-create_manifest "tick-feat" '{
+  create_manifest "tick-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
     "implementation": {}
   }
 }'
-create_implementation_file "tick-feat" "tick-feat" '---
+  create_implementation_file "tick-feat" "tick-feat" '---
 completed_tasks: [tick-abc123, tick-def456]
 completed_phases: [1]
 ---
 # Implementation
 '
-create_plan_file "tick-feat" "tick-feat" '# Plan: Tick Feat
+  create_plan_file "tick-feat" "tick-feat" '# Plan: Tick Feat
 
 ### Phase 1: Core
 status: approved
@@ -398,31 +266,31 @@ ext_id: tick-parent1
 | tick-feat-1-2 | Second Task | none | authored | tick-def456 |
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "tick-feat" "phases.implementation.completed_tasks")" '["tick-feat-1-1","tick-feat-1-2"]' "Tick IDs normalised to internal IDs"
+  assert_eq "tick IDs normalised to internal IDs" '["tick-feat-1-1","tick-feat-1-2"]' "$(get_field "tick-feat" "phases.implementation.completed_tasks")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Leaves internal IDs unchanged when no ext map match ---
+test_internal_ids_unchanged() {
+  setup
 
-echo -e "${YELLOW}Test: leaves internal IDs unchanged when no ext map match${NC}"
-setup_fixture
-
-create_manifest "internal-feat" '{
+  create_manifest "internal-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
     "implementation": {}
   }
 }'
-create_implementation_file "internal-feat" "internal-feat" '---
+  create_implementation_file "internal-feat" "internal-feat" '---
 completed_tasks: [internal-feat-1-1, internal-feat-1-2]
 completed_phases: [1]
 ---
 # Implementation
 '
-create_plan_file "internal-feat" "internal-feat" '# Plan: Internal Feat
+  create_plan_file "internal-feat" "internal-feat" '# Plan: Internal Feat
 
 ### Phase 1: Core
 status: approved
@@ -435,31 +303,31 @@ ext_id:
 | internal-feat-1-2 | Second Task | none | authored | |
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "internal-feat" "phases.implementation.completed_tasks")" '["internal-feat-1-1","internal-feat-1-2"]' "Internal IDs left unchanged"
+  assert_eq "internal IDs left unchanged" '["internal-feat-1-1","internal-feat-1-2"]' "$(get_field "internal-feat" "phases.implementation.completed_tasks")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Normalises with already-renamed External ID column ---
+test_normalise_renamed_column() {
+  setup
 
-echo -e "${YELLOW}Test: normalises with already-renamed External ID column${NC}"
-setup_fixture
-
-create_manifest "renamed-feat" '{
+  create_manifest "renamed-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
     "implementation": {}
   }
 }'
-create_implementation_file "renamed-feat" "renamed-feat" '---
+  create_implementation_file "renamed-feat" "renamed-feat" '---
 completed_tasks: [tick-aaa, tick-bbb]
 completed_phases: [1]
 ---
 # Implementation
 '
-create_plan_file "renamed-feat" "renamed-feat" '# Plan: Renamed Feat
+  create_plan_file "renamed-feat" "renamed-feat" '# Plan: Renamed Feat
 
 ### Phase 1: Core
 status: approved
@@ -472,123 +340,112 @@ external_id: tick-parent1
 | renamed-feat-1-2 | Second Task | none | authored | tick-bbb |
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "renamed-feat" "phases.implementation.completed_tasks")" '["renamed-feat-1-1","renamed-feat-1-2"]' "Normalisation works with already-renamed columns"
+  assert_eq "normalisation works with already-renamed columns" '["renamed-feat-1-1","renamed-feat-1-2"]' "$(get_field "renamed-feat" "phases.implementation.completed_tasks")"
 
-echo ""
+  teardown
+}
 
-# ============================================================================
-# STEP 3: Flatten review directories
-# ============================================================================
+# --- Test 9: Flattens r1/ directory ---
+test_flatten_r1() {
+  setup
 
-echo -e "${YELLOW}=== Step 3: Flatten review directories ===${NC}"
-echo ""
-
-echo -e "${YELLOW}Test: flattens r1/ directory${NC}"
-setup_fixture
-
-create_manifest "single-review" '{
+  create_manifest "single-review" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"review": {}}
 }'
-create_review_file "single-review" "single-review" "r1" "review.md" "# Review v1"
-create_review_file "single-review" "single-review" "r1" "qa-task-1.md" "# QA 1"
+  create_review_file "single-review" "single-review" "r1" "review.md" "# Review v1"
+  create_review_file "single-review" "single-review" "r1" "qa-task-1.md" "# QA 1"
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_file_exists "$TEST_DIR/.workflows/single-review/review/single-review/review.md" "review.md moved up"
-assert_file_exists "$TEST_DIR/.workflows/single-review/review/single-review/qa-task-1.md" "qa-task-1.md moved up"
-assert_dir_not_exists "$TEST_DIR/.workflows/single-review/review/single-review/r1" "r1/ removed"
-assert_contains "$output" "updated" "Reports keeping r1"
+  assert_eq "review.md moved up" "true" "$([ -f "$TEST_DIR/.workflows/single-review/review/single-review/review.md" ] && echo true || echo false)"
+  assert_eq "qa-task-1.md moved up" "true" "$([ -f "$TEST_DIR/.workflows/single-review/review/single-review/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "r1/ removed" "false" "$([ -d "$TEST_DIR/.workflows/single-review/review/single-review/r1" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 10: Keeps highest r{N} when multiple exist ---
+test_flatten_keeps_highest() {
+  setup
 
-echo -e "${YELLOW}Test: keeps highest r{N} when multiple exist${NC}"
-setup_fixture
-
-create_manifest "multi-review" '{
+  create_manifest "multi-review" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"review": {}}
 }'
-create_review_file "multi-review" "multi-review" "r1" "review.md" "# Review v1"
-create_review_file "multi-review" "multi-review" "r1" "qa-task-1.md" "# QA old"
-create_review_file "multi-review" "multi-review" "r2" "review.md" "# Review v2"
-create_review_file "multi-review" "multi-review" "r2" "qa-task-1.md" "# QA new"
-create_review_file "multi-review" "multi-review" "r2" "qa-task-2.md" "# QA 2 new"
+  create_review_file "multi-review" "multi-review" "r1" "review.md" "# Review v1"
+  create_review_file "multi-review" "multi-review" "r1" "qa-task-1.md" "# QA old"
+  create_review_file "multi-review" "multi-review" "r2" "review.md" "# Review v2"
+  create_review_file "multi-review" "multi-review" "r2" "qa-task-1.md" "# QA new"
+  create_review_file "multi-review" "multi-review" "r2" "qa-task-2.md" "# QA 2 new"
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-review_content=$(cat "$TEST_DIR/.workflows/multi-review/review/multi-review/review.md")
-assert_equals "$review_content" "# Review v2" "Kept r2 content (not r1)"
-assert_file_exists "$TEST_DIR/.workflows/multi-review/review/multi-review/qa-task-2.md" "r2 qa-task-2.md present"
-assert_dir_not_exists "$TEST_DIR/.workflows/multi-review/review/multi-review/r1" "r1/ removed"
-assert_dir_not_exists "$TEST_DIR/.workflows/multi-review/review/multi-review/r2" "r2/ removed"
-assert_contains "$output" "updated" "Reports keeping r2"
+  local review_content
+  review_content=$(cat "$TEST_DIR/.workflows/multi-review/review/multi-review/review.md")
+  assert_eq "kept r2 content (not r1)" "# Review v2" "$review_content"
+  assert_eq "r2 qa-task-2.md present" "true" "$([ -f "$TEST_DIR/.workflows/multi-review/review/multi-review/qa-task-2.md" ] && echo true || echo false)"
+  assert_eq "r1/ removed" "false" "$([ -d "$TEST_DIR/.workflows/multi-review/review/multi-review/r1" ] && echo true || echo false)"
+  assert_eq "r2/ removed" "false" "$([ -d "$TEST_DIR/.workflows/multi-review/review/multi-review/r2" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 11: Skips already-flat review directories ---
+test_skips_flat_review() {
+  setup
 
-echo -e "${YELLOW}Test: skips already-flat review directories${NC}"
-setup_fixture
-
-create_manifest "flat-review" '{
+  create_manifest "flat-review" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"review": {}}
 }'
-mkdir -p "$TEST_DIR/.workflows/flat-review/review/flat-review"
-echo "# Review" > "$TEST_DIR/.workflows/flat-review/review/flat-review/review.md"
+  mkdir -p "$TEST_DIR/.workflows/flat-review/review/flat-review"
+  echo "# Review" > "$TEST_DIR/.workflows/flat-review/review/flat-review/review.md"
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_file_exists "$TEST_DIR/.workflows/flat-review/review/flat-review/review.md" "Flat review unchanged"
-assert_not_contains "$output" "updated" "No flattening reported"
+  assert_eq "flat review unchanged" "true" "$([ -f "$TEST_DIR/.workflows/flat-review/review/flat-review/review.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: Flattens epic review directories per topic ---
+test_flatten_epic_reviews() {
+  setup
 
-echo -e "${YELLOW}Test: flattens epic review directories per topic${NC}"
-setup_fixture
-
-create_manifest "epic-review" '{
+  create_manifest "epic-review" '{
   "work_type": "epic",
   "status": "in-progress",
   "phases": {"review": {"items": {"auth": {}, "billing": {}}}}
 }'
-create_review_file "epic-review" "auth" "r1" "review.md" "# Auth review"
-create_review_file "epic-review" "auth" "r1" "qa-task-1.md" "# Auth QA"
-create_review_file "epic-review" "billing" "r1" "review.md" "# Billing review"
-create_review_file "epic-review" "billing" "r2" "review.md" "# Billing review v2"
+  create_review_file "epic-review" "auth" "r1" "review.md" "# Auth review"
+  create_review_file "epic-review" "auth" "r1" "qa-task-1.md" "# Auth QA"
+  create_review_file "epic-review" "billing" "r1" "review.md" "# Billing review"
+  create_review_file "epic-review" "billing" "r2" "review.md" "# Billing review v2"
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_file_exists "$TEST_DIR/.workflows/epic-review/review/auth/review.md" "Auth review flattened"
-assert_dir_not_exists "$TEST_DIR/.workflows/epic-review/review/auth/r1" "Auth r1/ removed"
-billing_content=$(cat "$TEST_DIR/.workflows/epic-review/review/billing/review.md")
-assert_equals "$billing_content" "# Billing review v2" "Billing kept r2 content"
-assert_dir_not_exists "$TEST_DIR/.workflows/epic-review/review/billing/r1" "Billing r1/ removed"
-assert_dir_not_exists "$TEST_DIR/.workflows/epic-review/review/billing/r2" "Billing r2/ removed"
+  assert_eq "auth review flattened" "true" "$([ -f "$TEST_DIR/.workflows/epic-review/review/auth/review.md" ] && echo true || echo false)"
+  assert_eq "auth r1/ removed" "false" "$([ -d "$TEST_DIR/.workflows/epic-review/review/auth/r1" ] && echo true || echo false)"
+  local billing_content
+  billing_content=$(cat "$TEST_DIR/.workflows/epic-review/review/billing/review.md")
+  assert_eq "billing kept r2 content" "# Billing review v2" "$billing_content"
+  assert_eq "billing r1/ removed" "false" "$([ -d "$TEST_DIR/.workflows/epic-review/review/billing/r1" ] && echo true || echo false)"
+  assert_eq "billing r2/ removed" "false" "$([ -d "$TEST_DIR/.workflows/epic-review/review/billing/r2" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ============================================================================
-# STEP 4: Rename ext_id → external_id
-# ============================================================================
+# --- Test 13: Renames ext_id in manifest JSON ---
+test_rename_ext_id_manifest() {
+  setup
 
-echo -e "${YELLOW}=== Step 4: Rename ext_id → external_id ===${NC}"
-echo ""
-
-echo -e "${YELLOW}Test: renames ext_id in manifest JSON${NC}"
-setup_fixture
-
-create_manifest "ext-feat" '{
+  create_manifest "ext-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -599,25 +456,24 @@ create_manifest "ext-feat" '{
   }
 }'
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_equals "$(get_field "ext-feat" "phases.planning.external_id")" "tick-parent1" "ext_id renamed to external_id in manifest"
-assert_equals "$(get_field "ext-feat" "phases.planning.ext_id")" "undefined" "Old ext_id removed"
-assert_contains "$output" "updated" "Reports manifest rename"
+  assert_eq "ext_id renamed to external_id in manifest" "tick-parent1" "$(get_field "ext-feat" "phases.planning.external_id")"
+  assert_eq "old ext_id removed" "undefined" "$(get_field "ext-feat" "phases.planning.ext_id")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 14: Renames Ext ID in plan table headers and ext_id: in phase entries ---
+test_rename_ext_id_plan() {
+  setup
 
-echo -e "${YELLOW}Test: renames Ext ID in plan table headers and ext_id: in phase entries${NC}"
-setup_fixture
-
-create_manifest "plan-rename" '{
+  create_manifest "plan-rename" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"planning": {}}
 }'
-create_plan_file "plan-rename" "plan-rename" '# Plan: Plan Rename
+  create_plan_file "plan-rename" "plan-rename" '# Plan: Plan Rename
 
 ### Phase 1: Core
 status: approved
@@ -629,22 +485,23 @@ ext_id: tick-parent1
 | plan-rename-1-1 | First Task | none | authored | tick-abc |
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-plan_content=$(cat "$TEST_DIR/.workflows/plan-rename/planning/plan-rename/planning.md")
-assert_contains "$plan_content" "External ID" "Ext ID renamed to External ID in table header"
-assert_not_contains "$plan_content" "Ext ID" "No Ext ID remaining"
-assert_contains "$plan_content" "external_id:" "ext_id: renamed to external_id: in phase entry"
-assert_not_contains "$plan_content" "ext_id:" "No ext_id: remaining"
+  local plan_content
+  plan_content=$(cat "$TEST_DIR/.workflows/plan-rename/planning/plan-rename/planning.md")
+  assert_eq "Ext ID renamed to External ID in table header" "true" "$(echo "$plan_content" | grep -qF 'External ID' && echo true || echo false)"
+  assert_eq "no Ext ID remaining" "false" "$(echo "$plan_content" | grep -qF 'Ext ID' && echo true || echo false)"
+  assert_eq "ext_id: renamed to external_id: in phase entry" "true" "$(echo "$plan_content" | grep -qF 'external_id:' && echo true || echo false)"
+  assert_eq "no ext_id: remaining" "false" "$(echo "$plan_content" | grep -qF 'ext_id:' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 15: Skips manifest already using external_id ---
+test_skips_already_external_id() {
+  setup
 
-echo -e "${YELLOW}Test: skips manifest already using external_id${NC}"
-setup_fixture
-
-create_manifest "already-renamed" '{
+  create_manifest "already-renamed" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -655,29 +512,23 @@ create_manifest "already-renamed" '{
   }
 }'
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_equals "$(get_field "already-renamed" "phases.planning.external_id")" "tick-parent1" "external_id preserved"
-assert_not_contains "$output" "updated" "No rename reported"
+  assert_eq "external_id preserved" "tick-parent1" "$(get_field "already-renamed" "phases.planning.external_id")"
 
-echo ""
+  teardown
+}
 
-# ============================================================================
-# STEP 5: Rename ID → Internal ID in plan table headers
-# ============================================================================
+# --- Test 16: Renames | ID | to | Internal ID | in task table ---
+test_rename_id_to_internal_id() {
+  setup
 
-echo -e "${YELLOW}=== Step 5: Rename ID → Internal ID in plan tables ===${NC}"
-echo ""
-
-echo -e "${YELLOW}Test: renames | ID | to | Internal ID | in task table${NC}"
-setup_fixture
-
-create_manifest "id-rename" '{
+  create_manifest "id-rename" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"planning": {}}
 }'
-create_plan_file "id-rename" "id-rename" '# Plan: ID Rename
+  create_plan_file "id-rename" "id-rename" '# Plan: ID Rename
 
 ### Phase 1: Core
 status: approved
@@ -689,28 +540,28 @@ external_id:
 | id-rename-1-1 | First Task | none | authored | |
 '
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-plan_content=$(cat "$TEST_DIR/.workflows/id-rename/planning/id-rename/planning.md")
-assert_contains "$plan_content" "| Internal ID |" "ID renamed to Internal ID in header"
-assert_contains "$plan_content" "|-------------|" "Separator widened for Internal ID"
-assert_not_contains "$plan_content" "| ID |" "No | ID | remaining"
-assert_contains "$plan_content" "| id-rename-1-1 |" "Data rows unchanged"
-assert_contains "$output" "updated" "Reports table header rename"
+  local plan_content
+  plan_content=$(cat "$TEST_DIR/.workflows/id-rename/planning/id-rename/planning.md")
+  assert_eq "ID renamed to Internal ID in header" "true" "$(echo "$plan_content" | grep -qF '| Internal ID |' && echo true || echo false)"
+  assert_eq "separator widened for Internal ID" "true" "$(echo "$plan_content" | grep -qF '|-------------|' && echo true || echo false)"
+  assert_eq "no | ID | remaining" "false" "$(echo "$plan_content" | grep -qF '| ID |' && echo true || echo false)"
+  assert_eq "data rows unchanged" "true" "$(echo "$plan_content" | grep -qF '| id-rename-1-1 |' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 17: Skips plan already using Internal ID ---
+test_skips_already_internal_id() {
+  setup
 
-echo -e "${YELLOW}Test: skips plan already using Internal ID${NC}"
-setup_fixture
-
-create_manifest "already-internal" '{
+  create_manifest "already-internal" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"planning": {}}
 }'
-create_plan_file "already-internal" "already-internal" '# Plan: Already Internal
+  create_plan_file "already-internal" "already-internal" '# Plan: Already Internal
 
 ### Phase 1: Core
 status: approved
@@ -722,23 +573,21 @@ external_id:
 | already-internal-1-1 | First Task | none | authored | |
 '
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_not_contains "$output" "updated" "No rename reported"
+  teardown
+}
 
-echo ""
+# --- Test 18: Renames across multiple phases in same plan ---
+test_rename_multiple_phases() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: renames across multiple phases in same plan${NC}"
-setup_fixture
-
-create_manifest "multi-phase" '{
+  create_manifest "multi-phase" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {"planning": {}}
 }'
-create_plan_file "multi-phase" "multi-phase" '# Plan: Multi Phase
+  create_plan_file "multi-phase" "multi-phase" '# Plan: Multi Phase
 
 ### Phase 1: Foundation
 status: approved
@@ -759,27 +608,23 @@ external_id:
 | multi-phase-2-1 | Second | none | authored | |
 '
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-plan_content=$(cat "$TEST_DIR/.workflows/multi-phase/planning/multi-phase/planning.md")
-id_count=$(echo "$plan_content" | grep -c '| Internal ID |')
-assert_equals "$id_count" "2" "Both phase tables renamed"
-old_id_count=$(echo "$plan_content" | grep -c '| ID |' || true)
-assert_equals "$old_id_count" "0" "No | ID | remaining"
+  local plan_content id_count old_id_count
+  plan_content=$(cat "$TEST_DIR/.workflows/multi-phase/planning/multi-phase/planning.md")
+  id_count=$(echo "$plan_content" | grep -c '| Internal ID |')
+  assert_eq "both phase tables renamed" "2" "$id_count"
+  old_id_count=$(echo "$plan_content" | grep -c '| ID |' || true)
+  assert_eq "no | ID | remaining" "0" "$old_id_count"
 
-echo ""
+  teardown
+}
 
-# ============================================================================
-# CROSS-CUTTING CONCERNS
-# ============================================================================
+# --- Test 19: All steps run together on same work unit ---
+test_all_steps_together() {
+  setup
 
-echo -e "${YELLOW}=== Cross-cutting ===${NC}"
-echo ""
-
-echo -e "${YELLOW}Test: all steps run together on same work unit${NC}"
-setup_fixture
-
-create_manifest "full-feat" '{
+  create_manifest "full-feat" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -790,13 +635,13 @@ create_manifest "full-feat" '{
     "review": {}
   }
 }'
-create_implementation_file "full-feat" "full-feat" '---
+  create_implementation_file "full-feat" "full-feat" '---
 completed_tasks: [tick-aaa, tick-bbb]
 completed_phases: [1]
 ---
 # Implementation
 '
-create_plan_file "full-feat" "full-feat" '# Plan: Full Feat
+  create_plan_file "full-feat" "full-feat" '# Plan: Full Feat
 
 ### Phase 1: Core
 status: approved
@@ -808,56 +653,59 @@ ext_id: tick-phase1
 | full-feat-1-1 | First | none | authored | tick-aaa |
 | full-feat-1-2 | Second | none | authored | tick-bbb |
 '
-create_review_file "full-feat" "full-feat" "r1" "review.md" "# Old review"
-create_review_file "full-feat" "full-feat" "r2" "review.md" "# New review"
+  create_review_file "full-feat" "full-feat" "r1" "review.md" "# Old review"
+  create_review_file "full-feat" "full-feat" "r2" "review.md" "# New review"
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-# Step 1+2: backfill + normalise
-assert_equals "$(get_field "full-feat" "phases.implementation.completed_tasks")" '["full-feat-1-1","full-feat-1-2"]' "Backfilled and normalised"
-assert_equals "$(get_field "full-feat" "phases.implementation.completed_phases")" '[1]' "Phases backfilled"
+  # Step 1+2: backfill + normalise
+  assert_eq "backfilled and normalised" '["full-feat-1-1","full-feat-1-2"]' "$(get_field "full-feat" "phases.implementation.completed_tasks")"
+  assert_eq "phases backfilled" '[1]' "$(get_field "full-feat" "phases.implementation.completed_phases")"
 
-# Step 3: flatten
-review_content=$(cat "$TEST_DIR/.workflows/full-feat/review/full-feat/review.md")
-assert_equals "$review_content" "# New review" "Review flattened to r2"
-assert_dir_not_exists "$TEST_DIR/.workflows/full-feat/review/full-feat/r1" "r1/ removed"
-assert_dir_not_exists "$TEST_DIR/.workflows/full-feat/review/full-feat/r2" "r2/ removed"
+  # Step 3: flatten
+  local review_content
+  review_content=$(cat "$TEST_DIR/.workflows/full-feat/review/full-feat/review.md")
+  assert_eq "review flattened to r2" "# New review" "$review_content"
+  assert_eq "r1/ removed" "false" "$([ -d "$TEST_DIR/.workflows/full-feat/review/full-feat/r1" ] && echo true || echo false)"
+  assert_eq "r2/ removed" "false" "$([ -d "$TEST_DIR/.workflows/full-feat/review/full-feat/r2" ] && echo true || echo false)"
 
-# Step 4: ext_id rename
-assert_equals "$(get_field "full-feat" "phases.planning.external_id")" "tick-plan1" "Manifest ext_id → external_id"
-plan_content=$(cat "$TEST_DIR/.workflows/full-feat/planning/full-feat/planning.md")
-assert_contains "$plan_content" "External ID" "Plan table: Ext ID → External ID"
-assert_contains "$plan_content" "external_id:" "Plan phase: ext_id: → external_id:"
+  # Step 4: ext_id rename
+  assert_eq "manifest ext_id -> external_id" "tick-plan1" "$(get_field "full-feat" "phases.planning.external_id")"
+  local plan_content
+  plan_content=$(cat "$TEST_DIR/.workflows/full-feat/planning/full-feat/planning.md")
+  assert_eq "plan table: Ext ID -> External ID" "true" "$(echo "$plan_content" | grep -qF 'External ID' && echo true || echo false)"
+  assert_eq "plan phase: ext_id: -> external_id:" "true" "$(echo "$plan_content" | grep -qF 'external_id:' && echo true || echo false)"
 
-# Step 5: ID → Internal ID
-assert_contains "$plan_content" "| Internal ID |" "Plan table: ID → Internal ID"
-assert_not_contains "$plan_content" "| ID |" "No old | ID | remaining"
+  # Step 5: ID -> Internal ID
+  assert_eq "plan table: ID -> Internal ID" "true" "$(echo "$plan_content" | grep -qF '| Internal ID |' && echo true || echo false)"
+  assert_eq "no old | ID | remaining" "false" "$(echo "$plan_content" | grep -qF '| ID |' && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 20: Skips dot-prefixed directories ---
+test_skips_dot_dirs() {
+  setup
 
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo '{"phases":{"planning":{"ext_id":"old"}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
+  create_manifest "real" '{"work_type":"feature","status":"in-progress","phases":{"planning":{"ext_id":"tick-1"}}}'
 
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo '{"phases":{"planning":{"ext_id":"old"}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
-create_manifest "real" '{"work_type":"feature","status":"in-progress","phases":{"planning":{"ext_id":"tick-1"}}}'
+  run_migration > /dev/null
 
-run_migration > /dev/null
+  local dot_extid
+  dot_extid=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).phases.planning.ext_id)" "$TEST_DIR/.workflows/.state/manifest.json")
+  assert_eq "dot-dir manifest not touched" "old" "$dot_extid"
+  assert_eq "real manifest updated" "tick-1" "$(get_field "real" "phases.planning.external_id")"
 
-dot_extid=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).phases.planning.ext_id)" "$TEST_DIR/.workflows/.state/manifest.json")
-assert_equals "$dot_extid" "old" "Dot-dir manifest not touched"
-assert_equals "$(get_field "real" "phases.planning.external_id")" "tick-1" "Real manifest updated"
+  teardown
+}
 
-echo ""
+# --- Test 21: Idempotent — running twice produces same result ---
+test_idempotent() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
-setup_fixture
-
-create_manifest "idem" '{
+  create_manifest "idem" '{
   "work_type": "feature",
   "status": "in-progress",
   "phases": {
@@ -866,13 +714,13 @@ create_manifest "idem" '{
     "review": {}
   }
 }'
-create_implementation_file "idem" "idem" '---
+  create_implementation_file "idem" "idem" '---
 completed_tasks: [tick-aaa]
 completed_phases: [1]
 ---
 # Implementation
 '
-create_plan_file "idem" "idem" '# Plan
+  create_plan_file "idem" "idem" '# Plan
 
 ### Phase 1: Core
 status: approved
@@ -883,43 +731,60 @@ ext_id: tick-p1
 |----|------|------------|--------|--------|
 | idem-1-1 | First | none | authored | tick-aaa |
 '
-create_review_file "idem" "idem" "r1" "review.md" "# Review"
+  create_review_file "idem" "idem" "r1" "review.md" "# Review"
 
-run_migration > /dev/null
-before_manifest=$(get_json "idem")
-before_plan=$(cat "$TEST_DIR/.workflows/idem/planning/idem/planning.md")
-output=$(run_migration)
-after_manifest=$(get_json "idem")
-after_plan=$(cat "$TEST_DIR/.workflows/idem/planning/idem/planning.md")
+  run_migration > /dev/null
+  local before_manifest before_plan
+  before_manifest=$(get_json "idem")
+  before_plan=$(cat "$TEST_DIR/.workflows/idem/planning/idem/planning.md")
+  run_migration > /dev/null
+  local after_manifest after_plan
+  after_manifest=$(get_json "idem")
+  after_plan=$(cat "$TEST_DIR/.workflows/idem/planning/idem/planning.md")
 
-assert_equals "$after_manifest" "$before_manifest" "Manifest unchanged on second run"
-assert_equals "$after_plan" "$before_plan" "Plan file unchanged on second run"
-assert_not_contains "$output" "updated" "No updates on second run"
+  assert_eq "manifest unchanged on second run" "$before_manifest" "$after_manifest"
+  assert_eq "plan file unchanged on second run" "$before_plan" "$after_plan"
 
+  teardown
+}
+
+# --- Test 22: No .workflows directory — exits cleanly ---
+test_no_workflows_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
+
+  run_migration > /dev/null
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 024 tests..."
 echo ""
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
-setup_fixture
-
-output=$(run_migration)
-
-assert_not_contains "$output" "updated" "No updates without .workflows dir"
+test_backfill_inline_array
+test_backfill_multiline
+test_no_overwrite_existing
+test_backfill_epic_items
+test_skips_no_implementation
+test_normalise_tick_ids
+test_internal_ids_unchanged
+test_normalise_renamed_column
+test_flatten_r1
+test_flatten_keeps_highest
+test_skips_flat_review
+test_flatten_epic_reviews
+test_rename_ext_id_manifest
+test_rename_ext_id_plan
+test_skips_already_external_id
+test_rename_id_to_internal_id
+test_skips_already_internal_id
+test_rename_multiple_phases
+test_all_steps_together
+test_skips_dot_dirs
+test_idempotent
+test_no_workflows_dir
 
 echo ""
-
-# ============================================================================
-# SUMMARY
-# ============================================================================
-
-echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-025.sh
+++ b/tests/scripts/test-migration-025.sh
@@ -1,134 +1,74 @@
 #!/bin/bash
 #
-# Tests migration 025-unify-manifest-items.sh
-# Validates wrapping flat feature/bugfix phase data into items[name].
+# Tests for migration 025: unify-manifest-items
+#
+# Run: bash tests/scripts/test-migration-025.sh
 #
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/025-unify-manifest-items.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/025-unify-manifest-items.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
+export -f report_update report_skip
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
 
-echo "Test directory: $TEST_DIR"
-echo ""
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-025-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
 
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
 create_manifest() {
-    local name="$1"
-    local content="$2"
-    mkdir -p "$TEST_DIR/.workflows/$name"
-    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
-}
-
-# Stub report_update for migration script
-report_update() { echo "updated"; }
-export -f report_update
-
-run_migration() {
-    cd "$TEST_DIR"
-    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+  local name="$1"
+  local content="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name"
+  echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
 get_field() {
-    local name="$1"
-    local field="$2"
-    node -e "
-      const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
-      const parts = process.argv[2].split('.');
-      let v = m;
-      for (const p of parts) v = (v || {})[p];
-      console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
-    " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
+  local name="$1"
+  local field="$2"
+  node -e "
+    const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    const parts = process.argv[2].split('.');
+    let v = m;
+    for (const p of parts) v = (v || {})[p];
+    console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
+  " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
 }
 
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+run_migration() {
+  cd "$TEST_DIR"
+  bash "$MIGRATION" 2>&1
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: Feature flat discussion wrapped into items ---
+test_feature_discussion_wrapped() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
-}
-
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: feature flat discussion wrapped into items${NC}"
-setup_fixture
-
-create_manifest "my-feat" '{
+  create_manifest "my-feat" '{
   "name": "my-feat",
   "work_type": "feature",
   "status": "in-progress",
@@ -137,19 +77,18 @@ create_manifest "my-feat" '{
   }
 }'
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_equals "$(get_field "my-feat" "phases.discussion.items.my-feat.status")" "completed" "Status moved into items"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "status moved into items" "completed" "$(get_field "my-feat" "phases.discussion.items.my-feat.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: Feature planning with extra fields wrapped correctly ---
+test_feature_planning_wrapped() {
+  setup
 
-echo -e "${YELLOW}Test: feature planning with extra fields wrapped correctly${NC}"
-setup_fixture
-
-create_manifest "plan-feat" '{
+  create_manifest "plan-feat" '{
   "name": "plan-feat",
   "work_type": "feature",
   "status": "in-progress",
@@ -158,20 +97,20 @@ create_manifest "plan-feat" '{
   }
 }'
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "plan-feat" "phases.planning.items.plan-feat.status")" "completed" "Status in items"
-assert_equals "$(get_field "plan-feat" "phases.planning.items.plan-feat.format")" "local-markdown" "Format in items"
-assert_equals "$(get_field "plan-feat" "phases.planning.items.plan-feat.task_list_gate_mode")" "gated" "Gate mode in items"
+  assert_eq "status in items" "completed" "$(get_field "plan-feat" "phases.planning.items.plan-feat.status")"
+  assert_eq "format in items" "local-markdown" "$(get_field "plan-feat" "phases.planning.items.plan-feat.format")"
+  assert_eq "gate mode in items" "gated" "$(get_field "plan-feat" "phases.planning.items.plan-feat.task_list_gate_mode")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: analysis_cache preserved at phase level ---
+test_analysis_cache_preserved() {
+  setup
 
-echo -e "${YELLOW}Test: analysis_cache preserved at phase level${NC}"
-setup_fixture
-
-create_manifest "cached" '{
+  create_manifest "cached" '{
   "name": "cached",
   "work_type": "feature",
   "status": "in-progress",
@@ -180,19 +119,19 @@ create_manifest "cached" '{
   }
 }'
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "cached" "phases.research.analysis_cache.checksum")" "abc123" "analysis_cache stays at phase level"
-assert_equals "$(get_field "cached" "phases.research.items.cached.status")" "completed" "Status moved to items"
+  assert_eq "analysis_cache stays at phase level" "abc123" "$(get_field "cached" "phases.research.analysis_cache.checksum")"
+  assert_eq "status moved to items" "completed" "$(get_field "cached" "phases.research.items.cached.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: Bugfix investigation wrapped into items ---
+test_bugfix_investigation_wrapped() {
+  setup
 
-echo -e "${YELLOW}Test: bugfix investigation wrapped into items${NC}"
-setup_fixture
-
-create_manifest "my-bug" '{
+  create_manifest "my-bug" '{
   "name": "my-bug",
   "work_type": "bugfix",
   "status": "in-progress",
@@ -201,18 +140,18 @@ create_manifest "my-bug" '{
   }
 }'
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "my-bug" "phases.investigation.items.my-bug.status")" "in-progress" "Bugfix investigation wrapped"
+  assert_eq "bugfix investigation wrapped" "in-progress" "$(get_field "my-bug" "phases.investigation.items.my-bug.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: Epic manifests are skipped ---
+test_epic_skipped() {
+  setup
 
-echo -e "${YELLOW}Test: epic manifests are skipped${NC}"
-setup_fixture
-
-create_manifest "my-epic" '{
+  create_manifest "my-epic" '{
   "name": "my-epic",
   "work_type": "epic",
   "status": "in-progress",
@@ -221,19 +160,18 @@ create_manifest "my-epic" '{
   }
 }'
 
-output=$(run_migration)
+  run_migration > /dev/null
 
-assert_equals "$(get_field "my-epic" "phases.discussion.items.auth.status")" "completed" "Epic items unchanged"
-assert_not_contains "$output" "updated" "No update for epic"
+  assert_eq "epic items unchanged" "completed" "$(get_field "my-epic" "phases.discussion.items.auth.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: Phases already with items are skipped ---
+test_already_has_items() {
+  setup
 
-echo -e "${YELLOW}Test: phases already with items are skipped${NC}"
-setup_fixture
-
-create_manifest "already-items" '{
+  create_manifest "already-items" '{
   "name": "already-items",
   "work_type": "feature",
   "status": "in-progress",
@@ -243,19 +181,19 @@ create_manifest "already-items" '{
   }
 }'
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "already-items" "phases.discussion.items.already-items.status")" "completed" "Existing items untouched"
-assert_equals "$(get_field "already-items" "phases.specification.items.already-items.status")" "in-progress" "Flat phase wrapped"
+  assert_eq "existing items untouched" "completed" "$(get_field "already-items" "phases.discussion.items.already-items.status")"
+  assert_eq "flat phase wrapped" "in-progress" "$(get_field "already-items" "phases.specification.items.already-items.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Multiple phases wrapped in one manifest ---
+test_multiple_phases_wrapped() {
+  setup
 
-echo -e "${YELLOW}Test: multiple phases wrapped in one manifest${NC}"
-setup_fixture
-
-create_manifest "multi" '{
+  create_manifest "multi" '{
   "name": "multi",
   "work_type": "feature",
   "status": "in-progress",
@@ -267,21 +205,21 @@ create_manifest "multi" '{
   }
 }'
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "multi" "phases.discussion.items.multi.status")" "completed" "Discussion wrapped"
-assert_equals "$(get_field "multi" "phases.specification.items.multi.status")" "completed" "Specification wrapped"
-assert_equals "$(get_field "multi" "phases.planning.items.multi.format")" "local-markdown" "Planning format in items"
-assert_equals "$(get_field "multi" "phases.implementation.items.multi.completed_tasks")" '["multi-1-1"]' "Implementation tasks in items"
+  assert_eq "discussion wrapped" "completed" "$(get_field "multi" "phases.discussion.items.multi.status")"
+  assert_eq "specification wrapped" "completed" "$(get_field "multi" "phases.specification.items.multi.status")"
+  assert_eq "planning format in items" "local-markdown" "$(get_field "multi" "phases.planning.items.multi.format")"
+  assert_eq "implementation tasks in items" '["multi-1-1"]' "$(get_field "multi" "phases.implementation.items.multi.completed_tasks")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Idempotent — running twice produces same result ---
+test_idempotent() {
+  setup
 
-echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
-setup_fixture
-
-create_manifest "idem" '{
+  create_manifest "idem" '{
   "name": "idem",
   "work_type": "feature",
   "status": "in-progress",
@@ -290,65 +228,61 @@ create_manifest "idem" '{
   }
 }'
 
-run_migration > /dev/null
-output=$(run_migration)
+  run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "idem" "phases.discussion.items.idem.status")" "completed" "Items still correct"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "items still correct" "completed" "$(get_field "idem" "phases.discussion.items.idem.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 9: Skips dot-prefixed directories ---
+test_skips_dot_dirs() {
+  setup
 
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo '{"name":".state","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
+  create_manifest "real" '{"name":"real","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}'
 
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo '{"name":".state","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
-create_manifest "real" '{"name":"real","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}'
+  run_migration > /dev/null
 
-run_migration > /dev/null
+  assert_eq "real manifest migrated" "completed" "$(get_field "real" "phases.discussion.items.real.status")"
+  local dot_status
+  dot_status=$(node -e "
+    const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(m.phases.discussion.status || 'missing');
+  " "$TEST_DIR/.workflows/.state/manifest.json")
+  assert_eq "dot-dir manifest untouched" "completed" "$dot_status"
 
-assert_equals "$(get_field "real" "phases.discussion.items.real.status")" "completed" "Real manifest migrated"
-# Dot-dir manifest should still have flat status
-dot_status=$(node -e "
-  const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
-  console.log(m.phases.discussion.status || 'missing');
-" "$TEST_DIR/.workflows/.state/manifest.json")
-assert_equals "$dot_status" "completed" "Dot-dir manifest untouched"
+  teardown
+}
 
-echo ""
+# --- Test 10: Empty phases object unchanged ---
+test_empty_phases() {
+  setup
 
-# ----------------------------------------------------------------------------
+  create_manifest "empty" '{"name":"empty","work_type":"feature","status":"in-progress","phases":{}}'
 
-echo -e "${YELLOW}Test: empty phases object unchanged${NC}"
-setup_fixture
+  run_migration > /dev/null
 
-create_manifest "empty" '{"name":"empty","work_type":"feature","status":"in-progress","phases":{}}'
+  teardown
+}
 
-output=$(run_migration)
+# --- Test 11: No .workflows directory — exits cleanly ---
+test_no_workflows_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
 
-assert_not_contains "$output" "updated" "No update for empty phases"
+  run_migration > /dev/null
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 12: Preserves other manifest fields ---
+test_preserves_fields() {
+  setup
 
-echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
-setup_fixture
-
-output=$(run_migration)
-
-assert_not_contains "$output" "updated" "No updates without .workflows dir"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
-setup_fixture
-
-create_manifest "preserve" '{
+  create_manifest "preserve" '{
   "name": "preserve",
   "work_type": "feature",
   "status": "in-progress",
@@ -359,26 +293,33 @@ create_manifest "preserve" '{
   }
 }'
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_equals "$(get_field "preserve" "name")" "preserve" "Name preserved"
-assert_equals "$(get_field "preserve" "work_type")" "feature" "Work type preserved"
-assert_equals "$(get_field "preserve" "created")" "2026-03-01" "Created date preserved"
-assert_equals "$(get_field "preserve" "description")" "Test preservation" "Description preserved"
+  assert_eq "name preserved" "preserve" "$(get_field "preserve" "name")"
+  assert_eq "work type preserved" "feature" "$(get_field "preserve" "work_type")"
+  assert_eq "created date preserved" "2026-03-01" "$(get_field "preserve" "created")"
+  assert_eq "description preserved" "Test preservation" "$(get_field "preserve" "description")"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 025 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_feature_discussion_wrapped
+test_feature_planning_wrapped
+test_analysis_cache_preserved
+test_bugfix_investigation_wrapped
+test_epic_skipped
+test_already_has_items
+test_multiple_phases_wrapped
+test_idempotent
+test_skips_dot_dirs
+test_empty_phases
+test_no_workflows_dir
+test_preserves_fields
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-026.sh
+++ b/tests/scripts/test-migration-026.sh
@@ -1,319 +1,233 @@
 #!/bin/bash
 #
-# Tests migration 026-rename-review-artifacts.sh
-# Validates renaming review.md → report.md and qa-task-{N}.md → report-{phase_id}-{task_id}.md
+# Tests for migration 026: rename-review-artifacts
+#
+# Run: bash tests/scripts/test-migration-026.sh
 #
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/026-rename-review-artifacts.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/026-rename-review-artifacts.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
+export -f report_update report_skip
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
 
-echo "Test directory: $TEST_DIR"
-echo ""
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-026-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
 
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
 create_manifest() {
-    local name="$1"
-    local content="$2"
-    mkdir -p "$TEST_DIR/.workflows/$name"
-    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+  local name="$1"
+  local content="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name"
+  echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
 create_plan_with_tasks() {
-    local wu="$1"
-    local topic="$2"
-    shift 2
-    local ids=("$@")
+  local wu="$1"
+  local topic="$2"
+  shift 2
+  local ids=("$@")
 
-    mkdir -p "$TEST_DIR/.workflows/$wu/planning/$topic"
-    local plan="$TEST_DIR/.workflows/$wu/planning/$topic/planning.md"
+  mkdir -p "$TEST_DIR/.workflows/$wu/planning/$topic"
+  local plan="$TEST_DIR/.workflows/$wu/planning/$topic/planning.md"
 
-    echo "# Plan" > "$plan"
-    echo "" >> "$plan"
-    echo "| Internal ID | Task | Phase |" >> "$plan"
-    echo "|-------------|------|-------|" >> "$plan"
-    for id in "${ids[@]}"; do
-        echo "| $id | Task description | Phase 1 |" >> "$plan"
-    done
+  echo "# Plan" > "$plan"
+  echo "" >> "$plan"
+  echo "| Internal ID | Task | Phase |" >> "$plan"
+  echo "|-------------|------|-------|" >> "$plan"
+  for id in "${ids[@]}"; do
+    echo "| $id | Task description | Phase 1 |" >> "$plan"
+  done
 }
 
 create_review_files() {
-    local wu="$1"
-    local topic="$2"
-    shift 2
+  local wu="$1"
+  local topic="$2"
+  shift 2
 
-    mkdir -p "$TEST_DIR/.workflows/$wu/review/$topic"
+  mkdir -p "$TEST_DIR/.workflows/$wu/review/$topic"
 
-    # Create review.md
-    echo "# Review" > "$TEST_DIR/.workflows/$wu/review/$topic/review.md"
+  echo "# Review" > "$TEST_DIR/.workflows/$wu/review/$topic/review.md"
 
-    # Create qa-task files
-    local n=1
-    for _ in "$@"; do
-        echo "QA findings for task $n" > "$TEST_DIR/.workflows/$wu/review/$topic/qa-task-${n}.md"
-        n=$((n + 1))
-    done
+  local n=1
+  for _ in "$@"; do
+    echo "QA findings for task $n" > "$TEST_DIR/.workflows/$wu/review/$topic/qa-task-${n}.md"
+    n=$((n + 1))
+  done
 }
-
-# Stub report functions for migration script
-report_update() { echo "updated"; }
-report_skip() { echo "skipped"; }
-export -f report_update
-export -f report_skip
 
 run_migration() {
-    cd "$TEST_DIR"
-    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+  cd "$TEST_DIR"
+  bash "$MIGRATION" 2>&1
 }
 
-assert_file_exists() {
-    local path="$1"
-    local description="$2"
+# --- Test 1: Feature — review.md renamed to report.md, qa-task files renamed ---
+test_feature_rename() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  create_manifest "my-feat" '{"name":"my-feat","work_type":"feature","status":"in-progress","phases":{}}'
+  create_plan_with_tasks "my-feat" "my-feat" "my-feat-1-1" "my-feat-1-2" "my-feat-2-1"
+  create_review_files "my-feat" "my-feat" t1 t2 t3
 
-    if [ -f "$path" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File not found: $path"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+  run_migration > /dev/null
+
+  assert_eq "review.md renamed to report.md" "true" "$([ -f "$TEST_DIR/.workflows/my-feat/review/my-feat/report.md" ] && echo true || echo false)"
+  assert_eq "old review.md removed" "false" "$([ -f "$TEST_DIR/.workflows/my-feat/review/my-feat/review.md" ] && echo true || echo false)"
+  assert_eq "qa-task-1.md -> report-1-1.md" "true" "$([ -f "$TEST_DIR/.workflows/my-feat/review/my-feat/report-1-1.md" ] && echo true || echo false)"
+  assert_eq "qa-task-2.md -> report-1-2.md" "true" "$([ -f "$TEST_DIR/.workflows/my-feat/review/my-feat/report-1-2.md" ] && echo true || echo false)"
+  assert_eq "qa-task-3.md -> report-2-1.md" "true" "$([ -f "$TEST_DIR/.workflows/my-feat/review/my-feat/report-2-1.md" ] && echo true || echo false)"
+  assert_eq "old qa-task-1.md removed" "false" "$([ -f "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "old qa-task-2.md removed" "false" "$([ -f "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-2.md" ] && echo true || echo false)"
+  assert_eq "old qa-task-3.md removed" "false" "$([ -f "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-3.md" ] && echo true || echo false)"
+
+  teardown
 }
 
-assert_file_not_exists() {
-    local path="$1"
-    local description="$2"
+# --- Test 2: Epic with multiple topics ---
+test_epic_multiple_topics() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  create_manifest "my-epic" '{"name":"my-epic","work_type":"epic","status":"in-progress","phases":{}}'
+  create_plan_with_tasks "my-epic" "auth" "auth-1-1" "auth-1-2"
+  create_plan_with_tasks "my-epic" "billing" "billing-1-1"
+  create_review_files "my-epic" "auth" t1 t2
+  create_review_files "my-epic" "billing" t1
 
-    if [ ! -f "$path" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    File should not exist: $path"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+  run_migration > /dev/null
+
+  assert_eq "auth: review.md -> report.md" "true" "$([ -f "$TEST_DIR/.workflows/my-epic/review/auth/report.md" ] && echo true || echo false)"
+  assert_eq "auth: qa-task-1 -> report-1-1" "true" "$([ -f "$TEST_DIR/.workflows/my-epic/review/auth/report-1-1.md" ] && echo true || echo false)"
+  assert_eq "auth: qa-task-2 -> report-1-2" "true" "$([ -f "$TEST_DIR/.workflows/my-epic/review/auth/report-1-2.md" ] && echo true || echo false)"
+  assert_eq "billing: review.md -> report.md" "true" "$([ -f "$TEST_DIR/.workflows/my-epic/review/billing/report.md" ] && echo true || echo false)"
+  assert_eq "billing: qa-task-1 -> report-1-1" "true" "$([ -f "$TEST_DIR/.workflows/my-epic/review/billing/report-1-1.md" ] && echo true || echo false)"
+
+  teardown
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 3: Already migrated — skip gracefully ---
+test_already_migrated() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  create_manifest "done" '{"name":"done","work_type":"feature","status":"completed","phases":{}}'
+  mkdir -p "$TEST_DIR/.workflows/done/review/done"
+  echo "# Report" > "$TEST_DIR/.workflows/done/review/done/report.md"
+  echo "findings" > "$TEST_DIR/.workflows/done/review/done/report-1-1.md"
 
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+  run_migration > /dev/null
+
+  assert_eq "report.md still exists" "true" "$([ -f "$TEST_DIR/.workflows/done/review/done/report.md" ] && echo true || echo false)"
+  assert_eq "report-1-1.md still exists" "true" "$([ -f "$TEST_DIR/.workflows/done/review/done/report-1-1.md" ] && echo true || echo false)"
+
+  teardown
 }
 
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 4: No plan exists — review.md renamed, qa-task files skipped ---
+test_no_plan() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
+  create_manifest "no-plan" '{"name":"no-plan","work_type":"feature","status":"in-progress","phases":{}}'
+  mkdir -p "$TEST_DIR/.workflows/no-plan/review/no-plan"
+  echo "# Review" > "$TEST_DIR/.workflows/no-plan/review/no-plan/review.md"
+  echo "findings" > "$TEST_DIR/.workflows/no-plan/review/no-plan/qa-task-1.md"
 
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
+  run_migration > /dev/null
+
+  assert_eq "review.md still renamed" "true" "$([ -f "$TEST_DIR/.workflows/no-plan/review/no-plan/report.md" ] && echo true || echo false)"
+  assert_eq "qa-task-1 preserved (no plan)" "true" "$([ -f "$TEST_DIR/.workflows/no-plan/review/no-plan/qa-task-1.md" ] && echo true || echo false)"
+
+  teardown
 }
 
-# ============================================================================
-# TEST CASES
-# ============================================================================
+# --- Test 5: Count mismatch — qa-task files skipped ---
+test_count_mismatch() {
+  setup
 
-echo -e "${YELLOW}Test: feature — review.md renamed to report.md, qa-task files renamed${NC}"
-setup_fixture
+  create_manifest "mismatch" '{"name":"mismatch","work_type":"feature","status":"in-progress","phases":{}}'
+  create_plan_with_tasks "mismatch" "mismatch" "mismatch-1-1" "mismatch-1-2"
+  mkdir -p "$TEST_DIR/.workflows/mismatch/review/mismatch"
+  echo "# Review" > "$TEST_DIR/.workflows/mismatch/review/mismatch/review.md"
+  echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-1.md"
+  echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-2.md"
+  echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-3.md"
 
-create_manifest "my-feat" '{"name":"my-feat","work_type":"feature","status":"in-progress","phases":{}}'
-create_plan_with_tasks "my-feat" "my-feat" "my-feat-1-1" "my-feat-1-2" "my-feat-2-1"
-create_review_files "my-feat" "my-feat" t1 t2 t3
+  run_migration > /dev/null
 
-output=$(run_migration)
+  assert_eq "review.md still renamed" "true" "$([ -f "$TEST_DIR/.workflows/mismatch/review/mismatch/report.md" ] && echo true || echo false)"
+  assert_eq "qa-task-1 preserved (mismatch)" "true" "$([ -f "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-1.md" ] && echo true || echo false)"
+  assert_eq "qa-task-2 preserved (mismatch)" "true" "$([ -f "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-2.md" ] && echo true || echo false)"
+  assert_eq "qa-task-3 preserved (mismatch)" "true" "$([ -f "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-3.md" ] && echo true || echo false)"
 
-assert_file_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/report.md" "review.md renamed to report.md"
-assert_file_not_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/review.md" "old review.md removed"
-assert_file_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/report-1-1.md" "qa-task-1.md → report-1-1.md"
-assert_file_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/report-1-2.md" "qa-task-2.md → report-1-2.md"
-assert_file_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/report-2-1.md" "qa-task-3.md → report-2-1.md"
-assert_file_not_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-1.md" "old qa-task-1.md removed"
-assert_file_not_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-2.md" "old qa-task-2.md removed"
-assert_file_not_exists "$TEST_DIR/.workflows/my-feat/review/my-feat/qa-task-3.md" "old qa-task-3.md removed"
-assert_contains "$output" "updated" "Reports review.md rename"
-assert_contains "$output" "updated" "Reports qa-task rename"
+  teardown
+}
 
-echo ""
+# --- Test 6: Topic with hyphens — suffix derived correctly ---
+test_hyphenated_topic() {
+  setup
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: epic with multiple topics${NC}"
-setup_fixture
-
-create_manifest "my-epic" '{"name":"my-epic","work_type":"epic","status":"in-progress","phases":{}}'
-create_plan_with_tasks "my-epic" "auth" "auth-1-1" "auth-1-2"
-create_plan_with_tasks "my-epic" "billing" "billing-1-1"
-create_review_files "my-epic" "auth" t1 t2
-create_review_files "my-epic" "billing" t1
-
-run_migration > /dev/null
-
-assert_file_exists "$TEST_DIR/.workflows/my-epic/review/auth/report.md" "auth: review.md → report.md"
-assert_file_exists "$TEST_DIR/.workflows/my-epic/review/auth/report-1-1.md" "auth: qa-task-1 → report-1-1"
-assert_file_exists "$TEST_DIR/.workflows/my-epic/review/auth/report-1-2.md" "auth: qa-task-2 → report-1-2"
-assert_file_exists "$TEST_DIR/.workflows/my-epic/review/billing/report.md" "billing: review.md → report.md"
-assert_file_exists "$TEST_DIR/.workflows/my-epic/review/billing/report-1-1.md" "billing: qa-task-1 → report-1-1"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: already migrated — skip gracefully${NC}"
-setup_fixture
-
-create_manifest "done" '{"name":"done","work_type":"feature","status":"completed","phases":{}}'
-mkdir -p "$TEST_DIR/.workflows/done/review/done"
-echo "# Report" > "$TEST_DIR/.workflows/done/review/done/report.md"
-echo "findings" > "$TEST_DIR/.workflows/done/review/done/report-1-1.md"
-
-output=$(run_migration)
-
-assert_file_exists "$TEST_DIR/.workflows/done/review/done/report.md" "report.md still exists"
-assert_file_exists "$TEST_DIR/.workflows/done/review/done/report-1-1.md" "report-1-1.md still exists"
-assert_not_contains "$output" "updated" "No renames reported"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: no plan exists — review.md renamed, qa-task files skipped${NC}"
-setup_fixture
-
-create_manifest "no-plan" '{"name":"no-plan","work_type":"feature","status":"in-progress","phases":{}}'
-mkdir -p "$TEST_DIR/.workflows/no-plan/review/no-plan"
-echo "# Review" > "$TEST_DIR/.workflows/no-plan/review/no-plan/review.md"
-echo "findings" > "$TEST_DIR/.workflows/no-plan/review/no-plan/qa-task-1.md"
-
-output=$(run_migration)
-
-assert_file_exists "$TEST_DIR/.workflows/no-plan/review/no-plan/report.md" "review.md still renamed"
-assert_file_exists "$TEST_DIR/.workflows/no-plan/review/no-plan/qa-task-1.md" "qa-task-1 preserved (no plan)"
-assert_contains "$output" "skipped" "Reports skip reason"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: count mismatch — qa-task files skipped${NC}"
-setup_fixture
-
-create_manifest "mismatch" '{"name":"mismatch","work_type":"feature","status":"in-progress","phases":{}}'
-create_plan_with_tasks "mismatch" "mismatch" "mismatch-1-1" "mismatch-1-2"
-mkdir -p "$TEST_DIR/.workflows/mismatch/review/mismatch"
-echo "# Review" > "$TEST_DIR/.workflows/mismatch/review/mismatch/review.md"
-echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-1.md"
-echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-2.md"
-echo "findings" > "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-3.md"
-
-output=$(run_migration)
-
-assert_file_exists "$TEST_DIR/.workflows/mismatch/review/mismatch/report.md" "review.md still renamed"
-assert_file_exists "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-1.md" "qa-task-1 preserved (mismatch)"
-assert_file_exists "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-2.md" "qa-task-2 preserved (mismatch)"
-assert_file_exists "$TEST_DIR/.workflows/mismatch/review/mismatch/qa-task-3.md" "qa-task-3 preserved (mismatch)"
-assert_contains "$output" "skipped" "Reports mismatch"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: topic with hyphens — suffix derived correctly${NC}"
-setup_fixture
-
-create_manifest "auto-cascade-parent-status" '{"name":"auto-cascade-parent-status","work_type":"feature","status":"in-progress","phases":{}}'
-create_plan_with_tasks "auto-cascade-parent-status" "auto-cascade-parent-status" \
+  create_manifest "auto-cascade-parent-status" '{"name":"auto-cascade-parent-status","work_type":"feature","status":"in-progress","phases":{}}'
+  create_plan_with_tasks "auto-cascade-parent-status" "auto-cascade-parent-status" \
     "auto-cascade-parent-status-1-1" "auto-cascade-parent-status-1-2"
-create_review_files "auto-cascade-parent-status" "auto-cascade-parent-status" t1 t2
+  create_review_files "auto-cascade-parent-status" "auto-cascade-parent-status" t1 t2
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-1.md" "Hyphenated topic: correct suffix 1-1"
-assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-2.md" "Hyphenated topic: correct suffix 1-2"
+  assert_eq "hyphenated topic: correct suffix 1-1" "true" "$([ -f "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-1.md" ] && echo true || echo false)"
+  assert_eq "hyphenated topic: correct suffix 1-2" "true" "$([ -f "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-2.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: Abbreviated ID prefix — suffix still derived correctly ---
+test_abbreviated_prefix() {
+  setup
 
-echo -e "${YELLOW}Test: abbreviated ID prefix — suffix still derived correctly${NC}"
-setup_fixture
-
-create_manifest "auto-cascade-parent-status" '{"name":"auto-cascade-parent-status","work_type":"feature","status":"in-progress","phases":{}}'
-# Plan uses abbreviated prefix "acps-" instead of full topic name
-create_plan_with_tasks "auto-cascade-parent-status" "auto-cascade-parent-status" \
+  create_manifest "auto-cascade-parent-status" '{"name":"auto-cascade-parent-status","work_type":"feature","status":"in-progress","phases":{}}'
+  create_plan_with_tasks "auto-cascade-parent-status" "auto-cascade-parent-status" \
     "acps-1-1" "acps-1-2" "acps-2-1"
-create_review_files "auto-cascade-parent-status" "auto-cascade-parent-status" t1 t2 t3
+  create_review_files "auto-cascade-parent-status" "auto-cascade-parent-status" t1 t2 t3
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-1.md" "Abbreviated prefix: correct suffix 1-1"
-assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-2.md" "Abbreviated prefix: correct suffix 1-2"
-assert_file_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-2-1.md" "Abbreviated prefix: correct suffix 2-1"
-assert_file_not_exists "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/qa-task-1.md" "Old qa-task-1 removed"
+  assert_eq "abbreviated prefix: correct suffix 1-1" "true" "$([ -f "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-1.md" ] && echo true || echo false)"
+  assert_eq "abbreviated prefix: correct suffix 1-2" "true" "$([ -f "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-1-2.md" ] && echo true || echo false)"
+  assert_eq "abbreviated prefix: correct suffix 2-1" "true" "$([ -f "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/report-2-1.md" ] && echo true || echo false)"
+  assert_eq "old qa-task-1 removed" "false" "$([ -f "$TEST_DIR/.workflows/auto-cascade-parent-status/review/auto-cascade-parent-status/qa-task-1.md" ] && echo true || echo false)"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: Plan with changelog dates — dates not mistaken for task IDs ---
+test_changelog_dates() {
+  setup
 
-echo -e "${YELLOW}Test: plan with changelog dates — dates not mistaken for task IDs${NC}"
-setup_fixture
-
-create_manifest "with-log" '{"name":"with-log","work_type":"feature","status":"in-progress","phases":{}}'
-mkdir -p "$TEST_DIR/.workflows/with-log/planning/with-log"
-cat > "$TEST_DIR/.workflows/with-log/planning/with-log/planning.md" <<'PLAN'
+  create_manifest "with-log" '{"name":"with-log","work_type":"feature","status":"in-progress","phases":{}}'
+  mkdir -p "$TEST_DIR/.workflows/with-log/planning/with-log"
+  cat > "$TEST_DIR/.workflows/with-log/planning/with-log/planning.md" <<'PLAN'
 # Plan
 
 | Internal ID | Task | Phase |
@@ -330,103 +244,104 @@ cat > "$TEST_DIR/.workflows/with-log/planning/with-log/planning.md" <<'PLAN'
 | 2026-02-10 | Phase 2 added |
 PLAN
 
-create_review_files "with-log" "with-log" t1 t2
+  create_review_files "with-log" "with-log" t1 t2
 
-run_migration > /dev/null
+  run_migration > /dev/null
 
-assert_file_exists "$TEST_DIR/.workflows/with-log/review/with-log/report-1-1.md" "Task 1 renamed correctly"
-assert_file_exists "$TEST_DIR/.workflows/with-log/review/with-log/report-1-2.md" "Task 2 renamed correctly"
-assert_file_not_exists "$TEST_DIR/.workflows/with-log/review/with-log/qa-task-1.md" "Old file removed"
+  assert_eq "task 1 renamed correctly" "true" "$([ -f "$TEST_DIR/.workflows/with-log/review/with-log/report-1-1.md" ] && echo true || echo false)"
+  assert_eq "task 2 renamed correctly" "true" "$([ -f "$TEST_DIR/.workflows/with-log/review/with-log/report-1-2.md" ] && echo true || echo false)"
+  assert_eq "old file removed" "false" "$([ -f "$TEST_DIR/.workflows/with-log/review/with-log/qa-task-1.md" ] && echo true || echo false)"
 
+  teardown
+}
+
+# --- Test 9: Idempotent — running twice produces same result ---
+test_idempotent() {
+  setup
+
+  create_manifest "idem" '{"name":"idem","work_type":"feature","status":"in-progress","phases":{}}'
+  create_plan_with_tasks "idem" "idem" "idem-1-1"
+  create_review_files "idem" "idem" t1
+
+  run_migration > /dev/null
+  run_migration > /dev/null
+
+  assert_eq "report.md still correct" "true" "$([ -f "$TEST_DIR/.workflows/idem/review/idem/report.md" ] && echo true || echo false)"
+  assert_eq "report-1-1.md still correct" "true" "$([ -f "$TEST_DIR/.workflows/idem/review/idem/report-1-1.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 10: No .workflows directory — exits cleanly ---
+test_no_workflows_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
+
+  run_migration > /dev/null
+
+  teardown
+}
+
+# --- Test 11: No review directory — skips work unit ---
+test_no_review_dir() {
+  setup
+
+  create_manifest "no-review" '{"name":"no-review","work_type":"feature","status":"in-progress","phases":{}}'
+
+  run_migration > /dev/null
+
+  teardown
+}
+
+# --- Test 12: review.md only, no qa-task files — just renames review.md ---
+test_review_only() {
+  setup
+
+  create_manifest "review-only" '{"name":"review-only","work_type":"feature","status":"in-progress","phases":{}}'
+  mkdir -p "$TEST_DIR/.workflows/review-only/review/review-only"
+  echo "# Review" > "$TEST_DIR/.workflows/review-only/review/review-only/review.md"
+
+  run_migration > /dev/null
+
+  assert_eq "review.md renamed" "true" "$([ -f "$TEST_DIR/.workflows/review-only/review/review-only/report.md" ] && echo true || echo false)"
+  assert_eq "old review.md gone" "false" "$([ -f "$TEST_DIR/.workflows/review-only/review/review-only/review.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 13: Skips dot-prefixed directories ---
+test_skips_dot_dirs() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state/review/topic"
+  echo '{"name":".state"}' > "$TEST_DIR/.workflows/.state/manifest.json"
+  echo "# Review" > "$TEST_DIR/.workflows/.state/review/topic/review.md"
+
+  run_migration > /dev/null
+
+  assert_eq "dot-dir review.md untouched" "true" "$([ -f "$TEST_DIR/.workflows/.state/review/topic/review.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 026 tests..."
 echo ""
 
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
-setup_fixture
-
-create_manifest "idem" '{"name":"idem","work_type":"feature","status":"in-progress","phases":{}}'
-create_plan_with_tasks "idem" "idem" "idem-1-1"
-create_review_files "idem" "idem" t1
-
-run_migration > /dev/null
-output=$(run_migration)
-
-assert_file_exists "$TEST_DIR/.workflows/idem/review/idem/report.md" "report.md still correct"
-assert_file_exists "$TEST_DIR/.workflows/idem/review/idem/report-1-1.md" "report-1-1.md still correct"
-assert_not_contains "$output" "updated" "No renames on second run"
+test_feature_rename
+test_epic_multiple_topics
+test_already_migrated
+test_no_plan
+test_count_mismatch
+test_hyphenated_topic
+test_abbreviated_prefix
+test_changelog_dates
+test_idempotent
+test_no_workflows_dir
+test_no_review_dir
+test_review_only
+test_skips_dot_dirs
 
 echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
-setup_fixture
-
-output=$(run_migration)
-
-assert_not_contains "$output" "updated" "No updates without .workflows dir"
-assert_not_contains "$output" "skipped" "No renames without .workflows dir"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: no review directory — skips work unit${NC}"
-setup_fixture
-
-create_manifest "no-review" '{"name":"no-review","work_type":"feature","status":"in-progress","phases":{}}'
-
-output=$(run_migration)
-
-assert_not_contains "$output" "updated" "No renames without review dir"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: review.md only, no qa-task files — just renames review.md${NC}"
-setup_fixture
-
-create_manifest "review-only" '{"name":"review-only","work_type":"feature","status":"in-progress","phases":{}}'
-mkdir -p "$TEST_DIR/.workflows/review-only/review/review-only"
-echo "# Review" > "$TEST_DIR/.workflows/review-only/review/review-only/review.md"
-
-output=$(run_migration)
-
-assert_file_exists "$TEST_DIR/.workflows/review-only/review/review-only/report.md" "review.md renamed"
-assert_file_not_exists "$TEST_DIR/.workflows/review-only/review/review-only/review.md" "old review.md gone"
-assert_contains "$output" "updated" "Reports rename"
-
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
-
-mkdir -p "$TEST_DIR/.workflows/.state/review/topic"
-echo '{"name":".state"}' > "$TEST_DIR/.workflows/.state/manifest.json"
-echo "# Review" > "$TEST_DIR/.workflows/.state/review/topic/review.md"
-
-output=$(run_migration)
-
-assert_file_exists "$TEST_DIR/.workflows/.state/review/topic/review.md" "Dot-dir review.md untouched"
-assert_not_contains "$output" "updated" "No renames for dot dirs"
-
-echo ""
-
-# ============================================================================
-# SUMMARY
-# ============================================================================
-
-echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-027.sh
+++ b/tests/scripts/test-migration-027.sh
@@ -1,122 +1,49 @@
 #!/bin/bash
 #
-# Tests migration 027-rename-external-deps-task-id.sh
-# Validates renaming of task_id → internal_id in external_dependencies entries.
+# Tests for migration 027: rename-external-deps-task-id
+#
+# Run: bash tests/scripts/test-migration-027.sh
 #
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/027-rename-external-deps-task-id.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/027-rename-external-deps-task-id.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Mock migration helper functions
-#
-
-report_update() {
-    echo "updated"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
-report_skip() {
-    echo "skipped"
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-027-test.XXXXXX)
+  mkdir -p "$TEST_DIR/.workflows"
 }
 
-# Export functions for sourced script
-export -f report_update report_skip
-
-#
-# Helper functions
-#
-
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        echo -e "    In: $content"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-assert_not_contains() {
-    local content="$1"
-    local unexpected="$2"
-    local description="$3"
+# --- Test 1: renames task_id to internal_id in epic topic items ---
+test_renames_task_id() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -q -- "$unexpected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Unexpectedly found: $unexpected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    fi
-}
-
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
-}
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
-    mkdir -p "$TEST_DIR/.workflows"
-}
-
-run_migration() {
-    cd "$TEST_DIR"
-    source "$MIGRATION_SCRIPT"
-}
-
-# ============================================================================
-# TESTS
-# ============================================================================
-
-echo -e "${YELLOW}Test: renames task_id to internal_id in epic topic items${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/my-epic"
-cat > "$TEST_DIR/.workflows/my-epic/manifest.json" << 'EOF'
+  mkdir -p "$TEST_DIR/.workflows/my-epic"
+  cat > "$TEST_DIR/.workflows/my-epic/manifest.json" << 'EOF'
 {
   "name": "my-epic",
   "work_type": "epic",
@@ -143,24 +70,28 @@ cat > "$TEST_DIR/.workflows/my-epic/manifest.json" << 'EOF'
   }
 }
 EOF
-output=$(run_migration 2>&1)
-content=$(cat "$TEST_DIR/.workflows/my-epic/manifest.json")
 
-assert_contains "$content" '"internal_id": "auth-1-3"' "task_id renamed to internal_id"
-assert_not_contains "$content" '"task_id"' "task_id field removed"
-assert_contains "$content" '"state": "resolved"' "state preserved"
-assert_contains "$content" '"description": "User authentication"' "description preserved"
-assert_contains "$content" '"state": "unresolved"' "unresolved dep unchanged"
-assert_contains "$output" "updated" "Reports update"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-echo ""
+  local content
+  content=$(cat "$TEST_DIR/.workflows/my-epic/manifest.json")
 
-# ----------------------------------------------------------------------------
+  assert_eq "task_id renamed to internal_id" "true" "$(echo "$content" | grep -qF '"internal_id": "auth-1-3"' && echo true || echo false)"
+  assert_eq "task_id field removed" "false" "$(echo "$content" | grep -qF '"task_id"' && echo true || echo false)"
+  assert_eq "state preserved" "true" "$(echo "$content" | grep -qF '"state": "resolved"' && echo true || echo false)"
+  assert_eq "description preserved" "true" "$(echo "$content" | grep -qF '"description": "User authentication"' && echo true || echo false)"
+  assert_eq "unresolved dep unchanged" "true" "$(echo "$content" | grep -qF '"state": "unresolved"' && echo true || echo false)"
 
-echo -e "${YELLOW}Test: already has internal_id — unchanged (idempotent)${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/already-done"
-cat > "$TEST_DIR/.workflows/already-done/manifest.json" << 'EOF'
+  teardown
+}
+
+# --- Test 2: already has internal_id — unchanged (idempotent) ---
+test_already_migrated() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/already-done"
+  cat > "$TEST_DIR/.workflows/already-done/manifest.json" << 'EOF'
 {
   "name": "already-done",
   "work_type": "epic",
@@ -182,21 +113,27 @@ cat > "$TEST_DIR/.workflows/already-done/manifest.json" << 'EOF'
   }
 }
 EOF
-before=$(cat "$TEST_DIR/.workflows/already-done/manifest.json")
-output=$(run_migration 2>&1)
-after=$(cat "$TEST_DIR/.workflows/already-done/manifest.json")
 
-assert_equals "$after" "$before" "Already-migrated manifest unchanged"
-assert_contains "$output" "skipped" "Reports skip for already-migrated"
+  local before
+  before=$(cat "$TEST_DIR/.workflows/already-done/manifest.json")
 
-echo ""
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# ----------------------------------------------------------------------------
+  local after
+  after=$(cat "$TEST_DIR/.workflows/already-done/manifest.json")
 
-echo -e "${YELLOW}Test: no external_dependencies field — unchanged${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/no-deps"
-cat > "$TEST_DIR/.workflows/no-deps/manifest.json" << 'EOF'
+  assert_eq "already-migrated manifest unchanged" "$before" "$after"
+
+  teardown
+}
+
+# --- Test 3: no external_dependencies field — unchanged ---
+test_no_deps() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/no-deps"
+  cat > "$TEST_DIR/.workflows/no-deps/manifest.json" << 'EOF'
 {
   "name": "no-deps",
   "work_type": "epic",
@@ -212,21 +149,27 @@ cat > "$TEST_DIR/.workflows/no-deps/manifest.json" << 'EOF'
   }
 }
 EOF
-before=$(cat "$TEST_DIR/.workflows/no-deps/manifest.json")
-output=$(run_migration 2>&1)
-after=$(cat "$TEST_DIR/.workflows/no-deps/manifest.json")
 
-assert_equals "$after" "$before" "No external_dependencies field left unchanged"
-assert_contains "$output" "skipped" "Reports skip for no deps"
+  local before
+  before=$(cat "$TEST_DIR/.workflows/no-deps/manifest.json")
 
-echo ""
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# ----------------------------------------------------------------------------
+  local after
+  after=$(cat "$TEST_DIR/.workflows/no-deps/manifest.json")
 
-echo -e "${YELLOW}Test: empty object external_dependencies — unchanged${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/empty-deps"
-cat > "$TEST_DIR/.workflows/empty-deps/manifest.json" << 'EOF'
+  assert_eq "no external_dependencies field left unchanged" "$before" "$after"
+
+  teardown
+}
+
+# --- Test 4: empty object external_dependencies — unchanged ---
+test_empty_deps() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/empty-deps"
+  cat > "$TEST_DIR/.workflows/empty-deps/manifest.json" << 'EOF'
 {
   "name": "empty-deps",
   "work_type": "epic",
@@ -243,21 +186,27 @@ cat > "$TEST_DIR/.workflows/empty-deps/manifest.json" << 'EOF'
   }
 }
 EOF
-before=$(cat "$TEST_DIR/.workflows/empty-deps/manifest.json")
-output=$(run_migration 2>&1)
-after=$(cat "$TEST_DIR/.workflows/empty-deps/manifest.json")
 
-assert_equals "$after" "$before" "Empty external_dependencies unchanged"
-assert_contains "$output" "skipped" "Reports skip for empty deps"
+  local before
+  before=$(cat "$TEST_DIR/.workflows/empty-deps/manifest.json")
 
-echo ""
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# ----------------------------------------------------------------------------
+  local after
+  after=$(cat "$TEST_DIR/.workflows/empty-deps/manifest.json")
 
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/.archive"
-cat > "$TEST_DIR/.workflows/.archive/manifest.json" << 'EOF'
+  assert_eq "empty external_dependencies unchanged" "$before" "$after"
+
+  teardown
+}
+
+# --- Test 5: skips dot-prefixed directories ---
+test_skips_dot_dirs() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.archive"
+  cat > "$TEST_DIR/.workflows/.archive/manifest.json" << 'EOF'
 {
   "name": "archived",
   "work_type": "epic",
@@ -275,21 +224,27 @@ cat > "$TEST_DIR/.workflows/.archive/manifest.json" << 'EOF'
   }
 }
 EOF
-before=$(cat "$TEST_DIR/.workflows/.archive/manifest.json")
-output=$(run_migration 2>&1)
-after=$(cat "$TEST_DIR/.workflows/.archive/manifest.json")
 
-assert_equals "$after" "$before" "Dot-prefixed directory skipped"
-assert_not_contains "$output" "updated" "No update for dot-prefixed directory"
+  local before
+  before=$(cat "$TEST_DIR/.workflows/.archive/manifest.json")
 
-echo ""
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-# ----------------------------------------------------------------------------
+  local after
+  after=$(cat "$TEST_DIR/.workflows/.archive/manifest.json")
 
-echo -e "${YELLOW}Test: mixed — some deps have task_id, some already internal_id${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/mixed"
-cat > "$TEST_DIR/.workflows/mixed/manifest.json" << 'EOF'
+  assert_eq "dot-prefixed directory skipped" "$before" "$after"
+
+  teardown
+}
+
+# --- Test 6: mixed — some deps have task_id, some already internal_id ---
+test_mixed_deps() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/mixed"
+  cat > "$TEST_DIR/.workflows/mixed/manifest.json" << 'EOF'
 {
   "name": "mixed",
   "work_type": "epic",
@@ -317,22 +272,27 @@ cat > "$TEST_DIR/.workflows/mixed/manifest.json" << 'EOF'
   }
 }
 EOF
-run_migration
-content=$(cat "$TEST_DIR/.workflows/mixed/manifest.json")
 
-assert_contains "$content" '"internal_id": "auth-1-3"' "task_id renamed to internal_id"
-assert_contains "$content" '"internal_id": "billing-2-1"' "existing internal_id preserved"
-assert_not_contains "$content" '"task_id"' "no task_id fields remain"
-assert_contains "$content" '"state": "unresolved"' "unresolved dep unchanged"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
-echo ""
+  local content
+  content=$(cat "$TEST_DIR/.workflows/mixed/manifest.json")
 
-# ----------------------------------------------------------------------------
+  assert_eq "task_id renamed to internal_id" "true" "$(echo "$content" | grep -qF '"internal_id": "auth-1-3"' && echo true || echo false)"
+  assert_eq "existing internal_id preserved" "true" "$(echo "$content" | grep -qF '"internal_id": "billing-2-1"' && echo true || echo false)"
+  assert_eq "no task_id fields remain" "false" "$(echo "$content" | grep -qF '"task_id"' && echo true || echo false)"
+  assert_eq "unresolved dep unchanged" "true" "$(echo "$content" | grep -qF '"state": "unresolved"' && echo true || echo false)"
 
-echo -e "${YELLOW}Test: multiple phases with deps — all processed${NC}"
-setup_fixture
-mkdir -p "$TEST_DIR/.workflows/multi-phase"
-cat > "$TEST_DIR/.workflows/multi-phase/manifest.json" << 'EOF'
+  teardown
+}
+
+# --- Test 7: multiple phases with deps — all processed ---
+test_multiple_phases() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/multi-phase"
+  cat > "$TEST_DIR/.workflows/multi-phase/manifest.json" << 'EOF'
 {
   "name": "multi-phase",
   "work_type": "epic",
@@ -364,27 +324,33 @@ cat > "$TEST_DIR/.workflows/multi-phase/manifest.json" << 'EOF'
   }
 }
 EOF
-run_migration
-content=$(cat "$TEST_DIR/.workflows/multi-phase/manifest.json")
 
-assert_contains "$content" '"internal_id": "auth-1"' "planning.core dep renamed"
-assert_contains "$content" '"internal_id": "core-2-3"' "planning.advanced dep renamed"
-assert_contains "$content" '"internal_id": "billing-1-2"' "implementation.core dep renamed"
-assert_not_contains "$content" '"task_id"' "no task_id fields remain across phases"
+  cd "$TEST_DIR"
+  source "$MIGRATION"
 
+  local content
+  content=$(cat "$TEST_DIR/.workflows/multi-phase/manifest.json")
+
+  assert_eq "planning.core dep renamed" "true" "$(echo "$content" | grep -qF '"internal_id": "auth-1"' && echo true || echo false)"
+  assert_eq "planning.advanced dep renamed" "true" "$(echo "$content" | grep -qF '"internal_id": "core-2-3"' && echo true || echo false)"
+  assert_eq "implementation.core dep renamed" "true" "$(echo "$content" | grep -qF '"internal_id": "billing-1-2"' && echo true || echo false)"
+  assert_eq "no task_id fields remain across phases" "false" "$(echo "$content" | grep -qF '"task_id"' && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 027 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_renames_task_id
+test_already_migrated
+test_no_deps
+test_empty_deps
+test_skips_dot_dirs
+test_mixed_deps
+test_multiple_phases
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-028.sh
+++ b/tests/scripts/test-migration-028.sh
@@ -1,141 +1,75 @@
 #!/bin/bash
 #
-# Tests migration 028-remove-phase-level-status.sh
-# Validates removal of flat phase-level status and backfilling of research items from disk.
+# Tests for migration 028: remove-phase-level-status
+#
+# Run: bash tests/scripts/test-migration-028.sh
 #
 
 set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MIGRATION_SCRIPT="$SCRIPT_DIR/../../skills/workflow-migrate/scripts/migrations/028-remove-phase-level-status.sh"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/028-remove-phase-level-status.sh"
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+PASS=0
+FAIL=0
 
-# Test counters
-TESTS_RUN=0
-TESTS_PASSED=0
-TESTS_FAILED=0
+report_update() { : ; }
+report_skip() { : ; }
 
-# Create a temporary directory for test fixtures
-TEST_DIR=$(mktemp -d)
-trap "rm -rf $TEST_DIR" EXIT
-
-echo "Test directory: $TEST_DIR"
-echo ""
-
-#
-# Helper functions
-#
-
-setup_fixture() {
-    rm -rf "$TEST_DIR/.workflows"
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
 }
 
 create_manifest() {
-    local name="$1"
-    local content="$2"
-    mkdir -p "$TEST_DIR/.workflows/$name"
-    echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
+  local name="$1"
+  local content="$2"
+  mkdir -p "$TEST_DIR/.workflows/$name"
+  echo "$content" > "$TEST_DIR/.workflows/$name/manifest.json"
 }
 
 create_research_file() {
-    local wu_name="$1"
-    local filename="$2"
-    mkdir -p "$TEST_DIR/.workflows/$wu_name/research"
-    echo "# Research: $filename" > "$TEST_DIR/.workflows/$wu_name/research/$filename"
-}
-
-# Stub report_update for migration script
-report_update() { echo "updated"; }
-export -f report_update
-
-run_migration() {
-    cd "$TEST_DIR"
-    PROJECT_DIR="$TEST_DIR" bash "$MIGRATION_SCRIPT" 2>&1
+  local wu_name="$1"
+  local filename="$2"
+  mkdir -p "$TEST_DIR/.workflows/$wu_name/research"
+  echo "# Research: $filename" > "$TEST_DIR/.workflows/$wu_name/research/$filename"
 }
 
 get_field() {
-    local name="$1"
-    local field="$2"
-    node -e "
-      const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
-      const parts = process.argv[2].split('.');
-      let v = m;
-      for (const p of parts) v = (v || {})[p];
-      console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
-    " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
+  local name="$1"
+  local field="$2"
+  node -e "
+    const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    const parts = process.argv[2].split('.');
+    let v = m;
+    for (const p of parts) v = (v || {})[p];
+    console.log(v === undefined ? 'undefined' : (typeof v === 'object' ? JSON.stringify(v) : v));
+  " "$TEST_DIR/.workflows/$name/manifest.json" "$field"
 }
 
-assert_equals() {
-    local actual="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if [ "$actual" = "$expected" ]; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected: $expected"
-        echo -e "    Actual:   $actual"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-028-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
 }
 
-assert_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
-
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    else
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Expected to find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    fi
+teardown() {
+  rm -rf "$TEST_DIR"
 }
 
-assert_not_contains() {
-    local content="$1"
-    local expected="$2"
-    local description="$3"
+# --- Test 1: research with flat status backfilled from disk files ---
+test_research_backfill() {
+  setup
 
-    TESTS_RUN=$((TESTS_RUN + 1))
-
-    if echo "$content" | grep -qF -- "$expected"; then
-        echo -e "  ${RED}✗${NC} $description"
-        echo -e "    Should not find: $expected"
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-        return 1
-    else
-        echo -e "  ${GREEN}✓${NC} $description"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-        return 0
-    fi
-}
-
-# ============================================================================
-# TEST CASES
-# ============================================================================
-
-echo -e "${YELLOW}Test: research with flat status backfilled from disk files${NC}"
-setup_fixture
-
-create_manifest "v1" '{
+  create_manifest "v1" '{
   "name": "v1",
   "work_type": "epic",
   "status": "in-progress",
@@ -144,25 +78,24 @@ create_manifest "v1" '{
     "discussion": { "items": { "auth": { "status": "completed" } } }
   }
 }'
-create_research_file "v1" "exploration.md"
-create_research_file "v1" "architecture.md"
+  create_research_file "v1" "exploration.md"
+  create_research_file "v1" "architecture.md"
 
-output=$(run_migration)
+  source "$MIGRATION"
 
-assert_equals "$(get_field "v1" "phases.research.items.exploration.status")" "completed" "exploration backfilled as item"
-assert_equals "$(get_field "v1" "phases.research.items.architecture.status")" "completed" "architecture backfilled as item"
-assert_equals "$(get_field "v1" "phases.research.status")" "undefined" "Flat status removed"
-assert_equals "$(get_field "v1" "phases.discussion.items.auth.status")" "completed" "Existing items untouched"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "exploration backfilled as item" "completed" "$(get_field "v1" "phases.research.items.exploration.status")"
+  assert_eq "architecture backfilled as item" "completed" "$(get_field "v1" "phases.research.items.architecture.status")"
+  assert_eq "flat status removed" "undefined" "$(get_field "v1" "phases.research.status")"
+  assert_eq "existing items untouched" "completed" "$(get_field "v1" "phases.discussion.items.auth.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 2: research flat status with no files on disk ---
+test_research_no_files() {
+  setup
 
-echo -e "${YELLOW}Test: research flat status with no files on disk${NC}"
-setup_fixture
-
-create_manifest "orphan" '{
+  create_manifest "orphan" '{
   "name": "orphan",
   "work_type": "epic",
   "status": "in-progress",
@@ -171,19 +104,18 @@ create_manifest "orphan" '{
   }
 }'
 
-output=$(run_migration)
+  source "$MIGRATION"
 
-assert_equals "$(get_field "orphan" "phases.research")" "undefined" "Empty phase object removed"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "empty phase object removed" "undefined" "$(get_field "orphan" "phases.research")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 3: flat status alongside existing items — just removes status ---
+test_flat_status_with_items() {
+  setup
 
-echo -e "${YELLOW}Test: flat status alongside existing items — just removes status${NC}"
-setup_fixture
-
-create_manifest "mixed" '{
+  create_manifest "mixed" '{
   "name": "mixed",
   "work_type": "epic",
   "status": "in-progress",
@@ -195,21 +127,20 @@ create_manifest "mixed" '{
   }
 }'
 
-output=$(run_migration)
+  source "$MIGRATION"
 
-assert_equals "$(get_field "mixed" "phases.discussion.status")" "undefined" "Flat status removed"
-assert_equals "$(get_field "mixed" "phases.discussion.items.auth.status")" "completed" "Items preserved"
-assert_equals "$(get_field "mixed" "phases.discussion.items.billing.status")" "in-progress" "Items preserved"
-assert_contains "$output" "updated" "Reports update"
+  assert_eq "flat status removed" "undefined" "$(get_field "mixed" "phases.discussion.status")"
+  assert_eq "auth item preserved" "completed" "$(get_field "mixed" "phases.discussion.items.auth.status")"
+  assert_eq "billing item preserved" "in-progress" "$(get_field "mixed" "phases.discussion.items.billing.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 4: non-research phase with flat status and no items ---
+test_non_research_flat_status() {
+  setup
 
-echo -e "${YELLOW}Test: non-research phase with flat status and no items${NC}"
-setup_fixture
-
-create_manifest "flat-disc" '{
+  create_manifest "flat-disc" '{
   "name": "flat-disc",
   "work_type": "feature",
   "status": "in-progress",
@@ -219,19 +150,19 @@ create_manifest "flat-disc" '{
   }
 }'
 
-run_migration > /dev/null
+  source "$MIGRATION"
 
-assert_equals "$(get_field "flat-disc" "phases.discussion")" "undefined" "Empty discussion phase removed"
-assert_equals "$(get_field "flat-disc" "phases.specification")" "undefined" "Empty specification phase removed"
+  assert_eq "empty discussion phase removed" "undefined" "$(get_field "flat-disc" "phases.discussion")"
+  assert_eq "empty specification phase removed" "undefined" "$(get_field "flat-disc" "phases.specification")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 5: manifest with no flat statuses — unchanged ---
+test_clean_manifest() {
+  setup
 
-echo -e "${YELLOW}Test: manifest with no flat statuses — unchanged${NC}"
-setup_fixture
-
-create_manifest "clean" '{
+  create_manifest "clean" '{
   "name": "clean",
   "work_type": "feature",
   "status": "in-progress",
@@ -240,19 +171,18 @@ create_manifest "clean" '{
   }
 }'
 
-output=$(run_migration)
+  source "$MIGRATION"
 
-assert_equals "$(get_field "clean" "phases.discussion.items.clean.status")" "completed" "Items untouched"
-assert_not_contains "$output" "updated" "No update for clean manifest"
+  assert_eq "items untouched" "completed" "$(get_field "clean" "phases.discussion.items.clean.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 6: multiple phases with flat status in one manifest ---
+test_multiple_flat_statuses() {
+  setup
 
-echo -e "${YELLOW}Test: multiple phases with flat status in one manifest${NC}"
-setup_fixture
-
-create_manifest "multi" '{
+  create_manifest "multi" '{
   "name": "multi",
   "work_type": "epic",
   "status": "in-progress",
@@ -262,23 +192,23 @@ create_manifest "multi" '{
     "planning": { "status": "in-progress" }
   }
 }'
-create_research_file "multi" "exploration.md"
+  create_research_file "multi" "exploration.md"
 
-output=$(run_migration)
+  source "$MIGRATION"
 
-assert_equals "$(get_field "multi" "phases.research.items.exploration.status")" "completed" "Research backfilled"
-assert_equals "$(get_field "multi" "phases.research.status")" "undefined" "Research flat status removed"
-assert_equals "$(get_field "multi" "phases.discussion")" "undefined" "Discussion orphan removed"
-assert_equals "$(get_field "multi" "phases.planning")" "undefined" "Planning orphan removed"
+  assert_eq "research backfilled" "completed" "$(get_field "multi" "phases.research.items.exploration.status")"
+  assert_eq "research flat status removed" "undefined" "$(get_field "multi" "phases.research.status")"
+  assert_eq "discussion orphan removed" "undefined" "$(get_field "multi" "phases.discussion")"
+  assert_eq "planning orphan removed" "undefined" "$(get_field "multi" "phases.planning")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 7: idempotent — running twice produces same result ---
+test_idempotent() {
+  setup
 
-echo -e "${YELLOW}Test: idempotent — running twice produces same result${NC}"
-setup_fixture
-
-create_manifest "idem" '{
+  create_manifest "idem" '{
   "name": "idem",
   "work_type": "epic",
   "status": "in-progress",
@@ -286,53 +216,53 @@ create_manifest "idem" '{
     "research": { "status": "completed" }
   }
 }'
-create_research_file "idem" "exploration.md"
+  create_research_file "idem" "exploration.md"
 
-run_migration > /dev/null
-output=$(run_migration)
+  source "$MIGRATION"
+  source "$MIGRATION"
 
-assert_equals "$(get_field "idem" "phases.research.items.exploration.status")" "completed" "Items still correct"
-assert_not_contains "$output" "updated" "No update on second run"
+  assert_eq "items still correct" "completed" "$(get_field "idem" "phases.research.items.exploration.status")"
 
-echo ""
+  teardown
+}
 
-# ----------------------------------------------------------------------------
+# --- Test 8: skips dot-prefixed directories ---
+test_skips_dot_dirs() {
+  setup
 
-echo -e "${YELLOW}Test: skips dot-prefixed directories${NC}"
-setup_fixture
+  mkdir -p "$TEST_DIR/.workflows/.state"
+  echo '{"name":".state","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
+  create_manifest "real" '{"name":"real","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}'
 
-mkdir -p "$TEST_DIR/.workflows/.state"
-echo '{"name":".state","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}' > "$TEST_DIR/.workflows/.state/manifest.json"
-create_manifest "real" '{"name":"real","work_type":"feature","status":"in-progress","phases":{"discussion":{"status":"completed"}}}'
+  source "$MIGRATION"
 
-run_migration > /dev/null
+  local dot_status
+  dot_status=$(node -e "
+    const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+    console.log(m.phases.discussion.status || 'missing');
+  " "$TEST_DIR/.workflows/.state/manifest.json")
+  assert_eq "dot-dir manifest untouched" "completed" "$dot_status"
 
-# Dot-dir manifest should still have flat status
-dot_status=$(node -e "
-  const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
-  console.log(m.phases.discussion.status || 'missing');
-" "$TEST_DIR/.workflows/.state/manifest.json")
-assert_equals "$dot_status" "completed" "Dot-dir manifest untouched"
+  teardown
+}
 
-echo ""
+# --- Test 9: no .workflows directory — exits cleanly ---
+test_no_workflows_dir() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
 
-# ----------------------------------------------------------------------------
+  source "$MIGRATION"
 
-echo -e "${YELLOW}Test: no .workflows directory — exits cleanly${NC}"
-setup_fixture
+  assert_eq "no crash without .workflows" "true" "true"
 
-output=$(run_migration)
+  teardown
+}
 
-assert_not_contains "$output" "updated" "No updates without .workflows dir"
+# --- Test 10: preserves other manifest fields ---
+test_preserves_fields() {
+  setup
 
-echo ""
-
-# ----------------------------------------------------------------------------
-
-echo -e "${YELLOW}Test: preserves other manifest fields${NC}"
-setup_fixture
-
-create_manifest "preserve" '{
+  create_manifest "preserve" '{
   "name": "preserve",
   "work_type": "epic",
   "status": "in-progress",
@@ -342,28 +272,33 @@ create_manifest "preserve" '{
     "research": { "status": "completed" }
   }
 }'
-create_research_file "preserve" "exploration.md"
+  create_research_file "preserve" "exploration.md"
 
-run_migration > /dev/null
+  source "$MIGRATION"
 
-assert_equals "$(get_field "preserve" "name")" "preserve" "Name preserved"
-assert_equals "$(get_field "preserve" "work_type")" "epic" "Work type preserved"
-assert_equals "$(get_field "preserve" "created")" "2026-03-01" "Created date preserved"
-assert_equals "$(get_field "preserve" "description")" "Test preservation" "Description preserved"
+  assert_eq "name preserved" "preserve" "$(get_field "preserve" "name")"
+  assert_eq "work type preserved" "epic" "$(get_field "preserve" "work_type")"
+  assert_eq "created date preserved" "2026-03-01" "$(get_field "preserve" "created")"
+  assert_eq "description preserved" "Test preservation" "$(get_field "preserve" "description")"
 
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 028 tests..."
 echo ""
 
-# ============================================================================
-# SUMMARY
-# ============================================================================
+test_research_backfill
+test_research_no_files
+test_flat_status_with_items
+test_non_research_flat_status
+test_clean_manifest
+test_multiple_flat_statuses
+test_idempotent
+test_skips_dot_dirs
+test_no_workflows_dir
+test_preserves_fields
 
 echo ""
-echo "========================================"
-echo -e "Tests run: $TESTS_RUN"
-echo -e "Passed: ${GREEN}$TESTS_PASSED${NC}"
-echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
-echo "========================================"
-
-if [ $TESTS_FAILED -gt 0 ]; then
-    exit 1
-fi
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/scripts/test-migration-034.sh
+++ b/tests/scripts/test-migration-034.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# Tests for migration 034: show-clear-context-on-plan-accept
+#
+# Run: bash tests/scripts/test-migration-034.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/034-show-clear-context-on-plan-accept.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-034-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Test 1: Creates settings.json from scratch ---
+test_no_settings_file() {
+  setup
+
+  source "$MIGRATION"
+
+  assert_eq "file created" "true" "$([ -f "$TEST_DIR/.claude/settings.json" ] && echo true || echo false)"
+  local val
+  val=$(node -e "const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')); console.log(s.showClearContextOnPlanAccept)" "$TEST_DIR/.claude/settings.json")
+  assert_eq "setting is true" "true" "$val"
+
+  teardown
+}
+
+# --- Test 2: Merges into existing settings.json ---
+test_existing_settings() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "permissions": {
+    "allow": ["Bash(git status:*)"]
+  }
+}
+EOF
+
+  source "$MIGRATION"
+
+  local val
+  val=$(node -e "const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')); console.log(s.showClearContextOnPlanAccept)" "$TEST_DIR/.claude/settings.json")
+  assert_eq "setting added" "true" "$val"
+
+  local perms
+  perms=$(node -e "const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')); console.log(JSON.stringify(s.permissions.allow))" "$TEST_DIR/.claude/settings.json")
+  assert_eq "existing settings preserved" '["Bash(git status:*)"]' "$perms"
+
+  teardown
+}
+
+# --- Test 3: Skips when setting already true ---
+test_already_set() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "showClearContextOnPlanAccept": true,
+  "other": "value"
+}
+EOF
+
+  local mtime_before
+  mtime_before=$(stat --format="%Y" "$TEST_DIR/.claude/settings.json" 2>/dev/null || stat -f "%m" "$TEST_DIR/.claude/settings.json")
+
+  source "$MIGRATION"
+
+  local mtime_after
+  mtime_after=$(stat --format="%Y" "$TEST_DIR/.claude/settings.json" 2>/dev/null || stat -f "%m" "$TEST_DIR/.claude/settings.json")
+  assert_eq "file not modified" "$mtime_before" "$mtime_after"
+
+  teardown
+}
+
+# --- Test 4: Overwrites when setting is false ---
+test_setting_false() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "showClearContextOnPlanAccept": false
+}
+EOF
+
+  source "$MIGRATION"
+
+  local val
+  val=$(node -e "const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')); console.log(s.showClearContextOnPlanAccept)" "$TEST_DIR/.claude/settings.json")
+  assert_eq "setting corrected to true" "true" "$val"
+
+  teardown
+}
+
+# --- Test 5: Creates .claude directory if missing ---
+test_no_claude_dir() {
+  setup
+
+  # Don't create .claude dir — migration should handle it
+  source "$MIGRATION"
+
+  assert_eq ".claude dir created" "true" "$([ -d "$TEST_DIR/.claude" ] && echo true || echo false)"
+  assert_eq "file created" "true" "$([ -f "$TEST_DIR/.claude/settings.json" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 034 tests..."
+echo ""
+
+test_no_settings_file
+test_existing_settings
+test_already_set
+test_setting_false
+test_no_claude_dir
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- **Migration 034**: Enables `showClearContextOnPlanAccept` in consumer project `.claude/settings.json` — required after Claude Code 2.1.81 hid the plan-mode clear-context button by default. Creates, merges, or skips as appropriate.
- **Test normalisation**: All 34 migration test files converted to a consistent harness pattern (single `assert_eq`, per-test `setup`/`teardown`, no colours, no report output assertions). Added missing tests for migrations 013–015, 021, 022.
- **CLAUDE.md**: Documented migration test conventions, harness template, and bash 3.2 compatibility requirements.

## Test plan

- [x] All 34 test files pass (753 assertions, 0 failures)
- [x] Migration 034 verified end-to-end: creates from scratch, merges into existing settings, skips when already set
- [x] No old-style test remnants (colours, old counters, old assert helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)