### PR TITLE
fix: prevent analysis loop skip after second task pass

### DIFF
--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -134,6 +134,8 @@ After the loop completes:
 
 #### Otherwise
 
+**CRITICAL**: This routing applies on **every** task loop completion — including after returning from Step 7 with analysis-created tasks. Step 6 and Step 7 form a mandatory cycle: tasks execute → analysis runs → new tasks may be created → tasks execute again → analysis runs again. Never skip Step 7 after a task loop completes.
+
 → Proceed to **Step 7**.
 
 ---

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -292,4 +292,6 @@ Code, tests, and plan progress — one commit per approved task.
 All tasks complete. {M} tasks implemented.
 ```
 
+**CRITICAL**: The caller always routes to the analysis loop after task loop completion — on every pass, not just the first. Even if you have already been through this cycle before, return to the caller and let it route to the analysis loop. Never skip ahead to completion from here.
+
 → Return to caller.


### PR DESCRIPTION
## Summary

- Agent was skipping the analysis loop (Step 7) after the second task loop completion, jumping straight to Step 8 (completion)
- Added CRITICAL anchors at both routing decision points: the task-loop exit (`task-loop.md` Section I) and the backbone routing (`SKILL.md` Step 6)
- Reinforces that Step 6 → Step 7 is a mandatory cycle on every pass, not just the first

## Test plan

- [ ] Run implementation process with a plan that triggers analysis findings
- [ ] Verify analysis creates new tasks and routes back to Step 6
- [ ] Verify second task loop completion routes to Step 7 (not Step 8)
- [ ] Verify clean analysis on second pass routes to Step 8 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)