### PR TITLE
fix: add explicit Step 0 routing after migration

### DIFF
--- a/skills/continue-bugfix/SKILL.md
+++ b/skills/continue-bugfix/SKILL.md
@@ -27,6 +27,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Discovery State

--- a/skills/continue-cross-cutting/SKILL.md
+++ b/skills/continue-cross-cutting/SKILL.md
@@ -27,6 +27,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Discovery State

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -27,6 +27,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Discovery State

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -27,6 +27,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Discovery State

--- a/skills/start-bugfix/SKILL.md
+++ b/skills/start-bugfix/SKILL.md
@@ -27,6 +27,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Gather Bug Context

--- a/skills/start-cross-cutting/SKILL.md
+++ b/skills/start-cross-cutting/SKILL.md
@@ -27,6 +27,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Gather Cross-Cutting Context

--- a/skills/start-epic/SKILL.md
+++ b/skills/start-epic/SKILL.md
@@ -27,6 +27,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Gather Epic Context

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -27,6 +27,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Gather Feature Context

--- a/skills/workflow-migrate/SKILL.md
+++ b/skills/workflow-migrate/SKILL.md
@@ -46,7 +46,7 @@ Migrations Applied
 All documents up to date.
 ```
 
-→ Return to the calling skill.
+→ Return to caller.
 
 ---
 
@@ -69,7 +69,7 @@ Ready to continue?
 
 Check `git status`. If migration changes are uncommitted, stage and commit them with the message `chore: apply workflow migrations` before returning.
 
-→ Return to the calling skill.
+→ Return to caller.
 
 #### If ask
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -50,6 +50,8 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Run Discovery


### PR DESCRIPTION
## Summary

- Adds `→ Proceed to **Step 1**.` to Step 0 in all 9 entry-point skills — fixes intermittent issue where Claude would stop after migration returned with no changes instead of continuing to Step 1
- Standardises `workflow-migrate` return phrasing from `→ Return to the calling skill.` to `→ Return to caller.` to match project conventions

## Test plan

- [ ] Run `/workflow-start` with no pending migrations — verify Claude proceeds to Step 1 after "All documents up to date"
- [ ] Run `/start-feature` or `/continue-feature` — same verification
- [ ] Run with pending migrations — verify the STOP gate and commit flow still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)