### PR TITLE
feat: add compliance self-check to all processing skills

### DIFF
--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -10,7 +10,7 @@ Foundation work. Adds review agents to phases that currently lack quality gates.
 
 | # | Idea | Scope |
 |---|------|-------|
-| 1 | [Skill Compliance Self-Check](skill-compliance-self-check.md) | All processing skills |
+| 1 | ~~[Skill Compliance Self-Check](skill-compliance-self-check.md)~~ | All processing skills | ✅ Done |
 | 2 | [Discussion Review Agent](discussion-review-agent.md) | Discussion phase |
 | 3 | [Investigation Synthesis Agent](investigation-synthesis-agent.md) | Investigation phase (bugfix) |
 

--- a/ideas/skill-compliance-self-check.md
+++ b/ideas/skill-compliance-self-check.md
@@ -1,4 +1,6 @@
-# Skill Compliance Self-Check
+# ~~Skill Compliance Self-Check~~ — Done
+
+> Implemented in PR #223. Shared reference file at `skills/workflow-shared/references/compliance-check.md`, wired into all 7 processing skills before their conclusion step.
 
 ## The Idea
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -101,6 +101,14 @@ Load **[discussion-session.md](references/discussion-session.md)** and follow it
 
 ---
 
-## Step 4: Conclude Discussion
+## Step 4: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 5**.
+
+---
+
+## Step 5: Conclude Discussion
 
 Load **[conclude-discussion.md](references/conclude-discussion.md)** and follow its instructions as written.

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -154,7 +154,15 @@ Load **[analysis-loop.md](references/analysis-loop.md)** and follow its instruct
 
 ---
 
-## Step 8: Mark Implementation Complete
+## Step 8: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 9**.
+
+---
+
+## Step 9: Mark Implementation Complete
 
 Load **[conclude-implementation.md](references/conclude-implementation.md)** and follow its instructions as written.
 

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -153,6 +153,14 @@ Load **[findings-review.md](references/findings-review.md)** and follow its inst
 
 ---
 
-## Step 6: Conclude Investigation
+## Step 6: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 7**.
+
+---
+
+## Step 7: Conclude Investigation
 
 Load **[conclude-investigation.md](references/conclude-investigation.md)** and follow its instructions as written.

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -203,6 +203,14 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 ---
 
-## Step 9: Conclude the Plan
+## Step 9: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 10**.
+
+---
+
+## Step 10: Conclude the Plan
 
 Load **[conclude-plan.md](references/conclude-plan.md)** and follow its instructions as written.

--- a/skills/workflow-research-process/references/topic-completion.md
+++ b/skills/workflow-research-process/references/topic-completion.md
@@ -8,6 +8,8 @@
 
 The current topic is converging — tradeoffs are clear, it's approaching decision territory.
 
+→ Load **[compliance-check.md](../../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -220,7 +220,15 @@ Load **[present-review.md](references/present-review.md)** and follow its instru
 
 ---
 
-## Step 7: Review Actions
+## Step 7: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 8**.
+
+---
+
+## Step 8: Review Actions
 
 Load **[review-actions-loop.md](references/review-actions-loop.md)** and follow its instructions as written.
 

--- a/skills/workflow-shared/references/compliance-check.md
+++ b/skills/workflow-shared/references/compliance-check.md
@@ -1,0 +1,70 @@
+# Compliance Self-Check
+
+*Shared reference for all processing skills.*
+
+---
+
+Before concluding this phase, verify that the skill instructions were followed correctly throughout this session. This check exists because context drift is real — after a long session, the original instructions may be buried under pages of conversation. Re-reading pulls them fresh into attention so the audit is actually effective.
+
+## A. Re-Read Skill Instructions
+
+1. **Re-read the processing skill's SKILL.md** — the top-level file of the current processing skill (the backbone that loaded this reference, or its parent backbone if loaded from within a reference file). Read it completely.
+2. **Re-read every reference file that was loaded during this session.** The SKILL.md's step directives list them. Re-read each one.
+
+This is non-negotiable. Do not skip this step or rely on your memory of what the instructions said. The re-read IS the mechanism.
+
+## B. Audit the Session
+
+With the instructions fresh in context, review the conversation transcript and compare what happened against what the instructions prescribed:
+
+1. **Step compliance** — Were all steps followed in the correct order? Were any skipped or executed out of sequence?
+2. **STOP gate compliance** — Were STOP gates respected? Was user input awaited where required?
+3. **Output compliance** — Did outputs match the display and rendering conventions specified in the instructions?
+4. **Hard rules** — Were any hard rules (if specified in the skill) violated?
+5. **Artifact correctness** — Are all working artifacts (discussion files, specifications, plans, investigation files, review reports, code) correct and consistent with what the instructions prescribed?
+6. **Manifest correctness** — Was the manifest updated via the CLI with the right fields, values, and paths? Were any manual edits made that should have gone through the CLI?
+7. **Commit discipline** — Were changes committed at natural breaks as required?
+
+## C. Assess and Act
+
+#### If no issues found
+
+Proceed silently. No output.
+
+→ Return to caller.
+
+#### If minor issues found
+
+Issues are minor when they have no downstream impact — nothing the user has seen is wrong, no artifacts are incorrect, no course correction is needed. Examples: a commit that could have happened one step earlier, a display convention that was slightly off but the user already moved past it.
+
+Self-correct where possible (e.g., make a missing commit now). No need to surface to the user.
+
+→ Return to caller.
+
+#### If significant issues found
+
+Issues are significant when they affect artifacts, code, manifest state, tracking files, or require the user to understand what happened before proceeding. Examples: a skipped step that produced incomplete artifacts, manifest state that doesn't reflect actual progress, code that doesn't match what the plan or specification called for, multiple steps executed out of order.
+
+Surface to the user:
+
+> *Output the next fenced block as a code block:*
+
+```
+Compliance Check — Issues Found
+
+{number} issue(s) detected during self-check.
+```
+
+For each issue, explain:
+
+1. **What happened** — which instruction was not followed and what occurred instead
+2. **Impact** — what was affected (files, manifest, code, tracking state, etc.)
+3. **Correction** — what needs to happen to fix it
+
+Apply corrections that are safe to make without user input (file updates, manifest fixes, missing commits). For corrections that would change code or artifacts the user has already seen and approved, explain the proposed change and get confirmation first.
+
+**STOP.** Wait for user response before proceeding.
+
+After corrections are applied:
+
+→ Return to caller.

--- a/skills/workflow-shared/references/compliance-check.md
+++ b/skills/workflow-shared/references/compliance-check.md
@@ -13,6 +13,8 @@ Before concluding this phase, verify that the skill instructions were followed c
 
 This is non-negotiable. Do not skip this step or rely on your memory of what the instructions said. The re-read IS the mechanism.
 
+→ Proceed to **B. Audit the Session**.
+
 ## B. Audit the Session
 
 With the instructions fresh in context, review the conversation transcript and compare what happened against what the instructions prescribed:
@@ -24,6 +26,8 @@ With the instructions fresh in context, review the conversation transcript and c
 5. **Artifact correctness** — Are all working artifacts (discussion files, specifications, plans, investigation files, review reports, code) correct and consistent with what the instructions prescribed?
 6. **Manifest correctness** — Was the manifest updated via the CLI with the right fields, values, and paths? Were any manual edits made that should have gone through the CLI?
 7. **Commit discipline** — Were changes committed at natural breaks as required?
+
+→ Proceed to **C. Assess and Act**.
 
 ## C. Assess and Act
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -168,7 +168,15 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 
 ---
 
-## Step 8: Assess Cross-Cutting & Conclude
+## Step 8: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 9**.
+
+---
+
+## Step 9: Assess Cross-Cutting & Conclude
 
 Load **[spec-completion.md](references/spec-completion.md)** and follow its instructions as written.
 


### PR DESCRIPTION
## Summary

- Adds shared `compliance-check.md` reference file in `workflow-shared` that re-reads all skill instructions and audits the session for drift before conclusion
- Wired into all 7 processing skills as a new step before the conclusion step (research uses inline insertion in `topic-completion.md` since it concludes via reference files)
- Three severity tiers: silent pass, silent self-correct, surface to user with explanation and correction plan

## Test plan

- [ ] Run each processing skill through to conclusion and verify the compliance check step executes before the conclude menu appears
- [ ] Verify routing integrity — no broken step references in backbone or reference files
- [ ] Verify relative paths resolve correctly from each skill to the shared reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)