### PR TITLE
feat: add investigation synthesis agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A development workflow for Claude Code that turns conversations into working sof
 - **Specifications that catch mistakes early.** The system analyses your discussions, filters hallucinations, fills gaps, and produces a validated spec before any code is written.
 - **Plans with real structure.** Specifications become phased implementation plans with tasks, acceptance criteria, and dependency ordering. Choose where tasks live — [local markdown files, Linear issues, or Tick CLI](#output-formats).
 - **Implementation via strict TDD.** Tests first, then code, commit after each task. Per-task approval gates keep you in control, or switch to auto-mode when you trust the flow.
-- **Validation at every stage.** Specifications get bidirectional review — one agent checks against source material for accuracy, another analyses the spec as a standalone document for gaps. Plans are checked for spec traceability and structural integrity. Implementation is analysed for architecture conformance, duplication, and coding standards. Review verifies against spec and plan. Findings become remediation tasks automatically.
+- **Validation at every stage.** Discussions are reviewed by a background agent for gaps and shallow coverage, with competing perspective agents for ambiguous decisions. Investigation root causes are independently validated by a synthesis agent before proceeding. Specifications get bidirectional review — one agent checks against source material for accuracy, another analyses the spec as a standalone document for gaps. Plans are checked for spec traceability and structural integrity. Implementation is analysed for architecture conformance, duplication, and coding standards. Review verifies against spec and plan. Findings become remediation tasks automatically.
 - **Context that survives.** Each phase clears the context window and starts fresh, so you're never fighting token limits on large work. All progress lives on disk — pick up exactly where you left off, even after context compaction or a new session.
 
 ## Getting Started
@@ -92,7 +92,7 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 
 **Features** are for adding functionality. Single topic, linear pipeline. Planning analyses your codebase and follows existing patterns — it won't introduce new architectural conventions unless the spec calls for it. Research is optional — skip it if you know what you're building. If a feature grows beyond scope, pivot it to an epic without losing progress.
 
-**Bugfixes** replace discussion with investigation — structured symptom gathering combined with code analysis to find the root cause before specifying the fix. Planning applies minimal-change surgical fixes with regression prevention as a first-class deliverable.
+**Bugfixes** replace discussion with investigation — structured symptom gathering combined with code analysis to find the root cause before specifying the fix. An optional synthesis agent independently validates the root cause hypothesis by tracing code fresh, catching flawed reasoning before it propagates through the pipeline. Planning applies minimal-change surgical fixes with regression prevention as a first-class deliverable.
 
 **Cross-cutting** concerns define patterns, policies, or architectural decisions that inform how features are built (caching strategies, error handling conventions, API versioning). They terminate after specification — there's nothing to build. During planning for any work type, completed cross-cutting specs are surfaced as context.
 
@@ -102,7 +102,7 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 |-------|---------|------------|
 | **Research** | Explore ideas, market fit, technical feasibility. Output is analysed to derive discussion topics automatically. | Epic, Feature (opt.), Cross-cutting (opt.) |
 | **Discussion** | Deep dives into architecture, edge cases, and rationale. Captures not just decisions, but *why* you made them. | Epic, Feature, Cross-cutting |
-| **Investigation** | Symptom gathering + code analysis to identify root cause. The bugfix alternative to discussion. | Bugfix |
+| **Investigation** | Symptom gathering + code analysis to identify root cause. Optional synthesis agent validates the hypothesis independently. The bugfix alternative to discussion. | Bugfix |
 | **Specification** | Analyses all discussions/investigation, filters hallucinations, enriches gaps, validates decisions. Reviewed against source material and analysed for gaps before finalising. The spec becomes the golden document — planning references only this. | All |
 | **Planning** | Converts specs into phased plans with tasks, acceptance criteria, and dependencies. Validated for spec traceability and structural integrity. Per-item approval gates with auto-mode. | All |
 | **Implementation** | Strict TDD — tests first, then code, commit per task. Post-implementation analysis agents check architecture, duplication, and standards. | All |
@@ -114,9 +114,9 @@ Work units are **in-progress**, **completed**, or **cancelled**. Completion happ
 
 ## Key Features
 
-### 17 Specialized Agents
+### 21 Specialized Agents
 
-Complex phases spawn parallel subagents for isolated concerns — planning uses 6 agents for phase design, task authoring, dependency graphing, and quality review. Implementation uses 7 for TDD execution, post-task review, and cross-cutting analysis. Specification and review each use 2 for input validation and gap analysis.
+Complex phases spawn parallel subagents for isolated concerns — discussion uses 3 agents for independent review, competing perspectives, and synthesis of tradeoffs. Investigation uses 1 for independent root cause validation. Specification and review each use 2 for input validation and gap analysis. Planning uses 6 for phase design, task authoring, dependency graphing, and quality review. Implementation uses 7 for TDD execution, post-task review, and cross-cutting analysis.
 
 ### Output Formats
 
@@ -193,11 +193,15 @@ Log ideas and bugs as you go — mid-conversation or from scratch. Say "log that
 </details>
 
 <details>
-<summary><strong>Agents</strong> — 17 subagents for parallel task execution</summary>
+<summary><strong>Agents</strong> — 21 subagents for parallel task execution</summary>
 
-**Planning:** [phase-designer](agents/workflow-planning-phase-designer.md) | [task-designer](agents/workflow-planning-task-designer.md) | [task-author](agents/workflow-planning-task-author.md) | [dependency-grapher](agents/workflow-planning-dependency-grapher.md) | [review-traceability](agents/workflow-planning-review-traceability.md) | [review-integrity](agents/workflow-planning-review-integrity.md)
+**Discussion:** [review](agents/workflow-discussion-review.md) | [perspective](agents/workflow-discussion-perspective.md) | [synthesis](agents/workflow-discussion-synthesis.md)
+
+**Investigation:** [synthesis](agents/workflow-investigation-synthesis.md)
 
 **Specification:** [review-input](agents/workflow-specification-review-input.md) | [review-gap-analysis](agents/workflow-specification-review-gap-analysis.md)
+
+**Planning:** [phase-designer](agents/workflow-planning-phase-designer.md) | [task-designer](agents/workflow-planning-task-designer.md) | [task-author](agents/workflow-planning-task-author.md) | [dependency-grapher](agents/workflow-planning-dependency-grapher.md) | [review-traceability](agents/workflow-planning-review-traceability.md) | [review-integrity](agents/workflow-planning-review-integrity.md)
 
 **Implementation:** [task-executor](agents/workflow-implementation-task-executor.md) | [task-reviewer](agents/workflow-implementation-task-reviewer.md) | [analysis-architecture](agents/workflow-implementation-analysis-architecture.md) | [analysis-duplication](agents/workflow-implementation-analysis-duplication.md) | [analysis-standards](agents/workflow-implementation-analysis-standards.md) | [analysis-synthesizer](agents/workflow-implementation-analysis-synthesizer.md) | [analysis-task-writer](agents/workflow-implementation-analysis-task-writer.md)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A development workflow for Claude Code that turns conversations into working sof
 **What you get:**
 
 - **An expert in the room.** The system acts as an expert architect — challenging your thinking, probing edge cases before they become bugs, and capturing not just decisions but *why* you made them. Every phase adds real analytical value, not just formatting.
-- **Decisions that stick.** Architecture choices, edge cases, and trade-offs are captured in discussion documents — not lost to chat history. When you come back in a week, the context is there.
+- **Decisions that stick.** Architecture choices, edge cases, and trade-offs are captured in discussion documents — not lost to chat history. A background review agent catches gaps as you go, and when a decision has genuine ambiguity, competing perspective agents argue each position before a synthesis agent maps the tradeoff landscape. When you come back in a week, the context is there.
 - **Specifications that catch mistakes early.** The system analyses your discussions, filters hallucinations, fills gaps, and produces a validated spec before any code is written.
 - **Plans with real structure.** Specifications become phased implementation plans with tasks, acceptance criteria, and dependency ordering. Choose where tasks live — [local markdown files, Linear issues, or Tick CLI](#output-formats).
 - **Implementation via strict TDD.** Tests first, then code, commit after each task. Per-task approval gates keep you in control, or switch to auto-mode when you trust the flow.
@@ -101,7 +101,7 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 | Phase | Purpose | Applies to |
 |-------|---------|------------|
 | **Research** | Explore ideas, market fit, technical feasibility. Output is analysed to derive discussion topics automatically. | Epic, Feature (opt.), Cross-cutting (opt.) |
-| **Discussion** | Deep dives into architecture, edge cases, and rationale. Captures not just decisions, but *why* you made them. | Epic, Feature, Cross-cutting |
+| **Discussion** | Deep dives into architecture, edge cases, and rationale. Background review agent catches gaps; competing perspective agents argue viable approaches on ambiguous decisions, then a synthesis agent maps the tradeoff landscape. | Epic, Feature, Cross-cutting |
 | **Investigation** | Symptom gathering + code analysis to identify root cause. Optional synthesis agent validates the hypothesis independently. The bugfix alternative to discussion. | Bugfix |
 | **Specification** | Analyses all discussions/investigation, filters hallucinations, enriches gaps, validates decisions. Reviewed against source material and analysed for gaps before finalising. The spec becomes the golden document — planning references only this. | All |
 | **Planning** | Converts specs into phased plans with tasks, acceptance criteria, and dependencies. Validated for spec traceability and structural integrity. Per-item approval gates with auto-mode. | All |

--- a/agents/workflow-investigation-synthesis.md
+++ b/agents/workflow-investigation-synthesis.md
@@ -1,0 +1,140 @@
+---
+name: workflow-investigation-synthesis
+description: Independently validates a root cause hypothesis by tracing code and checking symptom coverage. Invoked synchronously by workflow-investigation-process after root cause synthesis.
+tools: Read, Write, Glob, Grep, Bash
+model: opus
+---
+
+# Investigation Synthesis
+
+You are an independent analyst validating a root cause hypothesis for a bug investigation. You have no prior context — you are reading the investigation fresh and tracing code independently. This clean-slate perspective is intentional: you catch flawed reasoning, missed symptoms, and incomplete blast radius assessments that the investigator, deep in the trace, may have normalised or overlooked.
+
+## Your Input
+
+You receive via the orchestrator's prompt:
+
+1. **Investigation file path** — the investigation document containing symptoms, code analysis, and root cause hypothesis
+2. **Output file path** — where to write your analysis
+3. **Frontmatter** — the frontmatter block to use in the output file (includes type, status, date)
+
+## Your Process
+
+1. **Read the investigation file** completely before beginning validation
+2. **Understand the claim** — extract the root cause statement, the code trace that supports it, and the reported symptoms
+3. **Independently trace the root cause** through the codebase — use Glob, Grep, and Read to follow the code paths claimed by the investigation. Do not take the investigation's code trace at face value; verify it
+4. **Check symptom coverage** — does the proposed root cause explain ALL reported symptoms, not just some? For each symptom, confirm the causal chain from root cause to observable behaviour
+5. **Explore alternative causes** — are there other plausible explanations the investigation didn't consider? Look for similar patterns, recent changes, or adjacent code that could produce the same symptoms
+6. **Validate blast radius** — search for other callers, consumers, or dependents of the affected code. Are there impacts the investigation missed?
+7. **Assess fix direction** — could the proposed fix direction introduce new issues? Look for side effects, coupling, or assumptions that might break
+8. **Write findings** to the output file path
+
+## Hard Rules
+
+**MANDATORY. No exceptions.**
+
+1. **No git writes** — do not commit or stage. Writing the output file is your only file write.
+2. **Do not propose fixes** — you validate the hypothesis and identify gaps, not solve the bug.
+3. **Be specific** — reference file paths and line numbers when tracing code. "The blast radius might be larger" is not useful. "The `processOrder` function at `src/orders/processor.ts:45` also calls the affected `validateItem` method but is not listed in the blast radius" is useful.
+4. **Stay scoped** — validate what the investigation claims. Do not expand scope, introduce new requirements, or investigate unrelated issues.
+5. **Independent judgement** — do not trust the investigation's conclusions. Verify each claim against the code. The investigation may be wrong.
+6. **Targeted tracing** — follow the specific paths claimed by the investigation. This is a validation exercise, not a broad codebase exploration.
+
+## Output File Format
+
+Write to the output file path provided:
+
+```markdown
+{frontmatter provided by orchestrator}
+
+# Investigation Synthesis: {topic}
+
+## Confidence Assessment
+
+**Overall confidence:** {high | medium | low}
+**Root cause explains all symptoms:** {yes | partial | no}
+
+## Symptom Coverage
+
+| Symptom | Explained | Notes |
+|---------|-----------|-------|
+| {symptom} | {yes / partial / no} | {how the root cause connects, or why it doesn't} |
+
+## Code Trace Validation
+
+{Your independent trace through the codebase. Reference specific files and lines. Confirm or challenge each step of the investigation's code trace.}
+
+## Alternative Root Causes
+
+{Plausible alternatives not explored by the investigation. If none, state "None identified."}
+
+## Blast Radius Review
+
+{Validation of the blast radius assessment. Additional callers, consumers, or dependents affected that weren't identified. If complete, state "Blast radius assessment is complete."}
+
+## Fix Direction Risks
+
+{Risks the proposed fix direction might introduce — side effects, coupling, broken assumptions. If none, state "None identified."}
+
+## Gaps
+
+1. {Specific gap in the root cause analysis}
+2. {Specific gap}
+
+## Summary
+
+{One paragraph: overall assessment of the root cause hypothesis and investigation quality.}
+```
+
+If fully validated with no gaps:
+
+```markdown
+{frontmatter provided by orchestrator}
+
+# Investigation Synthesis: {topic}
+
+## Confidence Assessment
+
+**Overall confidence:** high
+**Root cause explains all symptoms:** yes
+
+## Symptom Coverage
+
+| Symptom | Explained | Notes |
+|---------|-----------|-------|
+| {symptom} | yes | {confirmation} |
+
+## Code Trace Validation
+
+{Confirmation of the investigation's code trace with independent verification.}
+
+## Alternative Root Causes
+
+None identified.
+
+## Blast Radius Review
+
+Blast radius assessment is complete.
+
+## Fix Direction Risks
+
+None identified.
+
+## Gaps
+
+None identified.
+
+## Summary
+
+{Assessment confirming thorough investigation.}
+```
+
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+STATUS: validated | gaps_found
+CONFIDENCE: high | medium | low
+GAPS_COUNT: {N}
+SUMMARY: {1 sentence}
+```

--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -12,7 +12,7 @@ Foundation work. Adds review agents to phases that currently lack quality gates.
 |---|------|-------|
 | 1 | ~~[Skill Compliance Self-Check](skill-compliance-self-check.md)~~ | All processing skills | ✅ Done |
 | 2 | ~~[Discussion Review Agent](discussion-review-agent.md)~~ | Discussion phase | ✅ Done |
-| 3 | [Investigation Synthesis Agent](investigation-synthesis-agent.md) | Investigation phase (bugfix) |
+| 3 | ~~[Investigation Synthesis Agent](investigation-synthesis-agent.md)~~ | Investigation phase (bugfix) | ✅ Done |
 
 ## Phase 2 — Discussion Evolution
 

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -145,22 +145,30 @@ Document in the investigation file and commit.
 
 ---
 
-## Step 5: Findings Review & Fix Discussion
+## Step 5: Root Cause Validation
 
-Load **[findings-review.md](references/findings-review.md)** and follow its instructions as written.
+Load **[synthesis-agent.md](references/synthesis-agent.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
 
 ---
 
-## Step 6: Compliance Self-Check
+## Step 6: Findings Review & Fix Discussion
 
-Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+Load **[findings-review.md](references/findings-review.md)** and follow its instructions as written.
 
 → Proceed to **Step 7**.
 
 ---
 
-## Step 7: Conclude Investigation
+## Step 7: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 8**.
+
+---
+
+## Step 8: Conclude Investigation
 
 Load **[conclude-investigation.md](references/conclude-investigation.md)** and follow its instructions as written.

--- a/skills/workflow-investigation-process/references/findings-review.md
+++ b/skills/workflow-investigation-process/references/findings-review.md
@@ -30,6 +30,19 @@ Why It Wasn't Caught:
   {testing gap, edge case, recent change}
 ```
 
+**If synthesis validation was run and found gaps**, add a synthesis block:
+
+> *Output the next fenced block as a code block:*
+
+```
+Synthesis Validation ({CONFIDENCE} confidence):
+  {gap 1}
+  {gap 2}
+
+These gaps may affect the root cause assessment. Consider them
+during your review.
+```
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```

--- a/skills/workflow-investigation-process/references/synthesis-agent.md
+++ b/skills/workflow-investigation-process/references/synthesis-agent.md
@@ -1,0 +1,124 @@
+# Synthesis Agent
+
+*Reference for **[workflow-investigation-process](../SKILL.md)***
+
+---
+
+An independent synthesis agent validates the root cause hypothesis by tracing code fresh. This step is optional — the user chooses whether to run it.
+
+## A. Offer Validation
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Root cause documented. Run synthesis validation?
+
+An independent agent will trace the code to validate the
+root cause hypothesis before you review findings.
+
+- **`y`/`yes`** — Run synthesis validation
+- **`s`/`skip`** — Skip straight to findings review
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `skip`
+
+→ Return to caller.
+
+#### If `yes`
+
+→ Proceed to **B. Dispatch**.
+
+---
+
+## B. Dispatch
+
+Ensure the cache directory exists:
+
+```bash
+mkdir -p .workflows/.cache/{work_unit}/investigation/{topic}
+```
+
+Determine the next set number by checking existing files:
+
+```bash
+ls .workflows/.cache/{work_unit}/investigation/{topic}/ 2>/dev/null
+```
+
+Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`).
+
+**Agent path**: `../../../agents/workflow-investigation-synthesis.md`
+
+> *Output the next fenced block as a code block:*
+
+```
+Validating root cause hypothesis... (synthesis agent running)
+```
+
+Dispatch **one agent** via the Task tool (**synchronous** — do not use `run_in_background`).
+
+The synthesis agent receives:
+
+1. **Investigation file path** — `.workflows/{work_unit}/investigation/{topic}.md`
+2. **Output file path** — `.workflows/.cache/{work_unit}/investigation/{topic}/synthesis-{NNN}.md`
+3. **Frontmatter** — the frontmatter block to write:
+   ```yaml
+   ---
+   type: synthesis
+   status: pending
+   created: {date}
+   ---
+   ```
+
+The synthesis agent returns:
+
+```
+STATUS: validated | gaps_found
+CONFIDENCE: high | medium | low
+GAPS_COUNT: {N}
+SUMMARY: {1 sentence}
+```
+
+→ Proceed to **C. Process Results**.
+
+---
+
+## C. Process Results
+
+Read the synthesis output file.
+
+#### If `validated`
+
+Update the output file frontmatter to `status: read`.
+
+> *Output the next fenced block as a code block:*
+
+```
+Synthesis: Root cause validated ({CONFIDENCE} confidence). No gaps found.
+```
+
+→ Return to caller.
+
+#### If `gaps_found`
+
+Update the output file frontmatter to `status: read`.
+
+Extract the key gaps from the synthesis file. Present a brief summary — do not dump the full output.
+
+> *Output the next fenced block as a code block:*
+
+```
+Synthesis: {CONFIDENCE} confidence. {GAPS_COUNT} gap(s) identified.
+
+  {gap 1}
+  {gap 2}
+
+Full analysis: .workflows/.cache/{work_unit}/investigation/{topic}/synthesis-{NNN}.md
+```
+
+Carry the synthesis context forward — Step 6 (Findings Review) will incorporate these gaps into the findings presentation.
+
+→ Return to caller.


### PR DESCRIPTION
## Summary

- Adds `workflow-investigation-synthesis` agent that independently validates root cause hypotheses by tracing code, checking symptom coverage, exploring alternative causes, and validating blast radius
- Inserts new Step 5 (Root Cause Validation) into the investigation pipeline between root cause synthesis and findings review — user always offered the choice to run or skip
- Surfaces synthesis gaps in the findings review presentation when validation identifies issues

## Test plan

- [ ] Verify SKILL.md step numbering is sequential (0-8) with correct routing
- [ ] Verify `conclude-investigation.md` Step 3 back-reference still correct after renumber
- [ ] Verify agent file follows established pattern (frontmatter, hard rules, output format, return status)
- [ ] Verify `synthesis-agent.md` follows reference file conventions (header, attribution, lettered sections, routing)
- [ ] Run a bugfix workflow end-to-end to confirm synthesis step integrates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)