### PR TITLE
feat: add quick-fix work type with scoping phase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ Always create a feature branch **before** the first commit. Never commit to main
 1. **Research** (`workflow-research-process` skill): EXPLORE - feasibility, market, viability, early ideas
 2. **Discussion** (`workflow-discussion-process` skill): Organic conversation guided by a live Discussion Map. Subtopics tracked through `pending` → `exploring` → `converging` → `decided`. Topic elevation seeds sibling concerns as separate discussion topics (epics only)
 3. **Investigation** (`workflow-investigation-process` skill): Bugfix-specific - symptom gathering + code analysis → root cause
-4. **Specification** (`workflow-specification-process` skill): Validate and refine into standalone spec
+4. **Scoping** (`workflow-scoping-process` skill): Quick-fix-specific - context, spec, and plan in one pass
+5. **Specification** (`workflow-specification-process` skill): Validate and refine into standalone spec
 5. **Planning** (`workflow-planning-process` skill): Define HOW - phases, tasks, acceptance criteria
 6. **Implementation** (`workflow-implementation-process` skill): Execute plan via strict TDD
 7. **Review** (`workflow-review-process` skill): Validate work against discussion, specification, and plan
@@ -49,14 +50,15 @@ Phase entry skills (`workflow-*-entry`) receive positional arguments: `$0` = wor
 
 ## Key Conventions
 
-**Work types and work units**: A *work type* is one of four pipeline shapes: epic, feature, bugfix, or cross-cutting. A *work unit* is a named instance of a work type (e.g., "auth-flow" is a feature work unit, "payments-overhaul" is an epic work unit). Each work unit gets its own directory under `.workflows/` and its own `manifest.json`.
+**Work types and work units**: A *work type* is one of five pipeline shapes: epic, feature, bugfix, quick-fix, or cross-cutting. A *work unit* is a named instance of a work type (e.g., "auth-flow" is a feature work unit, "payments-overhaul" is an epic work unit). Each work unit gets its own directory under `.workflows/` and its own `manifest.json`.
 
 - **Epic**: Multi-topic, multi-session, phase-centric (Research → Discussion → Specification → Planning → Implementation → Review)
 - **Feature**: Single-topic, single-session, linear (Discussion → Specification → Planning → Implementation → Review)
 - **Bugfix**: Single-topic, investigation-centric (Investigation → Specification → Planning → Implementation → Review)
+- **Quick-fix**: Single-topic, scoping-centric (Scoping → Implementation → Review)
 - **Cross-cutting**: Single-topic, project-level (Research (opt.) → Discussion → Specification — terminal)
 
-**Topics**: A *topic* is the item within a phase. For feature/bugfix, the topic name equals the work unit name (single topic moving through the pipeline). For epic, topics are distinct from the work unit name (multiple topics per phase). All work types use per-topic items in the manifest (unified structure). The discussion phase analyses all research files collectively to derive discussion topics.
+**Topics**: A *topic* is the item within a phase. For feature/bugfix/quick-fix, the topic name equals the work unit name (single topic moving through the pipeline). For epic, topics are distinct from the work unit name (multiple topics per phase). All work types use per-topic items in the manifest (unified structure). The discussion phase analyses all research files collectively to derive discussion topics.
 
 Work-unit-first directory structure with uniform `{topic}` in all paths. For feature/bugfix, `{topic}` equals `{work_unit}`. For epic, `{topic}` is the item within a phase.
 
@@ -72,8 +74,8 @@ Work-unit-first directory structure with uniform `{topic}` in all paths. For fea
 - State: `.workflows/{work_unit}/.state/` (per-work-unit analysis files)
 - Global state: `.workflows/.state/` (migrations, environment-setup.md)
 - Cache: `.workflows/.cache/{work_unit}/{phase}/{topic}/` (scratch files for any phase)
-- Inbox: `.workflows/.inbox/ideas/`, `.workflows/.inbox/bugs/` (pre-pipeline capture, plain markdown)
-- Inbox archive: `.workflows/.inbox/.archived/{ideas,bugs}/` (moved here when an inbox item enters the pipeline)
+- Inbox: `.workflows/.inbox/ideas/`, `.workflows/.inbox/bugs/`, `.workflows/.inbox/quickfixes/` (pre-pipeline capture, plain markdown)
+- Inbox archive: `.workflows/.inbox/.archived/{ideas,bugs,quickfixes}/` (moved here when an inbox item enters the pipeline)
 
 **Work unit lifecycle**: Each work unit has a `status` field in its manifest tracking its lifecycle state:
 - `in-progress` — actively being worked on (default on creation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,9 +19,9 @@ Always create a feature branch **before** the first commit. Never commit to main
 3. **Investigation** (`workflow-investigation-process` skill): Bugfix-specific - symptom gathering + code analysis → root cause
 4. **Scoping** (`workflow-scoping-process` skill): Quick-fix-specific - context, spec, and plan in one pass
 5. **Specification** (`workflow-specification-process` skill): Validate and refine into standalone spec
-5. **Planning** (`workflow-planning-process` skill): Define HOW - phases, tasks, acceptance criteria
-6. **Implementation** (`workflow-implementation-process` skill): Execute plan via strict TDD
-7. **Review** (`workflow-review-process` skill): Validate work against discussion, specification, and plan
+6. **Planning** (`workflow-planning-process` skill): Define HOW - phases, tasks, acceptance criteria
+7. **Implementation** (`workflow-implementation-process` skill): Execute plan via TDD (or verification workflow for quick-fix)
+8. **Review** (`workflow-review-process` skill): Validate work against discussion, specification, and plan
 
 ## Skill Architecture
 
@@ -33,7 +33,7 @@ Skills are organised in two tiers:
 
 **Processing skills** (`workflow-*-process`) are model-invocable. They assume pipeline context — work_type is set, prior phases are complete, artifacts are in expected locations. Phase entry skills provide all required inputs before invoking them.
 
-**Capture skills** (`workflow-log-idea`, `workflow-log-bug`) are model-invocable, lightweight skills outside the pipeline. They capture ideas or bugs as markdown files in the inbox (`.workflows/.inbox/`). No manifest, no migrations, no step/reference structure — just natural language instructions with capture-only constraints. They can be invoked directly by the user or discovered by the model when the user wants to log something.
+**Capture skills** (`workflow-log-idea`, `workflow-log-bug`, `workflow-log-quickfix`) are model-invocable, lightweight skills outside the pipeline. They capture ideas, bugs, or quick-fixes as markdown files in the inbox (`.workflows/.inbox/`). No manifest, no migrations, no step/reference structure — just natural language instructions with capture-only constraints. They can be invoked directly by the user or discovered by the model when the user wants to log something.
 
 ### Phase Entry Skill Routing
 
@@ -60,7 +60,7 @@ Phase entry skills (`workflow-*-entry`) receive positional arguments: `$0` = wor
 
 **Topics**: A *topic* is the item within a phase. For feature/bugfix/quick-fix, the topic name equals the work unit name (single topic moving through the pipeline). For epic, topics are distinct from the work unit name (multiple topics per phase). All work types use per-topic items in the manifest (unified structure). The discussion phase analyses all research files collectively to derive discussion topics.
 
-Work-unit-first directory structure with uniform `{topic}` in all paths. For feature/bugfix, `{topic}` equals `{work_unit}`. For epic, `{topic}` is the item within a phase.
+Work-unit-first directory structure with uniform `{topic}` in all paths. For feature/bugfix/quick-fix, `{topic}` equals `{work_unit}`. For epic, `{topic}` is the item within a phase.
 
 - Project manifest: `.workflows/manifest.json` (work unit registry + project defaults)
 - Manifest: `.workflows/{work_unit}/manifest.json`

--- a/README.md
+++ b/README.md
@@ -69,20 +69,23 @@ Or jump straight in:
 | `/start-feature` | You're adding functionality to an existing product |
 | `/start-epic` | The work spans multiple topics and sessions |
 | `/start-bugfix` | Something is broken and needs fixing |
+| `/start-quickfix` | A trivially scoped mechanical change (find-and-replace, syntax update) |
 | `/start-cross-cutting` | You're defining patterns or policies that inform features |
 | `/workflow-log-idea` | You want to capture an idea for later |
 | `/workflow-log-bug` | You want to log a bug for later |
+| `/workflow-log-quickfix` | You want to log a quick-fix for later |
 
 Each command gathers context through a brief interview, then pipelines you through every phase automatically. Phase transitions clear context and start fresh — you approve each one.
 
 ## The Workflow
 
-Three work types, each with its own pipeline:
+Five work types, each with its own pipeline:
 
 ```
 Epic:          Research → Discussion → Specification → Planning → Implementation → Review
 Feature:     (Research) → Discussion → Specification → Planning → Implementation → Review
 Bugfix:                Investigation → Specification → Planning → Implementation → Review
+Quick-fix:                   Scoping → Implementation → Review
 Cross-cutting: (Research) → Discussion → Specification (terminal)
 ```
 
@@ -94,6 +97,8 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 
 **Bugfixes** replace discussion with investigation — structured symptom gathering combined with code analysis to find the root cause before specifying the fix. An optional synthesis agent independently validates the root cause hypothesis by tracing code fresh, catching flawed reasoning before it propagates through the pipeline. Planning applies minimal-change surgical fixes with regression prevention as a first-class deliverable.
 
+**Quick-fixes** are for trivially scoped mechanical changes — global find-and-replace, syntax updates, API renames. Scoping combines context gathering, specification, and planning into a single pass, producing 1-2 tasks directly without agents or review cycles. Implementation uses a verification workflow (baseline → change → verify) instead of TDD, since mechanical changes can't meaningfully be test-driven. If scoping reveals the change is more complex than expected, it promotes to a feature or bugfix automatically.
+
 **Cross-cutting** concerns define patterns, policies, or architectural decisions that inform how features are built (caching strategies, error handling conventions, API versioning). They terminate after specification — there's nothing to build. During planning for any work type, completed cross-cutting specs are surfaced as context.
 
 ### The Phases
@@ -103,10 +108,11 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 | **Research** | Explore ideas, market fit, technical feasibility. Output is analysed to derive discussion topics automatically. | Epic, Feature (opt.), Cross-cutting (opt.) |
 | **Discussion** | Organic conversation guided by a live Discussion Map that tracks subtopics through pending → exploring → converging → decided. Background review agent catches gaps; competing perspective agents argue viable approaches on ambiguous decisions, then a synthesis agent maps the tradeoff landscape. For epics, sibling concerns discovered during discussion are elevated to their own topic automatically. | Epic, Feature, Cross-cutting |
 | **Investigation** | Symptom gathering + code analysis to identify root cause. Optional synthesis agent validates the hypothesis independently. The bugfix alternative to discussion. | Bugfix |
-| **Specification** | Analyses all discussions/investigation, filters hallucinations, enriches gaps, validates decisions. Reviewed against source material and analysed for gaps before finalising. The spec becomes the golden document — planning references only this. | All |
-| **Planning** | Converts specs into phased plans with tasks, acceptance criteria, and dependencies. Validated for spec traceability and structural integrity. Per-item approval gates with auto-mode. | All |
-| **Implementation** | Strict TDD — tests first, then code, commit per task. Post-implementation analysis agents check architecture, duplication, and standards. | All |
-| **Review** | Parallel subagents verify each task against spec and plan. Findings become remediation tasks that feed back into implementation. | All |
+| **Scoping** | Context gathering, specification, and planning in a single pass. Produces 1-2 tasks directly. Includes complexity check with promotion to feature/bugfix if needed. | Quick-fix |
+| **Specification** | Analyses all discussions/investigation, filters hallucinations, enriches gaps, validates decisions. Reviewed against source material and analysed for gaps before finalising. The spec becomes the golden document — planning references only this. | Epic, Feature, Bugfix, Cross-cutting |
+| **Planning** | Converts specs into phased plans with tasks, acceptance criteria, and dependencies. Validated for spec traceability and structural integrity. Per-item approval gates with auto-mode. | Epic, Feature, Bugfix |
+| **Implementation** | TDD (or verification workflow for quick-fix) — commit per task. Post-implementation analysis agents check architecture, duplication, and standards. | Epic, Feature, Bugfix, Quick-fix |
+| **Review** | Parallel subagents verify each task against spec and plan. Findings become remediation tasks that feed back into implementation. | Epic, Feature, Bugfix, Quick-fix |
 
 ### Lifecycle
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 
 ### Lifecycle
 
-Work units are **in-progress**, **completed**, or **cancelled**. Completion happens automatically when the pipeline finishes, or manually via the manage menu in `/workflow-start`. Completed and cancelled work can be reactivated. Feature and bugfix pipelines offer early completion after implementation (skip review).
+Work units are **in-progress**, **completed**, or **cancelled**. Completion happens automatically when the pipeline finishes, or manually via the manage menu in `/workflow-start`. Completed and cancelled work can be reactivated. Feature, bugfix, and quick-fix pipelines offer early completion after implementation (skip review).
 
 ## Key Features
 
@@ -188,11 +188,11 @@ Log ideas and bugs as you go — mid-conversation or from scratch. Say "log that
 <details>
 <summary><strong>Entry-Point Skills</strong> — user-facing commands</summary>
 
-**Start:** [`/start-feature`](skills/start-feature/) | [`/start-epic`](skills/start-epic/) | [`/start-bugfix`](skills/start-bugfix/) | [`/start-cross-cutting`](skills/start-cross-cutting/)
+**Start:** [`/start-feature`](skills/start-feature/) | [`/start-epic`](skills/start-epic/) | [`/start-bugfix`](skills/start-bugfix/) | [`/start-quickfix`](skills/start-quickfix/) | [`/start-cross-cutting`](skills/start-cross-cutting/)
 
-**Continue:** [`/workflow-start`](skills/workflow-start/) | [`/continue-feature`](skills/continue-feature/) | [`/continue-epic`](skills/continue-epic/) | [`/continue-bugfix`](skills/continue-bugfix/) | [`/continue-cross-cutting`](skills/continue-cross-cutting/)
+**Continue:** [`/workflow-start`](skills/workflow-start/) | [`/continue-feature`](skills/continue-feature/) | [`/continue-epic`](skills/continue-epic/) | [`/continue-bugfix`](skills/continue-bugfix/) | [`/continue-quickfix`](skills/continue-quickfix/) | [`/continue-cross-cutting`](skills/continue-cross-cutting/)
 
-**Capture:** [`/workflow-log-idea`](skills/workflow-log-idea/) | [`/workflow-log-bug`](skills/workflow-log-bug/)
+**Capture:** [`/workflow-log-idea`](skills/workflow-log-idea/) | [`/workflow-log-bug`](skills/workflow-log-bug/) | [`/workflow-log-quickfix`](skills/workflow-log-quickfix/)
 
 **Utilities:** [`/workflow-migrate`](skills/workflow-migrate/)
 

--- a/agents/workflow-implementation-task-executor.md
+++ b/agents/workflow-implementation-task-executor.md
@@ -1,19 +1,19 @@
 ---
 name: workflow-implementation-task-executor
-description: Implements a single task via strict TDD. Invoked by workflow-implementation-process skill for each task.
+description: Implements a single task via TDD or verification workflow. Invoked by workflow-implementation-process skill for each task.
 tools: Read, Glob, Grep, Edit, Write, Bash
 model: opus
 ---
 
 # Implementation Task Executor
 
-Act as an **expert senior developer** executing ONE task via strict TDD. Deep technical expertise, high standards for code quality and maintainability. Follow project-specific skills for language/framework conventions.
+Act as an **expert senior developer** executing ONE task. Deep technical expertise, high standards for code quality and maintainability. Follow project-specific skills for language/framework conventions.
 
 ## Your Input
 
 You receive file paths and context via the orchestrator's prompt:
 
-1. **tdd-workflow.md path** — TDD cycle rules
+1. **Workflow reference path** — TDD or verification cycle rules (depends on work type)
 2. **code-quality.md path** — Quality standards
 3. **Specification path** — For context when rationale is unclear
 4. **Project skill paths** — Relevant `.claude/skills/` paths for framework conventions
@@ -28,7 +28,7 @@ You are stateless — each invocation starts fresh. The full task content is alw
 
 ## Your Process
 
-1. **Read tdd-workflow.md** — absorb the full TDD cycle before writing any code
+1. **Read the workflow reference** — absorb the full cycle (TDD or verification) before writing any code
 2. **Read code-quality.md** — absorb quality standards
 3. **Read project skills** — absorb framework conventions, testing patterns, architecture patterns
 4. **Read specification** (if provided) — understand broader context for this task
@@ -39,8 +39,8 @@ You are stateless — each invocation starts fresh. The full task content is alw
    - Find similar implementations — if the task is "add endpoint X", find existing endpoints and follow the same pattern
    - Understand inputs, outputs, and callers of any code you'll modify
    - Note the testing approach used in this area — use the same patterns
-6. **Execute TDD cycle** — follow the process in tdd-workflow.md for each acceptance criterion and test case.
-7. **Verify all acceptance criteria met** — every criterion from the task must be satisfied
+6. **Execute the workflow cycle** — follow the process in the workflow reference for each acceptance criterion, verification step, or test case.
+7. **Verify all criteria met** — every criterion or verification step from the task must be satisfied
 8. **Return structured result**
 
 ## Code Only
@@ -59,7 +59,7 @@ Those are the orchestrator's responsibility.
 
 **MANDATORY. No exceptions. Violating these rules invalidates the work.**
 
-1. **No code before tests** — Write the failing test first. Always.
+1. **Follow the workflow** — TDD means test-first; verification means baseline-first. Read and follow whichever workflow reference you receive.
 2. **No test changes to pass** — Fix the code, not the test.
 3. **No scope expansion** — Only what's in the task. If you think "I should also handle X" — STOP. It's not in the task, don't build it.
 4. **No assumptions** — Uncertain about intent or approach? STOP and report back.

--- a/agents/workflow-implementation-task-reviewer.md
+++ b/agents/workflow-implementation-task-reviewer.md
@@ -41,11 +41,21 @@ Are all criteria genuinely met — not just self-reported?
 - Verify the code actually satisfies it (don't trust the executor's claim)
 - Check for criteria that are technically met but miss the intent
 
+**For quick-fix mechanical changes**: Instead of acceptance criteria, verify completeness:
+- Are all target files updated?
+- Do any occurrences of the old pattern remain in scope?
+- Were exclusions respected?
+
 ### 3. Test Adequacy
 Do tests actually verify the criteria? Are assertions precise? Are edge cases covered?
 - Is there a test for each acceptance criterion?
 - Would the tests fail if the feature broke?
 - Are edge cases from the task's test cases covered?
+
+**For quick-fix mechanical changes**: Instead of new test coverage, verify the verification workflow:
+- Were tests run before and after the change?
+- Do all previously passing tests still pass?
+- If tests were updated (e.g., to reference new API), are the updates correct?
 - **Assertion depth**: For mutation operations, do tests verify observable side effects — not just that the operation returned success? State changes should be asserted independently.
 - **Assertion precision**: When expected output is deterministic, do tests use exact comparison? Substring or partial matching masks formatting regressions and missing/extra content.
 - Flag both under-testing AND over-testing

--- a/skills/continue-quickfix/SKILL.md
+++ b/skills/continue-quickfix/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: continue-quickfix
+allowed-tools: Bash(node .claude/skills/continue-quickfix/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs)
+---
+
+Continue an in-progress quick-fix. Determines current phase and routes to the appropriate phase skill.
+
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
+## Instructions
+
+Follow these steps EXACTLY as written. Do not skip steps or combine them.
+
+**CRITICAL**: This guidance is mandatory.
+
+- After each user interaction, STOP and wait for their response before proceeding
+- Never assume or anticipate user choices
+- Complete each step fully before moving to the next
+
+---
+
+## Step 0: Initialisation
+
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+**Run migrations — this is mandatory. You must complete it before proceeding.**
+
+Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+→ Proceed to **Step 1**.
+
+---
+
+## Step 1: Discovery State
+
+!`node .claude/skills/continue-quickfix/scripts/discovery.cjs`
+
+If the above shows a script invocation rather than discovery output, the dynamic content preprocessor did not run. Execute the script before continuing:
+
+```bash
+node .claude/skills/continue-quickfix/scripts/discovery.cjs
+```
+
+If discovery output is already displayed, it has been run on your behalf.
+
+Parse the discovery output to understand:
+
+**From `quick_fixes` array:**
+- `name` - the work unit name
+- `next_phase` - the phase to route to
+- `phase_label` - human-readable phase status
+- `completed_phases` - list of completed phases (for backwards navigation)
+
+**From top-level fields:**
+- `count` - number of active quick-fixes
+- `summary` - human-readable state summary
+- `completed` / `cancelled` - arrays of non-active quick-fixes with name, status, last_phase
+- `completed_count` / `cancelled_count` - counts for each
+
+**IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
+
+→ Proceed to **Step 2**.
+
+---
+
+## Step 2: Check Count and Arguments
+
+#### If `count` is 0
+
+> *Output the next fenced block as a code block:*
+
+```
+Continue Quick-Fix
+
+No quick-fixes in progress.
+
+Run /start-quickfix to begin a new one.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+#### If `work_unit` argument `$0` provided
+
+Store the work_unit.
+
+→ Proceed to **Step 4**.
+
+#### If `work_unit` not provided
+
+→ Proceed to **Step 3**.
+
+---
+
+## Step 3: Select Quick-Fix
+
+Load **[select-quickfix.md](references/select-quickfix.md)** and follow its instructions as written.
+
+→ Proceed to **Step 4**.
+
+---
+
+## Step 4: Validate Selection
+
+Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
+
+→ Proceed to **Step 5**.
+
+---
+
+## Step 5: Backwards Navigation
+
+Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instructions as written.
+
+→ Proceed to **Step 6**.
+
+---
+
+## Step 6: Route to Phase Skill
+
+Using the selected quick-fix's `next_phase`, invoke the appropriate phase skill:
+
+| next_phase | Invoke |
+|------------|--------|
+| scoping | `/workflow-scoping-entry quick-fix {work_unit}` |
+| implementation | `/workflow-implementation-entry quick-fix {work_unit}` |
+| review | `/workflow-review-entry quick-fix {work_unit}` |
+
+Skills receive positional arguments: `$0` = work_type (`quick-fix`), `$1` = work_unit. Topic is inferred from work_unit.
+
+If the user chose to revisit a completed phase in Step 5, use that phase instead of `next_phase`.
+
+Invoke the skill. This is terminal — do not return to the backbone.

--- a/skills/continue-quickfix/references/revisit-phase.md
+++ b/skills/continue-quickfix/references/revisit-phase.md
@@ -1,0 +1,75 @@
+# Backwards Navigation
+
+*Reference for **[continue-quickfix](../SKILL.md)***
+
+---
+
+Offer the user a choice between proceeding to the next phase or revisiting an earlier completed phase.
+
+## A. Check for Earlier Phases
+
+Using the selected quick-fix's `completed_phases` list, determine if there are any completed phases that come before `next_phase` in the pipeline.
+
+#### If no earlier completed phases exist
+
+Skip this step — route directly to the next phase.
+
+→ Return to caller.
+
+#### If earlier completed phases exist
+
+→ Proceed to **B. Proceed or Revisit**.
+
+## B. Proceed or Revisit
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Continuing "{quickfix.name:(titlecase)}" — {quickfix.phase_label}.
+
+- **`y`/`yes`** — Proceed to {next_phase}
+- **`r`/`revisit`** — Revisit an earlier phase
+
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If user chose `y`/`yes`
+
+→ Return to caller.
+
+#### If user chose `r`/`revisit`
+
+→ Proceed to **C. Select Phase**.
+
+## C. Select Phase
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Which phase would you like to revisit?
+
+1. {phase:(titlecase)} — completed
+2. ...
+{N}. Back
+
+Select an option (enter number):
+· · · · · · · · · · · ·
+```
+
+List only phases from `completed_phases`.
+
+**STOP.** Wait for user response.
+
+#### If user chose Back
+
+→ Return to **B. Proceed or Revisit**.
+
+#### If user chose a phase
+
+Store the selected phase as the target phase (overriding `next_phase`).
+
+→ Return to caller.

--- a/skills/continue-quickfix/references/select-quickfix.md
+++ b/skills/continue-quickfix/references/select-quickfix.md
@@ -1,0 +1,75 @@
+# Select Quick-Fix
+
+*Reference for **[continue-quickfix](../SKILL.md)***
+
+---
+
+## A. Display and Select
+
+Display active quick-fixes and let the user select one.
+
+> *Output the next fenced block as a code block:*
+
+```
+Continue Quick-Fix
+
+{count} quick-fix(es) in progress:
+
+@foreach(quickfix in quick_fixes)
+  {N}. {quickfix.name:(titlecase)}
+     └─ {quickfix.phase_label:(titlecase)}
+
+@endforeach
+
+@if(completed_count > 0 || cancelled_count > 0)
+{completed_count} completed, {cancelled_count} cancelled.
+@endif
+```
+
+Build from the discovery output's `quick_fixes` array. Each quick-fix shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Which quick-fix would you like to continue?
+
+1. Continue "{quickfix.name:(titlecase)}" — {quickfix.phase_label}
+2. ...
+
+@if(completed_count > 0 || cancelled_count > 0)
+{N+1}. View completed & cancelled quick-fixes
+@endif
+- **`m`/`manage`** — Manage a quick-fix's lifecycle
+
+Select an option (enter number):
+· · · · · · · · · · · ·
+```
+
+Recreate with actual quick-fixes and `phase_label` values from discovery. No auto-select, even with one item.
+
+**STOP.** Wait for user response.
+
+#### If user chose a quick-fix number
+
+Store the selected quick-fix's name as `work_unit`.
+
+→ Return to caller.
+
+#### If user chose "View completed & cancelled"
+
+Set work_type filter = `quick-fix`.
+
+→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
+
+Re-run discovery to refresh state after potential changes.
+
+→ Return to **A. Display and Select**.
+
+#### If user chose `m`/`manage`
+
+→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
+
+Re-run discovery to refresh state after potential changes.
+
+→ Return to **A. Display and Select**.

--- a/skills/continue-quickfix/references/validate-selection.md
+++ b/skills/continue-quickfix/references/validate-selection.md
@@ -1,0 +1,27 @@
+# Validate Selection
+
+*Reference for **[continue-quickfix](../SKILL.md)***
+
+---
+
+Validate the selected work unit against the discovery output and store its data.
+
+#### If `work_unit` not found in quick_fixes array
+
+> *Output the next fenced block as a code block:*
+
+```
+Continue Quick-Fix
+
+No active quick-fix named "{work_unit}" found.
+
+Run /continue-quickfix to see available quick-fixes, or /start-quickfix to begin a new one.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+#### Otherwise
+
+Store the matched quick-fix's data (name, next_phase, phase_label, completed_phases).
+
+→ Return to caller.

--- a/skills/continue-quickfix/scripts/discovery.cjs
+++ b/skills/continue-quickfix/scripts/discovery.cjs
@@ -1,0 +1,83 @@
+'use strict';
+
+const { loadActiveManifests, loadAllManifests, phaseStatus, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils.cjs');
+
+const QUICKFIX_PIPELINE = ['scoping', 'implementation', 'review'];
+
+function lastCompletedPhase(manifest) {
+  let last = null;
+  for (const phase of QUICKFIX_PIPELINE) {
+    const s = phaseStatus(manifest, phase);
+    if (s === 'completed') last = phase;
+  }
+  return last;
+}
+
+function completedPhases(manifest) {
+  const completed = [];
+  for (const phase of QUICKFIX_PIPELINE) {
+    const s = phaseStatus(manifest, phase);
+    if (s === 'completed') {
+      completed.push(phase);
+    }
+  }
+  return completed;
+}
+
+function discover(cwd) {
+  const manifests = loadActiveManifests(cwd);
+  const quick_fixes = [];
+
+  for (const m of manifests) {
+    if (m.work_type !== 'quick-fix') continue;
+    const state = computeNextPhase(m);
+    if (state.next_phase === 'done') continue;
+    quick_fixes.push({
+      name: m.name,
+      next_phase: state.next_phase,
+      phase_label: state.phase_label,
+      completed_phases: completedPhases(m),
+    });
+  }
+
+  const allManifests = loadAllManifests(cwd);
+  const completed = [];
+  const cancelled = [];
+
+  for (const m of allManifests) {
+    if (m.work_type !== 'quick-fix') continue;
+    if (m.status === 'completed') {
+      completed.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
+    } else if (m.status === 'cancelled') {
+      cancelled.push({ name: m.name, status: m.status, last_phase: lastCompletedPhase(m) });
+    }
+  }
+
+  return {
+    quick_fixes,
+    count: quick_fixes.length,
+    completed,
+    cancelled,
+    completed_count: completed.length,
+    cancelled_count: cancelled.length,
+    summary: quick_fixes.length === 0
+      ? 'no active quick-fixes'
+      : `${quick_fixes.length} active quick-fix(es)`,
+  };
+}
+
+function format(result) {
+  const lines = [];
+  lines.push(`=== QUICK-FIXES (${result.count}) ===`);
+  lines.push(`summary: ${result.summary}`);
+  for (const q of result.quick_fixes) {
+    lines.push(`  ${q.name}: ${q.phase_label} [completed: ${q.completed_phases.join(', ') || 'none'}]`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+if (require.main === module) {
+  process.stdout.write(format(discover(process.cwd())));
+}
+
+module.exports = { discover, format };

--- a/skills/start-quickfix/SKILL.md
+++ b/skills/start-quickfix/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: start-quickfix
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
+---
+
+Start a new quick-fix. Gather a brief description, create the work unit, and route to scoping.
+
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
+## Instructions
+
+Follow these steps EXACTLY as written. Do not skip steps or combine them.
+
+**CRITICAL**: This guidance is mandatory.
+
+- After each user interaction, STOP and wait for their response before proceeding
+- Never assume or anticipate user choices
+- Complete each step fully before moving to the next
+
+---
+
+## Step 0: Initialisation
+
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+**Run migrations — this is mandatory. You must complete it before proceeding.**
+
+Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+→ Proceed to **Step 1**.
+
+---
+
+## Step 1: Gather Quick-Fix Context
+
+#### If inbox file path was provided as positional argument (`$0`)
+
+Read the inbox file at the provided path. Use its content as the quick-fix description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
+
+→ Proceed to **Step 2**.
+
+#### Otherwise
+
+Load **[gather-quickfix-context.md](references/gather-quickfix-context.md)** and follow its instructions as written.
+
+→ Proceed to **Step 2**.
+
+---
+
+## Step 2: Quick-Fix Name and Conflict Check
+
+Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 3**.
+
+---
+
+## Step 3: Invoke Entry-Point Skill
+
+Invoke `/workflow-scoping-entry quick-fix {work_unit}`.
+
+This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.

--- a/skills/start-quickfix/references/gather-quickfix-context.md
+++ b/skills/start-quickfix/references/gather-quickfix-context.md
@@ -1,0 +1,19 @@
+# Gather Quick-Fix Context
+
+*Reference for **[start-quickfix](../SKILL.md)***
+
+---
+
+Gather a brief description of the mechanical change — enough for a name and manifest description.
+
+> *Output the next fenced block as a code block:*
+
+```
+What needs changing?
+
+Describe the mechanical change briefly (what to change, where, why).
+```
+
+**STOP.** Wait for user response.
+
+→ Return to caller.

--- a/skills/start-quickfix/references/name-check.md
+++ b/skills/start-quickfix/references/name-check.md
@@ -1,0 +1,79 @@
+# Quick-Fix Name and Conflict Check
+
+*Reference for **[start-quickfix](../SKILL.md)***
+
+---
+
+## A. Name Suggestion
+
+Based on the quick-fix description, suggest a name in kebab-case. Once confirmed, this becomes both `{work_unit}` and `{topic}` — for quick-fix, they are always the same value.
+
+> *Output the next fenced block as a code block:*
+
+```
+Suggested quick-fix name: {work_unit}
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Is this name okay?
+
+- **`y`/`yes`** — Use this name
+- **something else** — Suggest a different name
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+→ Proceed to **B. Conflict Check**.
+
+## B. Conflict Check
+
+Check for naming conflicts:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}
+```
+
+#### If a work unit with the same name exists
+
+> *Output the next fenced block as a code block:*
+
+```
+A work unit named "{work_unit}" already exists.
+
+Run /continue-quickfix to resume, or choose a different name.
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+- **`n`/`new`** — Choose a different name
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+→ Return to **A. Name Suggestion**.
+
+#### If no conflict
+
+Create the work unit manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init {work_unit} --work-type quick-fix --description "{description}"
+```
+
+Where `{description}` is a concise one-line summary compiled from the quick-fix context gathered in Step 1.
+
+**If this work unit was started from an inbox file**, archive it:
+
+```bash
+mkdir -p .workflows/.inbox/.archived/quickfixes
+mv .workflows/.inbox/quickfixes/{file} .workflows/.inbox/.archived/quickfixes/{file}
+```
+
+→ Return to caller.

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -56,6 +56,10 @@ Load **[feature-continuation.md](references/feature-continuation.md)** and follo
 
 Load **[bugfix-continuation.md](references/bugfix-continuation.md)** and follow its instructions as written.
 
+#### If work type is `quick-fix`
+
+Load **[quickfix-continuation.md](references/quickfix-continuation.md)** and follow its instructions as written.
+
 #### If work type is `cross-cutting`
 
 Load **[cross-cutting-continuation.md](references/cross-cutting-continuation.md)** and follow its instructions as written.

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -1,0 +1,185 @@
+# Quick-Fix Continuation
+
+*Reference for **[workflow-bridge](../SKILL.md)***
+
+---
+
+Route a quick-fix to its next pipeline phase, with an option to revisit earlier phases.
+
+Quick-fix pipeline: Scoping → Implementation → Review
+
+## Phase Routing
+
+Use `next_phase` from discovery output to determine the target skill:
+
+| next_phase | Target Skill |
+|------------|--------------|
+| scoping | workflow-scoping-entry |
+| implementation | workflow-implementation-entry |
+| review | workflow-review-entry |
+| done | (terminal) |
+
+## A. Check Terminal
+
+#### If `next_phase` is `done`
+
+Set the work unit status to completed:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} status completed
+```
+
+Commit: `workflow({work_unit}): complete quick-fix pipeline`
+
+> *Output the next fenced block as a code block:*
+
+```
+Quick-Fix Completed
+
+"{work_unit:(titlecase)}" has completed all pipeline phases.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+#### Otherwise
+
+Set `target_phase` = `next_phase`.
+
+→ Proceed to **B. Offer Early Completion**.
+
+## B. Offer Early Completion
+
+#### If `next_phase` is `review`
+
+Implementation has just completed. Offer the user a choice to skip review and complete early.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Implementation completed for "{work_unit:(titlecase)}".
+
+- **`y`/`yes`** — Proceed to review
+- **`d`/`done`** — Complete without review
+
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If user chose `d`/`done`:**
+
+Set the work unit status to completed:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} status completed
+```
+
+Commit: `workflow({work_unit}): complete quick-fix pipeline (review skipped)`
+
+> *Output the next fenced block as a code block:*
+
+```
+Quick-Fix Completed
+
+"{work_unit:(titlecase)}" completed — review skipped.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If user chose `y`/`yes`:**
+
+→ Proceed to **C. Check for Earlier Phases**.
+
+#### Otherwise
+
+→ Proceed to **C. Check for Earlier Phases**.
+
+## C. Check for Earlier Phases
+
+Check if there are completed phases earlier in the pipeline that the user could revisit. Look at the discovery output's `phases` data — any phase with status `completed` that comes before `next_phase` in the pipeline order.
+
+#### If no earlier completed phases exist
+
+→ Proceed to **F. Enter Plan Mode**.
+
+#### If earlier completed phases exist
+
+→ Proceed to **D. Offer Revisit**.
+
+## D. Offer Revisit
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+{previous_phase:(titlecase)} completed for "{work_unit:(titlecase)}".
+
+- **`y`/`yes`** — Proceed to {next_phase}
+- **`r`/`revisit`** — Revisit an earlier phase
+
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If user chose `y`/`yes`
+
+→ Proceed to **F. Enter Plan Mode**.
+
+#### If user chose `r`/`revisit`
+
+→ Proceed to **E. Select Phase**.
+
+## E. Select Phase
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Which phase would you like to revisit?
+
+1. {phase:(titlecase)} — completed
+2. ...
+{N}. Back
+
+Select an option (enter number):
+· · · · · · · · · · · ·
+```
+
+List only completed phases that come before `next_phase`.
+
+**STOP.** Wait for user response.
+
+#### If user chose Back
+
+→ Return to **D. Offer Revisit**.
+
+#### If user chose a phase
+
+Set `target_phase` = selected phase.
+
+→ Proceed to **F. Enter Plan Mode**.
+
+## F. Enter Plan Mode
+
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+
+```
+# Continue Quick-Fix: {work_unit}
+
+@if(target_phase == next_phase) The previous phase has completed. Continue the pipeline. @else Revisiting an earlier phase. @endif
+
+## Next Step
+
+Invoke `/workflow-{target_phase}-entry quick-fix {work_unit}`
+
+Arguments: work_type = quick-fix, work_unit = {work_unit} (topic inferred from work_unit)
+The skill will skip discovery and proceed directly to validation.
+
+## How to proceed
+
+Clear context and continue.
+```
+
+Call the `ExitPlanMode` tool to present the plan to the user for approval.

--- a/skills/workflow-bridge/scripts/discovery.cjs
+++ b/skills/workflow-bridge/scripts/discovery.cjs
@@ -3,7 +3,7 @@
 const path = require('path');
 const { loadManifest, phaseStatus, fileExists, listFiles, listDirs, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils.cjs');
 
-const ALL_PHASES = ['research', 'discussion', 'investigation', 'specification', 'planning', 'implementation', 'review'];
+const ALL_PHASES = ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
 
 function phaseFileExists(cwd, workUnit, phase, manifest) {
   const dir = path.join(cwd, '.workflows', workUnit, phase);
@@ -11,6 +11,7 @@ function phaseFileExists(cwd, workUnit, phase, manifest) {
     case 'research':       return listFiles(dir, '.md').length > 0;
     case 'discussion':     return listFiles(dir, '.md').length > 0;
     case 'investigation':  return listFiles(dir, '.md').length > 0;
+    case 'scoping':        return phaseStatus(manifest, phase) !== null;
     case 'specification':  return listDirs(dir).some(d => fileExists(path.join(dir, d, 'specification.md')));
     case 'planning':       return phaseStatus(manifest, phase) !== null;
     case 'implementation': return phaseStatus(manifest, phase) !== null;

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -21,7 +21,7 @@ This is **Phase 5** of the six-phase workflow:
 | **5. Implementation** | DOING - tests first, then code | ◀ HERE |
 | 6. Review | VALIDATING - check work against artifacts | |
 
-**Stay in your lane**: Execute the plan via strict TDD - tests first, then code. Don't re-debate decisions from the specification or expand scope beyond the plan. The plan is your authority.
+**Stay in your lane**: Execute the plan via strict TDD (or verification workflow for quick-fix). Don't re-debate decisions from the specification or expand scope beyond the plan. The plan is your authority.
 
 ---
 

--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -20,9 +20,13 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} work_
 
 Use **verification-workflow.md** (`verification-workflow.md`) as the workflow reference (item 1 below).
 
+→ Proceed to **Invoke the Agent**.
+
 #### Otherwise
 
 Use **tdd-workflow.md** (`tdd-workflow.md`) as the workflow reference (item 1 below).
+
+→ Proceed to **Invoke the Agent**.
 
 ---
 

--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -8,11 +8,29 @@ This step invokes the `workflow-implementation-task-executor` agent (`../../../a
 
 ---
 
+## Determine Workflow Reference
+
+Check the work type:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} work_type
+```
+
+#### If work_type is `quick-fix`
+
+Use **verification-workflow.md** (`verification-workflow.md`) as the workflow reference (item 1 below).
+
+#### Otherwise
+
+Use **tdd-workflow.md** (`tdd-workflow.md`) as the workflow reference (item 1 below).
+
+---
+
 ## Invoke the Agent
 
 **Every invocation** — initial or re-attempt — includes these file paths:
 
-1. **tdd-workflow.md**: `tdd-workflow.md`
+1. **Workflow reference**: the file determined above
 2. **code-quality.md**: `code-quality.md`
 3. **Specification path**: from the specification (if available)
 4. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.implementation.{topic} project_skills`)

--- a/skills/workflow-implementation-process/references/verification-workflow.md
+++ b/skills/workflow-implementation-process/references/verification-workflow.md
@@ -1,0 +1,72 @@
+# Verification Workflow
+
+*Reference for **[workflow-implementation-process](../SKILL.md)***
+
+---
+
+## The Cycle
+
+BASELINE → CHANGE → VERIFY → LINT
+
+Repeat for each task. **Never skip steps. Never reorder.**
+
+### Mechanical Change Discipline
+
+This is NOT TDD. Quick-fixes are mechanical changes where the change is well-defined and existing tests serve as the safety net. The mandatory discipline is **baseline-first**:
+- You MUST capture a passing test baseline before any changes
+- You MUST make changes systematically (not ad hoc)
+- You MUST verify tests still pass after changes
+- You MUST NOT change test assertions to accommodate your changes (if a test fails, the change broke something — fix the change)
+
+## BASELINE: Capture Current State
+
+1. Run the full test suite (or relevant subset for the change's scope)
+2. Record which tests pass — this is your baseline
+3. If tests are already failing, note them separately — these are pre-existing failures, not caused by your change
+
+**Do not proceed if the baseline cannot be established.** Report back if the test suite doesn't run.
+
+## CHANGE: Apply Mechanical Transformation
+
+1. Read the task's implementation steps
+2. Apply the change systematically across all target files
+3. Use search/replace patterns where possible for consistency
+4. Check for completeness: verify no occurrences of the old pattern remain in the target scope
+5. If the change affects test files (e.g., tests reference the old API/syntax), update them to use the new form
+
+## VERIFY: Confirm No Regressions
+
+1. Run the same test suite from BASELINE
+2. Compare results — all previously passing tests must still pass
+3. If new failures appear:
+   - Inspect the failure — is it caused by your change?
+   - If yes: fix the change (not the test) and re-verify
+   - If no: note as pre-existing and continue
+4. Confirm completeness — search for remaining occurrences of the old pattern in scope
+
+## LINT: After Verification
+
+If linter commands are configured (passed by the orchestrator):
+1. Run each linter command
+2. If issues found: fix them
+3. Re-run linter to confirm clean
+4. Re-run tests to confirm no regressions
+5. If a linter fix breaks tests: revert the fix and note it in your report
+
+If no linters configured, skip this step.
+
+## COMMIT: Orchestrator Responsibility
+
+The executor agent does NOT commit. Your responsibility ends at VERIFY — all tests passing and change complete. The orchestrator commits after review approval.
+
+## When Tests CAN Change
+
+- Tests reference the old syntax/API being changed — update them to use the new form
+- Pre-existing test failures unrelated to your change
+- Genuine bug in test logic discovered during the change
+
+## When Tests CANNOT Change
+
+- To make broken code pass → **fix the code**
+- To accommodate unintended behavioral changes → **this is not a quick-fix**
+- To skip difficult verification → **do the verification**

--- a/skills/workflow-log-quickfix/SKILL.md
+++ b/skills/workflow-log-quickfix/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: workflow-log-quickfix
+description: Capture a quick-fix as a markdown file in the workflow inbox. Use when the user wants to log a trivially scoped mechanical change for later.
+allowed-tools: Bash(mkdir -p)
+---
+
+This skill captures a quick-fix and writes it to the inbox.
+
+If there's already conversation context about a mechanical change, synthesise it straight into the file without asking questions. If this is a cold start, ask what needs changing and have a natural back-and-forth to draw out the scope. Recognise when it has enough detail (typically 1-3 exchanges) and wrap up.
+
+**Capture only — these are rules, not guidelines:**
+- Do not read code or explore the codebase
+- Do not search the web or fetch external resources
+- Do not attempt to validate the change
+- Do not suggest approaches or implementation details
+- Do not diagnose complexity or recommend work types
+- Do not propose next steps
+
+When ready, generate a short kebab-case slug from the core change (e.g., `replace-interface-with-any`, `update-deprecated-api`) and write the file:
+
+```bash
+mkdir -p .workflows/.inbox/quickfixes
+```
+
+**File:** `.workflows/.inbox/quickfixes/{YYYY-MM-DD}--{slug}.md` (use today's actual date)
+- H1 title, prose body, 100-300 words
+- No forced headings — let the content flow naturally
+- Naturally cover what needs changing, where, and why
+- Mention relevant codebase files if they came up
+
+Confirm with a one-liner:
+
+> *Output the next fenced block as a code block:*
+
+```
+Logged quick-fix: {slug}
+```

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -110,7 +110,7 @@ $MANIFEST list [--status s] [--work-type t]
 Create a new work unit manifest.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init <name> --work-type <epic|feature|bugfix|cross-cutting> --description "..."
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init <name> --work-type <epic|feature|bugfix|quick-fix|cross-cutting> --description "..."
 ```
 
 Creates `.workflows/<name>/manifest.json` with identity fields and empty phases. Errors if manifest already exists. Rejects names containing dots or matching phase names.
@@ -191,8 +191,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set <name>.planning.a
 
 Values are parsed as JSON first (for arrays, objects, numbers, booleans), falling back to string. Validates structural fields:
 
-- **work_type**: `epic`, `feature`, `bugfix`
-- **phase names**: `research`, `discussion`, `investigation`, `specification`, `planning`, `implementation`, `review`
+- **work_type**: `epic`, `feature`, `bugfix`, `quick-fix`, `cross-cutting`
+- **phase names**: `research`, `discussion`, `investigation`, `scoping`, `specification`, `planning`, `implementation`, `review`
 - **phase statuses**: per-phase valid values (see Validation section)
 - **gate modes**: `gated`, `auto`
 - **work unit status**: `in-progress`, `completed`, `cancelled`
@@ -349,11 +349,12 @@ The CLI validates structural values to prevent invalid state:
 
 | Field                          | Valid Values                                       |
 |--------------------------------|----------------------------------------------------|
-| `work_type`                    | `epic`, `feature`, `bugfix`, `cross-cutting`       |
+| `work_type`                    | `epic`, `feature`, `bugfix`, `quick-fix`, `cross-cutting` |
 | `status` (work unit)           | `in-progress`, `completed`, `cancelled`            |
 | Item `status` (research)       | `in-progress`, `completed`                         |
 | Item `status` (discussion)     | `in-progress`, `completed`                         |
 | Item `status` (investigation)  | `in-progress`, `completed`                         |
+| Item `status` (scoping)        | `in-progress`, `completed`                         |
 | Item `status` (specification)  | `in-progress`, `completed`, `superseded`, `promoted` |
 | Item `status` (planning)       | `in-progress`, `completed`                         |
 | Item `status` (implementation) | `in-progress`, `completed`                         |

--- a/skills/workflow-manifest/scripts/manifest.cjs
+++ b/skills/workflow-manifest/scripts/manifest.cjs
@@ -10,10 +10,10 @@ const path = require('path');
 
 const WORKFLOWS_DIR = path.resolve(process.cwd(), '.workflows');
 
-const VALID_WORK_TYPES = ['epic', 'feature', 'bugfix', 'cross-cutting'];
+const VALID_WORK_TYPES = ['epic', 'feature', 'bugfix', 'cross-cutting', 'quick-fix'];
 
 const VALID_PHASES = [
-  'research', 'discussion', 'investigation',
+  'research', 'discussion', 'investigation', 'scoping',
   'specification', 'planning', 'implementation',
   'review'
 ];
@@ -22,6 +22,7 @@ const VALID_PHASE_STATUSES = {
   research:       ['in-progress', 'completed'],
   discussion:     ['in-progress', 'completed'],
   investigation:  ['in-progress', 'completed'],
+  scoping:        ['in-progress', 'completed'],
   specification:  ['in-progress', 'completed', 'superseded', 'promoted'],
   planning:       ['in-progress', 'completed'],
   implementation: ['in-progress', 'completed'],

--- a/skills/workflow-scoping-entry/SKILL.md
+++ b/skills/workflow-scoping-entry/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-scoping-entry
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(cat .workflows/.state/environment-setup.md)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs)
 ---
 
 Act as **precise intake coordinator**. Follow each step literally without interpretation. Do not engage with the subject matter — your role is preparation, not processing.
@@ -54,14 +54,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ---
 
-## Step 3: Check Environment
-
-Load **[environment-check.md](../workflow-implementation-entry/references/environment-check.md)** and follow its instructions as written.
-
-→ Proceed to **Step 4**.
-
----
-
-## Step 4: Invoke the Skill
+## Step 3: Invoke the Skill
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-scoping-entry/SKILL.md
+++ b/skills/workflow-scoping-entry/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: workflow-scoping-entry
+user-invocable: false
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(cat .workflows/.state/environment-setup.md)
+---
+
+Act as **precise intake coordinator**. Follow each step literally without interpretation. Do not engage with the subject matter — your role is preparation, not processing.
+
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
+## Workflow Context
+
+This is the **entry phase** of the quick-fix pipeline:
+
+| Phase | Focus | You |
+|-------|-------|-----|
+| **Scoping** | SCOPE - context, spec, plan in one pass | ◀ HERE |
+| Implementation | DOING - execute the plan | |
+| Review | VALIDATING - check work against artifacts | |
+
+**Stay in your lane**: Gather context, validate prerequisites, and hand off to the processing skill. Don't analyse the change or assess complexity — that's the processing skill's job.
+
+---
+
+## Instructions
+
+Follow these steps EXACTLY as written. Do not skip steps or combine them. Present output using the EXACT format shown in examples - do not simplify or alter the formatting.
+
+**CRITICAL**: This guidance is mandatory.
+
+- After each user interaction, STOP and wait for their response before proceeding
+- Never assume or anticipate user choices
+- Complete each step fully before moving to the next
+- Do not act on gathered information until the skill is loaded - it contains the instructions for how to proceed
+
+---
+
+## Step 1: Parse Arguments
+
+Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
+Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
+
+Store work_unit for the handoff.
+
+→ Proceed to **Step 2**.
+
+---
+
+## Step 2: Validate Phase
+
+Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
+
+→ Proceed to **Step 3**.
+
+---
+
+## Step 3: Check Environment
+
+Load **[environment-check.md](../workflow-implementation-entry/references/environment-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 4**.
+
+---
+
+## Step 4: Invoke the Skill
+
+Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-scoping-entry/references/invoke-skill.md
+++ b/skills/workflow-scoping-entry/references/invoke-skill.md
@@ -21,8 +21,6 @@ Scoping session for: {topic}
 Work unit: {work_unit}
 Description: {description}
 
-Environment: {Setup required | No special setup required}
-
 Invoke the workflow-scoping-process skill.
 ```
 

--- a/skills/workflow-scoping-entry/references/invoke-skill.md
+++ b/skills/workflow-scoping-entry/references/invoke-skill.md
@@ -1,0 +1,29 @@
+# Invoke the Skill
+
+*Reference for **[workflow-scoping-entry](../SKILL.md)***
+
+---
+
+This skill's purpose is now fulfilled. Construct the handoff and invoke the processing skill.
+
+---
+
+## Handoff
+
+Read the description from manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} description
+```
+
+```
+Scoping session for: {topic}
+Work unit: {work_unit}
+Description: {description}
+
+Environment: {Setup required | No special setup required}
+
+Invoke the workflow-scoping-process skill.
+```
+
+Invoke the [workflow-scoping-process](../../workflow-scoping-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-scoping-entry/references/validate-phase.md
+++ b/skills/workflow-scoping-entry/references/validate-phase.md
@@ -1,0 +1,49 @@
+# Validate Phase
+
+*Reference for **[workflow-scoping-entry](../SKILL.md)***
+
+---
+
+Check if scoping entry exists and determine entry state.
+
+## A. Scoping Check
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.scoping.{topic}
+```
+
+#### If scoping doesn't exist (`false`)
+
+Proceed normally (new entry).
+
+→ Return to caller.
+
+#### If scoping exists (`true`)
+
+Check status:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.scoping.{topic} status
+```
+
+**If status is `completed`:**
+
+Reset to in-progress:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.scoping.{topic} status in-progress
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Reopening scoping: {topic:(titlecase)}
+```
+
+→ Return to caller.
+
+**If status is `in-progress`:**
+
+Proceed normally.
+
+→ Return to caller.

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -10,9 +10,9 @@ Act as **expert technical analyst** performing rapid scoping of a mechanical cha
 
 ## Purpose in the Workflow
 
-This is the first and only pre-implementation phase for quick-fixes. It replaces discussion, specification, and planning with a single streamlined pass. The output is identical to what those three phases would produce: a specification file and a plan with task files.
+Scope a mechanical change — gather context, write a specification, and produce a plan with 1-2 task files ready for implementation.
 
-### What This Skill Needs
+## What This Skill Needs
 
 - **Work unit description** (required) - From the manifest, summarising the mechanical change
 - **Topic name** (required) - Same as work_unit for quick-fix

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: workflow-scoping-process
+user-invocable: false
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs)
+---
+
+# Scoping Process
+
+Act as **expert technical analyst** performing rapid scoping of a mechanical change. Assess scope, write a lightweight specification, and produce 1-2 task files — all in a single pass.
+
+## Purpose in the Workflow
+
+This is the first and only pre-implementation phase for quick-fixes. It replaces discussion, specification, and planning with a single streamlined pass. The output is identical to what those three phases would produce: a specification file and a plan with task files.
+
+### What This Skill Needs
+
+- **Work unit description** (required) - From the manifest, summarising the mechanical change
+- **Topic name** (required) - Same as work_unit for quick-fix
+- **Output format preference** (optional) - Will ask if not specified
+
+---
+
+## Resuming After Context Refresh
+
+Context refresh (compaction) summarizes the conversation, losing procedural detail. When you detect a context refresh has occurred — the conversation feels abruptly shorter, you lack memory of recent steps, or a summary precedes this message — follow this recovery protocol:
+
+1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
+2. **Check what artifacts exist on disk** — spec file, plan file, task files. Their presence reveals which steps completed.
+3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits.
+4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
+
+Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
+
+---
+
+## Hard Rules
+
+1. **Maximum 2 tasks** — if the change needs more, it's not a quick-fix. Promote it.
+2. **No acceptance criteria** — mechanical changes are verified by test baselines and completeness checks, not by acceptance criteria.
+3. **No agents** — scoping writes specs and tasks directly, without invoking planning agents or review cycles.
+
+## Output Formatting
+
+When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
+
+---
+
+## Step 0: Resume Detection
+
+Check if a specification already exists:
+
+```bash
+ls .workflows/{work_unit}/specification/{topic}/specification.md 2>/dev/null && echo "exists" || echo "none"
+```
+
+#### If specification exists
+
+Check if a plan also exists:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.planning.{topic}
+```
+
+**If plan exists and is completed:**
+
+> *Output the next fenced block as a code block:*
+
+```
+Scoping already completed for "{topic:(titlecase)}". Spec and plan are in place.
+```
+
+Mark scoping as completed if not already, then invoke the bridge:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.scoping.{topic}
+```
+
+If scoping doesn't exist, init and complete it:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.scoping.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.scoping.{topic} status completed
+```
+
+→ Proceed to **Step 6**.
+
+**Otherwise:**
+
+→ Proceed to **Step 1** (spec exists but plan is incomplete — resume from format selection).
+
+#### If specification does not exist
+
+→ Proceed to **Step 1**.
+
+---
+
+## Step 1: Gather Context
+
+Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
+
+→ Proceed to **Step 2**.
+
+---
+
+## Step 2: Complexity Check
+
+Load **[complexity-check.md](references/complexity-check.md)** and follow its instructions as written.
+
+→ Proceed to **Step 3**.
+
+---
+
+## Step 3: Write Specification
+
+Load **[write-specification.md](references/write-specification.md)** and follow its instructions as written.
+
+→ Proceed to **Step 4**.
+
+---
+
+## Step 4: Select Output Format
+
+Load **[select-format.md](references/select-format.md)** and follow its instructions as written.
+
+→ Proceed to **Step 5**.
+
+---
+
+## Step 5: Write Tasks
+
+Load **[write-tasks.md](references/write-tasks.md)** and follow its instructions as written.
+
+→ Proceed to **Step 6**.
+
+---
+
+## Step 6: Conclude Scoping
+
+> *Output the next fenced block as a code block:*
+
+```
+Scoping complete for "{topic:(titlecase)}".
+
+  Spec: .workflows/{work_unit}/specification/{topic}/specification.md
+  Plan: .workflows/{work_unit}/planning/{topic}/
+```
+
+Invoke the workflow-bridge skill with context:
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: scoping
+
+Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
+```

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -136,20 +136,4 @@ Load **[write-tasks.md](references/write-tasks.md)** and follow its instructions
 
 ## Step 6: Conclude Scoping
 
-> *Output the next fenced block as a code block:*
-
-```
-Scoping complete for "{topic:(titlecase)}".
-
-  Spec: .workflows/{work_unit}/specification/{topic}/specification.md
-  Plan: .workflows/{work_unit}/planning/{topic}/
-```
-
-Invoke the workflow-bridge skill with context:
-
-```
-Pipeline bridge for: {work_unit}
-Completed phase: scoping
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
-```
+Load **[conclude-scoping.md](references/conclude-scoping.md)** and follow its instructions as written.

--- a/skills/workflow-scoping-process/references/complexity-check.md
+++ b/skills/workflow-scoping-process/references/complexity-check.md
@@ -1,0 +1,80 @@
+# Complexity Check
+
+*Reference for **[workflow-scoping-process](../SKILL.md)***
+
+---
+
+Assess whether this change is genuinely quick-fix material. Evaluate against these criteria:
+
+- **Mechanical**: Is the change well-defined and repetitive? (find-and-replace, API rename, syntax update)
+- **Narrowly scoped**: Can it be expressed as 1-2 tasks?
+- **No design decisions**: Does it avoid architectural trade-offs or competing approaches?
+- **No new behaviour**: Does it preserve existing behaviour (just change how it's expressed)?
+- **Existing test coverage**: Can correctness be verified by running existing tests?
+
+## A. Evaluate
+
+If all criteria are met — proceed without comment.
+
+→ Return to caller.
+
+## B. Complexity Warning
+
+If any criterion fails, surface the concern:
+
+> *Output the next fenced block as a code block:*
+
+```
+Complexity Check
+
+This change may be more involved than a quick-fix:
+
+  • {specific concern — e.g., "Requires design decisions about the new API surface"}
+  • {additional concern if applicable}
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+How would you like to proceed?
+
+- **`c`/`continue`** — Continue as quick-fix anyway
+- **`f`/`feature`** — Promote to feature (full pipeline)
+- **`b`/`bugfix`** — Promote to bugfix (investigation pipeline)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `continue`
+
+→ Return to caller.
+
+#### If `feature`
+
+Update the work type in the manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_type feature
+```
+
+Commit: `workflow({work_unit}): promote quick-fix to feature`
+
+Invoke `/workflow-discussion-entry feature {work_unit}`.
+
+This skill ends. Terminal.
+
+#### If `bugfix`
+
+Update the work type in the manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_type bugfix
+```
+
+Commit: `workflow({work_unit}): promote quick-fix to bugfix`
+
+Invoke `/workflow-investigation-entry bugfix {work_unit}`.
+
+This skill ends. Terminal.

--- a/skills/workflow-scoping-process/references/complexity-check.md
+++ b/skills/workflow-scoping-process/references/complexity-check.md
@@ -61,9 +61,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_
 
 Commit: `workflow({work_unit}): promote quick-fix to feature`
 
-Invoke `/workflow-discussion-entry feature {work_unit}`.
-
-This skill ends. Terminal.
+Invoke `/workflow-discussion-entry feature {work_unit}`. This is terminal — do not return to the caller.
 
 #### If `bugfix`
 
@@ -75,6 +73,4 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_
 
 Commit: `workflow({work_unit}): promote quick-fix to bugfix`
 
-Invoke `/workflow-investigation-entry bugfix {work_unit}`.
-
-This skill ends. Terminal.
+Invoke `/workflow-investigation-entry bugfix {work_unit}`. This is terminal — do not return to the caller.

--- a/skills/workflow-scoping-process/references/conclude-scoping.md
+++ b/skills/workflow-scoping-process/references/conclude-scoping.md
@@ -1,0 +1,25 @@
+# Conclude Scoping
+
+*Reference for **[workflow-scoping-process](../SKILL.md)***
+
+---
+
+> *Output the next fenced block as a code block:*
+
+```
+Scoping complete for "{topic:(titlecase)}".
+
+  Spec: .workflows/{work_unit}/specification/{topic}/specification.md
+  Plan: .workflows/{work_unit}/planning/{topic}/
+```
+
+**Pipeline continuation** — Invoke the bridge:
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: scoping
+
+Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
+```
+
+**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-scoping-process/references/gather-context.md
+++ b/skills/workflow-scoping-process/references/gather-context.md
@@ -1,0 +1,36 @@
+# Gather Context
+
+*Reference for **[workflow-scoping-process](../SKILL.md)***
+
+---
+
+Gather targeted context about the mechanical change. Read the manifest description first, then fill gaps.
+
+## A. Read Existing Context
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} description
+```
+
+If the description already captures what, where, and why — skip to the complexity check. Otherwise, ask targeted questions.
+
+## B. Targeted Questions
+
+> *Output the next fenced block as a code block:*
+
+```
+Scoping: {topic:(titlecase)}
+
+A few questions to scope this change:
+
+- What exactly is being changed? (pattern, syntax, API)
+- Where in the codebase? (files, directories, packages)
+- Why? (deprecation, consistency, modernisation)
+- Any exceptions or areas to exclude?
+```
+
+**STOP.** Wait for user response.
+
+If answers are clear and complete, proceed. If gaps remain, ask one follow-up — no more than 2 exchanges total. Quick-fixes should be explainable in a sentence or two.
+
+→ Return to caller.

--- a/skills/workflow-scoping-process/references/select-format.md
+++ b/skills/workflow-scoping-process/references/select-format.md
@@ -1,0 +1,56 @@
+# Select Output Format
+
+*Reference for **[workflow-scoping-process](../SKILL.md)***
+
+---
+
+Select the plan output format using the same project-default logic as the planning skill.
+
+## A. Check Format Recommendation
+
+Check if a project-level default `plan_format` exists via manifest CLI:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists project.defaults.plan_format
+```
+
+#### If `false`
+
+→ Proceed to **B. Select Format**.
+
+#### Otherwise
+
+Read the project default `plan_format` via manifest CLI:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get project.defaults.plan_format
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Project default format is **{format}**. Use the same format?
+
+- **`y`/`yes`** — Use {format}
+- **`n`/`no`** — See all available formats
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `yes`:**
+
+→ Return to caller.
+
+**If `no`:**
+
+→ Proceed to **B. Select Format**.
+
+---
+
+## B. Select Format
+
+→ Load **[../../workflow-planning-process/references/output-formats.md](../../workflow-planning-process/references/output-formats.md)** and follow its instructions as written.
+
+→ Return to caller.

--- a/skills/workflow-scoping-process/references/write-specification.md
+++ b/skills/workflow-scoping-process/references/write-specification.md
@@ -1,0 +1,55 @@
+# Write Specification
+
+*Reference for **[workflow-scoping-process](../SKILL.md)***
+
+---
+
+Write a lightweight specification directly. No agents, no review cycles — the change is mechanical and well-understood.
+
+## A. Write the Spec
+
+Create the specification file at `.workflows/{work_unit}/specification/{topic}/specification.md`:
+
+```markdown
+# Specification: {Topic:(titlecase)}
+
+## Change Description
+
+{What is being changed and why — 2-3 sentences}
+
+## Scope
+
+{Files, directories, or patterns affected. Be specific:}
+{- "All .go files in pkg/" or "grep -r 'interface{}' --include='*.go'"}
+{- Include file counts or pattern matches if known}
+
+## Exclusions
+
+{Anything explicitly excluded from the change, or "None"}
+
+## Verification
+
+{How to verify the change is correct — typically:}
+{- All existing tests pass after the change}
+{- No occurrences of the old pattern remain in scope}
+{- Any additional checks specific to this change}
+```
+
+Present the spec to the user:
+
+> *Output the next fenced block as a code block:*
+
+```
+Specification written: .workflows/{work_unit}/specification/{topic}/specification.md
+```
+
+## B. Register in Manifest
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.specification.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} status completed
+```
+
+Commit: `spec({work_unit}): quick-fix specification`
+
+→ Return to caller.

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -85,7 +85,7 @@ Register the task_map entries. For each task, map internal_id to external_id:
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_map.{internal_id} {external_id}
 ```
 
-For local-markdown, the external_id equals the topic name. For tick/linear, use the ID returned by the creation command.
+The external_id is determined by the format's authoring instructions.
 
 ## D. Mark Scoping Complete
 

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -1,0 +1,103 @@
+# Write Tasks
+
+*Reference for **[workflow-scoping-process](../SKILL.md)***
+
+---
+
+Write 1-2 task files directly using the chosen output format. No planning agents, no review cycles.
+
+## A. Create Plan Structure
+
+Create the planning file at `.workflows/{work_unit}/planning/{topic}/planning.md`:
+
+```markdown
+# Plan: {Topic:(titlecase)}
+
+## Phase 1: Apply Change
+
+{One-line goal — e.g., "Replace all occurrences of interface{} with any across Go source files"}
+
+#### Tasks
+status: approved
+
+| Internal ID | Name | Edge Cases |
+|-------------|------|------------|
+| {topic}-1-1 | {task name} | {edge cases or "none"} |
+```
+
+If a second task is needed (e.g., separate pass for config files, test file updates, or documentation), add it:
+
+```
+| {topic}-1-2 | {second task name} | {edge cases or "none"} |
+```
+
+**Maximum 2 tasks.** If the change genuinely needs more, re-evaluate — it may not be a quick-fix.
+
+## B. Write Task Files
+
+Load the chosen format's **authoring.md** from `skills/workflow-planning-process/references/output-formats/{format}/authoring.md` and follow its task storage instructions.
+
+**Task content** — each task file includes:
+
+```markdown
+# {Task Name}
+
+**Goal**: {What this task accomplishes}
+
+**Implementation Steps**:
+- {Step-by-step mechanical instructions}
+- {Be explicit about patterns, files, and transformations}
+
+**Verification**:
+- All existing tests pass after the change
+- No occurrences of the old pattern remain in scope
+- {Any additional verification specific to this task}
+
+**Edge Cases**: {Edge cases to watch for, or "None"}
+
+**Spec Reference**: `.workflows/{work_unit}/specification/{topic}/specification.md`
+```
+
+**Do not include acceptance criteria.** Mechanical changes are verified by test baselines and completeness checks, not acceptance criteria.
+
+## C. Register Plan in Manifest
+
+Capture the current git commit hash: `git rev-parse HEAD`
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.planning.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} format {chosen-format}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set project.defaults.plan_format {chosen-format}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} spec_commit {commit-hash}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_list_gate_mode auto
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} author_gate_mode auto
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} finding_gate_mode auto
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} review_cycle 0
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} phase 1
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task '~'
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_map '{}'
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} status completed
+```
+
+Register the task_map entries. For each task, map internal_id to external_id:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_map.{internal_id} {external_id}
+```
+
+For local-markdown, the external_id equals the topic name. For tick/linear, use the ID returned by the creation command.
+
+## D. Mark Scoping Complete
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.scoping.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.scoping.{topic} status completed
+```
+
+Commit all scoping artifacts:
+
+```
+scoping({work_unit}): specification and plan
+```
+
+→ Return to caller.

--- a/skills/workflow-shared/scripts/discovery-utils.cjs
+++ b/skills/workflow-shared/scripts/discovery-utils.cjs
@@ -127,6 +127,17 @@ function computeNextPhase(manifest) {
 
   const ps = (phase) => phaseStatus(manifest, phase);
 
+  // Quick-fix has its own short pipeline: scoping → implementation → review
+  if (wt === 'quick-fix') {
+    if (ps('review') === 'completed') return { next_phase: 'done', phase_label: 'pipeline complete' };
+    if (ps('review') === 'in-progress') return { next_phase: 'review', phase_label: 'review (in-progress)' };
+    if (ps('implementation') === 'completed') return { next_phase: 'review', phase_label: 'ready for review' };
+    if (ps('implementation') === 'in-progress') return { next_phase: 'implementation', phase_label: 'implementation (in-progress)' };
+    if (ps('scoping') === 'completed') return { next_phase: 'implementation', phase_label: 'ready for implementation' };
+    if (ps('scoping') === 'in-progress') return { next_phase: 'scoping', phase_label: 'scoping (in-progress)' };
+    return { next_phase: 'scoping', phase_label: 'ready for scoping' };
+  }
+
   if (ps('review') === 'completed') {
     return { next_phase: 'done', phase_label: 'pipeline complete' };
   }

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -31,6 +31,15 @@ Bugfixes:
 @endforeach
 @endif
 
+@if(quickfix_count > 0)
+Quick Fixes:
+@foreach(unit in quick_fixes.work_units)
+  {N}. {unit.name:(titlecase)}
+     └─ {unit.phase_label:(titlecase)}
+
+@endforeach
+@endif
+
 @if(cross_cutting_count > 0)
 Cross-Cutting:
 @foreach(unit in cross_cutting.work_units)
@@ -64,6 +73,12 @@ Inbox:
     • {bug.title} — {bug.date}
 @endforeach
 @endif
+@if(quickfix_count > 0)
+  Quick Fixes:
+@foreach(qf in inbox.quickfixes)
+    • {qf.title} — {qf.date}
+@endforeach
+@endif
 @endif
 
 @if(completed_count > 0 || cancelled_count > 0)
@@ -85,12 +100,14 @@ What would you like to do?
 
 1. Continue "{feature.name:(titlecase)}" — feature, {feature.phase_label}
 2. Continue "{bugfix.name:(titlecase)}" — bugfix, {bugfix.phase_label}
-3. Continue "{cross_cutting.name:(titlecase)}" — cross-cutting, {cross_cutting.phase_label}
-4. Continue "{epic.name:(titlecase)}" — epic
+3. Continue "{quickfix.name:(titlecase)}" — quick-fix, {quickfix.phase_label}
+4. Continue "{cross_cutting.name:(titlecase)}" — cross-cutting, {cross_cutting.phase_label}
+5. Continue "{epic.name:(titlecase)}" — epic
 
 - **`f`/`feature`** — Start new feature
 - **`e`/`epic`** — Start new epic
 - **`b`/`bugfix`** — Start new bugfix
+- **`q`/`quick-fix`** — Start new quick-fix
 - **`c`/`cross-cutting`** — Start new cross-cutting concern
 @if(has_inbox)
 - **`i`/`inbox`** — Start from an inbox item
@@ -120,11 +137,13 @@ Invoke the selected skill:
 |-----------|--------|
 | Continue feature | `/continue-feature {work_unit}` |
 | Continue bugfix | `/continue-bugfix {work_unit}` |
+| Continue quick-fix | `/continue-quickfix {work_unit}` |
 | Continue cross-cutting | `/continue-cross-cutting {work_unit}` |
 | Continue epic | `/continue-epic {work_unit}` |
 | Start new feature | `/start-feature` |
 | Start new epic | `/start-epic` |
 | Start new bugfix | `/start-bugfix` |
+| Start new quick-fix | `/start-quickfix` |
 | Start new cross-cutting | `/start-cross-cutting` |
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -27,6 +27,7 @@ What would you like to start?
 - **`f`/`feature`** — Add functionality to an existing product
 - **`e`/`epic`** — Large initiative, multi-topic, multi-session
 - **`b`/`bugfix`** — Fix broken behavior
+- **`q`/`quick-fix`** — Trivially scoped mechanical change
 - **`c`/`cross-cutting`** — Define patterns or policies that inform features
 @if(has_inbox)
 - **`i`/`inbox`** — Start from an inbox item ({inbox_count} items)
@@ -47,7 +48,7 @@ Select an option:
 
 → Return to caller.
 
-#### If user chose `f`/`feature`, `e`/`epic`, `b`/`bugfix`, or `c`/`cross-cutting`
+#### If user chose `f`/`feature`, `e`/`epic`, `b`/`bugfix`, `q`/`quick-fix`, or `c`/`cross-cutting`
 
 Invoke the selected skill:
 
@@ -56,6 +57,7 @@ Invoke the selected skill:
 | Feature | `/start-feature` |
 | Epic | `/start-epic` |
 | Bugfix | `/start-bugfix` |
+| Quick-fix | `/start-quickfix` |
 | Cross-cutting | `/start-cross-cutting` |
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -27,6 +27,13 @@ Bugfixes:
 @endforeach
 @endif
 
+@if(quickfix_count > 0)
+Quick Fixes:
+@foreach(unit in quick_fixes.work_units)
+  {N}. {unit.name:(titlecase)}
+@endforeach
+@endif
+
 @if(cross_cutting_count > 0)
 Cross-Cutting:
 @foreach(unit in cross_cutting.work_units)

--- a/skills/workflow-start/references/start-from-inbox.md
+++ b/skills/workflow-start/references/start-from-inbox.md
@@ -18,7 +18,7 @@ Inbox
 @endforeach
 ```
 
-Build a numbered list combining all ideas and bugs, sorted by date (oldest first). Each shows title, type (idea/bug), and date.
+Build a numbered list combining all ideas, bugs, and quick-fixes, sorted by date (oldest first). Each shows title, type (idea/bug/quick-fix), and date.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -47,6 +47,14 @@ Read the full content of the selected inbox file.
 Invoke `/start-bugfix` with the inbox file path as positional argument:
 
 `/start-bugfix .workflows/.inbox/bugs/{file}`
+
+This skill ends. The invoked skill handles archival. Terminal.
+
+#### If selected item is a quick-fix
+
+Invoke `/start-quickfix` with the inbox file path as positional argument:
+
+`/start-quickfix .workflows/.inbox/quickfixes/{file}`
 
 This skill ends. The invoked skill handles archival. Terminal.
 

--- a/skills/workflow-start/scripts/discovery.cjs
+++ b/skills/workflow-start/scripts/discovery.cjs
@@ -6,7 +6,7 @@ const { loadActiveManifests, loadAllManifests, phaseStatus, phaseItems, computeN
 
 const EPIC_PHASES = ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
 
-const ALL_PHASES = ['research', 'discussion', 'investigation', 'specification', 'planning', 'implementation', 'review'];
+const ALL_PHASES = ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
 
 function lastCompletedPhase(manifest) {
   let last = null;
@@ -46,8 +46,9 @@ function discoverInbox(cwd) {
   const inboxDir = path.join(cwd, '.workflows', '.inbox');
   const ideas = [];
   const bugs = [];
+  const quickfixes = [];
 
-  for (const type of ['ideas', 'bugs']) {
+  for (const type of ['ideas', 'bugs', 'quickfixes']) {
     const dir = path.join(inboxDir, type);
     let files;
     try {
@@ -61,16 +62,19 @@ function discoverInbox(cwd) {
       const title = readTitle(path.join(dir, f)) || parsed.slug;
       const item = { slug: parsed.slug, date: parsed.date, title, file: f };
       if (type === 'ideas') ideas.push(item);
-      else bugs.push(item);
+      else if (type === 'bugs') bugs.push(item);
+      else quickfixes.push(item);
     }
   }
 
   return {
     ideas,
     bugs,
+    quickfixes,
     idea_count: ideas.length,
     bug_count: bugs.length,
-    total_count: ideas.length + bugs.length,
+    quickfix_count: quickfixes.length,
+    total_count: ideas.length + bugs.length + quickfixes.length,
   };
 }
 
@@ -79,6 +83,7 @@ function discover(cwd) {
   const epics = [];
   const features = [];
   const bugfixes = [];
+  const quick_fixes = [];
   const cross_cutting = [];
 
   for (const m of manifests) {
@@ -104,6 +109,8 @@ function discover(cwd) {
       epics.push(unit);
     } else if (m.work_type === 'bugfix') {
       bugfixes.push(unit);
+    } else if (m.work_type === 'quick-fix') {
+      quick_fixes.push(unit);
     } else if (m.work_type === 'cross-cutting') {
       cross_cutting.push(unit);
     } else {
@@ -130,6 +137,7 @@ function discover(cwd) {
     epics: { work_units: epics, count: epics.length },
     features: { work_units: features, count: features.length },
     bugfixes: { work_units: bugfixes, count: bugfixes.length },
+    quick_fixes: { work_units: quick_fixes, count: quick_fixes.length },
     cross_cutting: { work_units: cross_cutting, count: cross_cutting.length },
     completed,
     cancelled,
@@ -137,10 +145,11 @@ function discover(cwd) {
     cancelled_count: cancelled.length,
     inbox,
     state: {
-      has_any_work: (epics.length + features.length + bugfixes.length + cross_cutting.length) > 0,
+      has_any_work: (epics.length + features.length + bugfixes.length + quick_fixes.length + cross_cutting.length) > 0,
       epic_count: epics.length,
       feature_count: features.length,
       bugfix_count: bugfixes.length,
+      quickfix_count: quick_fixes.length,
       cross_cutting_count: cross_cutting.length,
       has_inbox: inbox.total_count > 0,
       inbox_count: inbox.total_count,
@@ -169,6 +178,7 @@ function format(result) {
   emitSection('epics', result.epics.work_units);
   emitSection('features', result.features.work_units);
   emitSection('bugfixes', result.bugfixes.work_units);
+  emitSection('quick-fixes', result.quick_fixes.work_units);
   emitSection('cross-cutting', result.cross_cutting.work_units);
 
   if (result.completed.length > 0) {
@@ -191,18 +201,22 @@ function format(result) {
     lines.push('=== INBOX ===');
     lines.push(`  ideas: ${result.inbox.idea_count}`);
     lines.push(`  bugs: ${result.inbox.bug_count}`);
+    lines.push(`  quickfixes: ${result.inbox.quickfix_count}`);
     for (const item of result.inbox.ideas) {
       lines.push(`  ${item.slug} (idea, ${item.date})`);
     }
     for (const item of result.inbox.bugs) {
       lines.push(`  ${item.slug} (bug, ${item.date})`);
     }
+    for (const item of result.inbox.quickfixes) {
+      lines.push(`  ${item.slug} (quick-fix, ${item.date})`);
+    }
     lines.push('');
   }
 
   lines.push('=== STATE ===');
   lines.push(`has_any_work: ${result.state.has_any_work}`);
-  lines.push(`counts: ${result.state.epic_count} epic, ${result.state.feature_count} feature, ${result.state.bugfix_count} bugfix, ${result.state.cross_cutting_count} cross-cutting`);
+  lines.push(`counts: ${result.state.epic_count} epic, ${result.state.feature_count} feature, ${result.state.bugfix_count} bugfix, ${result.state.quickfix_count} quick-fix, ${result.state.cross_cutting_count} cross-cutting`);
   lines.push(`completed_count: ${result.completed_count}`);
   lines.push(`cancelled_count: ${result.cancelled_count}`);
   lines.push(`has_inbox: ${result.state.has_inbox}`);

--- a/tests/scripts/test-discovery-for-continue-quickfix.cjs
+++ b/tests/scripts/test-discovery-for-continue-quickfix.cjs
@@ -1,0 +1,162 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const { setupFixture, cleanupFixture, createManifest } = require('./discovery-test-utils.cjs');
+const { discover, format } = require('../../skills/continue-quickfix/scripts/discovery.cjs');
+
+describe('continue-quickfix discovery', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('returns empty when no quick-fixes exist', () => {
+    const r = discover(dir);
+    assert.strictEqual(r.count, 0);
+    assert.strictEqual(r.quick_fixes.length, 0);
+    assert.strictEqual(r.summary, 'no active quick-fixes');
+  });
+
+  it('lists active quick-fixes only', () => {
+    createManifest(dir, 'rename-api', { work_type: 'quick-fix', phases: { scoping: { items: { 'rename-api': { status: 'in-progress' } } } } });
+    createManifest(dir, 'old', { work_type: 'quick-fix', status: 'completed' });
+    const r = discover(dir);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.quick_fixes[0].name, 'rename-api');
+  });
+
+  it('excludes non-quick-fix work types', () => {
+    createManifest(dir, 'rename-api', { work_type: 'quick-fix', phases: { scoping: { items: { 'rename-api': { status: 'in-progress' } } } } });
+    createManifest(dir, 'auth', { work_type: 'feature' });
+    const r = discover(dir);
+    assert.strictEqual(r.count, 1);
+  });
+
+  it('excludes done quick-fixes', () => {
+    createManifest(dir, 'done', {
+      work_type: 'quick-fix',
+      phases: {
+        scoping: { items: { done: { status: 'completed' } } },
+        implementation: { items: { done: { status: 'completed' } } },
+        review: { items: { done: { status: 'completed' } } },
+      },
+    });
+    const r = discover(dir);
+    assert.strictEqual(r.count, 0);
+  });
+
+  it('includes completed_phases', () => {
+    createManifest(dir, 'rename-api', {
+      work_type: 'quick-fix',
+      phases: {
+        scoping: { items: { 'rename-api': { status: 'completed' } } },
+        implementation: { items: { 'rename-api': { status: 'in-progress' } } },
+      },
+    });
+    const r = discover(dir);
+    assert.deepStrictEqual(r.quick_fixes[0].completed_phases, ['scoping']);
+  });
+
+  it('returns summary with count', () => {
+    createManifest(dir, 'rename-api', { work_type: 'quick-fix', phases: { scoping: { items: { 'rename-api': { status: 'in-progress' } } } } });
+    createManifest(dir, 'update-deps', { work_type: 'quick-fix', phases: { implementation: { items: { 'update-deps': { status: 'in-progress' } } } } });
+    const r = discover(dir);
+    assert.strictEqual(r.summary, '2 active quick-fix(es)');
+  });
+
+  it('includes completed quick-fixes in separate array', () => {
+    createManifest(dir, 'done', { work_type: 'quick-fix', status: 'completed', phases: { review: { items: { done: { status: 'completed' } } } } });
+    createManifest(dir, 'active', { work_type: 'quick-fix', phases: { scoping: { items: { active: { status: 'in-progress' } } } } });
+    const r = discover(dir);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.completed_count, 1);
+    assert.strictEqual(r.completed[0].name, 'done');
+    assert.strictEqual(r.completed[0].last_phase, 'review');
+  });
+
+  it('includes cancelled quick-fixes in separate array', () => {
+    createManifest(dir, 'stopped', { work_type: 'quick-fix', status: 'cancelled', phases: { scoping: { items: { stopped: { status: 'completed' } } } } });
+    const r = discover(dir);
+    assert.strictEqual(r.cancelled_count, 1);
+    assert.strictEqual(r.cancelled[0].name, 'stopped');
+    assert.strictEqual(r.cancelled[0].last_phase, 'scoping');
+  });
+
+  describe('edge cases', () => {
+    it('completed_phases includes all three pipeline phases when completed', () => {
+      createManifest(dir, 'qf', {
+        work_type: 'quick-fix',
+        phases: {
+          scoping: { items: { qf: { status: 'completed' } } },
+          implementation: { items: { qf: { status: 'completed' } } },
+          review: { items: { qf: { status: 'in-progress' } } },
+        },
+      });
+      const r = discover(dir);
+      assert.deepStrictEqual(r.quick_fixes[0].completed_phases, ['scoping', 'implementation']);
+    });
+
+    it('quick-fix in review in-progress is listed (not filtered as done)', () => {
+      createManifest(dir, 'qf', {
+        work_type: 'quick-fix',
+        phases: {
+          scoping: { items: { qf: { status: 'completed' } } },
+          implementation: { items: { qf: { status: 'completed' } } },
+          review: { items: { qf: { status: 'in-progress' } } },
+        },
+      });
+      const r = discover(dir);
+      assert.strictEqual(r.count, 1);
+      assert.strictEqual(r.quick_fixes[0].next_phase, 'review');
+    });
+
+    it('discussion is not in quick-fix completed_phases even if present', () => {
+      createManifest(dir, 'qf', {
+        work_type: 'quick-fix',
+        phases: {
+          discussion: { items: { qf: { status: 'completed' } } },
+          scoping: { items: { qf: { status: 'in-progress' } } },
+        },
+      });
+      const r = discover(dir);
+      assert.ok(!r.quick_fixes[0].completed_phases.includes('discussion'));
+    });
+  });
+});
+
+describe('continue-quickfix format', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('includes header with count', () => {
+    const out = format(discover(dir));
+    assert.ok(out.includes('=== QUICK-FIXES (0) ==='));
+  });
+
+  it('includes summary', () => {
+    const out = format(discover(dir));
+    assert.ok(out.includes('summary: no active quick-fixes'));
+  });
+
+  it('includes quick-fix with phase_label and completed_phases', () => {
+    createManifest(dir, 'rename-api', {
+      work_type: 'quick-fix',
+      phases: {
+        scoping: { items: { 'rename-api': { status: 'completed' } } },
+        implementation: { items: { 'rename-api': { status: 'in-progress' } } },
+      },
+    });
+    const out = format(discover(dir));
+    assert.ok(out.includes('  rename-api: implementation (in-progress) [completed: scoping]'));
+  });
+
+  it('shows none for empty completed_phases', () => {
+    createManifest(dir, 'rename-api', {
+      work_type: 'quick-fix',
+      phases: { scoping: { items: { 'rename-api': { status: 'in-progress' } } } },
+    });
+    const out = format(discover(dir));
+    assert.ok(out.includes('[completed: none]'));
+  });
+});

--- a/tests/scripts/test-discovery-for-start.cjs
+++ b/tests/scripts/test-discovery-for-start.cjs
@@ -153,6 +153,55 @@ describe('workflow-start discovery', () => {
     assert.strictEqual(r.state.has_any_work, false);
   });
 
+  it('groups quick-fix work units separately', () => {
+    createManifest(dir, 'rename-api', { work_type: 'quick-fix' });
+    createManifest(dir, 'auth', { work_type: 'feature' });
+    const r = discover(dir);
+    assert.strictEqual(r.state.quickfix_count, 1);
+    assert.strictEqual(r.quick_fixes.work_units[0].name, 'rename-api');
+    assert.strictEqual(r.state.feature_count, 1);
+    assert.strictEqual(r.state.has_any_work, true);
+  });
+
+  it('quick-fix includes phase_label', () => {
+    createManifest(dir, 'rename-api', {
+      work_type: 'quick-fix',
+      phases: { scoping: { items: { 'rename-api': { status: 'in-progress' } } } },
+    });
+    const r = discover(dir);
+    assert.strictEqual(r.quick_fixes.work_units[0].phase_label, 'scoping (in-progress)');
+  });
+
+  it('quick-fix done is excluded from active', () => {
+    createManifest(dir, 'done-qf', {
+      work_type: 'quick-fix',
+      phases: {
+        scoping: { items: { 'done-qf': { status: 'completed' } } },
+        implementation: { items: { 'done-qf': { status: 'completed' } } },
+        review: { items: { 'done-qf': { status: 'completed' } } },
+      },
+    });
+    const r = discover(dir);
+    assert.strictEqual(r.quick_fixes.count, 0);
+  });
+
+  it('discovers inbox quickfixes', () => {
+    createFile(dir, '.workflows/.inbox/quickfixes/2026-03-28--replace-interface.md', '# Replace Interface\n\nContent.');
+    const r = discover(dir);
+    assert.strictEqual(r.inbox.quickfix_count, 1);
+    assert.strictEqual(r.inbox.quickfixes[0].slug, 'replace-interface');
+    assert.strictEqual(r.inbox.quickfixes[0].date, '2026-03-28');
+    assert.strictEqual(r.inbox.quickfixes[0].title, 'Replace Interface');
+  });
+
+  it('includes quickfixes in inbox total_count', () => {
+    createFile(dir, '.workflows/.inbox/ideas/2026-03-19--idea.md', '# Idea\n\nContent.');
+    createFile(dir, '.workflows/.inbox/quickfixes/2026-03-28--qf.md', '# QF\n\nContent.');
+    const r = discover(dir);
+    assert.strictEqual(r.inbox.total_count, 2);
+    assert.strictEqual(r.state.inbox_count, 2);
+  });
+
   it('groups cross-cutting work units separately', () => {
     createManifest(dir, 'caching', { work_type: 'cross-cutting', phases: { discussion: { items: { caching: { status: 'in-progress' } } } } });
     createManifest(dir, 'auth', { work_type: 'feature' });
@@ -307,6 +356,7 @@ describe('workflow-start format', () => {
     assert.ok(out.includes('=== EPICS ==='));
     assert.ok(out.includes('=== FEATURES ==='));
     assert.ok(out.includes('=== BUGFIXES ==='));
+    assert.ok(out.includes('=== QUICK-FIXES ==='));
     assert.ok(out.includes('=== CROSS-CUTTING ==='));
     assert.ok(out.includes('=== STATE ==='));
   });
@@ -345,7 +395,7 @@ describe('workflow-start format', () => {
   it('includes counts in state', () => {
     createManifest(dir, 'auth', { work_type: 'feature' });
     const out = format(discover(dir));
-    assert.ok(out.includes('counts: 0 epic, 1 feature, 0 bugfix, 0 cross-cutting'));
+    assert.ok(out.includes('counts: 0 epic, 1 feature, 0 bugfix, 0 quick-fix, 0 cross-cutting'));
   });
 
   it('includes completed_count and cancelled_count', () => {
@@ -382,15 +432,18 @@ describe('workflow-start format', () => {
     assert.ok(!out.includes('=== CANCELLED ==='));
   });
 
-  it('emits inbox section with ideas and bugs', () => {
+  it('emits inbox section with ideas, bugs, and quickfixes', () => {
     createFile(dir, '.workflows/.inbox/ideas/2026-03-19--smart-retry.md', '# Smart Retry\n\nContent.');
     createFile(dir, '.workflows/.inbox/bugs/2026-03-18--login-timeout.md', '# Login Timeout\n\nContent.');
+    createFile(dir, '.workflows/.inbox/quickfixes/2026-03-28--rename-api.md', '# Rename API\n\nContent.');
     const out = format(discover(dir));
     assert.ok(out.includes('=== INBOX ==='));
     assert.ok(out.includes('  ideas: 1'));
     assert.ok(out.includes('  bugs: 1'));
+    assert.ok(out.includes('  quickfixes: 1'));
     assert.ok(out.includes('  smart-retry (idea, 2026-03-19)'));
     assert.ok(out.includes('  login-timeout (bug, 2026-03-18)'));
+    assert.ok(out.includes('  rename-api (quick-fix, 2026-03-28)'));
   });
 
   it('omits inbox section when empty', () => {

--- a/tests/scripts/test-discovery-utils.cjs
+++ b/tests/scripts/test-discovery-utils.cjs
@@ -545,6 +545,70 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.next_phase, 'review');
     });
 
+    it('quick-fix: returns scoping for fresh quick-fix', () => {
+      const r = computeNextPhase({ work_type: 'quick-fix', phases: {} });
+      assert.strictEqual(r.next_phase, 'scoping');
+      assert.strictEqual(r.phase_label, 'ready for scoping');
+    });
+
+    it('quick-fix: returns in-progress scoping', () => {
+      const r = computeNextPhase({ work_type: 'quick-fix', phases: { scoping: { items: { test: { status: 'in-progress' } } } } });
+      assert.strictEqual(r.next_phase, 'scoping');
+      assert.strictEqual(r.phase_label, 'scoping (in-progress)');
+    });
+
+    it('quick-fix: returns implementation when scoping completed', () => {
+      const r = computeNextPhase({ work_type: 'quick-fix', phases: { scoping: { items: { test: { status: 'completed' } } } } });
+      assert.strictEqual(r.next_phase, 'implementation');
+      assert.strictEqual(r.phase_label, 'ready for implementation');
+    });
+
+    it('quick-fix: returns in-progress implementation', () => {
+      const r = computeNextPhase({ work_type: 'quick-fix', phases: {
+        scoping: { items: { test: { status: 'completed' } } },
+        implementation: { items: { test: { status: 'in-progress' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'implementation');
+      assert.strictEqual(r.phase_label, 'implementation (in-progress)');
+    });
+
+    it('quick-fix: returns review when implementation completed', () => {
+      const r = computeNextPhase({ work_type: 'quick-fix', phases: {
+        scoping: { items: { test: { status: 'completed' } } },
+        implementation: { items: { test: { status: 'completed' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'review');
+      assert.strictEqual(r.phase_label, 'ready for review');
+    });
+
+    it('quick-fix: returns in-progress review', () => {
+      const r = computeNextPhase({ work_type: 'quick-fix', phases: {
+        scoping: { items: { test: { status: 'completed' } } },
+        implementation: { items: { test: { status: 'completed' } } },
+        review: { items: { test: { status: 'in-progress' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'review');
+      assert.strictEqual(r.phase_label, 'review (in-progress)');
+    });
+
+    it('quick-fix: returns done when review completed', () => {
+      const r = computeNextPhase({ work_type: 'quick-fix', phases: {
+        scoping: { items: { test: { status: 'completed' } } },
+        implementation: { items: { test: { status: 'completed' } } },
+        review: { items: { test: { status: 'completed' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'done');
+      assert.strictEqual(r.phase_label, 'pipeline complete');
+    });
+
+    it('quick-fix: does not fall through to discussion/spec phases', () => {
+      const r = computeNextPhase({ work_type: 'quick-fix', phases: {
+        discussion: { items: { test: { status: 'completed' } } },
+      } });
+      // Should still return scoping, not specification
+      assert.strictEqual(r.next_phase, 'scoping');
+    });
+
     it('epic: all items have no status falls back to null', () => {
       const r = computeNextPhase({
         work_type: 'epic',


### PR DESCRIPTION
## Summary

- **New `quick-fix` work type** with pipeline Scoping → Implementation → (Review) for trivially scoped mechanical changes (find-and-replace, syntax updates, API renames)
- **Scoping phase** combines context gathering, specification, and planning into a single pass — produces 1-2 tasks directly without agents or review cycles. Includes complexity check that promotes to feature/bugfix if the change is more involved than expected
- **Verification workflow** replaces TDD for mechanical changes (BASELINE → CHANGE → VERIFY → LINT). Executor and reviewer agents adapted polymorphically based on work type
- **Full infrastructure**: manifest schema, `computeNextPhase()` routing, global/bridge/continue discovery, inbox capture (`workflow-log-quickfix`), start/continue entry skills, bridge continuation, dashboard menus, and documentation

### Files: 20 new, 14 modified

## Test plan

- [ ] Verify `node skills/workflow-manifest/scripts/manifest.cjs init test-qf --work-type quick-fix --description "test"` succeeds
- [ ] Verify `computeNextPhase()` routes quick-fix through scoping → implementation → review → done
- [ ] Verify `node skills/workflow-start/scripts/discovery.cjs` shows quick-fix section
- [ ] Verify `node skills/continue-quickfix/scripts/discovery.cjs` lists active quick-fixes
- [ ] Verify bridge discovery includes scoping phase
- [ ] End-to-end: `/start-quickfix` → scoping → spec+plan artifacts created → implementation uses verification workflow


🤖 Generated with [Claude Code](https://claude.com/claude-code)