### PR TITLE
feat: user guidance and signposting conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,23 +303,15 @@ Rules:
 Guidance text rendered as markdown blockquotes. Used for phase entry context, pre-step guidance, post-phase closure, and explaining blockers or gates. Never for status data or interactive choices.
 
 ```
-> **Entering Specification.** Your completed discussions will be synthesised
-> into a formal spec. Expect questions about gaps, contradictions, and
-> missing edge cases. The output is a standalone document that drives planning.
-```
-
-Plain text example (most step signposts):
-
-```
-> Reading the handoff context to identify which
-> topic to implement.
+> Your completed discussions will be synthesised into a formal spec.
+> Expect questions about gaps, contradictions, and missing edge cases.
+> The output is a standalone document that drives planning.
 ```
 
 Rules:
 - Rendered as markdown (use the markdown rendering instruction)
 - **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~70 characters per line (including the `> ` prefix) to keep the blockquote visually intact
-- **Bold is optional and rare.** Most blockquotes should be plain text — the blockquote styling (indented, dimmed) already sets them apart. Use a short bold lead phrase (3-5 words) only when the blockquote has a distinct label + description pattern (e.g., `**Entering Specification.** Your discussions will be...`). Step signposts that are just a sentence of description should not be bold
-- If bold spans multiple lines, each line must have its own `**` open and close — bold does not carry across `>` prefixed line breaks
+- **Plain text only** — no bold. The blockquote styling (indented, dimmed) already sets signposts apart visually. If bold is ever needed on multiple lines, each line must have its own `**` open and close — bold does not carry across `>` prefixed line breaks
 - Lead phrases are freeform — no fixed vocabulary, chosen to fit the context
 - 1-3 sentences maximum — never compete with the actual content
 - Placement: after phase titles, before menus where context helps the decision, at phase transitions, explaining soft gates or blockers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,14 +245,14 @@ Bullet-bordered box. One per skill invocation. Serves as the top-level anchor te
 
 ```
 ●───────────────────────────────────────────────●
-  Specification
+  Specification Overview
 ●───────────────────────────────────────────────●
 ```
 
 Rules:
 - Fixed width: 49 characters total (● + 47 em-dashes + ●)
 - 2-space left padding on the title text
-- Title text is the phase or context name — no "Overview" suffix
+- Title text is the phase or context name (e.g., "Workflow Overview", "Planning Overview")
 - One blank line after the closing border before any content
 - **Must be inside a code block** — never markdown. Code blocks preserve the indentation and whitespace that the border layout depends on. Markdown rendering would collapse the spacing and break the layout
 
@@ -534,7 +534,7 @@ When a phase can't proceed — use the phase title at the top, then explain:
 
 ```
 ●───────────────────────────────────────────────●
-  Planning
+  Planning Overview
 ●───────────────────────────────────────────────●
 
 No specification found in .workflows/{work_unit}/specification/{topic}/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,7 +333,7 @@ The `workflow-start` skill uses an ASCII art banner as the entry point. It uses 
 |__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
 
 ●─────────────────────────────────────────────────────────────────●
-Agentic engineering workflows — from idea to implementation.
+  Agentic engineering workflows — from idea to implementation.
 ●─────────────────────────────────────────────────────────────────●
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ Rules:
 - **No step numbers** — steps may be skipped based on conditionals and routing is non-linear. Names alone are sufficient
 - Loop iterations shown in parentheses: `(cycle N)`, `(N of M)`
 - Route-back uses `Returning to {Name}`
-- Rendered as a single-line code block with its own rendering instruction
+- Rendered as a code block with its own rendering instruction. Include a trailing blank line after the marker inside the code block for breathing room
 
 ### Sub-step Markers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,7 @@ Guidance text rendered as markdown blockquotes. Used for phase entry context, pr
 
 Rules:
 - Rendered as markdown (use the markdown rendering instruction)
+- **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~50 characters per line to keep the blockquote visually intact
 - Bold lead phrase sets context: `**Entering Specification.**`, `**Heads up:**`, `**Blocked:**`, `**Specification complete.**`
 - Lead phrases are freeform — no fixed vocabulary, chosen to fit the context
 - 1-3 sentences maximum — never compete with the actual content

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ Rules:
 - One blank line after the closing border before any content
 - Rendered as a code block with its own rendering instruction
 
-Phase titles replace the old plain-text title pattern. Status displays that previously opened with a title line (e.g., `Planning Overview`) now use a separate phase title block above the status code block.
+Phase titles replace the old plain-text title pattern. Status displays that previously opened with a title line (e.g., `Planning Overview`) now use the phase title at the top of the same code block, followed by a blank line before the content.
 
 ### Step Markers
 
@@ -530,14 +530,13 @@ Automatically proceeding with "{topic:(titlecase)}".
 
 ### Block / Terminal Messages
 
-When a phase can't proceed — use the phase title, then explain in a separate code block:
+When a phase can't proceed — use the phase title at the top, then explain:
 
 ```
 ●───────────────────────────────────────────────●
   Planning
 ●───────────────────────────────────────────────●
-```
-```
+
 No specification found in .workflows/{work_unit}/specification/{topic}/
 
 The planning phase requires a completed specification.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ Rules:
 - 2-space left padding on the title text
 - Title text is the phase or context name — no "Overview" suffix
 - One blank line after the closing border before any content
-- Rendered as a code block with its own rendering instruction
+- **Must be inside a code block** — never markdown. Code blocks preserve the indentation and whitespace that the border layout depends on. Markdown rendering would collapse the spacing and break the layout
 
 Phase titles replace the old plain-text title pattern. Status displays that previously opened with a title line (e.g., `Planning Overview`) now use the phase title at the top of the same code block, followed by a blank line before the content.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,20 @@ The manifest CLI at `skills/workflow-manifest/scripts/manifest.cjs` is the singl
 
 These are hard rules, not suggestions. All entry-point skills that present discovery state, menus, or interactive choices MUST follow these conventions exactly. When writing or editing skill files, read existing skills and references as working examples — they are the authoritative demonstration of these rules in practice.
 
+### Visual Hierarchy
+
+All user-facing output uses five distinct visual tiers, each with a specific purpose. From heaviest to lightest:
+
+| Tier | Element | Purpose | Rendering |
+|------|---------|---------|-----------|
+| 1 | Phase title | "Where am I" — top-level anchor | Code block |
+| 2 | Signpost blockquote | "What's happening" — guidance, context, closure | Markdown |
+| 3 | Step marker | Progress through the phase | Code block |
+| 4 | Sub-step marker | Progress within a step | Code block |
+| 5 | Status / menu | Data displays and interactive choices | Code block / markdown |
+
+Every skill invocation should produce at most one phase title. Step markers appear at each step boundary. Signpost blockquotes appear at phase entry, before steps where context helps, and at phase completion. Status displays and menus are unchanged from existing conventions.
+
 ### Rendering Instructions
 
 Every **user-facing output** fenced block in skill files must be preceded by a rendering instruction. Fenced blocks that are model instructions (bash commands to execute, file paths to load) are exempt — they are not displayed to the user.
@@ -223,17 +237,106 @@ or:
 > *Output the next fenced block as markdown (not a code block):*
 ```
 
-Code blocks are used for informational displays (overviews, status, keys) — they preserve indentation for tree structures and aligned lists. Markdown is used for interactive elements (menus, prompts) where bold formatting is needed. When content benefits from rendered formatting (headings, checkboxes, bold) and indentation control isn't needed, prefer markdown rendering even for informational displays.
+Code blocks are used for informational displays (overviews, status, keys, phase titles, step markers) — they preserve indentation for tree structures and aligned lists. Markdown is used for interactive elements (menus, prompts) and signpost blockquotes where bold formatting is needed. When content benefits from rendered formatting (headings, checkboxes, bold) and indentation control isn't needed, prefer markdown rendering even for informational displays.
 
-### Title Pattern
+### Phase Titles
 
-Always `{Phase} Overview` as the first line of the opening code block, followed by a blank line and a summary sentence.
+Bullet-bordered box. One per skill invocation. Serves as the top-level anchor telling the user where they are. Always followed by a blank line before any subsequent content.
 
 ```
-Planning Overview
-
-4 specifications found. 2 plans exist.
+●───────────────────────────────────────────────●
+  Specification
+●───────────────────────────────────────────────●
 ```
+
+Rules:
+- Fixed width: 49 characters total (● + 47 em-dashes + ●)
+- 2-space left padding on the title text
+- Title text is the phase or context name — no "Overview" suffix
+- One blank line after the closing border before any content
+- Rendered as a code block with its own rendering instruction
+
+Phase titles replace the old plain-text title pattern. Status displays that previously opened with a title line (e.g., `Planning Overview`) now use a separate phase title block above the status code block.
+
+### Step Markers
+
+Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width.
+
+```
+── Step 3: Construct Specification ──────────────────
+```
+
+Variations for loops and routing:
+
+```
+── Step 4: Task Execution (3 of 12) ─────────────────
+── Step 5: Review (cycle 2) ─────────────────────────
+── Returning to Step 2: Discussion Session ──────────
+```
+
+Rules:
+- Always `── ` (two em-dashes + space) on the left
+- Right side padded with em-dashes to ~55 characters total
+- Step numbers match the skill file's internal step numbering
+- Loop iterations shown in parentheses: `(cycle N)`, `(N of M)`
+- Route-back uses `Returning to Step N: Name`
+- Rendered as a single-line code block with its own rendering instruction
+
+### Sub-step Markers
+
+Dot-framed markers for stages within a step. Visually lighter than step markers to indicate nesting.
+
+```
+·· Step 3a: Extract Sources ·························
+```
+
+Rules:
+- Always `·· ` (two middle dots + space) on the left
+- Right side padded with middle dots to ~55 characters total
+- Lettered suffixes: `3a`, `3b`, `3c` matching the parent step
+- Same loop/iteration conventions as step markers
+- Rendered as a single-line code block with its own rendering instruction
+
+### Signpost Blockquotes
+
+Guidance text rendered as markdown blockquotes. Used for phase entry context, pre-step guidance, post-phase closure, and explaining blockers or gates. Never for status data or interactive choices.
+
+```
+> **Entering Specification.** Your completed discussions will be synthesised
+> into a formal spec. Expect questions about gaps, contradictions, and
+> missing edge cases. The output is a standalone document that drives planning.
+```
+
+Rules:
+- Rendered as markdown (use the markdown rendering instruction)
+- Bold lead phrase sets context: `**Entering Specification.**`, `**Heads up:**`, `**Blocked:**`, `**Specification complete.**`
+- Lead phrases are freeform — no fixed vocabulary, chosen to fit the context
+- 1-3 sentences maximum — never compete with the actual content
+- Placement: after phase titles, before menus where context helps the decision, at phase transitions, explaining soft gates or blockers
+- Never between two code blocks that are part of the same logical display
+
+### Workflow Banner
+
+The `workflow-start` skill uses an ASCII art banner as the entry point. It uses the same bullet-border convention as phase titles, widened to accommodate the art:
+
+```
+●─────────────────────────────────────────────────────────────────●
+    ___   _____________   __________________
+   /   | / ____/ ____/ | / /_  __/  _/ ____/
+  / /| |/ / __/ __/ /  |/ / / /  / // /
+ / ___ / /_/ / /___/ /|  / / / _/ // /___
+/_/  |_\____/_____/_/ |_/ /_/ /___/\____/
+ _       ______  ____  __ __ ________    ____ _       _______
+| |     / / __ \/ __ \/ //_// ____/ /   / __ \ |     / / ___/
+| | /| / / / / / /_/ / ,<  / /_  / /   / / / / | /| / /\__ \
+| |/ |/ / /_/ / _, _/ /| |/ __/ / /___/ /_/ /| |/ |/ /___/ /
+|__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
+
+  Agentic engineering workflows — from idea to implementation.
+●─────────────────────────────────────────────────────────────────●
+```
+
+This is the only exception to the fixed-width phase title rule — the banner is wider to fit the ASCII art.
 
 ### Template Placeholders
 
@@ -427,11 +530,14 @@ Automatically proceeding with "{topic:(titlecase)}".
 
 ### Block / Terminal Messages
 
-When a phase can't proceed — use the phase title pattern, then explain:
+When a phase can't proceed — use the phase title, then explain in a separate code block:
 
 ```
-Planning Overview
-
+●───────────────────────────────────────────────●
+  Planning
+●───────────────────────────────────────────────●
+```
+```
 No specification found in .workflows/{work_unit}/specification/{topic}/
 
 The planning phase requires a completed specification.
@@ -443,13 +549,12 @@ Use `•` for all bulleted lists (sources, files, not-ready items, etc.).
 
 ### Spacing Rules
 
-Inside code blocks, maintain **one blank line** between:
-- Title/summary and first content
+**Between blocks**: One blank line after the phase title closing border before any content (code block, blockquote, or step marker). No `---` separators between code blocks (overview → not-ready → key → menu) — just natural block separation.
+
+**Inside code blocks**: One blank line between:
 - Each numbered tree item
 - Section headings and their content
 - Key categories
-
-Between code blocks (overview → not-ready → key → menu), no `---` separators — just the natural block separation.
 
 ## Structural Conventions (MANDATORY)
 
@@ -488,6 +593,7 @@ Sequential: `## Step 0`, `## Step 1`, `## Step 2`, etc.
 - **Step 0** runs migrations via the `/workflow-migrate` skill (mandatory in all entry-point skills)
 - Steps are separated by `---` horizontal rules
 - Each step completes fully before the next begins
+- User-facing step markers (see Display & Output Conventions → Step Markers) are embedded at each step boundary in the skill file — never instructed once at the top
 
 ### Conditional Routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Guidance text rendered as markdown blockquotes. Used for phase entry context, pr
 
 Rules:
 - Rendered as markdown (use the markdown rendering instruction)
-- **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~65 characters per line (after the `> `) to keep the blockquote visually intact
+- **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~70 characters per line (including the `> ` prefix) to keep the blockquote visually intact
 - Bold lead phrase sets context: `**Entering Specification.**`, `**Heads up:**`, `**Blocked:**`, `**Specification complete.**`
 - Lead phrases are freeform — no fixed vocabulary, chosen to fit the context
 - 1-3 sentences maximum — never compete with the actual content

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,13 +247,14 @@ Bullet-bordered box. One per skill invocation. Serves as the top-level anchor te
 ●───────────────────────────────────────────────●
   Specification Overview
 ●───────────────────────────────────────────────●
+
 ```
 
 Rules:
 - Fixed width: 49 characters total (● + 47 em-dashes + ●)
 - 2-space left padding on the title text
 - Title text is the phase or context name (e.g., "Workflow Overview", "Planning Overview")
-- One blank line after the closing border before any content
+- Include a trailing blank line after the closing border inside the code block — this creates visual breathing room in the rendered output
 - **Must be inside a code block** — never markdown. Code blocks preserve the indentation and whitespace that the border layout depends on. Markdown rendering would collapse the spacing and break the layout
 
 Phase titles replace the old plain-text title pattern. Status displays that previously opened with a title line (e.g., `Planning Overview`) now use the phase title at the top of the same code block, followed by a blank line before the content.
@@ -263,20 +264,20 @@ Phase titles replace the old plain-text title pattern. Status displays that prev
 Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width. Every step in a skill gets a marker, even if the step has no explicit output — Claude's visible processing (reading files, running commands, thinking) IS the user experience, and the marker labels that activity. Every step marker must be followed by a signpost blockquote explaining what the step does and why — the marker names the step, the signpost explains it.
 
 ```
-── Construct Specification ──────────────────────────
+── Construct Specification ─────────────────────
 ```
 
 Variations for loops and routing:
 
 ```
-── Task Execution (3 of 12) ─────────────────────────
-── Review (cycle 2) ─────────────────────────────────
-── Returning to Discussion Session ──────────────────
+── Task Execution (3 of 12) ────────────────────
+── Review (cycle 2) ────────────────────────────
+── Returning to Discussion Session ─────────────
 ```
 
 Rules:
 - Always `── ` (two em-dashes + space) on the left
-- Right side padded with em-dashes to ~55 characters total
+- Right side padded with em-dashes to 49 characters total — aligned with phase title width
 - **No step numbers** — steps may be skipped based on conditionals and routing is non-linear. Names alone are sufficient
 - Loop iterations shown in parentheses: `(cycle N)`, `(N of M)`
 - Route-back uses `Returning to {Name}`
@@ -287,12 +288,12 @@ Rules:
 Dot-framed markers for stages within a step. Visually lighter than step markers to indicate nesting.
 
 ```
-·· Extract Sources ··································
+·· Extract Sources ·································
 ```
 
 Rules:
 - Always `·· ` (two middle dots + space) on the left
-- Right side padded with middle dots to ~55 characters total
+- Right side padded with middle dots to 49 characters total — aligned with phase title and step marker width
 - Named only — no numbering or lettered suffixes
 - Same loop/iteration conventions as step markers
 - Rendered as a single-line code block with its own rendering instruction

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,7 +332,8 @@ The `workflow-start` skill uses an ASCII art banner as the entry point. It uses 
 | |/ |/ / /_/ / _, _/ /| |/ __/ / /___/ /_/ /| |/ |/ /___/ /
 |__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
 
-  Agentic engineering workflows — from idea to implementation.
+●─────────────────────────────────────────────────────────────────●
+Agentic engineering workflows — from idea to implementation.
 ●─────────────────────────────────────────────────────────────────●
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Guidance text rendered as markdown blockquotes. Used for phase entry context, pr
 
 Rules:
 - Rendered as markdown (use the markdown rendering instruction)
-- **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~50 characters per line to keep the blockquote visually intact
+- **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~65 characters per line (after the `> `) to keep the blockquote visually intact
 - Bold lead phrase sets context: `**Entering Specification.**`, `**Heads up:**`, `**Blocked:**`, `**Specification complete.**`
 - Lead phrases are freeform — no fixed vocabulary, chosen to fit the context
 - 1-3 sentences maximum — never compete with the actual content

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@ All user-facing output uses five distinct visual tiers, each with a specific pur
 | 4 | Sub-step marker | Progress within a step | Code block |
 | 5 | Status / menu | Data displays and interactive choices | Code block / markdown |
 
-Every skill invocation should produce at most one phase title. Step markers appear at each step boundary. Signpost blockquotes appear at phase entry, before steps where context helps, and at phase completion. Status displays and menus are unchanged from existing conventions.
+Every skill invocation should produce at most one phase title. Step markers appear at every step boundary — including steps with no explicit output, since Claude's visible processing (file reads, commands, thinking) is the user experience and the marker labels it. Signpost blockquotes appear at phase entry, before steps where context helps, and at phase completion. Status displays and menus are unchanged from existing conventions.
 
 ### Rendering Instructions
 
@@ -260,26 +260,26 @@ Phase titles replace the old plain-text title pattern. Status displays that prev
 
 ### Step Markers
 
-Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width.
+Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width. Every step in a skill gets a marker, even if the step has no explicit output — Claude's visible processing (reading files, running commands, thinking) IS the user experience, and the marker labels that activity.
 
 ```
-── Step 3: Construct Specification ──────────────────
+── Construct Specification ──────────────────────────
 ```
 
 Variations for loops and routing:
 
 ```
-── Step 4: Task Execution (3 of 12) ─────────────────
-── Step 5: Review (cycle 2) ─────────────────────────
-── Returning to Step 2: Discussion Session ──────────
+── Task Execution (3 of 12) ─────────────────────────
+── Review (cycle 2) ─────────────────────────────────
+── Returning to Discussion Session ──────────────────
 ```
 
 Rules:
 - Always `── ` (two em-dashes + space) on the left
 - Right side padded with em-dashes to ~55 characters total
-- Step numbers match the skill file's internal step numbering
+- **No step numbers** — steps may be skipped based on conditionals and routing is non-linear. Names alone are sufficient
 - Loop iterations shown in parentheses: `(cycle N)`, `(N of M)`
-- Route-back uses `Returning to Step N: Name`
+- Route-back uses `Returning to {Name}`
 - Rendered as a single-line code block with its own rendering instruction
 
 ### Sub-step Markers
@@ -287,13 +287,13 @@ Rules:
 Dot-framed markers for stages within a step. Visually lighter than step markers to indicate nesting.
 
 ```
-·· Step 3a: Extract Sources ·························
+·· Extract Sources ··································
 ```
 
 Rules:
 - Always `·· ` (two middle dots + space) on the left
 - Right side padded with middle dots to ~55 characters total
-- Lettered suffixes: `3a`, `3b`, `3c` matching the parent step
+- Named only — no numbering or lettered suffixes
 - Same loop/iteration conventions as step markers
 - Rendered as a single-line code block with its own rendering instruction
 
@@ -594,7 +594,7 @@ Sequential: `## Step 0`, `## Step 1`, `## Step 2`, etc.
 - **Step 0** runs migrations via the `/workflow-migrate` skill (mandatory in all entry-point skills)
 - Steps are separated by `---` horizontal rules
 - Each step completes fully before the next begins
-- User-facing step markers (see Display & Output Conventions → Step Markers) are embedded at each step boundary in the skill file — never instructed once at the top
+- User-facing step markers (see Display & Output Conventions → Step Markers) use names only — no numbers. They are embedded at each step boundary, including steps with no explicit output (Claude's visible processing labels the activity for the user)
 
 ### Conditional Routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,7 @@ Phase titles replace the old plain-text title pattern. Status displays that prev
 
 ### Step Markers
 
-Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width. Every step in a skill gets a marker, even if the step has no explicit output — Claude's visible processing (reading files, running commands, thinking) IS the user experience, and the marker labels that activity.
+Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width. Every step in a skill gets a marker, even if the step has no explicit output — Claude's visible processing (reading files, running commands, thinking) IS the user experience, and the marker labels that activity. Every step marker must be followed by a signpost blockquote explaining what the step does and why — the marker names the step, the signpost explains it.
 
 ```
 ── Construct Specification ──────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,6 +315,7 @@ Rules:
 - Lead phrases are freeform — no fixed vocabulary, chosen to fit the context
 - 1-3 sentences maximum — never compete with the actual content
 - Placement: after phase titles, before menus where context helps the decision, at phase transitions, explaining soft gates or blockers
+- Include a trailing blank line after the blockquote content inside the fenced block — this creates breathing room before whatever follows
 - Never between two code blocks that are part of the same logical display
 
 ### Workflow Banner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,10 +308,18 @@ Guidance text rendered as markdown blockquotes. Used for phase entry context, pr
 > missing edge cases. The output is a standalone document that drives planning.
 ```
 
+Plain text example (most step signposts):
+
+```
+> Reading the handoff context to identify which
+> topic to implement.
+```
+
 Rules:
 - Rendered as markdown (use the markdown rendering instruction)
 - **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~70 characters per line (including the `> ` prefix) to keep the blockquote visually intact
-- Bold lead phrase sets context: `**Entering Specification.**`, `**Heads up:**`, `**Blocked:**`, `**Specification complete.**`
+- **Bold is optional and rare.** Most blockquotes should be plain text — the blockquote styling (indented, dimmed) already sets them apart. Use a short bold lead phrase (3-5 words) only when the blockquote has a distinct label + description pattern (e.g., `**Entering Specification.** Your discussions will be...`). Step signposts that are just a sentence of description should not be bold
+- If bold spans multiple lines, each line must have its own `**` open and close — bold does not carry across `>` prefixed line breaks
 - Lead phrases are freeform — no fixed vocabulary, chosen to fit the context
 - 1-3 sentences maximum — never compete with the actual content
 - Placement: after phase titles, before menus where context helps the decision, at phase transitions, explaining soft gates or blockers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,7 @@ Rules:
 - **No step numbers** — steps may be skipped based on conditionals and routing is non-linear. Names alone are sufficient
 - Loop iterations shown in parentheses: `(cycle N)`, `(N of M)`
 - Route-back uses `Returning to {Name}`
-- Rendered as a code block with its own rendering instruction. Include a trailing blank line after the marker inside the code block for breathing room
+- Rendered as a code block with its own rendering instruction. No trailing blank line — natural block separation provides enough spacing
 
 ### Sub-step Markers
 
@@ -315,7 +315,7 @@ Rules:
 - Lead phrases are freeform — no fixed vocabulary, chosen to fit the context
 - 1-3 sentences maximum — never compete with the actual content
 - Placement: after phase titles, before menus where context helps the decision, at phase transitions, explaining soft gates or blockers
-- Include a trailing blank line after the blockquote content inside the fenced block — this creates breathing room before whatever follows
+- No trailing blank line inside the fenced block — natural block separation provides enough spacing
 - Never between two code blocks that are part of the same logical display
 
 ### Workflow Banner

--- a/skills/continue-bugfix/SKILL.md
+++ b/skills/continue-bugfix/SKILL.md
@@ -21,6 +21,27 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Continue Bugfix
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Running migrations to keep workflow files in sync.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
@@ -32,6 +53,18 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ---
 
 ## Step 1: Discovery State
+
+> *Output the next fenced block as a code block:*
+
+```
+── Run Discovery ────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Scanning for active bugfixes and their current progress.
+```
 
 !`node .claude/skills/continue-bugfix/scripts/discovery.cjs`
 
@@ -65,13 +98,23 @@ Parse the discovery output to understand:
 
 ## Step 2: Check Count and Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check State ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking if there are any bugfixes in progress.
+```
+
 #### If `count` is 0
 
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Bugfix
-
 No bugfixes in progress.
 
 Run /start-bugfix to begin a new one.
@@ -93,6 +136,18 @@ Store the work_unit.
 
 ## Step 3: Select Bugfix
 
+> *Output the next fenced block as a code block:*
+
+```
+── Select Bugfix ────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Showing your active bugfixes for selection.
+```
+
 Load **[select-bugfix.md](references/select-bugfix.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -100,6 +155,18 @@ Load **[select-bugfix.md](references/select-bugfix.md)** and follow its instruct
 ---
 
 ## Step 4: Validate Selection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Selection ───────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Confirming the selected bugfix exists and is active.
+```
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
@@ -109,6 +176,18 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Backwards Navigation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check Progress ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking whether earlier phases are available to revisit.
+```
+
 Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -116,6 +195,18 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 ---
 
 ## Step 6: Route to Phase Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route to Phase ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the next phase for this bugfix.
+```
 
 Using the selected bugfix's `next_phase`, invoke the appropriate phase skill:
 

--- a/skills/continue-bugfix/references/select-bugfix.md
+++ b/skills/continue-bugfix/references/select-bugfix.md
@@ -11,8 +11,6 @@ Display active bugfixes and let the user select one.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Bugfix
-
 {count} bugfix(es) in progress:
 
 @foreach(bugfix in bugfixes)

--- a/skills/continue-bugfix/references/validate-selection.md
+++ b/skills/continue-bugfix/references/validate-selection.md
@@ -11,8 +11,6 @@ Validate the selected work unit against the discovery output and store its data.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Bugfix
-
 No active bugfix named "{work_unit}" found.
 
 Run /continue-bugfix to see available bugfixes, or /start-bugfix to begin a new one.

--- a/skills/continue-cross-cutting/SKILL.md
+++ b/skills/continue-cross-cutting/SKILL.md
@@ -21,6 +21,27 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Continue Cross-Cutting
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Running migrations to keep workflow files in sync.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
@@ -32,6 +53,18 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ---
 
 ## Step 1: Discovery State
+
+> *Output the next fenced block as a code block:*
+
+```
+── Run Discovery ────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Scanning for active cross-cutting concerns and their progress.
+```
 
 !`node .claude/skills/continue-cross-cutting/scripts/discovery.cjs`
 
@@ -65,13 +98,23 @@ Parse the discovery output to understand:
 
 ## Step 2: Check Count and Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check State ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking if there are any cross-cutting concerns in progress.
+```
+
 #### If `count` is 0
 
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Cross-Cutting
-
 No cross-cutting concerns in progress.
 
 Run /start-cross-cutting to begin a new one.
@@ -93,6 +136,18 @@ Store the work_unit.
 
 ## Step 3: Select Cross-Cutting Concern
 
+> *Output the next fenced block as a code block:*
+
+```
+── Select Concern ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Showing your active cross-cutting concerns for selection.
+```
+
 Load **[select-cross-cutting.md](references/select-cross-cutting.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -100,6 +155,18 @@ Load **[select-cross-cutting.md](references/select-cross-cutting.md)** and follo
 ---
 
 ## Step 4: Validate Selection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Selection ───────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Confirming the selected concern exists and is active.
+```
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
@@ -109,6 +176,18 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Backwards Navigation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check Progress ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking whether earlier phases are available to revisit.
+```
+
 Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -116,6 +195,18 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 ---
 
 ## Step 6: Route to Phase Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route to Phase ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the next phase for this concern.
+```
 
 Using the selected cross-cutting concern's `next_phase`, invoke the appropriate phase skill:
 

--- a/skills/continue-cross-cutting/references/select-cross-cutting.md
+++ b/skills/continue-cross-cutting/references/select-cross-cutting.md
@@ -11,8 +11,6 @@ Display active cross-cutting concerns and let the user select one.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Cross-Cutting
-
 {count} cross-cutting concern(s) in progress:
 
 @foreach(cc in cross_cutting)

--- a/skills/continue-cross-cutting/references/validate-selection.md
+++ b/skills/continue-cross-cutting/references/validate-selection.md
@@ -11,8 +11,6 @@ Validate the selected work unit against the discovery output and store its data.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Cross-Cutting
-
 No active cross-cutting concern named "{work_unit}" found.
 
 Run /continue-cross-cutting to see available concerns, or /start-cross-cutting to begin a new one.

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -113,7 +113,7 @@ Parse the discovery output to understand:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Checking how many epics are in progress.
+> Checking if there are any epics in progress.
 ```
 
 #### If `count` is 0

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -21,6 +21,27 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Continue Epic
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Running migrations to keep workflow files in sync.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
@@ -32,6 +53,18 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ---
 
 ## Step 1: Discovery State
+
+> *Output the next fenced block as a code block:*
+
+```
+── Run Discovery ────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Scanning for active epics and their current progress.
+```
 
 !`node .claude/skills/continue-epic/scripts/discovery.cjs`
 
@@ -71,13 +104,23 @@ Parse the discovery output to understand:
 
 ## Step 2: Check Count and Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check State ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking how many epics are in progress.
+```
+
 #### If `count` is 0
 
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Epic
-
 No epics in progress.
 
 Run /start-epic to begin a new one.
@@ -99,6 +142,18 @@ Store the work_unit.
 
 ## Step 3: Select Epic
 
+> *Output the next fenced block as a code block:*
+
+```
+── Select Epic ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Showing your active epics for selection.
+```
+
 Load **[select-epic.md](references/select-epic.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -106,6 +161,18 @@ Load **[select-epic.md](references/select-epic.md)** and follow its instructions
 ---
 
 ## Step 4: Validate Selection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Selection ───────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Confirming the selected epic exists and is active.
+```
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
@@ -115,6 +182,18 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Display State and Menu
 
+> *Output the next fenced block as a code block:*
+
+```
+── Display State and Menu ───────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Showing the full phase-by-phase breakdown and available actions.
+```
+
 Load **[epic-display-and-menu.md](references/epic-display-and-menu.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -122,6 +201,18 @@ Load **[epic-display-and-menu.md](references/epic-display-and-menu.md)** and fol
 ---
 
 ## Step 6: Route Selection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route Selection ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the selected phase for this epic.
+```
 
 Invoke the appropriate skill based on the user's menu selection:
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -19,7 +19,9 @@ This reference collects the user's selection and returns control to the caller. 
 > *Output the next fenced block as a code block:*
 
 ```
-{work_unit:(titlecase)}
+●───────────────────────────────────────────────●
+  {work_unit:(titlecase)}
+●───────────────────────────────────────────────●
 
 No work started yet.
 ```
@@ -31,7 +33,9 @@ No work started yet.
 > *Output the next fenced block as a code block:*
 
 ```
-{work_unit:(titlecase)}
+●───────────────────────────────────────────────●
+  {work_unit:(titlecase)}
+●───────────────────────────────────────────────●
 
 @foreach(phase in phases)
 @if(phase.items)

--- a/skills/continue-epic/references/select-epic.md
+++ b/skills/continue-epic/references/select-epic.md
@@ -11,8 +11,6 @@ Display active epics and let the user select one.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Epic
-
 {count} epic(s) in progress:
 
 @foreach(epic in epics)

--- a/skills/continue-epic/references/validate-selection.md
+++ b/skills/continue-epic/references/validate-selection.md
@@ -11,8 +11,6 @@ Validate the selected work unit against the discovery output and store its data.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Epic
-
 No active epic named "{work_unit}" found.
 
 Run /continue-epic to see available epics, or /start-epic to begin a new one.

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -107,7 +107,7 @@ Parse the discovery output to understand:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Checking how many features are in progress.
+> Checking if there are any features in progress.
 ```
 
 #### If `count` is 0

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -27,6 +27,14 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Continue Feature
+●───────────────────────────────────────────────●
+```
+
 → Proceed to **Step 1**.
 
 ---
@@ -70,8 +78,6 @@ Parse the discovery output to understand:
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Feature
-
 No features in progress.
 
 Run /start-feature to begin a new one.

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -34,6 +34,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 ── Initialisation ───────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -58,6 +59,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ```
 ── Run Discovery ────────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -102,6 +104,7 @@ Parse the discovery output to understand:
 
 ```
 ── Check State ──────────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -140,6 +143,7 @@ Store the work_unit.
 
 ```
 ── Select Feature ───────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -160,6 +164,7 @@ Load **[select-feature.md](references/select-feature.md)** and follow its instru
 
 ```
 ── Validate Selection ───────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -180,6 +185,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ```
 ── Check Progress ───────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -200,6 +206,7 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 
 ```
 ── Route to Phase ───────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -21,12 +21,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
-**Run migrations — this is mandatory. You must complete it before proceeding.**
-
-Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
-
 > *Output the next fenced block as a code block:*
 
 ```
@@ -35,11 +29,41 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ●───────────────────────────────────────────────●
 ```
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Running migrations to keep workflow files in sync.**
+```
+
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+**Run migrations — this is mandatory. You must complete it before proceeding.**
+
+Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
 → Proceed to **Step 1**.
 
 ---
 
 ## Step 1: Discovery State
+
+> *Output the next fenced block as a code block:*
+
+```
+── Run Discovery ───────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Scanning for active features and their current progress.**
+```
 
 !`node .claude/skills/continue-feature/scripts/discovery.cjs`
 
@@ -73,6 +97,18 @@ Parse the discovery output to understand:
 
 ## Step 2: Check Count and Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check State ─────────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking how many features are in progress.**
+```
+
 #### If `count` is 0
 
 > *Output the next fenced block as a code block:*
@@ -99,6 +135,18 @@ Store the work_unit.
 
 ## Step 3: Select Feature
 
+> *Output the next fenced block as a code block:*
+
+```
+── Select Feature ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Showing your active features for selection.**
+```
+
 Load **[select-feature.md](references/select-feature.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -106,6 +154,18 @@ Load **[select-feature.md](references/select-feature.md)** and follow its instru
 ---
 
 ## Step 4: Validate Selection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Selection ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Confirming the selected feature exists and is active.**
+```
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
@@ -115,6 +175,18 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Backwards Navigation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check Progress ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking whether earlier phases are available to revisit.**
+```
+
 Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -122,6 +194,18 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 ---
 
 ## Step 6: Route to Phase Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route to Phase ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Handing off to the next phase for this feature.**
+```
 
 Using the selected feature's `next_phase`, invoke the appropriate phase skill:
 

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -34,14 +34,12 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 ── Initialisation ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Running migrations to keep workflow files in sync.**
-
 ```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
@@ -60,14 +58,12 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ```
 ── Run Discovery ────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Scanning for active features and their current progress.**
-
 ```
 
 !`node .claude/skills/continue-feature/scripts/discovery.cjs`
@@ -106,14 +102,12 @@ Parse the discovery output to understand:
 
 ```
 ── Check State ──────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Checking how many features are in progress.**
-
 ```
 
 #### If `count` is 0
@@ -146,14 +140,12 @@ Store the work_unit.
 
 ```
 ── Select Feature ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Showing your active features for selection.**
-
 ```
 
 Load **[select-feature.md](references/select-feature.md)** and follow its instructions as written.
@@ -168,14 +160,12 @@ Load **[select-feature.md](references/select-feature.md)** and follow its instru
 
 ```
 ── Validate Selection ───────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Confirming the selected feature exists and is active.**
-
 ```
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
@@ -190,14 +180,12 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ```
 ── Check Progress ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Checking whether earlier phases are available to revisit.**
-
 ```
 
 Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instructions as written.
@@ -212,14 +200,12 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 
 ```
 ── Route to Phase ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Handing off to the next phase for this feature.**
-
 ```
 
 Using the selected feature's `next_phase`, invoke the appropriate phase skill:

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -27,12 +27,13 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ●───────────────────────────────────────────────●
   Continue Feature
 ●───────────────────────────────────────────────●
+
 ```
 
 > *Output the next fenced block as a code block:*
 
 ```
-── Initialisation ──────────────────────────────────
+── Initialisation ───────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -56,7 +57,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as a code block:*
 
 ```
-── Run Discovery ───────────────────────────────────
+── Run Discovery ────────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -100,7 +101,7 @@ Parse the discovery output to understand:
 > *Output the next fenced block as a code block:*
 
 ```
-── Check State ─────────────────────────────────────
+── Check State ──────────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -138,7 +139,7 @@ Store the work_unit.
 > *Output the next fenced block as a code block:*
 
 ```
-── Select Feature ──────────────────────────────────
+── Select Feature ───────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -158,7 +159,7 @@ Load **[select-feature.md](references/select-feature.md)** and follow its instru
 > *Output the next fenced block as a code block:*
 
 ```
-── Validate Selection ──────────────────────────────
+── Validate Selection ───────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -178,7 +179,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 > *Output the next fenced block as a code block:*
 
 ```
-── Check Progress ──────────────────────────────────
+── Check Progress ───────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -198,7 +199,7 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 > *Output the next fenced block as a code block:*
 
 ```
-── Route to Phase ──────────────────────────────────
+── Route to Phase ───────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -39,7 +39,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Running migrations to keep workflow files in sync.**
+> Running migrations to keep workflow files in sync.
 ```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
@@ -63,7 +63,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Scanning for active features and their current progress.**
+> Scanning for active features and their current progress.
 ```
 
 !`node .claude/skills/continue-feature/scripts/discovery.cjs`
@@ -107,7 +107,7 @@ Parse the discovery output to understand:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking how many features are in progress.**
+> Checking how many features are in progress.
 ```
 
 #### If `count` is 0
@@ -145,7 +145,7 @@ Store the work_unit.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Showing your active features for selection.**
+> Showing your active features for selection.
 ```
 
 Load **[select-feature.md](references/select-feature.md)** and follow its instructions as written.
@@ -165,7 +165,7 @@ Load **[select-feature.md](references/select-feature.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Confirming the selected feature exists and is active.**
+> Confirming the selected feature exists and is active.
 ```
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
@@ -185,7 +185,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking whether earlier phases are available to revisit.**
+> Checking whether earlier phases are available to revisit.
 ```
 
 Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instructions as written.
@@ -205,7 +205,7 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Handing off to the next phase for this feature.**
+> Handing off to the next phase for this feature.
 ```
 
 Using the selected feature's `next_phase`, invoke the appropriate phase skill:

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -41,6 +41,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 > **Running migrations to keep workflow files in sync.**
+
 ```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
@@ -66,6 +67,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ```
 > **Scanning for active features and their current progress.**
+
 ```
 
 !`node .claude/skills/continue-feature/scripts/discovery.cjs`
@@ -111,6 +113,7 @@ Parse the discovery output to understand:
 
 ```
 > **Checking how many features are in progress.**
+
 ```
 
 #### If `count` is 0
@@ -150,6 +153,7 @@ Store the work_unit.
 
 ```
 > **Showing your active features for selection.**
+
 ```
 
 Load **[select-feature.md](references/select-feature.md)** and follow its instructions as written.
@@ -171,6 +175,7 @@ Load **[select-feature.md](references/select-feature.md)** and follow its instru
 
 ```
 > **Confirming the selected feature exists and is active.**
+
 ```
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
@@ -192,6 +197,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ```
 > **Checking whether earlier phases are available to revisit.**
+
 ```
 
 Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instructions as written.
@@ -213,6 +219,7 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 
 ```
 > **Handing off to the next phase for this feature.**
+
 ```
 
 Using the selected feature's `next_phase`, invoke the appropriate phase skill:

--- a/skills/continue-feature/references/select-feature.md
+++ b/skills/continue-feature/references/select-feature.md
@@ -11,8 +11,6 @@ Display active features and let the user select one.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Feature
-
 {count} feature(s) in progress:
 
 @foreach(feature in features)

--- a/skills/continue-feature/references/validate-selection.md
+++ b/skills/continue-feature/references/validate-selection.md
@@ -11,8 +11,6 @@ Validate the selected work unit against the discovery output and store its data.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Feature
-
 No active feature named "{work_unit}" found.
 
 Run /continue-feature to see available features, or /start-feature to begin a new one.

--- a/skills/continue-quickfix/SKILL.md
+++ b/skills/continue-quickfix/SKILL.md
@@ -21,6 +21,27 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Continue Quick-Fix
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Running migrations to keep workflow files in sync.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
@@ -32,6 +53,18 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ---
 
 ## Step 1: Discovery State
+
+> *Output the next fenced block as a code block:*
+
+```
+── Run Discovery ────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Scanning for active quick-fixes and their current progress.
+```
 
 !`node .claude/skills/continue-quickfix/scripts/discovery.cjs`
 
@@ -65,13 +98,23 @@ Parse the discovery output to understand:
 
 ## Step 2: Check Count and Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check State ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking if there are any quick-fixes in progress.
+```
+
 #### If `count` is 0
 
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Quick-Fix
-
 No quick-fixes in progress.
 
 Run /start-quickfix to begin a new one.
@@ -93,6 +136,18 @@ Store the work_unit.
 
 ## Step 3: Select Quick-Fix
 
+> *Output the next fenced block as a code block:*
+
+```
+── Select Quick-Fix ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Showing your active quick-fixes for selection.
+```
+
 Load **[select-quickfix.md](references/select-quickfix.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -100,6 +155,18 @@ Load **[select-quickfix.md](references/select-quickfix.md)** and follow its inst
 ---
 
 ## Step 4: Validate Selection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Selection ───────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Confirming the selected quick-fix exists and is active.
+```
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
@@ -109,6 +176,18 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Backwards Navigation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check Progress ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking whether earlier phases are available to revisit.
+```
+
 Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -116,6 +195,18 @@ Load **[revisit-phase.md](references/revisit-phase.md)** and follow its instruct
 ---
 
 ## Step 6: Route to Phase Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route to Phase ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the next phase for this quick-fix.
+```
 
 Using the selected quick-fix's `next_phase`, invoke the appropriate phase skill:
 

--- a/skills/continue-quickfix/references/select-quickfix.md
+++ b/skills/continue-quickfix/references/select-quickfix.md
@@ -11,8 +11,6 @@ Display active quick-fixes and let the user select one.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Quick-Fix
-
 {count} quick-fix(es) in progress:
 
 @foreach(quickfix in quick_fixes)

--- a/skills/continue-quickfix/references/validate-selection.md
+++ b/skills/continue-quickfix/references/validate-selection.md
@@ -11,8 +11,6 @@ Validate the selected work unit against the discovery output and store its data.
 > *Output the next fenced block as a code block:*
 
 ```
-Continue Quick-Fix
-
 No active quick-fix named "{work_unit}" found.
 
 Run /continue-quickfix to see available quick-fixes, or /start-quickfix to begin a new one.

--- a/skills/start-bugfix/SKILL.md
+++ b/skills/start-bugfix/SKILL.md
@@ -21,11 +21,39 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Running migrations to keep workflow files in sync.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Bugfix
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new bugfix. I'll ask what's broken, suggest a name,
+> then hand off to investigation to diagnose the root cause.
+```
 
 → Proceed to **Step 1**.
 
@@ -33,13 +61,33 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Bug Context
 
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Bug Context ───────────────────────────
+```
+
 #### If inbox file path was provided as positional argument (`$0`)
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Using context from your inbox item. Reading the inbox file
+> to understand the issue and suggest a name.
+```
 
 Read the inbox file at the provided path. Use its content as the bug description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
 
 → Proceed to **Step 2**.
 
 #### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Gathering context about the bug. A brief description of
+> what's broken is enough to get started.
+```
 
 Load **[gather-bug-context.md](references/gather-bug-context.md)** and follow its instructions as written.
 
@@ -49,6 +97,19 @@ Load **[gather-bug-context.md](references/gather-bug-context.md)** and follow it
 
 ## Step 2: Bugfix Name and Conflict Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Bugfix Name ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Naming the bugfix and checking for conflicts. The name becomes
+> the identifier used throughout the workflow.
+```
+
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -56,6 +117,19 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 ---
 
 ## Step 3: Invoke Entry-Point Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Investigation ─────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the investigation phase. This will gather
+> symptoms and analyse code to find the root cause.
+```
 
 Invoke `/workflow-investigation-entry bugfix {work_unit}`.
 

--- a/skills/start-cross-cutting/SKILL.md
+++ b/skills/start-cross-cutting/SKILL.md
@@ -21,11 +21,41 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Running migrations to keep workflow files in sync.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Cross-Cutting Concern
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new cross-cutting concern. I'll ask what pattern
+> or policy you're defining, suggest a name, then you'll choose
+> whether to research first or go straight to discussion. The
+> pipeline ends at specification — no planning or implementation.
+```
 
 → Proceed to **Step 1**.
 
@@ -33,13 +63,33 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Cross-Cutting Context
 
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Context ───────────────────────────────
+```
+
 #### If inbox file path was provided as positional argument (`$0`)
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Using context from your inbox item. Reading the inbox file
+> to understand the concern and suggest a name.
+```
 
 Read the inbox file at the provided path. Use its content as the description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
 
 → Proceed to **Step 2**.
 
 #### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Gathering context about the cross-cutting concern. Describe
+> the pattern, policy, or architectural decision you're defining.
+```
 
 Load **[gather-cc-context.md](references/gather-cc-context.md)** and follow its instructions as written.
 
@@ -49,6 +99,19 @@ Load **[gather-cc-context.md](references/gather-cc-context.md)** and follow its 
 
 ## Step 2: Name and Conflict Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Name Check ───────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Naming the concern and checking for conflicts. The name
+> becomes the identifier used throughout the workflow.
+```
+
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -57,6 +120,12 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 
 ## Step 3: Route to First Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Choose Starting Phase ────────────────────────
+```
+
 Load **[research-gating.md](references/research-gating.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -64,6 +133,19 @@ Load **[research-gating.md](references/research-gating.md)** and follow its inst
 ---
 
 ## Step 4: Invoke Entry-Point Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Phase Skill ───────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the selected phase. The next skill will load
+> and guide you through the process.
+```
 
 Invoke the appropriate entry-point skill based on the selected phase:
 

--- a/skills/start-cross-cutting/references/research-gating.md
+++ b/skills/start-cross-cutting/references/research-gating.md
@@ -9,6 +9,11 @@ Let the user choose whether to start with research or go directly to discussion.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> Choose your starting point. Research is open-ended exploration
+> — gather context, weigh options, no commitments. Discussion is
+> structured conversation that works toward decisions. If you're
+> unsure, research is a safe place to start.
+
 · · · · · · · · · · · ·
 How would you like to start?
 

--- a/skills/start-epic/SKILL.md
+++ b/skills/start-epic/SKILL.md
@@ -21,11 +21,40 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Running migrations to keep workflow files in sync.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Epic
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new epic. I'll ask what you're building, suggest
+> a name, then you'll choose whether to research first or go
+> straight to discussion.
+```
 
 → Proceed to **Step 1**.
 
@@ -33,13 +62,33 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Epic Context
 
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Epic Context ──────────────────────────
+```
+
 #### If inbox file path was provided as positional argument (`$0`)
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Using context from your inbox item. Reading the inbox file
+> to understand scope and suggest a name.
+```
 
 Read the inbox file at the provided path. Use its content as the epic description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
 
 → Proceed to **Step 2**.
 
 #### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Gathering context for the epic. A brief description is enough
+> to understand the scope and suggest a name.
+```
 
 Load **[gather-epic-context.md](references/gather-epic-context.md)** and follow its instructions as written.
 
@@ -49,6 +98,19 @@ Load **[gather-epic-context.md](references/gather-epic-context.md)** and follow 
 
 ## Step 2: Epic Name and Conflict Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Epic Name ────────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Naming the epic and checking for conflicts. The name becomes
+> the identifier used throughout the workflow.
+```
+
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -57,6 +119,12 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 
 ## Step 3: Route to First Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Choose Starting Phase ────────────────────────
+```
+
 Load **[route-first-phase.md](references/route-first-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -64,6 +132,19 @@ Load **[route-first-phase.md](references/route-first-phase.md)** and follow its 
 ---
 
 ## Step 4: Invoke Entry-Point Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Phase Skill ───────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the selected phase. The next skill will load
+> and guide you through the process.
+```
 
 Invoke the appropriate entry-point skill based on the selected phase:
 

--- a/skills/start-epic/references/route-first-phase.md
+++ b/skills/start-epic/references/route-first-phase.md
@@ -9,6 +9,11 @@ Let the user choose whether to start with research or go directly to discussion.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> Choose your starting point. Research is open-ended exploration
+> — gather context, weigh options, no commitments. Discussion is
+> structured conversation that works toward decisions. If you're
+> unsure, research is a safe place to start.
+
 · · · · · · · · · · · ·
 How would you like to start?
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -38,7 +38,10 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Starting a new feature.** I'll ask what you're building, suggest a name, then you'll choose whether to research first or go straight to discussion.
+> **Starting a new feature.** I'll ask what
+> you're building, suggest a name, then you'll
+> choose whether to research first or go straight
+> to discussion.
 ```
 
 → Proceed to **Step 1**.

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -25,6 +25,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 ── Initialisation ───────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -66,6 +67,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ```
 ── Gather Feature Context ───────────────────────
+
 ```
 
 #### If inbox file path was provided as positional argument (`$0`)
@@ -102,6 +104,7 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 
 ```
 ── Feature Name ─────────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -123,6 +126,7 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 
 ```
 ── Choose Starting Phase ────────────────────────
+
 ```
 
 Load **[research-gating.md](references/research-gating.md)** and follow its instructions as written.
@@ -137,6 +141,7 @@ Load **[research-gating.md](references/research-gating.md)** and follow its inst
 
 ```
 ── Invoke Phase Skill ───────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -27,12 +27,6 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
 
-→ Proceed to **Step 1**.
-
----
-
-## Step 1: Gather Feature Context
-
 > *Output the next fenced block as a code block:*
 
 ```
@@ -46,6 +40,12 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ```
 > **Starting a new feature.** I'll ask what you're building, suggest a name, then you'll choose whether to research first or go straight to discussion.
 ```
+
+→ Proceed to **Step 1**.
+
+---
+
+## Step 1: Gather Feature Context
 
 #### If inbox file path was provided as positional argument (`$0`)
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -61,13 +61,13 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Feature Context
 
-#### If inbox file path was provided as positional argument (`$0`)
-
 > *Output the next fenced block as a code block:*
 
 ```
 ── Gather Feature Context ──────────────────────────
 ```
+
+#### If inbox file path was provided as positional argument (`$0`)
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -81,12 +81,6 @@ Read the inbox file at the provided path. Use its content as the feature descrip
 → Proceed to **Step 2**.
 
 #### Otherwise
-
-> *Output the next fenced block as a code block:*
-
-```
-── Gather Feature Context ──────────────────────────
-```
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -25,14 +25,12 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 ── Initialisation ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Running migrations to keep workflow files in sync.**
-
 ```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
@@ -56,7 +54,6 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > **Starting a new feature.** I'll ask what you're building, suggest
 > a name, then you'll choose whether to research first or go straight
 > to discussion.
-
 ```
 
 → Proceed to **Step 1**.
@@ -69,7 +66,6 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ```
 ── Gather Feature Context ───────────────────────
-
 ```
 
 #### If inbox file path was provided as positional argument (`$0`)
@@ -79,7 +75,6 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ```
 > **Using context from your inbox item.** Reading the inbox file
 > to understand scope and suggest a name.
-
 ```
 
 Read the inbox file at the provided path. Use its content as the feature description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
@@ -93,7 +88,6 @@ Read the inbox file at the provided path. Use its content as the feature descrip
 ```
 > **Gathering context for the feature.** A brief description
 > is enough to understand the scope and suggest a name.
-
 ```
 
 Load **[gather-feature-context.md](references/gather-feature-context.md)** and follow its instructions as written.
@@ -108,7 +102,6 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 
 ```
 ── Feature Name ─────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -116,7 +109,6 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 ```
 > **Naming the feature and checking for conflicts.** The name becomes
 > the identifier used throughout the workflow.
-
 ```
 
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
@@ -131,7 +123,6 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 
 ```
 ── Choose Starting Phase ────────────────────────
-
 ```
 
 Load **[research-gating.md](references/research-gating.md)** and follow its instructions as written.
@@ -146,7 +137,6 @@ Load **[research-gating.md](references/research-gating.md)** and follow its inst
 
 ```
 ── Invoke Phase Skill ───────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -154,7 +144,6 @@ Load **[research-gating.md](references/research-gating.md)** and follow its inst
 ```
 > **Handing off to the selected phase.** The next skill will load
 > and guide you through the process.
-
 ```
 
 Invoke the appropriate entry-point skill based on the selected phase:

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -47,12 +47,6 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Feature Context
 
-> *Output the next fenced block as a code block:*
-
-```
-── Step 1: Gather Context ──────────────────────────
-```
-
 #### If inbox file path was provided as positional argument (`$0`)
 
 Read the inbox file at the provided path. Use its content as the feature description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
@@ -69,12 +63,6 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 
 ## Step 2: Feature Name and Conflict Check
 
-> *Output the next fenced block as a code block:*
-
-```
-── Step 2: Name Check ──────────────────────────────
-```
-
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -82,12 +70,6 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 ---
 
 ## Step 3: Route to First Phase
-
-> *Output the next fenced block as a code block:*
-
-```
-── Step 3: Choose Starting Phase ───────────────────
-```
 
 Load **[research-gating.md](references/research-gating.md)** and follow its instructions as written.
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -24,7 +24,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 > *Output the next fenced block as a code block:*
 
 ```
-── Initialisation ──────────────────────────────────
+── Initialisation ───────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -45,6 +45,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ●───────────────────────────────────────────────●
   New Feature
 ●───────────────────────────────────────────────●
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -64,7 +65,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as a code block:*
 
 ```
-── Gather Feature Context ──────────────────────────
+── Gather Feature Context ───────────────────────
 ```
 
 #### If inbox file path was provided as positional argument (`$0`)
@@ -100,7 +101,7 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 > *Output the next fenced block as a code block:*
 
 ```
-── Feature Name ────────────────────────────────────
+── Feature Name ─────────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -121,7 +122,7 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 > *Output the next fenced block as a code block:*
 
 ```
-── Choose Starting Phase ───────────────────────────
+── Choose Starting Phase ────────────────────────
 ```
 
 Load **[research-gating.md](references/research-gating.md)** and follow its instructions as written.
@@ -135,7 +136,7 @@ Load **[research-gating.md](references/research-gating.md)** and follow its inst
 > *Output the next fenced block as a code block:*
 
 ```
-── Invoke Phase Skill ──────────────────────────────
+── Invoke Phase Skill ───────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -61,6 +61,8 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Feature Context
 
+#### If inbox file path was provided as positional argument (`$0`)
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -70,17 +72,28 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Gathering context for the feature.** This is used to
-> understand the scope and suggest a name.
+> **Using context from your inbox item.** Reading the inbox file
+> to understand scope and suggest a name.
 ```
-
-#### If inbox file path was provided as positional argument (`$0`)
 
 Read the inbox file at the provided path. Use its content as the feature description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
 
 → Proceed to **Step 2**.
 
 #### Otherwise
+
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Feature Context ──────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Gathering context for the feature.** A brief description
+> is enough to understand the scope and suggest a name.
+```
 
 Load **[gather-feature-context.md](references/gather-feature-context.md)** and follow its instructions as written.
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -47,6 +47,12 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Feature Context
 
+> *Output the next fenced block as a code block:*
+
+```
+── Step 1: Gather Context ──────────────────────────
+```
+
 #### If inbox file path was provided as positional argument (`$0`)
 
 Read the inbox file at the provided path. Use its content as the feature description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
@@ -63,6 +69,12 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 
 ## Step 2: Feature Name and Conflict Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Step 2: Name Check ──────────────────────────────
+```
+
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -70,6 +82,12 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 ---
 
 ## Step 3: Route to First Phase
+
+> *Output the next fenced block as a code block:*
+
+```
+── Step 3: Choose Starting Phase ───────────────────
+```
 
 Load **[research-gating.md](references/research-gating.md)** and follow its instructions as written.
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -38,10 +38,9 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Starting a new feature.** I'll ask what
-> you're building, suggest a name, then you'll
-> choose whether to research first or go straight
-> to discussion.
+> **Starting a new feature.** I'll ask what you're building,
+> suggest a name, then you'll choose whether to research first
+> or go straight to discussion.
 ```
 
 → Proceed to **Step 1**.

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -31,6 +31,20 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ---
 
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Feature
+●───────────────────────────────────────────────●
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Starting a new feature.** I'll ask what you're building, suggest a name, then you'll choose whether to research first or go straight to discussion.
+```
+
 ## Step 1: Gather Feature Context
 
 #### If inbox file path was provided as positional argument (`$0`)

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -70,8 +70,8 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Tell me about the feature.** A brief description is enough
-> to get started — we'll explore the details in discussion.
+> **Gathering context for the feature.** This is used to
+> understand the scope and suggest a name.
 ```
 
 #### If inbox file path was provided as positional argument (`$0`)
@@ -99,8 +99,8 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Suggesting a name for this feature.** This becomes the identifier
-> used throughout the workflow — you can change it if it doesn't fit.
+> **Naming the feature and checking for conflicts.** The name becomes
+> the identifier used throughout the workflow.
 ```
 
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -51,7 +51,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Starting a new feature.** I'll ask what you're building, suggest
+> Starting a new feature. I'll ask what you're building, suggest
 > a name, then you'll choose whether to research first or go straight
 > to discussion.
 ```
@@ -73,7 +73,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Using context from your inbox item.** Reading the inbox file
+> Using context from your inbox item. Reading the inbox file
 > to understand scope and suggest a name.
 ```
 
@@ -86,7 +86,7 @@ Read the inbox file at the provided path. Use its content as the feature descrip
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Gathering context for the feature.** A brief description
+> Gathering context for the feature. A brief description
 > is enough to understand the scope and suggest a name.
 ```
 
@@ -107,7 +107,7 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Naming the feature and checking for conflicts.** The name becomes
+> Naming the feature and checking for conflicts. The name becomes
 > the identifier used throughout the workflow.
 ```
 
@@ -142,7 +142,7 @@ Load **[research-gating.md](references/research-gating.md)** and follow its inst
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Handing off to the selected phase.** The next skill will load
+> Handing off to the selected phase. The next skill will load
 > and guide you through the process.
 ```
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -30,7 +30,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Running migrations to keep workflow files in sync.**
+> Running migrations to keep workflow files in sync.
 ```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -21,6 +21,18 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Running migrations to keep workflow files in sync.**
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
@@ -49,6 +61,19 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Feature Context
 
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Feature Context ──────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Tell me about the feature.** A brief description is enough
+> to get started — we'll explore the details in discussion.
+```
+
 #### If inbox file path was provided as positional argument (`$0`)
 
 Read the inbox file at the provided path. Use its content as the feature description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
@@ -65,6 +90,19 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 
 ## Step 2: Feature Name and Conflict Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Feature Name ────────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Suggesting a name for this feature.** This becomes the identifier
+> used throughout the workflow — you can change it if it doesn't fit.
+```
+
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -73,6 +111,12 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 
 ## Step 3: Route to First Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Choose Starting Phase ───────────────────────────
+```
+
 Load **[research-gating.md](references/research-gating.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -80,6 +124,19 @@ Load **[research-gating.md](references/research-gating.md)** and follow its inst
 ---
 
 ## Step 4: Invoke Entry-Point Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Phase Skill ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Handing off to the selected phase.** The next skill will load
+> and guide you through the process.
+```
 
 Invoke the appropriate entry-point skill based on the selected phase:
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -38,9 +38,9 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Starting a new feature.** I'll ask what you're building,
-> suggest a name, then you'll choose whether to research first
-> or go straight to discussion.
+> **Starting a new feature.** I'll ask what you're building, suggest
+> a name, then you'll choose whether to research first or go straight
+> to discussion.
 ```
 
 → Proceed to **Step 1**.

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -31,6 +31,8 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ---
 
+## Step 1: Gather Feature Context
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -44,8 +46,6 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ```
 > **Starting a new feature.** I'll ask what you're building, suggest a name, then you'll choose whether to research first or go straight to discussion.
 ```
-
-## Step 1: Gather Feature Context
 
 #### If inbox file path was provided as positional argument (`$0`)
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -32,6 +32,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 > **Running migrations to keep workflow files in sync.**
+
 ```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
@@ -55,6 +56,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > **Starting a new feature.** I'll ask what you're building, suggest
 > a name, then you'll choose whether to research first or go straight
 > to discussion.
+
 ```
 
 → Proceed to **Step 1**.
@@ -77,6 +79,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ```
 > **Using context from your inbox item.** Reading the inbox file
 > to understand scope and suggest a name.
+
 ```
 
 Read the inbox file at the provided path. Use its content as the feature description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
@@ -90,6 +93,7 @@ Read the inbox file at the provided path. Use its content as the feature descrip
 ```
 > **Gathering context for the feature.** A brief description
 > is enough to understand the scope and suggest a name.
+
 ```
 
 Load **[gather-feature-context.md](references/gather-feature-context.md)** and follow its instructions as written.
@@ -112,6 +116,7 @@ Load **[gather-feature-context.md](references/gather-feature-context.md)** and f
 ```
 > **Naming the feature and checking for conflicts.** The name becomes
 > the identifier used throughout the workflow.
+
 ```
 
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
@@ -149,6 +154,7 @@ Load **[research-gating.md](references/research-gating.md)** and follow its inst
 ```
 > **Handing off to the selected phase.** The next skill will load
 > and guide you through the process.
+
 ```
 
 Invoke the appropriate entry-point skill based on the selected phase:

--- a/skills/start-feature/references/gather-feature-context.md
+++ b/skills/start-feature/references/gather-feature-context.md
@@ -9,8 +9,6 @@ Gather a brief description of the feature — enough for a name and manifest des
 > *Output the next fenced block as a code block:*
 
 ```
-── Step 1: Gather Context ──────────────────────────
-
 What feature are you adding?
 
 Describe briefly what you're building and why.

--- a/skills/start-feature/references/gather-feature-context.md
+++ b/skills/start-feature/references/gather-feature-context.md
@@ -9,6 +9,8 @@ Gather a brief description of the feature — enough for a name and manifest des
 > *Output the next fenced block as a code block:*
 
 ```
+── Step 1: Gather Context ──────────────────────────
+
 What feature are you adding?
 
 Describe briefly what you're building and why.

--- a/skills/start-feature/references/name-check.md
+++ b/skills/start-feature/references/name-check.md
@@ -11,8 +11,6 @@ Based on the feature description, suggest a name in kebab-case. Once confirmed, 
 > *Output the next fenced block as a code block:*
 
 ```
-── Step 2: Name Check ──────────────────────────────
-
 Suggested feature name: {work_unit}
 ```
 

--- a/skills/start-feature/references/name-check.md
+++ b/skills/start-feature/references/name-check.md
@@ -11,6 +11,8 @@ Based on the feature description, suggest a name in kebab-case. Once confirmed, 
 > *Output the next fenced block as a code block:*
 
 ```
+── Step 2: Name Check ──────────────────────────────
+
 Suggested feature name: {work_unit}
 ```
 

--- a/skills/start-feature/references/research-gating.md
+++ b/skills/start-feature/references/research-gating.md
@@ -9,6 +9,12 @@ Let the user choose whether to start with research or go directly to discussion.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> **Choose your starting point.** Research is open-ended exploration — gather context, weigh options, no commitments. Discussion is structured conversation that works toward decisions. If you're unsure, research is a safe place to start.
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
 · · · · · · · · · · · ·
 How would you like to start?
 

--- a/skills/start-feature/references/research-gating.md
+++ b/skills/start-feature/references/research-gating.md
@@ -9,7 +9,11 @@ Let the user choose whether to start with research or go directly to discussion.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Choose your starting point.** Research is open-ended exploration — gather context, weigh options, no commitments. Discussion is structured conversation that works toward decisions. If you're unsure, research is a safe place to start.
+> **Choose your starting point.** Research is
+> open-ended exploration — gather context, weigh
+> options, no commitments. Discussion is structured
+> conversation that works toward decisions. If
+> you're unsure, research is a safe place to start.
 
 · · · · · · · · · · · ·
 How would you like to start?

--- a/skills/start-feature/references/research-gating.md
+++ b/skills/start-feature/references/research-gating.md
@@ -9,7 +9,7 @@ Let the user choose whether to start with research or go directly to discussion.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Choose your starting point.** Research is open-ended exploration
+> Choose your starting point. Research is open-ended exploration
 > — gather context, weigh options, no commitments. Discussion is
 > structured conversation that works toward decisions. If you're
 > unsure, research is a safe place to start.

--- a/skills/start-feature/references/research-gating.md
+++ b/skills/start-feature/references/research-gating.md
@@ -6,12 +6,6 @@
 
 Let the user choose whether to start with research or go directly to discussion.
 
-> *Output the next fenced block as a code block:*
-
-```
-── Step 3: Choose Starting Phase ───────────────────
-```
-
 > *Output the next fenced block as markdown (not a code block):*
 
 ```

--- a/skills/start-feature/references/research-gating.md
+++ b/skills/start-feature/references/research-gating.md
@@ -9,11 +9,10 @@ Let the user choose whether to start with research or go directly to discussion.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Choose your starting point.** Research is
-> open-ended exploration — gather context, weigh
-> options, no commitments. Discussion is structured
-> conversation that works toward decisions. If
-> you're unsure, research is a safe place to start.
+> **Choose your starting point.** Research is open-ended
+> exploration — gather context, weigh options, no commitments.
+> Discussion is structured conversation that works toward
+> decisions. If you're unsure, research is a safe place to start.
 
 · · · · · · · · · · · ·
 How would you like to start?

--- a/skills/start-feature/references/research-gating.md
+++ b/skills/start-feature/references/research-gating.md
@@ -6,6 +6,12 @@
 
 Let the user choose whether to start with research or go directly to discussion.
 
+> *Output the next fenced block as a code block:*
+
+```
+── Step 3: Choose Starting Phase ───────────────────
+```
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```

--- a/skills/start-feature/references/research-gating.md
+++ b/skills/start-feature/references/research-gating.md
@@ -9,10 +9,10 @@ Let the user choose whether to start with research or go directly to discussion.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Choose your starting point.** Research is open-ended
-> exploration — gather context, weigh options, no commitments.
-> Discussion is structured conversation that works toward
-> decisions. If you're unsure, research is a safe place to start.
+> **Choose your starting point.** Research is open-ended exploration
+> — gather context, weigh options, no commitments. Discussion is
+> structured conversation that works toward decisions. If you're
+> unsure, research is a safe place to start.
 
 · · · · · · · · · · · ·
 How would you like to start?

--- a/skills/start-feature/references/research-gating.md
+++ b/skills/start-feature/references/research-gating.md
@@ -10,11 +10,7 @@ Let the user choose whether to start with research or go directly to discussion.
 
 ```
 > **Choose your starting point.** Research is open-ended exploration — gather context, weigh options, no commitments. Discussion is structured conversation that works toward decisions. If you're unsure, research is a safe place to start.
-```
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
 · · · · · · · · · · · ·
 How would you like to start?
 

--- a/skills/start-quickfix/SKILL.md
+++ b/skills/start-quickfix/SKILL.md
@@ -21,11 +21,40 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 0: Initialisation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialisation ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Running migrations to keep workflow files in sync.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Quick-Fix
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new quick-fix. I'll ask what needs changing, suggest
+> a name, then hand off to scoping — which combines context, spec,
+> and plan into a single streamlined pass.
+```
 
 → Proceed to **Step 1**.
 
@@ -33,13 +62,33 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ## Step 1: Gather Quick-Fix Context
 
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Context ───────────────────────────────
+```
+
 #### If inbox file path was provided as positional argument (`$0`)
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Using context from your inbox item. Reading the inbox file
+> to understand the change and suggest a name.
+```
 
 Read the inbox file at the provided path. Use its content as the quick-fix description — skip the gather-context prompt. The slug from the filename (strip the `YYYY-MM-DD--` prefix, strip `.md`) becomes the suggested work unit name in Step 2.
 
 → Proceed to **Step 2**.
 
 #### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Gathering context about the quick-fix. Describe what needs
+> changing, where, and why.
+```
 
 Load **[gather-quickfix-context.md](references/gather-quickfix-context.md)** and follow its instructions as written.
 
@@ -49,6 +98,19 @@ Load **[gather-quickfix-context.md](references/gather-quickfix-context.md)** and
 
 ## Step 2: Quick-Fix Name and Conflict Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Quick-Fix Name ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Naming the quick-fix and checking for conflicts. The name
+> becomes the identifier used throughout the workflow.
+```
+
 Load **[name-check.md](references/name-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -56,6 +118,20 @@ Load **[name-check.md](references/name-check.md)** and follow its instructions a
 ---
 
 ## Step 3: Invoke Entry-Point Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Scoping ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the scoping phase. This will gather context,
+> build a lightweight spec, and create the implementation plan
+> in a single pass.
+```
 
 Invoke `/workflow-scoping-entry quick-fix {work_unit}`.
 

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -45,7 +45,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ```
 ── Parse Arguments ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -53,7 +52,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 ```
 > **Reading the handoff context and determining which
 > discussion to work with.**
-
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -119,7 +117,6 @@ Parse the discovery output to understand:
 
 ```
 ── Validate Phase ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -127,7 +124,6 @@ Parse the discovery output to understand:
 ```
 > **Checking the status of this discussion — new,
 > in progress, or completed.**
-
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -142,7 +138,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ```
 ── Route Based on Scenario ──────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -150,7 +145,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ```
 > **Determining the best path based on existing research
 > and discussions.**
-
 ```
 
 Load **[route-scenario.md](references/route-scenario.md)** and follow its instructions as written.
@@ -175,7 +169,6 @@ Load **[route-scenario.md](references/route-scenario.md)** and follow its instru
 
 ```
 ── Research Analysis ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -183,7 +176,6 @@ Load **[route-scenario.md](references/route-scenario.md)** and follow its instru
 ```
 > **Analysing your research documents to identify potential
 > discussion topics.**
-
 ```
 
 Load **[research-analysis.md](references/research-analysis.md)** and follow its instructions as written.
@@ -198,14 +190,12 @@ Load **[research-analysis.md](references/research-analysis.md)** and follow its 
 
 ```
 ── Display Options ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Showing available research topics and existing discussions.**
-
 ```
 
 Load **[display-options.md](references/display-options.md)** and follow its instructions as written.
@@ -220,14 +210,12 @@ Load **[display-options.md](references/display-options.md)** and follow its inst
 
 ```
 ── Gather Context ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Collecting the context needed before starting the discussion.**
-
 ```
 
 #### If discussion context is already available in conversation
@@ -250,7 +238,6 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 
 ```
 ── Invoke Discussion ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -258,7 +245,6 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 ```
 > **Handing off to the discussion process with all
 > gathered context.**
-
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -50,8 +50,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reading the handoff context and determining which
-> discussion to work with.**
+> Reading the handoff context and determining which
+> discussion to work with.
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -122,8 +122,8 @@ Parse the discovery output to understand:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking the status of this discussion — new,
-> in progress, or completed.**
+> Checking the status of this discussion — new,
+> in progress, or completed.
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -143,8 +143,8 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Determining the best path based on existing research
-> and discussions.**
+> Determining the best path based on existing research
+> and discussions.
 ```
 
 Load **[route-scenario.md](references/route-scenario.md)** and follow its instructions as written.
@@ -174,8 +174,8 @@ Load **[route-scenario.md](references/route-scenario.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Analysing your research documents to identify potential
-> discussion topics.**
+> Analysing your research documents to identify potential
+> discussion topics.
 ```
 
 Load **[research-analysis.md](references/research-analysis.md)** and follow its instructions as written.
@@ -195,7 +195,7 @@ Load **[research-analysis.md](references/research-analysis.md)** and follow its 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Showing available research topics and existing discussions.**
+> Showing available research topics and existing discussions.
 ```
 
 Load **[display-options.md](references/display-options.md)** and follow its instructions as written.
@@ -215,7 +215,7 @@ Load **[display-options.md](references/display-options.md)** and follow its inst
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Collecting the context needed before starting the discussion.**
+> Collecting the context needed before starting the discussion.
 ```
 
 #### If discussion context is already available in conversation
@@ -243,8 +243,8 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Handing off to the discussion process with all
-> gathered context.**
+> Handing off to the discussion process with all
+> gathered context.
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -41,6 +41,20 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reading the handoff context and determining which
+> discussion to work with.**
+```
+
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -100,6 +114,20 @@ Parse the discovery output to understand:
 
 ## Step 2: Validate Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking the status of this discussion — new,
+> in progress, or completed.**
+```
+
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -107,6 +135,20 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 3: Route Based on Scenario
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route Based on Scenario ──────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Determining the best path based on existing research
+> and discussions.**
+```
 
 Load **[route-scenario.md](references/route-scenario.md)** and follow its instructions as written.
 
@@ -126,6 +168,20 @@ Load **[route-scenario.md](references/route-scenario.md)** and follow its instru
 
 ## Step 4: Research Analysis
 
+> *Output the next fenced block as a code block:*
+
+```
+── Research Analysis ────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Analysing your research documents to identify potential
+> discussion topics.**
+```
+
 Load **[research-analysis.md](references/research-analysis.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
@@ -134,6 +190,19 @@ Load **[research-analysis.md](references/research-analysis.md)** and follow its 
 
 ## Step 5: Display Options
 
+> *Output the next fenced block as a code block:*
+
+```
+── Display Options ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Showing available research topics and existing discussions.**
+```
+
 Load **[display-options.md](references/display-options.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -141,6 +210,19 @@ Load **[display-options.md](references/display-options.md)** and follow its inst
 ---
 
 ## Step 6: Gather Context
+
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Context ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Collecting the context needed before starting the discussion.**
+```
 
 #### If discussion context is already available in conversation
 
@@ -157,5 +239,19 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 ---
 
 ## Step 7: Invoke the Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Discussion ────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Handing off to the discussion process with all
+> gathered context.**
+```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -53,6 +53,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 ```
 > **Reading the handoff context and determining which
 > discussion to work with.**
+
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -126,6 +127,7 @@ Parse the discovery output to understand:
 ```
 > **Checking the status of this discussion — new,
 > in progress, or completed.**
+
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -148,6 +150,7 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ```
 > **Determining the best path based on existing research
 > and discussions.**
+
 ```
 
 Load **[route-scenario.md](references/route-scenario.md)** and follow its instructions as written.
@@ -180,6 +183,7 @@ Load **[route-scenario.md](references/route-scenario.md)** and follow its instru
 ```
 > **Analysing your research documents to identify potential
 > discussion topics.**
+
 ```
 
 Load **[research-analysis.md](references/research-analysis.md)** and follow its instructions as written.
@@ -201,6 +205,7 @@ Load **[research-analysis.md](references/research-analysis.md)** and follow its 
 
 ```
 > **Showing available research topics and existing discussions.**
+
 ```
 
 Load **[display-options.md](references/display-options.md)** and follow its instructions as written.
@@ -222,6 +227,7 @@ Load **[display-options.md](references/display-options.md)** and follow its inst
 
 ```
 > **Collecting the context needed before starting the discussion.**
+
 ```
 
 #### If discussion context is already available in conversation
@@ -252,6 +258,7 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 ```
 > **Handing off to the discussion process with all
 > gathered context.**
+
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-entry/references/display-options.md
+++ b/skills/workflow-discussion-entry/references/display-options.md
@@ -13,7 +13,9 @@ Present everything discovered to help the user make an informed choice.
 > *Output the next fenced block as a code block:*
 
 ```
-Discussion Overview
+●───────────────────────────────────────────────●
+  Discussion Overview
+●───────────────────────────────────────────────●
 
 {N} research topics found. {M} existing discussions.
 

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -10,6 +10,12 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 
 ## A. Core Problem
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Setting up the discussion.** I'll ask a few questions to understand the problem, constraints, and any relevant code before we begin.
+```
+
 > *Output the next fenced block as a code block:*
 
 ```

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -13,7 +13,9 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Setting up the discussion.** I'll ask a few questions to understand the problem, constraints, and any relevant code before we begin.
+> **Setting up the discussion.** I'll ask a few
+> questions to understand the problem, constraints,
+> and any relevant code before we begin.
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -16,7 +16,6 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 > **Setting up the discussion.** I'll ask a few questions to
 > understand the problem, constraints, and any relevant code
 > before we begin.
-
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -13,7 +13,7 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Setting up the discussion.** I'll ask a few questions to
+> Setting up the discussion. I'll ask a few questions to
 > understand the problem, constraints, and any relevant code
 > before we begin.
 ```

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -13,9 +13,9 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Setting up the discussion.** I'll ask a few questions
-> to understand the problem, constraints, and any relevant
-> code before we begin.
+> **Setting up the discussion.** I'll ask a few questions to
+> understand the problem, constraints, and any relevant code
+> before we begin.
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -16,6 +16,7 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 > **Setting up the discussion.** I'll ask a few questions to
 > understand the problem, constraints, and any relevant code
 > before we begin.
+
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -13,9 +13,9 @@ Ask each question below **one at a time**. After each, **STOP** and wait for the
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Setting up the discussion.** I'll ask a few
-> questions to understand the problem, constraints,
-> and any relevant code before we begin.
+> **Setting up the discussion.** I'll ask a few questions
+> to understand the problem, constraints, and any relevant
+> code before we begin.
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -92,7 +92,11 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discussion starting.** I'll track our conversation on a Discussion Map. You can lead wherever you want — I'll challenge thinking, explore edge cases, and capture decisions as we go.
+> **Discussion starting.** I'll track our
+> conversation on a Discussion Map. You can lead
+> wherever you want — I'll challenge thinking,
+> explore edge cases, and capture decisions as
+> we go.
 ```
 
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -33,12 +33,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ---
 
-## Output Formatting
-
-When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
-
----
-
 ## Step 0: Resume Detection
 
 Check if the discussion file exists at `.workflows/{work_unit}/discussion/{topic}.md`.
@@ -94,6 +88,12 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 ---
 
 ## Step 3: Discussion Session
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Discussion starting.** I'll track our conversation on a Discussion Map. You can lead wherever you want — I'll challenge thinking, explore edge cases, and capture decisions as we go.
+```
 
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -39,7 +39,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ```
 ── Resume Detection ─────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -47,7 +46,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 ```
 > **Checking for an existing discussion file.** If one exists,
 > you can pick up where you left off or start fresh.
-
 ```
 
 Check if the discussion file exists at `.workflows/{work_unit}/discussion/{topic}.md`.
@@ -92,7 +90,6 @@ Found existing discussion for **{topic:(titlecase)}**.
 
 ```
 ── Initialize Discussion ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -100,7 +97,6 @@ Found existing discussion for **{topic:(titlecase)}**.
 ```
 > **Creating the discussion file and seeding the Discussion Map
 > with initial subtopics from your context.**
-
 ```
 
 Load **[initialize-discussion.md](references/initialize-discussion.md)** and follow its instructions as written.
@@ -115,7 +111,6 @@ Load **[initialize-discussion.md](references/initialize-discussion.md)** and fol
 
 ```
 ── Load Discussion Guidelines ───────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -123,7 +118,6 @@ Load **[initialize-discussion.md](references/initialize-discussion.md)** and fol
 ```
 > **Loading the guidelines that shape how the discussion
 > is structured and documented.**
-
 ```
 
 Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and follow its instructions as written.
@@ -138,7 +132,6 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 
 ```
 ── Discussion Session ───────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -147,7 +140,6 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 > **Discussion starting.** I'll track our conversation on a Discussion
 > Map. You can lead wherever you want — I'll challenge thinking,
 > explore edge cases, and capture decisions as we go.
-
 ```
 
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.
@@ -162,14 +154,12 @@ Load **[discussion-session.md](references/discussion-session.md)** and follow it
 
 ```
 ── Compliance Self-Check ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Verifying the discussion file follows workflow conventions.**
-
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
@@ -184,7 +174,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ```
 ── Conclude Discussion ──────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -192,7 +181,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ```
 > **Wrapping up.** Final confirmation before marking the
 > discussion as complete.
-
 ```
 
 Load **[conclude-discussion.md](references/conclude-discussion.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -35,6 +35,20 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking for an existing discussion file.** If one exists,
+> you can pick up where you left off or start fresh.
+```
+
 Check if the discussion file exists at `.workflows/{work_unit}/discussion/{topic}.md`.
 
 #### If no file exists
@@ -73,6 +87,20 @@ Found existing discussion for **{topic:(titlecase)}**.
 
 ## Step 1: Initialize Discussion
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialize Discussion ────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Creating the discussion file and seeding the Discussion Map
+> with initial subtopics from your context.**
+```
+
 Load **[initialize-discussion.md](references/initialize-discussion.md)** and follow its instructions as written.
 
 → Proceed to **Step 2**.
@@ -81,6 +109,20 @@ Load **[initialize-discussion.md](references/initialize-discussion.md)** and fol
 
 ## Step 2: Load Discussion Guidelines
 
+> *Output the next fenced block as a code block:*
+
+```
+── Load Discussion Guidelines ───────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Loading the guidelines that shape how the discussion
+> is structured and documented.**
+```
+
 Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -88,6 +130,13 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 ---
 
 ## Step 3: Discussion Session
+
+> *Output the next fenced block as a code block:*
+
+```
+── Discussion Session ───────────────────────────
+
+```
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -105,6 +154,19 @@ Load **[discussion-session.md](references/discussion-session.md)** and follow it
 
 ## Step 4: Compliance Self-Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Compliance Self-Check ────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Verifying the discussion file follows workflow conventions.**
+```
+
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
@@ -112,5 +174,19 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ---
 
 ## Step 5: Conclude Discussion
+
+> *Output the next fenced block as a code block:*
+
+```
+── Conclude Discussion ──────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Wrapping up.** Final confirmation before marking the
+> discussion as complete.
+```
 
 Load **[conclude-discussion.md](references/conclude-discussion.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -44,7 +44,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking for an existing discussion file.** If one exists,
+> Checking for an existing discussion file. If one exists,
 > you can pick up where you left off or start fresh.
 ```
 
@@ -137,7 +137,7 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discussion starting.** I'll track our conversation on a Discussion
+> Discussion starting. I'll track our conversation on a Discussion
 > Map. You can lead wherever you want — I'll challenge thinking,
 > explore edge cases, and capture decisions as we go.
 ```
@@ -179,7 +179,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Wrapping up.** Final confirmation before marking the
+> Wrapping up. Final confirmation before marking the
 > discussion as complete.
 ```
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -95,8 +95,8 @@ Found existing discussion for **{topic:(titlecase)}**.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Creating the discussion file and seeding the Discussion Map
-> with initial subtopics from your context.**
+> Creating the discussion file and seeding the Discussion Map
+> with initial subtopics from your context.
 ```
 
 Load **[initialize-discussion.md](references/initialize-discussion.md)** and follow its instructions as written.
@@ -116,8 +116,8 @@ Load **[initialize-discussion.md](references/initialize-discussion.md)** and fol
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Loading the guidelines that shape how the discussion
-> is structured and documented.**
+> Loading the guidelines that shape how the discussion
+> is structured and documented.
 ```
 
 Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and follow its instructions as written.
@@ -159,7 +159,7 @@ Load **[discussion-session.md](references/discussion-session.md)** and follow it
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Verifying the discussion file follows workflow conventions.**
+> Verifying the discussion file follows workflow conventions.
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -92,10 +92,9 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discussion starting.** I'll track our conversation on a
-> Discussion Map. You can lead wherever you want — I'll
-> challenge thinking, explore edge cases, and capture
-> decisions as we go.
+> **Discussion starting.** I'll track our conversation on a Discussion
+> Map. You can lead wherever you want — I'll challenge thinking,
+> explore edge cases, and capture decisions as we go.
 ```
 
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -47,6 +47,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 ```
 > **Checking for an existing discussion file.** If one exists,
 > you can pick up where you left off or start fresh.
+
 ```
 
 Check if the discussion file exists at `.workflows/{work_unit}/discussion/{topic}.md`.
@@ -99,6 +100,7 @@ Found existing discussion for **{topic:(titlecase)}**.
 ```
 > **Creating the discussion file and seeding the Discussion Map
 > with initial subtopics from your context.**
+
 ```
 
 Load **[initialize-discussion.md](references/initialize-discussion.md)** and follow its instructions as written.
@@ -121,6 +123,7 @@ Load **[initialize-discussion.md](references/initialize-discussion.md)** and fol
 ```
 > **Loading the guidelines that shape how the discussion
 > is structured and documented.**
+
 ```
 
 Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and follow its instructions as written.
@@ -144,6 +147,7 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 > **Discussion starting.** I'll track our conversation on a Discussion
 > Map. You can lead wherever you want — I'll challenge thinking,
 > explore edge cases, and capture decisions as we go.
+
 ```
 
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.
@@ -165,6 +169,7 @@ Load **[discussion-session.md](references/discussion-session.md)** and follow it
 
 ```
 > **Verifying the discussion file follows workflow conventions.**
+
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
@@ -187,6 +192,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ```
 > **Wrapping up.** Final confirmation before marking the
 > discussion as complete.
+
 ```
 
 Load **[conclude-discussion.md](references/conclude-discussion.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -92,11 +92,10 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discussion starting.** I'll track our
-> conversation on a Discussion Map. You can lead
-> wherever you want — I'll challenge thinking,
-> explore edge cases, and capture decisions as
-> we go.
+> **Discussion starting.** I'll track our conversation on a
+> Discussion Map. You can lead wherever you want — I'll
+> challenge thinking, explore edge cases, and capture
+> decisions as we go.
 ```
 
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -32,7 +32,9 @@ Conclude this discussion and mark as completed?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discussion complete.** The specification phase will synthesise your decisions into a formal document.
+> **Discussion complete.** The specification
+> phase will synthesise your decisions into a
+> formal document.
 ```
 
 ```

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -29,6 +29,12 @@ Conclude this discussion and mark as completed?
 3. Final commit
 4. Invoke the bridge:
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Discussion complete.** The specification phase will synthesise your decisions into a formal document.
+```
+
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: discussion

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -32,7 +32,7 @@ Conclude this discussion and mark as completed?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discussion complete.** The specification phase will
+> Discussion complete. The specification phase will
 > synthesise your decisions into a formal document.
 ```
 

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -34,7 +34,6 @@ Conclude this discussion and mark as completed?
 ```
 > **Discussion complete.** The specification phase will
 > synthesise your decisions into a formal document.
-
 ```
 
 ```

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -34,6 +34,7 @@ Conclude this discussion and mark as completed?
 ```
 > **Discussion complete.** The specification phase will
 > synthesise your decisions into a formal document.
+
 ```
 
 ```

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -32,9 +32,8 @@ Conclude this discussion and mark as completed?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discussion complete.** The specification
-> phase will synthesise your decisions into a
-> formal document.
+> **Discussion complete.** The specification phase will
+> synthesise your decisions into a formal document.
 ```
 
 ```

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -50,8 +50,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reading the handoff context to identify which
-> topic to implement.**
+> Reading the handoff context to identify which
+> topic to implement.
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -74,8 +74,8 @@ Store work_unit for the handoff.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking that a completed plan exists and determining
-> where implementation left off.**
+> Checking that a completed plan exists and determining
+> where implementation left off.
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -95,8 +95,8 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Verifying that cross-plan dependencies are satisfied
-> before implementation begins.**
+> Verifying that cross-plan dependencies are satisfied
+> before implementation begins.
 ```
 
 Load **[validate-dependencies.md](references/validate-dependencies.md)** and follow its instructions as written.
@@ -116,8 +116,8 @@ Load **[validate-dependencies.md](references/validate-dependencies.md)** and fol
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking for any environment setup instructions
-> that need to be in place before coding begins.**
+> Checking for any environment setup instructions
+> that need to be in place before coding begins.
 ```
 
 Load **[environment-check.md](references/environment-check.md)** and follow its instructions as written.
@@ -137,8 +137,8 @@ Load **[environment-check.md](references/environment-check.md)** and follow its 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Handing off to the implementation process with
-> plan, specification, and environment context.**
+> Handing off to the implementation process with
+> plan, specification, and environment context.
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -45,7 +45,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ```
 ── Parse Arguments ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -53,7 +52,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 ```
 > **Reading the handoff context to identify which
 > topic to implement.**
-
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -71,7 +69,6 @@ Store work_unit for the handoff.
 
 ```
 ── Validate Phase ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -79,7 +76,6 @@ Store work_unit for the handoff.
 ```
 > **Checking that a completed plan exists and determining
 > where implementation left off.**
-
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -94,7 +90,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ```
 ── Check Dependencies ───────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -102,7 +97,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ```
 > **Verifying that cross-plan dependencies are satisfied
 > before implementation begins.**
-
 ```
 
 Load **[validate-dependencies.md](references/validate-dependencies.md)** and follow its instructions as written.
@@ -117,7 +111,6 @@ Load **[validate-dependencies.md](references/validate-dependencies.md)** and fol
 
 ```
 ── Check Environment ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -125,7 +118,6 @@ Load **[validate-dependencies.md](references/validate-dependencies.md)** and fol
 ```
 > **Checking for any environment setup instructions
 > that need to be in place before coding begins.**
-
 ```
 
 Load **[environment-check.md](references/environment-check.md)** and follow its instructions as written.
@@ -140,7 +132,6 @@ Load **[environment-check.md](references/environment-check.md)** and follow its 
 
 ```
 ── Invoke Implementation ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -148,7 +139,6 @@ Load **[environment-check.md](references/environment-check.md)** and follow its 
 ```
 > **Handing off to the implementation process with
 > plan, specification, and environment context.**
-
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -41,6 +41,21 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reading the handoff context to identify which
+> topic to implement.**
+
+```
+
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -52,6 +67,21 @@ Store work_unit for the handoff.
 
 ## Step 2: Validate Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking that a completed plan exists and determining
+> where implementation left off.**
+
+```
+
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -59,6 +89,21 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 3: Check Dependencies
+
+> *Output the next fenced block as a code block:*
+
+```
+── Check Dependencies ───────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Verifying that cross-plan dependencies are satisfied
+> before implementation begins.**
+
+```
 
 Load **[validate-dependencies.md](references/validate-dependencies.md)** and follow its instructions as written.
 
@@ -68,6 +113,21 @@ Load **[validate-dependencies.md](references/validate-dependencies.md)** and fol
 
 ## Step 4: Check Environment
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check Environment ────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking for any environment setup instructions
+> that need to be in place before coding begins.**
+
+```
+
 Load **[environment-check.md](references/environment-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
@@ -75,5 +135,20 @@ Load **[environment-check.md](references/environment-check.md)** and follow its 
 ---
 
 ## Step 5: Invoke the Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Implementation ────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Handing off to the implementation process with
+> plan, specification, and environment context.**
+
+```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -50,7 +50,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ```
 ── Resume Detection ─────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -59,7 +58,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > **Checking for existing implementation progress.** If a
 > previous session exists, gates and counters will be reset
 > for this session.
-
 ```
 
 Check if an implementation entry exists in the manifest:
@@ -98,7 +96,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.imple
 
 ```
 ── Environment Setup ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -106,7 +103,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.imple
 ```
 > **Checking for environment setup instructions.** Any
 > first-time setup will be handled before tasks begin.
-
 ```
 
 Load **[environment-setup.md](references/environment-setup.md)** and follow its instructions as written.
@@ -121,7 +117,6 @@ Load **[environment-setup.md](references/environment-setup.md)** and follow its 
 
 ```
 ── Read Plan ────────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -129,7 +124,6 @@ Load **[environment-setup.md](references/environment-setup.md)** and follow its 
 ```
 > **Reading the plan and loading the format adapter.**
 > This determines how tasks are extracted and tracked.
-
 ```
 
 Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its instructions as written.
@@ -144,7 +138,6 @@ Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its 
 
 ```
 ── Initialize Tracking ──────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -152,7 +145,6 @@ Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its 
 ```
 > **Setting up implementation tracking in the manifest.**
 > This records progress as tasks are completed.
-
 ```
 
 Load **[initialize-tracking.md](references/initialize-tracking.md)** and follow its instructions as written.
@@ -167,7 +159,6 @@ Load **[initialize-tracking.md](references/initialize-tracking.md)** and follow 
 
 ```
 ── Project Skills Discovery ─────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -175,7 +166,6 @@ Load **[initialize-tracking.md](references/initialize-tracking.md)** and follow 
 ```
 > **Discovering project-level skills that agents should
 > use during implementation.**
-
 ```
 
 Load **[project-skills-discovery.md](references/project-skills-discovery.md)** and follow its instructions as written.
@@ -190,7 +180,6 @@ Load **[project-skills-discovery.md](references/project-skills-discovery.md)** a
 
 ```
 ── Linter Discovery ─────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -198,7 +187,6 @@ Load **[project-skills-discovery.md](references/project-skills-discovery.md)** a
 ```
 > **Discovering linters and formatters that should be
 > run after each task to ensure code quality.**
-
 ```
 
 Load **[linter-setup.md](references/linter-setup.md)** and follow its instructions as written.
@@ -213,7 +201,6 @@ Load **[linter-setup.md](references/linter-setup.md)** and follow its instructio
 
 ```
 ── Task Loop ────────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -222,7 +209,6 @@ Load **[linter-setup.md](references/linter-setup.md)** and follow its instructio
 > **Executing tasks from the plan.** Each task is implemented
 > via TDD by an executor agent, then independently verified by
 > a reviewer agent. You'll approve each task before it proceeds.
-
 ```
 
 Load **[task-loop.md](references/task-loop.md)** and follow its instructions as written.
@@ -247,7 +233,6 @@ After the loop completes:
 
 ```
 ── Analysis Loop ────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -256,7 +241,6 @@ After the loop completes:
 > **Analysing the implementation for gaps and issues.**
 > Agents review what was built against the plan and spec.
 > New tasks may be created if problems are found.
-
 ```
 
 Load **[analysis-loop.md](references/analysis-loop.md)** and follow its instructions as written.
@@ -277,14 +261,12 @@ Load **[analysis-loop.md](references/analysis-loop.md)** and follow its instruct
 
 ```
 ── Compliance Self-Check ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Verifying the implementation follows workflow conventions.**
-
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
@@ -299,7 +281,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ```
 ── Conclude Implementation ──────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -307,7 +288,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ```
 > **Wrapping up.** Final confirmation before marking
 > implementation as complete and moving to review.
-
 ```
 
 Load **[conclude-implementation.md](references/conclude-implementation.md)** and follow its instructions as written.

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -44,13 +44,23 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 1. **No autonomous decisions on spec deviations** — when the executor reports a blocker or spec deviation, present to user and STOP. Never resolve on the user's behalf.
 2. **All git operations are the orchestrator's responsibility** — agents never commit, stage, or interact with git.
 
-## Output Formatting
-
-When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
-
----
-
 ## Step 0: Resume Detection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking for existing implementation progress.** If a
+> previous session exists, gates and counters will be reset
+> for this session.
+
+```
 
 Check if an implementation entry exists in the manifest:
 ```bash
@@ -84,6 +94,21 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.imple
 
 ## Step 1: Environment Setup
 
+> *Output the next fenced block as a code block:*
+
+```
+── Environment Setup ────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking for environment setup instructions.** Any
+> first-time setup will be handled before tasks begin.
+
+```
+
 Load **[environment-setup.md](references/environment-setup.md)** and follow its instructions as written.
 
 → Proceed to **Step 2**.
@@ -91,6 +116,21 @@ Load **[environment-setup.md](references/environment-setup.md)** and follow its 
 ---
 
 ## Step 2: Read Plan + Load Plan Adapter
+
+> *Output the next fenced block as a code block:*
+
+```
+── Read Plan ────────────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reading the plan and loading the format adapter.**
+> This determines how tasks are extracted and tracked.
+
+```
 
 Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its instructions as written.
 
@@ -100,6 +140,21 @@ Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its 
 
 ## Step 3: Initialize Implementation Tracking
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialize Tracking ──────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Setting up implementation tracking in the manifest.**
+> This records progress as tasks are completed.
+
+```
+
 Load **[initialize-tracking.md](references/initialize-tracking.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -107,6 +162,21 @@ Load **[initialize-tracking.md](references/initialize-tracking.md)** and follow 
 ---
 
 ## Step 4: Project Skills Discovery
+
+> *Output the next fenced block as a code block:*
+
+```
+── Project Skills Discovery ─────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Discovering project-level skills that agents should
+> use during implementation.**
+
+```
 
 Load **[project-skills-discovery.md](references/project-skills-discovery.md)** and follow its instructions as written.
 
@@ -116,6 +186,21 @@ Load **[project-skills-discovery.md](references/project-skills-discovery.md)** a
 
 ## Step 5: Linter Discovery
 
+> *Output the next fenced block as a code block:*
+
+```
+── Linter Discovery ─────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Discovering linters and formatters that should be
+> run after each task to ensure code quality.**
+
+```
+
 Load **[linter-setup.md](references/linter-setup.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -123,6 +208,22 @@ Load **[linter-setup.md](references/linter-setup.md)** and follow its instructio
 ---
 
 ## Step 6: Task Loop
+
+> *Output the next fenced block as a code block:*
+
+```
+── Task Loop ────────────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Executing tasks from the plan.** Each task is implemented
+> via TDD by an executor agent, then independently verified by
+> a reviewer agent. You'll approve each task before it proceeds.
+
+```
 
 Load **[task-loop.md](references/task-loop.md)** and follow its instructions as written.
 
@@ -142,6 +243,22 @@ After the loop completes:
 
 ## Step 7: Analysis Loop
 
+> *Output the next fenced block as a code block:*
+
+```
+── Analysis Loop ────────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Analysing the implementation for gaps and issues.**
+> Agents review what was built against the plan and spec.
+> New tasks may be created if problems are found.
+
+```
+
 Load **[analysis-loop.md](references/analysis-loop.md)** and follow its instructions as written.
 
 #### If new tasks were created in the plan
@@ -156,6 +273,20 @@ Load **[analysis-loop.md](references/analysis-loop.md)** and follow its instruct
 
 ## Step 8: Compliance Self-Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Compliance Self-Check ────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Verifying the implementation follows workflow conventions.**
+
+```
+
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 9**.
@@ -163,6 +294,21 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ---
 
 ## Step 9: Mark Implementation Complete
+
+> *Output the next fenced block as a code block:*
+
+```
+── Conclude Implementation ──────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Wrapping up.** Final confirmation before marking
+> implementation as complete and moving to review.
+
+```
 
 Load **[conclude-implementation.md](references/conclude-implementation.md)** and follow its instructions as written.
 

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -122,7 +122,7 @@ Load **[environment-setup.md](references/environment-setup.md)** and follow its 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reading the plan and loading the format adapter.**
+> Reading the plan and loading the format adapter.
 > This determines how tasks are extracted and tracked.
 ```
 
@@ -143,7 +143,7 @@ Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Setting up implementation tracking in the manifest.**
+> Setting up implementation tracking in the manifest.
 > This records progress as tasks are completed.
 ```
 
@@ -164,8 +164,8 @@ Load **[initialize-tracking.md](references/initialize-tracking.md)** and follow 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discovering project-level skills that agents should
-> use during implementation.**
+> Discovering project-level skills that agents should
+> use during implementation.
 ```
 
 Load **[project-skills-discovery.md](references/project-skills-discovery.md)** and follow its instructions as written.
@@ -185,8 +185,8 @@ Load **[project-skills-discovery.md](references/project-skills-discovery.md)** a
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Discovering linters and formatters that should be
-> run after each task to ensure code quality.**
+> Discovering linters and formatters that should be
+> run after each task to ensure code quality.
 ```
 
 Load **[linter-setup.md](references/linter-setup.md)** and follow its instructions as written.
@@ -238,7 +238,7 @@ After the loop completes:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Analysing the implementation for gaps and issues.**
+> Analysing the implementation for gaps and issues.
 > Agents review what was built against the plan and spec.
 > New tasks may be created if problems are found.
 ```
@@ -266,7 +266,7 @@ Load **[analysis-loop.md](references/analysis-loop.md)** and follow its instruct
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Verifying the implementation follows workflow conventions.**
+> Verifying the implementation follows workflow conventions.
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -55,7 +55,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking for existing implementation progress.** If a
+> Checking for existing implementation progress. If a
 > previous session exists, gates and counters will be reset
 > for this session.
 ```
@@ -101,7 +101,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.imple
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking for environment setup instructions.** Any
+> Checking for environment setup instructions. Any
 > first-time setup will be handled before tasks begin.
 ```
 
@@ -206,7 +206,7 @@ Load **[linter-setup.md](references/linter-setup.md)** and follow its instructio
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Executing tasks from the plan.** Each task is implemented
+> Executing tasks from the plan. Each task is implemented
 > via TDD by an executor agent, then independently verified by
 > a reviewer agent. You'll approve each task before it proceeds.
 ```
@@ -286,7 +286,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Wrapping up.** Final confirmation before marking
+> Wrapping up. Final confirmation before marking
 > implementation as complete and moving to review.
 ```
 

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -32,7 +32,17 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.imple
 
 Commit: `impl({work_unit}): complete implementation`
 
-**Pipeline continuation** — Invoke the bridge:
+**Pipeline continuation**:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Implementation complete.** The review phase will validate
+> your work against the specification and plan.
+
+```
+
+Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -39,7 +39,6 @@ Commit: `impl({work_unit}): complete implementation`
 ```
 > **Implementation complete.** The review phase will validate
 > your work against the specification and plan.
-
 ```
 
 Invoke the bridge:

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -37,7 +37,7 @@ Commit: `impl({work_unit}): complete implementation`
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Implementation complete.** The review phase will validate
+> Implementation complete. The review phase will validate
 > your work against the specification and plan.
 ```
 

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -38,6 +38,19 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 1: Parse Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reading the handoff context and checking for existing
+> investigation work.
+```
+
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -63,6 +76,19 @@ Set source="new".
 
 ## Step 2: Validate Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking the status of this investigation — new,
+> in progress, or completed.
+```
+
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 #### If source is `continue`
@@ -76,6 +102,19 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 3: Gather Bug Context
+
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Bug Context ───────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Collecting information about the bug — what's broken,
+> how it manifests, and any initial context.
+```
 
 #### If bug context is already available in conversation
 
@@ -98,5 +137,18 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 ---
 
 ## Step 4: Invoke the Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Investigation ─────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the investigation process to analyse
+> the bug and find the root cause.
+```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -56,13 +56,20 @@ The investigation file is your memory. Context compaction is lossy — what's no
 
 ---
 
-## Output Formatting
-
-When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
-
----
-
 ## Step 0: Resume Detection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking for an existing investigation. If one exists,
+> you can pick up where you left off or start fresh.
+```
 
 Check if the investigation file exists at `.workflows/{work_unit}/investigation/{topic}.md`.
 
@@ -102,6 +109,19 @@ Found existing investigation for **{topic:(titlecase)}**.
 
 ## Step 1: Initialize Investigation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialize Investigation ─────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Creating the investigation file and recording the initial
+> bug context.
+```
+
 Load **[initialize-investigation.md](references/initialize-investigation.md)** and follow its instructions as written.
 
 → Proceed to **Step 2**.
@@ -109,6 +129,19 @@ Load **[initialize-investigation.md](references/initialize-investigation.md)** a
 ---
 
 ## Step 2: Symptom Gathering
+
+> *Output the next fenced block as a code block:*
+
+```
+── Symptom Gathering ────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Gathering detailed symptoms — reproduction steps, error
+> messages, affected areas, and environmental context.
+```
 
 Load **[symptom-gathering.md](references/symptom-gathering.md)** and use its questions to gather symptoms from the user.
 
@@ -122,6 +155,19 @@ When symptoms are sufficiently understood to begin code analysis:
 
 ## Step 3: Code Analysis
 
+> *Output the next fenced block as a code block:*
+
+```
+── Code Analysis ────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Tracing the bug through the codebase — following code
+> paths, checking state, and narrowing down the root cause.
+```
+
 Load **[analysis-patterns.md](references/analysis-patterns.md)** and use its techniques to trace the bug through the code.
 
 Document findings in the investigation file as you analyze. Commit after each significant finding.
@@ -131,6 +177,19 @@ Document findings in the investigation file as you analyze. Commit after each si
 ---
 
 ## Step 4: Root Cause Synthesis
+
+> *Output the next fenced block as a code block:*
+
+```
+── Root Cause Synthesis ─────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Synthesising findings into a clear root cause statement,
+> contributing factors, and fix direction.
+```
 
 Synthesize findings into a clear root cause:
 
@@ -147,6 +206,19 @@ Document in the investigation file and commit.
 
 ## Step 5: Root Cause Validation
 
+> *Output the next fenced block as a code block:*
+
+```
+── Root Cause Validation ────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Validating the root cause analysis against the codebase
+> to confirm the diagnosis is correct.
+```
+
 Load **[synthesis-agent.md](references/synthesis-agent.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -154,6 +226,19 @@ Load **[synthesis-agent.md](references/synthesis-agent.md)** and follow its inst
 ---
 
 ## Step 6: Findings Review & Fix Discussion
+
+> *Output the next fenced block as a code block:*
+
+```
+── Findings Review ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Presenting the investigation findings and discussing
+> the fix approach with you.
+```
 
 Load **[findings-review.md](references/findings-review.md)** and follow its instructions as written.
 
@@ -163,6 +248,18 @@ Load **[findings-review.md](references/findings-review.md)** and follow its inst
 
 ## Step 7: Compliance Self-Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Compliance Self-Check ────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Verifying the investigation file follows workflow conventions.
+```
+
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 8**.
@@ -170,5 +267,18 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ---
 
 ## Step 8: Conclude Investigation
+
+> *Output the next fenced block as a code block:*
+
+```
+── Conclude Investigation ───────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Wrapping up. Final confirmation before marking the
+> investigation as complete.
+```
 
 Load **[conclude-investigation.md](references/conclude-investigation.md)** and follow its instructions as written.

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -43,7 +43,16 @@ Fix direction: {chosen approach}
 The investigation is completed. Root cause and fix direction are documented.
 ```
 
-4. Invoke the bridge:
+4. Closure signpost:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Investigation complete. The specification phase will formalise
+> the fix approach into a document that drives planning.
+```
+
+5. Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}

--- a/skills/workflow-planning-entry/SKILL.md
+++ b/skills/workflow-planning-entry/SKILL.md
@@ -45,7 +45,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ```
 ── Parse Arguments ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -53,7 +52,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 ```
 > **Reading the handoff context to identify which
 > topic to plan.**
-
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -71,7 +69,6 @@ Store work_unit for the handoff.
 
 ```
 ── Validate Specification ───────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -79,7 +76,6 @@ Store work_unit for the handoff.
 ```
 > **Checking that a completed specification exists
 > for this topic.**
-
 ```
 
 Load **[validate-spec.md](references/validate-spec.md)** and follow its instructions as written.
@@ -94,7 +90,6 @@ Load **[validate-spec.md](references/validate-spec.md)** and follow its instruct
 
 ```
 ── Validate Phase ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -102,7 +97,6 @@ Load **[validate-spec.md](references/validate-spec.md)** and follow its instruct
 ```
 > **Checking whether a plan already exists for this
 > topic.**
-
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -123,7 +117,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ```
 ── Cross-Cutting Context ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -131,7 +124,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ```
 > **Loading any cross-cutting specifications that apply
 > to this plan.**
-
 ```
 
 Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and follow its instructions as written.
@@ -146,7 +138,6 @@ Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and fol
 
 ```
 ── Invoke Planning ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -154,7 +145,6 @@ Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and fol
 ```
 > **Handing off to the planning process with
 > specification and context.**
-
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-planning-entry/SKILL.md
+++ b/skills/workflow-planning-entry/SKILL.md
@@ -50,8 +50,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reading the handoff context to identify which
-> topic to plan.**
+> Reading the handoff context to identify which
+> topic to plan.
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -74,8 +74,8 @@ Store work_unit for the handoff.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking that a completed specification exists
-> for this topic.**
+> Checking that a completed specification exists
+> for this topic.
 ```
 
 Load **[validate-spec.md](references/validate-spec.md)** and follow its instructions as written.
@@ -95,8 +95,8 @@ Load **[validate-spec.md](references/validate-spec.md)** and follow its instruct
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking whether a plan already exists for this
-> topic.**
+> Checking whether a plan already exists for this
+> topic.
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -122,8 +122,8 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Loading any cross-cutting specifications that apply
-> to this plan.**
+> Loading any cross-cutting specifications that apply
+> to this plan.
 ```
 
 Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and follow its instructions as written.
@@ -143,8 +143,8 @@ Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and fol
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Handing off to the planning process with
-> specification and context.**
+> Handing off to the planning process with
+> specification and context.
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-planning-entry/SKILL.md
+++ b/skills/workflow-planning-entry/SKILL.md
@@ -41,6 +41,21 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reading the handoff context to identify which
+> topic to plan.**
+
+```
+
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -52,6 +67,21 @@ Store work_unit for the handoff.
 
 ## Step 2: Validate Specification
 
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Specification ───────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking that a completed specification exists
+> for this topic.**
+
+```
+
 Load **[validate-spec.md](references/validate-spec.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -59,6 +89,21 @@ Load **[validate-spec.md](references/validate-spec.md)** and follow its instruct
 ---
 
 ## Step 3: Validate Phase
+
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking whether a plan already exists for this
+> topic.**
+
+```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
@@ -74,6 +119,21 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ## Step 4: Cross-Cutting Context
 
+> *Output the next fenced block as a code block:*
+
+```
+── Cross-Cutting Context ────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Loading any cross-cutting specifications that apply
+> to this plan.**
+
+```
+
 Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
@@ -81,5 +141,20 @@ Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and fol
 ---
 
 ## Step 5: Invoke the Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Planning ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Handing off to the planning process with
+> specification and context.**
+
+```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -58,7 +58,6 @@ Follow every step in sequence. No steps are optional.
 
 ```
 ── Resume Detection ─────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -66,7 +65,6 @@ Follow every step in sequence. No steps are optional.
 ```
 > **Checking for an existing plan.** If one exists, you can
 > pick up where you left off or start fresh.
-
 ```
 
 Check if a planning entry exists in the manifest:
@@ -148,7 +146,6 @@ Continue or restart?
 
 ```
 ── Initialize Plan ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -156,7 +153,6 @@ Continue or restart?
 ```
 > **Setting up the plan.** Selecting an output format and creating
 > the planning file structure.
-
 ```
 
 Load **[initialize-plan.md](references/initialize-plan.md)** and follow its instructions as written.
@@ -171,7 +167,6 @@ Load **[initialize-plan.md](references/initialize-plan.md)** and follow its inst
 
 ```
 ── Session Setup ────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -179,7 +174,6 @@ Load **[initialize-plan.md](references/initialize-plan.md)** and follow its inst
 ```
 > **Loading context from previous work.** Reading the specification
 > and any existing planning progress.
-
 ```
 
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
@@ -194,7 +188,6 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 
 ```
 ── Load Planning Principles ─────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -203,7 +196,6 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 > **Loading the guidelines for how plans are structured.**
 > These ensure tasks are well-scoped, testable, and sequenced
 > correctly.
-
 ```
 
 Load **[planning-principles.md](references/planning-principles.md)** and follow its instructions as written.
@@ -218,7 +210,6 @@ Load **[planning-principles.md](references/planning-principles.md)** and follow 
 
 ```
 ── Verify Source Material ───────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -226,7 +217,6 @@ Load **[planning-principles.md](references/planning-principles.md)** and follow 
 ```
 > **Reading the specification that drives this plan.** Everything
 > in the plan traces back to the specification.
-
 ```
 
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
@@ -241,7 +231,6 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 ```
 ── Plan Construction ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -250,7 +239,6 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 > **Building the plan.** Designing phases with goals and acceptance
 > criteria, then authoring detailed tasks for each phase. You'll
 > approve task lists and individual tasks as we go.
-
 ```
 
 Load **[plan-construction.md](references/plan-construction.md)** and follow its instructions as written.
@@ -265,7 +253,6 @@ Load **[plan-construction.md](references/plan-construction.md)** and follow its 
 
 ```
 ── Analyze Task Graph ───────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -273,7 +260,6 @@ Load **[plan-construction.md](references/plan-construction.md)** and follow its 
 ```
 > **Analysing dependencies between tasks.** Setting priority and
 > execution order based on what depends on what.
-
 ```
 
 Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow its instructions as written.
@@ -288,7 +274,6 @@ Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow it
 
 ```
 ── Resolve External Dependencies ────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -296,7 +281,6 @@ Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow it
 ```
 > **Checking for dependencies on other plans.** For epics,
 > tasks in one plan may depend on tasks in another.
-
 ```
 
 #### If work_type is not `epic`
@@ -317,7 +301,6 @@ Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follo
 
 ```
 ── Plan Review ──────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -326,7 +309,6 @@ Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follo
 > **Reviewing the plan.** Agents will check that tasks are
 > well-scoped, dependencies are sound, and nothing from the
 > specification was missed.
-
 ```
 
 Load **[plan-review.md](references/plan-review.md)** and follow its instructions as written.
@@ -341,14 +323,12 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 ```
 ── Compliance Self-Check ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Verifying the plan follows workflow conventions.**
-
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
@@ -363,7 +343,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ```
 ── Conclude the Plan ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -371,7 +350,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ```
 > **Wrapping up.** Final confirmation before marking the plan
 > as complete and handing off to implementation.
-
 ```
 
 Load **[conclude-plan.md](references/conclude-plan.md)** and follow its instructions as written.

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -193,7 +193,7 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Loading the guidelines for how plans are structured.**
+> Loading the guidelines for how plans are structured.
 > These ensure tasks are well-scoped, testable, and sequenced
 > correctly.
 ```
@@ -328,7 +328,7 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Verifying the plan follows workflow conventions.**
+> Verifying the plan follows workflow conventions.
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -52,13 +52,22 @@ This process constructs a plan from a specification. A plan consists of:
 
 Follow every step in sequence. No steps are optional.
 
-## Output Formatting
-
-When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
-
----
-
 ## Step 0: Resume Detection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking for an existing plan.** If one exists, you can
+> pick up where you left off or start fresh.
+
+```
 
 Check if a planning entry exists in the manifest:
 ```bash
@@ -135,6 +144,21 @@ Continue or restart?
 
 ## Step 1: Initialize Plan
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialize Plan ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Setting up the plan.** Selecting an output format and creating
+> the planning file structure.
+
+```
+
 Load **[initialize-plan.md](references/initialize-plan.md)** and follow its instructions as written.
 
 → Proceed to **Step 2**.
@@ -142,6 +166,21 @@ Load **[initialize-plan.md](references/initialize-plan.md)** and follow its inst
 ---
 
 ## Step 2: Session Setup
+
+> *Output the next fenced block as a code block:*
+
+```
+── Session Setup ────────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Loading context from previous work.** Reading the specification
+> and any existing planning progress.
+
+```
 
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
 
@@ -151,6 +190,22 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 
 ## Step 3: Load Planning Principles
 
+> *Output the next fenced block as a code block:*
+
+```
+── Load Planning Principles ─────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Loading the guidelines for how plans are structured.**
+> These ensure tasks are well-scoped, testable, and sequenced
+> correctly.
+
+```
+
 Load **[planning-principles.md](references/planning-principles.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -158,6 +213,21 @@ Load **[planning-principles.md](references/planning-principles.md)** and follow 
 ---
 
 ## Step 4: Verify Source Material
+
+> *Output the next fenced block as a code block:*
+
+```
+── Verify Source Material ───────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reading the specification that drives this plan.** Everything
+> in the plan traces back to the specification.
+
+```
 
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
 
@@ -167,6 +237,22 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 ## Step 5: Plan Construction
 
+> *Output the next fenced block as a code block:*
+
+```
+── Plan Construction ────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Building the plan.** Designing phases with goals and acceptance
+> criteria, then authoring detailed tasks for each phase. You'll
+> approve task lists and individual tasks as we go.
+
+```
+
 Load **[plan-construction.md](references/plan-construction.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -175,6 +261,21 @@ Load **[plan-construction.md](references/plan-construction.md)** and follow its 
 
 ## Step 6: Analyze Task Graph
 
+> *Output the next fenced block as a code block:*
+
+```
+── Analyze Task Graph ───────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Analysing dependencies between tasks.** Setting priority and
+> execution order based on what depends on what.
+
+```
+
 Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow its instructions as written.
 
 → Proceed to **Step 7**.
@@ -182,6 +283,21 @@ Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow it
 ---
 
 ## Step 7: Resolve External Dependencies
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resolve External Dependencies ────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking for dependencies on other plans.** For epics,
+> tasks in one plan may depend on tasks in another.
+
+```
 
 #### If work_type is not `epic`
 
@@ -197,6 +313,22 @@ Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follo
 
 ## Step 8: Plan Review
 
+> *Output the next fenced block as a code block:*
+
+```
+── Plan Review ──────────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reviewing the plan.** Agents will check that tasks are
+> well-scoped, dependencies are sound, and nothing from the
+> specification was missed.
+
+```
+
 Load **[plan-review.md](references/plan-review.md)** and follow its instructions as written.
 
 → Proceed to **Step 9**.
@@ -205,6 +337,20 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 ## Step 9: Compliance Self-Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Compliance Self-Check ────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Verifying the plan follows workflow conventions.**
+
+```
+
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 10**.
@@ -212,5 +358,20 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ---
 
 ## Step 10: Conclude the Plan
+
+> *Output the next fenced block as a code block:*
+
+```
+── Conclude the Plan ────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Wrapping up.** Final confirmation before marking the plan
+> as complete and handing off to implementation.
+
+```
 
 Load **[conclude-plan.md](references/conclude-plan.md)** and follow its instructions as written.

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -63,7 +63,7 @@ Follow every step in sequence. No steps are optional.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking for an existing plan.** If one exists, you can
+> Checking for an existing plan. If one exists, you can
 > pick up where you left off or start fresh.
 ```
 
@@ -151,7 +151,7 @@ Continue or restart?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Setting up the plan.** Selecting an output format and creating
+> Setting up the plan. Selecting an output format and creating
 > the planning file structure.
 ```
 
@@ -172,7 +172,7 @@ Load **[initialize-plan.md](references/initialize-plan.md)** and follow its inst
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Loading context from previous work.** Reading the specification
+> Loading context from previous work. Reading the specification
 > and any existing planning progress.
 ```
 
@@ -215,7 +215,7 @@ Load **[planning-principles.md](references/planning-principles.md)** and follow 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reading the specification that drives this plan.** Everything
+> Reading the specification that drives this plan. Everything
 > in the plan traces back to the specification.
 ```
 
@@ -236,7 +236,7 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Building the plan.** Designing phases with goals and acceptance
+> Building the plan. Designing phases with goals and acceptance
 > criteria, then authoring detailed tasks for each phase. You'll
 > approve task lists and individual tasks as we go.
 ```
@@ -258,7 +258,7 @@ Load **[plan-construction.md](references/plan-construction.md)** and follow its 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Analysing dependencies between tasks.** Setting priority and
+> Analysing dependencies between tasks. Setting priority and
 > execution order based on what depends on what.
 ```
 
@@ -279,7 +279,7 @@ Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow it
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking for dependencies on other plans.** For epics,
+> Checking for dependencies on other plans. For epics,
 > tasks in one plan may depend on tasks in another.
 ```
 
@@ -306,7 +306,7 @@ Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follo
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reviewing the plan.** Agents will check that tasks are
+> Reviewing the plan. Agents will check that tasks are
 > well-scoped, dependencies are sound, and nothing from the
 > specification was missed.
 ```
@@ -348,7 +348,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Wrapping up.** Final confirmation before marking the plan
+> Wrapping up. Final confirmation before marking the plan
 > as complete and handing off to implementation.
 ```
 

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -49,7 +49,6 @@ Status has been marked as `completed`. The plan is ready for implementation.
 ```
 > **Planning complete.** The implementation phase will execute
 > these tasks using TDD — tests first, then code.
-
 ```
 
 Invoke the bridge:

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -47,7 +47,7 @@ Status has been marked as `completed`. The plan is ready for implementation.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Planning complete.** The implementation phase will execute
+> Planning complete. The implementation phase will execute
 > these tasks using TDD — tests first, then code.
 ```
 

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -42,7 +42,17 @@ The plan contains **{N} phases** with **{M} tasks** total, reviewed for traceabi
 Status has been marked as `completed`. The plan is ready for implementation.
 ```
 
-4. **Pipeline continuation** — Invoke the bridge:
+4. **Pipeline continuation**:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Planning complete.** The implementation phase will execute
+> these tasks using TDD — tests first, then code.
+
+```
+
+Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -41,6 +41,19 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reading the handoff context and determining which
+> research topic to work with.
+```
+
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -70,6 +83,18 @@ Deferred — gather-context will resolve it.
 
 ## Step 2: Check Phase Entry
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check Phase Entry ────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking if research already exists for this topic.
+```
+
 Check if the research phase entry exists:
 
 ```bash
@@ -88,6 +113,19 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.re
 
 ## Step 3: Validate Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking the status of this research — in progress
+> or completed.
+```
+
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
@@ -95,6 +133,18 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 4: Gather Context
+
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Context ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Collecting initial context to seed the research session.
+```
 
 #### If research context is already available in conversation
 
@@ -111,5 +161,18 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 ---
 
 ## Step 5: Invoke the Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Research ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the research process with all
+> gathered context.
+```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -34,13 +34,20 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ---
 
-## Output Formatting
-
-When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
-
----
-
 ## Step 0: Resume Detection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking for existing research on this topic. If found,
+> you can pick up where you left off or start fresh.
+```
 
 Check if the research file exists at the handoff's Output path.
 
@@ -80,6 +87,19 @@ Found existing research for **{topic:(titlecase)}**.
 
 ## Step 1: Initialize Research
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialize Research ──────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Creating the research file and seeding it with initial
+> context from the handoff.
+```
+
 Load **[initialize-research.md](references/initialize-research.md)** and follow its instructions as written.
 
 → Proceed to **Step 2**.
@@ -87,6 +107,19 @@ Load **[initialize-research.md](references/initialize-research.md)** and follow 
 ---
 
 ## Step 2: File Strategy
+
+> *Output the next fenced block as a code block:*
+
+```
+── File Strategy ────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Determining how research files are organized for this
+> work type — single file or multiple topics.
+```
 
 Load **[file-strategy.md](references/file-strategy.md)** and follow its instructions as written.
 
@@ -96,6 +129,19 @@ Load **[file-strategy.md](references/file-strategy.md)** and follow its instruct
 
 ## Step 3: Research Guidelines
 
+> *Output the next fenced block as a code block:*
+
+```
+── Research Guidelines ──────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Loading the guidelines that shape how research is
+> conducted and documented.
+```
+
 Load **[research-guidelines.md](references/research-guidelines.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -103,5 +149,19 @@ Load **[research-guidelines.md](references/research-guidelines.md)** and follow 
 ---
 
 ## Step 4: Research Session
+
+> *Output the next fenced block as a code block:*
+
+```
+── Research Session ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting the research session. This is open-ended exploration
+> — follow threads, surface options, and document findings.
+> No decisions needed at this stage.
+```
 
 Load **[route-session.md](references/route-session.md)** and follow its instructions as written.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -9,7 +9,16 @@
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.research.{topic} status completed
    ```
 2. Final commit: `research({work_unit}): complete {topic} research`
-3. Invoke the `/workflow-bridge` skill:
+3. Closure signpost:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Research complete. The discussion phase will use these findings
+> to make decisions about architecture and approach.
+```
+
+4. Invoke the `/workflow-bridge` skill:
    ```
    Pipeline bridge for: {work_unit}
    Completed phase: research

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -41,6 +41,21 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reading the handoff context to identify which
+> topic to review.**
+
+```
+
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -52,6 +67,21 @@ Store work_unit for the handoff.
 
 ## Step 2: Validate Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking that a completed plan and implementation
+> exist for this topic.**
+
+```
+
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -59,5 +89,20 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 3: Invoke the Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Review ────────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Handing off to the review process to validate the
+> implementation against the specification and plan.**
+
+```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -50,8 +50,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reading the handoff context to identify which
-> topic to review.**
+> Reading the handoff context to identify which
+> topic to review.
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -74,8 +74,8 @@ Store work_unit for the handoff.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking that a completed plan and implementation
-> exist for this topic.**
+> Checking that a completed plan and implementation
+> exist for this topic.
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -95,8 +95,8 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Handing off to the review process to validate the
-> implementation against the specification and plan.**
+> Handing off to the review process to validate the
+> implementation against the specification and plan.
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -45,7 +45,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ```
 ── Parse Arguments ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -53,7 +52,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 ```
 > **Reading the handoff context to identify which
 > topic to review.**
-
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -71,7 +69,6 @@ Store work_unit for the handoff.
 
 ```
 ── Validate Phase ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -79,7 +76,6 @@ Store work_unit for the handoff.
 ```
 > **Checking that a completed plan and implementation
 > exist for this topic.**
-
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -94,7 +90,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ```
 ── Invoke Review ────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -102,7 +97,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ```
 > **Handing off to the review process to validate the
 > implementation against the specification and plan.**
-
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -51,7 +51,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ```
 ── Resume Detection ─────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -59,7 +58,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 ```
 > **Checking for an existing review.** If one exists, you can
 > continue reviewing unreviewed tasks or start fresh.
-
 ```
 
 Check if a review file exists at `.workflows/{work_unit}/review/{topic}/report.md`.
@@ -173,14 +171,12 @@ Set `unreviewed_tasks` = `[{list of unreviewed internal IDs}]`.
 
 ```
 ── Initialize Review ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Registering the review phase in the manifest.**
-
 ```
 
 Check if review phase is registered in manifest:
@@ -209,7 +205,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit
 
 ```
 ── Read Plans and Specifications ────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -217,7 +212,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit
 ```
 > **Reading the plan and specification that the
 > implementation was built from.**
-
 ```
 
 Load **[read-plans.md](references/read-plans.md)** and follow its instructions as written.
@@ -232,7 +226,6 @@ Load **[read-plans.md](references/read-plans.md)** and follow its instructions a
 
 ```
 ── Load Project Skills ──────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -240,7 +233,6 @@ Load **[read-plans.md](references/read-plans.md)** and follow its instructions a
 ```
 > **Loading project-level skills that inform
 > quality expectations.**
-
 ```
 
 Load **[load-project-skills.md](references/load-project-skills.md)** and follow its instructions as written.
@@ -255,7 +247,6 @@ Load **[load-project-skills.md](references/load-project-skills.md)** and follow 
 
 ```
 ── QA Verification ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -264,7 +255,6 @@ Load **[load-project-skills.md](references/load-project-skills.md)** and follow 
 > **Dispatching task verifier agents.** Each task is
 > independently verified against its acceptance criteria
 > and the specification.
-
 ```
 
 Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and follow its instructions as written.
@@ -279,7 +269,6 @@ Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and fol
 
 ```
 ── Produce Review ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -287,7 +276,6 @@ Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and fol
 ```
 > **Synthesising agent findings into the review report.**
 > Aggregating per-task results into an overall assessment.
-
 ```
 
 Load **[produce-review.md](references/produce-review.md)** and follow its instructions as written.
@@ -302,7 +290,6 @@ Load **[produce-review.md](references/produce-review.md)** and follow its instru
 
 ```
 ── Present Review ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -310,7 +297,6 @@ Load **[produce-review.md](references/produce-review.md)** and follow its instru
 ```
 > **Presenting the review findings.** You'll see the
 > verdict, summary, and detailed per-task results.
-
 ```
 
 Load **[present-review.md](references/present-review.md)** and follow its instructions as written.
@@ -325,14 +311,12 @@ Load **[present-review.md](references/present-review.md)** and follow its instru
 
 ```
 ── Compliance Self-Check ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Verifying the review follows workflow conventions.**
-
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
@@ -347,7 +331,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ```
 ── Review Actions ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -355,7 +338,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ```
 > **Deciding what to do with the findings.** You can
 > accept the review, request fixes, or ask questions.
-
 ```
 
 Load **[review-actions-loop.md](references/review-actions-loop.md)** and follow its instructions as written.

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -56,7 +56,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking for an existing review.** If one exists, you can
+> Checking for an existing review. If one exists, you can
 > continue reviewing unreviewed tasks or start fresh.
 ```
 
@@ -252,7 +252,7 @@ Load **[load-project-skills.md](references/load-project-skills.md)** and follow 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Dispatching task verifier agents.** Each task is
+> Dispatching task verifier agents. Each task is
 > independently verified against its acceptance criteria
 > and the specification.
 ```
@@ -295,7 +295,7 @@ Load **[produce-review.md](references/produce-review.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Presenting the review findings.** You'll see the
+> Presenting the review findings. You'll see the
 > verdict, summary, and detailed per-task results.
 ```
 
@@ -336,7 +336,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Deciding what to do with the findings.** You can
+> Deciding what to do with the findings. You can
 > accept the review, request fixes, or ask questions.
 ```
 

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -45,13 +45,22 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ---
 
-## Output Formatting
-
-When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
-
----
-
 ## Step 0: Resume Detection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking for an existing review.** If one exists, you can
+> continue reviewing unreviewed tasks or start fresh.
+
+```
 
 Check if a review file exists at `.workflows/{work_unit}/review/{topic}/report.md`.
 
@@ -160,6 +169,20 @@ Set `unreviewed_tasks` = `[{list of unreviewed internal IDs}]`.
 
 ## Step 1: Initialize Review
 
+> *Output the next fenced block as a code block:*
+
+```
+── Initialize Review ────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Registering the review phase in the manifest.**
+
+```
+
 Check if review phase is registered in manifest:
 
 ```bash
@@ -182,6 +205,21 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit
 
 ## Step 2: Read Plan(s) and Specification(s)
 
+> *Output the next fenced block as a code block:*
+
+```
+── Read Plans and Specifications ────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reading the plan and specification that the
+> implementation was built from.**
+
+```
+
 Load **[read-plans.md](references/read-plans.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -189,6 +227,21 @@ Load **[read-plans.md](references/read-plans.md)** and follow its instructions a
 ---
 
 ## Step 3: Load Project Skills
+
+> *Output the next fenced block as a code block:*
+
+```
+── Load Project Skills ──────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Loading project-level skills that inform
+> quality expectations.**
+
+```
 
 Load **[load-project-skills.md](references/load-project-skills.md)** and follow its instructions as written.
 
@@ -198,6 +251,22 @@ Load **[load-project-skills.md](references/load-project-skills.md)** and follow 
 
 ## Step 4: QA Verification
 
+> *Output the next fenced block as a code block:*
+
+```
+── QA Verification ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Dispatching task verifier agents.** Each task is
+> independently verified against its acceptance criteria
+> and the specification.
+
+```
+
 Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
@@ -205,6 +274,21 @@ Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and fol
 ---
 
 ## Step 5: Produce Review
+
+> *Output the next fenced block as a code block:*
+
+```
+── Produce Review ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Synthesising agent findings into the review report.**
+> Aggregating per-task results into an overall assessment.
+
+```
 
 Load **[produce-review.md](references/produce-review.md)** and follow its instructions as written.
 
@@ -214,6 +298,21 @@ Load **[produce-review.md](references/produce-review.md)** and follow its instru
 
 ## Step 6: Present Review
 
+> *Output the next fenced block as a code block:*
+
+```
+── Present Review ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Presenting the review findings.** You'll see the
+> verdict, summary, and detailed per-task results.
+
+```
+
 Load **[present-review.md](references/present-review.md)** and follow its instructions as written.
 
 → Proceed to **Step 7**.
@@ -222,6 +321,20 @@ Load **[present-review.md](references/present-review.md)** and follow its instru
 
 ## Step 7: Compliance Self-Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Compliance Self-Check ────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Verifying the review follows workflow conventions.**
+
+```
+
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 8**.
@@ -229,6 +342,21 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ---
 
 ## Step 8: Review Actions
+
+> *Output the next fenced block as a code block:*
+
+```
+── Review Actions ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Deciding what to do with the findings.** You can
+> accept the review, request fixes, or ask questions.
+
+```
 
 Load **[review-actions-loop.md](references/review-actions-loop.md)** and follow its instructions as written.
 

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -176,7 +176,7 @@ Set `unreviewed_tasks` = `[{list of unreviewed internal IDs}]`.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Registering the review phase in the manifest.**
+> Registering the review phase in the manifest.
 ```
 
 Check if review phase is registered in manifest:
@@ -210,8 +210,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reading the plan and specification that the
-> implementation was built from.**
+> Reading the plan and specification that the
+> implementation was built from.
 ```
 
 Load **[read-plans.md](references/read-plans.md)** and follow its instructions as written.
@@ -231,8 +231,8 @@ Load **[read-plans.md](references/read-plans.md)** and follow its instructions a
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Loading project-level skills that inform
-> quality expectations.**
+> Loading project-level skills that inform
+> quality expectations.
 ```
 
 Load **[load-project-skills.md](references/load-project-skills.md)** and follow its instructions as written.
@@ -274,7 +274,7 @@ Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and fol
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Synthesising agent findings into the review report.**
+> Synthesising agent findings into the review report.
 > Aggregating per-task results into an overall assessment.
 ```
 
@@ -316,7 +316,7 @@ Load **[present-review.md](references/present-review.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Verifying the review follows workflow conventions.**
+> Verifying the review follows workflow conventions.
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.

--- a/skills/workflow-scoping-entry/SKILL.md
+++ b/skills/workflow-scoping-entry/SKILL.md
@@ -37,6 +37,19 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reading the handoff context to identify which
+> quick-fix to scope.
+```
+
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -48,6 +61,19 @@ Store work_unit for the handoff.
 
 ## Step 2: Validate Phase
 
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking if scoping has already been started for
+> this quick-fix.
+```
+
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -55,5 +81,18 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 3: Invoke the Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Scoping ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the scoping process. This will gather
+> context, build a spec, and create the plan in one pass.
+```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -39,13 +39,20 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 2. **No acceptance criteria** — mechanical changes are verified by test baselines and completeness checks, not by acceptance criteria.
 3. **No agents** — scoping writes specs and tasks directly, without invoking planning agents or review cycles.
 
-## Output Formatting
-
-When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
-
----
-
 ## Step 0: Resume Detection
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking for existing scoping work. If a spec and plan
+> already exist, we can skip ahead.
+```
 
 Check if a specification already exists:
 
@@ -96,6 +103,19 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.scopi
 
 ## Step 1: Gather Context
 
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Context ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Understanding what needs changing — reading code, asking
+> clarifying questions, and building a picture of the change.
+```
+
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 2**.
@@ -103,6 +123,19 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 ---
 
 ## Step 2: Complexity Check
+
+> *Output the next fenced block as a code block:*
+
+```
+── Complexity Check ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Assessing whether this change fits the quick-fix model.
+> If it's too complex, it should be promoted to a feature.
+```
 
 Load **[complexity-check.md](references/complexity-check.md)** and follow its instructions as written.
 
@@ -112,6 +145,19 @@ Load **[complexity-check.md](references/complexity-check.md)** and follow its in
 
 ## Step 3: Write Specification
 
+> *Output the next fenced block as a code block:*
+
+```
+── Write Specification ──────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Writing a lightweight specification for the change.
+> This captures what's changing and why.
+```
+
 Load **[write-specification.md](references/write-specification.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -119,6 +165,18 @@ Load **[write-specification.md](references/write-specification.md)** and follow 
 ---
 
 ## Step 4: Select Output Format
+
+> *Output the next fenced block as a code block:*
+
+```
+── Select Output Format ─────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Choosing the output format for task files.
+```
 
 Load **[select-format.md](references/select-format.md)** and follow its instructions as written.
 
@@ -128,6 +186,19 @@ Load **[select-format.md](references/select-format.md)** and follow its instruct
 
 ## Step 5: Write Tasks
 
+> *Output the next fenced block as a code block:*
+
+```
+── Write Tasks ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Writing 1-2 task files for the change. Quick-fixes
+> are limited to two tasks maximum.
+```
+
 Load **[write-tasks.md](references/write-tasks.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -135,5 +206,17 @@ Load **[write-tasks.md](references/write-tasks.md)** and follow its instructions
 ---
 
 ## Step 6: Conclude Scoping
+
+> *Output the next fenced block as a code block:*
+
+```
+── Conclude Scoping ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Wrapping up. Spec and plan are ready for implementation.
+```
 
 Load **[conclude-scoping.md](references/conclude-scoping.md)** and follow its instructions as written.

--- a/skills/workflow-scoping-process/references/conclude-scoping.md
+++ b/skills/workflow-scoping-process/references/conclude-scoping.md
@@ -13,6 +13,13 @@ Scoping complete for "{topic:(titlecase)}".
   Plan: .workflows/{work_unit}/planning/{topic}/
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Scoping complete. The implementation phase will execute
+> these tasks using the verification workflow.
+```
+
 **Pipeline continuation** — Invoke the bridge:
 
 ```

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -76,6 +76,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.plann
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} phase 1
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task '~'
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_map '{}'
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} external_id {external_id}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} status completed
 ```
 
@@ -85,7 +86,7 @@ Register the task_map entries. For each task, map internal_id to external_id:
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_map.{internal_id} {external_id}
 ```
 
-The external_id is determined by the format's authoring instructions.
+Both the plan-level `external_id` and per-task external IDs are determined by the format's authoring instructions (see the Plan Structure and Task Storage sections).
 
 ## D. Mark Scoping Complete
 

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -76,7 +76,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.plann
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} phase 1
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task '~'
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_map '{}'
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} external_id {external_id}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} status completed
 ```
 

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -45,7 +45,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ```
 ── Parse Arguments ──────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -53,7 +52,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 ```
 > **Reading the handoff context and determining which
 > specification to work with.**
-
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -95,7 +93,6 @@ Parse the discovery output to understand:
 
 ```
 ── Validate Source Material ─────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -103,7 +100,6 @@ Parse the discovery output to understand:
 ```
 > **Checking that the required source material is ready
 > — completed discussions or investigations.**
-
 ```
 
 Load **[validate-source.md](references/validate-source.md)** and follow its instructions as written.
@@ -118,7 +114,6 @@ Load **[validate-source.md](references/validate-source.md)** and follow its inst
 
 ```
 ── Validate Phase ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -126,7 +121,6 @@ Load **[validate-source.md](references/validate-source.md)** and follow its inst
 ```
 > **Checking whether a specification already exists
 > for this topic.**
-
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -141,7 +135,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ```
 ── Invoke Specification ─────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -149,7 +142,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ```
 > **Handing off to the specification process with all
 > gathered context.**
-
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.
@@ -162,7 +154,6 @@ Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructio
 
 ```
 ── Check Prerequisites ──────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -170,7 +161,6 @@ Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructio
 ```
 > **Verifying that completed discussions are available
 > to build specifications from.**
-
 ```
 
 Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow its instructions as written.
@@ -185,7 +175,6 @@ Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow 
 
 ```
 ── Route Based on State ─────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -193,7 +182,6 @@ Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow 
 ```
 > **Evaluating what discussions and specifications exist
 > to determine next steps.**
-
 ```
 
 Load **[route-scenario.md](references/route-scenario.md)** and follow its instructions as written.

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -50,8 +50,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reading the handoff context and determining which
-> specification to work with.**
+> Reading the handoff context and determining which
+> specification to work with.
 ```
 
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
@@ -98,8 +98,8 @@ Parse the discovery output to understand:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking that the required source material is ready
-> — completed discussions or investigations.**
+> Checking that the required source material is ready
+> — completed discussions or investigations.
 ```
 
 Load **[validate-source.md](references/validate-source.md)** and follow its instructions as written.
@@ -119,8 +119,8 @@ Load **[validate-source.md](references/validate-source.md)** and follow its inst
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking whether a specification already exists
-> for this topic.**
+> Checking whether a specification already exists
+> for this topic.
 ```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
@@ -140,8 +140,8 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Handing off to the specification process with all
-> gathered context.**
+> Handing off to the specification process with all
+> gathered context.
 ```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.
@@ -159,8 +159,8 @@ Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructio
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Verifying that completed discussions are available
-> to build specifications from.**
+> Verifying that completed discussions are available
+> to build specifications from.
 ```
 
 Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow its instructions as written.
@@ -180,8 +180,8 @@ Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Evaluating what discussions and specifications exist
-> to determine next steps.**
+> Evaluating what discussions and specifications exist
+> to determine next steps.
 ```
 
 Load **[route-scenario.md](references/route-scenario.md)** and follow its instructions as written.

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -41,6 +41,21 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reading the handoff context and determining which
+> specification to work with.**
+
+```
+
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -76,6 +91,21 @@ Parse the discovery output to understand:
 
 ## Step 2: Validate Source Material
 
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Source Material ─────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking that the required source material is ready
+> — completed discussions or investigations.**
+
+```
+
 Load **[validate-source.md](references/validate-source.md)** and follow its instructions as written.
 
 → Proceed to **Step 3**.
@@ -83,6 +113,21 @@ Load **[validate-source.md](references/validate-source.md)** and follow its inst
 ---
 
 ## Step 3: Validate Phase
+
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking whether a specification already exists
+> for this topic.**
+
+```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
@@ -92,11 +137,41 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ## Step 4: Invoke the Skill
 
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Specification ─────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Handing off to the specification process with all
+> gathered context.**
+
+```
+
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.
 
 ---
 
 ## Step 5: Check Prerequisites
+
+> *Output the next fenced block as a code block:*
+
+```
+── Check Prerequisites ──────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Verifying that completed discussions are available
+> to build specifications from.**
+
+```
 
 Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow its instructions as written.
 
@@ -105,5 +180,20 @@ Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow 
 ---
 
 ## Step 6: Route Based on State
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route Based on State ─────────────────────────
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Evaluating what discussions and specifications exist
+> to determine next steps.**
+
+```
 
 Load **[route-scenario.md](references/route-scenario.md)** and follow its instructions as written.

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -46,7 +46,11 @@ No `---` separator before these messages.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **What happens next.** Your discussions will be analyzed for natural groupings to determine how they should be organized into specifications. Results are cached and reused until discussions change.
+> **What happens next.** Your discussions will be
+> analyzed for natural groupings to determine how
+> they should be organized into specifications.
+> Results are cached and reused until discussions
+> change.
 
 · · · · · · · · · · · ·
 Proceed with analysis?
@@ -64,7 +68,11 @@ Proceed with analysis?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Analysis outdated.** A previous grouping analysis exists but discussions have changed since it was created. Your discussions will be re-analyzed for natural groupings. Results are cached and reused until discussions change.
+> **Analysis outdated.** A previous grouping
+> analysis exists but discussions have changed
+> since it was created. Your discussions will be
+> re-analyzed for natural groupings. Results are
+> cached and reused until discussions change.
 
 · · · · · · · · · · · ·
 Proceed with analysis?

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -46,7 +46,7 @@ No `---` separator before these messages.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **What happens next.** Your discussions will be analyzed for natural
+> What happens next. Your discussions will be analyzed for natural
 > groupings to determine how they should be organized into specifications.
 > Results are cached and reused until discussions change.
 
@@ -66,7 +66,7 @@ Proceed with analysis?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Analysis outdated.** A previous grouping analysis exists but
+> Analysis outdated. A previous grouping analysis exists but
 > discussions have changed since it was created. Your discussions will
 > be re-analyzed for natural groupings. Results are cached and reused
 > until discussions change.

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -11,7 +11,9 @@ Prompted when multiple completed discussions exist, no specifications exist, and
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Overview
+●───────────────────────────────────────────────●
+  Specification Overview
+●───────────────────────────────────────────────●
 
 {N} completed discussions found. No specifications exist yet.
 

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -43,17 +43,11 @@ No `---` separator before these messages.
 
 #### If cache status is `none`
 
-> *Output the next fenced block as a code block:*
-
-```
-These discussions will be analyzed for natural groupings to determine
-how they should be organized into specifications. Results are cached
-and reused until discussions change.
-```
-
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> **What happens next.** Your discussions will be analyzed for natural groupings to determine how they should be organized into specifications. Results are cached and reused until discussions change.
+
 · · · · · · · · · · · ·
 Proceed with analysis?
 - **`y`/`yes`**
@@ -67,19 +61,11 @@ Proceed with analysis?
 
 #### If cache status is `stale`
 
-> *Output the next fenced block as a code block:*
-
-```
-A previous grouping analysis exists but is outdated — discussions
-have changed since it was created.
-
-These discussions will be re-analyzed for natural groupings. Results
-are cached and reused until discussions change.
-```
-
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> **Analysis outdated.** A previous grouping analysis exists but discussions have changed since it was created. Your discussions will be re-analyzed for natural groupings. Results are cached and reused until discussions change.
+
 · · · · · · · · · · · ·
 Proceed with analysis?
 - **`y`/`yes`**

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -46,10 +46,9 @@ No `---` separator before these messages.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **What happens next.** Your discussions will be analyzed
-> for natural groupings to determine how they should be
-> organized into specifications. Results are cached and
-> reused until discussions change.
+> **What happens next.** Your discussions will be analyzed for natural
+> groupings to determine how they should be organized into specifications.
+> Results are cached and reused until discussions change.
 
 · · · · · · · · · · · ·
 Proceed with analysis?
@@ -67,10 +66,10 @@ Proceed with analysis?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Analysis outdated.** A previous grouping analysis
-> exists but discussions have changed since it was created.
-> Your discussions will be re-analyzed for natural groupings.
-> Results are cached and reused until discussions change.
+> **Analysis outdated.** A previous grouping analysis exists but
+> discussions have changed since it was created. Your discussions will
+> be re-analyzed for natural groupings. Results are cached and reused
+> until discussions change.
 
 · · · · · · · · · · · ·
 Proceed with analysis?

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -46,11 +46,10 @@ No `---` separator before these messages.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **What happens next.** Your discussions will be
-> analyzed for natural groupings to determine how
-> they should be organized into specifications.
-> Results are cached and reused until discussions
-> change.
+> **What happens next.** Your discussions will be analyzed
+> for natural groupings to determine how they should be
+> organized into specifications. Results are cached and
+> reused until discussions change.
 
 · · · · · · · · · · · ·
 Proceed with analysis?
@@ -68,11 +67,10 @@ Proceed with analysis?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Analysis outdated.** A previous grouping
-> analysis exists but discussions have changed
-> since it was created. Your discussions will be
-> re-analyzed for natural groupings. Results are
-> cached and reused until discussions change.
+> **Analysis outdated.** A previous grouping analysis
+> exists but discussions have changed since it was created.
+> Your discussions will be re-analyzed for natural groupings.
+> Results are cached and reused until discussions change.
 
 · · · · · · · · · · · ·
 Proceed with analysis?

--- a/skills/workflow-specification-entry/references/display-blocks.md
+++ b/skills/workflow-specification-entry/references/display-blocks.md
@@ -11,7 +11,9 @@ Two terminal paths — the command stops and cannot proceed.
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Overview
+●───────────────────────────────────────────────●
+  Specification Overview
+●───────────────────────────────────────────────●
 
 No discussions found.
 
@@ -29,7 +31,9 @@ The specification phase requires completed discussions to work from.
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Overview
+●───────────────────────────────────────────────●
+  Specification Overview
+●───────────────────────────────────────────────●
 
 No completed discussions found.
 

--- a/skills/workflow-specification-entry/references/display-groupings.md
+++ b/skills/workflow-specification-entry/references/display-groupings.md
@@ -55,7 +55,9 @@ All items are first-class — every grouping (including single-discussion entrie
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Overview
+●───────────────────────────────────────────────●
+  Specification Overview
+●───────────────────────────────────────────────●
 
 Recommended breakdown for specifications with their source discussions.
 

--- a/skills/workflow-specification-entry/references/display-single-grouped.md
+++ b/skills/workflow-specification-entry/references/display-single-grouped.md
@@ -18,7 +18,9 @@ Extraction count: X = sources with `status: incorporated`, Y = total source coun
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Overview
+●───────────────────────────────────────────────●
+  Specification Overview
+●───────────────────────────────────────────────●
 
 Single completed discussion found with existing multi-source specification.
 

--- a/skills/workflow-specification-entry/references/display-single-has-spec.md
+++ b/skills/workflow-specification-entry/references/display-single-has-spec.md
@@ -13,7 +13,9 @@ Determine extraction count: check the spec's `sources` array from discovery. Cou
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Overview
+●───────────────────────────────────────────────●
+  Specification Overview
+●───────────────────────────────────────────────●
 
 Single completed discussion found with existing specification.
 

--- a/skills/workflow-specification-entry/references/display-single-no-spec.md
+++ b/skills/workflow-specification-entry/references/display-single-no-spec.md
@@ -11,7 +11,9 @@ No specification exists for this discussion.
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Overview
+●───────────────────────────────────────────────●
+  Specification Overview
+●───────────────────────────────────────────────●
 
 Single completed discussion found.
 

--- a/skills/workflow-specification-entry/references/display-specs-menu.md
+++ b/skills/workflow-specification-entry/references/display-specs-menu.md
@@ -11,7 +11,9 @@ Shows when multiple completed discussions exist, specifications exist, and cache
 > *Output the next fenced block as a code block:*
 
 ```
-Specification Overview
+●───────────────────────────────────────────────●
+  Specification Overview
+●───────────────────────────────────────────────●
 
 {N} completed discussions found. {M} specifications exist.
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -62,7 +62,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ```
 ── Resume Detection ─────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -70,7 +69,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 ```
 > **Checking for existing work.** If a specification is already
 > in progress, you can pick up where you left off or start fresh.
-
 ```
 
 Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
@@ -121,7 +119,6 @@ Continue or restart?
 
 ```
 ── Verify Source Material ───────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -130,7 +127,6 @@ Continue or restart?
 > **Checking your discussions and research are ready.** The
 > specification is built from these — if anything's missing or
 > incomplete, we'll flag it now.
-
 ```
 
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
@@ -145,7 +141,6 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 ```
 ── Initialize Specification ─────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -153,7 +148,6 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 ```
 > **Creating the specification file.** Setting up the document
 > structure that we'll populate together in the next step.
-
 ```
 
 Load **[initialize-specification.md](references/initialize-specification.md)** and follow its instructions as written.
@@ -168,7 +162,6 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 
 ```
 ── Session Setup ────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -177,7 +170,6 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 > **Loading context from previous work.** Reading your source
 > material and any existing progress so we're working from the
 > full picture.
-
 ```
 
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
@@ -192,7 +184,6 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 
 ```
 ── Load Specification Principles ────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -200,7 +191,6 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 ```
 > **Loading the guidelines for how specifications are built.**
 > These ensure consistency and completeness across the document.
-
 ```
 
 Load **[specification-principles.md](references/specification-principles.md)** and follow its instructions as written.
@@ -215,7 +205,6 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 
 ```
 ── Spec Construction ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -224,7 +213,6 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 > **Building the specification.** Topics from your source material will
 > be extracted and presented one at a time. Nothing gets written without
 > your explicit approval.
-
 ```
 
 Load **[spec-construction.md](references/spec-construction.md)** and follow its instructions as written.
@@ -239,7 +227,6 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 
 ```
 ── Document Dependencies ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -247,7 +234,6 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 ```
 > **Recording cross-topic dependencies.** For epics, specifications
 > may depend on each other — this step captures those relationships.
-
 ```
 
 #### If work_type is not `epic`
@@ -268,7 +254,6 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 
 ```
 ── Specification Review ─────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -277,7 +262,6 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 > **Reviewing the specification.** Agents will analyse it against
 > source material for gaps and inconsistencies. You'll approve or
 > dismiss each finding.
-
 ```
 
 Load **[spec-review.md](references/spec-review.md)** and follow its instructions as written.
@@ -292,7 +276,6 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 
 ```
 ── Compliance Self-Check ────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -300,7 +283,6 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 ```
 > **Verifying the specification follows workflow conventions.**
 > A quick internal check before we wrap up.
-
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
@@ -315,7 +297,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ```
 ── Conclude ─────────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -323,7 +304,6 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ```
 > **Wrapping up.** Final assessment, sign-off, and handover to the
 > planning phase.
-
 ```
 
 Load **[spec-completion.md](references/spec-completion.md)** and follow its instructions as written.

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -61,7 +61,8 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as a code block:*
 
 ```
-── Resume Detection ────────────────────────────────
+── Resume Detection ─────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -119,7 +120,8 @@ Continue or restart?
 > *Output the next fenced block as a code block:*
 
 ```
-── Verify Source Material ──────────────────────────
+── Verify Source Material ───────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -142,7 +144,8 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 > *Output the next fenced block as a code block:*
 
 ```
-── Initialize Specification ────────────────────────
+── Initialize Specification ─────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -164,7 +167,8 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 > *Output the next fenced block as a code block:*
 
 ```
-── Session Setup ───────────────────────────────────
+── Session Setup ────────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -187,7 +191,8 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 > *Output the next fenced block as a code block:*
 
 ```
-── Load Specification Principles ───────────────────
+── Load Specification Principles ────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -209,7 +214,8 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 > *Output the next fenced block as a code block:*
 
 ```
-── Spec Construction ───────────────────────────────
+── Spec Construction ────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -232,7 +238,8 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 > *Output the next fenced block as a code block:*
 
 ```
-── Document Dependencies ───────────────────────────
+── Document Dependencies ────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -260,7 +267,8 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 > *Output the next fenced block as a code block:*
 
 ```
-── Specification Review ────────────────────────────
+── Specification Review ─────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -283,7 +291,8 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 > *Output the next fenced block as a code block:*
 
 ```
-── Compliance Self-Check ───────────────────────────
+── Compliance Self-Check ────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -305,7 +314,8 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 > *Output the next fenced block as a code block:*
 
 ```
-── Conclude ────────────────────────────────────────
+── Conclude ─────────────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -64,6 +64,13 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 ── Resume Detection ────────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking for existing work.** If a specification is already
+> in progress, you can pick up where you left off or start fresh.
+```
+
 Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
 
 #### If no file exists
@@ -114,6 +121,14 @@ Continue or restart?
 ── Verify Source Material ──────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Checking your discussions and research are ready.** The
+> specification is built from these — if anything's missing or
+> incomplete, we'll flag it now.
+```
+
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
 
 → Proceed to **Step 2**.
@@ -126,6 +141,13 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 ```
 ── Initialize Specification ────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Creating the specification file.** Setting up the document
+> structure that we'll populate together in the next step.
 ```
 
 Load **[initialize-specification.md](references/initialize-specification.md)** and follow its instructions as written.
@@ -142,6 +164,14 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 ── Session Setup ───────────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Loading context from previous work.** Reading your source
+> material and any existing progress so we're working from the
+> full picture.
+```
+
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -154,6 +184,13 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 
 ```
 ── Load Specification Principles ───────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Loading the guidelines for how specifications are built.**
+> These ensure consistency and completeness across the document.
 ```
 
 Load **[specification-principles.md](references/specification-principles.md)** and follow its instructions as written.
@@ -190,6 +227,13 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 
 ```
 ── Document Dependencies ───────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Recording cross-topic dependencies.** For epics, specifications
+> may depend on each other — this step captures those relationships.
 ```
 
 #### If work_type is not `epic`
@@ -234,6 +278,13 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 ── Compliance Self-Check ───────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Verifying the specification follows workflow conventions.**
+> A quick internal check before we wrap up.
+```
+
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 9**.
@@ -246,6 +297,13 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ```
 ── Conclude ────────────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Wrapping up.** Final assessment, sign-off, and handover to the
+> planning phase.
 ```
 
 Load **[spec-completion.md](references/spec-completion.md)** and follow its instructions as written.

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -56,12 +56,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ---
 
-## Output Formatting
-
-When announcing a new step, output `── ── ── ── ──` on its own line before the step heading.
-
----
-
 ## Step 0: Resume Detection
 
 Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
@@ -140,6 +134,20 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 
 ## Step 5: Spec Construction
 
+> *Output the next fenced block as a code block:*
+
+```
+── Step 5: Spec Construction ───────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Building the specification.** Topics from your source material will
+> be extracted and presented one at a time. Nothing gets written without
+> your explicit approval.
+```
+
 Load **[spec-construction.md](references/spec-construction.md)** and follow its instructions as written.
 
 → Proceed to **Step 6**.
@@ -162,6 +170,20 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 
 ## Step 7: Specification Review
 
+> *Output the next fenced block as a code block:*
+
+```
+── Step 7: Specification Review ────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Reviewing the specification.** Agents will analyse it against
+> source material for gaps and inconsistencies. You'll approve or
+> dismiss each finding.
+```
+
 Load **[spec-review.md](references/spec-review.md)** and follow its instructions as written.
 
 → Proceed to **Step 8**.
@@ -177,6 +199,12 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ---
 
 ## Step 9: Assess Cross-Cutting & Conclude
+
+> *Output the next fenced block as a code block:*
+
+```
+── Step 9: Conclude ────────────────────────────────
+```
 
 Load **[spec-completion.md](references/spec-completion.md)** and follow its instructions as written.
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -69,6 +69,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 ```
 > **Checking for existing work.** If a specification is already
 > in progress, you can pick up where you left off or start fresh.
+
 ```
 
 Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
@@ -127,6 +128,7 @@ Continue or restart?
 > **Checking your discussions and research are ready.** The
 > specification is built from these — if anything's missing or
 > incomplete, we'll flag it now.
+
 ```
 
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
@@ -148,6 +150,7 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 ```
 > **Creating the specification file.** Setting up the document
 > structure that we'll populate together in the next step.
+
 ```
 
 Load **[initialize-specification.md](references/initialize-specification.md)** and follow its instructions as written.
@@ -170,6 +173,7 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 > **Loading context from previous work.** Reading your source
 > material and any existing progress so we're working from the
 > full picture.
+
 ```
 
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
@@ -191,6 +195,7 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 ```
 > **Loading the guidelines for how specifications are built.**
 > These ensure consistency and completeness across the document.
+
 ```
 
 Load **[specification-principles.md](references/specification-principles.md)** and follow its instructions as written.
@@ -213,6 +218,7 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 > **Building the specification.** Topics from your source material will
 > be extracted and presented one at a time. Nothing gets written without
 > your explicit approval.
+
 ```
 
 Load **[spec-construction.md](references/spec-construction.md)** and follow its instructions as written.
@@ -234,6 +240,7 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 ```
 > **Recording cross-topic dependencies.** For epics, specifications
 > may depend on each other — this step captures those relationships.
+
 ```
 
 #### If work_type is not `epic`
@@ -262,6 +269,7 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 > **Reviewing the specification.** Agents will analyse it against
 > source material for gaps and inconsistencies. You'll approve or
 > dismiss each finding.
+
 ```
 
 Load **[spec-review.md](references/spec-review.md)** and follow its instructions as written.
@@ -283,6 +291,7 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 ```
 > **Verifying the specification follows workflow conventions.**
 > A quick internal check before we wrap up.
+
 ```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
@@ -304,6 +313,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 ```
 > **Wrapping up.** Final assessment, sign-off, and handover to the
 > planning phase.
+
 ```
 
 Load **[spec-completion.md](references/spec-completion.md)** and follow its instructions as written.

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -189,7 +189,7 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Loading the guidelines for how specifications are built.**
+> Loading the guidelines for how specifications are built.
 > These ensure consistency and completeness across the document.
 ```
 
@@ -281,7 +281,7 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Verifying the specification follows workflow conventions.**
+> Verifying the specification follows workflow conventions.
 > A quick internal check before we wrap up.
 ```
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -58,6 +58,12 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ────────────────────────────────
+```
+
 Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
 
 #### If no file exists
@@ -102,6 +108,12 @@ Continue or restart?
 
 ## Step 1: Verify Source Material
 
+> *Output the next fenced block as a code block:*
+
+```
+── Verify Source Material ──────────────────────────
+```
+
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
 
 → Proceed to **Step 2**.
@@ -109,6 +121,12 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 ---
 
 ## Step 2: Initialize Specification
+
+> *Output the next fenced block as a code block:*
+
+```
+── Initialize Specification ────────────────────────
+```
 
 Load **[initialize-specification.md](references/initialize-specification.md)** and follow its instructions as written.
 
@@ -118,6 +136,12 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 
 ## Step 3: Session Setup
 
+> *Output the next fenced block as a code block:*
+
+```
+── Session Setup ───────────────────────────────────
+```
+
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
@@ -125,6 +149,12 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 ---
 
 ## Step 4: Load Specification Principles
+
+> *Output the next fenced block as a code block:*
+
+```
+── Load Specification Principles ───────────────────
+```
 
 Load **[specification-principles.md](references/specification-principles.md)** and follow its instructions as written.
 
@@ -137,7 +167,7 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 > *Output the next fenced block as a code block:*
 
 ```
-── Step 5: Spec Construction ───────────────────────
+── Spec Construction ───────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -156,6 +186,12 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 
 ## Step 6: Document Dependencies
 
+> *Output the next fenced block as a code block:*
+
+```
+── Document Dependencies ───────────────────────────
+```
+
 #### If work_type is not `epic`
 
 → Proceed to **Step 7**.
@@ -173,7 +209,7 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 > *Output the next fenced block as a code block:*
 
 ```
-── Step 7: Specification Review ────────────────────
+── Specification Review ────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -192,6 +228,12 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 
 ## Step 8: Compliance Self-Check
 
+> *Output the next fenced block as a code block:*
+
+```
+── Compliance Self-Check ───────────────────────────
+```
+
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
 → Proceed to **Step 9**.
@@ -203,7 +245,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 > *Output the next fenced block as a code block:*
 
 ```
-── Step 9: Conclude ────────────────────────────────
+── Conclude ────────────────────────────────────────
 ```
 
 Load **[spec-completion.md](references/spec-completion.md)** and follow its instructions as written.

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -67,7 +67,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking for existing work.** If a specification is already
+> Checking for existing work. If a specification is already
 > in progress, you can pick up where you left off or start fresh.
 ```
 
@@ -124,7 +124,7 @@ Continue or restart?
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Checking your discussions and research are ready.** The
+> Checking your discussions and research are ready. The
 > specification is built from these — if anything's missing or
 > incomplete, we'll flag it now.
 ```
@@ -146,7 +146,7 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Creating the specification file.** Setting up the document
+> Creating the specification file. Setting up the document
 > structure that we'll populate together in the next step.
 ```
 
@@ -167,7 +167,7 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Loading context from previous work.** Reading your source
+> Loading context from previous work. Reading your source
 > material and any existing progress so we're working from the
 > full picture.
 ```
@@ -210,7 +210,7 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Building the specification.** Topics from your source material will
+> Building the specification. Topics from your source material will
 > be extracted and presented one at a time. Nothing gets written without
 > your explicit approval.
 ```
@@ -232,7 +232,7 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Recording cross-topic dependencies.** For epics, specifications
+> Recording cross-topic dependencies. For epics, specifications
 > may depend on each other — this step captures those relationships.
 ```
 
@@ -259,7 +259,7 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Reviewing the specification.** Agents will analyse it against
+> Reviewing the specification. Agents will analyse it against
 > source material for gaps and inconsistencies. You'll approve or
 > dismiss each finding.
 ```
@@ -302,7 +302,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Wrapping up.** Final assessment, sign-off, and handover to the
+> Wrapping up. Final assessment, sign-off, and handover to the
 > planning phase.
 ```
 

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -165,7 +165,6 @@ If any of your sources were **existing specifications** (as opposed to discussio
 ```
 > **Specification complete.** The planning phase will break this into
 > implementable tasks with dependencies and acceptance criteria.
-
 ```
 
 Invoke the bridge:

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -163,7 +163,7 @@ If any of your sources were **existing specifications** (as opposed to discussio
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Specification complete.** The planning phase will break this into
+> Specification complete. The planning phase will break this into
 > implementable tasks with dependencies and acceptance criteria.
 ```
 

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -165,6 +165,7 @@ If any of your sources were **existing specifications** (as opposed to discussio
 ```
 > **Specification complete.** The planning phase will break this into
 > implementable tasks with dependencies and acceptance criteria.
+
 ```
 
 Invoke the bridge:

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -160,6 +160,13 @@ If any of your sources were **existing specifications** (as opposed to discussio
 
 #### Otherwise
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Specification complete.** The planning phase will break this into
+> implementable tasks with dependencies and acceptance criteria.
+```
+
 Invoke the bridge:
 
 ```

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -46,7 +46,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 ── Initialisation ───────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -54,7 +53,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ```
 > **Running migrations to keep workflow files in sync.**
 > This ensures everything is up to date before we proceed.
-
 ```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
@@ -73,7 +71,6 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ```
 ── Run Discovery ────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -81,7 +78,6 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ```
 > **Scanning your workflow directory.** Looking for active work,
 > completed items, and inbox entries to show you the full picture.
-
 ```
 
 !`node .claude/skills/workflow-start/scripts/discovery.cjs`
@@ -126,7 +122,6 @@ Parse the output to understand the current workflow state:
 
 ```
 ── Check State ──────────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -134,7 +129,6 @@ Parse the output to understand the current workflow state:
 ```
 > **Determining what to show you.** Routing based on whether
 > active work was found.
-
 ```
 
 #### If `state.has_any_work` is false
@@ -153,14 +147,12 @@ Load **[empty-state.md](references/empty-state.md)** and follow its instructions
 
 ```
 ── Display and Route ────────────────────────────
-
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > **Showing your active work and available options.**
-
 ```
 
 Load **[active-work.md](references/active-work.md)** and follow its instructions as written.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -20,6 +20,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ---
 
+## Step 0: Initialisation
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -40,9 +42,18 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ●─────────────────────────────────────────────────────────────────●
 ```
 
----
+> *Output the next fenced block as a code block:*
 
-## Step 0: Initialisation
+```
+── Initialisation ──────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Running migrations to keep workflow files in sync.**
+> This ensures everything is up to date before we proceed.
+```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
@@ -55,6 +66,19 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ---
 
 ## Step 1: Run Discovery
+
+> *Output the next fenced block as a code block:*
+
+```
+── Run Discovery ───────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Scanning your workflow directory.** Looking for active work,
+> completed items, and inbox entries to show you the full picture.
+```
 
 !`node .claude/skills/workflow-start/scripts/discovery.cjs`
 
@@ -94,6 +118,19 @@ Parse the output to understand the current workflow state:
 
 ## Step 2: Check State
 
+> *Output the next fenced block as a code block:*
+
+```
+── Check State ─────────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Determining what to show you.** Routing based on whether
+> active work was found.
+```
+
 #### If `state.has_any_work` is false
 
 Load **[empty-state.md](references/empty-state.md)** and follow its instructions as written.
@@ -105,5 +142,17 @@ Load **[empty-state.md](references/empty-state.md)** and follow its instructions
 ---
 
 ## Step 3: Display and Route
+
+> *Output the next fenced block as a code block:*
+
+```
+── Display and Route ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> **Showing your active work and available options.**
+```
 
 Load **[active-work.md](references/active-work.md)** and follow its instructions as written.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -36,7 +36,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 |__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
 
 ●─────────────────────────────────────────────────────────────────●
-Agentic engineering workflows — from idea to implementation.
+  Agentic engineering workflows — from idea to implementation.
 ●─────────────────────────────────────────────────────────────────●
 ```
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -46,6 +46,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 ── Initialisation ───────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -71,6 +72,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ```
 ── Run Discovery ────────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -122,6 +124,7 @@ Parse the output to understand the current workflow state:
 
 ```
 ── Check State ──────────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -147,6 +150,7 @@ Load **[empty-state.md](references/empty-state.md)** and follow its instructions
 
 ```
 ── Display and Route ────────────────────────────
+
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -45,7 +45,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 > *Output the next fenced block as a code block:*
 
 ```
-── Initialisation ──────────────────────────────────
+── Initialisation ───────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -70,7 +70,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as a code block:*
 
 ```
-── Run Discovery ───────────────────────────────────
+── Run Discovery ────────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -121,7 +121,7 @@ Parse the output to understand the current workflow state:
 > *Output the next fenced block as a code block:*
 
 ```
-── Check State ─────────────────────────────────────
+── Check State ──────────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -146,7 +146,7 @@ Load **[empty-state.md](references/empty-state.md)** and follow its instructions
 > *Output the next fenced block as a code block:*
 
 ```
-── Display and Route ───────────────────────────────
+── Display and Route ────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -54,6 +54,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ```
 > **Running migrations to keep workflow files in sync.**
 > This ensures everything is up to date before we proceed.
+
 ```
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
@@ -80,6 +81,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 ```
 > **Scanning your workflow directory.** Looking for active work,
 > completed items, and inbox entries to show you the full picture.
+
 ```
 
 !`node .claude/skills/workflow-start/scripts/discovery.cjs`
@@ -132,6 +134,7 @@ Parse the output to understand the current workflow state:
 ```
 > **Determining what to show you.** Routing based on whether
 > active work was found.
+
 ```
 
 #### If `state.has_any_work` is false
@@ -157,6 +160,7 @@ Load **[empty-state.md](references/empty-state.md)** and follow its instructions
 
 ```
 > **Showing your active work and available options.**
+
 ```
 
 Load **[active-work.md](references/active-work.md)** and follow its instructions as written.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -76,7 +76,7 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Scanning your workflow directory.** Looking for active work,
+> Scanning your workflow directory. Looking for active work,
 > completed items, and inbox entries to show you the full picture.
 ```
 
@@ -127,7 +127,7 @@ Parse the output to understand the current workflow state:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Determining what to show you.** Routing based on whether
+> Determining what to show you. Routing based on whether
 > active work was found.
 ```
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -23,7 +23,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 > *Output the next fenced block as a code block:*
 
 ```
-──────────────────────────────────────────────────────────────────────
+●─────────────────────────────────────────────────────────────────●
     ___   _____________   __________________
    /   | / ____/ ____/ | / /_  __/  _/ ____/
   / /| |/ / __/ __/ /  |/ / / /  / // /
@@ -35,9 +35,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 | |/ |/ / /_/ / _, _/ /| |/ __/ / /___/ /_/ /| |/ |/ /___/ /
 |__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
 
-──────────────────────────────────────────────────────────────────────
-Agentic engineering workflows — from idea to implementation.
-──────────────────────────────────────────────────────────────────────
+  Agentic engineering workflows — from idea to implementation.
+●─────────────────────────────────────────────────────────────────●
 ```
 
 ---

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -35,7 +35,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 | |/ |/ / /_/ / _, _/ /| |/ __/ / /___/ /_/ /| |/ |/ /___/ /
 |__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
 
-  Agentic engineering workflows — from idea to implementation.
+●─────────────────────────────────────────────────────────────────●
+Agentic engineering workflows — from idea to implementation.
 ●─────────────────────────────────────────────────────────────────●
 ```
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -51,7 +51,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Running migrations to keep workflow files in sync.**
+> Running migrations to keep workflow files in sync.
 > This ensures everything is up to date before we proceed.
 ```
 
@@ -152,7 +152,7 @@ Load **[empty-state.md](references/empty-state.md)** and follow its instructions
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Showing your active work and available options.**
+> Showing your active work and available options.
 ```
 
 Load **[active-work.md](references/active-work.md)** and follow its instructions as written.

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -12,7 +12,7 @@ Display all active work and present a unified menu for continuing or starting wo
 
 ```
 ●───────────────────────────────────────────────●
-  Workflow
+  Workflow Overview
 ●───────────────────────────────────────────────●
 
 @if(feature_count > 0)

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -14,11 +14,7 @@ Display all active work and present a unified menu for continuing or starting wo
 ●───────────────────────────────────────────────●
   Workflow
 ●───────────────────────────────────────────────●
-```
 
-> *Output the next fenced block as a code block:*
-
-```
 @if(feature_count > 0)
 Features:
 @foreach(unit in features.work_units)

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -97,7 +97,7 @@ Build the menu with numbered continue items first, then command options for star
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Numbered items continue existing work.** Letter commands below
+> Numbered items continue existing work. Letter commands below
 > start something new or manage lifecycle.
 
 · · · · · · · · · · · ·

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -11,8 +11,14 @@ Display all active work and present a unified menu for continuing or starting wo
 > *Output the next fenced block as a code block:*
 
 ```
-Workflow Overview
+●───────────────────────────────────────────────●
+  Workflow
+●───────────────────────────────────────────────●
+```
 
+> *Output the next fenced block as a code block:*
+
+```
 @if(feature_count > 0)
 Features:
 @foreach(unit in features.work_units)

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -97,6 +97,9 @@ Build the menu with numbered continue items first, then command options for star
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> **Numbered items continue existing work.** Letter commands below
+> start something new or manage lifecycle.
+
 · · · · · · · · · · · ·
 What would you like to do?
 

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -10,7 +10,7 @@ No active work found. Offer to start something new, with option to view complete
 
 ```
 ●───────────────────────────────────────────────●
-  Workflow
+  Workflow Overview
 ●───────────────────────────────────────────────●
 
 No active work found.

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -23,18 +23,19 @@ No active work found.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Each work type follows a different pipeline.** Features and epics
-> start with discussion, bugfixes start with investigation, quick-fixes
-> go straight to scoping. If unsure, feature is the most common choice.
+> **Each work type follows a different pipeline.** Features and
+> epics can start with research or discussion, bugfixes start with
+> investigation, quick-fixes go straight to scoping. If unsure,
+> feature is the most common choice.
 
 · · · · · · · · · · · ·
 What would you like to start?
 
-- **`f`/`feature`** — Single topic, discussion → spec → plan → implement → review
+- **`f`/`feature`** — Single topic: (research →) discussion → spec → plan → implement → review
 - **`e`/`epic`** — Multiple topics, multi-session, same pipeline per topic
 - **`b`/`bugfix`** — Investigation → spec → plan → implement → review
 - **`q`/`quick-fix`** — Scoping → implement → review (no formal planning)
-- **`c`/`cross-cutting`** — Patterns or policies that inform other work
+- **`c`/`cross-cutting`** — (Research →) discussion → spec (patterns or policies that inform other work)
 @if(has_inbox)
 - **`i`/`inbox`** — Start from an inbox item ({inbox_count} items)
 @endif

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -12,11 +12,7 @@ No active work found. Offer to start something new, with option to view complete
 ●───────────────────────────────────────────────●
   Workflow
 ●───────────────────────────────────────────────●
-```
 
-> *Output the next fenced block as a code block:*
-
-```
 No active work found.
 
 @if(completed_count > 0 || cancelled_count > 0)

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -23,7 +23,7 @@ No active work found.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Each work type follows a different pipeline.** Features and
+> Each work type follows a different pipeline. Features and
 > epics can start with research or discussion, bugfixes start with
 > investigation, quick-fixes go straight to scoping. If unsure,
 > feature is the most common choice.

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -9,8 +9,14 @@ No active work found. Offer to start something new, with option to view complete
 > *Output the next fenced block as a code block:*
 
 ```
-Workflow Overview
+●───────────────────────────────────────────────●
+  Workflow
+●───────────────────────────────────────────────●
+```
 
+> *Output the next fenced block as a code block:*
+
+```
 No active work found.
 
 @if(completed_count > 0 || cancelled_count > 0)

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -23,14 +23,18 @@ No active work found.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> **Each work type follows a different pipeline.** Features and epics
+> start with discussion, bugfixes start with investigation, quick-fixes
+> go straight to scoping. If unsure, feature is the most common choice.
+
 · · · · · · · · · · · ·
 What would you like to start?
 
-- **`f`/`feature`** — Add functionality to an existing product
-- **`e`/`epic`** — Large initiative, multi-topic, multi-session
-- **`b`/`bugfix`** — Fix broken behavior
-- **`q`/`quick-fix`** — Trivially scoped mechanical change
-- **`c`/`cross-cutting`** — Define patterns or policies that inform features
+- **`f`/`feature`** — Single topic, discussion → spec → plan → implement → review
+- **`e`/`epic`** — Multiple topics, multi-session, same pipeline per topic
+- **`b`/`bugfix`** — Investigation → spec → plan → implement → review
+- **`q`/`quick-fix`** — Scoping → implement → review (no formal planning)
+- **`c`/`cross-cutting`** — Patterns or policies that inform other work
 @if(has_inbox)
 - **`i`/`inbox`** — Start from an inbox item ({inbox_count} items)
 @endif

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -122,7 +122,7 @@ Set `implementation_completed` = true.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Lifecycle actions for this work unit.** Done marks it finished,
+> Lifecycle actions for this work unit. Done marks it finished,
 > cancel abandons it, pivot converts a feature to an epic when the
 > scope grows beyond a single topic.
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -11,7 +11,9 @@ Manage an in-progress work unit's lifecycle. Self-contained four-step flow.
 > *Output the next fenced block as a code block:*
 
 ```
-Manage
+●───────────────────────────────────────────────●
+  Manage
+●───────────────────────────────────────────────●
 
 @if(feature_count > 0)
 Features:

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -122,6 +122,10 @@ Set `implementation_completed` = true.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> **Lifecycle actions for this work unit.** Done marks it finished,
+> cancel abandons it, pivot converts a feature to an epic when the
+> scope grows beyond a single topic.
+
 · · · · · · · · · · · ·
 **{selected.name:(titlecase)}** ({selected.work_type})
 

--- a/skills/workflow-start/references/start-from-inbox.md
+++ b/skills/workflow-start/references/start-from-inbox.md
@@ -65,7 +65,7 @@ This skill ends. The invoked skill handles archival. Terminal.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> **Choose based on scope.** Feature for a single focused piece of work,
+> Choose based on scope. Feature for a single focused piece of work,
 > epic if it'll need multiple discussion topics, cross-cutting if it
 > defines patterns that other work will follow.
 

--- a/skills/workflow-start/references/start-from-inbox.md
+++ b/skills/workflow-start/references/start-from-inbox.md
@@ -65,12 +65,16 @@ This skill ends. The invoked skill handles archival. Terminal.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> **Choose based on scope.** Feature for a single focused piece of work,
+> epic if it'll need multiple discussion topics, cross-cutting if it
+> defines patterns that other work will follow.
+
 · · · · · · · · · · · ·
 What type of work unit?
 
-- **`f`/`feature`** — Single-topic feature
-- **`e`/`epic`** — Multi-topic initiative
-- **`c`/`cross-cutting`** — Cross-cutting concern (pattern or policy)
+- **`f`/`feature`** — Single-topic, linear pipeline
+- **`e`/`epic`** — Multiple topics, multi-session
+- **`c`/`cross-cutting`** — Patterns or policies that inform other work
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-start/references/start-from-inbox.md
+++ b/skills/workflow-start/references/start-from-inbox.md
@@ -11,7 +11,9 @@ Select an inbox item and route to the appropriate start skill.
 > *Output the next fenced block as a code block:*
 
 ```
-Inbox
+●───────────────────────────────────────────────●
+  Inbox
+●───────────────────────────────────────────────●
 
 @foreach(item in inbox_items sorted by date)
 {N}. {item.title} ({item.type}, {item.date})

--- a/skills/workflow-start/references/view-completed.md
+++ b/skills/workflow-start/references/view-completed.md
@@ -23,7 +23,11 @@ No completed or cancelled work units found.
 > *Output the next fenced block as a code block:*
 
 ```
-Completed & Cancelled @if(work_type_filter) {work_type_filter:(titlecase)}s @else Work Units @endif
+●───────────────────────────────────────────────●
+  Completed & Cancelled
+●───────────────────────────────────────────────●
+
+@if(work_type_filter) Showing: {work_type_filter:(titlecase)}s @endif
 
 @if(completed.length > 0)
 Completed:


### PR DESCRIPTION
## Summary

- Adds visual hierarchy conventions (phase titles, step markers, sub-step markers, signpost blockquotes, workflow banner) to CLAUDE.md
- Replaces plain-text title pattern with bullet-bordered boxes, adds em-dash step markers and dot sub-step markers
- Defines signpost blockquotes for phase entry context, guidance, and closure messages
- Updates terminal messages and spacing rules to use the new conventions

## Test plan

- [ ] Review CLAUDE.md conventions for completeness and clarity
- [ ] Verify phase title box renders correctly across terminals
- [ ] Apply conventions to skills incrementally (workflow-start first, then one skill at a time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)