### PR TITLE
chore: trim CLAUDE.md under 40k char limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Always create a feature branch **before** the first commit. Never commit to main
 ## Workflow Phases
 
 1. **Research** (`workflow-research-process` skill): EXPLORE - feasibility, market, viability, early ideas
-2. **Discussion** (`workflow-discussion-process` skill): Organic conversation guided by a live Discussion Map. Subtopics tracked through `pending` → `exploring` → `converging` → `decided`. Topic elevation seeds sibling concerns as separate discussion topics (epics only)
+2. **Discussion** (`workflow-discussion-process` skill): Organic conversation guided by a live Discussion Map (`pending` → `exploring` → `converging` → `decided`). Topic elevation seeds sibling discussions (epics only)
 3. **Investigation** (`workflow-investigation-process` skill): Bugfix-specific - symptom gathering + code analysis → root cause
 4. **Scoping** (`workflow-scoping-process` skill): Quick-fix-specific - context, spec, and plan in one pass
 5. **Specification** (`workflow-specification-process` skill): Validate and refine into standalone spec
@@ -27,13 +27,13 @@ Always create a feature branch **before** the first commit. Never commit to main
 
 Skills are organised in two tiers:
 
-**Entry-point skills** (`/start-*`, `/continue-*`, `/workflow-migrate`, etc.) are user-invocable. They gather context from files, prompts, or inline input, then invoke a processing skill. Utility entry-points (`/workflow-start`) have `disable-model-invocation: true`. `/workflow-migrate` has `user-invocable: false` — it is model-invoked only (Step 0 of every user-invocable entry-point skill).
+**Entry-point skills** (`/start-*`, `/continue-*`, `/workflow-migrate`, etc.) are user-invocable. Gather context from files, prompts, or inline input, then invoke a processing skill. Utility entry-points (`/workflow-start`) have `disable-model-invocation: true`. `/workflow-migrate` is model-invoked only (Step 0 of every entry-point skill).
 
-**Phase entry skills** (`workflow-*-entry`) are internal (`user-invocable: false`). They are invoked by start/continue/bridge skills with work_type and work_unit always provided. They handle phase-specific validation, bootstrap questions for new entries, and processing skill invocation.
+**Phase entry skills** (`workflow-*-entry`) are internal (`user-invocable: false`). Invoked by start/continue/bridge skills with work_type and work_unit always provided. Handle phase-specific validation, bootstrap questions, and processing skill invocation.
 
-**Processing skills** (`workflow-*-process`) are model-invocable. They assume pipeline context — work_type is set, prior phases are complete, artifacts are in expected locations. Phase entry skills provide all required inputs before invoking them.
+**Processing skills** (`workflow-*-process`) are model-invocable. Assume pipeline context — work_type is set, prior phases complete, artifacts in expected locations.
 
-**Capture skills** (`workflow-log-idea`, `workflow-log-bug`, `workflow-log-quickfix`) are model-invocable, lightweight skills outside the pipeline. They capture ideas, bugs, or quick-fixes as markdown files in the inbox (`.workflows/.inbox/`). No manifest, no migrations, no step/reference structure — just natural language instructions with capture-only constraints.
+**Capture skills** (`workflow-log-idea`, `workflow-log-bug`, `workflow-log-quickfix`) are model-invocable, lightweight skills outside the pipeline. Capture ideas, bugs, or quick-fixes as markdown files in the inbox (`.workflows/.inbox/`). No manifest, no migrations, no step/reference structure — just natural language instructions with capture-only constraints.
 
 ### Phase Entry Skill Routing
 
@@ -58,9 +58,9 @@ Phase entry skills (`workflow-*-entry`) receive positional arguments: `$0` = wor
 - **Quick-fix**: Single-topic, scoping-centric (Scoping → Implementation → Review)
 - **Cross-cutting**: Single-topic, project-level (Research (opt.) → Discussion → Specification — terminal)
 
-**Topics**: A *topic* is the item within a phase. For feature/bugfix/quick-fix, the topic name equals the work unit name (single topic moving through the pipeline). For epic, topics are distinct from the work unit name (multiple topics per phase). All work types use per-topic items in the manifest (unified structure). The discussion phase analyses all research files collectively to derive discussion topics.
+**Topics**: A *topic* is the item within a phase. For feature/bugfix/quick-fix, topic name equals work unit name. For epic, topics are distinct from the work unit name. All work types use per-topic manifest items (unified structure).
 
-Work-unit-first directory structure with uniform `{topic}` in all paths. For feature/bugfix/quick-fix, `{topic}` equals `{work_unit}`. For epic, `{topic}` is the item within a phase.
+Work-unit-first directory structure with uniform `{topic}` in all paths (`{topic}` = `{work_unit}` for feature/bugfix/quick-fix).
 
 - Project manifest: `.workflows/manifest.json` (work unit registry + project defaults)
 - Manifest: `.workflows/{work_unit}/manifest.json`
@@ -74,8 +74,7 @@ Work-unit-first directory structure with uniform `{topic}` in all paths. For fea
 - State: `.workflows/{work_unit}/.state/` (per-work-unit analysis files)
 - Global state: `.workflows/.state/` (migrations, environment-setup.md)
 - Cache: `.workflows/.cache/{work_unit}/{phase}/{topic}/` (scratch files for any phase)
-- Inbox: `.workflows/.inbox/ideas/`, `.workflows/.inbox/bugs/`, `.workflows/.inbox/quickfixes/` (pre-pipeline capture, plain markdown)
-- Inbox archive: `.workflows/.inbox/.archived/{ideas,bugs,quickfixes}/` (moved here when an inbox item enters the pipeline)
+- Inbox: `.workflows/.inbox/{ideas,bugs,quickfixes}/` (pre-pipeline capture; archived to `.archived/` subfolder when entering pipeline)
 
 **Work unit lifecycle**: Each work unit has a `status` field in its manifest tracking its lifecycle state:
 - `in-progress` — actively being worked on (default on creation)
@@ -86,7 +85,7 @@ Discovery filters by status — active work by default, with options to view com
 
 **Feature-to-epic pivot**: Features can be converted to epics via the manage menu (`p`/`pivot`). After pivot, the user can continue immediately as an epic or return to the previous view.
 
-**Epic soft gates**: When navigating forward between phases in an epic (via `continue-epic`), advisory gates warn if prerequisite phase items are still in-progress. These are informational, not blocking — the user can proceed anyway. The system recovers gracefully via re-analysis if the user proceeds early.
+**Epic soft gates**: When navigating forward between epic phases, advisory gates warn if prerequisite items are still in-progress. Informational, not blocking — the system recovers via re-analysis if the user proceeds early.
 
 Commit docs frequently (natural breaks, before context refresh). Skills capture context, don't implement.
 
@@ -118,7 +117,7 @@ The contract and scaffolding templates live in `.claude/skills/create-output-for
 
 ## Migrations
 
-The `/workflow-migrate` skill keeps workflow files in sync with the current system design. It runs via Step 0 at the start of every entry-point skill.
+The `/workflow-migrate` skill keeps workflow files in sync with the current system design (runs via Step 0 of every entry-point skill).
 
 **How it works:**
 - `skills/workflow-migrate/scripts/migrate.sh` runs all migration scripts in `skills/workflow-migrate/scripts/migrations/` in numeric order
@@ -134,58 +133,13 @@ The `/workflow-migrate` skill keeps workflow files in sync with the current syst
 
 **Critical: Migration scripts must not use the manifest CLI**
 
-Migration scripts are point-in-time snapshots. The manifest CLI validates values against the current schema, which changes over time (e.g., valid statuses). A migration that uses the CLI today may break silently when validation rules change in a later release. Always read and write `manifest.json` directly using `node` (or `jq`) — never via the manifest CLI. This ensures migrations remain stable regardless of future schema changes.
+Migration scripts are point-in-time snapshots. The manifest CLI validates against the current schema, which changes over time — a migration using it today may break silently later. Always read/write `manifest.json` directly with `node` or `jq`.
 
-**Bash 3.2 compatibility**: Migration scripts must be compatible with Bash 3.2 (macOS default). Avoid `mapfile`/`readarray` (bash 4+), associative arrays `declare -A` (bash 4+), and `local -n` namerefs (bash 4.3+).
+**Bash 3.2 compatibility** (macOS default): Avoid `mapfile`/`readarray`, `declare -A`, `local -n` (all bash 4+).
 
 **Testing migrations:**
 
-Every migration must have a corresponding test file at `tests/scripts/test-migration-NNN.sh`. The test harness follows this structure:
-
-```bash
-#!/bin/bash
-#
-# Tests for migration NNN: description
-#
-# Run: bash tests/scripts/test-migration-NNN.sh
-#
-
-set -eo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/NNN-description.sh"
-
-PASS=0
-FAIL=0
-
-report_update() { : ; }
-report_skip() { : ; }
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    PASS=$((PASS + 1))
-  else
-    FAIL=$((FAIL + 1))
-    echo "FAIL: $label"
-    echo "  expected: $expected"
-    echo "  actual:   $actual"
-  fi
-}
-
-setup() {
-  TEST_DIR=$(mktemp -d /tmp/migration-NNN-test.XXXXXX)
-  export PROJECT_DIR="$TEST_DIR"
-  mkdir -p "$TEST_DIR/.workflows"
-}
-
-teardown() {
-  rm -rf "$TEST_DIR"
-}
-```
-
-Conventions:
+Every migration must have a corresponding test file at `tests/scripts/test-migration-NNN.sh`. Follow the harness structure in existing test files (`set -eo pipefail`, `PASS`/`FAIL` counters, `report_update`/`report_skip` stubs, `assert_eq` function, `setup`/`teardown` with temp dir). Conventions:
 - **Invocation**: Use `source "$MIGRATION"` for migrations that use `return 0`. Use `bash "$MIGRATION"` with `export -f report_update report_skip` for migrations that use `exit 0`.
 - **Isolation**: Each test function calls `setup` at the start and `teardown` at the end. No shared state between tests.
 - **Assertions**: Use only `assert_eq`. Parameter order: `label`, `expected`, `actual`. Convert other checks inline:
@@ -199,7 +153,7 @@ Conventions:
 
 ## Manifest CLI
 
-The manifest CLI at `skills/workflow-manifest/scripts/manifest.cjs` is the single source of truth for all workflow state. Uses dot-path syntax: `command <work-unit>[.<phase>[.<topic>]] [field] [value]`. Segment count determines access level (1 = work unit, 2 = phase, 3 = topic). The reserved prefix `project` routes to the project manifest (`.workflows/manifest.json`) — e.g., `get project.defaults.plan_format`. See `skills/workflow-manifest/SKILL.md` for the full API.
+The manifest CLI at `skills/workflow-manifest/scripts/manifest.cjs` is the single source of truth for all workflow state. Dot-path syntax: `command <work-unit>[.<phase>[.<topic>]] [field] [value]`. Segment count determines access level (1 = work unit, 2 = phase, 3 = topic). Reserved prefix `project` routes to the project manifest — e.g., `get project.defaults.plan_format`.
 
 **Project defaults cascade**: `project.defaults` → topic level. Project defaults are suggestions (user confirms or overrides). Topic level records the actual value in use. There is no phase-level storage for settings like `plan_format`, `project_skills`, or `linters`.
 
@@ -255,13 +209,13 @@ Rules:
 - 2-space left padding on the title text
 - Title text is the phase or context name (e.g., "Workflow Overview", "Planning Overview")
 - Include a trailing blank line after the closing border inside the code block — this creates visual breathing room in the rendered output
-- **Must be inside a code block** — never markdown (markdown collapses the spacing the border depends on)
+- **Must be inside a code block** — never markdown. Code blocks preserve the indentation and whitespace that the border layout depends on. Markdown rendering would collapse the spacing and break the layout
 
 Status displays use the phase title at the top of the same code block, followed by a blank line before the content.
 
 ### Step Markers
 
-Em-dash framed progress indicators at each step boundary (never instructed once at the top of a file). Every step gets a marker, even if it has no explicit output — Claude's visible processing IS the user experience, and the marker labels it. Every step marker must be followed by a signpost blockquote explaining what the step does and why.
+Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width. Every step in a skill gets a marker, even if the step has no explicit output — Claude's visible processing (reading files, running commands, thinking) IS the user experience, and the marker labels that activity. Every step marker must be followed by a signpost blockquote explaining what the step does and why — the marker names the step, the signpost explains it.
 
 ```
 ── Construct Specification ─────────────────────
@@ -300,7 +254,15 @@ Rules:
 
 ### Signpost Blockquotes
 
-Guidance text rendered as markdown blockquotes. Used for phase entry context, pre-step guidance, post-phase closure, and explaining blockers or gates. Never for status data or interactive choices. Rules:
+Guidance text rendered as markdown blockquotes. Used for phase entry context, pre-step guidance, post-phase closure, and explaining blockers or gates. Never for status data or interactive choices.
+
+```
+> Your completed discussions will be synthesised into a formal spec.
+> Expect questions about gaps, contradictions, and missing edge cases.
+> The output is a standalone document that drives planning.
+```
+
+Rules:
 - Rendered as markdown (use the markdown rendering instruction)
 - **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~70 characters per line (including the `> ` prefix) to keep the blockquote visually intact
 - **Plain text only** — no bold. The blockquote styling (indented, dimmed) already sets signposts apart visually. If bold is ever needed on multiple lines, each line must have its own `**` open and close — bold does not carry across `>` prefixed line breaks
@@ -374,7 +336,30 @@ before they can be included in a specification.
 2. ...
 ```
 
-Richer hierarchies nest naturally (child items can have their own `├─`/`└─` branches). Unnumbered trees follow the same structure with blank lines between top-level items.
+Richer hierarchies nest naturally:
+
+```
+1. {topic:(titlecase)}
+   └─ Spec: {spec_status:[in-progress|completed]} ({extraction_summary})
+   └─ Discussions:
+      ├─ {discussion} ({status:[extracted|pending]})
+      └─ ...
+```
+
+Unnumbered trees follow the same structure:
+
+```
+Plans not ready for implementation:
+These plans have unresolved dependencies that must be
+addressed first.
+
+  Core Features
+  └─ Blocked by data-model:data-model-1-2
+
+  Advanced Features
+  ├─ Blocked by core-features:core-2-3
+  └─ Blocked by auth
+```
 
 ### Status Terms
 
@@ -443,7 +428,27 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-**Yes/no and multi-choice prompts** follow the same dot-separator pattern. Yes/no uses **`y`/`yes`** and **`n`/`no`**. Multi-choice uses letter shorthands (e.g., **`s`/`single`**, **`m`/`multi`**, **`a`/`all`**) with `— description`.
+**Yes/no prompt:**
+
+```
+· · · · · · · · · · · ·
+Proceed?
+- **`y`/`yes`**
+- **`n`/`no`**
+· · · · · · · · · · · ·
+```
+
+**Multi-choice prompt:**
+
+```
+· · · · · · · · · · · ·
+What scope would you like to review?
+
+- **`s`/`single`** — Review one plan's implementation
+- **`m`/`multi`** — Review selected plans
+- **`a`/`all`** — Review all implemented plans
+· · · · · · · · · · · ·
+```
 
 **Meta options** in selection menus get backtick-wrapped descriptions:
 
@@ -577,7 +582,13 @@ Rules:
 
 ### Navigation Arrows
 
-Use `→` for flow control: `→ Proceed to **Step 4**.`, `→ Load **[file.md](file.md)** and follow its instructions.`
+Use `→` for flow control between steps or to external files:
+
+```
+→ Proceed to **Step 4**.
+→ Proceed to **Step 7** to invoke the skill.
+→ Load **[file.md](file.md)** and follow its instructions.
+```
 
 ### Reference File Headers
 
@@ -593,11 +604,21 @@ Reference files loaded by skills use this header pattern:
 
 ### Critical / Important Markers
 
-Use bold labels with colons: `**CRITICAL**:`, `**IMPORTANT**:`, `**CHECKPOINT**:`.
+Use bold labels with colons for emphasis levels:
+
+```
+**CRITICAL**: This guidance is mandatory.
+**IMPORTANT**: Use ONLY this script for discovery.
+**CHECKPOINT**: Summarize progress before continuing.
+```
 
 ### Zero Output Rule
 
-Entry-point skills that invoke processing skills include: `> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.`
+Entry-point skills that invoke processing skills use this exact blockquote to prevent narration:
+
+```
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+```
 
 ### Auto-Mode Gates
 
@@ -605,7 +626,15 @@ Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STO
 
 **Manifest tracking**: Gate modes are stored in the manifest via CLI (`gated` or `auto`). This ensures they survive context refresh.
 
-**Behavior when `auto`**: Content is always rendered above the gate check (so both modes see identical output). Auto mode proceeds without a STOP gate. Use a rendering instruction + code block for the one-line announcement (e.g., `Task {M} of {total}: {Task Name} — authored. Logging to plan.`).
+**Behavior when `auto`**: Content is always rendered above the gate check (so both modes see identical output). Auto mode proceeds without a STOP gate. Use a rendering instruction + code block for the one-line announcement:
+
+```
+> *Output the next fenced block as a code block:*
+
+\```
+Task {M} of {total}: {Task Name} — authored. Logging to plan.
+\```
+```
 
 **Lifecycle**:
 - Default: `gated` (set in manifest on creation)
@@ -613,7 +642,10 @@ Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STO
 - Reset: entry-point skills reset gates to `gated` on fresh invocation (not on `continue`)
 - Context refresh: read gate modes from manifest and preserve
 
-**Menu option format**: Add `- **`a`/`auto`** — Approve this and all remaining {items} automatically` between the primary action and secondary options.
+**Menu option format**: Add between the primary action and secondary options:
+```
+- **`a`/`auto`** — Approve this and all remaining {items} automatically
+```
 
 **Re-loop safety cap**: When auto-mode enables automatic re-analysis loops, cap at 5 cycles before escalating to the user. This prevents infinite cascading.
 
@@ -770,7 +802,21 @@ How should this reference file exit?
 
 ### Internal Reference File Sections
 
-Complex reference files use lettered H2 headings (`## A. First Section`, `## B. Second Section`) to avoid collision with backbone step numbers. Navigate with `→ Proceed to **B. Section Name**.`. Simple reference files use named sections without letters.
+Complex reference files use lettered headings to organise sequential sections, avoiding collision with backbone step numbers:
+
+```markdown
+## A. First Section
+
+...
+→ Proceed to **B. Second Section**.
+
+## B. Second Section
+
+...
+→ Proceed to **C. Third Section**.
+```
+
+Simple reference files use named sections (`## Seed Idea`, `## Current Knowledge`) without letters.
 
 ### Reference File Naming
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Agentic Engineering Workflows for Claude Code. Installed via `npx agntc add leeovery/agentic-workflows`.
 
-**This CLAUDE.md is development documentation for authoring the workflows — it does not ship with the product.** When installed, only the skills and agents are copied into the target project (which has its own CLAUDE.md). Skills and agents must be fully self-contained — never rely on this file for runtime behaviour, conventions, or formats that agents need to follow.
+**Development documentation only — not shipped with the product.** Installed projects get their own CLAUDE.md. Skills and agents must be self-contained — never rely on this file for runtime behaviour.
 
 ## Git Workflow
 
@@ -33,7 +33,7 @@ Skills are organised in two tiers:
 
 **Processing skills** (`workflow-*-process`) are model-invocable. They assume pipeline context — work_type is set, prior phases are complete, artifacts are in expected locations. Phase entry skills provide all required inputs before invoking them.
 
-**Capture skills** (`workflow-log-idea`, `workflow-log-bug`, `workflow-log-quickfix`) are model-invocable, lightweight skills outside the pipeline. They capture ideas, bugs, or quick-fixes as markdown files in the inbox (`.workflows/.inbox/`). No manifest, no migrations, no step/reference structure — just natural language instructions with capture-only constraints. They can be invoked directly by the user or discovered by the model when the user wants to log something.
+**Capture skills** (`workflow-log-idea`, `workflow-log-bug`, `workflow-log-quickfix`) are model-invocable, lightweight skills outside the pipeline. They capture ideas, bugs, or quick-fixes as markdown files in the inbox (`.workflows/.inbox/`). No manifest, no migrations, no step/reference structure — just natural language instructions with capture-only constraints.
 
 ### Phase Entry Skill Routing
 
@@ -82,7 +82,7 @@ Work-unit-first directory structure with uniform `{topic}` in all paths. For fea
 - `completed` — pipeline finished (set automatically when the pipeline completes, or manually via the manage menu)
 - `cancelled` — abandoned (set manually via the manage menu)
 
-Discovery scripts filter by status — `workflow-start` and `continue-*` show active work by default, with menu options to view completed/cancelled items or manage lifecycle state. Completed/cancelled work units can be reactivated.
+Discovery filters by status — active work by default, with options to view completed/cancelled or manage lifecycle. Work units can be reactivated.
 
 **Feature-to-epic pivot**: Features can be converted to epics via the manage menu (`p`/`pivot`). After pivot, the user can continue immediately as an epic or return to the previous view.
 
@@ -221,7 +221,7 @@ All user-facing output uses five distinct visual tiers, each with a specific pur
 | 4 | Sub-step marker | Progress within a step | Code block |
 | 5 | Status / menu | Data displays and interactive choices | Code block / markdown |
 
-Every skill invocation should produce at most one phase title. Step markers appear at every step boundary — including steps with no explicit output, since Claude's visible processing (file reads, commands, thinking) is the user experience and the marker labels it. Signpost blockquotes appear at phase entry, before steps where context helps, and at phase completion. Status displays and menus are unchanged from existing conventions.
+Every skill invocation should produce at most one phase title. Signpost blockquotes appear at phase entry, before steps where context helps, and at phase completion.
 
 ### Rendering Instructions
 
@@ -255,13 +255,13 @@ Rules:
 - 2-space left padding on the title text
 - Title text is the phase or context name (e.g., "Workflow Overview", "Planning Overview")
 - Include a trailing blank line after the closing border inside the code block — this creates visual breathing room in the rendered output
-- **Must be inside a code block** — never markdown. Code blocks preserve the indentation and whitespace that the border layout depends on. Markdown rendering would collapse the spacing and break the layout
+- **Must be inside a code block** — never markdown (markdown collapses the spacing the border depends on)
 
-Phase titles replace the old plain-text title pattern. Status displays that previously opened with a title line (e.g., `Planning Overview`) now use the phase title at the top of the same code block, followed by a blank line before the content.
+Status displays use the phase title at the top of the same code block, followed by a blank line before the content.
 
 ### Step Markers
 
-Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width. Every step in a skill gets a marker, even if the step has no explicit output — Claude's visible processing (reading files, running commands, thinking) IS the user experience, and the marker labels that activity. Every step marker must be followed by a signpost blockquote explaining what the step does and why — the marker names the step, the signpost explains it.
+Em-dash framed progress indicators at each step boundary (never instructed once at the top of a file). Every step gets a marker, even if it has no explicit output — Claude's visible processing IS the user experience, and the marker labels it. Every step marker must be followed by a signpost blockquote explaining what the step does and why.
 
 ```
 ── Construct Specification ─────────────────────
@@ -300,15 +300,7 @@ Rules:
 
 ### Signpost Blockquotes
 
-Guidance text rendered as markdown blockquotes. Used for phase entry context, pre-step guidance, post-phase closure, and explaining blockers or gates. Never for status data or interactive choices.
-
-```
-> Your completed discussions will be synthesised into a formal spec.
-> Expect questions about gaps, contradictions, and missing edge cases.
-> The output is a standalone document that drives planning.
-```
-
-Rules:
+Guidance text rendered as markdown blockquotes. Used for phase entry context, pre-step guidance, post-phase closure, and explaining blockers or gates. Never for status data or interactive choices. Rules:
 - Rendered as markdown (use the markdown rendering instruction)
 - **Every line must start with `>`** — Claude Code only renders the blockquote border on lines that have the `>` prefix. A single long line will wrap without the border on subsequent lines. Wrap at ~70 characters per line (including the `> ` prefix) to keep the blockquote visually intact
 - **Plain text only** — no bold. The blockquote styling (indented, dimmed) already sets signposts apart visually. If bold is ever needed on multiple lines, each line must have its own `**` open and close — bold does not carry across `>` prefixed line breaks
@@ -320,27 +312,7 @@ Rules:
 
 ### Workflow Banner
 
-The `workflow-start` skill uses an ASCII art banner as the entry point. It uses the same bullet-border convention as phase titles, widened to accommodate the art:
-
-```
-●─────────────────────────────────────────────────────────────────●
-    ___   _____________   __________________
-   /   | / ____/ ____/ | / /_  __/  _/ ____/
-  / /| |/ / __/ __/ /  |/ / / /  / // /
- / ___ / /_/ / /___/ /|  / / / _/ // /___
-/_/  |_\____/_____/_/ |_/ /_/ /___/\____/
- _       ______  ____  __ __ ________    ____ _       _______
-| |     / / __ \/ __ \/ //_// ____/ /   / __ \ |     / / ___/
-| | /| / / / / / /_/ / ,<  / /_  / /   / / / / | /| / /\__ \
-| |/ |/ / /_/ / _, _/ /| |/ __/ / /___/ /_/ /| |/ |/ /___/ /
-|__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
-
-●─────────────────────────────────────────────────────────────────●
-  Agentic engineering workflows — from idea to implementation.
-●─────────────────────────────────────────────────────────────────●
-```
-
-This is the only exception to the fixed-width phase title rule — the banner is wider to fit the ASCII art.
+The `workflow-start` skill uses an ASCII art banner (see skill file for exact art). Uses the same bullet-border convention as phase titles, widened to accommodate the art — the only exception to the fixed-width rule.
 
 ### Template Placeholders
 
@@ -402,30 +374,7 @@ before they can be included in a specification.
 2. ...
 ```
 
-Richer hierarchies nest naturally:
-
-```
-1. {topic:(titlecase)}
-   └─ Spec: {spec_status:[in-progress|completed]} ({extraction_summary})
-   └─ Discussions:
-      ├─ {discussion} ({status:[extracted|pending]})
-      └─ ...
-```
-
-Unnumbered trees follow the same structure:
-
-```
-Plans not ready for implementation:
-These plans have unresolved dependencies that must be
-addressed first.
-
-  Core Features
-  └─ Blocked by data-model:data-model-1-2
-
-  Advanced Features
-  ├─ Blocked by core-features:core-2-3
-  └─ Blocked by auth
-```
+Richer hierarchies nest naturally (child items can have their own `├─`/`└─` branches). Unnumbered trees follow the same structure with blank lines between top-level items.
 
 ### Status Terms
 
@@ -494,27 +443,7 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
-**Yes/no prompt:**
-
-```
-· · · · · · · · · · · ·
-Proceed?
-- **`y`/`yes`**
-- **`n`/`no`**
-· · · · · · · · · · · ·
-```
-
-**Multi-choice prompt:**
-
-```
-· · · · · · · · · · · ·
-What scope would you like to review?
-
-- **`s`/`single`** — Review one plan's implementation
-- **`m`/`multi`** — Review selected plans
-- **`a`/`all`** — Review all implemented plans
-· · · · · · · · · · · ·
-```
+**Yes/no and multi-choice prompts** follow the same dot-separator pattern. Yes/no uses **`y`/`yes`** and **`n`/`no`**. Multi-choice uses letter shorthands (e.g., **`s`/`single`**, **`m`/`multi`**, **`a`/`all`**) with `— description`.
 
 **Meta options** in selection menus get backtick-wrapped descriptions:
 
@@ -561,7 +490,7 @@ Use `•` for all bulleted lists (sources, files, not-ready items, etc.).
 
 ## Structural Conventions (MANDATORY)
 
-These are hard rules, not suggestions. All skill files (entry-point and processing) MUST follow these conventions exactly. When writing or editing skill files, read existing skills and references as working examples — they are the authoritative demonstration of these rules in practice.
+These are hard rules, not suggestions. All skill files (entry-point and processing) MUST follow these conventions exactly.
 
 ### Stop Gates
 
@@ -648,13 +577,7 @@ Rules:
 
 ### Navigation Arrows
 
-Use `→` for flow control between steps or to external files:
-
-```
-→ Proceed to **Step 4**.
-→ Proceed to **Step 7** to invoke the skill.
-→ Load **[file.md](file.md)** and follow its instructions.
-```
+Use `→` for flow control: `→ Proceed to **Step 4**.`, `→ Load **[file.md](file.md)** and follow its instructions.`
 
 ### Reference File Headers
 
@@ -670,21 +593,11 @@ Reference files loaded by skills use this header pattern:
 
 ### Critical / Important Markers
 
-Use bold labels with colons for emphasis levels:
-
-```
-**CRITICAL**: This guidance is mandatory.
-**IMPORTANT**: Use ONLY this script for discovery.
-**CHECKPOINT**: Summarize progress before continuing.
-```
+Use bold labels with colons: `**CRITICAL**:`, `**IMPORTANT**:`, `**CHECKPOINT**:`.
 
 ### Zero Output Rule
 
-Entry-point skills that invoke processing skills use this exact blockquote to prevent narration:
-
-```
-> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
-```
+Entry-point skills that invoke processing skills include: `> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.`
 
 ### Auto-Mode Gates
 
@@ -692,15 +605,7 @@ Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STO
 
 **Manifest tracking**: Gate modes are stored in the manifest via CLI (`gated` or `auto`). This ensures they survive context refresh.
 
-**Behavior when `auto`**: Content is always rendered above the gate check (so both modes see identical output). Auto mode proceeds without a STOP gate. Use a rendering instruction + code block for the one-line announcement:
-
-```
-> *Output the next fenced block as a code block:*
-
-\```
-Task {M} of {total}: {Task Name} — authored. Logging to plan.
-\```
-```
+**Behavior when `auto`**: Content is always rendered above the gate check (so both modes see identical output). Auto mode proceeds without a STOP gate. Use a rendering instruction + code block for the one-line announcement (e.g., `Task {M} of {total}: {Task Name} — authored. Logging to plan.`).
 
 **Lifecycle**:
 - Default: `gated` (set in manifest on creation)
@@ -708,10 +613,7 @@ Task {M} of {total}: {Task Name} — authored. Logging to plan.
 - Reset: entry-point skills reset gates to `gated` on fresh invocation (not on `continue`)
 - Context refresh: read gate modes from manifest and preserve
 
-**Menu option format**: Add between the primary action and secondary options:
-```
-- **`a`/`auto`** — Approve this and all remaining {items} automatically
-```
+**Menu option format**: Add `- **`a`/`auto`** — Approve this and all remaining {items} automatically` between the primary action and secondary options.
 
 **Re-loop safety cap**: When auto-mode enables automatic re-analysis loops, cap at 5 cycles before escalating to the user. This prevents infinite cascading.
 
@@ -734,7 +636,7 @@ What's on your mind?
 
 ## Skill File Structure (MANDATORY)
 
-These are hard rules, not suggestions. All skills (entry-point and processing) use a backbone + reference file pattern. The backbone (SKILL.md) is always loaded and reads like a table of contents. Reference files contain step detail, loaded on demand via Load directives. When writing or editing skill files, read existing skills and references as working examples — they are the authoritative demonstration of these rules in practice.
+All skills (entry-point and processing) use a backbone + reference file pattern. The backbone (SKILL.md) is always loaded and reads like a table of contents. Reference files contain step detail, loaded on demand via Load directives.
 
 ### Backbone Structure
 
@@ -868,21 +770,7 @@ How should this reference file exit?
 
 ### Internal Reference File Sections
 
-Complex reference files use lettered headings to organise sequential sections, avoiding collision with backbone step numbers:
-
-```markdown
-## A. First Section
-
-...
-→ Proceed to **B. Second Section**.
-
-## B. Second Section
-
-...
-→ Proceed to **C. Third Section**.
-```
-
-Simple reference files use named sections (`## Seed Idea`, `## Current Knowledge`) without letters.
+Complex reference files use lettered H2 headings (`## A. First Section`, `## B. Second Section`) to avoid collision with backbone step numbers. Navigate with `→ Proceed to **B. Section Name**.`. Simple reference files use named sections without letters.
 
 ### Reference File Naming
 

--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -58,10 +58,9 @@ Leverage multiple AI models by dispatching work to the best model for each task 
 |---|------|-------|
 | 14 | [Codex Review Dispatch](codex-review-dispatch.md) | All review agents |
 
-## Phase 7 — Convention Normalisation
-
-Standardise patterns that have diverged across skills.
+## Unphased — New Ideas
 
 | # | Idea | Scope |
 |---|------|-------|
 | 15 | [Selection Menu Display Pattern](selection-menu-pattern.md) | All selection menus across skills |
+| 16 | [Background Sub-Agents in Research](research-background-agents.md) | Research processing skill |

--- a/ideas/research-background-agents.md
+++ b/ideas/research-background-agents.md
@@ -1,0 +1,42 @@
+# Background Sub-Agents in Research
+
+## The Idea
+
+During research sessions, allow the research skill to dispatch sub-agents for independent research threads in the background while the main conversation continues. The user and Claude keep exploring topics together while heavy research tasks (web searches, source code reviews, API documentation analysis) run in parallel.
+
+## Why This Matters
+
+Research sessions naturally generate multiple independent threads. Currently, the research skill processes everything sequentially — if the user wants to explore Bluetooth APIs, review a competitor's source code, and investigate networking options, each thread blocks the others.
+
+In a real-world research conversation between two people, one person might say "let me look that up while we keep talking." That's exactly what background sub-agents enable. The conversation stays fluid and productive while deep research runs in parallel.
+
+## Observed Behaviour (Real Session)
+
+This idea emerged from a live research session (trackpad-switcher-mvp epic, 2026-04-01) where background agents were used organically during research — not because the skill instructed it, but because the pattern fit naturally:
+
+1. **Networking research** — dispatched as a background agent while the main conversation continued exploring automation triggers and UX concepts. Results came back ~8 minutes later with a comprehensive 560-line analysis.
+2. **Blue Switch code review** — cloned the repo and dispatched a background agent to review all source files while continuing the conversation.
+3. **Bluetooth pairing behavior** — dispatched in parallel with the Blue Switch review, researching a completely independent technical question.
+
+The pattern worked well because:
+- The main conversation never stalled waiting for research results
+- The user and Claude continued exploring ideas, refining concepts, and documenting findings
+- When results arrived, they were naturally integrated into the conversation
+- Three independent research threads completed in the time one sequential thread would have taken
+
+## What It Would Look Like
+
+The research skill's session loop or guidelines would explicitly acknowledge this pattern:
+
+- When a research thread is independent and would benefit from deep web research or code analysis, offer to dispatch it as a background sub-agent
+- Continue the conversation on other threads while the agent works
+- When results arrive, summarise findings and integrate into the research document
+- Commit results as they land, not batched at the end
+
+## Design Tensions
+
+- **Context sharing**: Sub-agents don't see the ongoing conversation. They need self-contained briefs with enough context to do useful work. The main agent must compose good prompts.
+- **File conflicts**: Multiple agents writing to the same research file would cause problems. Each agent should write to its own file (e.g., `networking.md`, `blue-switch-review.md`) rather than appending to a shared document.
+- **Notification handling**: When a background agent completes mid-conversation, the main agent needs to handle the notification naturally without disrupting the current thread.
+- **Over-delegation**: Not everything should be a sub-agent. Quick lookups, single API checks, or questions that inform the next conversational turn should stay in the main thread. Sub-agents are for substantial, independent research that would take multiple minutes.
+- **Skill boundary**: This pattern uses the Agent tool which is always available. The skill doesn't need to "enable" it — but explicitly acknowledging the pattern in the research guidelines would make it a deliberate part of the process rather than an ad-hoc decision.

--- a/workflow-explorer.html
+++ b/workflow-explorer.html
@@ -2298,32 +2298,56 @@ const FLOWCHARTS = {
       { id: 'start', label: 'START', shape: 'pill', w: 150, h: 40, color: 'var(--accent)', bg: 'rgba(108,138,255,0.15)', desc: 'Entry: workflow-discussion-process skill receives context from entry skill.' },
       { id: 'resume', label: 'Existing discussion?', shape: 'diamond', w: 130, h: 130, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Step 0: Check if discussion file exists at .workflows/{work_unit}/discussion/{topic}.md.' },
       { id: 'resume-ask', label: 'ASK: Continue/restart?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Discussion exists: announce current state, ask whether to continue or restart.' },
-      { id: 'init', label: 'Initialize document', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Create {work_unit}/discussion/{topic}.md using template. Register in manifest. Commit.' },
-      { id: 'guidelines', label: 'Load guidelines', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 2: Load discussion-guidelines.md — internalize discussion session rules.' },
-      { id: 'engage', label: 'Engage on topic', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 3: Present topic for discussion. Ask probing questions one at a time.' },
-      { id: 'capture', label: 'Capture decisions', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Record options considered, journey of exploration, and decisions with rationale.' },
-      { id: 'document', label: 'Write to disk', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Write reasoning and context to the discussion file. Capture the journey, not the dialogue.' },
-      { id: 'commit', label: 'Commit & push', w: 180, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Commit at natural breaks. Never batch — context refresh loses unpushed work.' },
-      { id: 'more', label: 'More topics?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Are there more topics to discuss?' },
-      { id: 'complete', label: 'Conclude discussion', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 4: Load conclude-discussion.md — set status completed, final commit.' },
-      { id: 'end', label: '{work_unit}/discussion/{topic}.md', shape: 'pill', w: 175, h: 40, color: 'var(--discussion)', bg: 'var(--discussion-bg)', desc: 'Output: Completed discussion document ready for specification phase.' },
+      { id: 'init', label: 'Initialize document', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 1: Create discussion file with Discussion Map. If research provided, extract initial subtopics. Register in manifest. Commit.' },
+      { id: 'guidelines', label: 'Load guidelines', w: 180, h: 44, color: 'var(--text-dim)', bg: 'var(--surface2)', desc: 'Step 2: Load discussion-guidelines.md and meeting-assistant.md. Internalize dual-role: expert architect + documentation assistant.' },
+      // Session loop
+      { id: 'surface', label: 'Surface agent findings', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 3 entry: Check for completed background agent results. Surface review gaps, perspective analyses, or synthesis conclusions.' },
+      { id: 'engage', label: 'Engage on subtopic', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Discuss current subtopic. Challenge thinking, explore edge cases, push back. Subtopic states: pending → exploring → converging → decided.' },
+      { id: 'document', label: 'Navigate, write, commit', w: 200, h: 44, color: 'var(--accent)', bg: 'rgba(108,138,255,0.12)', desc: 'Update Discussion Map states. Write Context→Options→Journey→Decision for decided subtopics. Commit at natural pauses.' },
+      // Agent dispatch
+      { id: 'agent-check', label: 'Agent triggers?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Evaluate dispatch conditions: review agent (meaningful content, no agents in flight, 2-3 exchanges) or perspective agents (genuine ambiguity detected).' },
+      { id: 'review-agent', label: 'Review agent (bg)', w: 180, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', desc: 'Dispatch review agent in background. Identifies gaps, missed considerations, and untested assumptions. Results surfaced next loop.' },
+      { id: 'perspective-ask', label: 'ASK: Perspectives?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Genuine ambiguity detected. Offer to dispatch perspective agents to argue distinct approaches.' },
+      { id: 'perspectives', label: 'Perspective agents (bg)', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', desc: 'Dispatch multiple perspective agents in parallel (background). Each argues a distinct angle on the decision.' },
+      { id: 'synthesis', label: 'Synthesis agent (bg)', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', desc: 'Auto-dispatched when all perspectives complete. Reconciles divergent views into tensions, trade-offs, and a recommended decision.' },
+      // Convergence + elevation
+      { id: 'convergence', label: 'All decided?', shape: 'diamond', w: 120, h: 120, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Check Discussion Map: all subtopics decided or deliberately deferred? Review agent had chance to flag gaps?' },
+      { id: 'elevate', label: 'Elevate topic', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Epic only: subtopic expands beyond scope. Create seed discussion file, init manifest, update Discussion Map with elevation marker.' },
+      // Conclusion
+      { id: 'conclude', label: 'Conclude discussion', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 5: Populate Summary section. Set discussion status to completed via manifest. Final commit.' },
+      { id: 'end', label: '{topic}.md', shape: 'pill', w: 175, h: 40, color: 'var(--discussion)', bg: 'var(--discussion-bg)', desc: 'Output: Completed discussion document with Discussion Map, Context, and decided subtopics.' },
       { id: 'next', label: 'Invoke workflow-bridge', desc: 'Invoke the workflow-bridge skill to determine next phase and enter plan mode.', w: 200, h: 44, color: 'var(--skill)', bg: 'var(--skill-bg)', skillLink: 'workflow-bridge' },
     ],
     connections: [
+      // Resume
       { from: 'start', to: 'resume' },
       { from: 'resume', to: 'resume-ask', type: 'yes', label: 'exists' },
       { from: 'resume', to: 'init', type: 'no', label: 'new', weight: 2 },
       { from: 'resume-ask', to: 'init', label: 'restart' },
       { from: 'resume-ask', to: 'guidelines', label: 'continue', weight: 2 },
       { from: 'init', to: 'guidelines' },
-      { from: 'guidelines', to: 'engage' },
-      { from: 'engage', to: 'capture' },
-      { from: 'capture', to: 'document' },
-      { from: 'document', to: 'commit' },
-      { from: 'commit', to: 'more' },
-      { from: 'more', to: 'engage', type: 'backloop', label: 'yes', port: 'right' },
-      { from: 'more', to: 'complete', type: 'no', label: 'done' },
-      { from: 'complete', to: 'end' },
+      // Session loop entry
+      { from: 'guidelines', to: 'surface' },
+      // Session loop
+      { from: 'surface', to: 'engage' },
+      { from: 'engage', to: 'document' },
+      { from: 'document', to: 'agent-check' },
+      // Agent dispatch branches
+      { from: 'agent-check', to: 'review-agent', label: 'review' },
+      { from: 'agent-check', to: 'perspective-ask', label: 'ambiguity' },
+      { from: 'agent-check', to: 'convergence', type: 'no', label: 'none' },
+      { from: 'review-agent', to: 'convergence' },
+      { from: 'perspective-ask', to: 'perspectives', type: 'yes', label: 'yes' },
+      { from: 'perspective-ask', to: 'convergence', type: 'no', label: 'no' },
+      { from: 'perspectives', to: 'synthesis' },
+      { from: 'synthesis', to: 'convergence' },
+      // Convergence routing
+      { from: 'convergence', to: 'surface', type: 'backloop', label: 'continue' },
+      { from: 'convergence', to: 'elevate', label: 'elevate (epic)' },
+      { from: 'convergence', to: 'conclude', type: 'yes', label: 'all decided', weight: 2 },
+      { from: 'elevate', to: 'surface', type: 'backloop' },
+      // Conclusion
+      { from: 'conclude', to: 'end' },
       { from: 'end', to: 'next', type: 'transition' },
     ]
   },
@@ -2420,12 +2444,16 @@ const FLOWCHARTS = {
       // Post construction
       { id: 'analyze-graph', label: 'Analyze task graph', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', skillLink: 'workflow-planning-dependency-grapher', desc: 'Step 5: Invoke planning-dependency-grapher agent. Analyzes all tasks, assigns priorities, detects cycles.' },
       { id: 'deps', label: 'Resolve ext deps', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 6: Document external dependencies. Match to tasks in other plans if possible.' },
+      // Review — Cycle management
+      { id: 'review-cycle', label: 'Cycle management', w: 200, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Step 7: Increment review_cycle. If > 3 cycles, present proceed/skip gate. Auto mode caps at 5 cycles.' },
       // Review — Traceability
       { id: 'traceability', label: 'Traceability review', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', desc: 'Step 7a: Invoke planning-review-traceability agent. Two-direction check — Spec→Plan and Plan→Spec.', skillLink: 'workflow-planning-review-traceability' },
       { id: 'trace-finding', label: 'ASK: Approve fix?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Process findings one at a time. User: approve, skip, or comment.' },
       // Review — Integrity
       { id: 'integrity', label: 'Integrity review', w: 200, h: 44, color: 'var(--agent)', bg: 'var(--agent-bg)', desc: 'Step 7b: Invoke planning-review-integrity agent. Standalone plan quality check.', skillLink: 'workflow-planning-review-integrity' },
       { id: 'integ-finding', label: 'ASK: Approve fix?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Process integrity findings one at a time.' },
+      // Review — Re-loop
+      { id: 'reloop', label: 'Re-loop?', shape: 'diamond', w: 110, h: 110, color: 'var(--routing)', bg: 'var(--routing-bg)', desc: 'Both review phases clean → signoff. Findings applied → ask user: reanalyse (re-run cycle) or proceed to signoff.' },
       // Sign-off + Conclusion
       { id: 'signoff', label: 'ASK: Sign off plan?', w: 200, h: 44, color: 'var(--ask)', bg: 'var(--ask-bg)', desc: 'Step 8: Final sign-off gate. User: approve (y) to conclude, or comment to route back to review.' },
       { id: 'complete', label: 'Complete plan', w: 180, h: 44, color: 'var(--action)', bg: 'var(--action-bg)', desc: 'Set status: completed. Checkpoint: all tasks must be authored. Final commit.' },
@@ -2464,18 +2492,23 @@ const FLOWCHARTS = {
       { from: 'log-task', to: 'next-task', type: 'backloop', label: 'next task', toPort: 'lower-right' },
       // Post construction
       { from: 'analyze-graph', to: 'deps' },
+      // Review — cycle management
+      { from: 'deps', to: 'review-cycle' },
+      { from: 'review-cycle', to: 'traceability' },
       // Review — traceability
-      { from: 'deps', to: 'traceability' },
       { from: 'traceability', to: 'trace-finding' },
       { from: 'trace-finding', to: 'traceability', type: 'backloop', label: 'more findings' },
       { from: 'trace-finding', to: 'integrity', label: 'all processed' },
       // Review — integrity
       { from: 'integrity', to: 'integ-finding' },
       { from: 'integ-finding', to: 'integrity', type: 'backloop', label: 'more findings' },
-      { from: 'integ-finding', to: 'signoff', label: 'all processed' },
+      { from: 'integ-finding', to: 'reloop', label: 'all processed' },
+      // Re-loop + Sign-off
+      { from: 'reloop', to: 'review-cycle', type: 'backloop', label: 'reanalyse' },
+      { from: 'reloop', to: 'signoff', type: 'no', label: 'proceed', weight: 2 },
       // Sign-off + Conclusion
       { from: 'signoff', to: 'complete', type: 'yes', label: 'approve', weight: 2 },
-      { from: 'signoff', to: 'deps', type: 'backloop', label: 'comment' },
+      { from: 'signoff', to: 'review-cycle', type: 'backloop', label: 'comment' },
       { from: 'complete', to: 'end' },
       { from: 'end', to: 'next', type: 'transition' },
     ]
@@ -3586,10 +3619,11 @@ const FLOWCHART_DESCS = {
     meta: { output: '.workflows/{work_unit}/research/', complexity: 'Looping skill' }
   },
   'skill-discussion': {
-    summary: 'The discussion skill — captures decisions, debates, and edge cases through structured dialogue.',
-    body: `<p>Engages as an expert architect and meeting assistant. The core loop: <strong>Engage → Capture decisions → Write to disk → Commit → Repeat</strong> until the discussion is completed. Writes happen at natural pauses — partial and provisional documentation is expected and valuable.</p>
-<p>Each question is structured as <strong>Options → Journey → Decision</strong>. The skill documents competing solutions and why choices were made, capturing the full reasoning trail. The file on disk is the defence against context compaction — what's not written is lost. Frontmatter status progresses from <code>in-progress</code> to <code>completed</code>.</p>`,
-    meta: { output: '.workflows/{work_unit}/discussion/{topic}.md', complexity: 'Looping skill' }
+    summary: 'The discussion skill — organic conversation with background agents, convergence detection, and topic elevation.',
+    body: `<p>Engages as an expert architect and meeting assistant. The session loop: <strong>Surface agent findings → Engage on subtopic → Navigate &amp; write → Commit → Agent dispatch check → Convergence check → Repeat</strong>. Subtopics progress through <code>pending</code> → <code>exploring</code> → <code>converging</code> → <code>decided</code> on the Discussion Map.</p>
+<p><strong>Three background agents</strong>: a <strong>review agent</strong> (dispatched when content is meaningful, no agents in flight, and 2-3 exchanges since last — identifies gaps and missed considerations), <strong>perspective agents</strong> (dispatched in parallel when genuine ambiguity is detected and user approves — each argues a distinct angle), and a <strong>synthesis agent</strong> (auto-fired when all perspectives complete — reconciles views into tensions and a recommendation). Results are surfaced at the start of each loop iteration.</p>
+<p><strong>Topic elevation</strong> (epic only): when a subtopic expands beyond its scope, it is elevated to its own discussion file with a seed from the current context. <strong>Convergence</strong>: all subtopics decided or deliberately deferred + review agent had chance to flag gaps → conclude path.</p>`,
+    meta: { output: '.workflows/{work_unit}/discussion/{topic}.md', complexity: 'Agent-assisted skill', agents: 'review, perspective (×N), synthesis' }
   },
   'skill-specification': {
     summary: 'The specification skill — collaborative refinement with agent-driven review cycle.',


### PR DESCRIPTION
## Summary

- Trim CLAUDE.md from 43.6k to 39.7k chars to resolve the performance warning (42.0k > 40.0k)
- Condense verbose prose and remove redundant examples while preserving all convention rules, structural patterns, and complex examples
- Add new idea: background sub-agents in research phase; update ideas index with unphased section

## Test plan

- [ ] Open Claude Code in the repo — verify the 40k warning no longer appears
- [ ] Spot-check convention sections in CLAUDE.md for completeness
- [ ] Verify workflow-explorer.html renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)