### PR TITLE
feat: categorize review recommendations with inbox surfacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 | **Specification** | Analyses all discussions/investigation, filters hallucinations, enriches gaps, validates decisions. Reviewed against source material and analysed for gaps before finalising. The spec becomes the golden document — planning references only this. | Epic, Feature, Bugfix, Cross-cutting |
 | **Planning** | Converts specs into phased plans with tasks, acceptance criteria, and dependencies. Validated for spec traceability and structural integrity. Per-item approval gates with auto-mode. | Epic, Feature, Bugfix |
 | **Implementation** | TDD (or verification workflow for quick-fix) — commit per task. Post-implementation analysis agents check architecture, duplication, and standards. | Epic, Feature, Bugfix, Quick-fix |
-| **Review** | Parallel subagents verify each task against spec and plan. Findings become remediation tasks that feed back into implementation. | Epic, Feature, Bugfix, Quick-fix |
+| **Review** | Parallel subagents verify each task against spec and plan. Non-blocking recommendations are categorized as quick-fixes, ideas, or bugs — surface selected items to the inbox for future work. Blocking findings become remediation tasks that feed back into implementation. | Epic, Feature, Bugfix, Quick-fix |
 
 ### Lifecycle
 
@@ -154,7 +154,7 @@ Implementation auto-discovers linters (ESLint, Prettier, PHP CS Fixer, etc.) and
 
 ### Structured Review Findings
 
-Reviewers identify problems but don't fix them. Each finding includes a recommended fix, optional alternative approach, and confidence level. When multiple parallel reviewers flag the same issue, findings are deduplicated — and low-severity items are discarded unless they cluster into a pattern.
+Reviewers identify problems but don't fix them. Each finding includes a recommended fix, optional alternative approach, and confidence level. When multiple parallel reviewers flag the same issue, findings are deduplicated — and low-severity items are discarded unless they cluster into a pattern. Non-blocking recommendations are categorized as quick-fixes (mechanical, no logic changes), ideas (require discussion), or bugs (latent, non-blocking). Surface any of them to the inbox directly from the review verdict screen.
 
 ### Navigate Freely
 
@@ -162,7 +162,7 @@ Revisit any completed phase before moving forward — refine a discussion, updat
 
 ### Inbox Capture
 
-Log ideas and bugs as you go — mid-conversation or from scratch. Say "log that as an idea" during any conversation, or invoke `/workflow-log-idea` or `/workflow-log-bug` directly. Captured items land in `.inbox` as plain markdown files. When you're ready, `/workflow-start` shows your inbox and lets you promote items into the pipeline — pre-filling context and skipping the gather-context interview.
+Log ideas, bugs, and quick-fixes as you go — mid-conversation or from scratch. Say "log that as an idea" during any conversation, or invoke `/workflow-log-idea`, `/workflow-log-bug`, or `/workflow-log-quickfix` directly. Review recommendations can also be surfaced to the inbox from the verdict screen. Captured items land in `.inbox` as plain markdown files. When you're ready, `/workflow-start` shows your inbox and lets you promote items into the pipeline — pre-filling context and skipping the gather-context interview.
 
 ### Workflow Dashboard
 

--- a/agents/workflow-review-findings-synthesizer.md
+++ b/agents/workflow-review-findings-synthesizer.md
@@ -25,7 +25,7 @@ You receive via the orchestrator's prompt:
 2. **Read all report files** — read every `report-*.md` in the review path. Extract BLOCKING ISSUES and significant NON-BLOCKING NOTES with their file:line references
 3. **Deduplicate** — same issue found across multiple QA files → one finding, note all sources
 4. **Group related findings** — multiple findings about the same concern become one task (e.g., 3 QA findings about missing error handling in the same module = 1 "add error handling" task)
-5. **Filter** — discard low-severity non-blocking findings unless they cluster into a pattern. Never discard high-severity or blocking findings.
+5. **Filter** — discard low-severity non-blocking findings unless they cluster into a pattern. Never discard high-severity or blocking findings. NON-BLOCKING NOTES may carry category tags (`[quickfix]`, `[idea]`, `[bug]`). These tags classify the *type* of improvement, not severity. A `[bug]` tagged non-blocking note is a latent, non-blocking issue — do not escalate it to blocking severity based on the tag alone. Apply the same severity/clustering filter regardless of category tags.
 6. **Normalize** — convert each group into a task using the canonical task template (Problem / Solution / Outcome / Do / Acceptance Criteria / Tests)
 7. **Write report** — output to `.workflows/{work_unit}/implementation/{topic}/review-report-c{cycle}.md`
 8. **Write staging file** — if actionable tasks exist, write to `.workflows/{work_unit}/implementation/{topic}/review-tasks-c{cycle}.md` with `status: pending` for each task

--- a/agents/workflow-review-task-verifier.md
+++ b/agents/workflow-review-task-verifier.md
@@ -35,6 +35,8 @@ Plan Task (acceptance criteria)
     Verify Tests (adequate, not over/under tested)
     ↓
     Check Code Quality (readable, conventions)
+    ↓
+    Categorize Non-Blocking Notes (quickfix/idea/bug)
 ```
 
 ### Step 1: Understand the Task
@@ -85,6 +87,16 @@ Review the implementation as a senior architect would:
 - **Security**: No obvious vulnerabilities (injection, exposure, etc.)
 - **Performance**: No obvious inefficiencies (N+1 queries, unnecessary loops, etc.)
 
+### Step 6: Categorize Non-Blocking Notes
+
+Tag each non-blocking note with a category:
+
+- **`[quickfix]`** — Mechanical change with no logic impact. Typos, renames, linting, code style, find-and-replace. Achievable in minutes, no design decisions.
+- **`[idea]`** — Requires discussion or design. Architectural suggestions, refactoring, new functionality, deduplication. Not trivially scoped.
+- **`[bug]`** — Something is broken or incorrect but non-blocking. Latent bugs, unhandled edge cases, incorrect error mapping. These are non-blocking — they do not belong in BLOCKING ISSUES.
+
+If unsure, default to `[idea]` — it's the safest catch-all for anything that needs human judgment.
+
 ## Output File Format
 
 Write to `.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md`:
@@ -120,7 +132,7 @@ BLOCKING ISSUES:
 - [List any issues that must be fixed]
 
 NON-BLOCKING NOTES:
-- [Suggestions for improvement]
+- [{quickfix|idea|bug}] {description}
 ```
 
 ## Your Output

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-review-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(mkdir -p .workflows/.inbox)
 ---
 
 # Review Process

--- a/skills/workflow-review-process/references/present-review.md
+++ b/skills/workflow-review-process/references/present-review.md
@@ -20,6 +20,8 @@ Verdict: {Approve | Request Changes | Comments Only}
 {One paragraph summary from the review}
 ```
 
+Check whether the review contains a `## Recommendations` section with categorized subsections (`### Quick-fixes`, `### Ideas`, `### Bugs`). Set `has_recommendations` accordingly.
+
 #### If verdict is `Approve`
 
 > *Output the next fenced block as a code block:*
@@ -27,8 +29,27 @@ Verdict: {Approve | Request Changes | Comments Only}
 ```
 All acceptance criteria met. No blocking issues found.
 
-{Any recommendations, if present}
+@if(has_recommendations)
+Recommendations (non-blocking):
+
+@if(has_quickfixes)
+Quick-fixes (mechanical — no logic changes):
+  {N}. {description}
+@endif
+
+@if(has_ideas)
+Ideas (require discussion):
+  {N}. {description}
+@endif
+
+@if(has_bugs)
+Bugs:
+  {N}. {description}
+@endif
+@endif
 ```
+
+Items are numbered sequentially across all categories (matching the report's numbering).
 
 → Proceed to **B. Q&A Loop**.
 
@@ -44,7 +65,24 @@ Required Changes:
 
   2. ...
 
-{Recommendations section, if present}
+@if(has_recommendations)
+Recommendations (non-blocking):
+
+@if(has_quickfixes)
+Quick-fixes (mechanical — no logic changes):
+  {N}. {description}
+@endif
+
+@if(has_ideas)
+Ideas (require discussion):
+  {N}. {description}
+@endif
+
+@if(has_bugs)
+Bugs:
+  {N}. {description}
+@endif
+@endif
 ```
 
 → Proceed to **B. Q&A Loop**.
@@ -54,9 +92,22 @@ Required Changes:
 > *Output the next fenced block as a code block:*
 
 ```
-Comments:
+Comments (non-blocking):
 
-  {Recommendations from the review}
+@if(has_quickfixes)
+Quick-fixes (mechanical — no logic changes):
+  {N}. {description}
+@endif
+
+@if(has_ideas)
+Ideas (require discussion):
+  {N}. {description}
+@endif
+
+@if(has_bugs)
+Bugs:
+  {N}. {description}
+@endif
 ```
 
 → Proceed to **B. Q&A Loop**.
@@ -71,6 +122,9 @@ Comments:
 · · · · · · · · · · · ·
 Any questions before proceeding?
 
+@if(has_recommendations)
+- **`s`/`surface`** — Surface recommendations to inbox
+@endif
 - **`c`/`continue`** — Proceed to review actions
 - **Ask a question** — Ask about the review findings
 · · · · · · · · · · · ·
@@ -84,6 +138,57 @@ Answer the question using the review file, QA task files, specification, and pla
 
 → Return to **B. Q&A Loop**.
 
+#### If `surface`
+
+→ Proceed to **C. Surface to Inbox**.
+
 #### If `continue`
 
 → Return to caller.
+
+---
+
+## C. Surface to Inbox
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Which recommendations? (enter numbers, comma-separated, or **`a`/`all`**)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+Parse the selection — individual numbers, comma-separated list, or "all".
+
+For each selected recommendation:
+
+1. Determine its category from the grouped display (quickfix → `quickfixes/`, idea → `ideas/`, bug → `bugs/`)
+2. Create the inbox directory:
+   ```bash
+   mkdir -p .workflows/.inbox/{category}
+   ```
+3. Generate a kebab-case slug (2-4 words from the core recommendation, e.g., `volatile-marker-test`, `error-mapping-distinction`)
+4. Write the file to `.workflows/.inbox/{category}/{YYYY-MM-DD}--{slug}.md` (use today's date):
+
+```markdown
+# {Title derived from recommendation}
+
+{Full recommendation description from the review report}
+
+Source: review of {work_unit}/{topic}
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Surfaced to inbox:
+@foreach(item in surfaced_items)
+  • {item.number} → {item.category}/{item.date}--{item.slug}.md
+@endforeach
+```
+
+Commit: `review({work_unit}): surface recommendations to inbox`
+
+→ Return to **B. Q&A Loop**.

--- a/skills/workflow-review-process/references/produce-review.md
+++ b/skills/workflow-review-process/references/produce-review.md
@@ -13,9 +13,21 @@ Write the review to `.workflows/{work_unit}/review/{topic}/report.md`. The revie
 - **Request Changes** — Missing requirements, broken functionality, inadequate tests
 - **Comments Only** — Minor suggestions, non-blocking observations
 
-Commit: `review({work_unit}): complete review`
+### Categorizing Recommendations
 
-Present the review to the user.
+When writing the `## Recommendations` section, read the NON-BLOCKING NOTES from all `report-*.md` files and group them by their category tags:
+
+- `[quickfix]` → `### Quick-fixes`
+- `[idea]` → `### Ideas`
+- `[bug]` → `### Bugs`
+
+If a note lacks a category tag, categorize based on content: mechanical/cosmetic → quickfix, needs discussion/design → idea, broken behavior → bug.
+
+Only include subsections that have at least one item. Number items sequentially across all subsections (do not reset numbering per category). Omit the entire `## Recommendations` section if there are no non-blocking notes.
+
+### Commit and Continue
+
+Commit: `review({work_unit}): complete review`
 
 Your review feedback can be:
 - Addressed by implementation (same or new session)

--- a/skills/workflow-review-process/references/template.md
+++ b/skills/workflow-review-process/references/template.md
@@ -35,7 +35,15 @@
 1. [Specific actionable change]
 
 ## Recommendations
-[Combined non-blocking suggestions]
+
+### Quick-fixes
+[Mechanical, no-logic-change items — omit section if none]
+
+### Ideas
+[Items requiring discussion or design — omit section if none]
+
+### Bugs
+[Non-blocking broken behavior — omit section if none]
 ```
 
 ## Verdict Guidelines


### PR DESCRIPTION
## Summary

- Review task verifier now tags each non-blocking note as `[quickfix]`, `[idea]`, or `[bug]` with clear categorization criteria
- Review verdict display groups recommendations by category (Quick-fixes, Ideas, Bugs) with sequential numbering across all categories
- New `s/surface` menu option in the review Q&A loop lets users select recommendations to write directly to the workflow inbox (`.workflows/.inbox/{quickfixes,ideas,bugs}/`)
- Findings synthesizer updated to treat category tags as type classification, not severity — prevents `[bug]` tags from being escalated to blocking

## Test plan

- [ ] Run a review on a work unit with non-blocking findings — verify recommendations appear grouped by category
- [ ] Use `s/surface` to surface selected recommendations — verify files appear in correct inbox directories
- [ ] Verify `c/continue` still proceeds to review actions as before
- [ ] Verify an Approve verdict with no recommendations omits the `s/surface` menu option
- [ ] Run review synthesis (Request Changes verdict) — verify category tags don't affect severity filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)