### PR TITLE
feat: add background sub-agents to research skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Always create a feature branch **before** the first commit. Never commit to main
 
 ## Workflow Phases
 
-1. **Research** (`workflow-research-process` skill): EXPLORE - feasibility, market, viability, early ideas
+1. **Research** (`workflow-research-process` skill): EXPLORE - feasibility, market, viability, early ideas. Background review agent for gap analysis; deep-dive agents for independent thread investigation
 2. **Discussion** (`workflow-discussion-process` skill): Organic conversation guided by a live Discussion Map (`pending` → `exploring` → `converging` → `decided`). Topic elevation seeds sibling discussions (epics only)
 3. **Investigation** (`workflow-investigation-process` skill): Bugfix-specific - symptom gathering + code analysis → root cause
 4. **Scoping** (`workflow-scoping-process` skill): Quick-fix-specific - context, spec, and plan in one pass

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A development workflow for Claude Code that turns conversations into working sof
 - **Specifications that catch mistakes early.** The system analyses your discussions, filters hallucinations, fills gaps, and produces a validated spec before any code is written.
 - **Plans with real structure.** Specifications become phased implementation plans with tasks, acceptance criteria, and dependency ordering. Choose where tasks live — [Tick CLI, Linear issues, or local markdown files](#output-formats).
 - **Implementation via strict TDD.** Tests first, then code, commit after each task. Per-task approval gates keep you in control, or switch to auto-mode when you trust the flow.
-- **Validation at every stage.** Discussions are reviewed by a background agent for gaps and shallow coverage, with competing perspective agents for ambiguous decisions. Investigation root causes are independently validated by a synthesis agent before proceeding. Specifications get bidirectional review — one agent checks against source material for accuracy, another analyses the spec as a standalone document for gaps. Plans are checked for spec traceability and structural integrity. Implementation is analysed for architecture conformance, duplication, and coding standards. Review verifies against spec and plan. Findings become remediation tasks automatically.
+- **Validation at every stage.** Research is reviewed by a background agent for coverage gaps, shallow areas, and unvalidated assumptions — with deep-dive agents dispatched for independent investigation of substantial threads. Discussions are reviewed by a background agent for gaps and shallow coverage, with competing perspective agents for ambiguous decisions. Investigation root causes are independently validated by a synthesis agent before proceeding. Specifications get bidirectional review — one agent checks against source material for accuracy, another analyses the spec as a standalone document for gaps. Plans are checked for spec traceability and structural integrity. Implementation is analysed for architecture conformance, duplication, and coding standards. Review verifies against spec and plan. Findings become remediation tasks automatically.
 - **Context that survives.** Each phase clears the context window and starts fresh, so you're never fighting token limits on large work. All progress lives on disk — pick up exactly where you left off, even after context compaction or a new session.
 
 ## Getting Started
@@ -105,7 +105,7 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 
 | Phase | Purpose | Applies to |
 |-------|---------|------------|
-| **Research** | Explore ideas, market fit, technical feasibility. Output is analysed to derive discussion topics automatically. | Epic, Feature (opt.), Cross-cutting (opt.) |
+| **Research** | Explore ideas, market fit, technical feasibility. Background review agent identifies coverage gaps and shallow areas; deep-dive agents investigate independent threads (competitors, APIs, feasibility) in parallel. Output is analysed to derive discussion topics automatically. | Epic, Feature (opt.), Cross-cutting (opt.) |
 | **Discussion** | Organic conversation guided by a live Discussion Map that tracks subtopics through pending → exploring → converging → decided. Background review agent catches gaps; competing perspective agents argue viable approaches on ambiguous decisions, then a synthesis agent maps the tradeoff landscape. For epics, sibling concerns discovered during discussion are elevated to their own topic automatically. | Epic, Feature, Cross-cutting |
 | **Investigation** | Symptom gathering + code analysis to identify root cause. Optional synthesis agent validates the hypothesis independently. The bugfix alternative to discussion. | Bugfix |
 | **Scoping** | Context gathering, specification, and planning in a single pass. Produces 1-2 tasks directly. Includes complexity check with promotion to feature/bugfix if needed. | Quick-fix |
@@ -120,9 +120,9 @@ Work units are **in-progress**, **completed**, or **cancelled**. Completion happ
 
 ## Key Features
 
-### 21 Specialized Agents
+### 23 Specialized Agents
 
-Complex phases spawn parallel subagents for isolated concerns — discussion uses 3 agents for independent review, competing perspectives, and synthesis of tradeoffs. Investigation uses 1 for independent root cause validation. Specification and review each use 2 for input validation and gap analysis. Planning uses 6 for phase design, task authoring, dependency graphing, and quality review. Implementation uses 7 for TDD execution, post-task review, and cross-cutting analysis.
+Complex phases spawn parallel subagents for isolated concerns — research uses 2 agents for periodic gap analysis and independent deep-dive investigation. Discussion uses 3 for independent review, competing perspectives, and synthesis of tradeoffs. Investigation uses 1 for independent root cause validation. Specification and review each use 2 for input validation and gap analysis. Planning uses 6 for phase design, task authoring, dependency graphing, and quality review. Implementation uses 7 for TDD execution, post-task review, and cross-cutting analysis.
 
 ### Output Formats
 
@@ -199,7 +199,9 @@ Log ideas, bugs, and quick-fixes as you go — mid-conversation or from scratch.
 </details>
 
 <details>
-<summary><strong>Agents</strong> — 21 subagents for parallel task execution</summary>
+<summary><strong>Agents</strong> — 23 subagents for parallel task execution</summary>
+
+**Research:** [review](agents/workflow-research-review.md) | [deep-dive](agents/workflow-research-deep-dive.md)
 
 **Discussion:** [review](agents/workflow-discussion-review.md) | [perspective](agents/workflow-discussion-perspective.md) | [synthesis](agents/workflow-discussion-synthesis.md)
 

--- a/agents/workflow-research-deep-dive.md
+++ b/agents/workflow-research-deep-dive.md
@@ -1,0 +1,90 @@
+---
+name: workflow-research-deep-dive
+description: Conducts deep independent research on a specific thread — competitor analysis, API investigation, technical feasibility, market landscape. Invoked in the background by workflow-research-process skill.
+tools: Read, Write, WebSearch, WebFetch, Bash, Grep, Glob
+model: opus
+---
+
+# Research Deep Dive
+
+You are an independent researcher conducting a focused investigation on a specific thread. You have been given a clear research brief and your job is to explore it thoroughly — gathering facts, surfacing options, identifying limitations, and reporting what you find. You are not making decisions or recommendations. You are expanding the knowledge base.
+
+## Your Input
+
+You receive via the orchestrator's prompt:
+
+1. **Research brief** — what to investigate and why (enough context to work independently)
+2. **Research file path** — the current research document for background context
+3. **Output file path** — where to write your findings
+4. **Frontmatter** — the frontmatter block to use in the output file
+
+## Your Process
+
+1. **Read the research file** — understand the broader context, what's been explored, what questions are open
+2. **Plan your investigation** — what sources, searches, and analysis will be most productive for this brief?
+3. **Investigate thoroughly** — use web searches, fetch documentation, review publicly available source code, analyse APIs, read technical specs. Go deep. You have time and tools — use them.
+4. **Organise findings** — structure what you learned in a way that's useful to someone who wasn't there. Facts first, then analysis, then open questions.
+5. **Write findings** to the output file path
+
+## Investigation Approaches
+
+Choose based on the brief:
+
+- **Competitor/product analysis**: Find the product, explore its features, pricing, technical approach, limitations, user sentiment. Look at source code if open source. Check reviews, forums, GitHub issues.
+- **API/technical feasibility**: Find official documentation, explore capabilities and limitations, check authentication requirements, rate limits, pricing, community libraries. Try to understand what's possible vs what's practical.
+- **Market landscape**: Search for existing solutions, market size indicators, user demand signals (forums, surveys, app store reviews), pricing patterns, gaps in current offerings.
+- **Technical deep dive**: Research architecture approaches, review relevant open source implementations, check framework/library capabilities, identify known pitfalls and best practices.
+
+## Hard Rules
+
+**MANDATORY. No exceptions.**
+
+1. **No git writes** — do not commit or stage. Writing the output file is your only file write.
+2. **Do not decide** — present what you found, not what should be done with it. "This API supports X but not Y" is useful. "Therefore we should use this API" is not.
+3. **Cite sources** — when reporting facts from web research, include URLs. The orchestrator and user need to verify and explore further.
+4. **Stay scoped** — investigate the brief you were given. If you discover adjacent threads worth exploring, mention them in open questions — don't chase them yourself.
+5. **One file only** — write only to your output file path. Do not create additional files.
+6. **Substance over volume** — a focused, well-organised report beats a sprawling dump. Include what matters, skip what doesn't.
+
+## Output File Format
+
+Write to the output file path provided:
+
+```markdown
+{frontmatter provided by orchestrator}
+
+# Deep Dive: {Thread Title}
+
+## Brief
+
+{One paragraph: what was investigated and why.}
+
+## Key Findings
+
+{The core of what you discovered. Structure to serve the content — sections, tables, lists, whatever communicates most clearly. Include source URLs where applicable.}
+
+## Limitations and Caveats
+
+{What couldn't you verify? What's uncertain? What depends on assumptions? Be honest about the boundaries of your investigation.}
+
+## Open Questions
+
+1. {Question raised by the investigation that wasn't in the original brief}
+2. {Question}
+
+## Sources
+
+- {URL or source — description}
+- {URL or source — description}
+```
+
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+STATUS: complete
+THREAD: {thread name}
+FINDINGS_COUNT: {N}
+SUMMARY: {1-2 sentences — the most important thing discovered}
+```

--- a/agents/workflow-research-review.md
+++ b/agents/workflow-research-review.md
@@ -1,0 +1,106 @@
+---
+name: workflow-research-review
+description: Periodically reviews research files for coverage gaps, shallow areas, unvalidated assumptions, and missing angles. Invoked in the background by workflow-research-process skill during the session loop.
+tools: Read, Write
+model: opus
+---
+
+# Research Review
+
+You are an independent reviewer assessing the breadth, depth, and rigour of a research document. You have no prior context — you are reading this research fresh. This clean-slate perspective is intentional: you catch gaps that the participants, deep in exploration, may have normalised or overlooked.
+
+## Your Input
+
+You receive via the orchestrator's prompt:
+
+1. **Research file path(s)** — the research document(s) to review
+2. **Output file path** — where to write your analysis
+3. **Frontmatter** — the frontmatter block to use in the output file (includes type, status, set number, date)
+
+## Your Process
+
+1. **Read all research file(s)** completely before beginning assessment
+2. **Assess coverage breadth** — are there obvious areas unexplored? Competitors not mentioned, market segments not considered, technical alternatives not surfaced, regulatory or compliance implications ignored, resource or cost dimensions missing?
+3. **Assess depth** — where is coverage shallow? Options listed but not investigated, claims without evidence or examples, areas mentioned in passing but never explored, threads bookmarked and forgotten?
+4. **Identify unvalidated assumptions** — where does the research assume something is true without checking? "We assume X is possible", "users probably want Y", "the market is Z" — flag anything taken for granted that could be verified
+5. **Check for missing angles** — has the research only looked from one perspective? If it's all technical, where's the business angle? If it's all market, where's the feasibility angle? Research should span the landscape, not tunnel on one dimension
+6. **Note disconnected threads** — are there findings in different areas that could inform each other but haven't been connected?
+7. **Write findings** to the output file path
+
+## Hard Rules
+
+**MANDATORY. No exceptions.**
+
+1. **No git writes** — do not commit or stage. Writing the output file is your only file write.
+2. **Do not recommend directions** — you identify gaps, not fill them. "This area hasn't been explored" is useful. "You should explore X because it's the best option" is not.
+3. **Do not evaluate options** — whether one technical approach is better than another is not your concern. Whether the research has adequately explored the landscape of options is.
+4. **Be specific** — "needs more depth" is not useful. "The competitive landscape section mentions three alternatives but only investigates pricing for one — the technical capabilities and limitations of the other two are unexplored" is useful.
+5. **Stay scoped** — keep findings within what the research intends to cover. Do not introduce entirely new research domains or expand the scope.
+
+## Output File Format
+
+Write to the output file path provided:
+
+```markdown
+{frontmatter provided by orchestrator}
+
+# Research Review — Set {NNN}
+
+## Summary
+
+{One paragraph: overall assessment of research coverage and depth.}
+
+## Unexplored Areas
+
+1. {Specific area that hasn't been touched — what's missing and why it matters}
+2. {Specific area}
+
+## Shallow Coverage
+
+1. {Area where research exists but lacks depth — what's there and what's missing}
+2. {Area}
+
+## Unvalidated Assumptions
+
+1. {Assumption being taken for granted — what was assumed and how it could be checked}
+2. {Assumption}
+
+## Observations
+
+{Optional. Connections between threads, patterns across findings, angles that could complement each other. Keep brief.}
+```
+
+If no significant gaps found:
+
+```markdown
+{frontmatter provided by orchestrator}
+
+# Research Review — Set {NNN}
+
+## Summary
+
+{Assessment confirming thorough coverage across relevant dimensions.}
+
+## Unexplored Areas
+
+None identified.
+
+## Shallow Coverage
+
+None identified.
+
+## Unvalidated Assumptions
+
+None identified.
+```
+
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+STATUS: gaps_found | thorough
+GAPS_COUNT: {N}
+ASSUMPTIONS_COUNT: {N}
+SUMMARY: {1 sentence}
+```

--- a/ideas/research-background-agents.md
+++ b/ideas/research-background-agents.md
@@ -4,6 +4,8 @@
 
 During research sessions, allow the research skill to dispatch sub-agents for independent research threads in the background while the main conversation continues. The user and Claude keep exploring topics together while heavy research tasks (web searches, source code reviews, API documentation analysis) run in parallel.
 
+This must be a declared, controlled feature — not something that happens ad-hoc. The skill must own the lifecycle: when agents are dispatched, what files they create, and critically, that those files are registered in the manifest.
+
 ## Why This Matters
 
 Research sessions naturally generate multiple independent threads. Currently, the research skill processes everything sequentially — if the user wants to explore Bluetooth APIs, review a competitor's source code, and investigate networking options, each thread blocks the others.
@@ -24,19 +26,63 @@ The pattern worked well because:
 - When results arrived, they were naturally integrated into the conversation
 - Three independent research threads completed in the time one sequential thread would have taken
 
+### What Went Wrong
+
+The sub-agents created research files (`networking.md`, `rule-engine.md`, `blue-switch-review.md`, `bluetooth-pairing-behavior.md`) directly in the research directory without registering them in the manifest via `init-phase`. This left the workflow in an inconsistent state — files existed on disk that the manifest didn't know about.
+
+This happened because:
+- The Agent tool is always available — Claude used it as a general capability, not as part of the skill's process
+- The sub-agents had no awareness of the manifest or the registration requirement
+- The main agent didn't register the files on behalf of the sub-agents when results came back
+- The compliance check at the end of the session didn't catch the unregistered files
+
 ## What It Would Look Like
 
-The research skill's session loop or guidelines would explicitly acknowledge this pattern:
+The research skill's session loop or guidelines would explicitly declare this as a feature:
+
+### Dispatching
 
 - When a research thread is independent and would benefit from deep web research or code analysis, offer to dispatch it as a background sub-agent
+- Before dispatching, the main agent MUST register the new topic in the manifest:
+  ```bash
+  node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.research.{topic}
+  ```
+- The sub-agent brief must include the exact output file path
 - Continue the conversation on other threads while the agent works
-- When results arrive, summarise findings and integrate into the research document
-- Commit results as they land, not batched at the end
+
+### On Completion
+
+- When results arrive, summarise findings and integrate into the conversation
+- Commit the sub-agent's file
+- Verify the file matches the registered manifest entry
+
+### Sub-Agent Brief Requirements
+
+Sub-agents must receive:
+- The exact output file path (`.workflows/{work_unit}/research/{topic}.md`)
+- The research document template to follow
+- Enough context to do useful work without the conversation history
+- Clear instruction NOT to modify any other research files
+
+### Guardrails
+
+- Sub-agents write to their OWN file only — never the main exploration file or other topic files
+- The main agent is responsible for manifest registration, not the sub-agent
+- Quick lookups, single API checks, or questions that inform the next conversational turn stay in the main thread — sub-agents are for substantial, independent research
+- Maximum concurrent sub-agents should be reasonable (3-4) to avoid overwhelming the session with notifications
+
+## Compliance Check Updates
+
+The existing compliance check (`compliance-check.md`) should be extended with:
+
+1. **File-manifest consistency** — scan `.workflows/{work_unit}/research/` for any `.md` files that are NOT registered in the manifest. Flag unregistered files as a significant issue requiring correction.
+2. **Sub-agent file verification** — if sub-agents were dispatched during the session, verify each created file is registered and committed.
+3. **Template compliance** — verify sub-agent-created files follow the research document template structure.
 
 ## Design Tensions
 
 - **Context sharing**: Sub-agents don't see the ongoing conversation. They need self-contained briefs with enough context to do useful work. The main agent must compose good prompts.
-- **File conflicts**: Multiple agents writing to the same research file would cause problems. Each agent should write to its own file (e.g., `networking.md`, `blue-switch-review.md`) rather than appending to a shared document.
+- **File conflicts**: Multiple agents writing to the same research file would cause problems. Each agent should write to its own file rather than appending to a shared document.
 - **Notification handling**: When a background agent completes mid-conversation, the main agent needs to handle the notification naturally without disrupting the current thread.
-- **Over-delegation**: Not everything should be a sub-agent. Quick lookups, single API checks, or questions that inform the next conversational turn should stay in the main thread. Sub-agents are for substantial, independent research that would take multiple minutes.
-- **Skill boundary**: This pattern uses the Agent tool which is always available. The skill doesn't need to "enable" it — but explicitly acknowledging the pattern in the research guidelines would make it a deliberate part of the process rather than an ad-hoc decision.
+- **Over-delegation**: Not everything should be a sub-agent. The threshold should be high — substantial research that would take multiple minutes and is independent of the current conversation thread.
+- **Manifest as source of truth**: The manifest must always reflect reality. If a file exists, it must be registered. This is the core invariant that was violated in the observed session and the primary thing the skill must enforce.

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -27,8 +27,9 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Read all research files** in `.workflows/{work_unit}/research/`. These are the working documents this skill creates. Their content is your source of truth for progress.
-3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
-4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
+3. **Check agent cache.** Scan `.workflows/.cache/{work_unit}/research/` for any files with `status: pending` or `status: read` in their frontmatter. These are background agent results that may need surfacing or have been partially processed.
+4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
+5. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 

--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -1,0 +1,181 @@
+# Deep-Dive Agent
+
+*Reference for **[workflow-research-process](../SKILL.md)***
+
+---
+
+These instructions are loaded into context at the start of the research session but are not for immediate use. Deep-dive agents investigate specific threads independently in the background — competitor analysis, API exploration, technical feasibility, market landscapes. Apply the dispatch and results processing instructions below when the time is right.
+
+**Trigger conditions** — offer a deep-dive agent when:
+
+- A research thread is substantial enough to warrant independent investigation (not a quick lookup)
+- The thread is independent of the current conversation (exploring it won't block or depend on what's being discussed right now)
+- The investigation would benefit from dedicated tools (web search, source code review, documentation analysis)
+
+Two dispatch paths:
+
+1. **User-initiated** — the user explicitly asks for a deep dive ("can you look into X while we keep going?"). No offer needed — proceed directly to dispatch.
+2. **Orchestrator-offered** — you identify a thread that fits the criteria above. Offer to dispatch.
+
+Signals that suggest offering a deep dive:
+- A competitor or product is mentioned but not yet investigated
+- Technical feasibility is assumed but not verified
+- An API or service is referenced with uncertain capabilities
+- A market segment or user need is hypothesised but not validated
+- The review agent flagged a substantial gap that warrants dedicated investigation
+
+Do not fire for quick lookups, single searches, or questions that inform the next conversational turn — those stay in the main thread.
+
+---
+
+## A. Offer Deep Dive
+
+#### If user-initiated
+
+Skip the offer — the user already asked.
+
+→ Proceed to **B. Dispatch**.
+
+#### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+{Thread description} looks like it could use a deep dive.
+Want me to spin up a background investigation while we keep going?
+
+- **`y`/`yes`** — Dispatch a deep-dive agent
+- **`n`/`no`** — Skip, we'll cover it in conversation
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `no`:**
+
+Continue the research session without dispatching.
+
+→ Return to caller.
+
+**If `yes`:**
+
+→ Proceed to **B. Dispatch**.
+
+---
+
+## B. Dispatch
+
+Ensure the cache directory exists:
+
+```bash
+mkdir -p .workflows/.cache/{work_unit}/research/{topic}
+```
+
+Determine the next set number by checking existing files:
+
+```bash
+ls .workflows/.cache/{work_unit}/research/{topic}/ 2>/dev/null
+```
+
+Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`).
+
+Compose a research brief for the agent. The brief must be self-contained — the agent has no conversation history. Include:
+- What to investigate and why
+- Relevant context from the research so far (constraints, findings that inform this thread)
+- Specific questions to answer if applicable
+- Boundaries — what's in scope and what isn't
+
+**Agent path**: `../../../agents/workflow-research-deep-dive.md`
+
+Dispatch **one agent** via the Task tool with `run_in_background: true`.
+
+The deep-dive agent receives:
+
+1. **Research brief** — the self-contained investigation brief
+2. **Research file path** — `.workflows/{work_unit}/research/{topic}.md` (for background context)
+3. **Output file path** — `.workflows/.cache/{work_unit}/research/{topic}/deep-dive-{NNN}-{thread}.md`
+4. **Frontmatter** — the frontmatter block to write:
+   ```yaml
+   ---
+   type: deep-dive
+   status: pending
+   created: {date}
+   set: {NNN}
+   thread: {thread name}
+   ---
+   ```
+
+> *Output the next fenced block as a code block:*
+
+```
+Deep-dive dispatched: {thread description}.
+Results will be surfaced when available.
+```
+
+The deep-dive agent returns:
+
+```
+STATUS: complete
+THREAD: {thread name}
+FINDINGS_COUNT: {N}
+SUMMARY: {1-2 sentences}
+```
+
+The research session continues — do not wait for the agent to return.
+
+**Concurrency**: Before dispatching, count files matching `deep-dive-*.md` with `status: pending` in their frontmatter in the cache directory. Limit to 3-4 in flight at once. If the limit is reached, note the thread for later dispatch.
+
+---
+
+## C. Check for Results
+
+At natural conversational breaks, scan the cache directory for deep-dive files with `status: pending` in their frontmatter.
+
+#### If no pending deep-dive files
+
+Nothing to surface. Continue the research session.
+
+→ Return to caller.
+
+#### If a pending deep-dive file exists
+
+→ Proceed to **D. Surface Findings**.
+
+---
+
+## D. Surface Findings
+
+1. Read the deep-dive file
+2. Update its frontmatter to `status: read`
+3. Summarise the key findings conversationally
+
+**Do not dump the deep-dive output verbatim.** Present the highlights — what was found, what matters, what's surprising, what questions it raises. The user should understand the landscape without reading the full report.
+
+> *Output the next fenced block as a code block:*
+
+```
+Deep-dive results: {thread description}
+```
+
+Then summarise conversationally. Example approach:
+
+> "The deep dive on {thread} came back. Key findings: {finding 1}, {finding 2}. One thing that stood out — {surprising finding}. It also raised a question about {open question}. Want to dig into any of this?"
+
+After presenting findings, continue the conversation. The user may want to discuss the findings, ask questions, connect them to other threads, or park them for later. Follow their lead.
+
+**Promoting to a research file** (epic work type only): If findings are substantial enough to warrant their own research file — and the user agrees or requests it — promote them:
+
+1. Create a new research file at `.workflows/{work_unit}/research/{thread}.md`
+2. Synthesise the deep-dive findings into the file (don't copy the cache file verbatim — organise for the research document context)
+3. Register in the manifest:
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.research.{thread}
+   ```
+4. Commit: `research({work_unit}): add {thread} research from deep dive`
+
+For feature work types, deep-dive findings fold into the existing research file — there is only one research topic per feature.
+
+**Marking as incorporated**: After findings have been discussed, promoted, or deliberately parked, update the cache file frontmatter to `status: incorporated`. No commit needed for cache file status changes.
+
+→ Return to caller.

--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -4,15 +4,31 @@
 
 ---
 
+## A. Background Agents
+
+Two types of background agent operate during research. Load their lifecycle instructions now — apply them at the appropriate moments during the session loop.
+
+→ Load **[review-agent.md](review-agent.md)** and follow its instructions as written.
+
+→ Load **[deep-dive-agent.md](deep-dive-agent.md)** and follow its instructions as written.
+
+---
+
+## B. Session Loop
+
 Multi-file, topic-aware session with convergence routing.
 
 → Load **[session-loop.md](session-loop.md)** and follow its conversation process.
 
-## Topic Awareness
+---
+
+## C. Topic Awareness
 
 When working in a specific topic file and content drifts to another topic's scope, flag it and offer to switch to that topic's file or note it for later. Don't silently let content accumulate in the wrong file.
 
-## Convergence Routing
+---
+
+## D. Convergence Routing
 
 When you notice convergence signals (from the research guidelines), flag it and route to the appropriate action:
 
@@ -20,8 +36,47 @@ When you notice convergence signals (from the research guidelines), flag it and 
 
 → Load **[topic-splitting.md](topic-splitting.md)** and follow its instructions as written.
 
+→ Return to **B. Session Loop**.
+
 #### If the current topic is converging (tradeoffs clear, approaching decision territory)
+
+→ Proceed to **E. In-Flight Agent Handling**.
+
+---
+
+## E. In-Flight Agent Handling
+
+Before concluding, check for in-flight agents. Scan the cache directory for review or deep-dive files with `status: pending` in their frontmatter.
+
+#### If no agents are in flight
 
 → Load **[topic-completion.md](topic-completion.md)** and follow its instructions as written.
 
-After handling, both reference files route back to the session loop when appropriate (splitting always returns; completion returns for keep, bridges out for conclude).
+→ Return to **B. Session Loop**.
+
+#### If agents are still running
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+There are still {N} background agents working.
+
+- **`w`/`wait`** — Wait for results before concluding
+- **`p`/`proceed`** — Conclude now (results will persist in cache for reference)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `wait`:**
+
+Check for agent completion. When all agents have returned, surface their findings per the agent instructions loaded above.
+
+→ Return to **B. Session Loop**.
+
+**If `proceed`:**
+
+→ Load **[topic-completion.md](topic-completion.md)** and follow its instructions as written.
+
+→ Return to **B. Session Loop**.

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -4,12 +4,65 @@
 
 ---
 
+## A. Background Agents
+
+Two types of background agent operate during research. Load their lifecycle instructions now — apply them at the appropriate moments during the session loop.
+
+→ Load **[review-agent.md](review-agent.md)** and follow its instructions as written.
+
+→ Load **[deep-dive-agent.md](deep-dive-agent.md)** and follow its instructions as written.
+
+---
+
+## B. Session Loop
+
 Focused, single-topic session. No splitting, no multi-file management.
 
 → Load **[session-loop.md](session-loop.md)** and follow its conversation process.
 
-## Session Conclusion
+---
+
+## C. Session Conclusion
 
 When the topic feels well-explored or the user indicates they're done:
 
+→ Proceed to **D. In-Flight Agent Handling**.
+
+---
+
+## D. In-Flight Agent Handling
+
+Before concluding, check for in-flight agents. Scan the cache directory for review or deep-dive files with `status: pending` in their frontmatter.
+
+#### If no agents are in flight
+
 → Load **[topic-completion.md](topic-completion.md)** and follow its instructions as written.
+
+→ Return to **B. Session Loop**.
+
+#### If agents are still running
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+There are still {N} background agents working.
+
+- **`w`/`wait`** — Wait for results before concluding
+- **`p`/`proceed`** — Conclude now (results will persist in cache for reference)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `wait`:**
+
+Check for agent completion. When all agents have returned, surface their findings per the agent instructions loaded above.
+
+→ Return to **B. Session Loop**.
+
+**If `proceed`:**
+
+→ Load **[topic-completion.md](topic-completion.md)** and follow its instructions as written.
+
+→ Return to **B. Session Loop**.

--- a/skills/workflow-research-process/references/review-agent.md
+++ b/skills/workflow-research-process/references/review-agent.md
@@ -1,0 +1,109 @@
+# Review Agent
+
+*Reference for **[workflow-research-process](../SKILL.md)***
+
+---
+
+These instructions are loaded into context at the start of the research session but are not for immediate use. A review agent reads the research files with a clean slate in the background, identifying coverage gaps, shallow areas, and unvalidated assumptions. Apply the dispatch and results processing instructions below when the time is right.
+
+**Trigger conditions** — dispatch a review agent when **all** of the following are true:
+
+- The most recent commit added meaningful content (new findings documented, threads explored, open questions captured — not a typo fix or reformatting)
+- No review agent is currently in flight
+- This is not the first commit (the research needs enough content to review)
+- At least 2-3 conversational exchanges have passed since the last review dispatch
+
+When these conditions are met → Proceed to **A. Dispatch**.
+
+At natural conversational breaks, check for completed results → Proceed to **B. Check for Results**.
+
+---
+
+## A. Dispatch
+
+Ensure the cache directory exists:
+
+```bash
+mkdir -p .workflows/.cache/{work_unit}/research/{topic}
+```
+
+Determine the next set number by checking existing files:
+
+```bash
+ls .workflows/.cache/{work_unit}/research/{topic}/ 2>/dev/null
+```
+
+Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`).
+
+**Agent path**: `../../../agents/workflow-research-review.md`
+
+Dispatch **one agent** via the Task tool with `run_in_background: true`.
+
+The review agent receives:
+
+1. **Research file path(s)** — `.workflows/{work_unit}/research/{topic}.md` (for epic, include all research files in `.workflows/{work_unit}/research/` relevant to the current topic)
+2. **Output file path** — `.workflows/.cache/{work_unit}/research/{topic}/review-{NNN}.md`
+3. **Frontmatter** — the frontmatter block to write:
+   ```yaml
+   ---
+   type: review
+   status: pending
+   created: {date}
+   set: {NNN}
+   ---
+   ```
+
+> *Output the next fenced block as a code block:*
+
+```
+Background review dispatched. Results will be surfaced when available.
+```
+
+The review agent returns:
+
+```
+STATUS: gaps_found | thorough
+GAPS_COUNT: {N}
+ASSUMPTIONS_COUNT: {N}
+SUMMARY: {1 sentence}
+```
+
+The research session continues — do not wait for the agent to return.
+
+---
+
+## B. Check for Results
+
+Scan the cache directory for review files with `status: pending` in their frontmatter.
+
+#### If no pending review files
+
+Nothing to surface. Continue the research session.
+
+→ Return to caller.
+
+#### If a pending review file exists
+
+→ Proceed to **C. Surface Findings**.
+
+---
+
+## C. Surface Findings
+
+1. Read the review file
+2. Update its frontmatter to `status: read`
+3. Assess the findings — which gaps, shallow areas, and assumptions are genuinely worth exploring?
+
+**Do not dump the review output verbatim.** Digest it and present it conversationally. The review surfaces gaps — you turn them into productive research threads.
+
+Example phrasing — adapt naturally:
+
+> "A background review flagged some areas we haven't touched yet: we haven't looked at the regulatory side of {X}, and the competitor analysis assumed {Y} without checking. There's also a shallow spot around {Z} — we mentioned it but never dug in. Worth exploring any of these?"
+
+If all findings are minor or already addressed:
+
+> "A background review came back — nothing significant beyond what we've already covered."
+
+**Offering deep dives**: If a gap is substantial and independent enough for its own investigation, offer to dispatch a deep-dive agent for it. This is a natural transition — the review identifies what's missing, the deep dive goes and finds it. Follow the deep-dive agent instructions for the offer and dispatch.
+
+**Marking as incorporated**: After findings have been discussed and either explored or deliberately set aside, update the file frontmatter to `status: incorporated`. No commit needed for cache file status changes.

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -8,17 +8,21 @@
 
 Not a rigid checklist — a natural cadence for productive research conversations:
 
-1. **Explore** — Probe the topic from a relevant angle. Use the funnel technique: broad first, specific later. Choose your probe type deliberately. One question at a time — wait for the answer before asking the next.
+1. **Check for findings** — At natural conversational breaks, check for completed agent results and surface them per the review agent and deep-dive agent instructions loaded by the session wrapper. Skip on the first iteration (no agents have been dispatched yet).
 
-2. **Engage** — Don't just collect the answer. React to it. Challenge assumptions. Explore implications. Follow promising tangents. Connect what the user just said to something from earlier. This is where your value as a research partner lives — you're thinking alongside, not just recording.
+2. **Explore** — Probe the topic from a relevant angle. Use the funnel technique: broad first, specific later. Choose your probe type deliberately. One question at a time — wait for the answer before asking the next.
 
-3. **Synthesize** — Periodically step back and make sense of what's emerging. "So what I'm hearing is..." or "This connects to what you said earlier about..." Not a scheduled checkpoint — a natural part of the conversation when threads are accumulating. What's becoming clear? What's still uncertain? What patterns are forming?
+3. **Engage** — Don't just collect the answer. React to it. Challenge assumptions. Explore implications. Follow promising tangents. Connect what the user just said to something from earlier. This is where your value as a research partner lives — you're thinking alongside, not just recording.
 
-4. **Document** — At natural pauses, update the research file with insights, open questions, and emerging themes. Capture the substance, not a transcript. The research file is freeform — let structure emerge from the content rather than imposing it.
+4. **Synthesize** — Periodically step back and make sense of what's emerging. "So what I'm hearing is..." or "This connects to what you said earlier about..." Not a scheduled checkpoint — a natural part of the conversation when threads are accumulating. What's becoming clear? What's still uncertain? What patterns are forming?
 
-5. **Commit** — Git commit after each write. Don't batch. The commit history is your safety net across context compaction.
+5. **Document** — At natural pauses, update the research file with insights, open questions, and emerging themes. Capture the substance, not a transcript. The research file is freeform — let structure emerge from the content rather than imposing it.
 
-6. **Continue** — Follow the conversation where it leads. If a tangent is promising, pursue it. If a thread is exhausted, move on. If earlier threads gain new context from what was just discussed, circle back.
+6. **Commit** — Git commit after each write. Don't batch. The commit history is your safety net across context compaction.
+
+7. **Consider agents** — After each substantive commit, evaluate the trigger conditions defined in the review agent and deep-dive agent instructions loaded by the session wrapper. If conditions are met, follow their dispatch instructions.
+
+8. **Continue** — Follow the conversation where it leads. If a tangent is promising, pursue it. If a thread is exhausted, move on. If earlier threads gain new context from what was just discussed, circle back.
 
 ## Navigating the Conversation
 


### PR DESCRIPTION
## Summary

- Add two new research agents: `workflow-research-review` (periodic gap analysis) and `workflow-research-deep-dive` (independent thread investigation with web search, code review)
- Add dispatch/result-handling reference files (`review-agent.md`, `deep-dive-agent.md`) integrated into both epic and feature research sessions
- Update session loop with check-for-findings and consider-agents steps, add in-flight agent handling before conclusion, and add cache check to context refresh recovery

## Test plan

- [ ] Run an epic research session and verify review agent dispatches after meaningful commits
- [ ] Verify deep-dive agent offer appears when a substantial independent thread is identified
- [ ] Confirm sub-agent results are surfaced conversationally (not dumped verbatim)
- [ ] Test in-flight agent handling when concluding — wait/proceed menu appears
- [ ] Verify cache files use correct paths and frontmatter status lifecycle (pending → read → incorporated)
- [ ] Confirm promote-to-research-file path registers in manifest (epic only)
- [ ] Test feature session — verify no promote option, findings fold into existing file

🤖 Generated with [Claude Code](https://claude.com/claude-code)