### PR TITLE
fix: unify numbered menu items to match command option style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,13 +416,13 @@ Investigation complete. Ready to conclude?
 · · · · · · · · · · · ·
 ```
 
-**Selection menu** — use concrete examples showing verb-to-state mapping:
+**Selection menu** — use concrete examples showing verb-to-state mapping. Numbered items use the same `- **`N`** —` format as command options so the menu has a unified visual style:
 
 ```
 · · · · · · · · · · · ·
-1. Create "Auth Flow" — completed spec, no plan
-2. Continue "Data Model" — plan in-progress
-3. Review "Billing" — plan completed
+- **`1`** — Create "Auth Flow" — completed spec, no plan
+- **`2`** — Continue "Data Model" — plan in-progress
+- **`3`** — Review "Billing" — plan completed
 
 Select an option (enter number):
 · · · · · · · · · · · ·
@@ -453,7 +453,7 @@ What scope would you like to review?
 **Meta options** in selection menus get backtick-wrapped descriptions:
 
 ```
-3. Unify all into single specification
+- **`3`** — Unify all into single specification
    `All discussions combined into one specification.`
    `Existing specifications are incorporated and superseded.`
 ```

--- a/skills/continue-bugfix/references/revisit-phase.md
+++ b/skills/continue-bugfix/references/revisit-phase.md
@@ -52,11 +52,11 @@ Continuing "{bugfix.name:(titlecase)}" — {bugfix.phase_label}.
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — completed
-2. ...
-{N}. Back
+- **`1`** — {phase:(titlecase)} — completed
+- **`2`** — ...
+- **`{N}`** — Back
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-bugfix/references/select-bugfix.md
+++ b/skills/continue-bugfix/references/select-bugfix.md
@@ -32,15 +32,15 @@ Build from the discovery output's `bugfixes` array. Each bugfix shows `name` (ti
 · · · · · · · · · · · ·
 Which bugfix would you like to continue?
 
-1. Continue "{bugfix.name:(titlecase)}" — {bugfix.phase_label}
-2. ...
+- **`1`** — Continue "{bugfix.name:(titlecase)}" — {bugfix.phase_label}
+- **`2`** — ...
 
 @if(completed_count > 0 || cancelled_count > 0)
-{N+1}. View completed & cancelled bugfixes
+- **`{N+1}`** — View completed & cancelled bugfixes
 @endif
 - **`m`/`manage`** — Manage a bugfix's lifecycle
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-cross-cutting/references/revisit-phase.md
+++ b/skills/continue-cross-cutting/references/revisit-phase.md
@@ -52,11 +52,11 @@ Continuing "{cross_cutting.name:(titlecase)}" — {cross_cutting.phase_label}.
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — completed
-2. ...
-{N}. Back
+- **`1`** — {phase:(titlecase)} — completed
+- **`2`** — ...
+- **`{N}`** — Back
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-cross-cutting/references/select-cross-cutting.md
+++ b/skills/continue-cross-cutting/references/select-cross-cutting.md
@@ -32,15 +32,15 @@ Build from the discovery output's `cross_cutting` array. Each shows `name` (titl
 · · · · · · · · · · · ·
 Which cross-cutting concern would you like to continue?
 
-1. Continue "{cross_cutting.name:(titlecase)}" — {cross_cutting.phase_label}
-2. ...
+- **`1`** — Continue "{cross_cutting.name:(titlecase)}" — {cross_cutting.phase_label}
+- **`2`** — ...
 
 @if(completed_count > 0 || cancelled_count > 0)
-{N+1}. View completed & cancelled cross-cutting concerns
+- **`{N+1}`** — View completed & cancelled cross-cutting concerns
 @endif
 - **`m`/`manage`** — Manage a cross-cutting concern's lifecycle
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -197,18 +197,18 @@ Build a numbered menu with three sections:
 · · · · · · · · · · · ·
 What would you like to do?
 
-1. Continue "Auth Flow" — discussion (in-progress)
-2. Continue "Data Model" — specification (in-progress)
-3. Start planning for "User Profiles" — spec completed
-4. Continue "Caching" — planning (in-progress)
-5. Start implementation of "Notifications" — plan completed (recommended)
-6. Start implementation of "Reporting" — blocked by core-features:core-2-3
-7. Start specification — 3 discussion(s) not yet in a spec
-8. Start new discussion topic (from research)
-9. Start new research
-10. Resume a completed topic
+- **`1`** — Continue "Auth Flow" — discussion (in-progress)
+- **`2`** — Continue "Data Model" — specification (in-progress)
+- **`3`** — Start planning for "User Profiles" — spec completed
+- **`4`** — Continue "Caching" — planning (in-progress)
+- **`5`** — Start implementation of "Notifications" — plan completed (recommended)
+- **`6`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
+- **`7`** — Start specification — 3 discussion(s) not yet in a spec
+- **`8`** — Start new discussion topic (from research)
+- **`9`** — Start new research
+- **`10`** — Resume a completed topic
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 
@@ -370,11 +370,11 @@ Only show phases with completed items. Blank line between phase sections.
 · · · · · · · · · · · ·
 Which topic would you like to resume?
 
-1. Resume "{item.name:(titlecase)}" — {item.phase}
-2. ...
-{N}. Back to main menu
+- **`1`** — Resume "{item.name:(titlecase)}" — {item.phase}
+- **`2`** — ...
+- **`{N}`** — Back to main menu
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-epic/references/select-epic.md
+++ b/skills/continue-epic/references/select-epic.md
@@ -32,15 +32,15 @@ Build from the discovery output's `epics` array. Each epic shows `name` (titleca
 · · · · · · · · · · · ·
 Which epic would you like to continue?
 
-1. Continue "{epic.name:(titlecase)}"
-2. ...
+- **`1`** — Continue "{epic.name:(titlecase)}"
+- **`2`** — ...
 
 @if(completed_count > 0 || cancelled_count > 0)
-{N+1}. View completed & cancelled epics
+- **`{N+1}`** — View completed & cancelled epics
 @endif
 - **`m`/`manage`** — Manage an epic's lifecycle
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-feature/references/revisit-phase.md
+++ b/skills/continue-feature/references/revisit-phase.md
@@ -52,11 +52,11 @@ Continuing "{feature.name:(titlecase)}" — {feature.phase_label}.
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — completed
-2. ...
-{N}. Back
+- **`1`** — {phase:(titlecase)} — completed
+- **`2`** — ...
+- **`{N}`** — Back
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-feature/references/select-feature.md
+++ b/skills/continue-feature/references/select-feature.md
@@ -32,15 +32,15 @@ Build from the discovery output's `features` array. Each feature shows `name` (t
 · · · · · · · · · · · ·
 Which feature would you like to continue?
 
-1. Continue "{feature.name:(titlecase)}" — {feature.phase_label}
-2. ...
+- **`1`** — Continue "{feature.name:(titlecase)}" — {feature.phase_label}
+- **`2`** — ...
 
 @if(completed_count > 0 || cancelled_count > 0)
-{N+1}. View completed & cancelled features
+- **`{N+1}`** — View completed & cancelled features
 @endif
 - **`m`/`manage`** — Manage a feature's lifecycle
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-quickfix/references/revisit-phase.md
+++ b/skills/continue-quickfix/references/revisit-phase.md
@@ -52,11 +52,11 @@ Continuing "{quickfix.name:(titlecase)}" — {quickfix.phase_label}.
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — completed
-2. ...
-{N}. Back
+- **`1`** — {phase:(titlecase)} — completed
+- **`2`** — ...
+- **`{N}`** — Back
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/continue-quickfix/references/select-quickfix.md
+++ b/skills/continue-quickfix/references/select-quickfix.md
@@ -32,15 +32,15 @@ Build from the discovery output's `quick_fixes` array. Each quick-fix shows `nam
 · · · · · · · · · · · ·
 Which quick-fix would you like to continue?
 
-1. Continue "{quickfix.name:(titlecase)}" — {quickfix.phase_label}
-2. ...
+- **`1`** — Continue "{quickfix.name:(titlecase)}" — {quickfix.phase_label}
+- **`2`** — ...
 
 @if(completed_count > 0 || cancelled_count > 0)
-{N+1}. View completed & cancelled quick-fixes
+- **`{N+1}`** — View completed & cancelled quick-fixes
 @endif
 - **`m`/`manage`** — Manage a quick-fix's lifecycle
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -141,11 +141,11 @@ Check if there are completed phases earlier in the pipeline that the user could 
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — completed
-2. ...
-{N}. Back
+- **`1`** — {phase:(titlecase)} — completed
+- **`2`** — ...
+- **`{N}`** — Back
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -90,11 +90,11 @@ Check if there are completed phases earlier in the pipeline that the user could 
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — completed
-2. ...
-{N}. Back
+- **`1`** — {phase:(titlecase)} — completed
+- **`2`** — ...
+- **`{N}`** — Back
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -142,11 +142,11 @@ Check if there are completed phases earlier in the pipeline that the user could 
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — completed
-2. ...
-{N}. Back
+- **`1`** — {phase:(titlecase)} — completed
+- **`2`** — ...
+- **`{N}`** — Back
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -139,11 +139,11 @@ Check if there are completed phases earlier in the pipeline that the user could 
 · · · · · · · · · · · ·
 Which phase would you like to revisit?
 
-1. {phase:(titlecase)} — completed
-2. ...
-{N}. Back
+- **`1`** — {phase:(titlecase)} — completed
+- **`2`** — ...
+- **`{N}`** — Back
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-discussion-entry/references/display-options.md
+++ b/skills/workflow-discussion-entry/references/display-options.md
@@ -30,14 +30,18 @@ Research topics:
 2. ...
 ```
 
-If discussions exist that are NOT linked to a research topic, list them separately:
+If discussions exist that are NOT linked to a research topic, list them separately with continuing numbers:
 
 > *Output the next fenced block as a code block:*
 
 ```
 Existing discussions:
 
-  • {work_unit}/{topic} ({status:[in-progress|completed]}, {work_type:[epic|feature|bugfix]})
+{N+1}. {topic:(titlecase)}
+       ├─ Status: ({status:[in-progress|completed]})
+       └─ {work_type:[epic|feature|bugfix]} — {work_unit}
+
+{N+2}. ...
 ```
 
 ### Key/Legend
@@ -55,9 +59,7 @@ Key:
     pending     — identified by research, not yet discussed
 ```
 
-**Then present the menu.** Numbered items correspond to research topics in the overview. Verb reflects status: pending → "Discuss", in-progress → "Continue", completed → "Reopen". If standalone discussions exist (not from research), append them with continuing numbers using "Continue".
-
-#### If research exists
+**Then present the menu.** Numbered items match the overview (research topics first, then standalone discussions if any). Verb reflects status: pending → "Discuss", in-progress → "Continue", completed → "Reopen".
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -69,24 +71,9 @@ How would you like to proceed?
 - **`2`** — Continue "Auth Flow" (in-progress)
 - **`3`** — Reopen "Bluetooth Switching" (completed)
 
+@if(has_research)
 - **`r`/`refresh`** — Force fresh research analysis
-- **Fresh topic** — describe what you want to discuss
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-→ Proceed to **B. Handle Selection**.
-
-#### If only discussions exist
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-How would you like to proceed?
-
-- **Continue discussion** — name one above (e.g., "continue {topic}")
+@endif
 - **Fresh topic** — describe what you want to discuss
 · · · · · · · · · · · ·
 ```
@@ -106,28 +93,6 @@ Route based on the user's choice.
 Identify the selected topic from the numbered list (by number or name). Determine source from its status:
 - pending → source="research"
 - in-progress or completed → source="continue"
-
-→ Return to caller.
-
-#### If user chose `Continue discussion`
-
-Only applies when no research exists and user names a discussion directly.
-
-Set source="continue". Identify the selected discussion.
-
-**If user specified a discussion inline** (e.g., "continue auth-flow"):
-
-→ Return to caller.
-
-**If user just said "continue discussion" without specifying:**
-
-> *Output the next fenced block as a code block:*
-
-```
-Which discussion would you like to continue?
-```
-
-**STOP.** Wait for user response.
 
 → Return to caller.
 

--- a/skills/workflow-discussion-entry/references/display-options.md
+++ b/skills/workflow-discussion-entry/references/display-options.md
@@ -8,7 +8,7 @@
 
 Present everything discovered to help the user make an informed choice.
 
-**Present the full state:**
+**Present the full state.** Condense each topic's summary from the analysis cache into a single line (~80 chars max) — just enough to identify the topic's scope. The full analysis remains in the cache file unchanged.
 
 > *Output the next fenced block as a code block:*
 
@@ -22,9 +22,10 @@ Present everything discovered to help the user make an informed choice.
 Research topics:
 
 1. {theme_name}
-   └─ Sources: {filename1}.md, {filename2}.md
-   └─ Discussion: @if(has_discussion) {work_unit}/{topic} ({status:[in-progress|completed]}) @else (pending from research) @endif
-   └─ "{summary}"
+   ├─ Status: @if(has_discussion) ({status:[in-progress|completed]}) @else (pending) @endif
+   ├─ Sources: {filename1}.md, {filename2}.md
+   @if(has_discussion) ├─ Discussion: {work_unit}/{topic}
+   @endif └─ {summary_condensed_to_one_line}
 
 2. ...
 ```
@@ -48,15 +49,15 @@ No `---` separator before this section.
 ```
 Key:
 
-  Discussion status:
-    in-progress           — discussion is ongoing
-    completed             — discussion is done
-    pending from research — identified by research, not yet discussed
+  Status:
+    in-progress — discussion is ongoing
+    completed   — discussion is done
+    pending     — identified by research, not yet discussed
 ```
 
-**Then present the options based on what exists:**
+**Then present the menu.** Numbered items correspond to research topics in the overview. Verb reflects status: pending → "Discuss", in-progress → "Continue", completed → "Reopen". If standalone discussions exist (not from research), append them with continuing numbers using "Continue".
 
-#### If research and discussions exist
+#### If research exists
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -64,28 +65,12 @@ Key:
 · · · · · · · · · · · ·
 How would you like to proceed?
 
-- **`r`/`refresh`** — Force fresh research analysis
-- From research — pick a topic number above (e.g., "1" or "research 1")
-- Continue discussion — name one above (e.g., "continue {topic}")
-- Fresh topic — describe what you want to discuss
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-→ Proceed to **B. Handle Selection**.
-
-#### If only research exists
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-How would you like to proceed?
+- **`1`** — Discuss "Peer Networking" (pending)
+- **`2`** — Continue "Auth Flow" (in-progress)
+- **`3`** — Reopen "Bluetooth Switching" (completed)
 
 - **`r`/`refresh`** — Force fresh research analysis
-- From research — pick a topic number above (e.g., "1" or "research 1")
-- Fresh topic — describe what you want to discuss
+- **Fresh topic** — describe what you want to discuss
 · · · · · · · · · · · ·
 ```
 
@@ -101,8 +86,8 @@ How would you like to proceed?
 · · · · · · · · · · · ·
 How would you like to proceed?
 
-- Continue discussion — name one above (e.g., "continue {topic}")
-- Fresh topic — describe what you want to discuss
+- **Continue discussion** — name one above (e.g., "continue {topic}")
+- **Fresh topic** — describe what you want to discuss
 · · · · · · · · · · · ·
 ```
 
@@ -116,37 +101,21 @@ How would you like to proceed?
 
 Route based on the user's choice.
 
-#### If user chose `From research`
+#### If user chose a numbered topic or named a topic
 
-User chose to start from research (e.g., "research 1", "1", "from research", or a topic name).
-
-Set source="research".
-
-**If user specified a topic inline** (e.g., "research 2", "2", or topic name):
-- Identify the selected topic from the numbered list
-
-→ Return to caller.
-
-**If user just said "from research" without specifying:**
-
-> *Output the next fenced block as a code block:*
-
-```
-Which research topic would you like to discuss? (Enter a number or topic name)
-```
-
-**STOP.** Wait for user response.
+Identify the selected topic from the numbered list (by number or name). Determine source from its status:
+- pending → source="research"
+- in-progress or completed → source="continue"
 
 → Return to caller.
 
 #### If user chose `Continue discussion`
 
-User chose to continue a discussion (e.g., "continue auth-flow" or "continue discussion").
+Only applies when no research exists and user names a discussion directly.
 
-Set source="continue".
+Set source="continue". Identify the selected discussion.
 
 **If user specified a discussion inline** (e.g., "continue auth-flow"):
-- Identify the selected discussion from the list
 
 → Return to caller.
 

--- a/skills/workflow-implementation-entry/references/check-dependencies.md
+++ b/skills/workflow-implementation-entry/references/check-dependencies.md
@@ -123,10 +123,10 @@ Set `selected_topic` = `{dep_topic}`.
 · · · · · · · · · · · ·
 Which dependency has been satisfied?
 
-1. {dep_topic:(titlecase)} — {description}
-2. ...
+- **`1`** — {dep_topic:(titlecase)} — {description}
+- **`2`** — ...
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-specification-entry/references/display-groupings.md
+++ b/skills/workflow-specification-entry/references/display-groupings.md
@@ -138,17 +138,17 @@ After all grouping entries, append meta options:
 
 ```
 · · · · · · · · · · · ·
-1. Start "Auth Flow" — 2 ready discussions
-2. Continue "Data Model" — 1 source(s) pending extraction
-3. Unify all into single specification
+- **`1`** — Start "Auth Flow" — 2 ready discussions
+- **`2`** — Continue "Data Model" — 1 source(s) pending extraction
+- **`3`** — Unify all into single specification
    `All discussions are combined into one specification. Existing`
    `specifications are incorporated and superseded.`
-4. Re-analyze groupings
+- **`4`** — Re-analyze groupings
    `Current groupings are discarded and rebuilt. Existing`
    `specification names are preserved. You can provide guidance`
    `in the next step.`
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-specification-entry/references/display-specs-menu.md
+++ b/skills/workflow-specification-entry/references/display-specs-menu.md
@@ -122,14 +122,14 @@ List "Analyze for groupings (recommended)" first, then one entry per existing no
 
 ```
 · · · · · · · · · · · ·
-1. Analyze for groupings (recommended)
+- **`1`** — Analyze for groupings (recommended)
    `All discussions are analyzed for natural groupings. Existing`
    `specification names are preserved. You can provide guidance`
    `in the next step.`
-2. Continue "Auth Flow" — in-progress
-3. Refine "Data Model" — completed
+- **`2`** — Continue "Auth Flow" — in-progress
+- **`3`** — Refine "Data Model" — completed
 
-Select an option (enter number):
+Select an option:
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -103,11 +103,11 @@ Build the menu with numbered continue items first, then command options for star
 · · · · · · · · · · · ·
 What would you like to do?
 
-1. Continue "{feature.name:(titlecase)}" — feature, {feature.phase_label}
-2. Continue "{bugfix.name:(titlecase)}" — bugfix, {bugfix.phase_label}
-3. Continue "{quickfix.name:(titlecase)}" — quick-fix, {quickfix.phase_label}
-4. Continue "{cross_cutting.name:(titlecase)}" — cross-cutting, {cross_cutting.phase_label}
-5. Continue "{epic.name:(titlecase)}" — epic
+- **`1`** — Continue "{feature.name:(titlecase)}" — feature, {feature.phase_label}
+- **`2`** — Continue "{bugfix.name:(titlecase)}" — bugfix, {bugfix.phase_label}
+- **`3`** — Continue "{quickfix.name:(titlecase)}" — quick-fix, {quickfix.phase_label}
+- **`4`** — Continue "{cross_cutting.name:(titlecase)}" — cross-cutting, {cross_cutting.phase_label}
+- **`5`** — Continue "{epic.name:(titlecase)}" — epic
 
 - **`f`/`feature`** — Start new feature
 - **`e`/`epic`** — Start new epic
@@ -122,11 +122,11 @@ What would you like to do?
 @endif
 - **`m`/`manage`** — Manage a work unit's lifecycle
 
-Select an option (enter number or command):
+Select an option:
 · · · · · · · · · · · ·
 ```
 
-**Continue items:** Feature/bugfix/cross-cutting shows type + phase label. Epic just shows "epic" (detail is in continue-epic). No auto-select — always show the full menu. No "(recommended)" labels.
+**Continue items:** Same visual style as command options — `- **`N`** — description`. Feature/bugfix/cross-cutting shows type + phase label. Epic just shows "epic" (detail is in continue-epic). No auto-select — always show the full menu. No "(recommended)" labels.
 
 **Command options:** Start-new, inbox, view, and manage are always command options (not numbered). Always show all three start options.
 


### PR DESCRIPTION
## Summary

- Numbered selection items (`1.`, `2.`) now use the same `- **`N`** —` format as letter command options (`f`/`feature`), giving all menus a unified visual style
- Updated CLAUDE.md conventions (selection menu example, meta options example) to document the new format
- Applied across 19 skill reference files: select menus, revisit-phase menus, epic display, bridge continuations, specification entry, and implementation entry

## Test plan

- [ ] Run `/start` and verify the workflow overview menu renders numbered items in the new style
- [ ] Run `/continue-epic` and verify the 10-item epic menu uses unified format
- [ ] Spot-check a revisit-phase menu (e.g. via `/continue-feature`) to confirm phase selection uses new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)