### PR TITLE
fix: prevent Claude stopping after workflow-migrate returns

### DIFF
--- a/skills/continue-bugfix/SKILL.md
+++ b/skills/continue-bugfix/SKILL.md
@@ -36,17 +36,25 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to Step 1 below. Do not stop after migration completes.
 
 → Proceed to **Step 1**.
 

--- a/skills/continue-cross-cutting/SKILL.md
+++ b/skills/continue-cross-cutting/SKILL.md
@@ -36,17 +36,25 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to Step 1 below. Do not stop after migration completes.
 
 → Proceed to **Step 1**.
 

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -36,17 +36,25 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to Step 1 below. Do not stop after migration completes.
 
 → Proceed to **Step 1**.
 

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -36,17 +36,25 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to Step 1 below. Do not stop after migration completes.
 
 → Proceed to **Step 1**.
 

--- a/skills/continue-quickfix/SKILL.md
+++ b/skills/continue-quickfix/SKILL.md
@@ -36,17 +36,25 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to Step 1 below. Do not stop after migration completes.
 
 → Proceed to **Step 1**.
 

--- a/skills/start-bugfix/SKILL.md
+++ b/skills/start-bugfix/SKILL.md
@@ -27,17 +27,41 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Bugfix
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new bugfix. I'll ask what's broken, suggest a name,
+> then hand off to investigation to diagnose the root cause.
+```
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to the next instruction below. Do not stop after migration completes.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-cross-cutting/SKILL.md
+++ b/skills/start-cross-cutting/SKILL.md
@@ -27,17 +27,43 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Cross-Cutting Concern
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new cross-cutting concern. I'll ask what pattern
+> or policy you're defining, suggest a name, then you'll choose
+> whether to research first or go straight to discussion. The
+> pipeline ends at specification — no planning or implementation.
+```
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to the next instruction below. Do not stop after migration completes.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-epic/SKILL.md
+++ b/skills/start-epic/SKILL.md
@@ -27,17 +27,42 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Epic
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new epic. I'll ask what you're building, suggest
+> a name, then you'll choose whether to research first or go
+> straight to discussion.
+```
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to the next instruction below. Do not stop after migration completes.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -27,17 +27,42 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Feature
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new feature. I'll ask what you're building, suggest
+> a name, then you'll choose whether to research first or go straight
+> to discussion.
+```
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to the next instruction below. Do not stop after migration completes.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/start-quickfix/SKILL.md
+++ b/skills/start-quickfix/SKILL.md
@@ -27,17 +27,42 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
+#### If the `/workflow-migrate` skill has already been invoked in this conversation
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  New Quick-Fix
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Starting a new quick-fix. I'll ask what needs changing, suggest
+> a name, then hand off to scoping — which combines context, spec,
+> and plan into a single streamlined pass.
+```
+
+→ Proceed to **Step 1**.
+
+#### Otherwise
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Running migrations to keep workflow files in sync.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to the next instruction below. Do not stop after migration completes.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-migrate/SKILL.md
+++ b/skills/workflow-migrate/SKILL.md
@@ -46,6 +46,8 @@ Migrations Applied
 All documents up to date.
 ```
 
+**Do not stop here.** No migrations were needed — continue executing the calling skill immediately.
+
 → Return to caller.
 
 ---

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -48,6 +48,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
@@ -55,11 +57,11 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 > This ensures everything is up to date before we proceed.
 ```
 
-Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
-
 **Run migrations — this is mandatory. You must complete it before proceeding.**
 
 Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+
+**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to Step 1 below. Do not stop after migration completes.
 
 → Proceed to **Step 1**.
 


### PR DESCRIPTION
## Summary

- **workflow-migrate**: Added "Do not stop here" reinforcement before `→ Return to caller.` in the no-changes branch
- **All start/continue skills**: Added H4 conditional to skip redundant migration when already invoked earlier in the conversation (e.g. via `workflow-start`), with CRITICAL reinforcement in the Otherwise branch to ensure continuation after migrate returns
- **workflow-start**: Added CRITICAL reinforcement after migrate invoke and moved casing conventions load before migration signpost

## Test plan

- [ ] Run `/workflow-start` — verify Claude continues past migration to discovery step when no migrations needed
- [ ] From workflow-start menu, select a start/continue skill — verify migration is skipped and skill proceeds directly
- [ ] Run `/start-feature` directly (not via workflow-start) — verify migration runs and skill continues afterward
- [ ] Run `/continue-feature` directly — verify migration runs and skill continues afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)