### PR TITLE
refactor: overhaul display conventions for clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,7 +297,7 @@ Each part is optional — use only what's needed for clarity.
 @if(condition) truthy content @else falsy content @endif
 ```
 
-Example: `@if(has_discussion) {topic}.md ({status:[in-progress|completed]}) @else (no discussion) @endif`
+Example: `@if(has_discussion) {topic}.md [{status:[in-progress|completed]}] @else [no discussion] @endif`
 
 **Loop directives** for iterating over collections:
 
@@ -318,9 +318,9 @@ Two styles, chosen by whether items have sub-detail.
 **Bullets (`•`)** — flat list under a shared heading. Each item is self-contained on one line with no child data.
 
 ```
-Discussions not ready for specification:
-These discussions are still in progress and must be completed
-before they can be included in a specification.
+⚑ Discussions not ready for specification:
+  These discussions are still in progress and must be completed
+  before they can be included in a specification.
 
   • auth-flow
   • data-model
@@ -330,7 +330,7 @@ before they can be included in a specification.
 
 ```
 1. {topic:(titlecase)}
-   └─ Plan: @if(has_plan) {plan_status:[in-progress|completed]} @else (no plan) @endif
+   └─ Plan: @if(has_plan) {plan_status:[in-progress|completed]} @else [no plan] @endif
    └─ Spec: {spec_status:[in-progress|completed]}
 
 2. ...
@@ -342,16 +342,16 @@ Richer hierarchies nest naturally:
 1. {topic:(titlecase)}
    └─ Spec: {spec_status:[in-progress|completed]} ({extraction_summary})
    └─ Discussions:
-      ├─ {discussion} ({status:[extracted|pending]})
+      ├─ {discussion} [{status:[extracted|pending]}]
       └─ ...
 ```
 
 Unnumbered trees follow the same structure:
 
 ```
-Plans not ready for implementation:
-These plans have unresolved dependencies that must be
-addressed first.
+⚑ Plans not ready for implementation:
+  These plans have unresolved dependencies that must be
+  addressed first.
 
   Core Features
   └─ Blocked by data-model:data-model-1-2
@@ -363,9 +363,26 @@ addressed first.
 
 ### Status Terms
 
-Always parenthetical `(term)`. Never brackets or dash-separated.
+Item-level statuses use square brackets `[term]`. Phase header count summaries use parentheses `(N completed, M pending)`. Never dash-separated.
 
-Core vocabulary: `in-progress`, `completed`, `ready`, `extracted`, `pending`, `reopened`, `promoted`. Discussion Map uses `pending`, `exploring`, `converging`, `decided`. Phase-specific terms are fine but format is always `(term)`.
+Core vocabulary: `in-progress`, `completed`, `ready`, `extracted`, `pending`, `reopened`, `promoted`. Discussion Map uses `pending`, `exploring`, `converging`, `decided`. Phase-specific terms are fine but format is always `[term]` for items.
+
+### Callout Flag
+
+Advisory and gating messages inside code blocks use a `⚑` prefix to visually separate them from data. The flag sits at 2-space indent (aligned with phase headers). Multi-line callouts indent continuation lines to match (2-space, no flag).
+
+```
+  ⚑ Pending discussion topic(s) from research remain.
+    Consider starting these before specification.
+```
+
+"Not ready" blocks use the same flag on their heading line, with the explanatory text 2-space indented beneath:
+
+```
+⚑ Discussions not ready for specification:
+  These discussions are still in progress and must be completed
+  before they can be included in a specification.
+```
 
 ### Cross-Plan References
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -38,12 +38,12 @@ No work started yet.
 ●───────────────────────────────────────────────●
 
 @foreach(phase in phases)
-@if(phase.items)
-  {phase:(titlecase)}
+@if(phase.items or (phase == discussion and gating.has_pending_discussions))
+  {phase:(titlecase)} ({phase.count_summary})
 @foreach(item in phase.items)
-    └─ {item.name:(titlecase)} ({item.status})@if(phase == planning and item.format) [{item.format}]@endif
+    @if(last_item_in_phase and not (phase == discussion and gating.has_pending_discussions)) └─ @else ├─ @endif {item.name:(titlecase)} [{item.status}]@if(phase == planning and item.format) · {item.format}@endif
 @if(phase == specification and item.sources)
-       └─ {source.topic:(titlecase)} ({source.status})
+       └─ {source.topic:(titlecase)} [{source.status}]
 @endif
 @if(phase == implementation and item.current_phase)
        └─ Phase {item.current_phase}, {item.completed_tasks.length} task(s) completed
@@ -55,38 +55,38 @@ No work started yet.
 @endforeach
 @if(phase == discussion and gating.has_pending_discussions)
 @foreach(topic in pending_from_research)
-    └─ {topic.name:(titlecase)} (pending from research)
+    @if(last_pending_topic) └─ @else ├─ @endif {topic.name:(titlecase)} [pending from research]
 @endforeach
 @endif
 @endif
 
 @endforeach
 @if(gating.has_pending_discussions and not phases.discussion)
-  Discussion
+  Discussion ({pending_from_research.length} pending)
 @foreach(topic in pending_from_research)
-    └─ {topic.name:(titlecase)} (pending from research)
+    @if(last_pending_topic) └─ @else ├─ @endif {topic.name:(titlecase)} [pending from research]
 @endforeach
 
 @endif
 @if(recommendation)
-{recommendation text}
+  ⚑ {recommendation text}
 @endif
 ```
 
 **Display rules:**
 
-- Phase headers as section labels (titlecased)
-- Items under each phase use `└─` branches with titlecased names and parenthetical status
-- Planning items show format in brackets after status
+- Phase headers as section labels (titlecased) with a parenthetical count summary — e.g., `Discussion (3 completed, 1 pending)`, `Research (1 completed)`, `Specification (2 in-progress)`. Combine statuses present in that phase; omit zero counts
+- Items under each phase use proper tree grammar: `├─` for non-final siblings, `└─` for the final item. Pending discussion topics from research count as siblings when determining the final item
+- Planning items show format after status, separated by a middle dot: `[in-progress] · linear`
 - Specification items show their source discussions as a sub-tree beneath, one `└─` per source
-- Source status: `(incorporated)` or `(pending)` from manifest
+- Source status: `[incorporated]` or `[pending]` from manifest
 - Implementation items show progress: `Phase {N}, {M} task(s) completed` if in-progress with current_phase; `{M} task(s) completed` otherwise
-- Pending discussion topics from research appear under the Discussion phase heading with `(pending from research)` status, after any existing discussion items. If no discussion items exist yet, render a Discussion section with only the pending topics
+- Pending discussion topics from research appear under the Discussion phase heading with `[pending from research]` status, after any existing discussion items. If no discussion items exist yet, render a Discussion section with only the pending topics
 - Phases with no items don't appear (except Discussion, which appears if pending topics from research exist)
 - Blank line between phase sections
 - No trailing blank line after the last phase section (the code block ends immediately after the last item or recommendation)
 
-**Recommendations:** Check the following conditions in order. Show the first that applies as a line within the state display code block, separated by a blank line from the last phase section. If none apply, no recommendation.
+**Recommendations:** Check the following conditions in order. Show the first that applies as a `⚑`-prefixed line within the state display code block, 2-space indented and separated by a blank line from the last phase section. If the recommendation text is long, wrap it across two lines (both 2-space indented, only the first has `⚑`). If none apply, no recommendation.
 
 | Condition | Recommendation |
 |-----------|---------------|
@@ -104,9 +104,9 @@ No work started yet.
 > *Output the next fenced block as a code block:*
 
 ```
-Plans not ready for implementation:
-These plans have unresolved dependencies that must be
-addressed first.
+⚑ Plans not ready for implementation:
+  These plans have unresolved dependencies that must be
+  addressed first.
 
 @foreach(plan in plans_with_deps_blocking)
   {topic:(titlecase)}
@@ -152,10 +152,10 @@ Build a numbered menu with three sections:
 
 **Section 1 — In-progress items** (always first):
 - Any item with status `in-progress` in any phase
-- Planning in-progress: `Continue "{topic:(titlecase)}" — planning (in-progress)`
+- Planning in-progress: `Continue "{topic:(titlecase)}" — planning [in-progress]`
 - Implementation in-progress with progress: `Continue "{topic:(titlecase)}" — implementation (Phase {N}, Task {M})`
-- Implementation in-progress without progress: `Continue "{topic:(titlecase)}" — implementation (in-progress)`
-- Other phases: `Continue "{topic:(titlecase)}" — {phase} (in-progress)`
+- Implementation in-progress without progress: `Continue "{topic:(titlecase)}" — implementation [in-progress]`
+- Other phases: `Continue "{topic:(titlecase)}" — {phase} [in-progress]`
 
 **Section 2 — Next-phase-ready items:**
 - From `next_phase_ready` in discovery output
@@ -187,7 +187,7 @@ Build a numbered menu with three sections:
 - All implementations completed, some without reviews → first reviewable implementation "(recommended)"
 - Otherwise → no recommendation (complete in-progress work first)
 
-**Promoted items:** Items with `(promoted)` status are shown in the state display but are **not listed in the menu** — they've been moved to their own cross-cutting work unit and are no longer actionable in this epic.
+**Promoted items:** Items with `[promoted]` status are shown in the state display but are **not listed in the menu** — they've been moved to their own cross-cutting work unit and are no longer actionable in this epic.
 
 **Blocked items:** Items marked `blocked` in `next_phase_ready` are shown in the menu but are **not selectable**. If the user picks a blocked item, explain why it's blocked and re-present the menu.
 
@@ -197,10 +197,10 @@ Build a numbered menu with three sections:
 · · · · · · · · · · · ·
 What would you like to do?
 
-- **`1`** — Continue "Auth Flow" — discussion (in-progress)
-- **`2`** — Continue "Data Model" — specification (in-progress)
+- **`1`** — Continue "Auth Flow" — discussion [in-progress]
+- **`2`** — Continue "Data Model" — specification [in-progress]
 - **`3`** — Start planning for "User Profiles" — spec completed
-- **`4`** — Continue "Caching" — planning (in-progress)
+- **`4`** — Continue "Caching" — planning [in-progress]
 - **`5`** — Start implementation of "Notifications" — plan completed (recommended)
 - **`6`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
 - **`7`** — Start specification — 3 discussion(s) not yet in a spec
@@ -355,7 +355,7 @@ Completed Topics
 @if(phase.completed_items)
   {phase:(titlecase)}
 @foreach(item in completed where item.phase == phase)
-    └─ {item.name:(titlecase)} (completed)
+    └─ {item.name:(titlecase)} [completed]
 @endforeach
 @endif
 

--- a/skills/workflow-discussion-entry/references/display-options.md
+++ b/skills/workflow-discussion-entry/references/display-options.md
@@ -22,7 +22,7 @@ Present everything discovered to help the user make an informed choice.
 Research topics:
 
 1. {theme_name}
-   ├─ Status: @if(has_discussion) ({status:[in-progress|completed]}) @else (pending) @endif
+   ├─ Status: @if(has_discussion) [{status:[in-progress|completed]}] @else [pending] @endif
    ├─ Sources: {filename1}.md, {filename2}.md
    @if(has_discussion) ├─ Discussion: {work_unit}/{topic}
    @endif └─ {summary_condensed_to_one_line}
@@ -38,7 +38,7 @@ If discussions exist that are NOT linked to a research topic, list them separate
 Existing discussions:
 
 {N+1}. {topic:(titlecase)}
-       ├─ Status: ({status:[in-progress|completed]})
+       ├─ Status: [{status:[in-progress|completed]}]
        └─ {work_type:[epic|feature|bugfix]} — {work_unit}
 
 {N+2}. ...
@@ -67,14 +67,18 @@ Key:
 · · · · · · · · · · · ·
 How would you like to proceed?
 
-- **`1`** — Discuss "Peer Networking" (pending)
-- **`2`** — Continue "Auth Flow" (in-progress)
-- **`3`** — Reopen "Bluetooth Switching" (completed)
+- **`1`** — Discuss "Peer Networking" [pending]
+- **`2`** — Continue "Auth Flow" [in-progress]
+- **`3`** — Reopen "Bluetooth Switching" [completed]
+
+- **`f`/`fresh`** — Start a fresh topic not from research
 
 @if(has_research)
 - **`r`/`refresh`** — Force fresh research analysis
 @endif
-- **Fresh topic** — describe what you want to discuss
+@if(work_type == epic)
+- **`b`/`back`** — Return to epic menu
+@endif
 · · · · · · · · · · · ·
 ```
 
@@ -96,13 +100,17 @@ Identify the selected topic from the numbered list (by number or name). Determin
 
 → Return to caller.
 
-#### If user chose `Fresh topic`
+#### If user chose `fresh`
 
-User wants to start a fresh discussion.
+User wants to start a fresh discussion not derived from research.
 
 Set source="fresh".
 
 → Return to caller.
+
+#### If user chose `back`
+
+Re-invoke the caller's entry-point skill to return to its menu. Invoke `/continue-epic {work_unit}`. This is terminal — the invoked skill takes over.
 
 #### If user chose `refresh`
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -81,14 +81,14 @@ At natural breaks — after a decision, when transitioning between subtopics, or
 ```
 Discussion Map — {topic:(titlecase)}
 
-  {Subtopic A} (decided)
-  ├─ {Child} (decided)
-  └─ {Child} (decided)
+  {Subtopic A} [decided]
+  ├─ {Child} [decided]
+  └─ {Child} [decided]
 
-  {Subtopic B} (converging)
-  └─ {Child} (exploring)
+  {Subtopic B} [converging]
+  └─ {Child} [exploring]
 
-  {Subtopic C} (pending)
+  {Subtopic C} [pending]
 
 {decided_count} decided · {exploring_count} exploring · {pending_count} pending
 ```

--- a/skills/workflow-discussion-process/references/template.md
+++ b/skills/workflow-discussion-process/references/template.md
@@ -37,15 +37,15 @@ A living index of subtopics tracked during the discussion. This is the structura
 
 ### Map
 
-  {Subtopic A} (decided)
-  ├─ {Child subtopic} (decided)
-  └─ {Child subtopic} (converging)
+  {Subtopic A} [decided]
+  ├─ {Child subtopic} [decided]
+  └─ {Child subtopic} [converging]
 
-  {Subtopic B} (exploring)
-  ├─ {Child subtopic} (exploring)
-  └─ {Child subtopic} (pending)
+  {Subtopic B} [exploring]
+  ├─ {Child subtopic} [exploring]
+  └─ {Child subtopic} [pending]
 
-  {Subtopic C} (pending)
+  {Subtopic C} [pending]
 
   → Elevated: {sibling-topic} — discovered during discussion, seeded as separate topic
 

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -230,7 +230,7 @@ Update `status: approved` in the staging file.
 > *Output the next fenced block as a code block:*
 
 ```
-Task {current} of {total}: {title} — approved (auto).
+Task {current} of {total}: {title} — approved [auto].
 ```
 
 → Return to **F. Process Task**.

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -52,7 +52,7 @@ Commit after splitting.
 Which topic would you like to continue with?
 
 @foreach(topic in available_topics)
-**{N}. {topic:(titlecase)}** — {status:(in-progress)}
+**{N}. {topic:(titlecase)}** — {status:[in-progress]}
 @endforeach
 
 Select an option (enter number):

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -236,7 +236,7 @@ Update `status: approved` in the staging file.
 > *Output the next fenced block as a code block:*
 
 ```
-Task {current} of {total}: {title} — approved (auto).
+Task {current} of {total}: {title} — approved [auto].
 ```
 
 → Return to **D. Process Task**.

--- a/skills/workflow-specification-entry/references/confirm-continue.md
+++ b/skills/workflow-specification-entry/references/confirm-continue.md
@@ -13,10 +13,10 @@
 ```
 Continuing specification: {Title Case Name}
 
-Existing: .workflows/{work_unit}/specification/{topic}/specification.md (in-progress)
+Existing: .workflows/{work_unit}/specification/{topic}/specification.md [in-progress]
 
 Sources to extract:
-  • {discussion-name} (pending)
+  • {discussion-name} [pending]
 
 Previously extracted (for reference):
   • {discussion-name}
@@ -43,7 +43,7 @@ Proceed?
 ```
 Continuing specification: {Title Case Name}
 
-Existing: .workflows/{work_unit}/specification/{topic}/specification.md (in-progress)
+Existing: .workflows/{work_unit}/specification/{topic}/specification.md [in-progress]
 
 All sources extracted:
   • {discussion-name}
@@ -71,10 +71,10 @@ Proceed?
 ```
 Continuing specification: {Title Case Name}
 
-Existing: .workflows/{work_unit}/specification/{topic}/specification.md (completed)
+Existing: .workflows/{work_unit}/specification/{topic}/specification.md [completed]
 
 New sources to extract:
-  • {discussion-name} (pending)
+  • {discussion-name} [pending]
 
 Previously extracted (for reference):
   • {discussion-name}

--- a/skills/workflow-specification-entry/references/confirm-refine.md
+++ b/skills/workflow-specification-entry/references/confirm-refine.md
@@ -9,7 +9,7 @@
 ```
 Refining specification: {Title Case Name}
 
-Existing: .workflows/{work_unit}/specification/{topic}/specification.md (completed)
+Existing: .workflows/{work_unit}/specification/{topic}/specification.md [completed]
 
 All sources extracted:
   • {discussion-name}

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -30,9 +30,9 @@ List all completed discussions from discovery output.
 > *Output the next fenced block as a code block:*
 
 ```
-Discussions not ready for specification:
-These discussions are still in progress and must be completed
-before they can be included in a specification.
+⚑ Discussions not ready for specification:
+  These discussions are still in progress and must be completed
+  before they can be included in a specification.
 
   • {discussion-name}
 ```

--- a/skills/workflow-specification-entry/references/display-groupings.md
+++ b/skills/workflow-specification-entry/references/display-groupings.md
@@ -30,7 +30,7 @@ Spec status: show actual status with extraction count `({X} of {Y} sources extra
 **Regressed sources:** After processing the grouping's discussions, check the spec's
 `sources` array from discovery. For any source where `discussion_status` is neither
 `completed` nor `not-found`, and the source is not already in the grouping:
-- Add it to the discussion tree with status `(extracted, reopened)`
+- Add it to the discussion tree with status `[extracted, reopened]`
 
 These represent sources that were incorporated but whose discussions have since
 regressed to in-progress. Sources with `discussion_status: "not-found"` (deleted
@@ -62,9 +62,9 @@ All items are first-class — every grouping (including single-discussion entrie
 Recommended breakdown for specifications with their source discussions.
 
 1. {grouping_name:(titlecase)}
-   └─ Spec: @if(has_spec) {spec_status:[in-progress|completed]} ({extraction_summary}) @else (no spec) @endif
+   └─ Spec: @if(has_spec) {spec_status:[in-progress|completed]} ({extraction_summary}) @else [no spec] @endif
    └─ Discussions:
-      ├─ {discussion} ({status:[extracted|pending|ready|reopened]})
+      ├─ {discussion} [{status:[extracted|pending|ready|reopened]}]
       └─ ...
 
 2. ...
@@ -75,9 +75,9 @@ Recommended breakdown for specifications with their source discussions.
 > *Output the next fenced block as a code block:*
 
 ```
-Discussions not ready for specification:
-These discussions are still in progress and must be completed
-before they can be included in a specification.
+⚑ Discussions not ready for specification:
+  These discussions are still in progress and must be completed
+  before they can be included in a specification.
 
   • {discussion-name}
 ```

--- a/skills/workflow-specification-entry/references/display-single-grouped.md
+++ b/skills/workflow-specification-entry/references/display-single-grouped.md
@@ -7,9 +7,9 @@
 This discussion is covered by a specification with multiple sources.
 
 Use the spec for display. Show the spec name as the title. Show ALL the spec's sources (not just this discussion) with their statuses:
-- `incorporated` + `discussion_status: completed` or `not-found` → `(extracted)`
-- `incorporated` + `discussion_status: other` (e.g. `in-progress`) → `(extracted, reopened)`
-- `pending` → `(pending)`
+- `incorporated` + `discussion_status: completed` or `not-found` → `[extracted]`
+- `incorporated` + `discussion_status: other` (e.g. `in-progress`) → `[extracted, reopened]`
+- `pending` → `[pending]`
 
 Extraction count: X = sources with `status: incorporated`, Y = total source count from the spec's `sources` array.
 
@@ -27,8 +27,8 @@ Single completed discussion found with existing multi-source specification.
 1. {work_unit:(titlecase)}
    └─ Spec: {spec_status:[in-progress|completed]} ({X} of {Y} sources extracted)
    └─ Discussions:
-      ├─ {source-name} (extracted)
-      └─ {source-name} (extracted, reopened)
+      ├─ {source-name} [extracted]
+      └─ {source-name} [extracted, reopened]
 ```
 
 #### If in-progress discussions exist
@@ -36,9 +36,9 @@ Single completed discussion found with existing multi-source specification.
 > *Output the next fenced block as a code block:*
 
 ```
-Discussions not ready for specification:
-These discussions are still in progress and must be completed
-before they can be included in a specification.
+⚑ Discussions not ready for specification:
+  These discussions are still in progress and must be completed
+  before they can be included in a specification.
 
   • {discussion-name}
 ```

--- a/skills/workflow-specification-entry/references/display-single-has-spec.md
+++ b/skills/workflow-specification-entry/references/display-single-has-spec.md
@@ -22,7 +22,7 @@ Single completed discussion found with existing specification.
 1. {work_unit:(titlecase)}
    └─ Spec: {spec_status:[in-progress|completed]} ({X} of {Y} sources extracted)
    └─ Discussions:
-      └─ {discussion-name} (extracted)
+      └─ {discussion-name} [extracted]
 ```
 
 #### If in-progress discussions exist
@@ -30,9 +30,9 @@ Single completed discussion found with existing specification.
 > *Output the next fenced block as a code block:*
 
 ```
-Discussions not ready for specification:
-These discussions are still in progress and must be completed
-before they can be included in a specification.
+⚑ Discussions not ready for specification:
+  These discussions are still in progress and must be completed
+  before they can be included in a specification.
 
   • {discussion-name}
 ```

--- a/skills/workflow-specification-entry/references/display-single-no-spec.md
+++ b/skills/workflow-specification-entry/references/display-single-no-spec.md
@@ -18,9 +18,9 @@ No specification exists for this discussion.
 Single completed discussion found.
 
 1. {work_unit:(titlecase)}
-   └─ Spec: (no spec)
+   └─ Spec: [no spec]
    └─ Discussions:
-      └─ {discussion-name} (ready)
+      └─ {discussion-name} [ready]
 ```
 
 #### If in-progress discussions exist
@@ -28,9 +28,9 @@ Single completed discussion found.
 > *Output the next fenced block as a code block:*
 
 ```
-Discussions not ready for specification:
-These discussions are still in progress and must be completed
-before they can be included in a specification.
+⚑ Discussions not ready for specification:
+  These discussions are still in progress and must be completed
+  before they can be included in a specification.
 
   • {discussion-name}
 ```

--- a/skills/workflow-specification-entry/references/display-specs-menu.md
+++ b/skills/workflow-specification-entry/references/display-specs-menu.md
@@ -28,8 +28,8 @@ For each non-superseded specification from discovery output, display as nested t
 1. {work_unit:(titlecase)}
    └─ Spec: {spec_status:[in-progress|completed]} ({X} of {Y} sources extracted)
    └─ Discussions:
-      ├─ {source-name} (extracted)
-      └─ {source-name} (extracted)
+      ├─ {source-name} [extracted]
+      └─ {source-name} [extracted]
 ```
 
 Determine discussion status from the spec's `sources` array:
@@ -56,9 +56,9 @@ Completed discussions not in a specification:
 > *Output the next fenced block as a code block:*
 
 ```
-Discussions not ready for specification:
-These discussions are still in progress and must be completed
-before they can be included in a specification.
+⚑ Discussions not ready for specification:
+  These discussions are still in progress and must be completed
+  before they can be included in a specification.
 
   • {discussion-name}
 ```

--- a/skills/workflow-specification-entry/references/handoffs/continue-completed.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue-completed.md
@@ -15,7 +15,7 @@ This skill's purpose is now fulfilled. Invoke the [workflow-specification-proces
 ```
 Specification session for: {Title Case Name}
 
-Continuing existing: .workflows/{work_unit}/specification/{topic}/specification.md (completed)
+Continuing existing: .workflows/{work_unit}/specification/{topic}/specification.md [completed]
 
 New sources to extract:
 - .workflows/{work_unit}/discussion/{new-discussion-name}.md


### PR DESCRIPTION
## Summary

- **Status brackets**: Switch all item-level statuses from `(term)` to `[term]` for visual sharpness — phase header counts stay in parentheses `(N completed, M pending)`
- **Callout flag**: Add `⚑` prefix to advisory/gating messages (epic recommendations, "not ready" blocks) so they stand apart from data displays
- **Epic tree grammar**: Proper `├─`/`└─` usage with phase count summaries like `Discussion (3 completed, 1 pending)`
- **Discussion menu**: Replace `Fresh topic` prompt option with `f`/`fresh` command option; add `b`/`back` for epic navigation
- **Planning format**: Use middle dot separator `[in-progress] · linear` to avoid bracket collision with status

## Test plan

- [ ] Run `/continue-epic` on an epic with mixed phase statuses — verify tree grammar, bracket statuses, phase counts, and ⚑ recommendation render correctly
- [ ] Run `/continue-epic` → select "Start new discussion topic" — verify `f`/`fresh` and `b`/`back` options appear, `back` returns to epic menu
- [ ] Run specification entry on a work unit with in-progress discussions — verify ⚑ flag on "not ready" block
- [ ] Verify discussion map renders with `[decided]`, `[exploring]`, `[pending]` brackets

🤖 Generated with [Claude Code](https://claude.com/claude-code)