### PR TITLE
feat: diff view for resurfaced and modified approved content

### DIFF
--- a/agents/workflow-specification-review-gap-analysis.md
+++ b/agents/workflow-specification-review-gap-analysis.md
@@ -119,6 +119,9 @@ topic: {Topic Name}
 **Details**:
 {Explanation of what was found and why it matters}
 
+**Current**:
+{For Enhancement findings only — copy the existing specification content in the affected section that will be modified. This enables diff presentation to the user. Omit for New topic and Gap/Ambiguity findings.}
+
 **Proposed Addition**:
 {What you would add to the specification — leave blank until discussed}
 

--- a/agents/workflow-specification-review-input.md
+++ b/agents/workflow-specification-review-input.md
@@ -93,6 +93,9 @@ topic: {Topic Name}
 **Details**:
 {Explanation of what was found and why it matters}
 
+**Current**:
+{For Enhancement findings only — copy the existing specification content in the affected section that will be modified. This enables diff presentation to the user. Omit for New topic and Gap/Ambiguity findings.}
+
 **Proposed Addition**:
 {What you would add to the specification — leave blank until discussed}
 

--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -29,8 +29,8 @@ Standalone improvements. Can be done in any order within this phase.
 
 | # | Idea | Scope |
 |---|------|-------|
-| 6 | [User Guidance & Help](user-guidance-and-help.md) | All entry-point skills |
-| 7 | [Spec Diff on Resurface](spec-diff-on-resurface.md) | Specification processing skill |
+| 6 | ~~[User Guidance & Help](user-guidance-and-help.md)~~ | All entry-point skills | ✅ Done |
+| 7 | ~~[Spec Diff on Resurface](spec-diff-on-resurface.md)~~ | Specification processing skill | ✅ Done |
 | 8 | [Intelligent Escalation](intelligent-escalation.md) | All review/fix cycles |
 | 9 | [Epic Dependency Visualization](epic-dependency-visualization.md) | Continue-epic / workflow-start |
 

--- a/skills/workflow-planning-process/references/process-review-findings.md
+++ b/skills/workflow-planning-process/references/process-review-findings.md
@@ -55,7 +55,7 @@ Work through each finding **sequentially**. For each finding: present it, show t
 
 ### Present Finding
 
-Show the finding with its full fix content, read directly from the tracking file.
+Show the finding metadata, read directly from the tracking file:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -75,12 +75,49 @@ Show the finding with its full fix content, read directly from the tracking file
 @endif
 
 **Details**: {from tracking file}
+```
 
-**Current**:
-{from tracking file — the existing plan content}
+Then present the content based on **Change Type**:
 
+**If Change Type is `update-task`, `add-to-task`, or `remove-from-task`:**
+
+Present the changes as a diff. Read Current and Proposed from the tracking file. Show only the changed lines with 2 lines of context above and below:
+
+> *Output the next fenced block as a code block:*
+
+```
+╭─ Finding {N}: {Brief Title} ──────────────────────╮
+```
+
+> *Output the next fenced block as a code block:*
+
+```diff
+ {2 context lines above}
+-{lines from Current}
++{lines from Proposed}
+ {2 context lines below}
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+╰───────────────────────────────────────────────────╯
+```
+
+**If Change Type is `add-task`, `add-phase`, `remove-task`, or `remove-phase`:**
+
+Present full content from the tracking file. Include **Proposed** for additions, **Current** for removals — as written by the review agent:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+@if(Change Type is add-task or add-phase)
 **Proposed**:
-{from tracking file — the replacement content}
+{from tracking file — the new content}
+@else
+**Current**:
+{from tracking file — the content being removed}
+@endif
 ```
 
 ### Check Gate Mode
@@ -113,6 +150,9 @@ Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
 **Finding {N} of {total}: {Brief Title}**
 
 - **`y`/`yes`** — Apply to the plan verbatim
+@if(Change Type is update-task, add-to-task, or remove-from-task)
+- **`v`/`view full`** — Show full Current and Proposed content
+@endif
 - **`a`/`auto`** — Approve this and all remaining findings automatically
 - **`s`/`skip`** — Leave as-is, move to next finding
 - **Provide feedback** — Adjust before approving
@@ -121,9 +161,15 @@ Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
 
 **STOP.** Wait for user response.
 
+#### If `view full`
+
+Re-present the finding's **Current** and **Proposed** content in full from the tracking file. Then re-present the approval menu.
+
+→ Return to **B. Process One Item at a Time**.
+
 #### If the user provides feedback
 
-Incorporate feedback and re-present the proposed fix **in full**. Update the tracking file with the revised content.
+Incorporate feedback and update the tracking file with the revised content. Re-present the finding using the same presentation format (diff or full) as the original.
 
 → Return to **B. Process One Item at a Time**.
 

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -57,7 +57,7 @@ Work through each finding **sequentially**. For each finding: present it, show t
 
 ### Present Finding
 
-Show the finding with its proposed content, read directly from the tracking file.
+Show the finding metadata, read directly from the tracking file:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -72,7 +72,40 @@ Show the finding with its proposed content, read directly from the tracking file
 - **Affects**: {from tracking file}
 
 **Details**: {from tracking file}
+```
 
+Then present the content based on **Category**:
+
+**If Category is `Enhancement to existing topic` and Current field is present:**
+
+Present the changes as a diff. Read Current and Proposed Addition from the tracking file. Show only the changed lines with 2 lines of context above and below:
+
+> *Output the next fenced block as a code block:*
+
+```
+╭─ Finding {N}: {brief_title:(titlecase)} ──────────╮
+```
+
+> *Output the next fenced block as a code block:*
+
+```diff
+ {2 context lines above}
+-{lines from Current}
++{lines from Proposed Addition}
+ {2 context lines below}
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+╰───────────────────────────────────────────────────╯
+```
+
+**Otherwise:**
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
 **Proposed Addition**:
 {from tracking file — the content to add to the specification}
 ```
@@ -106,6 +139,9 @@ Finding {N} of {total}: {brief_title:(titlecase)} — approved. Added to specifi
 **Finding {N} of {total}: {brief_title:(titlecase)}**
 
 - **`y`/`yes`** — Add to the specification verbatim
+@if(Category is Enhancement to existing topic and Current field is present)
+- **`v`/`view full`** — Show full Current and Proposed Addition content
+@endif
 - **`a`/`auto`** — Approve this and all remaining findings automatically
 - **`s`/`skip`** — Leave as-is, move to next finding
 - **Provide feedback** — Adjust before approving
@@ -114,9 +150,15 @@ Finding {N} of {total}: {brief_title:(titlecase)} — approved. Added to specifi
 
 **STOP.** Wait for user response.
 
+#### If `view full`
+
+Re-present the finding's **Current** and **Proposed Addition** content in full from the tracking file. Then re-present the approval menu.
+
+→ Return to **B. Process One Item at a Time**.
+
 #### If the user provides feedback
 
-Incorporate feedback and re-present the proposed content **in full**. Update the tracking file with the revised content.
+Incorporate feedback and update the tracking file with the revised content. Re-present the finding using the same presentation format (diff or full) as the original.
 
 → Return to **B. Process One Item at a Time**.
 

--- a/skills/workflow-specification-process/references/review-tracking-format.md
+++ b/skills/workflow-specification-process/references/review-tracking-format.md
@@ -38,6 +38,9 @@ topic: [Topic Name]
 **Details**:
 [Explanation of what was found and why it matters]
 
+**Current**:
+[For Enhancement findings only — the existing specification content in the affected section that will be modified. Omit for New topic and Gap/Ambiguity findings.]
+
 **Proposed Addition**:
 [What you would add to the specification — leave blank until discussed]
 

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -27,9 +27,58 @@ When working with multiple sources, search each one — information about a sing
 
 When extraction reveals information that affects **already-logged topics**, resurface them immediately. Even mid-discussion — interrupt, flag what you found, and discuss whether it changes anything.
 
-If it does: summarize what's changing in the chat, then re-present the full updated topic. The summary is for discussion only — the specification just gets the clean replacement. **Standard workflow applies: user approves before you update.**
+If it does: summarize what's changing in the chat, then present the changes as a diff view. The summary is for discussion only — the specification just gets the clean replacement.
 
-> **CHECKPOINT**: Even when resurfacing content, you MUST NOT update the specification until the user explicitly approves the change. Present the updated version, wait for approval, then update.
+Read the current approved content from the specification file. Prepare the updated version. Present only the changed lines with 2 lines of context above and below, wrapped in a visual border:
+
+> *Output the next fenced block as a code block:*
+
+```
+╭─ Resurfacing: {section name} ─────────────────────╮
+```
+
+> *Output the next fenced block as a code block:*
+
+```diff
+ {2 context lines above}
+-{removed/changed lines}
++{new/replacement lines}
+ {2 context lines below}
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+╰───────────────────────────────────────────────────╯
+```
+
+Then, **separately from the diff above** (clear visual break):
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Record this to the specification verbatim?
+
+- **`y`/`yes`** — Apply changes to specification
+- **`v`/`view full`** — Show the full updated section, then decide
+- **Tell me what to change** — Revise before recording
+· · · · · · · · · · · ·
+```
+
+> **CHECKPOINT**: Even when resurfacing content, you MUST NOT update the specification until the user explicitly approves the change. STOP and wait for response.
+
+#### If `yes`
+
+Update the specification with the approved changes. Commit. Continue extraction.
+
+#### If `view full`
+
+Re-present the full updated section in the format it would appear in the specification. Then re-present the approval menu without `v`/`view full`.
+
+#### If the user provides feedback
+
+Work through the changes per **C. Discuss and Refine**, then re-present the diff with the revised content.
 
 Better to resurface and confirm "already covered" than let something slip past.
 


### PR DESCRIPTION
## Summary

- **Spec construction resurfacing**: replaces full section re-presentation with a `diff` code block (red/green syntax highlighting) wrapped in `╭╯` borders, showing only changed lines with 2 context lines above/below
- **Planning review findings**: modification-type findings (`update-task`, `add-to-task`, `remove-from-task`) now use diff view; additions/removals keep current format
- **Spec review findings**: Enhancement-category findings with a new `Current` field use diff view; New topic and Gap/Ambiguity findings unchanged
- All diff presentations include `v`/`view full` escape hatch to expand to full content

## Test plan

- [ ] Run a spec construction workflow that triggers context resurfacing — verify diff wrapper renders with colored syntax
- [ ] Run a planning review cycle with modification-type findings — verify diff presentation and `view full` option
- [ ] Run a spec review cycle with Enhancement findings — verify `Current` field is captured by agents and diff renders
- [ ] Verify addition-type findings (`add-task`, `add-phase`) still show full Proposed content (no diff)
- [ ] Verify `view full` correctly re-presents full Current/Proposed content

🤖 Generated with [Claude Code](https://claude.com/claude-code)