### PR TITLE
feat: intelligent escalation with convergence diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -664,7 +664,7 @@ Task {M} of {total}: {Task Name} — authored. Logging to plan.
 - **`a`/`auto`** — Approve this and all remaining {items} automatically
 ```
 
-**Re-loop safety cap**: When auto-mode enables automatic re-analysis loops, cap at 5 cycles before escalating to the user. This prevents infinite cascading. At escalation, a convergence analysis diagnostic (shared reference at `skills/workflow-shared/references/convergence-analysis.md`) reads prior cycle tracking files and presents what's resolving, what's recurring, and a trend assessment — replacing blind "continue or skip?" prompts with informed decisions.
+**Re-loop safety cap**: When auto-mode enables automatic re-analysis loops, cap at 5 cycles before escalating to the user. This prevents infinite cascading. At escalation, a convergence analysis diagnostic (shared reference at `skills/workflow-shared/references/convergence-analysis.md`) reads prior cycle tracking files and presents what's resolving, what's recurring, and a trend assessment to inform the user's decision.
 
 ### Rendering Instructions for Ask Blocks
 
@@ -727,6 +727,12 @@ Rules:
 - `→ Proceed to` appears after the Load directive, separated by a blank line
 - The final step has no `→ Proceed to` (it's terminal)
 - Within reference files routing to other reference files, use `→` before Load (it IS a routing instruction in that context)
+
+**Parameter passing**: When a shared reference needs context from the caller, append `with` followed by named assignments. String literals and variable values are both backtick-wrapped; variables use curly brace placeholders:
+
+```
+→ Load **[name.md](path)** with param = `literal`, other = `{variable}`.
+```
 
 ### Reference File Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -664,7 +664,7 @@ Task {M} of {total}: {Task Name} — authored. Logging to plan.
 - **`a`/`auto`** — Approve this and all remaining {items} automatically
 ```
 
-**Re-loop safety cap**: When auto-mode enables automatic re-analysis loops, cap at 5 cycles before escalating to the user. This prevents infinite cascading.
+**Re-loop safety cap**: When auto-mode enables automatic re-analysis loops, cap at 5 cycles before escalating to the user. This prevents infinite cascading. At escalation, a convergence analysis diagnostic (shared reference at `skills/workflow-shared/references/convergence-analysis.md`) reads prior cycle tracking files and presents what's resolving, what's recurring, and a trend assessment — replacing blind "continue or skip?" prompts with informed decisions.
 
 ### Rendering Instructions for Ask Blocks
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Every approval gate (task authoring, implementation, review findings) can be swi
 
 ### Smart Fix Loops
 
-When a task reviewer finds issues, the executor re-invokes with feedback automatically. Loops cap at 3 attempts before escalating to the user — no infinite cycles, but most issues self-resolve without intervention.
+When a task reviewer finds issues, the executor re-invokes with feedback automatically. Loops cap at 3 attempts before escalating with a convergence diagnostic — showing what's been resolved, what's still stuck, and a trend assessment (converging, stable, or diverging). The same diagnostic applies to analysis cycles, planning review, and specification review at their respective caps.
 
 ### Change Detection & Cached Analysis
 

--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -31,7 +31,7 @@ Standalone improvements. Can be done in any order within this phase.
 |---|------|-------|
 | 6 | ~~[User Guidance & Help](user-guidance-and-help.md)~~ | All entry-point skills | ✅ Done |
 | 7 | ~~[Spec Diff on Resurface](spec-diff-on-resurface.md)~~ | Specification processing skill | ✅ Done |
-| 8 | [Intelligent Escalation](intelligent-escalation.md) | All review/fix cycles |
+| 8 | ~~[Intelligent Escalation](intelligent-escalation.md)~~ | All review/fix cycles | ✅ Done |
 | 9 | [Epic Dependency Visualization](epic-dependency-visualization.md) | Continue-epic / workflow-start |
 
 ## Phase 4 — Implementation Improvements

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -32,7 +32,7 @@ Increment `analysis_cycle` via manifest CLI (`node .claude/skills/workflow-manif
 
 **Do NOT skip analysis autonomously.** This gate is an escape hatch for the user — not a signal to stop. The expected default is to continue running analysis until no issues are found. Present the choice and let the user decide.
 
-→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: analysis`, `work_unit`, `topic`.
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `analysis`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -32,14 +32,7 @@ Increment `analysis_cycle` via manifest CLI (`node .claude/skills/workflow-manif
 
 **Do NOT skip analysis autonomously.** This gate is an escape hatch for the user — not a signal to stop. The expected default is to continue running analysis until no issues are found. Present the choice and let the user decide.
 
-> *Output the next fenced block as a code block:*
-
-```
-Analysis cycle {N}
-
-Analysis has run {N-1} times so far. You can continue (recommended if issues
-were still found last cycle) or skip to completion.
-```
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: analysis`, `work_unit`, `topic`.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -132,7 +132,7 @@ NOTES:
 
 #### If `fix_attempts` >= 3
 
-→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: fix`, `work_unit`, `topic`, `internal_id`.
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `fix`, work_unit = `{work_unit}`, topic = `{topic}`, internal_id = `{internal_id}`.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -37,7 +37,8 @@ Follow the format's **reading.md** instructions to determine the next available 
 
 1. Normalise the task content following **[task-normalisation.md](task-normalisation.md)**.
 2. Reset `fix_attempts` to `0` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.implementation.{topic} fix_attempts 0`).
-3. Mark the task as in-progress — follow the format's **updating.md** status transition.
+3. Delete any existing fix tracking cache file for this task: `.workflows/.cache/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md` (clean slate per task).
+4. Mark the task as in-progress — follow the format's **updating.md** status transition.
 
 → Proceed to **B. Execute Task**.
 
@@ -117,12 +118,40 @@ Task failed. How would you like to proceed?
 
 Increment `fix_attempts` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.implementation.{topic} fix_attempts {N}`).
 
+**Persist fix tracking** — Append the reviewer's findings to the fix tracking cache file at `.workflows/.cache/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md`. If the file does not exist, create it. Append a section for this attempt:
+
+```markdown
+## Attempt {N}
+
+ISSUES:
+{copy ISSUES from reviewer output, including FIX, ALTERNATIVE, and CONFIDENCE per issue}
+
+NOTES:
+{copy NOTES from reviewer output}
+```
+
+#### If `fix_attempts` >= 3
+
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: fix`, `work_unit`, `topic`, `internal_id`.
+
 > *Output the next fenced block as a code block:*
 
 ```
-@if(fix_attempts >= 3)
-  The executor and reviewer have not converged after {N} attempts. Escalating for human review.
-@endif
+Review for Task {internal_id}: {Task Name} — needs changes (attempt {N})
+
+{ISSUES from reviewer, including FIX, ALTERNATIVE, and CONFIDENCE for each}
+
+Notes (non-blocking):
+{NOTES from reviewer}
+```
+
+→ Proceed to **F. Fix Approval Gate**.
+
+#### If `fix_attempts` < 3
+
+> *Output the next fenced block as a code block:*
+
+```
 Review for Task {internal_id}: {Task Name} — needs changes (attempt {N})
 
 {ISSUES from reviewer, including FIX, ALTERNATIVE, and CONFIDENCE for each}
@@ -133,11 +162,11 @@ Notes (non-blocking):
 
 Check `fix_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.implementation.{topic} fix_gate_mode`).
 
-#### If `fix_gate_mode` is `auto` and `fix_attempts` < 3
+**If `fix_gate_mode` is `auto`:**
 
 → Return to **B. Execute Task**.
 
-#### If `fix_gate_mode` is `gated` or `fix_attempts` >= 3
+**If `fix_gate_mode` is `gated`:**
 
 → Proceed to **F. Fix Approval Gate**.
 

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -58,7 +58,7 @@ Auto mode is active — pass through to review. Section E's safety cap (cycle 5)
 
 #### If `review_cycle` > 3 and `finding_gate_mode` is `gated` (or not set)
 
-→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: planning-review`, `work_unit`, `topic`.
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `planning-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -131,7 +131,7 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 #### If `finding_gate_mode` is `auto` and `review_cycle` >= 5
 
-→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: planning-review`, `work_unit`, `topic`.
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `planning-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 > *Output the next fenced block as a code block:*
 
@@ -164,7 +164,7 @@ Run another review round?
 
 #### If `finding_gate_mode` is `gated`
 
-→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: planning-review`, `work_unit`, `topic`.
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `planning-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -58,14 +58,7 @@ Auto mode is active — pass through to review. Section E's safety cap (cycle 5)
 
 #### If `review_cycle` > 3 and `finding_gate_mode` is `gated` (or not set)
 
-> *Output the next fenced block as a code block:*
-
-```
-Review cycle {N}
-
-Review has run {N-1} times so far. You can continue (recommended if issues
-were still found last cycle) or skip to completion.
-```
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: planning-review`, `work_unit`, `topic`.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -138,13 +131,7 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 #### If `finding_gate_mode` is `auto` and `review_cycle` >= 5
 
-> *Output the next fenced block as a code block:*
-
-```
-Review cycle {N}
-
-Auto-review has not converged after 5 cycles — escalating for human review.
-```
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: planning-review`, `work_unit`, `topic`.
 
 > *Output the next fenced block as a code block:*
 
@@ -176,6 +163,8 @@ Run another review round?
 → Proceed to **F. Completion**.
 
 #### If `finding_gate_mode` is `gated`
+
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: planning-review`, `work_unit`, `topic`.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-shared/references/convergence-analysis.md
+++ b/skills/workflow-shared/references/convergence-analysis.md
@@ -4,7 +4,7 @@
 
 ---
 
-When a review or fix cycle reaches its escalation threshold, this reference reads prior cycle tracking data to present a diagnostic — replacing blind "continue or skip?" prompts with visibility into what's converging, what's stuck, and why.
+When a review or fix cycle reaches its escalation threshold, read prior cycle tracking data and present a diagnostic showing what's converging, what's stuck, and why.
 
 ## Parameters
 

--- a/skills/workflow-shared/references/convergence-analysis.md
+++ b/skills/workflow-shared/references/convergence-analysis.md
@@ -1,0 +1,168 @@
+# Convergence Analysis
+
+*Shared reference for review/fix cycle escalation.*
+
+---
+
+When a review or fix cycle reaches its escalation threshold, this reference reads prior cycle tracking data to present a diagnostic — replacing blind "continue or skip?" prompts with visibility into what's converging, what's stuck, and why.
+
+## Parameters
+
+The caller provides these via context before loading:
+
+- `loop_type` — `fix` | `analysis` | `planning-review` | `spec-review`
+- `work_unit` — the work unit name
+- `topic` — the topic name
+- `internal_id` — (fix loop only) the task's internal ID
+
+## Threshold Check
+
+Cross-cycle analysis requires at least 2 data points. Determine the number of available cycles by checking which tracking files exist for this loop type.
+
+#### If fewer than 2 cycles of data exist
+
+→ Return to caller.
+
+#### If 2 or more cycles of data exist
+
+→ Proceed to **A. Gather Cycle Data**.
+
+---
+
+## A. Gather Cycle Data
+
+Read tracking data from all available cycles. Extract only finding titles, key identifiers, and resolutions — not full content. Record the highest cycle number found as `latest_cycle`.
+
+#### If `loop_type` is `fix`
+
+Read the fix tracking cache file:
+```
+.workflows/.cache/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md
+```
+
+For each `## Attempt {N}` section, extract:
+- Each ISSUE entry (the issue description line and file:line reference)
+- The CONFIDENCE level per issue
+
+→ Proceed to **B. Classify Findings**.
+
+#### If `loop_type` is `analysis`
+
+Read analysis reports and task staging files for all available cycles:
+```
+.workflows/{work_unit}/implementation/{topic}/analysis-report-c{1..N}.md
+.workflows/{work_unit}/implementation/{topic}/analysis-tasks-c{1..N}.md
+```
+
+For each cycle, extract:
+- From report frontmatter: `total_findings`, `deduplicated_findings`, `proposed_tasks`
+- From staging file: each task's title, severity, sources, and status (approved/skipped)
+
+→ Proceed to **B. Classify Findings**.
+
+#### If `loop_type` is `planning-review`
+
+Read tracking files for all available cycles:
+```
+.workflows/{work_unit}/planning/{topic}/review-traceability-tracking-c{1..N}.md
+.workflows/{work_unit}/planning/{topic}/review-integrity-tracking-c{1..N}.md
+```
+
+For each cycle, extract:
+- Each finding's title
+- Plan Reference field (which plan area is affected)
+- Resolution (Fixed/Skipped)
+
+→ Proceed to **B. Classify Findings**.
+
+#### If `loop_type` is `spec-review`
+
+Read tracking files for all available cycles:
+```
+.workflows/{work_unit}/specification/{topic}/review-input-tracking-c{1..N}.md
+.workflows/{work_unit}/specification/{topic}/review-gap-analysis-tracking-c{1..N}.md
+```
+
+For each cycle, extract:
+- Each finding's title
+- Affects field (which specification section)
+- Category
+- Resolution (Approved/Skipped)
+
+→ Proceed to **B. Classify Findings**.
+
+---
+
+## B. Classify Findings
+
+Compare findings across cycles. Two findings match if their titles share significant words OR they reference the same area (file:line, plan reference, or spec section).
+
+Treat the highest-numbered cycle as the **latest cycle** and all earlier cycles as **prior cycles**. For each finding identified across all cycles, classify as:
+
+- **Resolved** — appeared in a prior cycle but not in the latest cycle (the underlying issue was addressed)
+- **Recurring** — appeared in 2 or more cycles including the latest one (the issue persists despite fixes)
+- **New** — first appearance in the latest cycle
+
+Compute:
+- `resolved_count` — findings from prior cycles no longer appearing
+- `recurring_count` — findings persisting across cycles
+- `new_count` — findings appearing for the first time in the latest cycle
+- `trend`:
+  - **converging** — resolved_count > new_count (progress is being made)
+  - **stable** — resolved_count ≈ new_count (treading water)
+  - **diverging** — new_count > resolved_count (fixes are creating new issues)
+
+→ Proceed to **C. Display Diagnostic**.
+
+---
+
+## C. Display Diagnostic
+
+> *Output the next fenced block as a code block:*
+
+```
+{loop_type_label:(titlecase)} — {latest_cycle} cycle diagnostic
+
+  Trend: {trend:[converging|stable|diverging]}
+  Latest cycle: {finding_count} findings ({new_count} new, {recurring_count} recurring)
+
+  @if(resolved_count > 0)
+  Resolved:
+  @foreach(finding in resolved)
+    • {finding.title} (fixed in cycle {finding.last_seen_cycle})
+  @endforeach
+  @endif
+
+  @if(recurring_count > 0)
+  Recurring:
+  @foreach(finding in recurring)
+    • {finding.title} (cycles {finding.cycle_list})
+      {1-line root cause hypothesis based on the finding's history and affected area}
+  @endforeach
+  @endif
+
+  @if(new_count > 0)
+  New this cycle:
+  @foreach(finding in new)
+    • {finding.title}
+  @endforeach
+  @endif
+
+  @if(trend = converging)
+  ⚑ Continuing is likely to resolve remaining items.
+  @endif
+  @if(trend = stable)
+  ⚑ Same issues are cycling. Consider manual intervention on the recurring items.
+  @endif
+  @if(trend = diverging)
+  ⚑ Fixes are introducing new issues. Consider reviewing the approach.
+  @endif
+```
+
+Where `loop_type_label` maps:
+- `fix` → `Fix Loop`
+- `analysis` → `Analysis`
+- `planning-review` → `Plan Review`
+- `spec-review` → `Spec Review`
+
+→ Return to caller.

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -58,7 +58,7 @@ Auto mode is active — pass through to review. Section E's safety cap (cycle 5)
 
 **Do NOT skip review autonomously.** This gate is an escape hatch for the user — not a signal to stop. The expected default is to continue running review until no issues are found. Present the choice and let the user decide.
 
-→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: spec-review`, `work_unit`, `topic`.
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `spec-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -163,7 +163,7 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 #### If `finding_gate_mode` is `auto` and `review_cycle` >= 5
 
-→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: spec-review`, `work_unit`, `topic`.
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `spec-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -188,7 +188,7 @@ Run another review cycle?
 
 #### If `finding_gate_mode` is `gated`
 
-→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: spec-review`, `work_unit`, `topic`.
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `spec-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -58,14 +58,7 @@ Auto mode is active — pass through to review. Section E's safety cap (cycle 5)
 
 **Do NOT skip review autonomously.** This gate is an escape hatch for the user — not a signal to stop. The expected default is to continue running review until no issues are found. Present the choice and let the user decide.
 
-> *Output the next fenced block as a code block:*
-
-```
-Review cycle {N}
-
-Review has run {N-1} times so far. You can continue (recommended if issues
-were still found last cycle) or skip to completion.
-```
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: spec-review`, `work_unit`, `topic`.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -170,13 +163,7 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 #### If `finding_gate_mode` is `auto` and `review_cycle` >= 5
 
-> *Output the next fenced block as a code block:*
-
-```
-Review cycle {N}
-
-Auto-review has not converged after 5 cycles — escalating for human review.
-```
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: spec-review`, `work_unit`, `topic`.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -200,6 +187,8 @@ Run another review cycle?
 → Proceed to **F. Completion**.
 
 #### If `finding_gate_mode` is `gated`
+
+→ Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with `loop_type: spec-review`, `work_unit`, `topic`.
 
 > *Output the next fenced block as markdown (not a code block):*
 


### PR DESCRIPTION
## Summary

- Replace blind "continue or skip?" prompts at review/fix cycle caps with a convergence analysis diagnostic that reads prior cycle tracking data
- New shared reference (`convergence-analysis.md`) classifies findings as resolved/recurring/new across cycles, computes trend (converging/stable/diverging), and displays a recommendation
- Covers all four escalation points: implementation fix loop (3 attempts), analysis loop (>3 cycles), planning review (soft >3, hard >=5), and spec review (same caps)
- Persists reviewer ISSUES/NOTES per fix attempt to a cache file so the fix loop has cross-attempt data for comparison

## Test plan

- [ ] Verify convergence-analysis.md follows shared reference conventions (header, attribution, H4 conditionals with routing, rendering instructions)
- [ ] Trace task-loop.md §E paths: fix_attempts >= 3 loads diagnostic then routes to §F; fix_attempts < 3 checks gate mode and routes accordingly
- [ ] Trace analysis-loop.md §A: cycle > 3 loads diagnostic before proceed/skip menu
- [ ] Trace plan-review.md §B and §E: all three escalation locations load diagnostic correctly
- [ ] Trace spec-review.md §B and §E: mirrors plan-review changes
- [ ] Verify threshold check returns silently with < 2 cycles of data
- [ ] Verify fix tracking cache cleanup on new task (§A step 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)