### PR TITLE
feat: add epic dependency map visualization

### DIFF
--- a/skills/continue-epic/references/display-epic-map.md
+++ b/skills/continue-epic/references/display-epic-map.md
@@ -1,0 +1,215 @@
+# Epic Dependency Map
+
+*Reference for **[continue-epic](../SKILL.md)***
+
+---
+
+Display two complementary views of the epic's cross-phase progress: a compact summary matrix and a detailed phase-by-phase tree. The caller provides:
+- Discovery output from `continue-epic/scripts/discovery.cjs` (the `detail` object for the selected epic)
+- `work_unit` — the epic's work unit name
+
+---
+
+## A. Compute Pipelines
+
+Before rendering, derive the pipeline data from the discovery `detail` object. This section is not displayed to the user.
+
+**Pipeline definition:** Each specification topic defines a pipeline. The pipeline name is the spec topic name. Additional virtual rows exist for unassigned discussions and promoted items.
+
+**Per-pipeline data:**
+
+| Column | Source | Icon logic |
+|--------|--------|------------|
+| disc | Count of sources for this spec (from `phases.specification[topic].sources`). Each source has `topic` and `status` fields. | `{N}✓` if all source discussions are completed. `{N}◐` if any source discussion is in-progress. `N` is the source count. |
+| spec | `phases.specification[topic].status` | `✓` completed, `◐` in-progress, `○` not started |
+| plan | Match by topic name in `phases.planning` | Same icons. Blank if no matching plan exists. |
+| impl | Match by topic name in `phases.implementation` | Same icons. Blank if no matching impl exists. |
+| rev | Match by topic name in `phases.review` | Same icons. Blank if no matching review exists. |
+
+**Research summary:** Shared across all pipelines — shown as a standalone line, not a column. `✓` if all research items completed, `◐` if any in-progress, `○` if none exist.
+
+**Unassigned row:** From `unaccounted_discussions`. Count of unaccounted discussions. `{N}✓` if all completed, `{N}◐` if any in-progress. Only the `disc` column is populated.
+
+**Promoted row:** Spec items with status `promoted`. Show `promoted` in the spec column. Only the `disc` column (source count) and `spec` column are populated.
+
+**Pipeline ordering:** Completed pipelines first (all phases ✓), then in-progress (earliest active phase first), then not-started.
+
+**Phase-level status icon** (for detail view headers): `✓` if all items in that phase are completed, `◐` if any are in-progress or some are completed but not all, `○` if no items are completed. When pending topics from research exist, include them in the discussion count.
+
+→ Proceed to **B. Summary Matrix**.
+
+---
+
+## B. Summary Matrix
+
+#### If no phases have items (brand-new epic)
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Epic Map — {work_unit:(titlecase)}
+●───────────────────────────────────────────────●
+
+  No work started yet.
+```
+
+→ Proceed to **E. Back to Menu**.
+
+#### If phases have items
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Epic Map — {work_unit:(titlecase)}
+●───────────────────────────────────────────────●
+
+  Research: {status_icon} ({completed} of {total})
+
+@if(has_pipelines)
+                       disc  spec  plan  impl  rev
+@foreach(pipeline in pipelines)
+  {pipeline.name:(left-padded)}  {disc}  {spec}  {plan}  {impl}  {rev}
+@endforeach
+@if(has_promoted)
+  {promoted.name:(left-padded)}  {disc}  promoted
+@endif
+@if(has_unassigned)
+  unassigned{padding}  {disc}
+@endif
+@else
+  No pipelines yet — specifications define pipeline
+  structure.
+@if(has_unassigned)
+
+  Unassigned discussions: {count}
+@endif
+@endif
+```
+
+**Display rules:**
+
+- Research summary line: `Research: ✓ (2 of 2)` or `Research: ◐ (1 of 2)` or `Research: — (none)` if no research phase exists
+- Column headers right-aligned, 6 characters per column with 2 spaces between
+- Pipeline names left-aligned, padded to the longest pipeline name + 2 spaces before the first column
+- Status cells use icons: `✓`, `◐`, `○`. Discussion column prefixes with count: `3✓`, `2◐`
+- Blank cells (phase doesn't exist for this pipeline) use empty space
+- `promoted` spans from the spec column onward
+- Blank line between the research summary and the column headers
+- If no specification items exist, show the "No pipelines yet" message. Still show unassigned discussion count if applicable.
+
+→ Proceed to **C. Detail View**.
+
+---
+
+## C. Detail View
+
+> *Output the next fenced block as a code block:*
+
+```
+  Detail
+  ──────
+
+@foreach(phase in [research, discussion, specification, planning, implementation, review])
+@if(phase has items or (phase == discussion and pending_from_research exists))
+  {phase:(titlecase)} {phase_status_icon} ({completed_count} of {total_count})
+  │
+@foreach(item in phase.items)
+  @if(not last_in_phase) ├─ @else └─ @endif {item_status_icon} {item.name}
+@if(phase == specification and item.sources)
+@foreach(source in item.sources)
+  │  @if(not last_source) ├─ @else └─ @endif ← {source.topic}
+@endforeach
+@endif
+@if(phase == specification and item.status == 'promoted')
+  │  └─ → promoted to {item.promoted_to}
+@endif
+@if(phase == implementation and item.current_phase)
+  │  └─ Phase {item.current_phase}, {item.completed_tasks.length} task(s) completed
+@endif
+@endforeach
+@if(phase == discussion and pending_from_research exists)
+@foreach(topic in pending_from_research)
+  @if(last_pending_topic) └─ @else ├─ @endif ○ {topic.name} [pending from research]
+@endforeach
+@endif
+
+@endif
+@endforeach
+@if(has_unassigned_discussions)
+  ⚑ Unassigned discussions:
+@foreach(disc in unaccounted_discussions)
+    ✓ {disc}
+@endforeach
+
+@endif
+```
+
+**Display rules:**
+
+- Phase header: titlecased name, phase-level status icon, count in parens `({completed} of {total})`
+- Status icons before item names: `✓` completed, `◐` in-progress, `○` not started
+- Tree grammar: `├─` non-final, `└─` final within each phase
+- Specification items show source discussions as `← {source-topic}` sub-items using tree grammar
+- Promoted items show `→ promoted to {work_unit}` as a sub-item
+- Implementation items show progress as a sub-item when in-progress
+- Pending discussion topics from research appear at the end of the Discussion section with `○` and `[pending from research]`
+- Blank line between phase sections
+- Only show phases that have items (exception: Discussion appears if pending topics from research exist)
+- Unassigned discussions section: `⚑` callout with each discussion listed. Separated from the last phase by a blank line. These are completed discussions so use `✓` icon.
+- Item names in kebabcase as stored — these are technical identifiers
+
+→ Proceed to **D. Insights**.
+
+---
+
+## D. Insights
+
+Check all conditions below. Show all that apply. If none apply, skip this section entirely.
+
+> *Output the next fenced block as a code block:*
+
+Only output this block if at least one insight applies.
+
+```
+  Insights
+  ────────
+
+@foreach(insight in applicable_insights)
+  ⚑ {insight.text}
+@endforeach
+```
+
+**Insight conditions (check all, show all that apply):**
+
+| Condition | Text |
+|-----------|------|
+| `pending_from_research` has items | `{N} topic(s) from research not yet discussed.` |
+| `unaccounted_discussions` has items | `{N} completed discussion(s) not assigned to any specification.` |
+| Any plan has `deps_blocking` entries | `{topic:(titlecase)} plan blocked by {dep_topic}@if(dep.internal_id):{internal_id}@endif.` (one line per blocked plan) |
+| Critical path: an in-progress item whose completion unblocks 2+ downstream items in the same pipeline | `Critical path: completing {item.name} ({phase}) unblocks {N} downstream phase(s).` |
+
+**Critical path computation:**
+- For each in-progress item, count how many later phases have a matching item for the same pipeline (spec topic name). For discussion items, look up which spec(s) source them and count the spec's downstream phases. For spec items, count matching plan + impl + review. For plan items, count matching impl + review. For impl items, count matching review.
+- The item with the highest downstream count is the critical path.
+- Ties: pick the earliest-phase item.
+- Only show if downstream count is 2 or more.
+
+→ Proceed to **E. Back to Menu**.
+
+---
+
+## E. Back to Menu
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+- **`b`/`back`** — Return to menu
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+→ Return to caller.

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -165,7 +165,7 @@ Build a menu with two types of options:
 
 **Command options** — entry-point actions that launch a flow handling its own selection. Use letter shortcuts (first letter of command; second letter if disambiguation needed):
 - **`s`/`spec`** — Start specification — {N} discussion(s) not yet in a spec (only shown if `gating.can_start_specification` is true and `unaccounted_discussions` has items)
-- **`d`/`discuss`** — Start new discussion topic — {N} pending from research (if `gating.has_pending_discussions` is true; show count from `pending_from_research.length`). Without pending topics: @if(gating.has_research) `Start new discussion topic (from research)` @else `Start new discussion topic` @endif
+- **`d`/`discuss`** — Start new discussion (always present). When `gating.has_pending_discussions` is true, append ` — {N} pending from research` (count from `pending_from_research.length`)
 - **`p`/`pending`** — Manage pending topics (only shown when `gating.has_pending_discussions` is true)
 - **`r`/`research`** — Start new research (always present)
 - **`c`/`completed`** — Resume a completed topic (only shown when `completed` items exist)
@@ -203,7 +203,7 @@ What would you like to do?
 - **`4`** — Start planning for "User Profiles" — spec completed
 - **`5`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
 - **`s`/`spec`** — Start specification — 3 discussion(s) not yet in a spec
-- **`d`/`discuss`** — Start new discussion topic (from research)
+- **`d`/`discuss`** — Start new discussion
 - **`r`/`research`** — Start new research
 - **`c`/`completed`** — Resume a completed topic
 - **`m`/`map`** — View epic dependency map
@@ -338,7 +338,7 @@ Store the selected action, phase, and topic (if applicable). Map to a routing en
 | Start implementation of {topic} | implementation | {topic} |
 | Start review for {topic} | review | {topic} |
 | Start specification | specification | — |
-| Start new discussion topic / Start new discussion topic (from research) | discussion | — |
+| Start new discussion | discussion | — |
 | Discuss pending topic {topic} | discussion | {topic} |
 | Start new research | research | — |
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -148,31 +148,28 @@ Show only statuses and categories that appear in the current display. No `---` s
 
 ## C. Menu
 
-Build a numbered menu with three sections:
+Build a menu with two types of options:
 
-**Section 1 — In-progress items** (always first):
-- Any item with status `in-progress` in any phase
-- Planning in-progress: `Continue "{topic:(titlecase)}" — planning [in-progress]`
-- Implementation in-progress with progress: `Continue "{topic:(titlecase)}" — implementation (Phase {N}, Task {M})`
-- Implementation in-progress without progress: `Continue "{topic:(titlecase)}" — implementation [in-progress]`
-- Other phases: `Continue "{topic:(titlecase)}" — {phase} [in-progress]`
+**Numbered items** — topic-targeting actions where you're selecting a specific topic. Use sequential numbers. These include:
+- Continue items: any item with status `in-progress` in any phase
+  - Planning in-progress: `Continue "{topic:(titlecase)}" — planning [in-progress]`
+  - Implementation in-progress with progress: `Continue "{topic:(titlecase)}" — implementation (Phase {N}, Task {M})`
+  - Implementation in-progress without progress: `Continue "{topic:(titlecase)}" — implementation [in-progress]`
+  - Other phases: `Continue "{topic:(titlecase)}" — {phase} [in-progress]`
+- Next-phase-ready items from `next_phase_ready` in discovery output:
+  - Completed spec with no plan: `Start planning for "{topic:(titlecase)}" — spec completed`
+  - Completed plan with no implementation:
+    - If `blocked`: show but mark as not selectable: `Start implementation of "{topic:(titlecase)}" — blocked by {dep_topic}:{internal_id}`
+    - Otherwise: `Start implementation of "{topic:(titlecase)}" — plan completed`
+  - Completed implementation with no review: `Start review for "{topic:(titlecase)}" — implementation completed`
 
-**Section 2 — Next-phase-ready items:**
-- From `next_phase_ready` in discovery output
-- Completed spec with no plan: `Start planning for "{topic:(titlecase)}" — spec completed`
-- Completed plan with no implementation:
-  - If `blocked`: show but mark as not selectable: `Start implementation of "{topic:(titlecase)}" — blocked by {dep_topic}:{internal_id}`
-  - Otherwise: `Start implementation of "{topic:(titlecase)}" — plan completed`
-- Completed implementation with no review: `Start review for "{topic:(titlecase)}" — implementation completed`
-- Unaccounted discussions (from `unaccounted_discussions`): `Start specification — {N} discussion(s) not yet in a spec`
-  - Only show if `gating.can_start_specification` is true (at least one completed discussion)
-
-**Section 3 — Standing options:**
-- `Start new discussion topic — {N} pending from research` (if `gating.has_pending_discussions` is true; show count from `pending_from_research.length`). Without pending topics: @if(gating.has_research) `Start new discussion topic (from research)` @else `Start new discussion topic` @endif
-- `Manage pending topics` (only shown when `gating.has_pending_discussions` is true)
-- `Start new research` (always present)
-- `Resume a completed topic` (only shown when `completed` items exist)
-- `View epic dependency map` (always present when at least one phase has items)
+**Command options** — entry-point actions that launch a flow handling its own selection. Use letter shortcuts (first letter of command; second letter if disambiguation needed):
+- **`s`/`spec`** — Start specification — {N} discussion(s) not yet in a spec (only shown if `gating.can_start_specification` is true and `unaccounted_discussions` has items)
+- **`d`/`discuss`** — Start new discussion topic — {N} pending from research (if `gating.has_pending_discussions` is true; show count from `pending_from_research.length`). Without pending topics: @if(gating.has_research) `Start new discussion topic (from research)` @else `Start new discussion topic` @endif
+- **`p`/`pending`** — Manage pending topics (only shown when `gating.has_pending_discussions` is true)
+- **`r`/`research`** — Start new research (always present)
+- **`c`/`completed`** — Resume a completed topic (only shown when `completed` items exist)
+- **`m`/`map`** — View epic dependency map (always present when at least one phase has items)
 
 **Phase-forward gating:**
 - No "Start planning" unless `gating.can_start_planning` is true
@@ -180,13 +177,15 @@ Build a numbered menu with three sections:
 - No "Start review" unless `gating.can_start_review` is true
 - No "Start specification" unless `gating.can_start_specification` is true
 
-**Recommendation marking:** Mark one item as `(recommended)` based on phase completion state:
-- All discussions completed, no specifications exist, `gating.has_pending_discussions` is false → "Start specification (recommended)"
-- All discussions completed, no specifications exist, `gating.has_pending_discussions` is true → "Start new discussion topic (recommended)"
+**Ordering:** The recommended item always appears first. Mark one item as `(recommended)` based on phase completion state:
+- All discussions completed, no specifications exist, `gating.has_pending_discussions` is false → `s`/`spec` (recommended)
+- All discussions completed, no specifications exist, `gating.has_pending_discussions` is true → `d`/`discuss` (recommended)
 - All plannable specifications completed, some without plans → first plannable spec "(recommended)"
 - All plans completed (and deps satisfied), some without implementations → first implementable plan "(recommended)"
 - All implementations completed, some without reviews → first reviewable implementation "(recommended)"
 - Otherwise → no recommendation (complete in-progress work first)
+
+After the recommended item, list remaining numbered items, then command options.
 
 **Promoted items:** Items with `[promoted]` status are shown in the state display but are **not listed in the menu** — they've been moved to their own cross-cutting work unit and are no longer actionable in this epic.
 
@@ -198,23 +197,22 @@ Build a numbered menu with three sections:
 · · · · · · · · · · · ·
 What would you like to do?
 
-- **`1`** — Continue "Auth Flow" — discussion [in-progress]
-- **`2`** — Continue "Data Model" — specification [in-progress]
-- **`3`** — Start planning for "User Profiles" — spec completed
-- **`4`** — Continue "Caching" — planning [in-progress]
-- **`5`** — Start implementation of "Notifications" — plan completed (recommended)
-- **`6`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
-- **`7`** — Start specification — 3 discussion(s) not yet in a spec
-- **`8`** — Start new discussion topic (from research)
-- **`9`** — Start new research
-- **`10`** — Resume a completed topic
+- **`1`** — Start implementation of "Notifications" — plan completed (recommended)
+- **`2`** — Continue "Auth Flow" — discussion [in-progress]
+- **`3`** — Continue "Caching" — planning [in-progress]
+- **`4`** — Start planning for "User Profiles" — spec completed
+- **`5`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
+- **`s`/`spec`** — Start specification — 3 discussion(s) not yet in a spec
+- **`d`/`discuss`** — Start new discussion topic (from research)
+- **`r`/`research`** — Start new research
+- **`c`/`completed`** — Resume a completed topic
 - **`m`/`map`** — View epic dependency map
 
 Select an option:
 · · · · · · · · · · · ·
 ```
 
-Recreate with actual items from discovery. Blank line between sections.
+Recreate with actual items from discovery.
 
 **STOP.** Wait for user response.
 
@@ -271,11 +269,11 @@ Load **[display-epic-map.md](display-epic-map.md)** and follow its instructions 
 
 → Return to **C. Menu**.
 
-#### If user chose `Manage pending topics`
+#### If user chose `p`/`pending`
 
 → Proceed to **G. Manage Pending**.
 
-#### If user chose `Resume a completed topic`
+#### If user chose `c`/`completed`
 
 → Proceed to **F. Resume Completed**.
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -168,11 +168,11 @@ Build a numbered menu with three sections:
   - Only show if `gating.can_start_specification` is true (at least one completed discussion)
 
 **Section 3 — Standing options:**
-- `View epic dependency map` (always present when at least one phase has items)
 - `Start new discussion topic — {N} pending from research` (if `gating.has_pending_discussions` is true; show count from `pending_from_research.length`). Without pending topics: @if(gating.has_research) `Start new discussion topic (from research)` @else `Start new discussion topic` @endif
 - `Manage pending topics` (only shown when `gating.has_pending_discussions` is true)
 - `Start new research` (always present)
 - `Resume a completed topic` (only shown when `completed` items exist)
+- `View epic dependency map` (always present when at least one phase has items)
 
 **Phase-forward gating:**
 - No "Start planning" unless `gating.can_start_planning` is true
@@ -205,10 +205,10 @@ What would you like to do?
 - **`5`** — Start implementation of "Notifications" — plan completed (recommended)
 - **`6`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
 - **`7`** — Start specification — 3 discussion(s) not yet in a spec
-- **`m`/`map`** — View epic dependency map
 - **`8`** — Start new discussion topic (from research)
 - **`9`** — Start new research
 - **`10`** — Resume a completed topic
+- **`m`/`map`** — View epic dependency map
 
 Select an option:
 · · · · · · · · · · · ·

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -168,6 +168,7 @@ Build a numbered menu with three sections:
   - Only show if `gating.can_start_specification` is true (at least one completed discussion)
 
 **Section 3 — Standing options:**
+- `View epic dependency map` (always present when at least one phase has items)
 - `Start new discussion topic — {N} pending from research` (if `gating.has_pending_discussions` is true; show count from `pending_from_research.length`). Without pending topics: @if(gating.has_research) `Start new discussion topic (from research)` @else `Start new discussion topic` @endif
 - `Manage pending topics` (only shown when `gating.has_pending_discussions` is true)
 - `Start new research` (always present)
@@ -204,6 +205,7 @@ What would you like to do?
 - **`5`** — Start implementation of "Notifications" — plan completed (recommended)
 - **`6`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
 - **`7`** — Start specification — 3 discussion(s) not yet in a spec
+- **`m`/`map`** — View epic dependency map
 - **`8`** — Start new discussion topic (from research)
 - **`9`** — Start new research
 - **`10`** — Resume a completed topic
@@ -260,6 +262,12 @@ Commit the change.
 → Return to **C. Menu**.
 
 **If user chose `back`:**
+
+→ Return to **C. Menu**.
+
+#### If user chose `m`/`map`
+
+Load **[display-epic-map.md](display-epic-map.md)** and follow its instructions as written.
 
 → Return to **C. Menu**.
 

--- a/skills/continue-epic/scripts/discovery.cjs
+++ b/skills/continue-epic/scripts/discovery.cjs
@@ -62,8 +62,11 @@ function buildEpicDetail(cwd, manifest) {
       const entry = { name: item.name, status: item.status || 'unknown' };
 
       if (phase === 'specification' && item.sources) {
-        entry.sources = item.sources;
-        for (const src of item.sources) {
+        const sourcesArr = Array.isArray(item.sources)
+          ? item.sources
+          : Object.entries(item.sources).map(([topic, data]) => ({ topic, ...data }));
+        entry.sources = sourcesArr;
+        for (const src of sourcesArr) {
           allSourcedDiscussions.add(src.topic || src.name);
         }
       }
@@ -243,7 +246,10 @@ function format(result) {
       for (const item of items) {
         let line = `      - ${item.name} (${item.status})`;
         if (item.sources) {
-          const srcNames = item.sources.map(s => `${s.topic || s.name}:${s.status || '?'}`);
+          const sourcesArr = Array.isArray(item.sources)
+            ? item.sources
+            : Object.entries(item.sources).map(([topic, data]) => ({ topic, ...data }));
+          const srcNames = sourcesArr.map(s => `${s.topic || s.name}:${s.status || '?'}`);
           line += ` [sources: ${srcNames.join(', ')}]`;
         }
         if (item.format) line += ` [format: ${item.format}]`;

--- a/tests/scripts/test-discovery-for-continue-epic.cjs
+++ b/tests/scripts/test-discovery-for-continue-epic.cjs
@@ -468,6 +468,80 @@ describe('continue-epic discovery', () => {
       assert.strictEqual(g.can_start_review, false);
     });
 
+    it('normalizes object-format sources to array', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          specification: {
+            items: {
+              'core-system': {
+                status: 'in-progress',
+                sources: {
+                  'core-architecture': { status: 'incorporated' },
+                  'cli-commands-ux': { status: 'incorporated' },
+                },
+              },
+            },
+          },
+        },
+      });
+      const r = discover(dir);
+      const spec = r.epics[0].detail.phases.specification[0];
+      assert.strictEqual(Array.isArray(spec.sources), true);
+      assert.strictEqual(spec.sources.length, 2);
+      assert.strictEqual(spec.sources[0].topic, 'core-architecture');
+      assert.strictEqual(spec.sources[0].status, 'incorporated');
+      assert.strictEqual(spec.sources[1].topic, 'cli-commands-ux');
+    });
+
+    it('object-format sources track unaccounted discussions correctly', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: {
+            items: {
+              auth: { status: 'completed' },
+              payments: { status: 'completed' },
+              billing: { status: 'completed' },
+            },
+          },
+          specification: {
+            items: {
+              'core-system': {
+                status: 'in-progress',
+                sources: {
+                  auth: { status: 'incorporated' },
+                },
+              },
+            },
+          },
+        },
+      });
+      const r = discover(dir);
+      assert.deepStrictEqual(r.epics[0].detail.unaccounted_discussions.sort(), ['billing', 'payments']);
+    });
+
+    it('object-format sources detect reopened discussions', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { auth: { status: 'in-progress' } } },
+          specification: {
+            items: {
+              'core-system': {
+                status: 'in-progress',
+                sources: {
+                  auth: { status: 'incorporated' },
+                },
+              },
+            },
+          },
+        },
+      });
+      const r = discover(dir);
+      assert.deepStrictEqual(r.epics[0].detail.reopened_discussions, ['auth']);
+    });
+
     it('completed discussion that is in-progress is not both reopened and unaccounted', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
@@ -662,6 +736,27 @@ describe('continue-epic format', () => {
     });
     const out = format(discover(dir));
     assert.ok(out.includes('    pending_from_research: auth, billing'));
+  });
+
+  it('formats object-format sources correctly', () => {
+    createManifest(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        specification: {
+          items: {
+            'core-system': {
+              status: 'in-progress',
+              sources: {
+                auth: { status: 'incorporated' },
+                billing: { status: 'pending' },
+              },
+            },
+          },
+        },
+      },
+    });
+    const out = format(discover(dir));
+    assert.ok(out.includes('[sources: auth:incorporated, billing:pending]'));
   });
 
   it('includes unaccounted_discussions', () => {


### PR DESCRIPTION
## Summary

- Adds `m`/`map` option to continue-epic menu showing cross-phase pipeline progress for epics
- Two views: compact summary matrix (pipelines x phases) and detailed phase-by-phase tree with equal visual weight for all phases (research through review)
- Fixes latent bug where object-format spec sources would crash discovery iteration

## Test plan

- [ ] Run continue-epic on an in-progress epic, select `m`/`map`, verify both views render
- [ ] Verify matrix alignment with varying pipeline name lengths
- [ ] Test edge cases: brand-new epic (no items), research-only epic, epic with promoted specs
- [ ] Confirm `b`/`back` returns to the continue-epic menu
- [ ] Run discovery against a project with object-format spec sources (e.g. agntc v1 manually set to in-progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)