### PR TITLE
fix(tests): update discussion format test for gap cache section

### DIFF
--- a/tests/scripts/test-discovery-for-discussion.cjs
+++ b/tests/scripts/test-discovery-for-discussion.cjs
@@ -209,13 +209,14 @@ describe('workflow-discussion-entry format', () => {
     assert.ok(out.includes('=== RESEARCH ==='));
     assert.ok(out.includes('=== DISCUSSIONS ==='));
     assert.ok(out.includes('=== CACHE ==='));
+    assert.ok(out.includes('=== GAP CACHE ==='));
     assert.ok(out.includes('=== STATE ==='));
   });
 
   it('shows (none) for empty sections', () => {
     const out = format(discover(dir));
     const noneCount = (out.match(/\(none\)/g) || []).length;
-    assert.strictEqual(noneCount, 3);
+    assert.strictEqual(noneCount, 4);
   });
 
   it('includes research files with checksum', () => {


### PR DESCRIPTION
## Summary

- The discussion gap analysis feature added a `=== GAP CACHE ===` section to the discovery format output
- The existing `shows (none) for empty sections` test expected 3 `(none)` lines but now gets 4
- Updates the count assertion and adds `GAP CACHE` to the section headers check

## Test plan

- [x] `test-discovery-for-discussion.cjs` — 21/21 pass
- [x] All 10 discovery test suites — zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)