### PR TITLE
feat(manage): absorb feature into existing epic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,8 @@ Discovery filters by status — active work by default, with options to view com
 
 **Feature-to-epic pivot**: Features can be converted to epics via the manage menu (`p`/`pivot`). After pivot, the user can continue immediately as an epic or return to the previous view.
 
+**Feature absorption**: Features can be merged into an existing in-progress epic via the manage menu (`a`/`absorb`). Moves the feature's discussion and research into the epic as a new topic, then deletes the feature entirely. Guarded: requires a discussion, no spec-or-beyond, and at least one in-progress epic. Git history serves as provenance.
+
 **Epic soft gates**: When navigating forward between epic phases, advisory gates warn if prerequisite items are still in-progress. Informational, not blocking — the system recovers via re-analysis if the user proceeds early.
 
 Commit docs frequently (natural breaks, before context refresh). Skills capture context, don't implement.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ These aren't just different shapes — every phase adapts its behaviour to the w
 
 **Epics** are for large initiatives spanning multiple sessions. Topics move independently — 10 discussions might yield 5 specifications, each planned and implemented separately. Research analysis identifies potential discussion topics and tracks which ones haven't been started yet. As discussions mature, a discussion gap analysis reads all completed discussions holistically to surface cross-discussion themes, elevated-but-uncreated topics, emergent topics, and integration gaps — suggesting new discussions that research couldn't have anticipated. Both sources of pending topics are managed from the epic menu (discuss or skip). Planning uses walking skeletons and steel threads to prove architecture end-to-end before building features on top. Advisory soft gates warn when moving between phases if prerequisite items are still in progress. When a spec is assessed as cross-cutting, it's auto-promoted to its own cross-cutting work unit.
 
-**Features** are for adding functionality. Single topic, linear pipeline. Planning analyses your codebase and follows existing patterns — it won't introduce new architectural conventions unless the spec calls for it. Research is optional — skip it if you know what you're building, or import existing research files to pick up where you left off. If a feature grows beyond scope, pivot it to an epic without losing progress.
+**Features** are for adding functionality. Single topic, linear pipeline. Planning analyses your codebase and follows existing patterns — it won't introduce new architectural conventions unless the spec calls for it. Research is optional — skip it if you know what you're building, or import existing research files to pick up where you left off. If a feature grows beyond scope, pivot it to an epic without losing progress. If it belongs in an existing epic, absorb it — the discussion and research move into the epic as a new topic.
 
 **Bugfixes** replace discussion with investigation — structured symptom gathering combined with code analysis to find the root cause before specifying the fix. An optional synthesis agent independently validates the root cause hypothesis by tracing code fresh, catching flawed reasoning before it propagates through the pipeline. Planning applies minimal-change surgical fixes with regression prevention as a first-class deliverable.
 
@@ -166,7 +166,7 @@ Log ideas, bugs, and quick-fixes as you go — mid-conversation or from scratch.
 
 ### Workflow Dashboard
 
-`/workflow-start` is a unified dashboard — view all active work, manage lifecycle (complete, cancel, reactivate), pivot features to epics, browse your inbox, and route to the right skill.
+`/workflow-start` is a unified dashboard — view all active work, manage lifecycle (complete, cancel, reactivate), pivot features to epics, absorb features into existing epics, browse your inbox, and route to the right skill.
 
 ## Skills Reference
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(mkdir -p .workflows/)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs)
 ---
 
 Unified workflow entry point. Discovers state, shows all active work, and routes to start or continue skills.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/), Bash(rm -rf .workflows/)
 ---
 
 Unified workflow entry point. Discovers state, shows all active work, and routes to start or continue skills.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(mkdir -p .workflows/)
 ---
 
 Unified workflow entry point. Discovers state, shows all active work, and routes to start or continue skills.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/), Bash(rm -rf .workflows/)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/)
 ---
 
 Unified workflow entry point. Discovers state, shows all active work, and routes to start or continue skills.

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -49,8 +49,8 @@ Default topic name = `{selected.name}` (the feature's work unit name).
 Topic name in **{target_epic:(titlecase)}**: **{selected.name}**
 
 - **`y`/`yes`** — Use this name
-- **`r`/`rename`** — Enter a different name (kebab-case)
 - **`b`/`back`** — Return
+- **Rename** — Enter a different name (kebab-case)
 · · · · · · · · · · · ·
 ```
 
@@ -66,15 +66,7 @@ Set `topic` = `{selected.name}`.
 
 → Proceed to **C. Collision Check**.
 
-#### If user chose `r`/`rename`
-
-> *Output the next fenced block as a code block:*
-
-```
-Enter topic name (kebab-case):
-```
-
-**STOP.** Wait for user response.
+#### If rename
 
 Set `topic` to the user's input.
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -11,9 +11,9 @@ Merge a feature's discussion into an existing epic as a new topic, then remove t
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> This will move the feature's discussion into the selected epic as
-> a new topic and delete the feature work unit. Git history serves
-> as provenance.
+> This will move the feature's discussion and research into the
+> selected epic as a new topic and delete the feature work unit.
+> Git history serves as provenance.
 
 · · · · · · · · · · · ·
 Select a target epic:
@@ -107,7 +107,7 @@ Set `topic` to the user's input.
 
 → Proceed to **D. Research Warning**.
 
-## D. Research Warning
+## D. Research Check
 
 Check if the feature has research:
 
@@ -117,17 +117,29 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name
 
 #### If `true`
 
-> *Output the next fenced block as markdown (not a code block):*
+Set `has_research` = true.
 
+Read the research items to get topic names and statuses:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get '{selected.name}.research.*' status
 ```
-> Research files for this feature won't be moved — their value is
-> already captured in the discussion. They will be deleted with the
-> feature directory.
+
+Store as `research_items` (list of topic name + status pairs).
+
+For each research item, check for collision in the target epic:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {target_epic}.research.{research_topic}
 ```
+
+If a collision exists, rename by appending `-{selected.name}` (e.g. `exploration` becomes `exploration-{selected.name}`). Store the mapping of original name → target name as `research_moves`.
 
 → Proceed to **E. Confirm**.
 
 #### Otherwise
+
+Set `has_research` = false.
 
 → Proceed to **E. Confirm**.
 
@@ -150,9 +162,15 @@ Absorb Summary
   Target:     {target_epic:(titlecase)}
   Topic:      {topic}
   Discussion: [{discussion_status}]
+@if(has_research)
+  Research:   {research_item_count} file(s)
+@endif
 
   Actions:
   • Move discussion file to epic
+@if(has_research)
+  • Move research file(s) to epic
+@endif
   • Register topic in epic manifest
   • Remove feature work unit and directory
 ```
@@ -189,7 +207,7 @@ mkdir -p .workflows/{target_epic}/discussion/
 mv .workflows/{selected.name}/discussion/{selected.name}.md .workflows/{target_epic}/discussion/{topic}.md
 ```
 
-Register the topic in the epic manifest:
+Register the discussion topic in the epic manifest:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.discussion.{topic}
@@ -199,6 +217,25 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_ep
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discussion.{topic} status completed
+```
+
+**If `has_research` is true:**
+
+For each item in `research_moves` (original_name → target_name):
+
+```bash
+mkdir -p .workflows/{target_epic}/research/
+mv .workflows/{selected.name}/research/{original_name}.md .workflows/{target_epic}/research/{target_name}.md
+```
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.research.{target_name}
+```
+
+If the original research item status was `completed`:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.research.{target_name} status completed
 ```
 
 Remove the feature from the project manifest:
@@ -227,6 +264,9 @@ Absorbed into Epic
   Topic "{topic:(titlecase)}" added to {target_epic:(titlecase)}.
 
   • Discussion: moved
+@if(has_research)
+  • Research: moved
+@endif
   • Feature: removed
 ```
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -38,6 +38,8 @@ Store the selected epic as `target_epic`.
 
 → Proceed to **B. Name Topic**.
 
+---
+
 ## B. Name Topic
 
 Default topic name = `{selected.name}` (the feature's work unit name).
@@ -72,6 +74,8 @@ Set `topic` to the user's input.
 
 → Proceed to **C. Collision Check**.
 
+---
+
 ## C. Collision Check
 
 Check if a discussion topic with this name already exists in the target epic:
@@ -98,6 +102,8 @@ Set `topic` to the user's input.
 #### If `false`
 
 → Proceed to **D. Research Check**.
+
+---
 
 ## D. Research Check
 
@@ -134,6 +140,8 @@ Collisions are resolved by appending `-{selected.name}` (e.g. `exploration` beco
 Set `has_research` = false.
 
 → Proceed to **E. Confirm**.
+
+---
 
 ## E. Confirm
 
@@ -187,6 +195,8 @@ Proceed?
 
 → Proceed to **F. Move Discussion**.
 
+---
+
 ## F. Move Discussion
 
 ```bash
@@ -214,6 +224,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.dis
 #### Otherwise
 
 → Proceed to **G. Move Research**.
+
+---
 
 ## G. Move Research
 
@@ -244,6 +256,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.res
 
 → Proceed to **H. Cleanup**.
 
+---
+
 ## H. Cleanup
 
 Remove the feature from the project manifest:
@@ -261,6 +275,8 @@ rm -rf .workflows/{selected.name}/
 Commit: `workflow({selected.name}): absorb into {target_epic}`
 
 → Proceed to **I. Post-Absorption**.
+
+---
 
 ## I. Post-Absorption
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -234,6 +234,8 @@ Absorbed into Epic
 
 ```
 · · · · · · · · · · · ·
+**{selected.name:(titlecase)}** absorbed into **{target_epic:(titlecase)}**.
+
 - **`c`/`continue`** — Continue {target_epic:(titlecase)} as epic
 - **`b`/`back`** — Return to previous view
 · · · · · · · · · · · ·

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -125,7 +125,7 @@ For each research item, check for collision in the target epic:
 node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {target_epic}.research.{research_topic}
 ```
 
-If a collision exists, rename by appending `-{selected.name}` (e.g. `exploration` becomes `exploration-{selected.name}`). Store the mapping of original name → target name as `research_moves`.
+Collisions are resolved by appending `-{selected.name}` (e.g. `exploration` becomes `exploration-{selected.name}`). Store the mapping of original name → target name as `research_moves`.
 
 → Proceed to **E. Confirm**.
 
@@ -199,19 +199,14 @@ mkdir -p .workflows/{target_epic}/discussion/
 mv .workflows/{selected.name}/discussion/{selected.name}.md .workflows/{target_epic}/discussion/{topic}.md
 ```
 
-Register the discussion topic in the epic manifest:
+Register the discussion topic in the epic manifest, preserving the original status:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.discussion.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discussion.{topic} status {discussion_status}
 ```
 
-**If `discussion_status` is `completed`:**
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discussion.{topic} status completed
-```
-
-**If `has_research` is true:**
+**If `has_research` is `true`:**
 
 For each item in `research_moves` (original_name → target_name):
 
@@ -220,14 +215,11 @@ mkdir -p .workflows/{target_epic}/research/
 mv .workflows/{selected.name}/research/{original_name}.md .workflows/{target_epic}/research/{target_name}.md
 ```
 
+Register in the epic manifest, preserving the original status:
+
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.research.{target_name}
-```
-
-If the original research item status was `completed`:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.research.{target_name} status completed
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.research.{target_name} status {original_status}
 ```
 
 Remove the feature from the project manifest:

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -1,0 +1,250 @@
+# Absorb Feature into Epic
+
+*Reference for **[manage-work-unit](manage-work-unit.md)***
+
+---
+
+Merge a feature's discussion into an existing epic as a new topic, then remove the feature entirely.
+
+## A. Select Target Epic
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> This will move the feature's discussion into the selected epic as
+> a new topic and delete the feature work unit. Git history serves
+> as provenance.
+
+· · · · · · · · · · · ·
+Select a target epic:
+
+@foreach(epic in available_epics)
+- **`{N}`** — {epic.name:(titlecase)}
+@endforeach
+
+- **`b`/`back`** — Return
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If user chose `b`/`back`
+
+→ Return to caller.
+
+#### If user chose a number
+
+Store the selected epic as `target_epic`.
+
+→ Proceed to **B. Name Topic**.
+
+## B. Name Topic
+
+Default topic name = `{selected.name}` (the feature's work unit name).
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Topic name in **{target_epic:(titlecase)}**: **{selected.name}**
+
+- **`y`/`yes`** — Use this name
+- **`r`/`rename`** — Enter a different name (kebab-case)
+- **`b`/`back`** — Return
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If user chose `b`/`back`
+
+→ Return to caller.
+
+#### If user chose `y`/`yes`
+
+Set `topic` = `{selected.name}`.
+
+→ Proceed to **C. Collision Check**.
+
+#### If user chose `r`/`rename`
+
+> *Output the next fenced block as a code block:*
+
+```
+Enter topic name (kebab-case):
+```
+
+**STOP.** Wait for user response.
+
+Set `topic` to the user's input.
+
+→ Proceed to **C. Collision Check**.
+
+## C. Collision Check
+
+Check if a discussion topic with this name already exists in the target epic:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {target_epic}.discussion.{topic}
+```
+
+#### If `true`
+
+> *Output the next fenced block as a code block:*
+
+```
+Topic "{topic}" already exists in {target_epic:(titlecase)}.
+Enter a different name (kebab-case):
+```
+
+**STOP.** Wait for user response.
+
+Set `topic` to the user's input.
+
+→ Return to **C. Collision Check**.
+
+#### If `false`
+
+→ Proceed to **D. Research Warning**.
+
+## D. Research Warning
+
+Check if the feature has research:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.research
+```
+
+#### If `true`
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Research files for this feature won't be moved — their value is
+> already captured in the discussion. They will be deleted with the
+> feature directory.
+```
+
+→ Proceed to **E. Confirm**.
+
+#### Otherwise
+
+→ Proceed to **E. Confirm**.
+
+## E. Confirm
+
+Read the discussion status:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {selected.name}.discussion.{selected.name} status
+```
+
+Store the result as `discussion_status`.
+
+> *Output the next fenced block as a code block:*
+
+```
+Absorb Summary
+
+  Feature:    {selected.name:(titlecase)}
+  Target:     {target_epic:(titlecase)}
+  Topic:      {topic}
+  Discussion: [{discussion_status}]
+
+  Actions:
+  • Move discussion file to epic
+  • Register topic in epic manifest
+  • Remove feature work unit and directory
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Proceed?
+- **`y`/`yes`**
+- **`n`/`no`**
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If user chose `n`/`no`
+
+→ Return to caller.
+
+#### If user chose `y`/`yes`
+
+→ Proceed to **F. Execute Absorption**.
+
+## F. Execute Absorption
+
+Execute the following operations in order:
+
+```bash
+mkdir -p .workflows/{target_epic}/discussion/
+```
+
+```bash
+mv .workflows/{selected.name}/discussion/{selected.name}.md .workflows/{target_epic}/discussion/{topic}.md
+```
+
+Register the topic in the epic manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.discussion.{topic}
+```
+
+**If `discussion_status` is `completed`:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discussion.{topic} status completed
+```
+
+Remove the feature from the project manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete project.work_units.{selected.name}
+```
+
+Remove the feature directory:
+
+```bash
+rm -rf .workflows/{selected.name}/
+```
+
+Commit: `workflow({selected.name}): absorb into {target_epic}`
+
+→ Proceed to **G. Post-Absorption**.
+
+## G. Post-Absorption
+
+> *Output the next fenced block as a code block:*
+
+```
+Absorbed into Epic
+
+  Topic "{topic:(titlecase)}" added to {target_epic:(titlecase)}.
+
+  • Discussion: moved
+  • Feature: removed
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+- **`c`/`continue`** — Continue {target_epic:(titlecase)} as epic
+- **`b`/`back`** — Return to previous view
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If user chose `c`/`continue`
+
+Invoke the `/continue-epic` skill. This is terminal — do not return to the caller.
+
+#### If user chose `b`/`back`
+
+→ Return to caller.

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -105,7 +105,7 @@ Set `topic` to the user's input.
 
 #### If `false`
 
-→ Proceed to **D. Research Warning**.
+→ Proceed to **D. Research Check**.
 
 ## D. Research Check
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -185,11 +185,9 @@ Proceed?
 
 #### If user chose `y`/`yes`
 
-→ Proceed to **F. Execute Absorption**.
+→ Proceed to **F. Move Discussion**.
 
-## F. Execute Absorption
-
-Execute the following operations in order:
+## F. Move Discussion
 
 ```bash
 mkdir -p .workflows/{target_epic}/discussion/
@@ -199,14 +197,27 @@ mkdir -p .workflows/{target_epic}/discussion/
 mv .workflows/{selected.name}/discussion/{selected.name}.md .workflows/{target_epic}/discussion/{topic}.md
 ```
 
-Register the discussion topic in the epic manifest, preserving the original status:
+Register the discussion topic in the epic manifest:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.discussion.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discussion.{topic} status {discussion_status}
 ```
 
-**If `has_research` is `true`:**
+#### If `discussion_status` is `completed`
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discussion.{topic} status completed
+```
+
+→ Proceed to **G. Move Research**.
+
+#### Otherwise
+
+→ Proceed to **G. Move Research**.
+
+## G. Move Research
+
+#### If `has_research` is `true`
 
 For each item in `research_moves` (original_name → target_name):
 
@@ -215,12 +226,25 @@ mkdir -p .workflows/{target_epic}/research/
 mv .workflows/{selected.name}/research/{original_name}.md .workflows/{target_epic}/research/{target_name}.md
 ```
 
-Register in the epic manifest, preserving the original status:
+Register in the epic manifest:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.research.{target_name}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.research.{target_name} status {original_status}
 ```
+
+**If the original item status was `completed`:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.research.{target_name} status completed
+```
+
+→ Proceed to **H. Cleanup**.
+
+#### Otherwise
+
+→ Proceed to **H. Cleanup**.
+
+## H. Cleanup
 
 Remove the feature from the project manifest:
 
@@ -236,9 +260,9 @@ rm -rf .workflows/{selected.name}/
 
 Commit: `workflow({selected.name}): absorb into {target_epic}`
 
-→ Proceed to **G. Post-Absorption**.
+→ Proceed to **I. Post-Absorption**.
 
-## G. Post-Absorption
+## I. Post-Absorption
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -75,7 +75,7 @@ Store the selected work unit.
 
 ## B. Pre-Checks
 
-Default `implementation_completed` = false, `has_plan` = false, `has_spec` = false, `has_discussion` = false, `has_in_progress_epics` = false.
+Default `implementation_completed` = false, `has_plan` = false.
 
 Check whether the planning phase exists:
 
@@ -84,6 +84,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name
 ```
 
 If the result is `true`, set `has_plan` = true.
+
+**If `selected.work_type` is `feature`:**
+
+Default `has_spec` = false, `has_discussion` = false, `has_in_progress_epics` = false.
 
 Check whether the specification phase exists:
 
@@ -115,11 +119,11 @@ Check whether the implementation phase exists:
 node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.implementation
 ```
 
-#### If the result is `false`
+#### If the implementation phase does not exist
 
 → Proceed to **D. Action Menu**.
 
-#### If the result is `true`
+#### If the implementation phase exists
 
 → Proceed to **C. Completion Check**.
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -75,7 +75,7 @@ Store the selected work unit.
 
 ## B. Pre-Checks
 
-Default `implementation_completed` = false, `has_plan` = false.
+Default `implementation_completed` = false, `has_plan` = false, `has_spec` = false, `has_discussion` = false, `has_in_progress_epics` = false.
 
 Check whether the planning phase exists:
 
@@ -84,6 +84,30 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name
 ```
 
 If the result is `true`, set `has_plan` = true.
+
+Check whether the specification phase exists:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.specification
+```
+
+If the result is `true`, set `has_spec` = true.
+
+Check whether the discussion phase exists:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.discussion
+```
+
+If the result is `true`, set `has_discussion` = true.
+
+List in-progress epics:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs list --status in-progress --work-type epic
+```
+
+If the result is a non-empty JSON array, set `has_in_progress_epics` = true and store the array as `available_epics`.
 
 Check whether the implementation phase exists:
 
@@ -124,7 +148,8 @@ Set `implementation_completed` = true.
 ```
 > Lifecycle actions for this work unit. Done marks it finished,
 > cancel abandons it, pivot converts a feature to an epic when the
-> scope grows beyond a single topic.
+> scope grows beyond a single topic, absorb merges a feature's
+> discussion into an existing epic.
 
 · · · · · · · · · · · ·
 **{selected.name:(titlecase)}** ({selected.work_type})
@@ -134,6 +159,9 @@ Set `implementation_completed` = true.
 @endif
 @if(selected.work_type == 'feature')
 - **`p`/`pivot`** — Convert to epic (enables multiple topics)
+@endif
+@if(selected.work_type == 'feature' and !has_spec and has_discussion and has_in_progress_epics)
+- **`a`/`absorb`** — Merge into an existing epic
 @endif
 @if(has_plan)
 - **`v`/`view-plan`** — View the implementation plan
@@ -186,6 +214,12 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {selected.name} w
 Invoke the `/continue-epic` skill. This is terminal — do not return to the caller.
 
 **If user chose `b`/`back`:**
+
+→ Return to caller.
+
+#### If user chose `a`/`absorb`
+
+→ Load **[absorb-into-epic.md](absorb-into-epic.md)** and follow its instructions as written.
 
 → Return to caller.
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -4,7 +4,7 @@
 
 ---
 
-Manage an in-progress work unit's lifecycle. Self-contained four-step flow.
+Manage an in-progress work unit's lifecycle.
 
 ## A. Select
 
@@ -77,33 +77,27 @@ Store the selected work unit.
 
 Default `implementation_completed` = false, `has_plan` = false.
 
-Check whether the planning phase exists:
+Check whether the planning phase exists and store the result as `has_plan`:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.planning
 ```
 
-If the result is `true`, set `has_plan` = true.
-
-**If `selected.work_type` is `feature`:**
+#### If `selected.work_type` is `feature`
 
 Default `has_spec` = false, `has_discussion` = false, `has_in_progress_epics` = false.
 
-Check whether the specification phase exists:
+Check whether the specification phase exists and store the result as `has_spec`:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.specification
 ```
 
-If the result is `true`, set `has_spec` = true.
-
-Check whether the discussion phase exists:
+Check whether the discussion phase exists and store the result as `has_discussion`:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.discussion
 ```
-
-If the result is `true`, set `has_discussion` = true.
 
 List in-progress epics:
 
@@ -113,6 +107,14 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs list --status in-prog
 
 If the result is a non-empty JSON array, set `has_in_progress_epics` = true and store the array as `available_epics`.
 
+→ Proceed to **C. Implementation Check**.
+
+#### Otherwise
+
+→ Proceed to **C. Implementation Check**.
+
+## C. Implementation Check
+
 Check whether the implementation phase exists:
 
 ```bash
@@ -121,13 +123,13 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name
 
 #### If the implementation phase does not exist
 
-→ Proceed to **D. Action Menu**.
+→ Proceed to **E. Action Menu**.
 
 #### If the implementation phase exists
 
-→ Proceed to **C. Completion Check**.
+→ Proceed to **D. Completion Check**.
 
-## C. Completion Check
+## D. Completion Check
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs get '{selected.name}.implementation.*' status
@@ -139,13 +141,13 @@ This returns all topic statuses in the implementation phase.
 
 Set `implementation_completed` = true.
 
-→ Proceed to **D. Action Menu**.
+→ Proceed to **E. Action Menu**.
 
 #### Otherwise
 
-→ Proceed to **D. Action Menu**.
+→ Proceed to **E. Action Menu**.
 
-## D. Action Menu
+## E. Action Menu
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -231,7 +233,7 @@ Invoke the `/continue-epic` skill. This is terminal — do not return to the cal
 
 → Load **[view-plan.md](view-plan.md)** and follow its instructions as written.
 
-→ Return to **D. Action Menu**.
+→ Return to **E. Action Menu**.
 
 #### If user chose `c`/`cancel`
 
@@ -257,4 +259,4 @@ Commit: `workflow({selected.name}): mark as cancelled`
 
 Answer the question.
 
-→ Return to **D. Action Menu**.
+→ Return to **E. Action Menu**.


### PR DESCRIPTION
## Summary

- Adds an **absorb** option to the manage menu that merges a feature's discussion and research into an existing in-progress epic as a new topic, then deletes the feature
- Guarded by pre-checks: feature must have a discussion, must not have a spec, and at least one in-progress epic must exist
- Handles topic name collisions, research file collisions (renames by appending feature name), and preserves manifest statuses

## Test plan

- [ ] Create a feature with a completed discussion and an in-progress epic
- [ ] `/workflow-start` → `m`/`manage` → select feature → verify `a`/`absorb` appears
- [ ] Walk through the absorption flow end-to-end
- [ ] Verify: discussion file exists in epic directory, topic in epic manifest, feature directory removed, feature gone from project manifest
- [ ] Verify a feature with a spec phase does NOT show the absorb option
- [ ] Verify a feature with research moves research files into the epic
- [ ] Verify no epics in-progress hides the option

🤖 Generated with [Claude Code](https://claude.com/claude-code)