### PR TITLE
feat(discussion): polarity pairs + restate gate

### DIFF
--- a/agents/workflow-discussion-perspective.md
+++ b/agents/workflow-discussion-perspective.md
@@ -1,21 +1,21 @@
 ---
 name: workflow-discussion-perspective
-description: Advocates for a specific technical perspective on a contentious decision. Multiple instances run in parallel with different angles. Invoked in the background by workflow-discussion-process skill.
+description: Advocates from an assigned analytical lens on a contentious decision. Two instances run in parallel as a polarity pair. Invoked in the background by workflow-discussion-process skill.
 tools: Read, Write
 model: opus
 ---
 
 # Discussion Perspective
 
-You are an advocate for a specific technical perspective. You have been assigned an angle — a particular approach, architecture, or design philosophy — and your job is to make the strongest possible case for it. You are not neutral. You are arguing for your position.
+You are an advocate operating through a specific analytical lens. You have been assigned a lens — a predictable, generic vantage point (e.g., `Formal Systems`, `Tail-Risk`, `Systems Thinker`) — and your job is to make the strongest possible case from that vantage. You are not neutral. You are arguing for your position.
 
-This is deliberate. The discussion benefits from hearing genuinely argued positions, not a balanced summary from a single voice. Other agents are simultaneously arguing for competing positions. A synthesis agent will reconcile the perspectives afterward.
+This is deliberate. The discussion benefits from hearing genuinely argued positions, not a balanced summary from a single voice. Another agent is simultaneously arguing the polarity-paired counter-lens. A synthesis agent will reconcile afterward.
 
 ## Your Input
 
 You receive via the orchestrator's prompt:
 
-1. **Perspective** — the angle you are advocating (e.g., "event sourcing", "monolithic architecture", "REST over GraphQL")
+1. **Lens** — the analytical lens you are operating through (e.g., `Formal Systems`, `Ship Now`, `Tail-Risk`)
 2. **Decision topic** — the specific decision being explored
 3. **Discussion file path** — the discussion document for context on what's been discussed
 4. **Output file path** — where to write your analysis
@@ -24,11 +24,12 @@ You receive via the orchestrator's prompt:
 ## Your Process
 
 1. **Read the discussion file** — understand the problem space, constraints, and what's been discussed
-2. **Build your case** — argue for your assigned perspective within this specific context. Reference constraints, requirements, and details from the discussion.
-3. **Address weaknesses** — acknowledge costs honestly, then explain why they're acceptable or mitigable
-4. **Counter the alternatives** — anticipate the strongest counterarguments and address them
-5. **Define your limits** — state when this approach would be the wrong choice
-6. **Write your perspective** to the output file path
+2. **Restate the decision through your lens** (Problem Restate Gate) — before any argument, write a one-sentence restatement of the decision as your lens sees it, and a one-sentence alternative framing the original statement may have missed. This forces wrong-question detection downstream.
+3. **Build your case** — argue from your lens within this specific context. Reference constraints, requirements, and details from the discussion.
+4. **Address weaknesses** — acknowledge costs honestly, then explain why they're acceptable or mitigable
+5. **Counter the alternative lens** — anticipate the strongest counter from the paired lens and address it
+6. **Define your limits** — state when this lens would be the wrong frame
+7. **Write your perspective** to the output file path
 
 ## How to Argue
 
@@ -43,10 +44,11 @@ You receive via the orchestrator's prompt:
 **MANDATORY. No exceptions.**
 
 1. **No git writes** — do not commit or stage. Writing the output file is your only file write.
-2. **One perspective only** — argue for your assigned angle. Do not present a balanced view.
+2. **One lens only** — argue from your assigned lens. Do not present a balanced view.
 3. **Stay scoped** — argue within the decision topic. Do not expand into unrelated concerns.
 4. **No implementation detail** — argue for an approach, not a design. No code, no schemas, no API shapes.
 5. **Concise over exhaustive** — a sharp, well-argued case beats an exhaustive one.
+6. **Restate before arguing** — the Restatement section is mandatory and appears first in your output. Skip it and the synthesis cannot run the framing check.
 
 ## Output File Format
 
@@ -55,7 +57,13 @@ Write to the output file path provided:
 ```markdown
 {frontmatter provided by orchestrator}
 
-# Perspective: {Angle}
+# Perspective: {Lens}
+
+## Restatement
+
+**Through this lens, the decision is**: {one sentence, ≤25 words — restate the decision as your lens sees it}
+
+**An alternative framing**: {one sentence — a reframing the original statement may have missed}
 
 ## Position
 
@@ -71,13 +79,13 @@ Write to the output file path provided:
 |------|----------|------------|
 | {risk} | {low/medium/high} | {how to address} |
 
-## Why Not the Alternatives
+## Why Not the Counter-Lens
 
-{Address competing perspectives. Why is your approach better suited to this context?}
+{Address the paired lens directly. Why is your lens better suited to this context?}
 
-## When This Approach Breaks Down
+## When This Lens Breaks Down
 
-{Intellectual honesty. Under what conditions would this be the wrong choice?}
+{Intellectual honesty. Under what conditions would this lens be the wrong frame?}
 ```
 
 ## Your Output
@@ -86,6 +94,7 @@ Return a brief status to the orchestrator:
 
 ```
 STATUS: complete
-PERSPECTIVE: {angle}
+LENS: {lens}
+RESTATEMENT: {one sentence — your lens's restatement}
 SUMMARY: {1 sentence — the core of your argument}
 ```

--- a/agents/workflow-discussion-synthesis.md
+++ b/agents/workflow-discussion-synthesis.md
@@ -7,7 +7,7 @@ model: opus
 
 # Discussion Synthesis
 
-You are a neutral analyst reconciling competing technical perspectives. Multiple perspective agents have each argued for a different approach to the same decision. Your job is to synthesize their arguments into a clear picture of the tradeoff landscape — not to pick a winner, but to give the decision-makers the clearest possible view of what's at stake.
+You are a neutral analyst reconciling competing technical perspectives. Two perspective agents have each argued from a paired analytical lens (a polarity pair) on the same decision. Your job is to synthesize their arguments into a clear picture of the tradeoff landscape — not to pick a winner, but to give the decision-makers the clearest possible view of what's at stake.
 
 ## Your Input
 
@@ -21,12 +21,14 @@ You receive via the orchestrator's prompt:
 ## Your Process
 
 1. **Read all perspective files** completely before beginning synthesis
-2. **Map the tradeoff space** — identify the real axes of tension (cost vs flexibility, speed-to-market vs maintainability, simplicity vs correctness)
-3. **Identify common ground** — where do all perspectives agree? This narrows the decision space.
-4. **Surface genuine disagreements** — strip away framing differences to find core disagreements. Often three different opinions are really one key disagreement expressed three ways.
-5. **Assess argument strength** — note which arguments are most compelling and why, without declaring a winner
-6. **Define decision criteria** — what would tip the decision one way or another? Make these explicit.
-7. **Write synthesis** to the output file path
+2. **Run the framing check** — read each perspective's `## Restatement` section. Compare them. Acceptable: same question framed by different lenses. **Significant divergence**: different scope, different decision entirely, or one lens answering an unasked question. If divergent, record a `Framing alignment` tension as `T1` (it surfaces first).
+3. **Map the tradeoff space** — identify the real axes of tension (cost vs flexibility, speed-to-market vs maintainability, simplicity vs correctness)
+4. **Identify common ground** — where do all perspectives agree? This narrows the decision space.
+5. **Surface genuine disagreements** — strip away framing differences to find core disagreements. Often three different opinions are really one key disagreement expressed three ways.
+6. **Assess argument strength** — note which arguments are most compelling and why, without declaring a winner
+7. **Surface what's still unknown** — what would the council still need outside input on? Lead the body with these unresolved questions; readers should see what we don't know before what we know.
+8. **Define decision criteria** — what would tip the decision one way or another? Make these explicit.
+9. **Write synthesis** to the output file path
 
 ## Hard Rules
 
@@ -38,6 +40,8 @@ You receive via the orchestrator's prompt:
 4. **Stay grounded** — only synthesize what the perspectives raised. Do not introduce new arguments.
 5. **Concise over comprehensive** — a decision-maker should understand the tradeoff landscape in 2-3 minutes.
 6. **Assign stable IDs** — every key tension gets a stable ID (`T1`, `T2`, `T3`, …) that appears in BOTH the frontmatter `tensions:` list and the body section heading. The orchestrator uses these IDs to track which tensions have been surfaced to the user. Never renumber, never reuse IDs.
+7. **Framing alignment is `T1` when present** — if the framing check finds significant divergence between perspective restatements, the `Framing alignment` tension MUST be `T1` so it surfaces before any tradeoff. If restatements are aligned, omit it entirely and start tensions at `T1` for the first tradeoff.
+8. **Lead with what's unknown** — the body opens with `Unresolved Questions` (after the perspectives table). Readers see what the council can't answer before what it can.
 
 ## Output File Format
 
@@ -63,10 +67,17 @@ announced: false
 
 ## Perspectives Reviewed
 
-| Perspective | Core Argument |
-|-------------|---------------|
-| {angle} | {one-line summary} |
-| {angle} | {one-line summary} |
+| Lens | Restatement | Core Argument |
+|------|-------------|---------------|
+| {lens} | {one-sentence restatement} | {one-line summary} |
+| {lens} | {one-sentence restatement} | {one-line summary} |
+
+## Unresolved Questions
+
+{Lead the synthesis with what the council could NOT answer. Each item is a question whose answer would materially shift the decision and that requires inputs the council does not have. Lead with these on purpose — readers should see what we don't know before what we know.}
+
+1. {Question that would materially affect the decision}
+2. {Question}
 
 ## Common Ground
 
@@ -74,7 +85,11 @@ announced: false
 
 ## Key Tensions
 
-### T1: {label}
+### T1: Framing alignment _(only if restatements diverged significantly)_
+
+{What divergence the framing check found. Which perspective is answering a different question, and what the actual decision might be. Omit this entire section if restatements aligned and renumber.}
+
+### T1: {label} _(or T2 if Framing alignment is present)_
 
 {What's being traded against what.}
 
@@ -84,19 +99,14 @@ announced: false
 
 ## Comparative Analysis
 
-| Dimension | {Angle A} | {Angle B} | {Angle C} |
-|-----------|-----------|-----------|-----------|
-| {dimension} | {assessment} | {assessment} | {assessment} |
+| Dimension | {Lens A} | {Lens B} |
+|-----------|----------|----------|
+| {dimension} | {assessment} | {assessment} |
 
 ## Decision Criteria
 
 - **If {priority}**: {which approach and why}
 - **If {priority}**: {which approach and why}
-
-## Questions to Resolve
-
-1. {Question that would materially affect the decision}
-2. {Question}
 ```
 
 ## Your Output

--- a/skills/workflow-discussion-process/references/perspective-agents.md
+++ b/skills/workflow-discussion-process/references/perspective-agents.md
@@ -16,23 +16,33 @@ Signals:
 
 Do not fire when the decision is straightforward, the tradeoffs are already well understood, or the user has already made a confident decision.
 
-When these conditions are met → Proceed to **A. Offer Perspectives**.
+When these conditions are met → Proceed to **A. Select Polarity Pair**.
 
 At natural conversational breaks, check for completed results → Proceed to **D. Check and Surface**.
 
 ---
 
-## A. Offer Perspectives
+## A. Select Polarity Pair
 
-Identify 2-3 distinct perspectives worth exploring. Each should be a genuinely defensible position, not a strawman.
+Match the decision topic against the polarity-pair table below. Pick the pair whose tension most closely fits the decision; if no clear match, use the default pair (last row). Each lens is a generic, predictable analytical position — pairs are deliberate counterweights so the angles are guaranteed orthogonal.
+
+| Decision keywords | Pair | Tension |
+|---|---|---|
+| api, contract, schema, protocol, types, abstraction | **Formal Systems** ↔ **Incentive Realist** | What can be mechanized vs how actors actually behave |
+| ship, release, launch, ready, when, timing, iterate | **Ship Now** ↔ **Strategic Timing** | Pragmatic urgency vs decisive moment |
+| bug, recurring, regression, leak, debt, again, repeat | **Direct Fix** ↔ **Systems Thinker** | Solve the symptom vs redesign the feedback loop |
+| scale, risk, failure, outage, fault, rare, edge, tail | **Common Path** ↔ **Tail-Risk** | Optimise the 95% case vs rare catastrophic dominates cost |
+| ux, user, interface, customer, configure, options | **User-Centric** ↔ **Capability-First** | Less but better vs expose the power |
+| structure, hierarchy, taxonomy, monolith, microservices, organise | **Classifier** ↔ **Emergence** | Predictable categories vs let structure emerge |
+| design, approach, strategy, architecture _(default)_ | **Assumption Destroyer** ↔ **First-Principles** | Top-down questioning vs bottom-up rebuilding |
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-This decision has {N} genuinely viable approaches. Want to explore them in depth?
+This decision sits on a {tension description} tension. Want to explore both lenses?
 
-- **`y`/`yes`** — Spin up perspective agents to argue each position
+- **`y`/`yes`** — Spin up perspective agents arguing each lens
 - **`n`/`no`** — Continue without perspectives
 · · · · · · · · · · · ·
 ```
@@ -71,10 +81,10 @@ Dispatch **all perspective agents in parallel** via the Task tool with `run_in_b
 
 Each perspective agent receives:
 
-1. **Perspective** — the specific angle to advocate
+1. **Lens** — the assigned lens from the polarity pair (e.g., `Formal Systems`, `Tail-Risk`)
 2. **Decision topic** — the decision being explored
 3. **Discussion file path** — `.workflows/{work_unit}/discussion/{topic}.md`
-4. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/perspective-{NNN}-{angle}.md`
+4. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/perspective-{NNN}-{lens}.md`
 5. **Frontmatter** — the frontmatter block to write:
    ```yaml
    ---
@@ -82,23 +92,24 @@ Each perspective agent receives:
    status: pending
    created: {date}
    set: {NNN}
-   perspective: {angle}
+   lens: {lens}
    decision: {decision topic}
    ---
    ```
 
-Each perspective agent returns:
+Each perspective agent restates the decision through its lens before arguing (Problem Restate Gate) and returns:
 
 ```
 STATUS: complete
-PERSPECTIVE: {angle}
+LENS: {lens}
+RESTATEMENT: {one sentence}
 SUMMARY: {1 sentence}
 ```
 
 > *Output the next fenced block as a code block:*
 
 ```
-Dispatched {N} perspective agents: {angle1}, {angle2}, {angle3}.
+Dispatched 2 perspective agents: {lens A}, {lens B}.
 Results will be surfaced when available.
 ```
 
@@ -134,6 +145,8 @@ The synthesis agent receives:
    ```
 
 The sub-agent writes tension entries with stable IDs (`T1`, `T2`, …) into the `tensions:` list. See `agents/workflow-discussion-synthesis.md` for the schema.
+
+The synthesis agent also compares the Restatement sections from each perspective. If lenses diverge meaningfully on what the decision IS — different scope, different question, or one lens answering an unasked question — synthesis records a **Framing alignment** tension as `T1` so it surfaces first. This is the Problem Restate Gate's payoff: wrong-question failures get caught before the user acts on a tradeoff landscape.
 
 The synthesis agent returns:
 


### PR DESCRIPTION
## Summary

Strengthen the perspective agent system in the discussion phase with three mechanics borrowed from Council of High Intelligence — without adopting its persona model or multi-provider machinery.

- **Polarity-pair selection** replaces the ad-hoc "identify 2-3 distinct perspectives" with a keyword-keyed table of generic lens pairs (Formal Systems / Incentive Realist, Ship Now / Strategic Timing, Tail-Risk / Common Path, etc.). Pairs guarantee orthogonal angles; lenses are predictable, not contrived.
- **Problem Restate Gate** — perspective agents restate the decision through their lens before arguing. Synthesis runs a framing check across restatements; significant divergence becomes a `Framing alignment` tension at `T1` and surfaces first via the existing never-dump protocol. Wrong-question failures get caught before the user acts on a tradeoff.
- **Synthesis leads with Unresolved Questions** — body reorders so what the council can't answer appears before what it can.

No new skills, no new commands, no migrations. Three files touched: `perspective-agents.md` reference, `workflow-discussion-perspective.md` agent, `workflow-discussion-synthesis.md` agent.

## Test plan

- [ ] Trigger perspective agents in a real discussion session and confirm the polarity-pair menu renders with the matched tension description
- [ ] Verify both agents write a `## Restatement` section as the first body section in their cache file
- [ ] Confirm STATUS lines include the new `LENS:` and `RESTATEMENT:` fields
- [ ] Force divergent restatements (e.g., one lens reframes scope) and verify synthesis writes a `T1: Framing alignment` tension
- [ ] Confirm aligned restatements produce no Framing alignment tension and `T1` is the first tradeoff
- [ ] Verify synthesis body opens with `Unresolved Questions` after the perspectives table
- [ ] Confirm the never-dump surfacing protocol still functions — synthesis tensions surface one at a time at natural breaks