### PR TITLE
chore(conventions): formalise menu single-source and prelude conditional patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,8 @@ Select an option (enter number):
 · · · · · · · · · · · ·
 ```
 
+**Single source of truth** — items appear once, inside the menu. Do not display items as a numbered list (or tree) above the menu and then re-list them as numbered options below. The menu IS the display. Sub-detail (statuses, sources, plan progress) goes inline on each option using `[term]` or `— description`. The exception is when items have rich multi-line child detail (blocking reasons, dependency chains) that genuinely doesn't fit a one-line option — in that case keep the tree display and reference it from a short prompt below, but this should be rare.
+
 **Yes/no prompt:**
 
 ```
@@ -649,6 +651,22 @@ Use H4 headings for if/else branches within a step:
 ...
 ```
 
+**Prelude and post-STOP exception** — at file prelude (above any `## A.` lettered section) and immediately after STOP-gate responses, bold `**If ...:**` is acceptable for top-level conditionals. H4 in these positions visually competes with the lettered section headings that follow, and disrupts the prelude flow. Inside a lettered section's body, top-level conditionals stay H4.
+
+```
+**Trigger checklist** — evaluate after every commit:
+- □ Meaningful content committed?
+- □ All prior reviews drained?
+
+**If all checked:**
+
+→ Proceed to **A. Dispatch**.
+
+**If any unchecked:**
+
+No dispatch needed. Continue with the session loop.
+```
+
 Rules:
 - Never use else-if chains — each condition gets its own `#### If` heading
 - Lowercase after "If" (e.g., `#### If completed_count == 1`)
@@ -656,7 +674,7 @@ Rules:
 - Use backticks around specific values, variables, and statuses in H4 headings (e.g., `` #### If `STATUS` is `clean` ``, `` #### If work type is `feature` ``). Natural language conditions stay plain text (e.g., `#### If no plan provided`)
 - Use "and" between conditions, not commas
 - Drop implied conditions (e.g., if Step 2 already gates on `completed_count >= 1`, Step 3 doesn't need to repeat it on every branch)
-- H4 for top-level conditionals, bold text for nested — never use H5/H6 for conditional nesting
+- H4 for top-level conditionals inside lettered sections, bold text for nested or for prelude/post-STOP positions — never use H5/H6 for conditional nesting
 - If double-nesting would occur, flatten by combining the parent and child conditions into a single bold conditional
 - Every conditional branch must include its own routing instruction (`→ Proceed to` or `→ Return to`). Never place routing outside a conditional expecting it to apply to all branches — each branch is self-contained. Even if multiple branches route to the same destination, each states it explicitly.
 

--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -53,6 +53,6 @@ Leverage multiple AI models by dispatching work to the best model for each task 
 
 | # | Idea | Scope |
 |---|------|-------|
-| 13 | [Selection Menu Display Pattern](selection-menu-pattern.md) | All selection menus across skills |
-| 14 | [Background Sub-Agents in Research](research-background-agents.md) | Research processing skill |
-| 15 | [Top-Level Conditional Routing: Bold vs H4](top-level-conditional-routing.md) | Convention drift across ~53 skill files |
+| 13 | ~~[Selection Menu Display Pattern](selection-menu-pattern.md)~~ | All selection menus across skills | ✅ Done |
+| 14 | ~~[Background Sub-Agents in Research](research-background-agents.md)~~ | Research processing skill | ✅ Done (superseded by deep-dive-agent) |
+| 15 | ~~[Top-Level Conditional Routing: Bold vs H4](top-level-conditional-routing.md)~~ | Convention drift across ~53 skill files | ✅ Done |

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -426,38 +426,23 @@ Store the selected phase and topic.
 
 Display pending discussion topics from both research analysis and discussion gap analysis. Uses `pending_from_research` and `pending_from_gaps` from discovery output.
 
-> *Output the next fenced block as a code block:*
-
-```
-Pending Discussion Topics
-
-Topics identified by research analysis and discussion
-gap analysis that have not yet been discussed.
-
-@foreach(topic in pending_from_research)
-  {N}. {topic.name:(titlecase)} [from research]
-@endforeach
-@foreach(topic in pending_from_gaps)
-  {N}. {topic.name:(titlecase)} [from gap analysis]
-@endforeach
-```
-
 Number all topics sequentially across both lists. Track the source of each item for routing the skip action.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Start a discussion for a pending topic, or skip one:
+Pending discussion topics from research and gap analysis.
+Start a discussion for one, or skip:
 
-- **`1`** — Start discussion for "{topic_1.name:(titlecase)}"
-- **`2`** — Start discussion for "{topic_2.name:(titlecase)}"
+- **`1`** — Start discussion for "{topic_1.name:(titlecase)}" [from research]
+- **`2`** — Start discussion for "{topic_2.name:(titlecase)}" [from gap analysis]
 - **`s`/`skip`** — Remove a topic from pending list
 - **`b`/`back`** — Return to menu
 · · · · · · · · · · · ·
 ```
 
-Numbered items correspond to the list above. Recreate with actual topics from discovery.
+Recreate the numbered options with actual topics from discovery, preserving the source marker (`[from research]` or `[from gap analysis]`) on each.
 
 **STOP.** Wait for user response.
 


### PR DESCRIPTION
## Summary

- Documents the bold-conditional pattern already in use across ~56 skill files at prelude positions and post-STOP responses, where H4 would visually compete with the lettered section headings that follow.
- Adds a single-source-of-truth rule to the Menus section forbidding tree+menu duplication; fixes the one outlier in `epic-display-and-menu.md` section G by collapsing the duplicated list into a single menu with inline source markers.
- Marks ideas #13 and #15 done; #14 superseded by the existing deep-dive-agent feature.

## Test plan

- [ ] Skim CLAUDE.md Conditional Routing section — exception reads cleanly and the rule summary update lines up
- [ ] Skim CLAUDE.md Menus / Interactive Prompts section — single-source-of-truth rule slots in naturally
- [ ] Walk a continue-epic flow that hits Manage Pending — single menu renders correctly, source markers present

🤖 Generated with [Claude Code](https://claude.com/claude-code)