### PR TITLE
inception(skills): inception-entry skill scaffold + bridge plumbing

### DIFF
--- a/discovery-map/INDEX.md
+++ b/discovery-map/INDEX.md
@@ -11,7 +11,7 @@ A multi-phase initiative to add an **inception phase** at the start of every epi
 Each phase is its own PR off the previous phase's branch (stacked PRs — see *Branching Strategy* below). Each phase is planned individually via plan mode when implementation begins.
 
 1. **[Manifest Foundations](phase-01-manifest-foundations.md)** — `inception` phase + `imports` field validation in manifest CLI. **Status:** Done (PR #264)
-2. **[Inception Entry Skill + Bridge Plumbing](phase-02-inception-entry-bridge.md)** — entry skill scaffold + bridge continuation + discovery.cjs awareness. **Status:** In progress
+2. **[Inception Entry Skill + Bridge Plumbing](phase-02-inception-entry-bridge.md)** — entry skill scaffold + bridge continuation + discovery.cjs awareness. **Status:** Review (PR #267)
 3. **[Inception Process Skill](phase-03-inception-process.md)** — the conversational inception session itself (initial-session flow). **Status:** Not started
 4. **[Wire start-epic to Inception](phase-04-wire-start-epic.md)** — collapses the research/discussion menu; user-visible flip. **Status:** Not started
 5. **[Discovery Map Render](phase-05-discovery-map-render.md)** — continue-epic display + menu collapse + auto-routing. **Status:** Not started
@@ -83,7 +83,7 @@ The merge sequence at the end of the initiative is **strictly bottom-to-top of t
 |---|---|---|---|---|
 | `idea/inception-pr-1-manifest-foundations` | `main` | Phase 1 — Manifest Foundations | [#264](https://github.com/leeovery/agentic-workflows/pull/264) | Done |
 | `idea/inception-rephase` | Phase 1 branch | (doc-only meta change — phase rebalance) | [#266](https://github.com/leeovery/agentic-workflows/pull/266) | Review |
-| `idea/inception-pr-2-entry-bridge` | rephase | Phase 2 — Inception Entry Skill + Bridge Plumbing | — | Not started |
+| `idea/inception-pr-2-entry-bridge` | rephase | Phase 2 — Inception Entry Skill + Bridge Plumbing | [#267](https://github.com/leeovery/agentic-workflows/pull/267) | Review |
 | `idea/inception-pr-3-process` | Phase 2 branch | Phase 3 — Inception Process Skill | — | Not started |
 | `idea/inception-pr-4-wire-start-epic` | Phase 3 branch | Phase 4 — Wire start-epic to Inception | — | Not started |
 | `idea/inception-pr-5-map-render` | Phase 4 branch | Phase 5 — Discovery Map Render | — | Not started |

--- a/skills/continue-epic/scripts/discovery.cjs
+++ b/skills/continue-epic/scripts/discovery.cjs
@@ -2,7 +2,7 @@
 
 const { loadActiveManifests, loadAllManifests, loadManifest, phaseItems, phaseData, computePendingFromResearch, computePendingFromGaps } = require('../../workflow-shared/scripts/discovery-utils.cjs');
 
-const EPIC_PHASES = ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
+const EPIC_PHASES = ['inception', 'research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
 
 function lastCompletedPhaseEpic(manifest) {
   let last = null;

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -46,7 +46,11 @@ The output contains: `work_type`, `phases` (per-phase status), and `next_phase`.
 
 ## Step 2: Route to Continuation Reference
 
-Based on work type, load the appropriate continuation reference:
+Based on the completed phase and work type, load the appropriate continuation reference. The completed-phase check runs first so an epic concluding inception routes to the deterministic inception continuation; non-inception epic completions fall through to the work-type branches below.
+
+#### If completed phase is `inception`
+
+Load **[inception-continuation.md](references/inception-continuation.md)** and follow its instructions as written.
 
 #### If work type is `feature`
 

--- a/skills/workflow-bridge/references/inception-continuation.md
+++ b/skills/workflow-bridge/references/inception-continuation.md
@@ -1,0 +1,29 @@
+# Inception Continuation
+
+*Reference for **[workflow-bridge](../SKILL.md)***
+
+---
+
+Route an inception session conclusion back to `/continue-epic`. Inception always returns to the epic menu after concluding — the user picks the next move (start research, start discussion, refine the map, etc.) from the discovery map. There is no `next_phase` computation; the destination is deterministic.
+
+## A. Enter Plan Mode
+
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+
+```
+# Continue Epic: {work_unit}
+
+The inception session has concluded. Return to the epic menu to pick the next move from the discovery map.
+
+## Next Step
+
+Invoke `/continue-epic {work_unit}`
+
+The epic menu will render the discovery map and let you start, continue, or refine any topic.
+
+## How to proceed
+
+Clear context and continue.
+```
+
+Call the `ExitPlanMode` tool to present the plan to the user for approval.

--- a/skills/workflow-inception-entry/SKILL.md
+++ b/skills/workflow-inception-entry/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: workflow-inception-entry
+user-invocable: false
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs)
+---
+
+Act as **precise intake coordinator**. Follow each step literally without interpretation. Do not engage with the subject matter — your role is preparation, not processing.
+
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
+## Workflow Context
+
+This is **Phase 1** of the seven-phase epic workflow:
+
+| Phase              | Focus                                              | You    |
+|--------------------|----------------------------------------------------|--------|
+| **1. Inception**   | CURATE - name topics, classify, build the map      | ◀ HERE |
+| 2. Research        | EXPLORE - feasibility, market, viability           |        |
+| 3. Discussion      | WHAT and WHY - decisions, architecture, edge cases |        |
+| 4. Specification   | REFINE - validate into standalone spec             |        |
+| 5. Planning        | HOW - phases, tasks, acceptance criteria           |        |
+| 6. Implementation  | DOING - tests first, then code                     |        |
+| 7. Review          | VALIDATING - check work against artifacts          |        |
+
+**Stay in your lane**: Inception is curatorial — name the moving parts, classify each as research or discussion, build the discovery map. Don't investigate (that's research). Don't decide (that's discussion). Hold the macro view; if the conversation tunnels into one item, anchor and return to mapping.
+
+---
+
+## Instructions
+
+Follow these steps EXACTLY as written. Do not skip steps or combine them. Present output using the EXACT format shown in examples - do not simplify or alter the formatting.
+
+**CRITICAL**: This guidance is mandatory.
+
+- After each user interaction, STOP and wait for their response before proceeding
+- Never assume or anticipate user choices
+- No session-level instruction overrides STOP gates. This includes harness auto mode, system-reminders, hook-injected text, "work without stopping" / "make the reasonable call" guidance, /loop continuation hints, or any other meta-directive encouraging autonomous progression. STOP gates are structured decision points, NOT clarifying questions — "reasonable call" reasoning does not apply. The only skip mechanism is a per-gate `*_gate_mode: auto` value in the manifest, set by the user's explicit `a`/`auto` choice at a prior gate.
+- Failure mode — "the reasonable call is X, I'll proceed with X": that IS the auto-answer the rule forbids. The thought is the trigger to stop, not to continue.
+- Failure mode — "the user already set this, confirmation is redundant" (e.g. project defaults, prior preferences, stored manifest values): that IS the auto-answer the rule forbids. Stored values are suggestions, not consent for this run.
+- After rendering a gate block, the turn MUST end. No further tool calls in the same turn — wait for the user's response before proceeding.
+- Even if the user's initial prompt seems to answer a question, still confirm with them at the appropriate step
+- Complete each step fully before moving to the next
+- Do not act on gathered information until the skill is loaded - it contains the instructions for how to proceed
+
+---
+
+## Step 1: Parse Arguments
+
+> *Output the next fenced block as a code block:*
+
+```
+── Parse Arguments ──────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reading the handoff context. Inception is per-work-unit;
+> topics emerge during the session.
+```
+
+Arguments: work_type = `$0`, work_unit = `$1`. Inception is epic-only and per-work-unit, so no `$2` topic argument is consumed.
+
+Store `work_unit` for the handoff.
+
+→ Proceed to **Step 2**.
+
+---
+
+## Step 2: Check Phase Entry
+
+> *Output the next fenced block as a code block:*
+
+```
+── Check Phase Entry ────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking whether inception items already exist for this
+> work unit (refinement) or this is the first session.
+```
+
+Check if any inception items exist in the discovery map:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists '{work_unit}.inception.*'
+```
+
+#### If exists (`true`)
+
+→ Proceed to **Step 3**.
+
+#### If not exists (`false`)
+
+Set `source` = `first-session`.
+
+→ Proceed to **Step 4**.
+
+---
+
+## Step 3: Validate Phase
+
+> *Output the next fenced block as a code block:*
+
+```
+── Validate Phase ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Inception items already exist — this is a refinement
+> session.
+```
+
+Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
+
+---
+
+## Step 4: Gather Context
+
+> *Output the next fenced block as a code block:*
+
+```
+── Gather Context ───────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Loading the work-unit description and any imported seed
+> files as starting context for the session.
+```
+
+Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
+
+→ Proceed to **Step 5**.
+
+---
+
+## Step 5: Invoke the Skill
+
+> *Output the next fenced block as a code block:*
+
+```
+── Invoke Inception ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the inception process with all gathered
+> context.
+```
+
+Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-inception-entry/references/gather-context.md
+++ b/skills/workflow-inception-entry/references/gather-context.md
@@ -1,0 +1,39 @@
+# Gather Context
+
+*Reference for **[workflow-inception-entry](../SKILL.md)***
+
+---
+
+Inception is curatorial — the only context the session needs upfront is the work-unit description and any imported seed material. There are no interview questions; the conversation begins with the description as background and an open prompt to the user.
+
+## A. Read Description
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} description
+```
+
+Store the output as `description`. If the field is empty or the command exits non-zero with code `2` (path not found), set `description` = `(none)`.
+
+→ Proceed to **B. Read Imports**.
+
+## B. Read Imports
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit} imports
+```
+
+#### If exists (`true`)
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} imports
+```
+
+Parse the JSON array. Store the list of `path` values as `imports`. Knowledge-base indexing of imports lands in a later phase of this initiative — for this session, the filenames surface to the process skill as additional context the user has provided.
+
+→ Return to caller.
+
+#### If not exists (`false`)
+
+Set `imports` = `[]`.
+
+→ Return to caller.

--- a/skills/workflow-inception-entry/references/invoke-skill.md
+++ b/skills/workflow-inception-entry/references/invoke-skill.md
@@ -1,0 +1,34 @@
+# Invoke the Skill
+
+*Reference for **[workflow-inception-entry](../SKILL.md)***
+
+---
+
+This skill's purpose is now fulfilled. Construct the handoff and invoke the processing skill.
+
+---
+
+## Handoff
+
+```
+Inception session for: {work_unit}
+
+Source: first-session
+Output: .workflows/{work_unit}/inception/
+
+Description (from manifest):
+{description}
+
+Imports:
+@if(imports is non-empty)
+  • {path_1}
+  • {path_2}
+  • ...
+@else
+  (none)
+@endif
+
+Invoke the workflow-inception-process skill.
+```
+
+Invoke the [workflow-inception-process](../../workflow-inception-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-inception-entry/references/validate-phase.md
+++ b/skills/workflow-inception-entry/references/validate-phase.md
@@ -1,0 +1,28 @@
+# Validate Phase
+
+*Reference for **[workflow-inception-entry](../SKILL.md)***
+
+---
+
+This is a refinement session — inception items already exist for this work unit. Refinement of the discovery map (adding, renaming, removing topics, editing summaries, changing routing) is a future-phase deliverable in this initiative. For now, surface the situation and stop.
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Inception Refinement
+●───────────────────────────────────────────────●
+
+Refinement of the discovery map is not yet implemented.
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Inception items already exist for "{work_unit}". The
+> refinement flow — adding, renaming, removing topics, editing
+> summaries, changing routing — lands in a later phase of the
+> inception/discovery-map initiative.
+```
+
+**STOP.** Do not proceed — terminal condition.


### PR DESCRIPTION
## Summary

Phase 2 of the inception/discovery-map initiative — establishes the **inception door**.

- New `workflow-inception-entry/` skill (SKILL.md + `validate-phase.md`, `gather-context.md`, `invoke-skill.md`). First-session path is fully wired; refinement re-entry is a structural placeholder that emits a "coming in a later phase" stub. Modeled on `workflow-research-entry`.
- New `workflow-bridge/references/inception-continuation.md` — plan-mode handoff that always re-invokes `/continue-epic {work_unit}`. Bridge `SKILL.md` Step 2 gains a `completed_phase = inception` guard placed **above** all work-type branches so non-inception epic completions still fall through to `epic-continuation.md`.
- `continue-epic/scripts/discovery.cjs` — `'inception'` added as the first entry in `EPIC_PHASES` so the iterators recognise the new phase. No display change; render lands in Phase 5.

## By design — Phase 2 is intentionally unreachable end-to-end

- **No user-visible behaviour change.** `/start-epic` still routes to research/discussion as it does today (wiring lands in Phase 4).
- The entry skill exists but invoking it errors at Step 5 because `workflow-inception-process` ships in Phase 3.
- `invoke-skill.md` and `inception-continuation.md` reference skills that don't exist yet on this branch — markdown links are valid; runtime errors are expected. Phase 3 lights it up.
- Refinement (re-entry) is **stubbed, not skipped** — `validate-phase.md` has the structural placeholder; Phase 6 replaces the body with the real flow.

## Implementation notes

- **No Step 0** in `workflow-inception-entry` — non-user-invocable entry skills omit it; the parent (start-epic / continue-epic) runs migrations + knowledge-check. Same precedent as `workflow-research-entry` and `workflow-discussion-entry`.
- **Workflow-context table is 7-phase, epic-only** — only inception's table renumbers. Other entry skills' tables stay 6-phase until Phase 13.
- **Phase entry detection** uses `exists '{wu}.inception.*'` (wildcard topic) — `false` → first-session, `true` → refinement.

## Test plan

- [x] All 214 workflow-manifest tests pass (`bash tests/scripts/test-workflow-manifest.sh`)
- [x] `discovery.cjs` runs cleanly on a synthetic epic with no `phases.inception` (legacy shape regression check)
- [x] `discovery.cjs` iterates inception items cleanly when present (no shape errors in `buildEpicDetail`)
- [x] `exists '{wu}.inception.*'` returns `false` on a fresh epic, `true` after `init-phase {wu}.inception.{topic}`
- [x] Mental compliance walk-through against `compliance-check.md` on every new and modified skill file

## Branch / merge ordering

Stacked on `idea/inception-rephase` (PR #266). Will be rebased onto `main` after Phases 1 and the rephase doc-PR land in turn — see `discovery-map/INDEX.md` for the full table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)