### PR TITLE
inception phase 4: wire start-epic to inception

### DIFF
--- a/discovery-map/INDEX.md
+++ b/discovery-map/INDEX.md
@@ -13,7 +13,7 @@ Each phase is its own PR off the previous phase's branch (stacked PRs — see *B
 1. **[Manifest Foundations](phase-01-manifest-foundations.md)** — `inception` phase + `imports` field validation in manifest CLI. **Status:** Done (PR #264)
 2. **[Inception Entry Skill + Bridge Plumbing](phase-02-inception-entry-bridge.md)** — entry skill scaffold + bridge continuation + discovery.cjs awareness. **Status:** Review (PR #267)
 3. **[Inception Process Skill](phase-03-inception-process.md)** — the conversational inception session itself (initial-session flow). **Status:** Review (PR #268)
-4. **[Wire start-epic to Inception](phase-04-wire-start-epic.md)** — collapses the research/discussion menu; user-visible flip. **Status:** Not started
+4. **[Wire start-epic to Inception](phase-04-wire-start-epic.md)** — collapses the research/discussion menu; user-visible flip. **Status:** Review (PR #269)
 5. **[Discovery Map Render](phase-05-discovery-map-render.md)** — continue-epic display + menu collapse + auto-routing. **Status:** Not started
 6. **[Refinement Session](phase-06-refinement-session.md)** — re-entry path, map editing operations, safety-by-destructiveness. **Status:** Not started
 7. **[Self-Healing Re-point](phase-07-self-healing.md)** — research-analysis and gap-analysis re-point to map at continue-epic boot-up. **Status:** Not started
@@ -85,7 +85,7 @@ The merge sequence at the end of the initiative is **strictly bottom-to-top of t
 | `idea/inception-rephase` | Phase 1 branch | (doc-only meta change — phase rebalance) | [#266](https://github.com/leeovery/agentic-workflows/pull/266) | Review |
 | `idea/inception-pr-2-entry-bridge` | rephase | Phase 2 — Inception Entry Skill + Bridge Plumbing | [#267](https://github.com/leeovery/agentic-workflows/pull/267) | Review |
 | `idea/inception-pr-3-process` | Phase 2 branch | Phase 3 — Inception Process Skill | [#268](https://github.com/leeovery/agentic-workflows/pull/268) | Review |
-| `idea/inception-pr-4-wire-start-epic` | Phase 3 branch | Phase 4 — Wire start-epic to Inception | — | Not started |
+| `idea/inception-pr-4-wire-start-epic` | Phase 3 branch | Phase 4 — Wire start-epic to Inception | [#269](https://github.com/leeovery/agentic-workflows/pull/269) | Review |
 | `idea/inception-pr-5-map-render` | Phase 4 branch | Phase 5 — Discovery Map Render | — | Not started |
 | `idea/inception-pr-6-refinement` | Phase 5 branch | Phase 6 — Refinement Session | — | Not started |
 | `idea/inception-pr-7-self-healing` | Phase 6 branch | Phase 7 — Self-Healing Re-point | — | Not started |

--- a/skills/start-epic/SKILL.md
+++ b/skills/start-epic/SKILL.md
@@ -74,8 +74,8 @@ Invoke the `/workflow-migrate` skill and follow its instructions exactly — if 
 
 ```
 > Starting a new epic. I'll ask what you're building, suggest
-> a name, then you'll choose whether to research first or go
-> straight to discussion.
+> a name, then we'll begin an inception session to map the
+> topics.
 ```
 
 Load **[knowledge-check.md](../workflow-knowledge/references/knowledge-check.md)** and follow its instructions as written.
@@ -166,15 +166,14 @@ Load **[route-first-phase.md](references/route-first-phase.md)** and follow its 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Handing off to the selected phase. The next skill will load
-> and guide you through the process.
+> Handing off to inception. The next skill will load and
+> guide the session.
 ```
 
-Invoke the appropriate entry-point skill based on the selected phase:
+Invoke the inception entry skill:
 
 | Phase | Invoke |
 |-------|--------|
-| research | `/workflow-research-entry epic {work_unit}` |
-| discussion | `/workflow-discussion-entry epic {work_unit}` |
+| inception | `/workflow-inception-entry epic {work_unit}` |
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.

--- a/skills/start-epic/references/collect-import.md
+++ b/skills/start-epic/references/collect-import.md
@@ -4,7 +4,7 @@
 
 ---
 
-Gather the file paths to import. No topic naming needed — epic research imports into the default exploration file.
+Gather the file paths to import, then copy each into `.workflows/{work_unit}/imports/` and record it on the manifest's `imports[]` array. The inception session will read these as the conversation launchpad.
 
 > *Output the next fenced block as a code block:*
 
@@ -16,7 +16,7 @@ Gather the file paths to import. No topic naming needed — epic research import
 
 ```
 > Provide the path(s) to the files you want to import.
-> Content will be ingested verbatim — no summarization.
+> Content will be copied verbatim — no summarisation.
 
 · · · · · · · · · · · ·
 Which files should be imported?
@@ -29,6 +29,19 @@ Which files should be imported?
 
 Validate each path exists. If any are missing, report which ones and ask again.
 
-Store the validated paths as `import_files`.
+Once all paths are valid, ensure the imports directory exists:
+
+```bash
+mkdir -p .workflows/{work_unit}/imports/
+```
+
+For each validated path, copy the file and record it on the manifest:
+
+```bash
+cp <path> .workflows/{work_unit}/imports/<basename>
+node .claude/skills/workflow-manifest/scripts/manifest.cjs push {work_unit} imports '{"path":"imports/<basename>","imported_at":"<iso>"}'
+```
+
+Where `<iso>` is the current UTC timestamp in ISO 8601 (`date -u +%Y-%m-%dT%H:%M:%SZ`). Use one timestamp per file, generated at copy time.
 
 → Return to caller.

--- a/skills/start-epic/references/route-first-phase.md
+++ b/skills/start-epic/references/route-first-phase.md
@@ -4,22 +4,22 @@
 
 ---
 
-Let the user choose whether to start with research or go directly to discussion.
+New epics route to inception. The only branch here is whether the user wants to import seed material first.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Choose your starting point. Research is open-ended exploration
-> — gather context, weigh options, no commitments. Discussion is
-> structured conversation that works toward decisions. If you're
-> unsure, research is a safe place to start.
+> Inception is a short conversational session that surfaces
+> the topics this epic will cover and tags each as research
+> or discussion. If you have existing notes or research files,
+> you can import them first — they become the launchpad for
+> the session.
 
 · · · · · · · · · · · ·
 How would you like to start?
 
-- **`r`/`research`** — Explore ideas and options first, no decisions yet
-- **`d`/`discussion`** — Ready to discuss and make decisions
-- **`i`/`import`** — Import existing research files verbatim
+- **`c`/`continue`** — Begin the inception session now
+- **`i`/`import`** — Import existing files first, then begin inception
 
 Select an option:
 · · · · · · · · · · · ·
@@ -27,22 +27,12 @@ Select an option:
 
 **STOP.** Wait for user response.
 
-#### If user chooses research
-
-Set phase="research".
-
-→ Return to caller.
-
-#### If user chooses discussion
-
-Set phase="discussion".
+#### If user chooses continue
 
 → Return to caller.
 
 #### If user chooses import
 
 Load **[collect-import.md](collect-import.md)** and follow its instructions as written.
-
-Set phase="research" and source="import".
 
 → Return to caller.

--- a/skills/workflow-inception-process/references/session-loop.md
+++ b/skills/workflow-inception-process/references/session-loop.md
@@ -29,6 +29,33 @@ Where do you want to take it from here?
 
 → Proceed to **B. Session Loop**.
 
+#### If imports exist
+
+Check for imports:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit} imports
+```
+
+If `true`, read each file listed under `manifest.imports[]` (paths are relative to `.workflows/{work_unit}/`). Use the import content as the conversation launchpad: reflect what's actually in the seed material, propose tentative topic shapes drawn from it, and ask which to develop first. Don't dump the imports back at the user verbatim — synthesise.
+
+> *Output the next fenced block as a code block:*
+
+```
+Read your import(s). Here's what I'm picking up so far:
+
+  • {tentative-topic-1} — {one-line shape inferred from seed}
+  • {tentative-topic-2} — {one-line shape inferred from seed}
+
+These are openers, not commitments. Which would you like
+to develop first, or is there something else in there I
+should be reading differently?
+```
+
+**STOP.** Wait for user response.
+
+→ Proceed to **B. Session Loop**.
+
 #### Otherwise
 
 Fresh start. The work-unit description has been read silently — don't narrate or summarise it back. Open with this prompt:

--- a/skills/workflow-inception-process/references/session-loop.md
+++ b/skills/workflow-inception-process/references/session-loop.md
@@ -29,7 +29,7 @@ Where do you want to take it from here?
 
 → Proceed to **B. Session Loop**.
 
-#### If imports exist
+#### If **Topics Identified** is empty and imports exist
 
 Check for imports:
 


### PR DESCRIPTION
## Summary

Phase 4 of the inception/discovery-map initiative — first user-visible flip of the new flow.

- `/start-epic` Step 3 collapses to a 2-option menu: continue to inception (default) or `i`/`import` first.
- Step 4 always invokes `/workflow-inception-entry epic {work_unit}` (single row).
- `i`/`import` route preserved but rerouted: imports land in `.workflows/{wu}/imports/` and are recorded on `manifest.imports[]` (`{path, imported_at}`). KB indexing comes in Phase 8.
- Session-loop Section A gets a third branch: when Topics Identified is empty and imports exist, the inception session reads imports and reflects them as the launchpad rather than the generic "tell me what to build" prompt.

After this PR, new epics go through inception when started.

## Test plan

- [ ] `bash tests/scripts/test-workflow-manifest.sh` — passes (214/214 — verified locally)
- [ ] `node skills/continue-epic/scripts/discovery.cjs` runs cleanly on a fresh dir (verified locally)
- [ ] End-to-end smoke (no import path): `/start-epic` → describe → name → land directly in inception session; topics persist with right shape; bridge fires; `/continue-epic` doesn't error
- [ ] End-to-end smoke (import path): `i`/`import` → seed file → imports/ populated → manifest.imports[] has entry → inception opens with import content reflected
- [ ] Inbox-path smoke: positional arg → inbox content used as description → continue-or-import menu still appears → on continue, inception opens

## Out of scope

Map render in continue-epic (Phase 5), KB indexing of imports + feature import behaviour change (Phase 8), removing route-first-phase.md (Phase 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)