### PR TITLE
inception(phase-10): direct-entry auto-add via shared ensure-inception-item ref

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,15 @@ Always create a feature branch **before** the first commit. Never commit to main
 
 ## Workflow Phases
 
-1. **Research** (`workflow-research-process`): EXPLORE — feasibility, market, viability, early ideas. Import existing research verbatim via `i`/`import` at phase selection (epic, feature). Background review agent for topical gaps; document review reconciles session against research file to catch undocumented substance (both mandatory before conclusion); deep-dive agents for independent thread investigation.
-2. **Discussion** (`workflow-discussion-process`): Organic conversation guided by a live Discussion Map (`pending` → `exploring` → `converging` → `decided`). Background review agent for topical gaps; document review reconciles session against discussion file to catch undocumented substance (both mandatory before conclusion). Topic elevation seeds sibling discussions (epics only). Discussion gap analysis (epics only) reads all completed discussions holistically to surface cross-discussion themes, elevated-but-uncreated topics, emergent topics, integration gaps — cached and manifest-tracked under `phases.discussion`.
-3. **Investigation** (`workflow-investigation-process`): Bugfix-specific — symptom gathering + code analysis → root cause.
-4. **Scoping** (`workflow-scoping-process`): Quick-fix-specific — context, spec, plan in one pass.
-5. **Specification** (`workflow-specification-process`): Validate and refine into standalone spec.
-6. **Planning** (`workflow-planning-process`): Define HOW — phases, tasks, acceptance criteria.
-7. **Implementation** (`workflow-implementation-process`): Execute plan via TDD (or verification workflow for quick-fix).
-8. **Review** (`workflow-review-process`): Validate work against discussion, specification, plan.
+1. **Inception** (`workflow-inception-process`): CURATE — epic-only. Name topics, classify each as research or discussion, build the discovery map. Refinement session for add/dismiss/edit-summary/change-routing/split/elevate; self-healing dispatch for research-analysis and discussion-gap-analysis caches; direct-entry items land here with `source: direct-start`.
+2. **Research** (`workflow-research-process`): EXPLORE — feasibility, market, viability, early ideas. Import existing research verbatim via `i`/`import` at phase selection (epic, feature). Background review agent for topical gaps; document review reconciles session against research file to catch undocumented substance (both mandatory before conclusion); deep-dive agents for independent thread investigation.
+3. **Discussion** (`workflow-discussion-process`): Organic conversation guided by a live Discussion Map (`pending` → `exploring` → `converging` → `decided`). Background review agent for topical gaps; document review reconciles session against discussion file to catch undocumented substance (both mandatory before conclusion). Topic elevation seeds sibling discussions (epics only). Discussion gap analysis (epics only) reads all completed discussions holistically to surface cross-discussion themes, elevated-but-uncreated topics, emergent topics, integration gaps — cached and manifest-tracked under `phases.discussion`.
+4. **Investigation** (`workflow-investigation-process`): Bugfix-specific — symptom gathering + code analysis → root cause.
+5. **Scoping** (`workflow-scoping-process`): Quick-fix-specific — context, spec, plan in one pass.
+6. **Specification** (`workflow-specification-process`): Validate and refine into standalone spec.
+7. **Planning** (`workflow-planning-process`): Define HOW — phases, tasks, acceptance criteria.
+8. **Implementation** (`workflow-implementation-process`): Execute plan via TDD (or verification workflow for quick-fix).
+9. **Review** (`workflow-review-process`): Validate work against discussion, specification, plan.
 
 ## Skill Architecture
 
@@ -54,7 +55,7 @@ Phase entry skills (`workflow-*-entry`) receive positional arguments: `$0` = wor
 
 **Work types and work units**: *Work type* = one of five pipeline shapes: epic, feature, bugfix, quick-fix, cross-cutting. *Work unit* = named instance of a work type (e.g., "auth-flow" is a feature work unit, "payments-overhaul" an epic work unit). Each work unit gets its own directory under `.workflows/` and its own `manifest.json`.
 
-- **Epic**: Multi-topic, multi-session, phase-centric (Research → Discussion → Specification → Planning → Implementation → Review)
+- **Epic**: Multi-topic, multi-session, phase-centric (Inception → Research → Discussion → Specification → Planning → Implementation → Review)
 - **Feature**: Single-topic, single-session, linear (Discussion → Specification → Planning → Implementation → Review)
 - **Bugfix**: Single-topic, investigation-centric (Investigation → Specification → Planning → Implementation → Review)
 - **Quick-fix**: Single-topic, scoping-centric (Scoping → Implementation → Review)

--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ Each command gathers context through a brief interview, then pipelines you throu
 Five work types, each with its own pipeline:
 
 ```
-Epic:          Research → Discussion → Specification → Planning → Implementation → Review
-Feature:     (Research) → Discussion → Specification → Planning → Implementation → Review
-Bugfix:                Investigation → Specification → Planning → Implementation → Review
-Quick-fix:                   Scoping → Implementation → Review
-Cross-cutting: (Research) → Discussion → Specification (terminal)
+Epic:          Inception → Research → Discussion → Specification → Planning → Implementation → Review
+Feature:                (Research) → Discussion → Specification → Planning → Implementation → Review
+Bugfix:                             Investigation → Specification → Planning → Implementation → Review
+Quick-fix:                                                Scoping → Implementation → Review
+Cross-cutting:          (Research) → Discussion → Specification (terminal)
 ```
 
 These aren't just different shapes — every phase adapts its behaviour to the work type. This runs deep, from how research is analysed to how plans are structured to how review findings are prioritised.

--- a/discovery-map/INDEX.md
+++ b/discovery-map/INDEX.md
@@ -94,7 +94,7 @@ The merge sequence at the end of the initiative is **strictly bottom-to-top of t
 | `idea/inception-pr-7-self-healing` | Phase 6 branch | Phase 7 — Self-Healing Re-point | [#272](https://github.com/leeovery/agentic-workflows/pull/272) | Review |
 | `idea/inception-pr-8-imports` | Phase 7 branch | Phase 8 — Imports | [#273](https://github.com/leeovery/agentic-workflows/pull/273) | Review |
 | `idea/inception-pr-9-split-elevation` | Phase 7 branch | Phase 9 — Topic Splitting and Elevation | [#274](https://github.com/leeovery/agentic-workflows/pull/274) | Review |
-| `idea/inception-pr-10-direct-entry` | Phase 7 branch | Phase 10 — Direct-Entry Auto-Add | — | Not started |
+| `idea/inception-pr-10-direct-entry` | Phase 7 branch | Phase 10 — Direct-Entry Auto-Add | [#275](https://github.com/leeovery/agentic-workflows/pull/275) | Review |
 | `idea/inception-pr-11-migration` | Phase 5 branch | Phase 11 — Migration | — | Not started |
 | `idea/inception-pr-12-drop-explore` | Phase 11 branch | Phase 12 — Drop Explore Mode | — | Not started |
 | `idea/inception-pr-13-docs` | Phase 12 branch | Phase 13 — Documentation Cleanup | — | Not started |

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -79,7 +79,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.di
 
 Set `source = "topic-provided"`.
 
-Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
+Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
 
 → Proceed to **Step 3** (Gather Context).
 
@@ -116,7 +116,7 @@ Use the response as `{topic}` (convert to kebab-case via the casing conventions)
 > in progress, or completed.
 ```
 
-Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
+Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -79,6 +79,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.di
 
 Set `source = "topic-provided"`.
 
+Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
+
 → Proceed to **Step 3** (Gather Context).
 
 #### If no `topic` (epic — no-topic path)
@@ -113,6 +115,8 @@ Use the response as `{topic}` (convert to kebab-case via the casing conventions)
 > Checking the status of this discussion — new,
 > in progress, or completed.
 ```
+
+Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -10,16 +10,13 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is **Phase 2** of the six-phase workflow:
+You are in the **Discussion** phase — capturing WHAT and WHY through decisions, rationale, competing approaches, and edge cases. Where Discussion sits in the pipeline depends on the work type:
 
-| Phase              | Focus                                              | You    |
-|--------------------|----------------------------------------------------|--------|
-| 1. Research        | EXPLORE - ideas, feasibility, market, business     |        |
-| **2. Discussion**  | WHAT and WHY - decisions, architecture, edge cases | ◀ HERE |
-| 3. Specification   | REFINE - validate into standalone spec             |        |
-| 4. Planning        | HOW - phases, tasks, acceptance criteria           |        |
-| 5. Implementation  | DOING - tests first, then code                     |        |
-| 6. Review          | VALIDATING - check work against artifacts          |        |
+| Work type | Pipeline |
+|---|---|
+| Epic | Inception → Research → **Discussion** → Specification → Planning → Implementation → Review |
+| Feature | **Discussion** → Specification → Planning → Implementation → Review |
+| Cross-cutting | Research (optional) → **Discussion** → Specification (terminal) |
 
 **Stay in your lane**: Capture the WHAT and WHY - decisions, rationale, competing approaches, edge cases. Don't jump to specifications, plans, or code. This is the time for debate and documentation.
 

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -10,16 +10,14 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is **Phase 5** of the six-phase workflow:
+You are in the **Implementation** phase — executing the plan: tests first, then code (or verification flow for quick-fix). Where Implementation sits in the pipeline depends on the work type:
 
-| Phase | Focus | You |
-|-------|-------|-----|
-| 1. Research | EXPLORE - ideas, feasibility, market, business | |
-| 2. Discussion | WHAT and WHY - decisions, architecture, edge cases | |
-| 3. Specification | REFINE - validate into standalone spec | |
-| 4. Planning | HOW - phases, tasks, acceptance criteria | |
-| **5. Implementation** | DOING - tests first, then code | ◀ HERE |
-| 6. Review | VALIDATING - check work against artifacts | |
+| Work type | Pipeline |
+|---|---|
+| Epic | Inception → Research → Discussion → Specification → Planning → **Implementation** → Review |
+| Feature | Discussion → Specification → Planning → **Implementation** → Review |
+| Bugfix | Investigation → Specification → Planning → **Implementation** → Review |
+| Quick-fix | Scoping → **Implementation** → Review |
 
 **Stay in your lane**: Execute the plan via strict TDD (or verification workflow for quick-fix). Don't re-debate decisions from the specification or expand scope beyond the plan. The plan is your authority.
 

--- a/skills/workflow-inception-entry/SKILL.md
+++ b/skills/workflow-inception-entry/SKILL.md
@@ -10,17 +10,11 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is **Phase 1** of the seven-phase epic workflow:
+You are in the **Inception** phase of the epic pipeline — the curation surface where moving parts are named, classified as research or discussion, and shaped into the discovery map:
 
-| Phase              | Focus                                              | You    |
-|--------------------|----------------------------------------------------|--------|
-| **1. Inception**   | CURATE - name topics, classify, build the map      | ◀ HERE |
-| 2. Research        | EXPLORE - feasibility, market, viability           |        |
-| 3. Discussion      | WHAT and WHY - decisions, architecture, edge cases |        |
-| 4. Specification   | REFINE - validate into standalone spec             |        |
-| 5. Planning        | HOW - phases, tasks, acceptance criteria           |        |
-| 6. Implementation  | DOING - tests first, then code                     |        |
-| 7. Review          | VALIDATING - check work against artifacts          |        |
+**Inception** → Research → Discussion → Specification → Planning → Implementation → Review
+
+Inception is epic-only — features, bugfixes, quick-fixes, and cross-cutting work units skip this phase.
 
 **Stay in your lane**: Inception is curatorial — name the moving parts, classify each as research or discussion, build the discovery map. Don't investigate (that's research). Don't decide (that's discussion). Hold the macro view; if the conversation tunnels into one item, anchor and return to mapping.
 

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -10,15 +10,11 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is **Phase 1** of the bugfix pipeline:
+You are in the **Investigation** phase of the bugfix pipeline:
 
-| Phase              | Focus                                              | You    |
-|--------------------|----------------------------------------------------|--------|
-| **Investigation**  | Symptom gathering + code analysis → root cause     | ◀ HERE |
-| 2. Specification   | REFINE - validate into fix specification           |        |
-| 3. Planning        | HOW - phases, tasks, acceptance criteria           |        |
-| 4. Implementation  | DOING - tests first, then code                     |        |
-| 5. Review          | VALIDATING - check work against artifacts          |        |
+**Investigation** → Specification → Planning → Implementation → Review
+
+Investigation gathers symptoms and traces code to find the root cause before any fix is written.
 
 **Stay in your lane**: Investigate the bug — gather symptoms, trace code, find root cause. Don't jump to fixing or implementing. This is the time for deep analysis.
 

--- a/skills/workflow-planning-entry/SKILL.md
+++ b/skills/workflow-planning-entry/SKILL.md
@@ -10,16 +10,13 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is **Phase 4** of the six-phase workflow:
+You are in the **Planning** phase — defining HOW: phases, tasks, acceptance criteria. Where Planning sits in the pipeline depends on the work type:
 
-| Phase | Focus | You |
-|-------|-------|-----|
-| 1. Research | EXPLORE - ideas, feasibility, market, business | |
-| 2. Discussion | WHAT and WHY - decisions, architecture, edge cases | |
-| 3. Specification | REFINE - validate into standalone spec | |
-| **4. Planning** | HOW - phases, tasks, acceptance criteria | ◀ HERE |
-| 5. Implementation | DOING - tests first, then code | |
-| 6. Review | VALIDATING - check work against artifacts | |
+| Work type | Pipeline |
+|---|---|
+| Epic | Inception → Research → Discussion → Specification → **Planning** → Implementation → Review |
+| Feature | Discussion → Specification → **Planning** → Implementation → Review |
+| Bugfix | Investigation → Specification → **Planning** → Implementation → Review |
 
 **Stay in your lane**: Create the plan - phases, tasks, and acceptance criteria. Don't jump to implementation or write code. The specification is your sole input; transform it into actionable work items.
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -107,7 +107,7 @@ Deferred — gather-context will resolve it.
 > Checking if research already exists for this topic.
 ```
 
-Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`.
+Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`.
 
 Check if the research phase entry exists:
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -73,7 +73,7 @@ Imports already populated context via `imports/` and the knowledge base — skip
 
 → Proceed to **Step 5**.
 
-#### If work_type is `feature`
+#### If work_type is `feature` or `cross-cutting`
 
 `resolved_filename = {topic}.md`
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -107,6 +107,8 @@ Deferred — gather-context will resolve it.
 > Checking if research already exists for this topic.
 ```
 
+Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`.
+
 Check if the research phase entry exists:
 
 ```bash

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -10,16 +10,13 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is **Phase 1** of the six-phase workflow:
+You are in the **Research** phase — exploring ideas, feasibility, market, and viability. Where Research sits in the pipeline depends on the work type:
 
-| Phase             | Focus                                              | You    |
-|-------------------|----------------------------------------------------|--------|
-| **1. Research**   | EXPLORE - ideas, feasibility, market, business     | ◀ HERE |
-| 2. Discussion     | WHAT and WHY - decisions, architecture, edge cases |        |
-| 3. Specification  | REFINE - validate into standalone spec             |        |
-| 4. Planning       | HOW - phases, tasks, acceptance criteria           |        |
-| 5. Implementation | DOING - tests first, then code                     |        |
-| 6. Review         | VALIDATING - check work against artifacts          |        |
+| Work type | Pipeline |
+|---|---|
+| Epic | Inception → **Research** → Discussion → Specification → Planning → Implementation → Review |
+| Feature | **Research** (imported) → Discussion → Specification → Planning → Implementation → Review |
+| Cross-cutting | **Research** (optional) → Discussion → Specification (terminal) |
 
 **Stay in your lane**: Explore freely. This is the time for broad thinking, feasibility checks, and learning. Surface options and tradeoffs — don't make decisions. When a topic converges toward a conclusion, that's a signal it's ready for discussion phase, not a cue to start deciding. Park it and move on.
 

--- a/skills/workflow-research-entry/references/gather-context.md
+++ b/skills/workflow-research-entry/references/gather-context.md
@@ -126,7 +126,7 @@ Any constraints or context I should know about upfront?
 
 ## F. Ensure Inception Item
 
-The no-topic-epic path enters this reference with no inception item written and bypasses Step 2 on exit. Run the auto-create here so direct-entry topics land on the discovery map. The shared reference is idempotent — if the caller (Step 4 from Step 2's not-exists branch) already ran it, this is a no-op; if `work_type` is not `epic`, it returns immediately.
+The no-topic-epic path enters this reference with no inception item written and bypasses Step 2 on exit, so the auto-create must run here. The shared reference is idempotent: when Step 2 already ran the load on a topic-resolved path, the existence check in the shared reference returns true and F is a no-op; for non-epic work_types, the gate returns immediately.
 
 → Load **[ensure-inception-item.md](../../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`.
 

--- a/skills/workflow-research-entry/references/gather-context.md
+++ b/skills/workflow-research-entry/references/gather-context.md
@@ -120,4 +120,14 @@ Any constraints or context I should know about upfront?
 
 **STOP.** Wait for user response.
 
+→ Proceed to **F. Ensure Inception Item**.
+
+---
+
+## F. Ensure Inception Item
+
+The no-topic-epic path enters this reference with no inception item written and bypasses Step 2 on exit. Run the auto-create here so direct-entry topics land on the discovery map. The check is idempotent — if the caller (Step 4 from Step 2's not-exists branch) already ran it, this is a no-op.
+
+Load **[ensure-inception-item.md](../../workflow-shared/references/ensure-inception-item.md)** with work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`.
+
 → Return to caller.

--- a/skills/workflow-research-entry/references/gather-context.md
+++ b/skills/workflow-research-entry/references/gather-context.md
@@ -126,8 +126,8 @@ Any constraints or context I should know about upfront?
 
 ## F. Ensure Inception Item
 
-The no-topic-epic path enters this reference with no inception item written and bypasses Step 2 on exit. Run the auto-create here so direct-entry topics land on the discovery map. The check is idempotent — if the caller (Step 4 from Step 2's not-exists branch) already ran it, this is a no-op.
+The no-topic-epic path enters this reference with no inception item written and bypasses Step 2 on exit. Run the auto-create here so direct-entry topics land on the discovery map. The shared reference is idempotent — if the caller (Step 4 from Step 2's not-exists branch) already ran it, this is a no-op; if `work_type` is not `epic`, it returns immediately.
 
-Load **[ensure-inception-item.md](../../workflow-shared/references/ensure-inception-item.md)** with work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`.
+→ Load **[ensure-inception-item.md](../../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`.
 
 → Return to caller.

--- a/skills/workflow-research-entry/references/gather-context.md
+++ b/skills/workflow-research-entry/references/gather-context.md
@@ -23,7 +23,9 @@ Do you have a specific topic to research, or explore openly?
 
 **If `explore`:**
 
-`resolved_filename = exploration.md`
+`topic = exploration`
+
+`resolved_filename = {topic}.md`
 
 → Proceed to **B. Seed Idea**.
 
@@ -37,11 +39,11 @@ What topic would you like to research?
 
 **STOP.** Wait for user response.
 
-User provides topic name → `resolved_filename = {topic:(kebabcase)}.md`
+User provides topic name → set `topic` to the kebab-cased response, `resolved_filename = {topic}.md`.
 
 → Proceed to **B. Seed Idea**.
 
-#### If work_type is `feature`
+#### If work_type is `feature` or `cross-cutting`
 
 No question needed. `resolved_filename = {topic}.md`
 

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -10,16 +10,14 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is **Phase 6** of the six-phase workflow:
+You are in the **Review** phase — validating completed work against discussion, specification, and plan. Where Review sits in the pipeline depends on the work type:
 
-| Phase | Focus | You |
-|-------|-------|-----|
-| 1. Research | EXPLORE - ideas, feasibility, market, business | |
-| 2. Discussion | WHAT and WHY - decisions, architecture, edge cases | |
-| 3. Specification | REFINE - validate into standalone spec | |
-| 4. Planning | HOW - phases, tasks, acceptance criteria | |
-| 5. Implementation | DOING - tests first, then code | |
-| **6. Review** | VALIDATING - check work against artifacts | ◀ HERE |
+| Work type | Pipeline |
+|---|---|
+| Epic | Inception → Research → Discussion → Specification → Planning → Implementation → **Review** |
+| Feature | Discussion → Specification → Planning → Implementation → **Review** |
+| Bugfix | Investigation → Specification → Planning → Implementation → **Review** |
+| Quick-fix | Scoping → Implementation → **Review** |
 
 **Stay in your lane**: Verify that every plan task was implemented, tested adequately, and meets quality standards. Don't fix code - identify problems. You're reviewing, not building.
 

--- a/skills/workflow-scoping-entry/SKILL.md
+++ b/skills/workflow-scoping-entry/SKILL.md
@@ -10,13 +10,11 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is the **entry phase** of the quick-fix pipeline:
+You are in the **Scoping** phase of the quick-fix pipeline:
 
-| Phase | Focus | You |
-|-------|-------|-----|
-| **Scoping** | SCOPE - context, spec, plan in one pass | ◀ HERE |
-| Implementation | DOING - execute the plan | |
-| Review | VALIDATING - check work against artifacts | |
+**Scoping** → Implementation → Review
+
+Scoping gathers context, builds the spec, and writes the plan in a single pass.
 
 **Stay in your lane**: Gather context, validate prerequisites, and hand off to the processing skill. Don't analyse the change or assess complexity — that's the processing skill's job.
 

--- a/skills/workflow-shared/references/ensure-inception-item.md
+++ b/skills/workflow-shared/references/ensure-inception-item.md
@@ -21,13 +21,13 @@ The caller provides these via context before loading:
 
 The discovery map is epic-only. Features, bugfixes, quick-fixes, and cross-cutting work units have no inception phase, and writing one would corrupt their manifests.
 
-#### If `work_type` is not `epic`
-
-→ Return to caller.
-
 #### If `work_type` is `epic`
 
 → Proceed to **B. Check Existence**.
+
+#### Otherwise
+
+→ Return to caller.
 
 ## B. Check Existence
 
@@ -35,13 +35,13 @@ The discovery map is epic-only. Features, bugfixes, quick-fixes, and cross-cutti
 node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.inception.{topic}
 ```
 
-#### If `true`
+#### If exists (`true`)
 
 The topic is already on the map. Nothing to do — fall through to the caller's existing flow.
 
 → Return to caller.
 
-#### If `false`
+#### If not exists (`false`)
 
 → Proceed to **C. Check Dismissed and Pull**.
 
@@ -53,13 +53,7 @@ Most epics never dismiss anything, so the dismissed list is usually absent. Prob
 node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.inception dismissed
 ```
 
-#### If `false`
-
-No dismissed list — nothing to pull.
-
-→ Proceed to **D. Create Inception Item**.
-
-#### If `true`
+#### If exists (`true`)
 
 Read the list:
 
@@ -72,6 +66,12 @@ If `{topic}` appears in the returned JSON array, pull it (user-explicit spawns b
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.inception dismissed "{topic}"
 ```
+
+→ Proceed to **D. Create Inception Item**.
+
+#### If not exists (`false`)
+
+No dismissed list — nothing to pull.
 
 → Proceed to **D. Create Inception Item**.
 

--- a/skills/workflow-shared/references/ensure-inception-item.md
+++ b/skills/workflow-shared/references/ensure-inception-item.md
@@ -4,7 +4,7 @@
 
 ---
 
-Idempotently ensures a `phases.inception.items.{topic}` entry exists for the given topic on the given work unit. If the item already exists, this reference is a no-op. Otherwise, it pulls the topic from `dismissed[]` (if present) and creates the item with `source: direct-start` and the caller-supplied `routing`.
+Idempotently ensures a `phases.inception.items.{topic}` entry exists for the given topic on the given work unit. If the work unit is not an epic, returns immediately — only epics have a discovery map. Otherwise: if the item already exists, this reference is a no-op; if not, it pulls the topic from `dismissed[]` (when present) and creates the item with `source: direct-start` and the caller-supplied `routing`.
 
 The reference assumes `topic` is already kebab-case — callers normalise before invoking. No summary is set; direct-entry items have no source content to summarise. The user can backfill via refinement's edit-summary later.
 
@@ -12,49 +12,70 @@ The reference assumes `topic` is already kebab-case — callers normalise before
 
 The caller provides these via context before loading:
 
+- `work_type` — the work unit's type. The reference no-ops for any value other than `epic`.
 - `work_unit` — the epic's work unit name. Always present.
 - `topic` — the kebab-case topic name. Always present.
 - `routing` — the literal `research` or `discussion`. Set by the caller based on which entry verb the user picked.
 
-## A. Check Existence
+## A. Gate on Work Type
+
+The discovery map is epic-only. Features, bugfixes, quick-fixes, and cross-cutting work units have no inception phase, and writing one would corrupt their manifests.
+
+#### If `work_type` is not `epic`
+
+→ Return to caller.
+
+#### If `work_type` is `epic`
+
+→ Proceed to **B. Check Existence**.
+
+## B. Check Existence
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.inception.{topic}
 ```
 
-#### If exists (`true`)
+#### If `true`
 
 The topic is already on the map. Nothing to do — fall through to the caller's existing flow.
 
 → Return to caller.
 
-#### If not exists (`false`)
+#### If `false`
 
-→ Proceed to **B. Check Dismissed and Pull**.
+→ Proceed to **C. Check Dismissed and Pull**.
 
-## B. Check Dismissed and Pull
+## C. Check Dismissed and Pull
 
-Read the dismissed list:
+Most epics never dismiss anything, so the dismissed list is usually absent. Probe for its existence first to avoid surfacing a "Path not found" error from a bare `get`:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.inception dismissed
+```
+
+#### If `false`
+
+No dismissed list — nothing to pull.
+
+→ Proceed to **D. Create Inception Item**.
+
+#### If `true`
+
+Read the list:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.inception dismissed
 ```
 
-#### If `{topic}` is in the returned array
-
-User-explicit spawns bypass the dismissed list — pull the name before writing the new item:
+If `{topic}` appears in the returned JSON array, pull it (user-explicit spawns bypass dismissal):
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.inception dismissed "{topic}"
 ```
 
-→ Proceed to **C. Create Inception Item**.
+→ Proceed to **D. Create Inception Item**.
 
-#### Otherwise
-
-→ Proceed to **C. Create Inception Item**.
-
-## C. Create Inception Item
+## D. Create Inception Item
 
 Initialise the item and set provenance fields:
 

--- a/skills/workflow-shared/references/ensure-inception-item.md
+++ b/skills/workflow-shared/references/ensure-inception-item.md
@@ -1,0 +1,69 @@
+# Ensure Inception Item
+
+*Shared reference. Loaded by `workflow-research-entry`, `workflow-discussion-entry`, and any flow that needs to auto-create a direct-entry inception item.*
+
+---
+
+Idempotently ensures a `phases.inception.items.{topic}` entry exists for the given topic on the given work unit. If the item already exists, this reference is a no-op. Otherwise, it pulls the topic from `dismissed[]` (if present) and creates the item with `source: direct-start` and the caller-supplied `routing`.
+
+The reference assumes `topic` is already kebab-case — callers normalise before invoking. No summary is set; direct-entry items have no source content to summarise. The user can backfill via refinement's edit-summary later.
+
+## Parameters
+
+The caller provides these via context before loading:
+
+- `work_unit` — the epic's work unit name. Always present.
+- `topic` — the kebab-case topic name. Always present.
+- `routing` — the literal `research` or `discussion`. Set by the caller based on which entry verb the user picked.
+
+## A. Check Existence
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.inception.{topic}
+```
+
+#### If exists (`true`)
+
+The topic is already on the map. Nothing to do — fall through to the caller's existing flow.
+
+→ Return to caller.
+
+#### If not exists (`false`)
+
+→ Proceed to **B. Check Dismissed and Pull**.
+
+## B. Check Dismissed and Pull
+
+Read the dismissed list:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.inception dismissed
+```
+
+#### If `{topic}` is in the returned array
+
+User-explicit spawns bypass the dismissed list — pull the name before writing the new item:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.inception dismissed "{topic}"
+```
+
+→ Proceed to **C. Create Inception Item**.
+
+#### Otherwise
+
+→ Proceed to **C. Create Inception Item**.
+
+## C. Create Inception Item
+
+Initialise the item and set provenance fields:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.inception.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} routing {routing}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} source direct-start
+```
+
+No commit here — the manifest writes are folded into the next commit produced by the calling phase's process.
+
+→ Return to caller.

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -10,16 +10,14 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-This is **Phase 3** of the six-phase workflow:
+You are in the **Specification** phase — refining prior work into a standalone spec. Where Specification sits in the pipeline depends on the work type:
 
-| Phase                | Focus                                              | You    |
-|----------------------|----------------------------------------------------|--------|
-| 1. Research          | EXPLORE - ideas, feasibility, market, business     |        |
-| 2. Discussion        | WHAT and WHY - decisions, architecture, edge cases |        |
-| **3. Specification** | REFINE - validate into standalone spec             | ◀ HERE |
-| 4. Planning          | HOW - phases, tasks, acceptance criteria           |        |
-| 5. Implementation    | DOING - tests first, then code                     |        |
-| 6. Review            | VALIDATING - check work against artifacts          |        |
+| Work type | Pipeline |
+|---|---|
+| Epic | Inception → Research → Discussion → **Specification** → Planning → Implementation → Review |
+| Feature | Discussion → **Specification** → Planning → Implementation → Review |
+| Bugfix | Investigation → **Specification** → Planning → Implementation → Review |
+| Cross-cutting | Research (optional) → Discussion → **Specification** (terminal) |
 
 **Stay in your lane**: Validate and refine discussion content into standalone specifications. Don't jump to planning, phases, tasks, or code. The specification is the "line in the sand" - everything after this has hard dependencies on it.
 


### PR DESCRIPTION
## Summary

Phase 10 of the inception/discovery-map initiative. Closes the last surface where map writes were silently bypassed: direct-entry from `/continue-epic` via `d`/`discuss` and `r`/`research`. After this PR, every research/discussion topic that gets created by the entry skills also lands on the discovery map with `source: direct-start` and the chosen `routing`.

- New shared reference `skills/workflow-shared/references/ensure-inception-item.md` — idempotent: `exists` check returns immediately if the item is already on the map; otherwise pulls the topic from `dismissed[]` (user-explicit spawns bypass dismissal per design) and writes `init-phase` + `routing` + `source: direct-start`.
- `workflow-research-entry/SKILL.md` loads it at the start of Step 2 (covers Step 1 → Step 2 paths). `references/gather-context.md` gains a final section F that loads it before returning to caller (covers the no-topic-epic Step 1 → Step 4 → Step 5 path which bypasses Step 2). Idempotency makes the redundant invocation when Step 4 loads gather-context after Step 2 a safe no-op.
- `workflow-discussion-entry/SKILL.md` loads it at the start of Step 2 (resume + fresh paths converge there) and inside Step 1's topic-provided-but-not-exists branch (which routes to Step 3 and bypasses Step 2).

No `continue-epic`, `manifest.cjs`, `discovery-utils.cjs`, or knowledge-base changes — every existing surface (resume, refinement adds, splits, elevations, self-healing) keeps working untouched. `source: direct-start` rendering already exists in `computeSourceProvenance` with passing fixtures. No migration in this PR — Phase 11 backfills any pre-Phase-10 orphans where direct-entry left a research/discussion item without a corresponding inception entry.

**Stacked on `idea/inception-pr-7-self-healing` (PR #272).** Sibling of Phase 8 (imports) and Phase 9 (split/elevation) — INDEX.md records all three as branching from Phase 7. Doesn't depend on Phase 9's `topic-name-validation.md` (its `collision-active` rejection semantics don't fit the resume-or-create direct-entry contract; direct manifest checks are cleaner here).

## Test plan

- [x] `bash tests/scripts/test-workflow-manifest.sh` — 214/214
- [x] `node --test tests/scripts/test-discovery-for-*.cjs tests/scripts/test-discovery-utils.cjs tests/scripts/test-refinement-session.cjs` — 329/329 (incl. existing `direct-start` provenance fixture)
- [x] All 38 migration tests pass
- [x] Knowledge tests pass (store/chunker/config/embeddings/openai/retry/integration/cli/build)
- [ ] End-to-end smoke (manual): direct-entry research with new topic → inception item created with `routing: research, source: direct-start`
- [ ] End-to-end smoke (manual): direct-entry discussion with new topic → inception item with `routing: discussion, source: direct-start`
- [ ] End-to-end smoke (manual): direct-entry with existing-name → resume flow unchanged (idempotent no-op)
- [ ] End-to-end smoke (manual): direct-entry with dismissed name → name pulled from `dismissed[]`, fresh inception item created
- [ ] End-to-end smoke (manual): bypass invocation (`/workflow-research-entry epic foo new-topic`) → inception item auto-created identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)