### PR TITLE
Phase 14 — Two-tier provenance for inception items

### DIFF
--- a/discovery-map/INDEX.md
+++ b/discovery-map/INDEX.md
@@ -106,7 +106,7 @@ The merge sequence at the end of the initiative is **strictly bottom-to-top of t
 | `idea/inception-pr-11-migration` | Phase 10 branch | Phase 11 — Migration | [#276](https://github.com/leeovery/agentic-workflows/pull/276) | Review |
 | `idea/inception-pr-12-drop-explore` | Phase 11 branch | Phase 12 — Drop Explore Mode | [#277](https://github.com/leeovery/agentic-workflows/pull/277) | Review |
 | `idea/inception-pr-13-docs` | Phase 12 branch | Phase 13 — Documentation Cleanup | [#278](https://github.com/leeovery/agentic-workflows/pull/278) | Review |
-| `idea/inception-pr-14-provenance` | Phase 13 branch | Phase 14 — Two-Tier Provenance | — | Not started |
+| `idea/inception-pr-14-provenance` | Phase 13 branch | Phase 14 — Two-Tier Provenance | [#279](https://github.com/leeovery/agentic-workflows/pull/279) | Review |
 | `idea/inception-pr-15-kb-index-analysis` | Phase 14 branch | Phase 15 — KB Index Analysis Caches | — | Not started |
 | `idea/inception-pr-16-cleanup` | Phase 15 branch | Phase 16 — Final Review and Cleanup | — | Not started |
 | TBD | Phase 16 branch | Phase 17 — Entry UX & Inception Unification | — | Exploratory (design not settled) |

--- a/discovery-map/design.md
+++ b/discovery-map/design.md
@@ -80,6 +80,7 @@ The map lives in the work-unit manifest at `phases.inception.items.{topic}`. Eac
 
 - `name` — the topic identifier (kebab-case, used as filename for downstream phases)
 - `summary` — one-line description of what the topic covers
+- `description` — paragraph or two of richer context, loaded by entry skills as opening context for the session
 - `routing` — `research` | `discussion`. The *initial intent* set in inception. Source of truth for menu routing only when no per-phase items exist; otherwise the actual flow is determined by which phase items exist.
 - `source` — provenance: `inception`, `research-split:{parent}`, `discussion-elevation:{parent}`, `gap-analysis`, `research-analysis`, `direct-start`
 - `created`, `updated` — timestamps

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -252,7 +252,7 @@ node .claude/skills/continue-epic/scripts/discovery.cjs {work_unit}
 
 ## Step 6: Summary Backfill
 
-Read `discovery_map` from the selected epic's `detail`. Filter for items where `source` starts with `'migration-seeded'` and `summary` is null or missing.
+Read `discovery_map` from the selected epic's `detail`. Filter for items where `source` starts with `'migration-seeded'` and either `summary` or `description` is null or missing. Both fields are populated together — pre-Phase-14 items backfilled only `summary` and re-enter this flow once for `description`.
 
 #### If no items match
 
@@ -260,7 +260,7 @@ Read `discovery_map` from the selected epic's `detail`. Filter for items where `
 
 #### If one or more items match
 
-Store the filtered list as `items_to_recover`.
+Store the filtered list as `items_to_recover`. Each item carries `name`, `routing`, current `summary` (possibly null), and current `description` (possibly null) — the reference decides which fields to draft.
 
 Load **[summary-backfill.md](references/summary-backfill.md)** with work_unit = `{work_unit}`, items_to_recover = `{items_to_recover}`.
 

--- a/skills/continue-epic/references/summary-backfill.md
+++ b/skills/continue-epic/references/summary-backfill.md
@@ -7,7 +7,7 @@
 The caller passes:
 
 - `work_unit` — the selected epic
-- `items_to_recover` — list of inception items missing summaries; each has at minimum `name` and `routing`
+- `items_to_recover` — list of inception items missing summary, description, or both. Each item has at minimum `name`, `routing`, plus the current values of `summary` and `description` (either may be null)
 
 On exit, re-runs discovery so the caller has fresh state.
 
@@ -22,23 +22,28 @@ On exit, re-runs discovery so the caller has fresh state.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Inception items missing summaries. Drafting them from the
-> existing research and discussion files for review.
+> Inception items missing summary or description. Drafting
+> them from the existing research and discussion files for
+> review.
 ```
 
 For each item in `items_to_recover`:
 
 - If `routing` is `research`: read `.workflows/{work_unit}/research/{item.name}.md`
 - If `routing` is `discussion`: read `.workflows/{work_unit}/discussion/{item.name}.md`
-- If the file is missing or empty (rare — the topic exists in the manifest but the file is gone), record `summary: null` and a note `(source file missing)` for that item
+- If the file is missing or empty (rare — the topic exists in the manifest but the file is gone), record `derived_summary: null` and `derived_description: null` and a note `(source file missing)` for that item
 
-For each readable file, derive a one-line summary that captures what the topic is about. Aim for 8–15 words. Use the file's headings and opening paragraphs as the primary signal. Attach each derived summary to its item in conversation memory as `item.derived_summary` — section **B** reads it from there.
+For each readable file:
+
+- If the item's current `summary` is null, derive a one-line summary that captures what the topic is about. Aim for 8–15 words. Use the file's headings and opening paragraphs as the primary signal. Attach as `item.derived_summary`.
+- If the item's current `description` is null, derive a paragraph or two of richer context — what the topic covers, why it surfaced, key dimensions. Use the file's body content (not just headings). Attach as `item.derived_description`.
+- If a field is already populated, leave its current value in place and skip derivation for that field. Track `item.needs_summary` and `item.needs_description` so section **D** writes only the newly-drafted fields.
 
 → Proceed to **B. Batch Review**.
 
 ## B. Batch Review
 
-Render the proposed summaries as a single batch:
+Render the proposed summaries as a single batch. Description is drafted silently in the background — paragraphs would bloat the batch view, and entry skills will use whatever the auto-draft produces. The user can refine a description later via refinement's Edit Description op.
 
 > *Output the next fenced block as a code block:*
 
@@ -47,10 +52,12 @@ Proposed summaries for {N} topic(s):
 
 @foreach(item in items_to_recover)
   {N}. {item.name:(titlecase)}  ({item.routing})
-@if(item.derived_summary)
+@if(item.needs_summary and item.derived_summary)
        {item.derived_summary}
-@else
+@elseif(item.needs_summary)
        (source file missing — please provide)
+@else
+       {item.summary}  (already populated)
 @endif
 @endforeach
 ```
@@ -59,9 +66,9 @@ Proposed summaries for {N} topic(s):
 
 ```
 · · · · · · · · · · · ·
-- **`y`/`yes`** — Accept all summaries as drafted
-- **`e`/`edit`** — Edit one or more lines before accepting
-- **`s`/`skip`** — Skip the whole batch (leave summaries blank)
+- **`y`/`yes`** — Accept all summaries as drafted (description is auto-drafted silently)
+- **`e`/`edit`** — Edit one or more summary lines before accepting
+- **`s`/`skip`** — Skip the whole batch (leave fields blank)
 · · · · · · · · · · · ·
 ```
 
@@ -111,19 +118,27 @@ Update the in-memory summary for that item with the user's response. Re-render t
 
 ## D. Write and Commit
 
-For each item with a non-null summary, write to the manifest:
+For each item, write only the newly-drafted fields:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{item.name} summary "{summary}"
-```
+- If `item.needs_summary` is true and `item.derived_summary` is non-null:
 
-Skip items where the summary is null (source file was missing) — they remain unset and will trigger this flow again on the next continue-epic invocation, giving the user another chance to provide a summary manually.
+  ```bash
+  node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{item.name} summary "{summary}"
+  ```
+
+- If `item.needs_description` is true and `item.derived_description` is non-null:
+
+  ```bash
+  node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{item.name} description "{description}"
+  ```
+
+Skip items where the relevant derived field is null (source file was missing) — they remain unset and will trigger this flow again on the next continue-epic invocation, giving the user another chance.
 
 Single commit covering all writes:
 
 ```bash
 git add -- .workflows/{work_unit}/manifest.json
-git commit -m "inception({work_unit}): populate {N} inception summary(ies) from source files"
+git commit -m "inception({work_unit}): backfill {N} inception provenance field(s) from source files"
 ```
 
 Re-run discovery so the caller has fresh state:

--- a/skills/continue-epic/scripts/discovery.cjs
+++ b/skills/continue-epic/scripts/discovery.cjs
@@ -182,6 +182,7 @@ function buildEpicDetail(cwd, manifest) {
       return {
         name: item.name,
         summary: item.summary || null,
+        description: item.description || null,
         routing: item.routing || null,
         source: item.source || 'inception',
         source_provenance,

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -92,6 +92,8 @@ What topic would you like to discuss?
 
 Kebab-case the response, store as `{topic}`. Set `source = "fresh"`.
 
+Silently derive `direct_entry_summary` (one-line) and `direct_entry_description` (one or two paragraphs) from the user's response. Do not render anything — these are local variables passed to `ensure-inception-item` in Step 2. The derivation is part of the same Claude turn that kebab-cases the response; no separate STOP gate.
+
 → Proceed to **Step 2** (Validate Phase).
 
 ---
@@ -111,7 +113,7 @@ Kebab-case the response, store as `{topic}`. Set `source = "fresh"`.
 > in progress, or completed.
 ```
 
-Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
+Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`. On the direct-entry path (`source = "fresh"`), also pass summary = `{direct_entry_summary}`, description = `{direct_entry_description}`. On the topic-resolved path, omit both — the caller didn't derive them.
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 

--- a/skills/workflow-discussion-entry/references/invoke-skill.md
+++ b/skills/workflow-discussion-entry/references/invoke-skill.md
@@ -10,6 +10,18 @@ This skill's purpose is now fulfilled. Construct the handoff and invoke the proc
 
 ---
 
+## Load Inception Description
+
+For every source branch except `continue`, read the inception item's `description` so it can be appended to the handoff. The item exists on the map by this point — every non-`continue` branch passed through `ensure-inception-item` earlier in the flow.
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.inception.{topic} description
+```
+
+The CLI may return empty output (no `description` set on legacy items, or migration-seeded items). Treat empty/null output as "skip the Description block in the handoff" — the legacy fallback. When the value is non-empty, append the block below in the position shown for each branch.
+
+---
+
 ## Handoff
 
 #### If source is `research`
@@ -24,10 +36,13 @@ Research files:
 - .workflows/{work_unit}/research/{filename2}.md
 Topic context: {summary from analysis cache}
 
+Description:
+{description text — paragraph or two, preserved as-is}
+
 Invoke the workflow-discussion-process skill.
 ```
 
-Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### If source is `topic-provided-with-research`
 
@@ -41,10 +56,13 @@ Research files:
 - .workflows/{work_unit}/research/{filename2}.md
 Topic context: {brief orientation from user context}
 
+Description:
+{description text — paragraph or two, preserved as-is}
+
 Invoke the workflow-discussion-process skill.
 ```
 
-Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### If source is `gap-analysis`
 
@@ -58,10 +76,13 @@ Source discussions:
 - .workflows/{work_unit}/discussion/{discussion2}.md
 Topic context: {summary from gap analysis cache}
 
+Description:
+{description text — paragraph or two, preserved as-is}
+
 Invoke the workflow-discussion-process skill.
 ```
 
-Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### If source is `continue`
 
@@ -74,7 +95,7 @@ Output: {output_path}
 Invoke the workflow-discussion-process skill.
 ```
 
-Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+No description load for `continue` — resuming an existing session, no need to re-prime. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### If source is `fresh` or `topic-provided`
 
@@ -84,7 +105,10 @@ Work unit: {work_unit}
 Source: fresh
 Output: {output_path}
 
+Description:
+{description text — paragraph or two, preserved as-is}
+
 Invoke the workflow-discussion-process skill.
 ```
 
-Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-discussion-entry/references/invoke-skill.md
+++ b/skills/workflow-discussion-entry/references/invoke-skill.md
@@ -12,13 +12,22 @@ This skill's purpose is now fulfilled. Construct the handoff and invoke the proc
 
 ## Load Inception Description
 
-For every source branch except `continue`, read the inception item's `description` so it can be appended to the handoff. The item exists on the map by this point — every non-`continue` branch passed through `ensure-inception-item` earlier in the flow.
+For every source branch except `continue`, attempt to read the inception item's `description` so it can be appended to the handoff. Two preconditions must hold before the read — both must be true, otherwise treat description as null and skip the Description block:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.inception.{topic} description
-```
+1. `work_type` is `epic`. Non-epic work units (feature, bugfix, cross-cutting) have no inception phase — skip.
+2. The `description` subkey exists on the inception item. Probe with `exists` first to avoid surfacing a "Path not found" error from a bare `get`:
 
-The CLI may return empty output (no `description` set on legacy items, or migration-seeded items). Treat empty/null output as "skip the Description block in the handoff" — the legacy fallback. When the value is non-empty, append the block below in the position shown for each branch.
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.inception.{topic} description
+   ```
+
+   If the probe returns `true`, read the value:
+
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.inception.{topic} description
+   ```
+
+When `description` is loaded and non-empty, append the Description block shown in each source branch below. When either precondition fails, or the read returns empty, omit the Description block entirely — no header, no empty body.
 
 ---
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -131,7 +131,7 @@ During organic discussion, a subtopic may grow beyond the scope of the current t
 
    On `collision-active`, re-prompt for an alternative and re-validate — loop until `ok` or `matches-dismissed`, or the user cancels the elevation. On `matches-dismissed`, proceed (the dismissed entry is pulled in step 4). On `ok`, proceed.
 
-2. Generate a one-sentence summary of the elevated concern (drawn from the context that triggered elevation). This becomes the inception item's `summary` field.
+2. Generate a one-sentence summary of the elevated concern (drawn from the context that triggered elevation). This becomes the inception item's `summary` field. Generate a paragraph or two of richer context in the same turn — this becomes the `description` field, loaded by discussion-entry as opening context when the user later picks the elevated topic up.
 
 3. Create the seed discussion file at `.workflows/{work_unit}/discussion/{new-topic}.md` with:
    - Context section capturing what prompted the topic and any initial thinking from the current discussion
@@ -151,6 +151,7 @@ During organic discussion, a subtopic may grow beyond the scope of the current t
    node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.inception.{new-topic}
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{new-topic} routing discussion
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{new-topic} summary "{one-line summary}"
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{new-topic} description "{paragraphs}"
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{new-topic} source "discussion-elevation:{topic}"
    ```
 

--- a/skills/workflow-inception-process/references/confirm-and-persist.md
+++ b/skills/workflow-inception-process/references/confirm-and-persist.md
@@ -11,9 +11,12 @@ For each topic on the working list, in the order the user surfaced them:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.inception.{topic}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} summary "{one-line summary}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} description "{paragraphs}"
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} routing {research|discussion}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} source inception
 ```
+
+Derive `summary` and `description` from the same session conversation in the same turn — no separate prompt. The compact `• {topic} — {summary}` form in the working list stays unchanged; description is generated only at persist time.
 
 If any command fails, surface the error and stop before the commit so the user can recover.
 
@@ -22,6 +25,7 @@ Notes:
 - `init-phase` creates the item with `status: in-progress` automatically. Inception items have no other valid status — do not pass `status` explicitly.
 - The topic name is the manifest dict key (third dot-path segment). There is no separate `name` field to set.
 - `summary` is the one-line description from the working list. Quote the value in shell — single quotes if it contains `[]`, `{}`, `~`, or backticks.
+- `description` is a paragraph or two of richer context, derived from the same conversation that produced the summary. Entry skills load it as opening context when the user later picks the topic up for research or discussion. Length is not enforced — a paragraph or two is the target, but more or less is fine. Map renders never show it. Quote the value the same way as summary; multi-paragraph content can include embedded newlines.
 - `routing` is the value the user agreed to during the session.
 - `source: inception` distinguishes initial-session topics from later-phase additions (`research-analysis`, `gap-analysis`, `split`, `elevation`, `direct-start`, `migration-seeded`).
 

--- a/skills/workflow-inception-process/references/map-operations.md
+++ b/skills/workflow-inception-process/references/map-operations.md
@@ -22,13 +22,14 @@ Read `discovery_map` (per-topic `tier`, `lifecycle`, `routing`, `summary`, `sour
 
 Then read the user's most recent message. Extract one or more operations. Recognised intents:
 
-| User phrasing                                   | Operation       | Required values                          |
-| ----------------------------------------------- | --------------- | ---------------------------------------- |
-| *"add X as research"*, *"add Y as discussion"*  | Add             | name, routing                            |
-| *"edit summary of X to Y"*, *"reword X's blurb"*| Edit summary    | name, new summary                        |
-| *"remove X"*, *"drop X"*, *"delete X"*          | Remove          | name                                     |
-| *"rename X to Y"*                               | Rename          | old name, new name                       |
-| *"change routing of X to discussion"*           | Change routing  | name, new routing                        |
+| User phrasing                                              | Operation         | Required values        |
+| ---------------------------------------------------------- | ----------------- | ---------------------- |
+| *"add X as research"*, *"add Y as discussion"*             | Add               | name, routing          |
+| *"edit summary of X to Y"*, *"reword X's blurb"*           | Edit summary      | name, new summary      |
+| *"edit description of X to Y"*, *"reword X's description"* | Edit description  | name, new description  |
+| *"remove X"*, *"drop X"*, *"delete X"*                     | Remove            | name                   |
+| *"rename X to Y"*                                          | Rename            | old name, new name     |
+| *"change routing of X to discussion"*                      | Change routing    | name, new routing      |
 
 If routing is omitted on Add, infer from cues in the user's framing (factual unknowns → research; opinion or design → discussion). The proposal is tentative — the STOP gate is where the user flips it.
 
@@ -36,7 +37,7 @@ If the message is ambiguous (e.g. *"fix X"*, *"that one looks wrong"*), ask one 
 
 **Group operations** for safety-by-destructiveness:
 
-- **Additive group** — a contiguous run of Add operations *or* a contiguous run of Edit summary operations. Each group batches into one STOP gate, one commit, one session-log entry.
+- **Additive group** — a contiguous run of Add operations *or* a contiguous run of Edit summary operations *or* a contiguous run of Edit description operations. Each group batches into one STOP gate, one commit, one session-log entry.
 - **Destructive group** — a single Remove, Rename, or Change routing operation. Each is its own group of one with its own STOP gate and commit.
 
 Walk the groups in user order. For mixed batches (e.g. *"remove A, rename B to B2, add C"*), each destructive op is its own group; contiguous additive ops in between batch.
@@ -55,6 +56,7 @@ Apply per-operation validation gates **before** any STOP gate. If validation fai
 | Rename          | `fresh`            | all others                                                                  |
 | Change routing  | `fresh`            | all others (routing is implicit once a phase item exists)                   |
 | Edit summary    | any                | —                                                                           |
+| Edit description| any                | —                                                                           |
 | Add             | n/a (new item)     | —                                                                           |
 
 `cancelled` is also disallowed for Remove because the inception item is the historical record of the topic ever having existed. Removal is for never-started topics only; cancel-then-vanish would erase the audit trail. The `a`/`cancel` flow in `/continue-epic` is the right tool for stopping in-flight work.
@@ -113,9 +115,13 @@ Walk the validated operation groups in user order. For the next pending group:
 
 → Proceed to **H. Change Routing**.
 
+#### If the group is one or more Edit description operations
+
+→ Proceed to **I. Edit Description**.
+
 #### Otherwise (no groups remain)
 
-→ Proceed to **I. Done**.
+→ Proceed to **J. Done**.
 
 ## D. Add
 
@@ -165,11 +171,12 @@ For each name in the batch:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.inception.{name}
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} summary "{one-line summary}"
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} description "{paragraphs}"
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} routing {research|discussion}
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} source inception
    ```
 
-   Source is `inception` for refinement-added topics — they are user-curated, indistinguishable from initial-session items for provenance purposes.
+   Source is `inception` for refinement-added topics — they are user-curated, indistinguishable from initial-session items for provenance purposes. Derive `summary` (one-line) and `description` (paragraph or two) from the user's framing of the Add operation in the same turn that proposes the routing. Quote both values with single quotes; description may span multiple paragraphs.
 
 3. Append a single batch entry to the session log under **Changes** (one bullet per name). If the section currently reads `(none)`, replace it with the bullets:
 
@@ -419,7 +426,64 @@ git commit -m "inception({work_unit}): re-route {name} to {new routing}"
 
 → Return to **C. Apply** for the next group.
 
-## I. Done
+## I. Edit Description
+
+Render the proposal once for the whole batch. Description may span paragraphs — show a truncated preview (about 140 characters with `…`) in the proposal block so the STOP gate stays readable; the full description is written verbatim on confirm.
+
+> *Output the next fenced block as a code block:*
+
+```
+Updating {N} description(s):
+
+  • {name_1}: "{truncated description}"
+  • {name_2}: "{truncated description}"
+  ...
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Apply?
+
+- **`y`/`yes`**
+- **`n`/`no`**
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `no`
+
+Skip the batch. No manifest writes, no session-log entry, no commit.
+
+→ Return to **C. Apply** for the next group.
+
+#### If `yes`
+
+For each, write the full description verbatim (not the truncated preview):
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} description "{new description}"
+```
+
+Append a single batch entry to the session log under **Changes**. If the section currently reads `(none)`, replace it with the bullets:
+
+```markdown
+- Edited description: {name_1} — {short note}
+- Edited description: {name_2} — {short note}
+```
+
+Single commit:
+
+```bash
+git add -- .workflows/{work_unit}/manifest.json .workflows/{work_unit}/inception/session-{NNN}.md
+git commit -m "inception({work_unit}): edit {N} description(s)"
+```
+
+→ Return to **C. Apply** for the next group.
+
+## J. Done
 
 All operation groups have been processed.
 

--- a/skills/workflow-inception-process/scripts/discovery.cjs
+++ b/skills/workflow-inception-process/scripts/discovery.cjs
@@ -20,6 +20,7 @@ function buildDiscoveryMap(manifest) {
     return {
       name: item.name,
       summary: item.summary || null,
+      description: item.description || null,
       routing: item.routing || null,
       source: item.source || 'inception',
       source_provenance: computeSourceProvenance(item.source),

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -86,6 +86,8 @@ What topic would you like to research?
 
 Kebab-case the response, store as `{topic}`. `resolved_filename = {topic}.md`.
 
+Silently derive `direct_entry_summary` (one-line) and `direct_entry_description` (one or two paragraphs) from the user's response. Do not render anything — these are local variables passed to `ensure-inception-item` in Step 2. The derivation is part of the same Claude turn that kebab-cases the response; no separate STOP gate.
+
 → Proceed to **Step 2**.
 
 ---
@@ -104,7 +106,7 @@ Kebab-case the response, store as `{topic}`. `resolved_filename = {topic}.md`.
 > Checking if research already exists for this topic.
 ```
 
-Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`.
+Load **[ensure-inception-item.md](../workflow-shared/references/ensure-inception-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`. On the direct-entry path (no topic supplied as `$2`), also pass summary = `{direct_entry_summary}`, description = `{direct_entry_description}`. When the topic was provided by the caller, omit both — the caller didn't derive them.
 
 Check if the research phase entry exists:
 

--- a/skills/workflow-research-entry/references/invoke-skill.md
+++ b/skills/workflow-research-entry/references/invoke-skill.md
@@ -8,6 +8,18 @@ This skill's purpose is now fulfilled. Construct the handoff and invoke the proc
 
 ---
 
+## Load Inception Description
+
+For every source branch except `continue`, read the inception item's `description` so it can be appended to the handoff. The item exists on the map by this point — every non-`continue` branch passed through `ensure-inception-item` earlier in the flow.
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.inception.{topic} description
+```
+
+The CLI may return empty output (no `description` set on legacy items, or migration-seeded items). Treat empty/null output as "skip the Description block in the handoff" — the legacy fallback. When the value is non-empty, append the block below in the position shown for each branch.
+
+---
+
 ## Handoff
 
 #### If source is `continue`
@@ -22,7 +34,7 @@ Output: .workflows/{work_unit}/research/{resolved_filename}
 Invoke the workflow-research-process skill.
 ```
 
-Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+No description load for `continue` — resuming an existing session, no need to re-prime. Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### If source is `import`
 
@@ -37,10 +49,13 @@ Imports tracked in manifest.imports[] and indexed into the
 knowledge base — relevant chunks will surface via the
 session-start contextual query. Starting Point stays empty.
 
+Description:
+{description text — paragraph or two, preserved as-is}
+
 Invoke the workflow-research-process skill.
 ```
 
-Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### Otherwise
 
@@ -56,7 +71,10 @@ Context:
 - Starting point: {technical feasibility, market, business model, or general direction}
 - Constraints: {any constraints mentioned, or "none"}
 
+Description:
+{description text — paragraph or two, preserved as-is}
+
 Invoke the workflow-research-process skill.
 ```
 
-Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-research-entry/references/invoke-skill.md
+++ b/skills/workflow-research-entry/references/invoke-skill.md
@@ -10,13 +10,22 @@ This skill's purpose is now fulfilled. Construct the handoff and invoke the proc
 
 ## Load Inception Description
 
-For every source branch except `continue`, read the inception item's `description` so it can be appended to the handoff. The item exists on the map by this point — every non-`continue` branch passed through `ensure-inception-item` earlier in the flow.
+For every source branch except `continue`, attempt to read the inception item's `description` so it can be appended to the handoff. Two preconditions must hold before the read — both must be true, otherwise treat description as null and skip the Description block:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.inception.{topic} description
-```
+1. `work_type` is `epic`. Non-epic work units (feature, cross-cutting) have no inception phase — skip.
+2. The `description` subkey exists on the inception item. Probe with `exists` first to avoid surfacing a "Path not found" error from a bare `get`:
 
-The CLI may return empty output (no `description` set on legacy items, or migration-seeded items). Treat empty/null output as "skip the Description block in the handoff" — the legacy fallback. When the value is non-empty, append the block below in the position shown for each branch.
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.inception.{topic} description
+   ```
+
+   If the probe returns `true`, read the value:
+
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.inception.{topic} description
+   ```
+
+When `description` is loaded and non-empty, append the Description block shown in each source branch below. When either precondition fails, or the read returns empty, omit the Description block entirely — no header, no empty body.
 
 ---
 

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -44,7 +44,7 @@ For each split topic:
 
 2. Create `.workflows/{work_unit}/research/{new_topic}.md` using **[template.md](template.md)**. Move content verbatim from the source file — reword only for flow and readability, no summarisation. Remove the extracted content from the source file.
 
-3. Generate a one-sentence summary of the extracted content (drawn from the thread itself). This becomes the inception item's `summary` field, used in map renders.
+3. Generate a one-sentence summary of the extracted content (drawn from the thread itself). This becomes the inception item's `summary` field, used in map renders. Generate a paragraph or two of richer context in the same turn — this becomes the `description` field, loaded by entry skills as opening context when the user later picks the topic up.
 
 4. Write manifest items — research first, then inception. If the validation returned `matches-dismissed`, pull from the dismissed list first:
 
@@ -59,6 +59,7 @@ For each split topic:
    node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.inception.{new_topic}
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{new_topic} routing research
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{new_topic} summary "{one-line summary}"
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{new_topic} description "{paragraphs}"
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{new_topic} source "research-split:{parent_topic}"
    ```
 

--- a/skills/workflow-shared/references/discussion-gap-analysis.md
+++ b/skills/workflow-shared/references/discussion-gap-analysis.md
@@ -111,11 +111,14 @@ Initialise the inception item and write its fields:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.inception.{name}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} summary "{one-line summary}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} description "{paragraphs}"
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} routing discussion
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} source gap-analysis
 ```
 
 Routing is `discussion` — gap topics are discussion candidates by definition.
+
+`description` is a paragraph or two extracted from the gap analysis for this topic — richer context than the one-line summary, loaded by entry skills as opening context when the user later picks the topic up for discussion. Quote with single quotes; description may span multiple paragraphs.
 
 Append the name to the caller's `tracker` so the orchestrator can surface it via callout / Self-Healing Arrivals.
 

--- a/skills/workflow-shared/references/ensure-inception-item.md
+++ b/skills/workflow-shared/references/ensure-inception-item.md
@@ -6,7 +6,7 @@
 
 Idempotently ensures a `phases.inception.items.{topic}` entry exists for the given topic on the given work unit. If the work unit is not an epic, returns immediately — only epics have a discovery map. Otherwise: if the item already exists, this reference is a no-op; if not, it pulls the topic from `dismissed[]` (when present) and creates the item with `source: direct-start` and the caller-supplied `routing`.
 
-The reference assumes `topic` is already kebab-case — callers normalise before invoking. No summary is set; direct-entry items have no source content to summarise. The user can backfill via refinement's edit-summary later.
+The reference assumes `topic` is already kebab-case — callers normalise before invoking. Callers may pass `summary` and `description` when they have material to derive from (e.g. the user's opening response to "what topic"); when omitted, the item is created with routing + source only and the user can backfill via refinement later.
 
 ## Parameters
 
@@ -16,6 +16,8 @@ The caller provides these via context before loading:
 - `work_unit` — the epic's work unit name. Always present.
 - `topic` — the kebab-case topic name. Always present.
 - `routing` — the literal `research` or `discussion`. Set by the caller based on which entry verb the user picked.
+- `summary` — optional one-line summary. Written only on creation, only when provided and non-empty.
+- `description` — optional paragraph or two of richer context. Written only on creation, only when provided and non-empty.
 
 ## A. Gate on Work Type
 
@@ -83,6 +85,18 @@ Initialise the item and set provenance fields:
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.inception.{topic}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} routing {routing}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} source direct-start
+```
+
+If `summary` was supplied and is non-empty, write it. Quote with single quotes; preserve apostrophes inside via standard shell escaping:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} summary "{summary}"
+```
+
+If `description` was supplied and is non-empty, write it. Description may span multiple paragraphs; quote the same way as summary:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{topic} description "{description}"
 ```
 
 No commit here — the manifest writes are folded into the next commit produced by the calling phase's process.

--- a/skills/workflow-shared/references/research-analysis.md
+++ b/skills/workflow-shared/references/research-analysis.md
@@ -100,11 +100,14 @@ Initialise the inception item and write its fields:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.inception.{name}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} summary "{one-line summary}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} description "{paragraphs}"
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} routing discussion
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.inception.{name} source research-analysis
 ```
 
 Routing is `discussion` — research-surfaced themes are discussion candidates by definition.
+
+`description` is a paragraph or two extracted from the analysis output for this topic — richer context than the one-line summary, loaded by entry skills as opening context when the user later picks the topic up for discussion. Quote with single quotes; description may span multiple paragraphs.
 
 Append the name to the caller's `tracker` so the orchestrator can surface it via callout / Self-Healing Arrivals.
 

--- a/tests/scripts/test-discovery-for-continue-epic.cjs
+++ b/tests/scripts/test-discovery-for-continue-epic.cjs
@@ -297,22 +297,26 @@ describe('continue-epic discovery', () => {
       assert.strictEqual(d.analysis_caches.gap_analysis.status, 'absent');
     });
 
-    it('discovery_map exposes source and summary per item for legacy-recovery filter', () => {
-      // Continue-epic Step 6 (Legacy Recovery) filters discovery_map by
-      // source.startsWith('migration-seeded') && !summary. This locks the shape.
-      // The startsWith check is necessary because Phase 7's analyses append
+    it('discovery_map exposes source, summary, and description per item for legacy-recovery filter', () => {
+      // Continue-epic Step 6 (Summary Backfill) filters discovery_map by
+      // source.startsWith('migration-seeded') && (!summary || !description).
+      // Phase 14 expanded the filter from summary-only to also catch
+      // description-null items, so pre-Phase-14 backfills (summary present,
+      // description null) re-enter the flow once to populate description.
+      // The startsWith check on source remains: Phase 7's analyses append
       // their tag to existing source values (e.g. 'migration-seeded,research-analysis')
-      // when re-surfacing a migrated topic, without writing a summary.
+      // when re-surfacing a migrated topic, without writing summary or description.
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
           inception: {
             items: {
-              'pristine': { routing: 'research', source: 'inception', summary: 'Brand-new topic with summary' },
+              'pristine': { routing: 'research', source: 'inception', summary: 'Brand-new topic with summary', description: 'Already grounded' },
               'migrated-no-summary': { routing: 'research', source: 'migration-seeded' },
-              'migrated-with-summary': { routing: 'discussion', source: 'migration-seeded', summary: 'Already populated' },
+              'migrated-summary-no-description': { routing: 'discussion', source: 'migration-seeded', summary: 'Backfilled before Phase 14' },
+              'migrated-fully-populated': { routing: 'discussion', source: 'migration-seeded', summary: 'Both populated', description: 'Backfilled after Phase 14' },
               'migrated-then-resurfaced': { routing: 'discussion', source: 'migration-seeded,research-analysis' },
-              'analysis-only': { routing: 'discussion', source: 'research-analysis', summary: 'From analysis' },
+              'analysis-only': { routing: 'discussion', source: 'research-analysis', summary: 'From analysis', description: 'analysis paragraphs' },
             },
           },
         },
@@ -323,22 +327,35 @@ describe('continue-epic discovery', () => {
 
       assert.strictEqual(byName['pristine'].source, 'inception');
       assert.strictEqual(byName['pristine'].summary, 'Brand-new topic with summary');
+      assert.strictEqual(byName['pristine'].description, 'Already grounded');
 
       assert.strictEqual(byName['migrated-no-summary'].source, 'migration-seeded');
       assert.strictEqual(byName['migrated-no-summary'].summary, null);
+      assert.strictEqual(byName['migrated-no-summary'].description, null);
 
-      assert.strictEqual(byName['migrated-with-summary'].source, 'migration-seeded');
-      assert.strictEqual(byName['migrated-with-summary'].summary, 'Already populated');
+      assert.strictEqual(byName['migrated-summary-no-description'].summary, 'Backfilled before Phase 14');
+      assert.strictEqual(byName['migrated-summary-no-description'].description, null);
+
+      assert.strictEqual(byName['migrated-fully-populated'].summary, 'Both populated');
+      assert.strictEqual(byName['migrated-fully-populated'].description, 'Backfilled after Phase 14');
 
       assert.strictEqual(byName['migrated-then-resurfaced'].source, 'migration-seeded,research-analysis');
       assert.strictEqual(byName['migrated-then-resurfaced'].summary, null);
+      assert.strictEqual(byName['migrated-then-resurfaced'].description, null);
 
       assert.strictEqual(byName['analysis-only'].source, 'research-analysis');
 
-      // The legacy-recovery filter contract — matches origin via startsWith
-      const toRecover = map.filter(t => t.source && t.source.startsWith('migration-seeded') && !t.summary);
+      // The Phase-14 filter contract — migration-seeded items missing either summary or description
+      const toRecover = map.filter(t =>
+        t.source && t.source.startsWith('migration-seeded') && (!t.summary || !t.description)
+      );
       const recoverNames = toRecover.map(t => t.name).sort();
-      assert.deepStrictEqual(recoverNames, ['migrated-no-summary', 'migrated-then-resurfaced']);
+      assert.deepStrictEqual(
+        recoverNames,
+        ['migrated-no-summary', 'migrated-summary-no-description', 'migrated-then-resurfaced'],
+      );
+      // Items already fully populated are excluded
+      assert.ok(!recoverNames.includes('migrated-fully-populated'));
     });
   });
 

--- a/tests/scripts/test-discovery-for-refinement.cjs
+++ b/tests/scripts/test-discovery-for-refinement.cjs
@@ -83,7 +83,7 @@ describe('workflow-inception-process discovery', () => {
       phases: {
         inception: {
           items: {
-            'auth-flow': { status: 'in-progress', summary: 'oauth + sessions', routing: 'research', source: 'inception' },
+            'auth-flow': { status: 'in-progress', summary: 'oauth + sessions', description: 'two paragraphs of richer context', routing: 'research', source: 'inception' },
           },
         },
       },
@@ -92,12 +92,22 @@ describe('workflow-inception-process discovery', () => {
     const t = r.discovery_map[0];
     assert.strictEqual(t.name, 'auth-flow');
     assert.strictEqual(t.summary, 'oauth + sessions');
+    assert.strictEqual(t.description, 'two paragraphs of richer context');
     assert.strictEqual(t.routing, 'research');
     assert.strictEqual(t.source, 'inception');
     assert.strictEqual(t.lifecycle, 'fresh');
     assert.strictEqual(t.tier, '○');
     assert.strictEqual(t.current_phase, null);
     assert.strictEqual(t.source_provenance, null);
+  });
+
+  it('defaults description to null when missing — legacy/migration-seeded item back-compat', () => {
+    createManifest(dir, 'payments', {
+      work_type: 'epic',
+      phases: { inception: { items: { 'a': { status: 'in-progress', routing: 'research', source: 'migration-seeded' } } } },
+    });
+    const r = discover(dir, 'payments');
+    assert.strictEqual(r.discovery_map[0].description, null);
   });
 
   it('defaults summary to null when missing', () => {

--- a/tests/scripts/test-ensure-inception-item.cjs
+++ b/tests/scripts/test-ensure-inception-item.cjs
@@ -1,0 +1,170 @@
+'use strict';
+
+// The ensure-inception-item reference is markdown — it instructs Claude to
+// invoke the manifest CLI with a specific sequence of commands. These tests
+// exercise the same CLI sequence the reference prescribes, so we lock in the
+// observable manifest state and the back-compat shape:
+//
+// - No summary / no description supplied → item carries routing + source only.
+// - Summary only → summary present, description absent.
+// - Both → both present.
+// - Idempotency → if the item already exists, the reference returns early
+//   (in B. Check Existence) and no overwrite happens — caller-supplied summary
+//   and description must not stomp existing values.
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const MANIFEST_CLI = path.resolve(
+  __dirname, '..', '..', 'skills', 'workflow-manifest', 'scripts', 'manifest.cjs'
+);
+
+let dir;
+
+function setup() {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-inception-test-'));
+  fs.mkdirSync(path.join(dir, '.workflows'), { recursive: true });
+}
+
+function cleanup() {
+  if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  dir = null;
+}
+
+function runCli(...args) {
+  const r = spawnSync('node', [MANIFEST_CLI, ...args], { cwd: dir, encoding: 'utf8' });
+  return { stdout: r.stdout, stderr: r.stderr, status: r.status };
+}
+
+function readManifest(workUnit) {
+  return JSON.parse(fs.readFileSync(
+    path.join(dir, '.workflows', workUnit, 'manifest.json'), 'utf8'
+  ));
+}
+
+function seedEpic(workUnit) {
+  const manifestDir = path.join(dir, '.workflows', workUnit);
+  fs.mkdirSync(manifestDir, { recursive: true });
+  const manifest = {
+    name: workUnit,
+    work_type: 'epic',
+    status: 'in-progress',
+    description: `Test: ${workUnit}`,
+    phases: { inception: { items: {} } },
+  };
+  fs.writeFileSync(
+    path.join(manifestDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2),
+  );
+  const projPath = path.join(dir, '.workflows', 'manifest.json');
+  let proj = {};
+  if (fs.existsSync(projPath)) proj = JSON.parse(fs.readFileSync(projPath, 'utf8'));
+  if (!proj.work_units) proj.work_units = {};
+  proj.work_units[workUnit] = { work_type: 'epic' };
+  fs.writeFileSync(projPath, JSON.stringify(proj, null, 2));
+}
+
+// Re-creates the CLI sequence in D. Create Inception Item. Summary and
+// description are only written when supplied + non-empty (back-compat: existing
+// callers pass neither and the item carries routing + source only).
+function ensureCreate(workUnit, topic, routing, { summary, description } = {}) {
+  assert.strictEqual(
+    runCli('init-phase', `${workUnit}.inception.${topic}`).status, 0,
+  );
+  assert.strictEqual(
+    runCli('set', `${workUnit}.inception.${topic}`, 'routing', routing).status, 0,
+  );
+  assert.strictEqual(
+    runCli('set', `${workUnit}.inception.${topic}`, 'source', 'direct-start').status, 0,
+  );
+  if (summary) {
+    assert.strictEqual(
+      runCli('set', `${workUnit}.inception.${topic}`, 'summary', summary).status, 0,
+    );
+  }
+  if (description) {
+    assert.strictEqual(
+      runCli('set', `${workUnit}.inception.${topic}`, 'description', description).status, 0,
+    );
+  }
+}
+
+describe('ensure-inception-item: create without summary or description', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('creates an item with routing + source only (back-compat)', () => {
+    seedEpic('payments');
+    ensureCreate('payments', 'auth', 'discussion');
+
+    const item = readManifest('payments').phases.inception.items['auth'];
+    assert.strictEqual(item.routing, 'discussion');
+    assert.strictEqual(item.source, 'direct-start');
+    assert.ok(!('summary' in item), 'summary unexpectedly written');
+    assert.ok(!('description' in item), 'description unexpectedly written');
+  });
+});
+
+describe('ensure-inception-item: create with summary only', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('writes summary but no description', () => {
+    seedEpic('payments');
+    ensureCreate('payments', 'auth', 'research', { summary: 'oauth + sessions' });
+
+    const item = readManifest('payments').phases.inception.items['auth'];
+    assert.strictEqual(item.summary, 'oauth + sessions');
+    assert.ok(!('description' in item), 'description unexpectedly written');
+  });
+});
+
+describe('ensure-inception-item: create with summary and description', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  it('writes both fields verbatim', () => {
+    seedEpic('payments');
+    const desc = 'Two paragraphs.\n\nSecond paragraph with apostrophe\'s and "quotes".';
+    ensureCreate('payments', 'auth', 'research', {
+      summary: 'oauth + sessions',
+      description: desc,
+    });
+
+    const item = readManifest('payments').phases.inception.items['auth'];
+    assert.strictEqual(item.summary, 'oauth + sessions');
+    assert.strictEqual(item.description, desc);
+    assert.strictEqual(item.routing, 'research');
+    assert.strictEqual(item.source, 'direct-start');
+  });
+});
+
+describe('ensure-inception-item: idempotency on existing item', () => {
+  beforeEach(setup);
+  afterEach(cleanup);
+
+  // Section B. Check Existence: when the item already exists, the reference
+  // returns to caller before D. Create — so caller-supplied summary/description
+  // never reach the CLI. This test exercises the existence check directly: if
+  // exists returns true, ensureCreate must NOT run.
+  it('returns existence=true and does not overwrite existing summary or description', () => {
+    seedEpic('payments');
+    ensureCreate('payments', 'auth', 'research', {
+      summary: 'original summary',
+      description: 'original description',
+    });
+
+    const existsResult = runCli('exists', 'payments.inception.auth');
+    assert.strictEqual(existsResult.status, 0);
+    assert.strictEqual(existsResult.stdout.trim(), 'true');
+
+    // Caller short-circuits — ensureCreate is not invoked again. Manifest stays.
+    const item = readManifest('payments').phases.inception.items['auth'];
+    assert.strictEqual(item.summary, 'original summary');
+    assert.strictEqual(item.description, 'original description');
+  });
+});

--- a/tests/scripts/test-refinement-session.cjs
+++ b/tests/scripts/test-refinement-session.cjs
@@ -199,6 +199,104 @@ describe('refinement: rename mechanical sequence', () => {
   });
 });
 
+describe('refinement: edit description', () => {
+  beforeEach(setupFixture);
+  afterEach(cleanupFixture);
+
+  // Section I. Edit Description mirrors E. Edit Summary — a single
+  // `set ... description` per topic, preserving the other fields.
+  it('overwrites description and preserves summary, routing, source', () => {
+    seedEpic('payments', {
+      'auth-flow': {
+        status: 'in-progress',
+        summary: 'oauth + sessions',
+        description: 'original paragraph',
+        routing: 'research',
+        source: 'inception',
+      },
+    });
+
+    const r = runCli('set', 'payments.inception.auth-flow', 'description', 'replacement description spans\n\ntwo paragraphs');
+    assert.strictEqual(r.status, 0, `set failed: ${r.stderr}`);
+
+    const item = readManifest('payments').phases.inception.items['auth-flow'];
+    assert.strictEqual(item.description, 'replacement description spans\n\ntwo paragraphs');
+    assert.strictEqual(item.summary, 'oauth + sessions');
+    assert.strictEqual(item.routing, 'research');
+    assert.strictEqual(item.source, 'inception');
+  });
+
+  it('is idempotent when the same description is written twice', () => {
+    seedEpic('payments', {
+      'auth-flow': {
+        status: 'in-progress',
+        summary: 'oauth + sessions',
+        description: 'original paragraph',
+        routing: 'research',
+        source: 'inception',
+      },
+    });
+
+    runCli('set', 'payments.inception.auth-flow', 'description', 'second take');
+    const first = readManifest('payments').phases.inception.items['auth-flow'].description;
+    runCli('set', 'payments.inception.auth-flow', 'description', 'second take');
+    const second = readManifest('payments').phases.inception.items['auth-flow'].description;
+
+    assert.strictEqual(first, 'second take');
+    assert.strictEqual(second, 'second take');
+  });
+
+  it('writes description on a lifecycle past fresh — no gate', () => {
+    // Edit description lifecycle row says "any" — researching/discussing items
+    // are valid targets.
+    seedEpic('payments', {
+      'auth-flow': {
+        status: 'in-progress',
+        summary: 'oauth + sessions',
+        description: 'before',
+        routing: 'research',
+        source: 'inception',
+      },
+    });
+    const manifest = readManifest('payments');
+    manifest.phases.research = { items: { 'auth-flow': { status: 'in-progress' } } };
+    fs.writeFileSync(
+      path.join(dir, '.workflows', 'payments', 'manifest.json'),
+      JSON.stringify(manifest, null, 2),
+    );
+
+    const r = runCli('set', 'payments.inception.auth-flow', 'description', 'after');
+    assert.strictEqual(r.status, 0);
+    assert.strictEqual(
+      readManifest('payments').phases.inception.items['auth-flow'].description,
+      'after',
+    );
+  });
+});
+
+describe('refinement: add operation persists description', () => {
+  beforeEach(setupFixture);
+  afterEach(cleanupFixture);
+
+  // Section D. Add now writes description after summary when an Add proposal
+  // carries it (the same Claude turn that proposes routing derives both).
+  it('writes description on a newly-added topic', () => {
+    seedEpic('payments', {});
+
+    assert.strictEqual(runCli('init-phase', 'payments.inception.tax-handling').status, 0);
+    assert.strictEqual(runCli('set', 'payments.inception.tax-handling', 'summary', 'VAT + invoice rules').status, 0);
+    assert.strictEqual(runCli('set', 'payments.inception.tax-handling', 'description', 'two-paragraph framing of the tax problem space').status, 0);
+    assert.strictEqual(runCli('set', 'payments.inception.tax-handling', 'routing', 'research').status, 0);
+    assert.strictEqual(runCli('set', 'payments.inception.tax-handling', 'source', 'inception').status, 0);
+
+    const item = readManifest('payments').phases.inception.items['tax-handling'];
+    assert.strictEqual(item.summary, 'VAT + invoice rules');
+    assert.strictEqual(item.description, 'two-paragraph framing of the tax problem space');
+    assert.strictEqual(item.routing, 'research');
+    assert.strictEqual(item.source, 'inception');
+  });
+});
+
 describe('refinement: lifecycle gate via computeTopicLifecycle', () => {
   beforeEach(setupFixture);
   afterEach(cleanupFixture);


### PR DESCRIPTION
## Summary

- Adds a `description` field (paragraph or two) to every inception item alongside `summary`. Every write surface — initial inception, refinement Add, research-analysis, gap-analysis, topic split, discussion elevation, and direct-entry — now populates both fields from the same source material in the same Claude turn.
- Direct-entry now derives summary + description from the user's opening response: `ensure-inception-item` accepts both as optional parameters; `workflow-discussion-entry` and `workflow-research-entry` derive them silently before invoking the reference.
- Entry skills read `description` from the manifest and append a Description block to the handoff for every non-`continue` source branch, so research/discussion sessions open grounded rather than blank. Legacy items with null description fall through silently — block omitted, no header with empty body.
- Refinement gains a new **Edit Description** operation that mirrors Edit Summary (batched STOP gate, single `set ... description` per topic, session-log entry, single commit).
- `discovery.cjs` now exposes `description` on each map item so the new Edit Description op can show the current value.
- `design.md` data-model bullets gain `description` as a peer field. No migration to back-fill — legacy items stay `null` until the user edits via refinement.

## Test plan

- [x] `node --test tests/scripts/test-*.cjs` — 639 passing
- [x] Migration tests regression — all pass
- [x] Knowledge tests regression — all pass
- [ ] Manual smoke: fresh epic → inception persist writes description; refinement Add writes description; refinement Edit Description preserves other fields; `/continue-epic` on a topic with `research-analysis` source has description set
- [ ] Manual smoke: discussion handoff includes Description block when description present; omits it for legacy null description
- [ ] Manual smoke: direct-entry `d`/`discuss` and `r`/`research` populate summary and description, opening session is grounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)