### PR TITLE
Investigation: show findings before synthesis-validation gate

### DIFF
--- a/ideas/investigation-show-interim-findings.md
+++ b/ideas/investigation-show-interim-findings.md
@@ -2,7 +2,7 @@
 
 ## The Idea
 
-In the bugfix investigation phase, present discovery findings to the user *before* asking whether to run the synthesis/check step. Reorder the flow so the validate/skip decision is made against visible content, not a blind prompt.
+In the bugfix investigation phase, present discovery findings to the user *before* asking whether to run the synthesis/check step. Frame them as interim — "this is what I have so far. Want me to verify these, go deeper to confirm they're right, or is this enough?"
 
 ## Why This Matters
 
@@ -12,33 +12,8 @@ Most of the machinery is already there. The discovery happens, the content gets 
 
 Even if the findings turn out to be wrong, presenting them as tentative is far more useful than hiding them. The user can spot obvious gaps, confirm a direction, or say "yes, dig into this one specifically" — none of which are possible when the prompt arrives with no context.
 
-## The Reorder
-
-The synthesis agent has a hard rule against modifying the investigation file — it writes only to a cache file. Findings content is therefore unchanged before and after synthesis runs, which means re-rendering the same structured block in two places is duplication.
-
-The fix is a real reorder, not an additive interim render:
-
-1. **Step 7 (`synthesis-agent.md`)** gains a new first section that renders the structured findings block (Root Cause / Contributing Factors / Blast Radius / Why It Wasn't Caught) before the validate/skip prompt. The synthesis result (validated line or gaps summary) prints immediately after, so the user sees findings + any gaps together upthread.
-2. **Step 8 (`findings-review.md`)** stops re-rendering the same block on entry. It becomes a pure confirmation gate: "do these match your understanding?" against the content already visible above.
-
-## The Feedback-Loop Split
-
-Removing the entry render from Step 8 creates one wrinkle: the existing feedback branch updates the investigation file and loops back to re-show the findings before re-gating. If Step 8's first entry skips the render, the loop branch still needs one — otherwise the user is gating against stale content the second time around.
-
-Split Step 8 into two sections:
-
-- **Confirm Findings** — first-entry gate, no render. Findings are already visible upthread. Includes a fallback line for resume-after-compaction: if the user lands here without findings in view, ask and re-render.
-- **Findings Updated — Re-Present** — feedback branch, with the structured render restored. Re-renders updated findings, then re-gates. Loops on itself until the user accepts.
-
-## Outcome
-
-- One findings render per investigation (two if the user pushes back).
-- Two STOP gates on the happy path.
-- Validate/skip is no longer blind.
-- No content lost from either reference file.
-
 ## Design Consideration
 
-The framing matters. Not "here are the conclusions" (which would overclaim and discourage the deeper check), but "root cause documented — verify, or skip?" That keeps the door open to the synthesis step without forcing the user to commit blind.
+The framing matters. Not "here are the conclusions" (which would overclaim and discourage the deeper check), but "here's what I've gathered so far — worth verifying, or good enough?" That keeps the door open to the synthesis step without forcing the user to commit blind.
 
 This pattern probably generalises beyond investigation — anywhere a phase asks "want me to do extra validation?" the user is better served by seeing the candidate output first.

--- a/ideas/investigation-show-interim-findings.md
+++ b/ideas/investigation-show-interim-findings.md
@@ -2,7 +2,7 @@
 
 ## The Idea
 
-In the bugfix investigation phase, present discovery findings to the user *before* asking whether to run the synthesis/check step. Frame them as interim — "this is what I have so far. Want me to verify these, go deeper to confirm they're right, or is this enough?"
+In the bugfix investigation phase, present discovery findings to the user *before* asking whether to run the synthesis/check step. Reorder the flow so the validate/skip decision is made against visible content, not a blind prompt.
 
 ## Why This Matters
 
@@ -12,8 +12,33 @@ Most of the machinery is already there. The discovery happens, the content gets 
 
 Even if the findings turn out to be wrong, presenting them as tentative is far more useful than hiding them. The user can spot obvious gaps, confirm a direction, or say "yes, dig into this one specifically" — none of which are possible when the prompt arrives with no context.
 
+## The Reorder
+
+The synthesis agent has a hard rule against modifying the investigation file — it writes only to a cache file. Findings content is therefore unchanged before and after synthesis runs, which means re-rendering the same structured block in two places is duplication.
+
+The fix is a real reorder, not an additive interim render:
+
+1. **Step 7 (`synthesis-agent.md`)** gains a new first section that renders the structured findings block (Root Cause / Contributing Factors / Blast Radius / Why It Wasn't Caught) before the validate/skip prompt. The synthesis result (validated line or gaps summary) prints immediately after, so the user sees findings + any gaps together upthread.
+2. **Step 8 (`findings-review.md`)** stops re-rendering the same block on entry. It becomes a pure confirmation gate: "do these match your understanding?" against the content already visible above.
+
+## The Feedback-Loop Split
+
+Removing the entry render from Step 8 creates one wrinkle: the existing feedback branch updates the investigation file and loops back to re-show the findings before re-gating. If Step 8's first entry skips the render, the loop branch still needs one — otherwise the user is gating against stale content the second time around.
+
+Split Step 8 into two sections:
+
+- **Confirm Findings** — first-entry gate, no render. Findings are already visible upthread. Includes a fallback line for resume-after-compaction: if the user lands here without findings in view, ask and re-render.
+- **Findings Updated — Re-Present** — feedback branch, with the structured render restored. Re-renders updated findings, then re-gates. Loops on itself until the user accepts.
+
+## Outcome
+
+- One findings render per investigation (two if the user pushes back).
+- Two STOP gates on the happy path.
+- Validate/skip is no longer blind.
+- No content lost from either reference file.
+
 ## Design Consideration
 
-The framing matters. Not "here are the conclusions" (which would overclaim and discourage the deeper check), but "here's what I've gathered so far — worth verifying, or good enough?" That keeps the door open to the synthesis step without forcing the user to commit blind.
+The framing matters. Not "here are the conclusions" (which would overclaim and discourage the deeper check), but "root cause documented — verify, or skip?" That keeps the door open to the synthesis step without forcing the user to commit blind.
 
 This pattern probably generalises beyond investigation — anywhere a phase asks "want me to do extra validation?" the user is better served by seeing the candidate output first.

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -275,8 +275,8 @@ Document in the investigation file and commit.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Validating the root cause analysis against the codebase
-> to confirm the diagnosis is correct.
+> Reviewing the findings and optionally validating the root
+> cause against the codebase.
 ```
 
 Load **[synthesis-agent.md](references/synthesis-agent.md)** and follow its instructions as written.
@@ -296,8 +296,8 @@ Load **[synthesis-agent.md](references/synthesis-agent.md)** and follow its inst
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Presenting the investigation findings and discussing
-> the fix approach with you.
+> Confirming the findings and discussing the fix approach
+> with you.
 ```
 
 Load **[findings-review.md](references/findings-review.md)** and follow its instructions as written.

--- a/skills/workflow-investigation-process/references/findings-review.md
+++ b/skills/workflow-investigation-process/references/findings-review.md
@@ -8,8 +8,6 @@ Present your analysis to the user for validation, then collaboratively agree on 
 
 ## A. Confirm Findings
 
-Findings have already been presented upthread (and any synthesis gaps with them). This is the confirmation gate before fix discussion. If you resumed mid-flow and the findings aren't visible above, ask and I'll re-render.
-
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
@@ -35,7 +33,7 @@ Do these findings match your understanding?
 
 ## B. Findings Updated — Re-Present
 
-Address the user's concerns directly. Re-trace code paths if needed. Provide supporting evidence from the code trace. Update the investigation file with corrections, and commit.
+Address the user's concerns directly. Re-trace code paths if needed. Provide supporting evidence from the code trace. Update the investigation file with corrections or new information, and commit.
 
 Re-render the updated findings so the user is gating against the new content, not the old. Pull current values from the investigation file.
 

--- a/skills/workflow-investigation-process/references/findings-review.md
+++ b/skills/workflow-investigation-process/references/findings-review.md
@@ -6,9 +6,38 @@
 
 Present your analysis to the user for validation, then collaboratively agree on fix direction. Simple bugs flow fast (2 STOP gates). Complex bugs expand naturally through discussion.
 
-## A. Present Findings
+## A. Confirm Findings
 
-Summarize the investigation findings in a structured display. Pull from the investigation file — do not invent or embellish.
+Findings have already been presented upthread (and any synthesis gaps with them). This is the confirmation gate before fix discussion. If you resumed mid-flow and the findings aren't visible above, ask and I'll re-render.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Do these findings match your understanding?
+
+- **`y`/`yes`** — Findings are correct, discuss fix direction
+- **Provide feedback** — Tell me what's off or unclear
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `yes`
+
+→ Proceed to **C. Fix Direction Discussion**.
+
+#### If the user provides feedback
+
+→ Proceed to **B. Findings Updated — Re-Present**.
+
+---
+
+## B. Findings Updated — Re-Present
+
+Address the user's concerns directly. Re-trace code paths if needed. Provide supporting evidence from the code trace. Update the investigation file with corrections, and commit.
+
+Re-render the updated findings so the user is gating against the new content, not the old. Pull current values from the investigation file.
 
 > *Output the next fenced block as a code block:*
 
@@ -30,19 +59,6 @@ Why It Wasn't Caught:
   {testing gap, edge case, recent change}
 ```
 
-**If synthesis validation was run and found gaps**, add a synthesis block:
-
-> *Output the next fenced block as a code block:*
-
-```
-Synthesis Validation ({CONFIDENCE} confidence):
-  {gap 1}
-  {gap 2}
-
-These gaps may affect the root cause assessment. Consider them
-during your review.
-```
-
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
@@ -56,19 +72,17 @@ Do these findings match your understanding?
 
 **STOP.** Wait for user response.
 
-#### If the user provides feedback
-
-Address their concerns directly. Re-trace code paths if needed. Provide supporting evidence from the code trace. Update the investigation file with corrections or new information, and commit.
-
-→ Return to **A. Present Findings**.
-
 #### If `yes`
 
-→ Proceed to **B. Fix Direction Discussion**.
+→ Proceed to **C. Fix Direction Discussion**.
+
+#### If the user provides feedback
+
+→ Return to **B. Findings Updated — Re-Present**.
 
 ---
 
-## B. Fix Direction Discussion
+## C. Fix Direction Discussion
 
 Present what the analysis surfaced about how to fix this. Let the findings guide the shape — there's no required number of approaches:
 
@@ -109,7 +123,7 @@ Engage collaboratively. Stay bounded — focus on:
 
 Do not go into implementation detail — that belongs in the specification.
 
-→ Return to **B. Fix Direction Discussion**.
+→ Return to **C. Fix Direction Discussion**.
 
 #### If `yes`
 

--- a/skills/workflow-investigation-process/references/synthesis-agent.md
+++ b/skills/workflow-investigation-process/references/synthesis-agent.md
@@ -4,7 +4,7 @@
 
 ---
 
-An independent synthesis agent validates the root cause hypothesis by tracing code fresh. This step is optional — the user chooses whether to run it, with the findings visible first.
+An independent synthesis agent validates the root cause hypothesis by tracing code fresh. This step is optional — the user chooses whether to run it.
 
 ## A. Present Findings
 
@@ -146,7 +146,5 @@ Synthesis: {CONFIDENCE} confidence. {GAPS_COUNT} gap(s) identified.
 
 Full analysis: .workflows/.cache/{work_unit}/investigation/{topic}/synthesis-{NNN}.md
 ```
-
-The gaps are now visible upthread alongside the findings — Step 8 (Findings Review) is purely a confirmation gate and does not re-render.
 
 → Return to caller.

--- a/skills/workflow-investigation-process/references/synthesis-agent.md
+++ b/skills/workflow-investigation-process/references/synthesis-agent.md
@@ -4,9 +4,37 @@
 
 ---
 
-An independent synthesis agent validates the root cause hypothesis by tracing code fresh. This step is optional — the user chooses whether to run it.
+An independent synthesis agent validates the root cause hypothesis by tracing code fresh. This step is optional — the user chooses whether to run it, with the findings visible first.
 
-## A. Offer Validation
+## A. Present Findings
+
+Summarize the investigation findings in a structured display. Pull from the investigation file — do not invent or embellish.
+
+> *Output the next fenced block as a code block:*
+
+```
+Investigation Findings: {work_unit}
+
+Root Cause:
+  {clear, precise root cause statement}
+
+Contributing Factors:
+  {factor 1}
+  {factor 2}
+
+Blast Radius:
+  Directly affected:  {components}
+  Potentially affected: {components sharing code/patterns}
+
+Why It Wasn't Caught:
+  {testing gap, edge case, recent change}
+```
+
+→ Proceed to **B. Offer Validation**.
+
+---
+
+## B. Offer Validation
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -15,7 +43,7 @@ An independent synthesis agent validates the root cause hypothesis by tracing co
 Root cause documented. Run synthesis validation?
 
 An independent agent will trace the code to validate the
-root cause hypothesis before you review findings.
+root cause hypothesis before confirming.
 
 - **`y`/`yes`** — Run synthesis validation
 - **`s`/`skip`** — Skip straight to findings review
@@ -30,11 +58,11 @@ root cause hypothesis before you review findings.
 
 #### If `yes`
 
-→ Proceed to **B. Dispatch**.
+→ Proceed to **C. Dispatch**.
 
 ---
 
-## B. Dispatch
+## C. Dispatch
 
 Ensure the cache directory exists:
 
@@ -82,11 +110,11 @@ GAPS_COUNT: {N}
 SUMMARY: {1 sentence}
 ```
 
-→ Proceed to **C. Process Results**.
+→ Proceed to **D. Process Results**.
 
 ---
 
-## C. Process Results
+## D. Process Results
 
 Read the synthesis output file.
 
@@ -119,6 +147,6 @@ Synthesis: {CONFIDENCE} confidence. {GAPS_COUNT} gap(s) identified.
 Full analysis: .workflows/.cache/{work_unit}/investigation/{topic}/synthesis-{NNN}.md
 ```
 
-Carry the synthesis context forward — Step 8 (Findings Review) will incorporate these gaps into the findings presentation.
+The gaps are now visible upthread alongside the findings — Step 8 (Findings Review) is purely a confirmation gate and does not re-render.
 
 → Return to caller.


### PR DESCRIPTION
## Summary

- Reorder bugfix investigation flow so users see structured findings (Root Cause / Contributing Factors / Blast Radius / Why It Wasn't Caught) **before** the synthesis validate/skip prompt instead of after it.
- Slim Step 8 (`findings-review.md`) to a pure confirmation gate on first entry — no duplicate render — while restoring a render in the feedback branch so re-gating is against updated content.
- Rewrite the `ideas/investigation-show-interim-findings.md` doc to match the final reorder shape (it previously described an additive interim render).

## What changed

- `skills/workflow-investigation-process/references/synthesis-agent.md` — new `A. Present Findings`; renumber to B/C/D; update gate sub-text and trailing note.
- `skills/workflow-investigation-process/references/findings-review.md` — split entry gate (A) from feedback re-present branch (B); renumber Fix Direction Discussion to C; update self-loop arrow.
- `ideas/investigation-show-interim-findings.md` — rewrite body.

## Test plan

- [ ] Paper-trace: skip path → 1 render, 2 STOP gates
- [ ] Paper-trace: validated path → 1 render + validated line, 2 STOP gates
- [ ] Paper-trace: gaps_found path → 1 render + gaps summary, 2 STOP gates, no second render
- [ ] Paper-trace: feedback loop → each iteration = 1 re-render + 1 gate
- [ ] All `→ Proceed to` / `→ Return to` arrows resolve to existing headings in both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)