### PR TITLE
continue-epic: stop and advise restart after backfill pass

### DIFF
--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -227,7 +227,7 @@ Then read `discovery_map` from the most recent discovery `detail` and filter for
 
 Load **[backfill-checks.md](references/backfill-checks.md)** with work_unit = `{work_unit}`, qualifying_sources = `{qualifying_sources}`, items_to_recover = `{items_to_recover}`.
 
-→ Proceed to **Step 6**.
+backfill-checks is terminal when it fires — it commits the recovery work and stops, advising the user to `/clear` and re-run `/continue-epic`. Do not proceed to Step 6 on this branch.
 
 ---
 

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -227,7 +227,7 @@ Then read `discovery_map` from the most recent discovery `detail` and filter for
 
 Load **[backfill-checks.md](references/backfill-checks.md)** with work_unit = `{work_unit}`, qualifying_sources = `{qualifying_sources}`, items_to_recover = `{items_to_recover}`.
 
-backfill-checks is terminal when it fires — it commits the recovery work and stops, advising the user to `/clear` and re-run `/continue-epic`. Do not proceed to Step 6 on this branch.
+backfill-checks is terminal when it fires — it commits the recovery work and stops, advising the user to `/clear` and re-run `/workflow-start`. Do not proceed to Step 6 on this branch.
 
 ---
 

--- a/skills/continue-epic/references/backfill-checks.md
+++ b/skills/continue-epic/references/backfill-checks.md
@@ -61,11 +61,11 @@ Mutations from A and B are already committed. Returning to the caller would cont
 > context-heavy — decomposing legacy research files and
 > drafting missing inception summaries from source content.
 >
-> Run `/clear`, then `/continue-epic` again to pick up with a
-> clean window. The backfill gates will be no-ops on the next
-> pass: legacy sources are now renamed and excluded, and
-> populated summaries skip the recovery filter — the normal
-> epic flow takes over immediately.
+> Run `/clear`, then `/workflow-start` to pick up with a clean
+> window. The backfill gates will be no-ops on the next pass:
+> legacy sources are now renamed and excluded, and populated
+> summaries skip the recovery filter — the normal epic flow
+> takes over immediately.
 ```
 
 **STOP.** Terminal — do not return to the caller's Step 6.

--- a/skills/continue-epic/references/backfill-checks.md
+++ b/skills/continue-epic/references/backfill-checks.md
@@ -46,7 +46,7 @@ Load **[summary-backfill.md](summary-backfill.md)** with work_unit = `{work_unit
 
 ## C. Advise Restart
 
-Mutations from A and B are already committed (apply.cjs commits per source; summary-backfill commits its batch). Returning to the caller would continue Step 6 onward inside the same conversation, but the backfill pass — particularly legacy decomposition — is context-heavy by design. Hand the user a fresh window before the rest of `/continue-epic` runs.
+Mutations from A and B are already committed. Returning to the caller would continue Step 6 onward inside the same conversation, but the backfill pass — particularly legacy decomposition — is context-heavy by design. Hand the user a fresh window before the rest of `/continue-epic` runs.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/continue-epic/references/backfill-checks.md
+++ b/skills/continue-epic/references/backfill-checks.md
@@ -38,8 +38,34 @@ Re-filter `discovery_map` for items where `summary` or `description` is null or 
 
 Load **[summary-backfill.md](summary-backfill.md)** with work_unit = `{work_unit}`, items_to_recover = `{items_to_recover}`.
 
-→ Return to caller.
+→ Proceed to **C. Advise Restart**.
 
 #### If `items_to_recover` is empty
 
-→ Return to caller.
+→ Proceed to **C. Advise Restart**.
+
+## C. Advise Restart
+
+Mutations from A and B are already committed (apply.cjs commits per source; summary-backfill commits its batch). Returning to the caller would continue Step 6 onward inside the same conversation, but the backfill pass — particularly legacy decomposition — is context-heavy by design. Hand the user a fresh window before the rest of `/continue-epic` runs.
+
+> *Output the next fenced block as a code block:*
+
+```
+── Backfill Complete ────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Backfill work is recorded and committed. This pass was
+> context-heavy — decomposing legacy research files and
+> drafting missing inception summaries from source content.
+>
+> Run `/clear`, then `/continue-epic` again to pick up with a
+> clean window. The backfill gates will be no-ops on the next
+> pass: legacy sources are now renamed and excluded, and
+> populated summaries skip the recovery filter — the normal
+> epic flow takes over immediately.
+```
+
+**STOP.** Terminal — do not return to the caller's Step 6.

--- a/skills/workflow-legacy-research-split/references/dialog.md
+++ b/skills/workflow-legacy-research-split/references/dialog.md
@@ -59,9 +59,6 @@ For each candidate theme, build a tentative entry:
 - `kebab_name` — short, kebab-cased
 - `summary` — one line
 - `description` — paragraph or two synthesised from the source
-- `routing` — assigned per the criteria below
-
-→ Load **[routing-decision.md](../../workflow-shared/references/routing-decision.md)**.
 
 Hold these in working memory. Do NOT write any cache files yet.
 
@@ -79,7 +76,6 @@ Candidate themes for {current_source}.md:
 @foreach(theme in candidates)
 {N}. {theme.kebab_name}
    └─ {theme.summary}
-   └─ Routing: {theme.routing}
 @endforeach
 ```
 
@@ -88,7 +84,7 @@ Candidate themes for {current_source}.md:
 ```
 · · · · · · · · · · · ·
 - **`y`/`yes`** — Proceed to draft cache files
-- **Redirect** — Adjust the theme list (rename, change routing, merge two, split one, add, remove)
+- **Redirect** — Adjust the theme list (rename, merge two, split one, add, remove)
 - **`a`/`abandon`** — Skip this source file
 · · · · · · · · · · · ·
 ```
@@ -104,7 +100,6 @@ Candidate themes for {current_source}.md:
 Apply the user's adjustment in working memory (no files written yet). Supported in-memory operations:
 
 - **Rename** — update `kebab_name` on the named theme
-- **Change routing** — flip `routing` on the named theme
 - **Merge two** — combine two candidate themes into one
 - **Split one** — replace one candidate theme with two
 - **Add** — insert a new candidate
@@ -162,8 +157,7 @@ Schema:
     {
       "kebab_name":  "auth",
       "summary":     "one-line summary",
-      "description": "paragraph or two synthesised from the source",
-      "routing":     "discussion" | "research"
+      "description": "paragraph or two synthesised from the source"
     }
   ]
 }
@@ -193,7 +187,6 @@ Plan for {current_source}.md:
 @foreach(theme in plan.themes)
 {N}. {theme.kebab_name}
    └─ Summary: {theme.summary}
-   └─ Routing: {theme.routing}
    └─ Content: {paragraph_count} para(s) — "{content_preview}..."
    └─ Cache: .workflows/.cache/{work_unit}/legacy-split/{current_source}/{theme.kebab_name}.md
 @endforeach
@@ -206,7 +199,7 @@ Source file will be renamed to {current_source}-superseded-{datetime}.md.
 ```
 · · · · · · · · · · · ·
 - **`y`/`yes`** — Apply this plan
-- **Edit** — Modify cache files or plan.json (rename, change routing, merge, split, add, remove). To rewrite a draft, edit the cache file directly between renders.
+- **Edit** — Modify cache files or plan.json (rename, merge, split, add, remove). To rewrite a draft, edit the cache file directly between renders.
 - **`a`/`abandon`** — Skip this source file
 · · · · · · · · · · · ·
 ```
@@ -232,10 +225,6 @@ Dispatch to the matching operation based on the user's request. Every operation 
 #### If the edit is a rename
 
 → Proceed to **K. Rename a Theme**.
-
-#### If the edit is a routing change
-
-→ Proceed to **L. Change Routing**.
 
 #### If the edit merges two themes
 
@@ -363,15 +352,6 @@ User specifies `old_name` and `new_name`.
 
 → Return to **F. Propose Plan**.
 
-## L. Change Routing
-
-User specifies `theme_name` and new `routing` (`discussion` | `research`).
-
-1. Read `plan.json`. Set the theme's `routing` to the new value.
-2. Write `plan.json`.
-
-→ Return to **F. Propose Plan**.
-
 ## M. Merge Two Themes
 
 User specifies `theme_a`, `theme_b`, and `surviving_name` (often equal to `theme_a` or `theme_b`).
@@ -382,7 +362,7 @@ User specifies `theme_a`, `theme_b`, and `surviving_name` (often equal to `theme
    - If `surviving_name == theme_a`: `rm .workflows/.cache/{work_unit}/legacy-split/{current_source}/{theme_b}.md`
    - If `surviving_name == theme_b`: `rm .workflows/.cache/{work_unit}/legacy-split/{current_source}/{theme_a}.md`
    - Otherwise (new name): `rm` both originals.
-4. Read `plan.json`. Remove both original theme entries. Add a new entry with `kebab_name = surviving_name`, summary/description merged or rewritten as the user directs, routing per the user's instruction.
+4. Read `plan.json`. Remove both original theme entries. Add a new entry with `kebab_name = surviving_name`, summary/description merged or rewritten as the user directs.
 5. Write `plan.json`.
 
 → Return to **F. Propose Plan**.
@@ -401,14 +381,14 @@ User specifies `original_name`, `name_a`, `name_b`, and (in their message) what 
    ```bash
    rm .workflows/.cache/{work_unit}/legacy-split/{current_source}/{original_name}.md
    ```
-4. Read `plan.json`. Remove the original theme entry. Add two new entries (`name_a`, `name_b`) with appropriate summary/description/routing. If any field is ambiguous, ask one clarifying question before proceeding — this is conversational flow, not a structured STOP.
+4. Read `plan.json`. Remove the original theme entry. Add two new entries (`name_a`, `name_b`) with appropriate summary/description. If any field is ambiguous, ask one clarifying question before proceeding — this is conversational flow, not a structured STOP.
 5. Write `plan.json`.
 
 → Return to **F. Propose Plan**.
 
 ## O. Add a Theme
 
-User specifies `kebab_name`, summary, description, routing, and the content for the new cache file.
+User specifies `kebab_name`, summary, description, and the content for the new cache file.
 
 1. Read `plan.json`. Add the new theme entry.
 2. Write `plan.json`.

--- a/skills/workflow-legacy-research-split/scripts/apply.cjs
+++ b/skills/workflow-legacy-research-split/scripts/apply.cjs
@@ -189,7 +189,7 @@ function apply(cwd, workUnit, currentSource) {
 
       runCli(cwd, ['init-phase', `${workUnit}.research.${theme.kebab_name}`]);
       runCli(cwd, ['init-phase', `${workUnit}.inception.${theme.kebab_name}`]);
-      runCli(cwd, ['set', `${workUnit}.inception.${theme.kebab_name}`, 'routing', theme.routing]);
+      runCli(cwd, ['set', `${workUnit}.inception.${theme.kebab_name}`, 'routing', 'research']);
       runCli(cwd, ['set', `${workUnit}.inception.${theme.kebab_name}`, 'summary', theme.summary]);
       runCli(cwd, ['set', `${workUnit}.inception.${theme.kebab_name}`, 'description', theme.description]);
       runCli(cwd, ['set', `${workUnit}.inception.${theme.kebab_name}`, 'source', `legacy-split:${currentSource}`]);

--- a/skills/workflow-legacy-research-split/scripts/validate.cjs
+++ b/skills/workflow-legacy-research-split/scripts/validate.cjs
@@ -16,14 +16,11 @@ const path = require('path');
 //     {
 //       "kebab_name":  "<string, unique within plan>",
 //       "summary":     "<non-empty, non-whitespace string>",
-//       "description": "<non-empty, non-whitespace string>",
-//       "routing":     "discussion" | "research"
+//       "description": "<non-empty, non-whitespace string>"
 //     },
 //     ...
 //   ]
 // }
-
-const VALID_ROUTING = new Set(['discussion', 'research']);
 
 function die(msg, code = 1) {
   process.stderr.write(`Error: ${msg}\n`);
@@ -98,10 +95,6 @@ function validate(cwd, workUnit, currentSource) {
     const description = typeof theme.description === 'string' ? theme.description.trim() : '';
     if (description === '') {
       errors.push(`theme '${label}' has empty description`);
-    }
-
-    if (!VALID_ROUTING.has(theme.routing)) {
-      errors.push(`theme '${label}' has invalid routing '${theme.routing}' (expected discussion|research)`);
     }
 
     if (typeof kebab === 'string' && kebab.trim() !== '') {

--- a/skills/workflow-shared/references/routing-decision.md
+++ b/skills/workflow-shared/references/routing-decision.md
@@ -1,6 +1,6 @@
 # Routing Decision
 
-*Shared reference. Loaded by `research-analysis.md`, `inception-gap-analysis.md`, and `workflow-legacy-research-split/references/dialog.md`.*
+*Shared reference. Loaded by `research-analysis.md` and `inception-gap-analysis.md`.*
 
 ---
 
@@ -31,6 +31,6 @@ Route to **`research`** when:
 
 When uncertain, prefer **`research`**. It's the lower-cost-to-reverse direction — research can conclude and route forward to discussion at any time; forcing discussion too early just sends the topic back for more research and burns user time.
 
-This default especially applies to material originating from a research file (legacy-split, research-analysis) — the file's existence implies the material is at research stage, and a candidate extracted from it should usually stay at research stage unless it visibly meets the discussion criteria above.
+This default especially applies to candidates extracted from a completed research file (research-analysis) — the file's existence implies the material is at research stage, and an extracted candidate should usually stay at research stage unless it visibly meets the discussion criteria above.
 
 → Return to caller.

--- a/tests/scripts/test-legacy-research-split.cjs
+++ b/tests/scripts/test-legacy-research-split.cjs
@@ -201,7 +201,6 @@ describe('validate.cjs: cache shape contract', () => {
     kebab_name: 'auth',
     summary: 'Auth flow',
     description: 'Auth description.',
-    routing: 'discussion',
     _content: 'auth content',
   });
 
@@ -217,7 +216,7 @@ describe('validate.cjs: cache shape contract', () => {
     const cacheDir = path.join(dir, '.workflows', '.cache', 'wu', 'legacy-split', 'src');
     fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(path.join(cacheDir, 'plan.json'), JSON.stringify({
-      themes: [{ kebab_name: 'auth', summary: 's', description: 'd', routing: 'discussion' }],
+      themes: [{ kebab_name: 'auth', summary: 's', description: 'd' }],
     }));
     const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
     assert.strictEqual(r.json.ok, false);
@@ -253,13 +252,6 @@ describe('validate.cjs: cache shape contract', () => {
     const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
     assert.strictEqual(r.json.ok, false);
     assert.ok(r.json.errors.some(e => e.includes('empty description')));
-  });
-
-  it('rejects invalid routing', () => {
-    writeCachePlan('wu', 'src', [{ ...baseTheme(), routing: 'foo' }]);
-    const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
-    assert.strictEqual(r.json.ok, false);
-    assert.ok(r.json.errors.some(e => e.includes('invalid routing')));
   });
 
   it('accepts a valid plan', () => {
@@ -338,7 +330,7 @@ describe('validate.cjs: cache shape contract', () => {
     const cacheDir = path.join(dir, '.workflows', '.cache', 'wu', 'legacy-split', 'src');
     fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(path.join(cacheDir, 'plan.json'), JSON.stringify({
-      themes: [{ summary: 's', description: 'd', routing: 'discussion' }],
+      themes: [{ summary: 's', description: 'd' }],
     }));
     const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
     assert.strictEqual(r.json.ok, false);
@@ -360,7 +352,7 @@ describe('validate.cjs: cache shape contract', () => {
     const cacheDir = path.join(dir, '.workflows', '.cache', 'wu', 'legacy-split', 'src');
     fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(path.join(cacheDir, 'plan.json'), JSON.stringify({
-      themes: [{ kebab_name: '   ', summary: 's', description: 'd', routing: 'discussion' }],
+      themes: [{ kebab_name: '   ', summary: 's', description: 'd' }],
     }));
     const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
     assert.strictEqual(r.json.ok, false);
@@ -378,9 +370,9 @@ describe('apply.cjs: end-to-end', () => {
     seedLegacyEpic('e1', 'exploration');
     writeCachePlan('e1', 'exploration', [
       { kebab_name: 'auth', summary: 'Auth', description: 'auth desc',
-        routing: 'discussion', _content: 'auth content' },
+        _content: 'auth content' },
       { kebab_name: 'caching', summary: 'Cache', description: 'cache desc',
-        routing: 'research', _content: 'cache content' },
+        _content: 'cache content' },
     ]);
 
     const r = runScriptJson(APPLY_CLI, 'e1', 'exploration');
@@ -404,7 +396,8 @@ describe('apply.cjs: end-to-end', () => {
     assert.strictEqual(m.phases.research.items[supersededName].status, 'superseded');
 
     // New inception + research items with correct metadata.
-    assert.strictEqual(m.phases.inception.items.auth.routing, 'discussion');
+    assert.strictEqual(m.phases.inception.items.auth.routing, 'research');
+    assert.strictEqual(m.phases.inception.items.caching.routing, 'research');
     assert.strictEqual(m.phases.inception.items.auth.summary, 'Auth');
     assert.strictEqual(m.phases.inception.items.auth.description, 'auth desc');
     assert.strictEqual(m.phases.inception.items.auth.source, 'legacy-split:exploration');
@@ -427,9 +420,9 @@ describe('apply.cjs: end-to-end', () => {
     seedLegacyEpic('e2', 'auth');
     writeCachePlan('e2', 'auth', [
       { kebab_name: 'auth', summary: 'Auth core', description: 'auth desc',
-        routing: 'discussion', _content: 'auth-only content' },
+        _content: 'auth-only content' },
       { kebab_name: 'caching', summary: 'Cache', description: 'cache desc',
-        routing: 'research', _content: 'cache content' },
+        _content: 'cache content' },
     ]);
 
     const r = runScriptJson(APPLY_CLI, 'e2', 'auth');
@@ -450,7 +443,7 @@ describe('apply.cjs: end-to-end', () => {
     seedLegacyEpic('e2b', 'auth');
     writeCachePlan('e2b', 'auth', [
       { kebab_name: 'auth', summary: 'Auth flow', description: 'Reflowed auth description.',
-        routing: 'discussion', _content: 'Re-flowed auth content for the new file.' },
+        _content: 'Re-flowed auth content for the new file.' },
     ]);
 
     const r = runScriptJson(APPLY_CLI, 'e2b', 'auth');
@@ -474,7 +467,7 @@ describe('apply.cjs: end-to-end', () => {
     const m = readManifest('e2b');
     assert.strictEqual(m.phases.inception.items.auth.summary, 'Auth flow');
     assert.strictEqual(m.phases.inception.items.auth.description, 'Reflowed auth description.');
-    assert.strictEqual(m.phases.inception.items.auth.routing, 'discussion');
+    assert.strictEqual(m.phases.inception.items.auth.routing, 'research');
     assert.strictEqual(m.phases.inception.items.auth.source, 'legacy-split:auth');
   });
 
@@ -482,7 +475,7 @@ describe('apply.cjs: end-to-end', () => {
     seedLegacyEpic('e4', 'exploration');
     writeCachePlan('e4', 'exploration', [
       { kebab_name: 'auth', summary: 'Auth', description: 'auth desc',
-        routing: 'discussion', _content: 'auth content' },
+        _content: 'auth content' },
     ]);
 
     const hookDir = path.join(dir, '.git', 'hooks');
@@ -512,7 +505,7 @@ describe('apply.cjs: end-to-end', () => {
     seedLegacyEpic('e4b', 'exploration');
     writeCachePlan('e4b', 'exploration', [
       { kebab_name: 'auth', summary: 'Auth', description: 'auth desc',
-        routing: 'discussion', _content: 'auth content' },
+        _content: 'auth content' },
     ]);
 
     // Make the source file unreadable by removing it before apply — fs.renameSync will
@@ -548,7 +541,7 @@ describe('apply.cjs: end-to-end', () => {
     fs.renameSync(orig, renamed);
 
     writeCachePlan('e9', 'exploration', [
-      { kebab_name: 'auth', summary: 'Auth', description: 'd', routing: 'discussion',
+      { kebab_name: 'auth', summary: 'Auth', description: 'd',
         _content: 'auth content' },
     ]);
 
@@ -580,7 +573,7 @@ describe('apply.cjs: end-to-end', () => {
 
     writeCachePlan('e10', 'exploration', [
       { kebab_name: 'auth', summary: 'Auth', description: 'auth desc',
-        routing: 'discussion', _content: 'auth content' },
+        _content: 'auth content' },
     ]);
 
     const r = runScriptJson(APPLY_CLI, 'e10', 'exploration');
@@ -595,10 +588,10 @@ describe('apply.cjs: end-to-end', () => {
 
   it('apply re-validates and reports cache errors at start', () => {
     seedLegacyEpic('e5', 'exploration');
-    // Write a plan with invalid routing — validate will reject.
+    // Write a plan with empty description — validate will reject.
     writeCachePlan('e5', 'exploration', [
-      { kebab_name: 'auth', summary: 'Auth', description: 'auth desc',
-        routing: 'wrong', _content: 'auth content' },
+      { kebab_name: 'auth', summary: 'Auth', description: '',
+        _content: 'auth content' },
     ]);
 
     const r = runScriptJson(APPLY_CLI, 'e5', 'exploration');


### PR DESCRIPTION
## Summary

- After legacy-split or summary-backfill fires, render a terminal stop telling the user to `/clear` and re-run `/continue-epic` instead of silently flowing into Step 6.
- Legacy decomposition is heavy on context — proceeding to display/menu inside the same conversation starts the rest of the epic in an already-loaded window.
- Backfill commits are already in place (apply.cjs per-source, summary-backfill batch); the gates self-exclude on the second pass, so the advisory's promise that "this won't run again" holds.

## Test plan

- [ ] Trigger legacy-split scenario on a fixture epic — verify the terminal stop renders and Step 6 doesn't run.
- [ ] Trigger summary-backfill-only scenario — verify same stop fires.
- [ ] Re-run `/continue-epic` after `/clear`: confirm Step 5 silently passes through (both gates empty) and normal flow takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)