### PR TITLE
continue-epic: expose summary/description presence in discovery

### DIFF
--- a/ideas/INDEX.md
+++ b/ideas/INDEX.md
@@ -67,3 +67,4 @@ Leverage multiple AI models by dispatching work to the best model for each task 
 | 24 | [Inception Self-Healing on Legacy / Kitchen-Sink Research](inception-self-healing-on-legacy-research.md) | Migration 038 + `research-analysis` input guards + manifest `get` exit-2 + `routing` hardcode |
 | 25 | [Analysis Cycle Counter Resets on Resume Collide with File Naming](analysis-cycle-counter-reset-collision.md) | `workflow-implementation-process` Step 0 + `analysis-loop.md` + `invoke-analysis.md` |
 | 26 | [Review Not Re-Offered After Loopback from Review Remediation](review-not-re-offered-after-loopback.md) | `workflow-implementation-entry/validate-phase.md` + `workflow-bridge/discovery.cjs` |
+| 27 | [Continue-Epic Step 5 Asks the Agent to Filter Data the Discovery Script Doesn't Expose](continue-epic-items-to-recover-unobservable.md) | `continue-epic/SKILL.md` Step 5 + `continue-epic/scripts/discovery.cjs` text formatter |

--- a/ideas/continue-epic-items-to-recover-unobservable.md
+++ b/ideas/continue-epic-items-to-recover-unobservable.md
@@ -1,0 +1,50 @@
+# Continue-Epic Step 5 Asks the Agent to Filter Data the Discovery Script Doesn't Expose
+
+## The Idea
+
+`continue-epic/SKILL.md` Step 5 (Backfill) tells the agent to read `discovery_map` from the most recent discovery `detail` and filter for items where `summary` or `description` is null or missing. The discovery script collects those fields but does not include them in its text output, so the check cannot be performed against the data the agent actually sees. Either the script should surface the fields the skill instruction relies on, or the check should be delegated to a dedicated detector script (parallel to `workflow-legacy-research-split/scripts/detect.cjs`) so the agent doesn't have to parse anything.
+
+## What Happened
+
+Resuming the `galley-v1` epic via `/workflow-start` → continue → `1`. At Step 5 the legacy-split detector returned `qualifying_sources: []`, so the first half of the backfill check was clearly empty. The second half — `items_to_recover` from the discovery map — wasn't present in any output I'd seen.
+
+The instruction says read `discovery_map` from the "most recent discovery `detail`". The only discovery output rendered to me was the text emission from `continue-epic/scripts/discovery.cjs`, which prints each map row as:
+
+```
+- ◐ ai-content-engine [researching] -> continue_research (from exploration)
+```
+
+No `summary`, no `description`. Without those fields visible, I couldn't perform the filter. Instead of either (a) trusting the obvious signal that there was nothing to recover and moving on, or (b) saying "I can't perform this check," I went searching — running `find` against `.workflows/` to locate the discovery map artifact and inspect it directly. The user interrupted to ask why I was stalling.
+
+When asked to verify it was a bug, I read the discovery script. Lines 178–194 of `continue-epic/scripts/discovery.cjs` populate each `discovery_map` item with `summary` and `description` in the JS object. Lines 322–327 emit those items as text — and only emit `tier`, `name`, `lifecycle`, `next_action`, and `source_provenance`. The script has no `--json` mode (line 365 always calls `format`). So the fields the skill tells the agent to filter on are computed but never reach the agent.
+
+## Why This Slowed Things Down
+
+The skill presents the backfill check as a hard step the agent must run. When the agent can't see the data, it has three options, all bad:
+
+1. Skip silently — feels like ignoring an instruction.
+2. Say "I can't do this" — feels like a tool failure, not a smooth workflow.
+3. Go fishing for the underlying artifact — what I did. Slow, defensive, and the wrong layer of work for a routing skill.
+
+`qualifying_sources` is cleanly delegated to a script. The agent runs the detector, gets a yes/no answer, and routes. `items_to_recover` is split between the script (which has the data) and the agent (which doesn't get it). That asymmetry is what makes the step undefined — and what produced the dillydallying.
+
+## What I Discovered
+
+- The data exists. It's computed in `buildEpicDetail` and held on every map item.
+- The text formatter drops it.
+- No JSON-mode flag exists on the script.
+- The instruction in Step 5 references "the most recent discovery `detail`" as if the agent has the full detail object — but in practice the agent only has the formatted text.
+
+## Out of Scope (For This Bug Report)
+
+The fix shape isn't mine to call — I don't know whether `items_to_recover` is meant to catch a real ongoing scenario (in which case it needs to be properly surfaced) or whether the legacy-split detector already covers every recovery case in practice (in which case the second check may be dead weight). That judgement needs context I don't have.
+
+## Scope
+
+- `.claude/skills/continue-epic/SKILL.md` — Step 5 Backfill instruction
+- `.claude/skills/continue-epic/scripts/discovery.cjs` — text formatter omits `summary` / `description`; no JSON mode
+- Possibly `.claude/skills/workflow-legacy-research-split/scripts/detect.cjs` — if the recovery scan belongs alongside `qualifying_sources`
+
+## Severity
+
+Low-to-medium for behaviour, medium for UX. The check is silently skippable without any data corruption, and a defensive agent that ignores the instruction won't break anything. But the skill *reads* as mandatory, and a literal reading produces stalling — agents go searching for data they should have been handed. That friction recurs every time the skill runs.

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -217,7 +217,7 @@ node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs {work_unit
 
 Parse `qualifying_sources` from the JSON output.
 
-Then read `discovery_map` from the most recent discovery `detail` and filter for items where `summary` or `description` is null or missing — regardless of `source`. Store the filtered list as `items_to_recover`.
+Then read `discovery_map` from the most recent discovery `detail` and filter for items where `summary_present` is false or `description_present` is false — regardless of `source`. Store the filtered list as `items_to_recover`.
 
 #### If `qualifying_sources` is empty and `items_to_recover` is empty
 

--- a/skills/continue-epic/references/backfill-checks.md
+++ b/skills/continue-epic/references/backfill-checks.md
@@ -10,7 +10,7 @@ The caller provides via context:
 
 - `work_unit` — the epic's work unit name
 - `qualifying_sources` — legacy-bridge detector output (parsed from `detect.cjs`)
-- `items_to_recover` — list of map items missing `summary` or `description`
+- `items_to_recover` — list of map items where `summary_present` is false or `description_present` is false
 
 ## A. Legacy-Bridge Gate
 
@@ -24,7 +24,7 @@ On return, re-run discovery so **B** sees the post-split map state:
 node .claude/skills/continue-epic/scripts/discovery.cjs {work_unit}
 ```
 
-Re-filter `discovery_map` for items where `summary` or `description` is null or missing. Overwrite `items_to_recover` with this fresh list — legacy-split creates themes with full metadata and removes the source's inception item, so the caller's pre-split filter is stale.
+Re-filter `discovery_map` for items where `summary_present` is false or `description_present` is false. Overwrite `items_to_recover` with this fresh list — legacy-split creates themes with full metadata and removes the source's inception item, so the caller's pre-split filter is stale.
 
 → Proceed to **B. Summary-Backfill Gate**.
 

--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -61,6 +61,9 @@ Render the discovery map block at the top, then the build-phase tree (specificat
 
 @foreach(topic in discovery_map)
   @if(not last_topic) ├─ @else └─ @endif {topic.tier}  {topic.name:(titlecase)}  {lifecycle_label}
+@if(topic.summary)
+       {topic.summary}
+@endif
 @if(topic.source_provenance)
        {topic.source_provenance}
 @endif
@@ -104,6 +107,7 @@ Render the discovery map block at the top, then the build-phase tree (specificat
   - `✓` (decided) — `decided`
   - `○` (fresh) — `fresh · routed to {topic.routing}` (omit the ` · routed to ...` segment if `topic.routing` is null)
   - `⊘` (cancelled) — `cancelled`
+- **Summary sub-line**: render only when `topic.summary` is non-null. Indent at 7 spaces (under the title text, past the tree branch). Example: `       AI generation pipeline for recipe content with editorial review.` Sits directly under the title row, above the provenance sub-line when both are present.
 - **Source provenance sub-line**: render only when `topic.source_provenance` is non-null. Indent at 7 spaces (under the title text, past the tree branch). Example: `       from kitchen-hardware`. Source `inception` has no provenance line.
 - **Build-phase tree below**: render only `specification`, `planning`, `implementation`, `review` from `phases`. Skip `research`, `discussion`, and `inception` — they are represented in the map above. Tree grammar (`├─` non-final, `└─` final), planning format suffix (`· {format}`), specification source rows, and implementation progress lines render the same way as the otherwise branch below. Skip phases with no items. Blank line between sections.
 - **No trailing recommendation callout** in this code block. Build-phase recommendations attach to menu entries (see **C. Menu**), not the state display.

--- a/skills/continue-epic/references/summary-backfill.md
+++ b/skills/continue-epic/references/summary-backfill.md
@@ -7,9 +7,7 @@
 The caller passes:
 
 - `work_unit` — the selected epic
-- `items_to_recover` — list of inception items missing summary, description, or both. Each item has at minimum `name`, `routing`, plus the current values of `summary` and `description` (either may be null)
-
-On exit, re-runs discovery so the caller has fresh state.
+- `items_to_recover` — list of inception items missing summary, description, or both. Each item has at minimum `name`, `routing`, `summary_present`, `description_present`, plus the current value of `summary` (null when `summary_present` is false)
 
 ## A. Read Source Files
 
@@ -35,9 +33,10 @@ For each item in `items_to_recover`:
 
 For each readable file:
 
-- If the item's current `summary` is null, derive a one-line summary that captures what the topic is about. Aim for 8–15 words. Use the file's headings and opening paragraphs as the primary signal. Attach as `item.derived_summary`.
-- If the item's current `description` is null, derive a paragraph or two of richer context — what the topic covers, why it surfaced, key dimensions. Use the file's body content (not just headings). Attach as `item.derived_description`.
-- If a field is already populated, leave its current value in place and skip derivation for that field. Track `item.needs_summary` and `item.needs_description` so section **D** writes only the newly-drafted fields.
+- Set `item.needs_summary = !item.summary_present` and `item.needs_description = !item.description_present` so section **D** writes only the newly-drafted fields.
+- If `item.needs_summary`, derive a one-line summary that captures what the topic is about. Aim for 8–15 words. Use the file's headings and opening paragraphs as the primary signal. Attach as `item.derived_summary`.
+- If `item.needs_description`, derive a paragraph or two of richer context — what the topic covers, why it surfaced, key dimensions. Use the file's body content (not just headings). Attach as `item.derived_description`.
+- If a field is already populated, leave its current value in place and skip derivation for that field.
 
 → Proceed to **B. Batch Review**.
 
@@ -139,12 +138,6 @@ Single commit covering all writes:
 ```bash
 git add -- .workflows/{work_unit}/manifest.json
 git commit -m "inception({work_unit}): backfill {N} inception provenance field(s) from source files"
-```
-
-Re-run discovery so the caller has fresh state:
-
-```bash
-node .claude/skills/continue-epic/scripts/discovery.cjs {work_unit}
 ```
 
 → Return to caller.

--- a/skills/continue-epic/scripts/discovery.cjs
+++ b/skills/continue-epic/scripts/discovery.cjs
@@ -179,10 +179,13 @@ function buildEpicDetail(cwd, manifest) {
       const { lifecycle, tier, current_phase } = computeTopicLifecycle(manifest, item.name);
       const next_action = computeNextAction(item.routing, lifecycle);
       const source_provenance = computeSourceProvenance(item.source);
+      const summaryText = typeof item.summary === 'string' && item.summary.trim() ? item.summary : null;
+      const descriptionText = typeof item.description === 'string' && item.description.trim() ? item.description : null;
       return {
         name: item.name,
-        summary: item.summary || null,
-        description: item.description || null,
+        summary_present: summaryText !== null,
+        summary: summaryText,
+        description_present: descriptionText !== null,
         routing: item.routing || null,
         source: item.source || 'inception',
         source_provenance,
@@ -322,8 +325,12 @@ function format(result) {
       for (const t of d.discovery_map) {
         let line = `      - ${t.tier} ${t.name} [${t.lifecycle}]`;
         if (t.next_action) line += ` -> ${t.next_action}`;
+        line += ` [summary: ${t.summary_present ? 'present' : 'absent'}, description: ${t.description_present ? 'present' : 'absent'}]`;
         if (t.source_provenance) line += ` (${t.source_provenance})`;
         lines.push(line);
+        if (t.summary) {
+          lines.push(`             summary: ${t.summary}`);
+        }
       }
     }
     if (d.in_progress.length > 0) {

--- a/tests/scripts/test-discovery-for-continue-epic.cjs
+++ b/tests/scripts/test-discovery-for-continue-epic.cjs
@@ -297,10 +297,11 @@ describe('continue-epic discovery', () => {
       assert.strictEqual(d.analysis_caches.gap_analysis.status, 'absent');
     });
 
-    it('discovery_map exposes source, summary, and description per item for legacy-recovery filter', () => {
-      // Continue-epic Step 6 (Summary Backfill) filters discovery_map by
-      // (!summary || !description) — source-agnostic. Any write path that
-      // lands an item with missing fields surfaces for review:
+    it('discovery_map exposes source, summary text, and presence booleans per item for legacy-recovery filter', () => {
+      // Continue-epic Step 5 (Backfill) filters discovery_map by
+      // (!summary_present || !description_present) — source-agnostic. Any
+      // write path that lands an item with missing fields surfaces for
+      // review:
       // - migration-seeded items (legacy back-fill)
       // - pre-Phase-14 items with summary but no description
       // - absorption-registered items (no source set, defaults to "inception"
@@ -328,30 +329,38 @@ describe('continue-epic discovery', () => {
 
       assert.strictEqual(byName['pristine'].source, 'inception');
       assert.strictEqual(byName['pristine'].summary, 'Brand-new topic with summary');
-      assert.strictEqual(byName['pristine'].description, 'Already grounded');
+      assert.strictEqual(byName['pristine'].summary_present, true);
+      assert.strictEqual(byName['pristine'].description_present, true);
 
       assert.strictEqual(byName['migrated-no-summary'].source, 'migration-seeded');
       assert.strictEqual(byName['migrated-no-summary'].summary, null);
-      assert.strictEqual(byName['migrated-no-summary'].description, null);
+      assert.strictEqual(byName['migrated-no-summary'].summary_present, false);
+      assert.strictEqual(byName['migrated-no-summary'].description_present, false);
 
       assert.strictEqual(byName['migrated-summary-no-description'].summary, 'Backfilled before Phase 14');
-      assert.strictEqual(byName['migrated-summary-no-description'].description, null);
+      assert.strictEqual(byName['migrated-summary-no-description'].summary_present, true);
+      assert.strictEqual(byName['migrated-summary-no-description'].description_present, false);
 
       assert.strictEqual(byName['migrated-fully-populated'].summary, 'Both populated');
-      assert.strictEqual(byName['migrated-fully-populated'].description, 'Backfilled after Phase 14');
+      assert.strictEqual(byName['migrated-fully-populated'].summary_present, true);
+      assert.strictEqual(byName['migrated-fully-populated'].description_present, true);
 
       assert.strictEqual(byName['migrated-then-resurfaced'].source, 'migration-seeded,research-analysis');
       assert.strictEqual(byName['migrated-then-resurfaced'].summary, null);
-      assert.strictEqual(byName['migrated-then-resurfaced'].description, null);
+      assert.strictEqual(byName['migrated-then-resurfaced'].summary_present, false);
+      assert.strictEqual(byName['migrated-then-resurfaced'].description_present, false);
 
       assert.strictEqual(byName['analysis-only'].source, 'research-analysis');
+      assert.strictEqual(byName['analysis-only'].summary_present, true);
+      assert.strictEqual(byName['analysis-only'].description_present, true);
 
       assert.strictEqual(byName['absorbed-no-fields'].source, 'inception');
       assert.strictEqual(byName['absorbed-no-fields'].summary, null);
-      assert.strictEqual(byName['absorbed-no-fields'].description, null);
+      assert.strictEqual(byName['absorbed-no-fields'].summary_present, false);
+      assert.strictEqual(byName['absorbed-no-fields'].description_present, false);
 
       // Filter contract — any item missing summary OR description, regardless of source.
-      const toRecover = map.filter(t => !t.summary || !t.description);
+      const toRecover = map.filter(t => !t.summary_present || !t.description_present);
       const recoverNames = toRecover.map(t => t.name).sort();
       assert.deepStrictEqual(
         recoverNames,


### PR DESCRIPTION
## Summary

Step 5's backfill filter was reading text fields (`summary`/`description`) that the discovery text formatter never emitted — only the JS object held them. Result: the agent couldn't filter against the data it saw, so the gate either stalled (agent went hunting for the artifact directly) or silently no-op'd.

- `discovery.cjs` now emits explicit `summary_present` / `description_present` booleans on each `discovery_map` row, plus `[summary: present|absent, description: present|absent]` inline in the text format and the summary text on a sub-line when present.
- Step 5, `backfill-checks.md` section A, and `summary-backfill.md` section A switch their filters to the new booleans — explicit, not text-presence-as-boolean.
- `epic-display-and-menu.md` gains a summary sub-line in the Discovery Map (the original point of the inception summary — what each topic *is*).
- Dead re-run-discovery dropped from `summary-backfill.md` section D — the caller terminates at backfill-checks section C "Advise Restart", so fresh state was never consumed.

## Test plan

- [x] `tests/scripts/test-discovery-for-continue-epic.cjs` — updated to assert the new booleans + filter contract (77 tests pass)
- [x] `tests/scripts/test-discovery-for-refinement.cjs` — refinement's own discovery script untouched (65 tests pass)
- [x] Full `tests/scripts/test-*.cjs` suite — no regressions
- [ ] Manual: `/continue-epic` on `galley-v1` — Step 5 backfill gate behaves; map display shows summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)