### PR TITLE
discovery map: tighten header and clean up tree rendering

### DIFF
--- a/skills/continue-epic/references/epic-display-and-menu.md
+++ b/skills/continue-epic/references/epic-display-and-menu.md
@@ -40,18 +40,15 @@ Render the discovery map block at the top, then the build-phase tree (specificat
   {work_unit:(titlecase)}
 ●───────────────────────────────────────────────●
 
-  Discovery Map ({summary_line})
-@if(imports_count == 1)
-  · 1 imported seed
+  Discovery Map ({total} topics{tier_breakdown})
+@if(show_imports_callout)
+  · {imports_count} imported {seed|seeds}
 @endif
-@if(imports_count > 1)
-  · {imports_count} imported seeds
-@endif
-  @if(convergence_state == 'in-progress')
+@if(convergence_state == 'in-progress')
   ⚑ Discovery in progress — {N} topics not yet decided.
-  @else
+@else
   ✓ Discovery settled — ready for specification.
-  @endif
+@endif
 @if(new_arrivals.research_analysis.length > 0)
   ⚑ {N} new topic(s) added to the map from research-analysis.
 @endif
@@ -60,12 +57,14 @@ Render the discovery map block at the top, then the build-phase tree (specificat
 @endif
 
 @foreach(topic in discovery_map)
-  @if(not last_topic) ├─ @else └─ @endif {topic.tier}  {topic.name:(titlecase)}  {lifecycle_label}
+  {branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]
 @if(topic.summary)
-       {topic.summary}
+@foreach(line in wrap(topic.summary, 65))
+  {gutter}{line}
+@endforeach
 @endif
 @if(topic.source_provenance)
-       {topic.source_provenance}
+  {gutter}{topic.source_provenance}
 @endif
 @endforeach
 
@@ -92,14 +91,15 @@ Render the discovery map block at the top, then the build-phase tree (specificat
 
 **Discovery map display rules:**
 
-- **Summary line**: `{total} topics — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {cancelled} cancelled`. Read counts from `map_summary`. **Omit zero-count categories** from the dot-separated list. Always render `{total} topics`.
-  - Example: `8 topics — 2 decided · 3 in flight · 1 ready · 2 fresh`
-  - Example with zeros omitted: `5 topics — 5 fresh`
-- **Imports callout**: rendered immediately under the summary line when `imports_count > 0`. Format: `· {imports_count} imported seed` for 1, `· {imports_count} imported seeds` for 2+. Sits above the convergence callout — both stack under the summary line. Omitted when `imports_count == 0`.
-- **Convergence callout**: rendered immediately under the imports callout (or under the summary line if imports are absent), before the topic rows. `⚑ Discovery in progress — {N} topics not yet decided.` when `convergence_state == 'in-progress'` (where N excludes cancelled). `✓ Discovery settled — ready for specification.` when `convergence_state == 'settled'`.
+- **Tier breakdown** (`{tier_breakdown}`): when more than one tier bucket has a non-zero count, append ` — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {cancelled} cancelled` to the topic count (omitting zero-count categories). When only one bucket is non-zero — e.g. every topic in flight — the breakdown is redundant with the rows; omit it and render just `Discovery Map ({total} topics)`. Read counts from `map_summary`.
+  - Example (mixed): `Discovery Map (8 topics — 2 decided · 3 in flight · 1 ready · 2 fresh)`
+  - Example (single bucket): `Discovery Map (9 topics)`
+- **Imports callout** (`{show_imports_callout}`): true only when `imports_count > 0` **and** `imports_count != discovery_map.length`. When every topic is itself an import, per-row provenance already says so on every line and the callout is redundant. Format when shown: `· {imports_count} imported seed` for 1, `· {imports_count} imported seeds` for 2+.
+- **Convergence callout**: rendered after the optional imports callout, before the topic rows. Always present. `⚑ Discovery in progress — {N} topics not yet decided.` when `convergence_state == 'in-progress'` (where N excludes cancelled). `✓ Discovery settled — ready for specification.` when `convergence_state == 'settled'`.
 - **New-arrivals callout** (optional): when the caller passes a non-empty `new_arrivals.research_analysis` or `new_arrivals.gap_analysis` list, render `⚑ {N} new topic(s) added to the map from {analysis}.` lines beneath the convergence callout, one per analysis with arrivals. Shown once per boot-up that added items — subsequent invocations without changes don't repeat it (the items are now part of the map). Sub-line provenance on the topic rows is the persistent surface afterwards.
 - **Tier ordering and sort**: rows are pre-sorted by the discovery script (tier rank `→ ◐ ✓ ○ ⊘`, then alphabetical within each tier). Render in the order given.
-- **Topic row**: `{tier}  {name:(titlecase)}  {lifecycle_label}` with two spaces between each segment. Use tree grammar (`├─` non-final, `└─` final).
+- **Topic row**: `{branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]`. Single space between each segment. Lifecycle label wrapped in square brackets.
+  - `{branch}`: `┌─` for the first row, `└─` for the last, `├─` for the rest. With a single row, use `└─` (no upward stroke).
 - **Lifecycle label** by tier:
   - `→` (ready_for_discussion) — `research complete · ready for discussion`
   - `◐` (researching) — `researching`
@@ -107,8 +107,27 @@ Render the discovery map block at the top, then the build-phase tree (specificat
   - `✓` (decided) — `decided`
   - `○` (fresh) — `fresh · routed to {topic.routing}` (omit the ` · routed to ...` segment if `topic.routing` is null)
   - `⊘` (cancelled) — `cancelled`
-- **Summary sub-line**: render only when `topic.summary` is non-null. Indent at 7 spaces (under the title text, past the tree branch). Example: `       AI generation pipeline for recipe content with editorial review.` Sits directly under the title row, above the provenance sub-line when both are present.
-- **Source provenance sub-line**: render only when `topic.source_provenance` is non-null. Indent at 7 spaces (under the title text, past the tree branch). Example: `       from kitchen-hardware`. Source `inception` has no provenance line.
+- **Summary / provenance sub-lines** — both follow the same `{gutter}` rule. Summary appears first when present; provenance below it. Source `inception` produces no provenance line.
+  - **Wrap**: hard-wrap the summary text at 65 characters before emitting. Provenance is short — no wrap needed.
+  - **`{gutter}`** governs the indent and continuation tree on every sub-line:
+    - **Non-last topic**: `│` followed by 6 spaces (7 chars total). The `│` runs continuously down through every sub-line of every non-last topic, so the tree never breaks.
+    - **Last topic**: 7 spaces — no `│`, so the tree doesn't dangle below `└─`.
+  - **Alignment**: text starts one visual column to the right of the topic name (compensates for the bullet's visual width in most monospace fonts).
+  - **Example** (non-last topic, summary wraps onto three lines, provenance below):
+    ```
+      ├─ ◐ Ai Content Engine [researching]
+      │      AI imagery (enhancement-only v1), description
+      │      generation, per-tenant tone / base-knowledge
+      │      primitive, allowance + overage cost shape
+      │      from exploration
+    ```
+  - **Example** (last topic — same shape, no `│`):
+    ```
+      └─ ◐ Menu And Admin [researching]
+             Business-side menu modelling, admin shell (Filament vs
+             custom Vue/Nuxt), JustEat import, staff/roles
+             from exploration
+    ```
 - **Build-phase tree below**: render only `specification`, `planning`, `implementation`, `review` from `phases`. Skip `research`, `discussion`, and `inception` — they are represented in the map above. Tree grammar (`├─` non-final, `└─` final), planning format suffix (`· {format}`), specification source rows, and implementation progress lines render the same way as the otherwise branch below. Skip phases with no items. Blank line between sections.
 - **No trailing recommendation callout** in this code block. Build-phase recommendations attach to menu entries (see **C. Menu**), not the state display.
 

--- a/skills/workflow-inception-process/references/session-loop.md
+++ b/skills/workflow-inception-process/references/session-loop.md
@@ -48,18 +48,19 @@ The map exists; editing existing items is available alongside new exploration. R
   Inception — {work_unit:(titlecase)}
 ●───────────────────────────────────────────────●
 
-  Discovery Map ({map_summary})
+  Discovery Map ({total} topics{tier_breakdown})
 
 @foreach(topic in discovery_map)
-  @if(not last_topic) ├─ @else └─ @endif {topic.tier}  {topic.name:(titlecase)}  {lifecycle_label}
+  {branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]
 @endforeach
 ```
 
 Render rules:
 
-- `map_summary` — `{total} topics — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {cancelled} cancelled`. Omit zero-count categories from the dot-separated tail. Always include `{total} topics`.
+- `tier_breakdown` — append ` — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {cancelled} cancelled` (omitting zero-count categories) only when more than one tier bucket is non-zero. When only one bucket is non-zero, omit the breakdown and render just `Discovery Map ({total} topics)`.
+- `{branch}` — `┌─` for the first row, `└─` for the last, `├─` for the rest. With a single row, use `└─` (no upward stroke).
 - Tier ordering — discovery output is already tier-sorted (`→ ◐ ✓ ○ ⊘`, alphabetical within tier). Render in the order given.
-- `lifecycle_label` by tier:
+- `lifecycle_label` by tier (wrapped in square brackets per the row template):
   - `→` — `research complete · ready for discussion`
   - `◐` — `researching` or `discussing` (use `topic.current_phase`)
   - `✓` — `decided`


### PR DESCRIPTION
## Summary
- Drop the tier breakdown suffix when only one bucket is non-zero (e.g. `Discovery Map (9 topics)` instead of `9 topics — 9 in flight`), and drop the imports callout when every topic is itself an import (per-row provenance already says it). Convergence callout stays — it's the only line that changes state.
- First topic now renders with `┌─` instead of `├─` so the tree has no upward stroke at the top; single-row maps use `└─`. State labels wrapped in `[brackets]`, single space between the bullet symbol and the topic name.
- Summary text hard-wraps at 65 chars and aligns under the topic name. `│` runs continuously through non-last topic sub-lines so the tree never breaks; blank spaces under the last topic so nothing dangles below `└─`.

## Test plan
- [ ] Run `/continue-epic` on a real epic with a populated discovery map and visually inspect the render (mixed tiers, single-tier-bucket, single-row, all-imports cases).
- [ ] Run `/continue-epic` immediately after `inception` to confirm the inception-anchor render in `session-loop.md` matches.
- [ ] Confirm wrapped summary lines remain aligned with the tree connector across all rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)