### PR TITLE
Forbid priming analysis sub-agents across cycles

### DIFF
--- a/skills/workflow-implementation-process/references/invoke-analysis.md
+++ b/skills/workflow-implementation-process/references/invoke-analysis.md
@@ -22,6 +22,8 @@ This captures all files touched by implementation commits for the topic.
 
 ## Dispatch All Three Agents
 
+> **CRITICAL — dispatch with clean context.** Pass each agent **only** the seven inputs listed below. Do **not** include prior cycle findings, summaries of what earlier cycles caught or missed, your own hunches, or any framing that suggests where to look. Each cycle must run independently — cross-cycle synthesis happens in the synthesizer, not in the agents. Priming biases results (a clean cycle-N report after a high-finding cycle-(N-1) is a red flag, not convergence).
+
 Dispatch **all three in parallel** via the Task tool. Each agent receives the same inputs:
 
 1. **Implementation files** — the file list from scope identification


### PR DESCRIPTION
## Summary
- Add a CRITICAL callout at the dispatch point in `invoke-analysis.md` instructing the orchestrator to pass each analysis sub-agent **only** the seven specified inputs — no prior cycle findings, summaries, or framing hints.
- Motivated by an observed regression: cycle 1 produced 10 findings, cycle 2 came back clean after the orchestrator primed the sub-agent. A suspiciously clean cycle after a high-finding cycle is a red flag, not convergence.
- Cross-cycle synthesis already happens in the synthesizer; the per-cycle agents must run independently for the convergence signal to mean anything.

## Test plan
- [ ] Trigger an analysis cycle on an implementation topic and confirm the orchestrator no longer adds prior-cycle context to sub-agent prompts.
- [ ] Verify findings counts decline gradually across cycles rather than dropping to zero abruptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)