### PR TITLE
refactor(discussion): align Discussion Map render with Discovery Map style

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -82,18 +82,62 @@ At natural breaks — after a decision, when transitioning between subtopics, or
 > *Output the next fenced block as a code block:*
 
 ```
-Discussion Map — {topic:(titlecase)}
+  Discussion Map — {topic:(titlecase)} ({total} subtopics{state_breakdown})
 
-  {Subtopic A} [decided]
-  ├─ {Child} [decided]
-  └─ {Child} [decided]
+@foreach(parent in subtopics)
+  {parent_branch} {state_glyph} {parent.name:(titlecase)} [{parent.state}]
+@foreach(child in parent.children)
+  {parent_gutter}{child_branch} {state_glyph} {child.name:(titlecase)} [{child.state}]
+@endforeach
+@endforeach
+```
 
-  {Subtopic B} [converging]
-  └─ {Child} [exploring]
+**Render rules — follow exactly. Do not improvise spacing, glyphs, or branches.**
 
-  {Subtopic C} [pending]
+- **Two-space left indent** on every row (matches the discovery map). Header included.
+- **Header**: `Discussion Map — {topic:(titlecase)} ({total} subtopics{state_breakdown})`. Followed by **one blank line** before the first row.
+  - `{total}` — count of **all subtopics** (parents + children), excluding `⤴ Elevated:` marker rows.
+  - `{state_breakdown}` — append ` — {decided} decided · {converging} converging · {exploring} exploring · {pending} pending`, **omitting zero-count categories**. When only one state bucket is non-zero (e.g. every subtopic still `pending`), the breakdown is redundant with the rows; omit it and render just `({total} subtopics)`.
+  - Examples: `Discussion Map — Portal Observability Layer (12 subtopics)` · `Discussion Map — Portal Observability Layer (12 subtopics — 3 decided · 2 converging · 1 exploring · 6 pending)`.
+- **Parent row**: `{parent_branch} {state_glyph} {name:(titlecase)} [{state}]`. **Single space** between each of the four segments. State label in lowercase, wrapped in square brackets.
+  - `{parent_branch}`: `┌─` for the first parent, `└─` for the last parent, `├─` for the rest. **With a single parent, use `└─`** (no upward stroke).
+- **Child row**: `{parent_gutter}{child_branch} {state_glyph} {name:(titlecase)} [{state}]`. Single space between segments after the gutter+branch.
+  - `{parent_gutter}` governs the continuation tree under the parent:
+    - **Parent is not the last parent**: `│  ` — `│` followed by **2 spaces** (3 chars total). The `│` runs continuously down through every child row of that parent so the trunk never breaks.
+    - **Parent is the last parent**: `   ` — **3 spaces** (no `│`), so the tree doesn't dangle below `└─`.
+  - `{child_branch}`: `├─` for a non-final child, `└─` for the final child. **With a single child, use `└─`**.
+  - Children never have grandchildren — the map is two levels deep maximum.
+- **State glyphs** — exactly one character before the name. **Do not substitute.**
+  - `pending` — `○`
+  - `exploring` — `◐`
+  - `converging` — `→`
+  - `decided` — `✓`
+- **Elevated marker** — when a subtopic was elevated to a sibling discussion, its row is replaced by an elevation marker that **occupies the same slot in the tree**:
+  - Parent slot: `{parent_branch} ⤴ Elevated: {sibling-topic:(titlecase)}`
+  - Child slot: `{parent_gutter}{child_branch} ⤴ Elevated: {sibling-topic:(titlecase)}`
+  - No state glyph, no `[state]` bracket. `⤴` is reserved for this marker and never appears as a state glyph. Elevated rows are **not** counted in `{total}` or the state breakdown.
+- **Row order** within the map matches the order parents and children appear in the file's Discussion Map section. Do not re-sort.
 
-{decided_count} decided · {exploring_count} exploring · {pending_count} pending
+**Single-row case (one parent, no children):**
+
+```
+  Discussion Map — {topic:(titlecase)} (1 subtopic)
+
+  └─ ○ Subsystem Prefix Taxonomy [pending]
+```
+
+**Full example (mixed states, nested children, one elevation):**
+
+```
+  Discussion Map — Portal Observability Layer (12 subtopics — 3 decided · 2 converging · 1 exploring · 5 pending)
+
+  ┌─ ✓ Subsystem Prefix Taxonomy [decided]
+  ├─ → Decision-Point INFO Line Shape [converging]
+  │  ├─ ✓ Field Order [decided]
+  │  └─ ◐ Truncation Rules [exploring]
+  ├─ → Diagnostic Context Preservation At Boundaries [converging]
+  ├─ ⤴ Elevated: Log Aggregation Backend
+  └─ ○ Rollout Sequencing And Scope Bundling [pending]
 ```
 
 Don't render the map after every exchange — do it at meaningful transitions. If the user has just seen a similar state, skip it.
@@ -157,7 +201,7 @@ During organic discussion, a subtopic may grow beyond the scope of the current t
 
    `routing: discussion` because elevation fires inside a discussion session. `source: discussion-elevation:{parent_topic}` is historical provenance; no cascade.
 
-5. Update the current Discussion Map — replace the subtopic with `→ Elevated: {new-topic}`.
+5. Update the current Discussion Map — replace the subtopic row with `⤴ Elevated: {new-topic:(titlecase)}` in the same slot (same branch, same gutter if it was a child). See **E. Status Display** for the marker rules.
 
 6. Commit: `discussion({work_unit}/{topic}): elevate {new-topic} to separate discussion`
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -96,7 +96,7 @@ At natural breaks — after a decision, when transitioning between subtopics, or
 
 - **Two-space left indent** on every row (matches the discovery map). Header included.
 - **Header**: `Discussion Map — {topic:(titlecase)} ({total} subtopics{state_breakdown})`. Followed by **one blank line** before the first row.
-  - `{total}` — count of **all subtopics** (parents + children), excluding `⤴ Elevated:` marker rows.
+  - `{total}` — count of **all subtopics** (parents + children), excluding `↑ Elevated:` marker rows.
   - `{state_breakdown}` — append ` — {decided} decided · {converging} converging · {exploring} exploring · {pending} pending`, **omitting zero-count categories**. When only one state bucket is non-zero (e.g. every subtopic still `pending`), the breakdown is redundant with the rows; omit it and render just `({total} subtopics)`.
   - Examples: `Discussion Map — Portal Observability Layer (12 subtopics)` · `Discussion Map — Portal Observability Layer (12 subtopics — 3 decided · 2 converging · 1 exploring · 6 pending)`.
 - **Parent row**: `{parent_branch} {state_glyph} {name:(titlecase)} [{state}]`. **Single space** between each of the four segments. State label in lowercase, wrapped in square brackets.
@@ -113,9 +113,9 @@ At natural breaks — after a decision, when transitioning between subtopics, or
   - `converging` — `→`
   - `decided` — `✓`
 - **Elevated marker** — when a subtopic was elevated to a sibling discussion, its row is replaced by an elevation marker that **occupies the same slot in the tree**:
-  - Parent slot: `{parent_branch} ⤴ Elevated: {sibling-topic:(titlecase)}`
-  - Child slot: `{parent_gutter}{child_branch} ⤴ Elevated: {sibling-topic:(titlecase)}`
-  - No state glyph, no `[state]` bracket. `⤴` is reserved for this marker and never appears as a state glyph. Elevated rows are **not** counted in `{total}` or the state breakdown.
+  - Parent slot: `{parent_branch} ↑ Elevated: {sibling-topic:(titlecase)}`
+  - Child slot: `{parent_gutter}{child_branch} ↑ Elevated: {sibling-topic:(titlecase)}`
+  - No state glyph, no `[state]` bracket. `↑` is reserved for this marker and never appears as a state glyph. Elevated rows are **not** counted in `{total}` or the state breakdown.
 - **Row order** within the map matches the order parents and children appear in the file's Discussion Map section. Do not re-sort.
 
 **Single-row case (one parent, no children):**
@@ -136,7 +136,7 @@ At natural breaks — after a decision, when transitioning between subtopics, or
   │  ├─ ✓ Field Order [decided]
   │  └─ ◐ Truncation Rules [exploring]
   ├─ → Diagnostic Context Preservation At Boundaries [converging]
-  ├─ ⤴ Elevated: Log Aggregation Backend
+  ├─ ↑ Elevated: Log Aggregation Backend
   └─ ○ Rollout Sequencing And Scope Bundling [pending]
 ```
 
@@ -201,7 +201,7 @@ During organic discussion, a subtopic may grow beyond the scope of the current t
 
    `routing: discussion` because elevation fires inside a discussion session. `source: discussion-elevation:{parent_topic}` is historical provenance; no cascade.
 
-5. Update the current Discussion Map — replace the subtopic row with `⤴ Elevated: {new-topic:(titlecase)}` in the same slot (same branch, same gutter if it was a child). See **E. Status Display** for the marker rules.
+5. Update the current Discussion Map — replace the subtopic row with `↑ Elevated: {new-topic:(titlecase)}` in the same slot (same branch, same gutter if it was a child). See **E. Status Display** for the marker rules.
 
 6. Commit: `discussion({work_unit}/{topic}): elevate {new-topic} to separate discussion`
 

--- a/skills/workflow-discussion-process/references/template.md
+++ b/skills/workflow-discussion-process/references/template.md
@@ -45,7 +45,7 @@ A living index of subtopics tracked during the discussion. This is the structura
   ├─ ◐ {Subtopic B} [exploring]
   │  ├─ ◐ {Child subtopic} [exploring]
   │  └─ ○ {Child subtopic} [pending]
-  ├─ ⤴ Elevated: {Sibling Topic}
+  ├─ ↑ Elevated: {Sibling Topic}
   └─ ○ {Subtopic C} [pending]
 
 ---
@@ -129,7 +129,7 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 - Update states as the conversation progresses
 - New child subtopics can be added under parents
 - The map is the user's visibility into discussion shape and your tracking mechanism
-- Elevated topics (siblings that became their own discussion) are noted with `⤴ Elevated:` on the map, occupying the same slot in the tree as the original subtopic
+- Elevated topics (siblings that became their own discussion) are noted with `↑ Elevated:` on the map, occupying the same slot in the tree as the original subtopic
 
 **Flexibility**: Not every subtopic needs all sections. Some have clear options with pros/cons. Some have heated debate worth capturing. Some are straightforward. Document what naturally came up — don't force structure onto a simple discussion.
 

--- a/skills/workflow-discussion-process/references/template.md
+++ b/skills/workflow-discussion-process/references/template.md
@@ -30,24 +30,23 @@ A living index of subtopics tracked during the discussion. This is the structura
 
 ### States
 
-- **pending** — identified but not yet explored
-- **exploring** — actively being discussed
-- **converging** — narrowing toward a decision
-- **decided** — decision reached with rationale documented
+- **pending** (`○`) — identified but not yet explored
+- **exploring** (`◐`) — actively being discussed
+- **converging** (`→`) — narrowing toward a decision
+- **decided** (`✓`) — decision reached with rationale documented
 
 ### Map
 
-  {Subtopic A} [decided]
-  ├─ {Child subtopic} [decided]
-  └─ {Child subtopic} [converging]
+  Discussion Map — {Topic} ({total} subtopics{state_breakdown})
 
-  {Subtopic B} [exploring]
-  ├─ {Child subtopic} [exploring]
-  └─ {Child subtopic} [pending]
-
-  {Subtopic C} [pending]
-
-  → Elevated: {sibling-topic} — discovered during discussion, seeded as separate topic
+  ┌─ ✓ {Subtopic A} [decided]
+  │  ├─ ✓ {Child subtopic} [decided]
+  │  └─ → {Child subtopic} [converging]
+  ├─ ◐ {Subtopic B} [exploring]
+  │  ├─ ◐ {Child subtopic} [exploring]
+  │  └─ ○ {Child subtopic} [pending]
+  ├─ ⤴ Elevated: {Sibling Topic}
+  └─ ○ {Subtopic C} [pending]
 
 ---
 
@@ -130,7 +129,7 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 - Update states as the conversation progresses
 - New child subtopics can be added under parents
 - The map is the user's visibility into discussion shape and your tracking mechanism
-- Elevated topics (siblings that became their own discussion) are noted with `→ Elevated:` on the map
+- Elevated topics (siblings that became their own discussion) are noted with `⤴ Elevated:` on the map, occupying the same slot in the tree as the original subtopic
 
 **Flexibility**: Not every subtopic needs all sections. Some have clear options with pros/cons. Some have heated debate worth capturing. Some are straightforward. Document what naturally came up — don't force structure onto a simple discussion.
 

--- a/skills/workflow-shared/references/discovery-gap-analysis.md
+++ b/skills/workflow-shared/references/discovery-gap-analysis.md
@@ -27,7 +27,7 @@ Read `.workflows/{work_unit}/research/{name}.md` for each `completed_research` n
 
 For each discussion, note:
 - The Discussion Map state (topics and their statuses: pending, exploring, converging, decided)
-- Any `→ Elevated: {topic}` markers
+- Any `⤴ Elevated: {topic}` markers
 - Key decisions made and their dependencies on other topics
 - Deferred items, open threads, and unresolved questions
 - Integration points with other discussions
@@ -44,7 +44,7 @@ Analyse the artifacts from A to identify gaps across five categories:
 
 1. **Cross-artifact themes** — concepts, concerns, or architectural patterns that appear in multiple artifacts but are not the primary focus of any. These often emerge as recurring assumptions or shared constraints that deserve dedicated exploration.
 
-2. **Elevated but uncreated** — `→ Elevated: {topic}` markers in Discussion Maps where no corresponding discussion file or manifest entry exists. These are topics explicitly flagged during discussion as needing their own conversation.
+2. **Elevated but uncreated** — `⤴ Elevated: {topic}` markers in Discussion Maps where no corresponding discussion file or manifest entry exists. These are topics explicitly flagged during discussion as needing their own conversation.
 
 3. **Research themes uncovered** — themes from completed research files that are not addressed by any completed discussion. Only identify themes that are genuinely unaddressed — a theme partially touched in a discussion does not count as a gap.
 

--- a/skills/workflow-shared/references/discovery-gap-analysis.md
+++ b/skills/workflow-shared/references/discovery-gap-analysis.md
@@ -27,7 +27,7 @@ Read `.workflows/{work_unit}/research/{name}.md` for each `completed_research` n
 
 For each discussion, note:
 - The Discussion Map state (topics and their statuses: pending, exploring, converging, decided)
-- Any `⤴ Elevated: {topic}` markers
+- Any `↑ Elevated: {topic}` markers
 - Key decisions made and their dependencies on other topics
 - Deferred items, open threads, and unresolved questions
 - Integration points with other discussions
@@ -44,7 +44,7 @@ Analyse the artifacts from A to identify gaps across five categories:
 
 1. **Cross-artifact themes** — concepts, concerns, or architectural patterns that appear in multiple artifacts but are not the primary focus of any. These often emerge as recurring assumptions or shared constraints that deserve dedicated exploration.
 
-2. **Elevated but uncreated** — `⤴ Elevated: {topic}` markers in Discussion Maps where no corresponding discussion file or manifest entry exists. These are topics explicitly flagged during discussion as needing their own conversation.
+2. **Elevated but uncreated** — `↑ Elevated: {topic}` markers in Discussion Maps where no corresponding discussion file or manifest entry exists. These are topics explicitly flagged during discussion as needing their own conversation.
 
 3. **Research themes uncovered** — themes from completed research files that are not addressed by any completed discussion. Only identify themes that are genuinely unaddressed — a theme partially touched in a discussion does not count as a gap.
 


### PR DESCRIPTION
## Summary

- Discussion Map render now mirrors the Discovery Map's tree grammar: count summary with state breakdown, ┌─/├─/└─ branches (with single-row case), state glyphs (○ ◐ → ✓), and explicit gutter rules for nested children
- Render rules are spelled out exhaustively in `discussion-session.md` (indent, header, branch, gutter widths, reserved glyphs) so there's no improvisation at render time
- Elevated marker moved from `→ Elevated:` to `⤴ Elevated:` to avoid colliding with `→` (converging glyph); marker now occupies the original subtopic's slot in the tree. Template and gap-analysis reference updated to match.

## Test plan

- [ ] Render the Discussion Map mid-session and confirm header, branches, glyphs match the Discovery Map's visual style
- [ ] Render with a single subtopic and confirm `└─` (not `┌─`) is used
- [ ] Trigger a topic elevation and confirm the row renders as `⤴ Elevated: {Sibling}` in the same slot
- [ ] Render with nested children under a non-last parent and confirm the `│  ` gutter runs continuously