### PR TITLE
Phase 17b — Discovery becomes work-type-aware (scaffolding)

### DIFF
--- a/skills/workflow-discovery-entry/SKILL.md
+++ b/skills/workflow-discovery-entry/SKILL.md
@@ -10,13 +10,16 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-You are in the **Discovery** phase of the epic pipeline — the curation surface where moving parts are named, classified as research or discussion, and shaped into the discovery map:
+You are in the **Discovery** phase — the universal first step for all brand-new work. Discovery shapes the work: macro routing (what kind of work this is — epic, feature, bugfix, quickfix, cross-cutting), and where applicable micro routing (per-topic research vs discussion):
 
-**Discovery** → Research → Discussion → Specification → Planning → Implementation → Review
+**Discovery** → {Research / Discussion / Investigation / Scoping} → ... → Review
 
-Discovery is epic-only — features, bugfixes, quick-fixes, and cross-cutting work units skip this phase.
+Output shape varies by work type, not the conversational pattern:
+- **Epic** — multi-topic map with per-topic routing
+- **Feature / cross-cutting** — single-topic shape with routing
+- **Bugfix / quickfix** — brief intent capture + routing decision (no map)
 
-**Stay in your lane**: Discovery is curatorial — name the moving parts, classify each as research or discussion, build the discovery map. Don't investigate (that's research). Don't decide (that's discussion). Hold the macro view; if the conversation tunnels into one item, anchor and return to mapping.
+**Stay in your lane**: Discovery handles SHAPE; downstream phases FILL the shape. No research (research phase does that), no investigation (investigation phase does that), no decision-making (discussion phase does that), no scope work (specification does that). Read seed material to shape the conversation, not to extract substantive content.
 
 ---
 
@@ -54,9 +57,11 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 > topics emerge during the session.
 ```
 
-Arguments: work_type = `$0`, work_unit = `$1`. Discovery is epic-only and per-work-unit, so no `$2` topic argument is consumed.
+Arguments: work_type = `$0`, work_unit = `$1`. Discovery is per-work-unit across every work type, so no `$2` topic argument is consumed.
 
-Store `work_unit` for the handoff.
+`work_type` may be empty when the caller is the `/start` ambiguous path — Discovery's classifier resolves it during the conversation. When pre-seeded (any of `epic`, `feature`, `bugfix`, `quick-fix`, `cross-cutting`), Discovery still runs the same loop and may still offer a pivot.
+
+Store `work_type` and `work_unit` for the handoff.
 
 → Proceed to **Step 2**.
 

--- a/skills/workflow-discovery-entry/references/invoke-skill.md
+++ b/skills/workflow-discovery-entry/references/invoke-skill.md
@@ -12,6 +12,7 @@ This skill's purpose is now fulfilled. Construct the handoff and invoke the proc
 
 ```
 Discovery session for: {work_unit}
+Work type: {work_type|"(unknown — classifier mode)"}
 
 Output: .workflows/{work_unit}/discovery/
 
@@ -29,5 +30,7 @@ Imports:
 
 Invoke the workflow-discovery-process skill.
 ```
+
+`work_type` is forwarded so the processing skill can dispatch shape-appropriate behaviour (multi-topic synthesis for epic, single-topic for feature/cross-cutting, brief intent for bugfix/quickfix). When empty, the processing skill treats the conversation as classifier mode and resolves the work_type during exploration.
 
 Invoke the [workflow-discovery-process](../../workflow-discovery-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-discovery-process/SKILL.md
+++ b/skills/workflow-discovery-process/SKILL.md
@@ -6,15 +6,22 @@ allowed-tools: Bash(node .claude/skills/workflow-discovery-process/scripts/disco
 
 # Discovery Process
 
-Act as **curator**. Your job is naming and shaping the topics that will populate the discovery map — not investigating, not deciding. Read what the user describes; reflect distinct shapes back; suggest tentative groupings; infer routing from cues; let the user flip or refine. Hold the macro view; if the conversation tunnels into one item, anchor and return to mapping.
+Act as **shape detector and curator**. Discovery is the universal first step for all brand-new work. Your job is figuring out what kind of work this is (macro routing), and where applicable curating its topics with per-topic routing (micro routing). You do not investigate, decide, or design — those are downstream phases. Read what the user describes; reflect distinct shapes back; commit only when signals have converged and stabilised; let the user override at any point.
 
 ## Purpose in the Workflow
 
-Opens and continues the discovery map for an epic. Every entry — first or Nth — is the same: a curatorial conversation that surfaces topics, classifies routing, and persists items. When the map is already populated, the same conversation also lets the user edit existing items (rename, re-route, edit summary or description, remove never-started topics) — those moves activate because there's something to act on, not because the session is in a different mode.
+Opens (and for epics, continues) the discovery surface. Every entry — first or Nth — runs the same conversational loop. Output shape varies by work type:
+
+- **Epic** — multi-topic discovery map persisted at `phases.discovery.items.{topic}`. Continuing sessions also let the user edit existing items (rename, re-route, edit summary/description, remove never-started topics).
+- **Feature / cross-cutting** — single-topic shape committed with its routing decision.
+- **Bugfix / quickfix** — brief intent capture + routing decision. No discovery map; the session log itself is the journey record.
+
+The conversational pattern is the same across modes: open with the seed material if any, explore breadth not depth, watch for shape signals, mid-loop surface tentative reads, commit when signals are stable, honour user override. See [shape-detection.md](references/shape-detection.md), [routing-commit.md](references/routing-commit.md), and [pivot-watchpoints.md](references/pivot-watchpoints.md) for the shape-detection discipline; see [opener-pattern.md](references/opener-pattern.md) for the opener shape per entry path; see [discovery-guidelines.md](references/discovery-guidelines.md) for the curatorial moves and hard rules.
 
 ### What This Skill Needs
 
-- **Work unit** (required) — the epic being framed
+- **Work type** (optional) — pre-seeded by the menu choice or absent on the `/start` ambiguous path. Discovery's classifier resolves it during the conversation when absent.
+- **Work unit** (required) — the named work being framed
 - **Description** (required) — the work-unit description from the manifest, captured during the entry skill's handoff
 - **Imports** (optional) — filenames of seed material the user attached at work-unit creation
 

--- a/skills/workflow-discovery-process/references/conclude-discovery.md
+++ b/skills/workflow-discovery-process/references/conclude-discovery.md
@@ -24,6 +24,10 @@ If the working tree is already clean, skip the commit.
 
 ## B. Bridge
 
+Bridge varies by `work_type` — epic returns to the discovery map menu so the user can pick the next move; non-epic single-topic work types continue directly into the routed phase (the bootstrap utility wires this in Phase 17d; here the bridge handoff names the destination).
+
+#### If `work_type` is `epic` (or missing — epic is default for back-compat)
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
@@ -36,6 +40,48 @@ Pipeline bridge for: {work_unit}
 Completed phase: discovery
 
 Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+#### If `work_type` is `feature` or `cross-cutting`
+
+The single-topic shape was committed in confirm-and-persist with its routing decision. Bridge into the routed phase via the bootstrap utility — bootstrap creates any missing manifest state, copies imports to their final location, and routes to research or discussion based on the per-topic routing.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Discovery session complete. Routing into {research|discussion}
+> via workflow-bootstrap.
+```
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: discovery
+Next phase: {research|discussion}
+
+Invoke the workflow-bootstrap skill with work_type={work_type}, work_unit={work_unit}, routing={research|discussion}.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+#### If `work_type` is `bugfix` or `quick-fix`
+
+The intent paragraph and routing decision were committed in confirm-and-persist. Bridge into the routed phase via the bootstrap utility — bootstrap routes to investigation (bugfix) or scoping (quickfix).
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Discovery session complete. Routing into {investigation|scoping}
+> via workflow-bootstrap.
+```
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: discovery
+Next phase: {investigation|scoping}
+
+Invoke the workflow-bootstrap skill with work_type={work_type}, work_unit={work_unit}, routing={investigation|scoping}.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-discovery-process/references/confirm-and-persist.md
+++ b/skills/workflow-discovery-process/references/confirm-and-persist.md
@@ -4,9 +4,25 @@
 
 ---
 
-Persists the topic set produced by [topic-synthesis.md](topic-synthesis.md) to the manifest, writes the **Topics Identified** section of the session log, clears the active-session marker, and finalises the **Conclusion** placeholder.
+Persists the synthesised output to the manifest and session log, clears the active-session marker, and finalises the **Conclusion** placeholder.
 
-Edits to existing items committed via [map-operations.md](map-operations.md) during the session loop. For edits-only sessions, the manifest-writes step is empty but the marker delete and Conclusion finalisation still run.
+Behaviour varies by `work_type`:
+
+- **Epic** — persist N topic items at `phases.discovery.items.{topic}`, write multi-section **Topics Identified** to the log. Edits committed via [map-operations.md](map-operations.md) during the loop run alongside; for edits-only sessions, the manifest-writes step is empty but the marker delete and Conclusion finalisation still run.
+- **Feature / cross-cutting** — persist a single item at `phases.discovery.items.{work_unit}` with the routing decision, write a single-section **Topics Identified**.
+- **Bugfix / quickfix** — write the intent paragraph and routing decision to the session log; **no `phases.discovery.items` writes**. Single-topic work types that route to investigation / scoping don't seed a discovery map.
+
+#### If `work_type` is `epic` (or missing — epic is default for back-compat)
+
+→ Proceed to **A. Persist New Topics**.
+
+#### If `work_type` is `feature` or `cross-cutting`
+
+→ Proceed to **D. Persist Single Topic**.
+
+#### If `work_type` is `bugfix` or `quick-fix`
+
+→ Proceed to **E. Persist Intent (No Map)**.
 
 ## A. Persist New Topics
 
@@ -94,5 +110,74 @@ git commit -m "{message}"
 ```
 
 If `git status` reports nothing to commit, skip the commit entirely.
+
+→ Return to caller.
+
+## D. Persist Single Topic (feature / cross-cutting)
+
+The synthesised working state is a single row: `topic_name = {work_unit}`, plus `summary`, `description`, `routing`. Persist as one item at `phases.discovery.items.{work_unit}`:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{work_unit}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{work_unit} summary "{one-line summary}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{work_unit} description "{paragraphs}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{work_unit} routing {research|discussion}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{work_unit} source discovery
+```
+
+Ensure the session log exists ([template.md](template.md) lazy-creation rule). Populate **Topics Identified** with one section using the work-unit name as the topic name:
+
+```markdown
+### {work_unit}
+
+- Routing: {research|discussion}
+- Why: {one-line rationale from synthesis}
+```
+
+Clear the active-session marker:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery active_session
+```
+
+Replace the **Conclusion** placeholder: `Single-topic shape committed. Routing: {research|discussion}.`
+
+Commit:
+
+```bash
+git add .workflows/{work_unit}/manifest.json .workflows/{work_unit}/discovery/session-{session_number:03d}.md
+git commit -m "discovery({work_unit}): commit single-topic shape"
+```
+
+→ Return to caller.
+
+## E. Persist Intent (bugfix / quickfix)
+
+The synthesised working state is a one-paragraph intent capture + routing decision (investigation for bugfix, scoping for quickfix). **No `phases.discovery.items` writes** — single-topic constrained-shape work types don't seed a discovery map.
+
+Ensure the session log exists. Replace the placeholder **Topics Identified** section with an **Intent** section:
+
+```markdown
+### Intent
+
+{intent paragraph from synthesis}
+
+- Routing: {investigation|scoping}
+```
+
+Clear the active-session marker:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery active_session
+```
+
+Replace the **Conclusion** placeholder: `Intent committed. Routing: {investigation|scoping}.`
+
+Commit:
+
+```bash
+git add .workflows/{work_unit}/discovery/session-{session_number:03d}.md
+git commit -m "discovery({work_unit}): commit intent and route to {investigation|scoping}"
+```
 
 → Return to caller.

--- a/skills/workflow-discovery-process/references/discovery-guidelines.md
+++ b/skills/workflow-discovery-process/references/discovery-guidelines.md
@@ -4,10 +4,19 @@
 
 ---
 
-## A. Curatorial Moves
+These guidelines are **shared across all work types**. Mode-specific overlays live in [discovery-mode-overlays.md](discovery-mode-overlays.md) — what each work type produces at endpoint, and which pivot signals each mode watches for. The conversational discipline below applies regardless of mode.
 
-- **Open exploration is the loop.** The session is a conversation that pulls on the idea — sketches the shape, finds the edges, sees how the parts connect. Topics emerge at endpoint from the picture as a whole.
-- **Macro view always.** Don't tunnel into one item. If the user goes deep on mechanism, gently anchor and return to the map level.
+For the wider shape-detection and commit discipline, see:
+
+- [opener-pattern.md](opener-pattern.md) — the four-element opener (signpost → seed acknowledgment → opening question → no preamble)
+- [shape-detection.md](shape-detection.md) — substance signals, surfacing language, confidence heuristics
+- [routing-commit.md](routing-commit.md) — the commit moment with AskUserTool
+- [pivot-watchpoints.md](pivot-watchpoints.md) — macro pivots and inbox surfaces
+
+## A. Curatorial Moves (Shared Core)
+
+- **Open exploration is the loop.** The session is a conversation that pulls on the idea — sketches the shape, finds the edges, sees how the parts connect. Output emerges at endpoint from the picture as a whole.
+- **Macro view always.** Don't tunnel into one item. If the user goes deep on mechanism, gently anchor and return to the shape level.
 - **Tentative grouping** *during exploration*, not as topic decomposition. *"Sounds like the offline-mode bits all live together — agree?"* — confirming a surface boundary, not naming a topic.
 - **Coarseness check** *during exploration*. *"That's a lot of small operational things — most of those will fall out inside bigger discussions later."*
 - **Anchor and return.** When the conversation pulls into detail, gently re-anchor. *"We got pulled into payments mechanism — that's discussion territory once we're there. Want to come back to mapping the rest first?"*
@@ -53,14 +62,21 @@ The user can signal endpoint explicitly (*"that covers it"*, *"let's wrap"*, *"d
 
 When you observe these signals, **propose** endpoint to the user. Don't declare it. Use optional pushback if there's a genuinely unexplored angle worth surfacing first — but don't fabricate angles. If nothing comes to mind, just ask whether to proceed.
 
-## D. Hard Rules
+## D. Hard Rules — Shape vs Content Guardrail
 
-- **No inline topic decomposition.** Do not surface "hearing X, Y, Z as distinct shapes" moves during the loop. Topics are synthesised at endpoint.
+The most important constraint on Discovery's behaviour. Discovery handles SHAPE; downstream phases FILL the shape.
+
+- **No research.** No investigating market, tech, or feasibility — research phase does that.
+- **No investigation.** No symptom analysis, reproduction, or root-cause hunting — investigation phase does that.
+- **No decision-making.** No resolving design questions, no choosing between options — discussion phase does that.
+- **No scope work.** No spec content, no plan content.
+- **No inline topic decomposition.** Do not surface "hearing X, Y, Z as distinct shapes" moves during the loop. Topic synthesis happens at endpoint (for work types that have topics).
 - **The user confirms endpoint.** You can propose, but the user decides. Don't move to synthesis without explicit confirmation.
 - **Initial spike, not exhaustive.** 2 topics is fine, 20 is fine. The map fills out as work progresses — analyses auto-add, splits and elevations spawn. Don't push for completeness at synthesis.
 - **No active missing-piece probes during exploration.** Don't list things the user "hasn't mentioned" as if you're auditing coverage. If something comes to mind during exploration, raise it as a natural question. At endpoint, optional pushback can surface one or two angles — bounded, not exhaustive.
-- **No decisions, no investigations.** Defer mechanism questions to discussion; defer feasibility to research. Use what you and the user already know; don't go searching.
 - **No code, no architecture, no implementation talk.** Topics are named at the level a future research or discussion phase would pick up — *kitchen-printers*, *menu-management*, *analytics* — not API shapes or data models.
+
+The discipline is recognising the difference between *"this is shaping up as a bugfix"* (Discovery's job) and *"the bug is probably in the session middleware"* (Investigation's job). Discovery makes the routing call; downstream does the work.
 
 ## E. Worked Examples
 

--- a/skills/workflow-discovery-process/references/discovery-mode-overlays.md
+++ b/skills/workflow-discovery-process/references/discovery-mode-overlays.md
@@ -1,0 +1,60 @@
+# Discovery Mode Overlays
+
+*Reference for **[workflow-discovery-process](../SKILL.md)***
+
+---
+
+Mode-specific overlays on top of the shared conversational discipline in [discovery-guidelines.md](discovery-guidelines.md). The conversational pattern is the same; what differs per work type is **what synthesis produces at endpoint** and **what pivot signals each mode watches for**.
+
+## A. Endpoint Output by Work Type
+
+| Work type | Endpoint output |
+|---|---|
+| Epic | Multi-row discovery map persisted at `phases.discovery.items.{topic}` with per-topic routing (research / discussion). See [topic-synthesis.md](topic-synthesis.md). |
+| Feature | Single-topic shape with routing decision (research or discussion). One-row map persisted as a single discovery item. |
+| Cross-cutting | Single-topic shape with routing decision (research or discussion). One-row map persisted as a single discovery item. |
+| Bugfix | Brief intent capture (one paragraph) + routing decision to investigation. No discovery map — the session log is the journey record. |
+| Quickfix | Brief intent capture (one paragraph) + routing decision to scoping. No discovery map — the session log is the journey record. |
+
+The shared conversational loop holds across all modes — open exploration, no decisions, anchor and return, propose endpoint. Only the synthesis at endpoint diverges.
+
+## B. Pivot Watchpoints by Mode
+
+Each mode listens for the cues that suggest a different shape might be the right one. Pivot offers surface mid-loop as conversational reads (see [pivot-watchpoints.md](pivot-watchpoints.md) for the full pivot table and mechanics).
+
+| Mode | Pivot signals to watch for |
+|---|---|
+| Epic | One coherent topic emerges; "multiple shapes" never quite materialises → consider feature pivot |
+| Feature | Multiple distinct concerns from one description; topic seeds clustering → consider epic pivot |
+| Bugfix | "Broken" turns out to be missing-by-design → consider feature pivot |
+| Quickfix | Scope discussion gets substantive; behaviour debate emerges → consider feature or bugfix pivot |
+| Cross-cutting | Customer-facing deliverable emerges → consider feature or epic pivot |
+| Any mode | Tangential concern surfaces that's separate from the current work → inbox surface offer (see [pivot-watchpoints.md](pivot-watchpoints.md) section E) |
+
+## C. Seed-Material Interpretation by Mode
+
+Imports and inbox items are read at the opener (see [opener-pattern.md](opener-pattern.md)). Mode-specific interpretation:
+
+| Mode | Seed-material role |
+|---|---|
+| Epic | Imports drive topic decomposition |
+| Feature | Imports inform single-topic shape; multi-topic content triggers epic-pivot offer |
+| Cross-cutting | Imports inform pattern / principle definition; customer-facing content triggers feature-pivot offer |
+| Bugfix | Imports are reference material (logs, error reports, prior tickets) — read for context, NOT analysed for root cause (shape vs content guardrail) |
+| Quickfix | Imports are reference material — context only, no scope debate |
+
+The shape-vs-content guardrail applies particularly hard for bugfix and quickfix: imports must not turn the conversation into investigation or scoping.
+
+## D. Conversational Posture by Mode
+
+The conversational discipline is shared. The *flavour* of the questions follows the seed and the user's framing — but the posture stays consistent:
+
+- One question at a time
+- Open, exploratory questions; no checklists
+- Mirror the shape back so the user can correct it
+- Anchor and return when conversation tunnels
+- Surface tentative reads mid-loop when signals converge
+
+Bugfix mode tends to converge fast (the user often arrives knowing the failure mode). Quickfix mode tends to converge fastest. Epic mode tends to take longest (multiple surfaces to map). Feature and cross-cutting sit in the middle. Pace the loop to the work type's natural depth — don't artificially extend a quickfix conversation, don't artificially shorten an epic conversation.
+
+→ Return to caller.

--- a/skills/workflow-discovery-process/references/opener-pattern.md
+++ b/skills/workflow-discovery-process/references/opener-pattern.md
@@ -1,0 +1,78 @@
+# Opener Pattern
+
+*Reference for **[workflow-discovery-process](../SKILL.md)***
+
+---
+
+The Discovery opener has four elements applied in sequence. The PATTERN is universal across entry paths and work types; the SPECIFIC TEXT varies for conversational naturalness.
+
+## A. Phase Signpost
+
+The boundary from `/workflow-start` into Discovery is marked via the established step-marker + signpost-blockquote convention. The signpost text carries shape-appropriate framing:
+
+| Entry path | Signpost framing |
+|---|---|
+| `/start` (ambiguous) | *"Figuring out what kind of work this is, then the details inside it."* |
+| `e`/`epic` | *"Setting up the epic — we'll pull on shape before naming topics."* |
+| `f`/`feature` | *"Setting up the feature — we'll pull on shape before committing routing."* |
+| `b`/`bugfix` | *"Setting up the fix — we'll capture intent and route to investigation."* |
+| `q`/`quickfix` | *"Setting up the change — we'll capture intent and route to scoping."* |
+| `c`/`cross-cutting` | *"Setting up the cross-cutting concern — we'll pull on shape before committing routing."* |
+| inbox | *"Reading your {bug/idea/quickfix} and shaping it for the pipeline."* |
+
+One sentence. Same convention as the rest of the workflow.
+
+## B. Seed-Material Acknowledgment (when seed material is present)
+
+Imports and inbox items count as seed material. When present, read them and surface a brief sketch of what was picked up — sketch first, then the opening question:
+
+> *Output the next fenced block as a code block:*
+
+```
+Read your {import(s) / inbox item}. Here's the shape I'm picking up:
+
+  {one-line summary of what the seed material describes}
+
+{targeted opening question}
+```
+
+Reflect the shape, do not regurgitate the content verbatim. The sketch is one line — enough that the user knows you read it.
+
+**Mode-specific interpretation** of seed material (see [discovery-guidelines.md](discovery-guidelines.md) for the full overlay):
+
+- Epic-mode — imports drive topic decomposition
+- Feature / cc-mode — imports inform single-topic shape; multi-topic content triggers an epic-pivot offer (see [pivot-watchpoints.md](pivot-watchpoints.md))
+- Bugfix-mode — imports are reference material (logs, error reports, prior tickets). Read for context, do not analyse for root cause — that would violate the shape vs content guardrail
+- Quickfix-mode — similar to bugfix; reference material only
+
+## C. Opening Question, Shape-Appropriate
+
+Phrased per `work_type` pre-seed (or fully open for `/start`). Illustrative wording — adapt for naturalness:
+
+| Entry path | Opening question |
+|---|---|
+| `/start` | *"Tell me what's on your mind. I'll ask open questions and we'll figure out the shape together."* |
+| `e`/`epic` | *"Tell me about the epic. I'll ask open questions to pull on it before we synthesise topics."* |
+| `f`/`feature` | *"Tell me about the feature."* |
+| `b`/`bugfix` | *"What's broken?"* |
+| `q`/`quickfix` | *"What's the change?"* |
+| `c`/`cc` | *"Tell me about the cross-cutting concern."* |
+| inbox (after seed acknowledgment) | *"{targeted question drawn from the seed material}."* |
+
+One question. Wait for the answer. Let the answer shape where you push next.
+
+## D. No Pre-Announce of Process Discipline
+
+Do not preamble *"we're in setup mode, not problem-solving"* or *"discovery handles shape, not content."* Discipline is enforced by behaviour:
+
+- Open exploratory questions, no commitments
+- Redirect deep dives when they happen: *"hold that thread — we'll cover it in {research / discussion / investigation}"*
+- No premature decisions, no premature bucket-labelling
+
+The user finds out *what* Discovery does by being in it — they don't need a meta-explanation upfront. Pre-announcing the process is annoying for repeat users.
+
+## E. Symmetry at the Pattern Level
+
+The four-element pattern (signpost → seed-material acknowledgment → opening question → no preamble) is identical regardless of entry path or work type. Specific text varies. This preserves cross-worktype symmetry at the structural level while letting the conversational phrasing feel natural for each entry path.
+
+→ Return to caller.

--- a/skills/workflow-discovery-process/references/pivot-watchpoints.md
+++ b/skills/workflow-discovery-process/references/pivot-watchpoints.md
@@ -1,0 +1,87 @@
+# Pivot Watchpoints
+
+*Reference for **[workflow-discovery-process](../SKILL.md)***
+
+---
+
+Two pivot patterns live here: **macro pivots** (raising a different work-type when signals point elsewhere) and **scope-down + inbox surface** (peeling off tangential concerns without contaminating the current shape).
+
+## A. Macro Pivot Triggers
+
+When Discovery is running with a pre-seeded or tentatively-converging shape, and signals start pointing at a *different* shape, raise the pivot. Same threshold as the regular shape-detection threshold (multiple converging signals, consistent framing, etc.) — applied to the *competing* shape rather than the current one. Same patience discipline: don't pivot on a single weak signal.
+
+Pivot direction cues (illustrative — tune via real use):
+
+| Pivot direction | Cues |
+|---|---|
+| feature → epic | Multiple distinct concerns surface from what was framed as one feature; topic seeds start clustering into independent groups; user describes scope expansion mid-conversation |
+| epic → feature | Synthesis converges on one coherent topic; *"multiple shapes"* never quite materialises; user keeps pulling back to one core concern |
+| bugfix → feature | Described *"broken"* behaviour turns out to be missing-by-design rather than malfunction; user struggles to describe a working state before the bug |
+| feature → bugfix | Described *"new"* behaviour is actually restoring something that should already work; user mentions regression or *"it used to work"* |
+| quickfix → feature / bugfix | Scope discussion gets substantive; behaviour debate emerges; user starts describing how the change *should* work |
+| any → cross-cutting | Described work turns out to be defining a pattern, principle, or strategy rather than shipping a feature; no customer-facing deliverable surfaces |
+
+## B. How to Surface a Pivot
+
+The pivot offer surfaces mid-loop as a tentative read (see [shape-detection.md](shape-detection.md) → *Mid-Loop Surfacing*). Plain language, not workflow jargon:
+
+> *"This is shaping bigger than one feature — sounds like several connected things. Want to treat as a larger initiative made of multiple features?"*
+
+User confirms, declines, or redirects — take the call. The pivot offer is conversational, not an AskUserTool prompt (the same rationale as mid-loop surfacings).
+
+Pivot offers can fire multiple times in one Discovery session. Each one is a tentative surfacing, easy to push back on.
+
+## C. Reasoning Surfacing in Pivots
+
+Same principle as routing-commit reasoning (see [routing-commit.md](routing-commit.md) → *Explain the Reasoning*). Name the specific signals that drove the pivot read:
+
+> *"Sounds like several connected things rather than one — you've sketched menu-management, kitchen-printers, and operator-analytics as distinct concerns. Want to treat as a larger initiative?"*
+
+Brief, concrete, pull-on-able. The user can challenge specific cues (*"actually menu-management and analytics are the same thing for me — I'm seeing one feature"*) and you adjust the read.
+
+## D. Pivot Mechanics (Post-Acceptance)
+
+When the user accepts a pivot, the operational moves depend on direction:
+
+- **Direction widens** (e.g. feature → epic): the current single-topic shape becomes one of several topics in an epic map. Stay in Discovery; continue exploration as an epic conversation. Existing topic cues become candidate epic topics.
+- **Direction narrows** (e.g. epic → feature): the multi-topic map collapses to a single chosen topic. Ask the user which of the candidate threads is the focus; archive the rest (they can surface to inbox or stay as future epics).
+- **Direction shifts type** (e.g. feature → bugfix): the shape changes substantively. Reset the synthesis intent — bugfix routes to investigation rather than research/discussion.
+
+The pivot commit lands the same way as a routing commit (see [routing-commit.md](routing-commit.md)). No silent shape change — the user sees the new shape and confirms before Discovery continues.
+
+## E. Scope-Down + Inbox Surface
+
+During Discovery for one work unit, you may notice a related-but-separate concern the user mentions in passing. Without a release valve, this would either (a) scope-creep into the current work unit, contaminating its shape, or (b) get lost entirely. Surface to inbox for later — keep the current work focused.
+
+When you notice a tangential concern that doesn't fit the current shape, surface a brief offer:
+
+> *"You mentioned X — that feels separate from what we're shaping. Surface to inbox for later?"*
+
+The decision moment is conversational, not structured — soft surfacing, easy redirect. No AskUserTool needed.
+
+### Mechanism (if user accepts)
+
+Pick the inbox-capture skill based on the tangential concern's shape:
+
+- **Bug-shaped** → invoke `/workflow-log-bug`
+- **Idea-shaped** (default when uncertain) → invoke `/workflow-log-idea`
+- **Quickfix-shaped** → invoke `/workflow-log-quickfix`
+
+The capture skill writes the file to `.workflows/.inbox/{bugs,ideas,quickfixes}/` per existing inbox capture pattern. Discovery's session log notes the surfacing as part of the journey record, so it's discoverable in the journey record even if the inbox file gets actioned later.
+
+Conversation continues with the original work, now without scope creep.
+
+### If user declines
+
+Fold the tangential concern into the current work. The surfacing offer is the value-add either way — it surfaces the question rather than silently scope-creeping.
+
+## F. Pivot vs Inbox Surface — Which Move?
+
+Both peel concerns away from the current shape, but they're different operations:
+
+- **Pivot** reshapes the *current* work unit (different macro shape, same fundamental scope).
+- **Inbox surface** removes a *separate* concern from the current work unit (different scope altogether).
+
+Diagnostic: *"Is this the work, or is this adjacent to the work?"* If it's adjacent, inbox surface. If it's the work itself looking different, pivot.
+
+→ Return to caller.

--- a/skills/workflow-discovery-process/references/routing-commit.md
+++ b/skills/workflow-discovery-process/references/routing-commit.md
@@ -1,0 +1,88 @@
+# Routing Commit
+
+*Reference for **[workflow-discovery-process](../SKILL.md)***
+
+---
+
+The moment shape commits — moving from *"I have an opinion"* to *"we've committed"*. Covers macro routing (what kind of work this is) and, for work types that have it, micro routing (per-topic research vs discussion). Loaded from [topic-synthesis.md](topic-synthesis.md) and from the loop in [session-loop.md](session-loop.md) when commit conditions are met.
+
+## A. State the Read
+
+Say what the shape is in plain user-facing terms, with the workflow bucket name folded in naturally — not before. Example:
+
+> *"This is feature-shaped — one focused thing to build. The routing tendency I'm reading is discussion since the shape is clear and the open questions are about trade-offs not unknowns."*
+
+The bucket name (*"feature-shaped"*) appears alongside the substance description, not in place of it.
+
+## B. Explain the Reasoning
+
+The user needs to be informed enough to agree or push back. Surface the specific signals that drove the read:
+
+- **Brief** — one or two sentences. The point is to make the read auditable, not to defend it.
+- **Specific** — name the cues (*"because you described X and Y as separate concerns and each came with substantive weight"*), not vague (*"based on the conversation"*).
+- **Pull-on-able** — the user can challenge specific cues, not just accept-or-reject the whole conclusion. Saying *"because you described X and Y as separate concerns"* lets the user respond *"actually X and Y are the same thing — Y is a subset"* — take that as an update to the read.
+
+This is the difference between *"trust me"* reasoning and *"check my work"* reasoning. Use the latter.
+
+When you don't have enough signal to give pull-on-able reasoning, that's the trigger to keep exploring rather than surface a read — the read isn't ready yet.
+
+## C. Invite Confirmation or Override
+
+Use AskUserTool for the routing-commit moment. Structured confirm-or-override locks the call cleanly without ambiguity and matches the formality of a commit. The user sees the proposed routing, the reasoning, and structured options:
+
+- **Confirm** — accept the proposed shape and routing
+- **Override** — pick a different shape (the alternative the user has in mind)
+- **Discuss more** — return to exploration before committing
+
+AskUserTool is the right surface here because:
+
+- The commit is a structured decision, not a conversational nudge
+- Override needs a clean affordance, not a free-text pushback that risks ambiguity
+- The user benefits from seeing the proposal and the alternatives side by side
+
+## D. Honour User Override Authoritatively
+
+If the user pushes back, take their call as final. No re-litigation. If the user redirects to a different shape, adjust without needing further justification — the override is the authoritative input, not a negotiation opener.
+
+If the override creates a routing conflict (e.g. user overrides epic → feature, but Discovery has accumulated three candidate topics), surface the implication and ask one clarifying question (*"that pushes us to a single feature — which of these three threads is the focus?"*) rather than silently dropping signal.
+
+## E. Patience on the Commit
+
+Even when signals have reached the surfacing threshold (see [shape-detection.md](shape-detection.md) section C), hold off committing until:
+
+- Signals have **converged AND been stable** across the last few exchanges — not just hit threshold this turn
+- Mid-loop tentative surfacings have been **confirmed or adjusted** by the user
+- The natural next move would **drop into content** if we kept exploring — the shape conversation has truly run as far as it can without violating the shape-vs-content guardrail
+- The user's framing has been **consistent** — not about to revert the commit in two turns
+
+This is the same patience discipline as the surfacing threshold, applied one step later in the loop. Substance-focus enables it: stay on what's being built / fixed / changed, not on which bucket it lands in, and the commit lands when it's actually ready.
+
+## F. Operational Commit Semantics
+
+Once routing is committed:
+
+- The committed shape is written to Discovery's session log (the journey record)
+- Transition into shape-appropriate output:
+  - **Epic** → topic synthesis (see [topic-synthesis.md](topic-synthesis.md))
+  - **Feature / cross-cutting** → single-topic commit + routing
+  - **Bugfix / quickfix** → brief intent capture + routing decision; no map
+- Pivots after commit are possible but expensive — they reset the synthesis. Treat post-commit pivots as deliberate redirects, not casual exploration ([pivot-watchpoints.md](pivot-watchpoints.md))
+- For epic / feature / cross-cutting, the macro commit doesn't necessarily lock micro routing yet — per-topic routing commits happen during/after synthesis
+
+The macro and micro commits can land at the same conversational moment (single-topic feature: *"feature-shaped, routing is discussion"*) or at different moments (epic: macro commit first, then per-topic routing commits during synthesis).
+
+## G. AskUserTool — When and When Not
+
+Summary of where AskUserTool fits in the Discovery loop:
+
+| Moment | AskUserTool? |
+|---|---|
+| Mid-loop tentative surfacings | No — stays conversational |
+| Explicit shape questions (binary disambiguator) | OK when the disambiguation is genuinely binary and explicit framing helps |
+| Routing commit moment (this file) | Yes — structured confirm/override/discuss-more |
+| Endpoint / synthesis confirmation | Yes — matches today's pattern |
+| Adjustments after synthesis (split / merge / rename / re-route) | Yes — structured slots |
+
+Principle: AskUserTool appears at structured decision moments, not during conversational exploration. The tool's clarity is its value at commit; that same clarity is its cost mid-loop.
+
+→ Return to caller.

--- a/skills/workflow-discovery-process/references/shape-detection.md
+++ b/skills/workflow-discovery-process/references/shape-detection.md
@@ -1,0 +1,92 @@
+# Shape Detection
+
+*Reference for **[workflow-discovery-process](../SKILL.md)***
+
+---
+
+The listening discipline that drives the Discovery loop. Two angles: *what signals to listen for* (substance) and *how to surface tentative reads* (user-facing language). Pairs with [routing-commit.md](routing-commit.md) (the commit moment) and [pivot-watchpoints.md](pivot-watchpoints.md) (mid-conversation re-shaping).
+
+## A. Signals Are About Substance, Not Bucket Names
+
+The bucket names (epic / feature / bugfix / quickfix / cross-cutting) are workflow internals. Saying *"this sounds like an epic"* assumes a vocabulary the user often lacks. Detect *what kind of work the user is actually describing*, in plain terms, and translate to a bucket only at routing commit.
+
+Substance signals (illustrative cues — tune via real use):
+
+| Substance signal (what is being described) | Routes to internally |
+|---|---|
+| New behaviour not present today, single coherent scope, clear actors and flows | feature |
+| Multiple distinct concerns from one description, multi-week / multi-phase shape, broader system-level reshaping, *"project"* / *"initiative"* framing | epic |
+| System-wide concern affecting multiple work units, pattern / principle / strategy definition (*"error response shape"*, *"auth strategy"*, *"logging convention"*), no customer-facing deliverable | cross-cutting |
+| Past-tense or present-broken descriptions, specific failure cases with reproducible conditions, error messages / stack traces in imports | bugfix |
+| Imperative scoped changes (*"bump the timeout"*, *"rename X to Y"*, *"add a flag"*), one-shot adjustments without behaviour debate | quickfix |
+| *"Not sure how"*, *"what's possible"* — could route research-shaped; descriptions that mix broken + new — could be bugfix-with-feature-followup | ambiguous — keep exploring |
+
+These are first-pass cues, not a checklist. Hardcoding strict matches risks trigger-happy reads on weak signals.
+
+## B. Surfacing Language Stays Plain Until Commit
+
+When sharing a tentative read or asking for confirmation, speak in user-facing shape-terms:
+
+| Internal (workflow lingo) | User-facing (plain shape) |
+|---|---|
+| *"This sounds like an epic"* | *"This sounds like several distinct things — more than one feature in scope"* |
+| *"This is a feature"* | *"Sounds like a single coherent piece of work"* |
+| *"This is cross-cutting"* | *"Sounds like a pattern or principle that affects the whole project — something to define, not something to ship as a feature"* |
+| *"This is a bugfix"* | *"Sounds like something broken we're fixing rather than something new we're building"* |
+| *"This is a quickfix"* | *"Sounds like a small targeted change — adjustment rather than a whole feature"* |
+
+Bucket names only appear at the routing-commit moment ([routing-commit.md](routing-commit.md)), and even then framed naturally. Up until commit, everything is described in terms of what the user is actually doing.
+
+## C. Confidence Heuristics — When to Surface a Tentative Read
+
+You are *"confident enough to surface"* when ALL of the following hold:
+
+- **Multiple converging signals** point at the same shape (not just one weak hint)
+- **User framing has been consistent** across multiple turns (not switching shapes mid-conversation)
+- **Ambiguity has been resolved** — at least one explicit-shape question has been asked if ambiguity was present, and the user's answer resolved it
+- **Pivot signals aren't lit** — you aren't sitting on a competing shape's signals at the same time
+
+Below this threshold, keep exploring. A weak surfacing reads as fishing and breaks user trust in the conversation.
+
+## D. Mid-Loop Surfacing
+
+When patterns clearly emerge, share a tentative read mid-loop rather than holding to endpoint. The user gets to push back while reads are still tentative, before momentum builds. Examples (illustrative):
+
+- After several exchanges hinting at multiple concerns: *"I'm hearing a few distinct things — this might be more than one feature. Want to pull on that or stay focused?"*
+- After enough scope clarity: *"Sounds like a single coherent thing, with the routing tendency I'm reading as discussion-shaped. Anything I'm missing?"*
+- After a tangential concern surfaces: *"You mentioned X — that feels separate from what we're shaping. Surface to inbox for later?"* (see [pivot-watchpoints.md](pivot-watchpoints.md))
+- After topic seeds start clustering (epic mode): *"I'm seeing menu-management and kitchen-printers as candidate topics. Sound right or wrong shape?"*
+
+Surfacings are **conversational** — soft, easy for the user to redirect. Not every signal triggers a surfacing; only when there's enough to test against the user usefully.
+
+Mid-loop surfacings stay conversational. AskUserTool is NOT used here — tool prompts in the middle of an exploratory flow break the conversational rhythm without adding clarity.
+
+## E. The Explicit Shape Question
+
+When shape questions are exhausted but ambiguity remains. Trigger: the next natural question would drop into content territory (research, decision-making, investigation) and would violate the shape-vs-content guardrail. Move: ask the user directly to disambiguate.
+
+Examples (illustrative):
+
+- *"Two readings here — this could be fixing something that's currently broken, or adding something new that doesn't exist yet. Which is closer?"*
+- *"This is shaping bigger than a single feature — does it feel to you like one focused thing, or several connected things?"*
+- *"This sounds like a small targeted change, but if it touches behaviour the user sees, we should treat it as a feature instead. How does it feel from your end?"*
+
+These force a commit so the conversation can progress. The explicit shape question is OK as an AskUserTool prompt when the disambiguation is genuinely binary and the user benefits from explicit framing — use judiciously.
+
+## F. The Hardest Discriminations — Pairs at the Boundaries
+
+These are where mid-loop surfacings and explicit shape questions earn their keep:
+
+- **Single feature vs multi-feature** — *"is this one thing or several things stuck together?"*
+- **Building vs fixing** — *"is the behaviour missing, or is the behaviour broken?"*
+- **Quick targeted change vs feature vs bugfix** — *"is this a small adjustment, a new behaviour, or a fix?"*
+
+Patience pays here. Premature commit on a borderline pair reads as bucket-labelling rather than shape-detection.
+
+## G. Macro and Micro Signals Co-Emerge
+
+Not sequential phases. A user describing *"operators do X, kitchen does Y, customers do Z"* surfaces BOTH multi-shape (macro signal — likely epic) AND candidate topic seeds (micro signal). The macro/micro structure is about routing OUTPUTS, not loop sequencing. One loop, both signal flavours accumulating in parallel.
+
+For work types with per-topic micro routing (epic / feature / cross-cutting), gather routing cues during the exploration — they bind at synthesis. For bugfix / quickfix, no micro routing applies; the route-out is fixed by macro shape (bugfix → investigation, quickfix → scoping).
+
+→ Return to caller.

--- a/skills/workflow-discovery-process/references/topic-synthesis.md
+++ b/skills/workflow-discovery-process/references/topic-synthesis.md
@@ -4,7 +4,25 @@
 
 ---
 
-The endpoint ceremony. Analyse the session's exploration as a whole, produce a topic set, and confirm it with the user. Loaded by [session-loop.md](session-loop.md) C when the user confirms ready to synthesise.
+The endpoint ceremony. Analyse the session's exploration, produce a shape-appropriate output, and confirm it with the user. Loaded by [session-loop.md](session-loop.md) C when the user confirms ready to synthesise.
+
+Output shape varies by `work_type` ([discovery-mode-overlays.md](discovery-mode-overlays.md) section A):
+
+- **Epic** — full multi-row topic proposal (sections A–E below)
+- **Feature / cross-cutting** — single-topic shape + routing (section F)
+- **Bugfix / quickfix** — brief intent capture + routing decision, no map (section G)
+
+#### If `work_type` is `epic` (or missing — epic is the default for back-compat)
+
+→ Proceed to **A. Gather Source Material**.
+
+#### If `work_type` is `feature` or `cross-cutting`
+
+→ Proceed to **F. Single-Topic Synthesis**.
+
+#### If `work_type` is `bugfix` or `quick-fix`
+
+→ Proceed to **G. Brief Intent Synthesis**.
 
 ## A. Gather Source Material
 
@@ -101,3 +119,75 @@ Apply the named adjustments to the working set:
 After applying, re-render the proposal (back to the top of **E**) and ask again. Loop until confirmed or `explore` is chosen.
 
 → Return to **E. Render Proposal**.
+
+## F. Single-Topic Synthesis (feature / cross-cutting)
+
+Feature and cross-cutting produce one row, not many. The topic name equals the work-unit name (single-topic work types use the work unit as the topic). Synthesis names the one-line summary, the description, and the routing decision (research vs discussion).
+
+Re-read the **Exploration** section and in-context conversation. Synthesise:
+
+- **One-line summary** — the shape in a sentence
+- **Description** — paragraphs capturing what was explored
+- **Routing** — `research` if the conversation was full of open questions / feasibility unknowns / external dependencies; `discussion` if the shape is clear and the open work is about trade-offs and decisions
+
+Load [routing-inference.md](routing-inference.md) for the cue lists.
+
+Then surface the commit proposal — use the routing-commit discipline:
+
+→ Load **[routing-commit.md](routing-commit.md)** and follow its instructions as written.
+
+When the user confirms (or you've honoured an override), hold the single-row result as the working list for Step 6 confirm-and-persist:
+
+- `topic_name = {work_unit}`
+- `summary`, `description`, `routing` as synthesised
+- `source = discovery`
+
+→ Return to caller.
+
+## G. Brief Intent Synthesis (bugfix / quickfix)
+
+Bugfix and quickfix produce no map. Synthesis is a brief intent capture written to the session log + a routing decision (bugfix → investigation, quickfix → scoping). No items are persisted to `phases.discovery.items`.
+
+Re-read the **Exploration** section. Synthesise a one-paragraph intent capture that names:
+
+- For bugfix: the failure symptom, the reproduction condition (if known), the surface affected
+- For quickfix: the change being made, the surface affected, any constraint the user surfaced
+
+Stay on shape, not investigation / scoping content. The downstream phase fills in the substance.
+
+Routing decision is fixed by macro shape:
+
+- Bugfix → investigation
+- Quickfix → scoping
+
+Surface the commit using the routing-commit discipline (the macro shape was committed earlier in the loop; this is a confirm-and-record beat):
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Ready to commit?
+
+- **`y`/`yes`** — Commit intent and route to {investigation|scoping}
+- **`e`/`explore`** — Go back to exploration; not ready to commit yet
+- **Adjust** — Tell me what to revise in the intent paragraph
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `yes`
+
+Hold the intent paragraph and routing decision as the working state for Step 6 confirm-and-persist. No `phases.discovery.items` writes.
+
+→ Return to caller.
+
+#### If `explore`
+
+→ Return to caller for **B. Session Loop**.
+
+#### If adjust
+
+Apply the named revisions to the intent paragraph and re-surface the gate. Loop until confirmed or `explore` is chosen.
+
+→ Return to **G. Brief Intent Synthesis**.


### PR DESCRIPTION
## Summary

Phase 17b of the universal-Discovery stack. Teaches `workflow-discovery-{entry,process}` to run in all five work-type modes — but **does not yet wire any non-epic path to Discovery**. Scaffolding for 17c (bootstrap utility) and 17d (cutover).

- Drop "Discovery is epic-only" rejection at the entry guard
- Reframe Purpose for the universal role; cross-reference new shape-detection / routing-commit / pivot-watchpoints / opener-pattern files
- Split `discovery-guidelines.md` into shared core + mode overlays; tighten the shape-vs-content guardrail
- New: `discovery-mode-overlays.md`, `shape-detection.md`, `routing-commit.md`, `pivot-watchpoints.md`, `opener-pattern.md`
- `topic-synthesis.md` / `confirm-and-persist.md` / `conclude-discovery.md` gain mode dispatch at the top; epic falls through to the existing flow unchanged. Feature/cross-cutting persist a single-topic shape; bugfix/quick-fix capture brief intent with no map.

Epic flow remains the default for back-compat (`if work_type is epic (or missing)` — existing routing).

Stacks on #300 (Phase 17a).

## Test plan
- [x] All 251 manifest tests pass
- [x] All discovery tests pass (`test-discovery-*`)
- [x] No epic-flow regression — dispatch branches gate non-epic behind explicit `work_type` checks
- [ ] Non-epic paths not yet exercised in this PR (cutover lands in 17d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)