### PR TITLE
Phase 17c — workflow-bootstrap utility (scaffold)

### DIFF
--- a/skills/workflow-bootstrap/SKILL.md
+++ b/skills/workflow-bootstrap/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: workflow-bootstrap
+user-invocable: false
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(mkdir -p .workflows/), Bash(cp), Bash(git)
+---
+
+Bootstrap a work unit after Discovery has resolved its shape. Single utility replacing the per-work-type start-* skills. Model-invocable only — Discovery's terminal step invokes it; users never reach it directly.
+
+> **⚠️ ZERO OUTPUT RULE**: Do not narrate your processing. Produce no output until a step or reference file explicitly specifies display content. No "proceeding with...", no discovery summaries, no routing decisions, no transition text. Your first output must be content explicitly called for by the instructions.
+
+## Workflow Context
+
+You are at the boundary between **Discovery** and the next phase. Discovery committed the work-unit shape; your job is to land that commit on disk and hand off to the first work-type-appropriate phase entry:
+
+Discovery → **Bootstrap** → {Research / Discussion / Investigation / Scoping}
+
+**Stay in your lane**: do not gather context, do not classify shape, do not negotiate routing. Discovery already did. Your work is mechanical — create the manifest if it does not exist, land imports, route to the next phase.
+
+### What This Skill Needs
+
+The caller (Discovery's `conclude-discovery.md`) provides these via the handoff:
+
+- `work_type` — required. One of `epic`, `feature`, `bugfix`, `quick-fix`, `cross-cutting`. Discovery resolved it.
+- `work_unit` — required. The named work being bootstrapped.
+- `routing` — required.
+  - Epic: per-topic routing is already persisted on the discovery items; `routing` is unused
+  - Feature / cross-cutting: `research` or `discussion`
+  - Bugfix: fixed to `investigation`
+  - Quick-fix: fixed to `scoping`
+- `description` — optional. If the manifest already exists, the description on disk wins. Otherwise the provided description seeds the manifest.
+- `imports_staging` — optional. Path to a staging directory holding files Discovery collected. Empty / absent when no imports were collected.
+
+---
+
+## Instructions
+
+Follow these steps EXACTLY as written. Do not skip steps or combine them.
+
+**CRITICAL**: This guidance is mandatory.
+
+- Bootstrap is mechanical — do not introduce conversational beats
+- Do not re-run Step 0 elements that `/workflow-start` already ran (casing, migrations, knowledge check, knowledge compact)
+- After rendering a gate block (if any), the turn MUST end
+- Complete each step fully before moving to the next
+
+---
+
+## Step 1: Ensure Manifest
+
+Load **[ensure-manifest.md](references/ensure-manifest.md)** and follow its instructions as written.
+
+→ Proceed to **Step 2**.
+
+---
+
+## Step 2: Land Imports
+
+Load **[land-imports.md](references/land-imports.md)** and follow its instructions as written.
+
+→ Proceed to **Step 3**.
+
+---
+
+## Step 3: Route to First Phase
+
+Load **[route-to-phase.md](references/route-to-phase.md)** and follow its instructions as written.
+
+This skill ends. The invoked entry-point skill will load and provide its own instructions. Terminal.

--- a/skills/workflow-bootstrap/references/ensure-manifest.md
+++ b/skills/workflow-bootstrap/references/ensure-manifest.md
@@ -1,0 +1,45 @@
+# Ensure Manifest
+
+*Reference for **[workflow-bootstrap](../SKILL.md)***
+
+---
+
+Create the work-unit manifest if it does not already exist. On the menu-fast-paths (`e`/`f`/`b`/`q`/`c`), `/workflow-start` may have already created the manifest before Discovery ran. On the `s`/`start` ambiguous path, the manifest is created here — work_type was resolved during Discovery and is now bound.
+
+## A. Check Existence
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}
+```
+
+`exists` returns exit 0 when the work unit's manifest is present, exit 2 (expected miss) when absent. Capture the exit code as `manifest_present`.
+
+#### If `manifest_present` is `0`
+
+The manifest already exists. Read its `work_type` and verify it matches the handoff:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} work_type
+```
+
+If the stored `work_type` differs from the handoff `work_type` (e.g. user accepted a pivot during Discovery), update it:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_type {work_type}
+```
+
+→ Proceed to **B. Name Check** (no-op when manifest already exists).
+
+#### Otherwise
+
+The manifest does not exist. Create it.
+
+→ Proceed to **B. Name Check**.
+
+## B. Name Check
+
+Load **[name-check.md](name-check.md)** with work_unit = `{work_unit}`, work_type = `{work_type}`, description = `{description}`.
+
+When name-check returns, the manifest is guaranteed to exist with the expected `work_type` and `description`.
+
+→ Return to caller.

--- a/skills/workflow-bootstrap/references/land-imports.md
+++ b/skills/workflow-bootstrap/references/land-imports.md
@@ -1,0 +1,59 @@
+# Land Imports
+
+*Reference for **[workflow-bootstrap](../SKILL.md)***
+
+---
+
+Move any files Discovery collected from staging into the work unit's `imports/` directory, register them in the manifest, and index them into the knowledge base. Reuses the shared **[import-files.md](../../workflow-shared/references/import-files.md)** reference for the per-file mechanics.
+
+## A. Check for Staged Imports
+
+#### If `imports_staging` is empty or absent
+
+No imports to land — Discovery did not collect any.
+
+→ Return to caller.
+
+#### Otherwise
+
+Verify the staging directory exists on disk. If it does not exist (Discovery indicated imports but they are missing), surface the error and stop:
+
+```
+Imports staging directory not found: {imports_staging}
+
+Bootstrap cannot proceed without the staged imports. Re-enter via
+/workflow-start to restart the work unit.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+If the staging directory exists, list its files and capture the paths as `import_paths`.
+
+→ Proceed to **B. Land Files**.
+
+## B. Land Files
+
+Hand off to the shared import-files reference. It validates paths, normalises filenames, copies each file into `.workflows/{work_unit}/imports/`, pushes a manifest entry per file, and indexes each file into the knowledge base.
+
+→ Load **[import-files.md](../../workflow-shared/references/import-files.md)** with work_unit = `{work_unit}`, import_paths = `{import_paths}`.
+
+When import-files returns:
+
+→ Proceed to **C. Clean Staging**.
+
+## C. Clean Staging
+
+Remove the staging directory now that its contents have been landed:
+
+```bash
+rm -rf "{imports_staging}"
+```
+
+Commit the manifest writes and the imports directory:
+
+```bash
+git add .workflows/{work_unit}/manifest.json .workflows/{work_unit}/imports/
+git commit -m "bootstrap({work_unit}): land {N} import(s)"
+```
+
+→ Return to caller.

--- a/skills/workflow-bootstrap/references/name-check.md
+++ b/skills/workflow-bootstrap/references/name-check.md
@@ -1,0 +1,65 @@
+# Name and Conflict Check
+
+*Reference for **[workflow-bootstrap](../SKILL.md)***
+
+---
+
+Parameterised name + conflict check. Replaces the five per-work-type `start-*/references/name-check.md` files. Called only when the manifest does not yet exist (see [ensure-manifest.md](ensure-manifest.md)).
+
+## Parameters
+
+The caller provides:
+
+- `work_unit` — kebab-case name resolved by Discovery
+- `work_type` — one of `epic`, `feature`, `bugfix`, `quick-fix`, `cross-cutting`
+- `description` — concise one-line summary from Discovery's session log
+
+## A. Conflict Check
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}
+```
+
+#### If a work unit with the same name exists
+
+A name collision was not caught upstream — surface it and ask Discovery to resolve.
+
+> *Output the next fenced block as a code block:*
+
+```
+A work unit named "{work_unit}" already exists.
+
+Re-enter Discovery to choose a different name, or run /workflow-start
+to resume the existing work unit.
+```
+
+**STOP.** Do not proceed — terminal condition. The user re-enters via `/workflow-start`.
+
+#### Otherwise
+
+→ Proceed to **B. Create Manifest**.
+
+## B. Create Manifest
+
+Initialise the work unit:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init {work_unit} --work-type {work_type} --description "{description}"
+```
+
+Quote `{description}` with single quotes if it contains `[]`, `{}`, `~`, or backticks.
+
+→ Proceed to **C. Archive Inbox Source (if applicable)**.
+
+## C. Archive Inbox Source (if applicable)
+
+If Discovery seeded the work unit from an inbox file, archive the original so it does not re-surface in the inbox menu:
+
+```bash
+mkdir -p .workflows/.inbox/.archived/{ideas,bugs,quickfixes}
+mv .workflows/.inbox/{folder}/{file} .workflows/.inbox/.archived/{folder}/{file}
+```
+
+Where `{folder}` is one of `ideas`, `bugs`, `quickfixes` — matched to where the inbox file originated. Skip this section if the work unit was not seeded from an inbox file.
+
+→ Return to caller.

--- a/skills/workflow-bootstrap/references/route-to-phase.md
+++ b/skills/workflow-bootstrap/references/route-to-phase.md
@@ -1,0 +1,85 @@
+# Route to First Phase
+
+*Reference for **[workflow-bootstrap](../SKILL.md)***
+
+---
+
+Hand off to the work-type-appropriate entry skill. The routing matrix is determined by `work_type` × `routing`:
+
+| `work_type` | `routing` | Entry skill |
+|---|---|---|
+| `epic` | (n/a — per-topic) | `/workflow-bridge` (returns the user to the epic discovery-map menu so they can pick the next move per topic) |
+| `feature` | `research` | `/workflow-research-entry feature {work_unit}` |
+| `feature` | `discussion` | `/workflow-discussion-entry feature {work_unit}` |
+| `cross-cutting` | `research` | `/workflow-research-entry cross-cutting {work_unit}` |
+| `cross-cutting` | `discussion` | `/workflow-discussion-entry cross-cutting {work_unit}` |
+| `bugfix` | `investigation` (fixed) | `/workflow-investigation-entry bugfix {work_unit}` |
+| `quick-fix` | `scoping` (fixed) | `/workflow-scoping-entry quick-fix {work_unit}` |
+
+## A. Dispatch
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route to {phase:(titlecase)} ─────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the {phase} entry skill. The next skill will
+> load and guide you through the phase.
+```
+
+#### If `work_type` is `epic`
+
+Invoke `/workflow-bridge` with the discovery completion handoff. The user is returned to the discovery-map menu so they can pick the next topic to start.
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: discovery
+
+Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
+```
+
+Terminal.
+
+#### If `work_type` is `feature` or `cross-cutting`
+
+Invoke the routed entry skill. The skill is selected by `routing`:
+
+- `routing == research` → `/workflow-research-entry {work_type} {work_unit}`
+- `routing == discussion` → `/workflow-discussion-entry {work_type} {work_unit}`
+
+Terminal.
+
+#### If `work_type` is `bugfix`
+
+Routing is fixed to `investigation`:
+
+`/workflow-investigation-entry bugfix {work_unit}`
+
+Terminal.
+
+#### If `work_type` is `quick-fix`
+
+Routing is fixed to `scoping`:
+
+`/workflow-scoping-entry quick-fix {work_unit}`
+
+Terminal.
+
+## B. Failure Mode — Unknown Routing
+
+If `work_type` is unrecognised or `routing` does not match an expected value for the work_type, surface the error and stop. This indicates an upstream bug in Discovery's commit:
+
+```
+Bootstrap routing failed.
+
+work_type = {work_type}
+routing   = {routing}
+
+Re-enter Discovery via /workflow-start to repeat the routing commit.
+```
+
+**STOP.** Do not proceed — terminal condition.


### PR DESCRIPTION
## Summary

Phase 17c of the universal-Discovery stack. Lands the new shared utility (`workflow-bootstrap`) as scaffolding for 17d's wiring. Model-only — not yet invoked anywhere.

Replaces the per-work-type start-* skills with one parameterised utility. Its job:

1. **Ensure manifest** — exists-check + work_type sync; creates the manifest on the `s`/start path where it does not yet exist
2. **Land imports** — moves Discovery-staged imports to the work unit and indexes them via the shared `import-files.md`
3. **Route to first phase** — matrix-dispatch by work_type × routing

Interface contract matches what Discovery's `conclude-discovery.md` constructs in 17b. No live invocation in this PR — risk surface is interface drift only.

Stacks on #301 (Phase 17b).

## Test plan
- [x] Skill files load and parse
- [x] No regression in any existing tests
- [ ] Live invocation lands in 17d — no end-to-end test in this PR (per plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)