### PR TITLE
Phase 17e — workflow-start adds s/start, start-* go model-only

### DIFF
--- a/skills/start-bugfix/SKILL.md
+++ b/skills/start-bugfix/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: start-bugfix
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 

--- a/skills/start-cross-cutting/SKILL.md
+++ b/skills/start-cross-cutting/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: start-cross-cutting
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 

--- a/skills/start-epic/SKILL.md
+++ b/skills/start-epic/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: start-epic
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 

--- a/skills/start-feature/SKILL.md
+++ b/skills/start-feature/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: start-feature
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 

--- a/skills/start-quickfix/SKILL.md
+++ b/skills/start-quickfix/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: start-quickfix
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(ls .workflows/), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
 ---
 

--- a/skills/workflow-discovery-entry/SKILL.md
+++ b/skills/workflow-discovery-entry/SKILL.md
@@ -59,9 +59,16 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 Arguments: work_type = `$0`, work_unit = `$1`. Discovery is per-work-unit across every work type, so no `$2` topic argument is consumed.
 
-`work_type` may be empty when the caller is the `/start` ambiguous path — Discovery's classifier resolves it during the conversation. When pre-seeded (any of `epic`, `feature`, `bugfix`, `quick-fix`, `cross-cutting`), Discovery still runs the same loop and may still offer a pivot.
+Three entry modes by argument shape:
 
-Store `work_type` and `work_unit` for the handoff.
+| `work_type` | `work_unit` | Mode |
+|---|---|---|
+| set (`epic`, `feature`, `bugfix`, `quick-fix`, `cross-cutting`) | set | **Pre-seeded** — start-* invoked Discovery after creating the manifest. Discovery runs the loop with both pre-seeds; pivots remain available. |
+| empty | empty | **Classifier** — `/workflow-start`'s `s`/`start` option invoked Discovery without pre-seed. Discovery resolves both shape and name during the conversation. The manifest is created later by workflow-bootstrap once the commit lands. |
+| set | empty | **Reserved** — unused. Surface an error if encountered. |
+| empty | set | **Reserved** — unused. Surface an error if encountered. |
+
+Store `work_type` and `work_unit` for the handoff. Detect classifier mode (`work_type` and `work_unit` both empty) and forward the flag to the processing skill — it routes through Discovery's shape-detection without reading the manifest.
 
 → Proceed to **Step 2**.
 

--- a/skills/workflow-discovery-entry/references/gather-context.md
+++ b/skills/workflow-discovery-entry/references/gather-context.md
@@ -6,6 +6,12 @@
 
 Discovery is curatorial — the only context the session needs upfront is the work-unit description and any imported seed material. There are no interview questions; the conversation begins with the description as background and an open prompt to the user.
 
+#### If `work_unit` is empty (classifier mode)
+
+No manifest exists yet — Discovery resolves shape and name during the conversation. Set `description = (none)` and `imports = []`. The session's seed material is the user's own framing of the work as it unfolds.
+
+→ Return to caller.
+
 ## A. Read Description
 
 ```bash

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -109,6 +109,7 @@ What would you like to do?
 - **`4`** — Continue "{cross_cutting.name:(titlecase)}" — cross-cutting, {cross_cutting.phase_label}
 - **`5`** — Continue "{epic.name:(titlecase)}" — epic
 
+- **`s`/`start`** — Start new work — Discovery figures out the shape with you
 - **`f`/`feature`** — Start new feature
 - **`e`/`epic`** — Start new epic
 - **`b`/`bugfix`** — Start new bugfix
@@ -133,6 +134,12 @@ Select an option:
 Recreate with actual work units from discovery.
 
 **STOP.** Wait for user response.
+
+#### If user chose `s`/`start`
+
+Invoke `/workflow-discovery-entry "" ""` — both work_type and work_unit are empty. Discovery's classifier resolves the shape and name during the conversation.
+
+This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
 
 #### If user chose a continue or start-new option
 

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -31,6 +31,7 @@ No active work found.
 · · · · · · · · · · · ·
 What would you like to start?
 
+- **`s`/`start`** — Not sure yet — Discovery figures out the shape with you
 - **`f`/`feature`** — Single topic: (research →) discussion → spec → plan → implement → review
 - **`e`/`epic`** — Multiple topics, multi-session, same pipeline per topic
 - **`b`/`bugfix`** — Investigation → spec → plan → implement → review
@@ -54,6 +55,12 @@ Select an option:
 → Load **[start-from-inbox.md](start-from-inbox.md)** and follow its instructions as written.
 
 → Return to caller.
+
+#### If user chose `s`/`start`
+
+Invoke `/workflow-discovery-entry "" ""` — both work_type and work_unit are empty. Discovery's classifier resolves the shape and name during the conversation.
+
+This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
 
 #### If user chose `f`/`feature`, `e`/`epic`, `b`/`bugfix`, `q`/`quick-fix`, or `c`/`cross-cutting`
 


### PR DESCRIPTION
## Summary

Phase 17e of the universal-Discovery stack. Cuts the umbilical from user → start-* direct invocation.

- **`s`/`start` menu option** added to `/workflow-start` (both empty-state and active-work menus). Routes to `/workflow-discovery-entry "" ""` — Discovery's classifier handles macro routing AND naming during the conversation.
- **start-{epic,feature,bugfix,quickfix,cross-cutting}** flipped to `user-invocable: false`. Direct `/start-feature` etc. now produces a non-invocable error.
- **workflow-discovery-entry** documents the three entry modes via argument shape: pre-seeded / classifier / reserved.
- **gather-context.md** short-circuits when `work_unit` is empty (classifier mode — no manifest to read yet).

End-to-end:

```
/workflow-start
  → s/start → /workflow-discovery-entry "" ""
  → Discovery classifier → routing-commit
  → /workflow-bootstrap → routed phase
```

Bridge invocations (workflow-bridge, manage-work-unit, absorb-into-epic) keep working — model-side invocation of `user-invocable: false` skills is allowed.

Stacks on #303 (Phase 17d).

## Test plan
- [x] All 251 manifest tests pass
- [x] All discovery tests pass
- [x] Menu rendering — `s`/`start` appears as the first start-new option
- [ ] Live `/workflow-start` → `s` flow — exercised in 17g end-to-end smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)