### PR TITLE
Phase 17f — continue-* model-only + user-facing text migration

### DIFF
--- a/skills/continue-bugfix/SKILL.md
+++ b/skills/continue-bugfix/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: continue-bugfix
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/continue-bugfix/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
 ---
 

--- a/skills/continue-bugfix/references/validate-selection.md
+++ b/skills/continue-bugfix/references/validate-selection.md
@@ -13,7 +13,7 @@ Validate the selected work unit against the discovery output and store its data.
 ```
 No active bugfix named "{work_unit}" found.
 
-Run /continue-bugfix to see available bugfixes, or /start-bugfix to begin a new one.
+Run /workflow-start to see available bugfixes or begin a new one.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/continue-cross-cutting/SKILL.md
+++ b/skills/continue-cross-cutting/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: continue-cross-cutting
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/continue-cross-cutting/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
 ---
 

--- a/skills/continue-cross-cutting/references/validate-selection.md
+++ b/skills/continue-cross-cutting/references/validate-selection.md
@@ -13,7 +13,7 @@ Validate the selected work unit against the discovery output and store its data.
 ```
 No active cross-cutting concern named "{work_unit}" found.
 
-Run /continue-cross-cutting to see available concerns, or /start-cross-cutting to begin a new one.
+Run /workflow-start to see available cross-cutting concerns or begin a new one.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/continue-epic/SKILL.md
+++ b/skills/continue-epic/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: continue-epic
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/continue-epic/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs), Bash(node .claude/skills/workflow-discovery-process/scripts/discovery.cjs)
 ---
 

--- a/skills/continue-epic/references/validate-selection.md
+++ b/skills/continue-epic/references/validate-selection.md
@@ -13,7 +13,7 @@ Validate the selected work unit against the discovery output and store its data.
 ```
 No active epic named "{work_unit}" found.
 
-Run /continue-epic to see available epics, or /start-epic to begin a new one.
+Run /workflow-start to see available epics or begin a new one.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/continue-feature/SKILL.md
+++ b/skills/continue-feature/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: continue-feature
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/continue-feature/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
 ---
 

--- a/skills/continue-feature/references/validate-selection.md
+++ b/skills/continue-feature/references/validate-selection.md
@@ -13,7 +13,7 @@ Validate the selected work unit against the discovery output and store its data.
 ```
 No active feature named "{work_unit}" found.
 
-Run /continue-feature to see available features, or /start-feature to begin a new one.
+Run /workflow-start to see available features or begin a new one.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/continue-quickfix/SKILL.md
+++ b/skills/continue-quickfix/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: continue-quickfix
+user-invocable: false
 allowed-tools: Bash(node .claude/skills/continue-quickfix/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
 ---
 

--- a/skills/continue-quickfix/references/validate-selection.md
+++ b/skills/continue-quickfix/references/validate-selection.md
@@ -13,7 +13,7 @@ Validate the selected work unit against the discovery output and store its data.
 ```
 No active quick-fix named "{work_unit}" found.
 
-Run /continue-quickfix to see available quick-fixes, or /start-quickfix to begin a new one.
+Run /workflow-start to see available quick-fixes or begin a new one.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/start-bugfix/references/name-check.md
+++ b/skills/start-bugfix/references/name-check.md
@@ -44,7 +44,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}
 ```
 A work unit named "{work_unit}" already exists.
 
-Run /continue-bugfix to resume, or choose a different name.
+Run /workflow-start to resume this bugfix, or choose a different name.
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/start-cross-cutting/references/name-check.md
+++ b/skills/start-cross-cutting/references/name-check.md
@@ -44,7 +44,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}
 ```
 A work unit named "{work_unit}" already exists.
 
-Run /continue-cross-cutting to resume, or choose a different name.
+Run /workflow-start to resume this cross-cutting concern, or choose a different name.
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/start-epic/references/name-check.md
+++ b/skills/start-epic/references/name-check.md
@@ -44,7 +44,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}
 ```
 A work unit named "{work_unit}" already exists.
 
-Run /continue-epic to resume, or choose a different name.
+Run /workflow-start to resume this epic, or choose a different name.
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/start-feature/references/name-check.md
+++ b/skills/start-feature/references/name-check.md
@@ -44,7 +44,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}
 ```
 A work unit named "{work_unit}" already exists.
 
-Run /continue-feature to resume, or choose a different name.
+Run /workflow-start to resume this feature, or choose a different name.
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/start-quickfix/references/name-check.md
+++ b/skills/start-quickfix/references/name-check.md
@@ -44,7 +44,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}
 ```
 A work unit named "{work_unit}" already exists.
 
-Run /continue-quickfix to resume, or choose a different name.
+Run /workflow-start to resume this quick-fix, or choose a different name.
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discovery-process/references/map-operations.md
+++ b/skills/workflow-discovery-process/references/map-operations.md
@@ -63,7 +63,7 @@ Apply per-operation validation gates **before** any STOP gate. If validation fai
 | Edit summary    | any                | —                                                                           |
 | Edit description| any                | —                                                                           |
 
-`cancelled` is also disallowed for Remove because the discovery item is the historical record of the topic ever having existed. Removal is for never-started topics only; cancel-then-vanish would erase the audit trail. The `a`/`cancel` flow in `/continue-epic` is the right tool for stopping in-flight work.
+`cancelled` is also disallowed for Remove because the discovery item is the historical record of the topic ever having existed. Removal is for never-started topics only; cancel-then-vanish would erase the audit trail. The `a`/`cancel` flow in the epic menu (via /workflow-start) is the right tool for stopping in-flight work.
 
 Render the rejection in a code block:
 
@@ -71,8 +71,8 @@ Render the rejection in a code block:
 
 ```
 "{topic}" can't be {removed|renamed|re-routed} from the map —
-{lifecycle_phrase}. To stop work on it, use `a`/`cancel` in
-/continue-epic instead.
+{lifecycle_phrase}. To stop work on it, use `a`/`cancel` from
+the epic menu (run /workflow-start) instead.
 ```
 
 `{lifecycle_phrase}` examples:

--- a/skills/workflow-legacy-research-split/SKILL.md
+++ b/skills/workflow-legacy-research-split/SKILL.md
@@ -10,7 +10,7 @@ Act as **curator + interviewer**. Walk the user through decomposing broad resear
 
 ### What This Skill Needs
 
-- **Work unit** (required) — the epic to normalise. Passed by `continue-epic` Step 5.
+- **Work unit** (required) — the epic to normalise. Passed by the continue-epic phase at Step 5 (model-only invocation; user reaches it via /workflow-start).
 
 ---
 
@@ -124,8 +124,8 @@ Evaluate the branches below in order — error reporting takes precedence over c
 ```
 > {errored_count} source file(s) aborted mid-apply; {applied_count}
 > decomposed; {abandoned_count} skipped. See "Recovery from
-> Interrupted Apply" below to clear stuck sentinels before the
-> next /continue-epic.
+> Interrupted Apply" below to clear stuck sentinels before
+> resuming via /workflow-start.
 ```
 
 → Return to caller.
@@ -158,7 +158,7 @@ Evaluate the branches below in order — error reporting takes precedence over c
 ```
 > {applied_count} source file(s) decomposed; {abandoned_count}
 > skipped. Skipped files remain on the map and can be revisited
-> on the next /continue-epic.
+> on the next /workflow-start resume.
 ```
 
 → Return to caller.
@@ -169,8 +169,8 @@ Evaluate the branches below in order — error reporting takes precedence over c
 
 ```
 > No source files decomposed — every qualifying file was skipped.
-> They remain on the map and can be revisited on the next
-> /continue-epic.
+> They remain on the map and can be revisited via the next
+> /workflow-start resume.
 ```
 
 → Return to caller.

--- a/skills/workflow-legacy-research-split/scripts/apply.cjs
+++ b/skills/workflow-legacy-research-split/scripts/apply.cjs
@@ -203,7 +203,7 @@ function apply(cwd, workUnit, currentSource) {
         `theme application failed mid-flight. Source file renamed to ${supersededFile}; ` +
         `source discovery item already deleted. Some themes may have been partially written. ` +
         `Inspect ${researchDir} and manifest items, clean up partial themes manually, ` +
-        `then re-run /continue-epic.`,
+        `then resume the epic via /workflow-start.`,
     };
   }
 

--- a/skills/workflow-migrate/scripts/migrations/038-add-inception-phase.sh
+++ b/skills/workflow-migrate/scripts/migrations/038-add-inception-phase.sh
@@ -110,8 +110,8 @@ for (const entry of entries) {
     lines.push('This work unit pre-dates the discovery-map system. The map was seeded');
     lines.push('from ' + count + ' topic(s) found in existing research/discussion items (source: migration-seeded).');
     lines.push('');
-    lines.push('Open the epic via \`/continue-epic\` — the legacy-recovery flow will');
-    lines.push('draft summaries from the existing source files and present them for review.');
+    lines.push('Open the epic via \`/workflow-start\` and resume — the legacy-recovery');
+    lines.push('flow will draft summaries from the existing source files and present them for review.');
     lines.push('');
     fs.writeFileSync(sessionPath, lines.join('\n'));
   }

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -106,7 +106,7 @@ No Completed Discussions
 No completed discussions found for "{work_unit:(titlecase)}".
 
 At least one completed discussion is required before specification can begin.
-Run /continue-epic to continue an in-progress discussion.
+Run /workflow-start to continue an in-progress discussion.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/tests/scripts/test-migration-038.sh
+++ b/tests/scripts/test-migration-038.sh
@@ -487,7 +487,7 @@ JSON
   content=$(cat "$wu_dir/inception/session-001.md")
   assert_eq "session: contains migration heading" "true" "$(echo "$content" | grep -qF -- 'Initial Framing — Pre-Inception Migration' && echo true || echo false)"
   assert_eq "session: counts items" "true" "$(echo "$content" | grep -qF -- '2 topic(s) found in existing research/discussion items' && echo true || echo false)"
-  assert_eq "session: mentions continue-epic" "true" "$(echo "$content" | grep -qF -- '/continue-epic' && echo true || echo false)"
+  assert_eq "session: mentions workflow-start" "true" "$(echo "$content" | grep -qF -- '/workflow-start' && echo true || echo false)"
 
   teardown
 }


### PR DESCRIPTION
## Summary

Phase 17f of the universal-Discovery stack. Two mechanical moves:

1. **continue-{epic,feature,bugfix,quickfix,cross-cutting}** flipped to `user-invocable: false`. /workflow-start is now the only user-typed entry.
2. **Eleven user-facing files** rewritten so users are never told to type `/continue-X` directly:
    - 5× `start-*/references/name-check.md`
    - 5× `continue-*/references/validate-selection.md`
    - `workflow-specification-entry/references/validate-source.md`
    - `workflow-legacy-research-split/SKILL.md` (3 mentions)
    - `workflow-discovery-process/references/map-operations.md`

Two supporting touches:
- `migrations/038-add-inception-phase.sh` seeded text now points at `/workflow-start`; `test-migration-038.sh` assertion updated.
- `workflow-legacy-research-split/scripts/apply.cjs` recovery_hint updated.

Five internal model-side invocation sites intentionally keep `/continue-X` per plan:
- `workflow-bridge/references/{discovery,epic}-continuation.md`
- `workflow-start/references/{manage-work-unit,absorb-into-epic}.md`
- `workflow-shared/references/topic-discovery-dispatch.md`

The harness allows model-side invocation of `user-invocable: false` skills.

Stacks on #304 (Phase 17e).

## Test plan
- [x] All 251 manifest tests pass
- [x] Migration 038 test passes (assertion updated to match new seeded text)
- [x] Legacy research split tests pass
- [x] `grep -rn "/continue-" skills/` returns only known model-side / file-load / agent-internal-prose matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)