### PR TITLE
Phase 17 — Discovery as universal entry, /workflow-start as sole entry

### DIFF
--- a/discovery-map/phase-17-entry-ux-redesign.md
+++ b/discovery-map/phase-17-entry-ux-redesign.md
@@ -213,3 +213,178 @@ These came up during the conversation but are clearly their own things, not part
 4. **Once the design lands, replace this doc** with a proper "what ships" phase doc (or set of phase docs). The journey-and-open-questions content here is temporary; it captures the path, not the destination.
 
 The phase number (17) is reserved. The slug is TBD. The branch name is TBD. Everything else is up in the air.
+
+---
+
+## Current Design (2026-05-29 onward)
+
+This section captures the design as it crystallises through ongoing discussion. The journey above is historical context for how we got here — read it for the path that led us here, but treat what follows as the live working surface.
+
+We're running this in the spirit of a real discussion process (Discussion Map, lifecycle states, per-subtopic documentation) but without manifest writes or workflow-skill invocation. This project authors the workflow system; we can't dogfood it for design work on the system itself.
+
+**Naming note 2:** Beyond the earlier inception → discovery rename, this section drops the "Inception" label entirely. Discovery absorbs the role that the original Phase 17 sketches imagined for a separate Inception phase. The word "inception" stays unused in the workflow phase taxonomy from this section forward.
+
+### Discussion Map
+
+```
+Discovery as universal entry              [decided]
+├─ Macro/micro routing structure          [decided]
+├─ Cross-worktype symmetry                [decided]
+└─ Shape vs content guardrail             [decided]
+
+Discovery loop mechanics                  [exploring]
+├─ Opener shapes across worktypes         [exploring]
+├─ Shape-detection heuristics             [exploring]
+├─ Routing-confirmation mechanism         [exploring]
+└─ AskUserTool integration                [pending]
+
+Pivot mechanics                           [exploring]
+├─ Macro pivot triggers                   [pending]
+├─ Scope-down + inbox surface             [converging]
+└─ Reasoning surfacing                    [pending]
+
+Imports & inbox handling                  [decided]
+
+Entry surface design                      [converging]
+├─ /workflow-start menu                   [decided]
+├─ start-* future                         [exploring]
+└─ continue-* mirror question             [exploring]
+
+Migration & cutover                       [pending]
+```
+
+State key: `pending` (not yet discussed), `exploring` (active discussion), `converging` (narrowing toward decision), `decided` (locked in this pass; future refinements may revisit).
+
+---
+
+### Discovery as universal entry [decided]
+
+**Context.** The original Phase 17 sketches treated "inception" (now discovery) as a specialised epic-only phase we'd extend. After the inception → discovery rename, the word "inception" was free again, and we considered reintroducing it as a separate classifier phase between workflow-start and start-*. The question was whether to introduce that separate phase or to make Discovery itself the universal entry.
+
+**Journey.** We considered three handoff models for connecting a separate Inception classifier to Discovery:
+- **A.** Inception writes a draft Discovery session log; Discovery's existing resume mechanism picks it up.
+- **B.** Inception writes a structured seed to manifest; Discovery reads it on first invocation and skips its own opener.
+- **C.** Re-merge them into one continuous flow.
+
+(A) had appeal because it reused the existing resume mechanism — no new wiring. But on reflection it was solving a problem created by the artificial split. (B) was cleaner data-modelling but worse continuity. (C) was conceptually clean but felt like undoing the rename's separation.
+
+Then the framing changed: "Discovery just IS the universal first step regardless, and handles macro routing before micro routing." That collapsed the question — no separate Inception skill, no handoff seam, no continuity problem. The classifier conversation IS the opening of the Discovery conversation; they're not two things glued together.
+
+**Decision.** Discovery is the universal first step for all brand-new work. The word "inception" stays unused in the workflow phase taxonomy. Discovery's role expands beyond epic-only topic curation to include shape detection for all work types.
+
+---
+
+### Macro/micro routing structure [decided]
+
+**Context.** Discovery now handles two distinct routing levels: *what kind of work is this* (epic / feature / bugfix / quickfix / cc), and for work types with per-topic routing decisions, *how to handle each topic* (research vs discussion).
+
+**Decision.** Two routing levels stack inside one continuous Discovery conversation:
+
+- **Macro routing** — shape detection. *"What kind of work is this?"* Applies to all work types. Pre-seeded by user's menu choice from workflow-start, OR inferred conversationally by Claude when the entry is via `/start`.
+- **Micro routing** — topic-level routing. *"For this topic, research or discussion?"* Applies to epic / feature / cross-cutting (the work types that have a research/discussion split in their pipelines). Does not apply to bugfix or quickfix — those pipelines are constrained-shape and don't carry a research/discussion choice.
+
+The conversation transitions from macro to micro naturally as shape settles. For epic/feature/cc, the conversation continues into topic synthesis with micro routing per topic. For bugfix/quickfix, the conversation produces a brief intent capture and routes out — no micro routing applies.
+
+---
+
+### Cross-worktype symmetry [decided]
+
+**Context.** Should Discovery look meaningfully different across work types, or share most of its structure?
+
+**Journey.** First instinct was to design mode-specific conversation shapes (epic mode does decomposition, feature mode does single-topic confirmation, bugfix mode is brief and routing-focused). On reflection, that introduced unnecessary variance. The exploration loop is the same regardless of work type; only what gets produced at the end differs.
+
+**Decision.** Discovery's conversation pattern is **largely the same across all work types**. Same opener pattern (read seed material if any, ask the user to describe what they want), same exploration discipline (open questions, no premature decisions, listen for shape signals), same shape-watching behaviour.
+
+What differs by work type:
+- **What synthesis produces at endpoint** — multi-row map for epic, single-row map for feature/cc, brief intent capture + routing decision for bugfix/quickfix
+- **What pivot heuristics watch for** — feature mode watches for "this is multi-topic, suggesting epic"; epic mode watches for "this is actually one topic, suggesting feature"; bugfix mode watches for "this is new behaviour, not a bug"; etc.
+
+There's no "epic mode" vs "feature mode" vs "bugfix mode" as distinct conversation shapes. There's one Discovery conversation with shape-detection and shape-appropriate synthesis at endpoint.
+
+The discovery-guidelines reference grows from "epic curatorial moves" to "shared core + per-mode pivot watchpoints" — likely implemented as a shared core reference plus small mode-specific overlays. Implementation detail; comes later.
+
+---
+
+### Shape vs content guardrail [decided]
+
+**Context.** Discovery in the old (epic-only) form was structurally constrained from "doing research" or "making decisions" by its specific role of curating topics. With Discovery becoming universal and running for bugfix/quickfix too, this constraint needs to be explicit — otherwise the conversation could drift into symptom analysis (bugfix mode), architecture talk (feature mode), or thread-pulling (epic mode).
+
+**Decision.** Discovery handles SHAPE; downstream phases FILL the shape. Hard rules:
+
+- Discovery does not do **research** (no investigating market/tech/feasibility — research phase does that)
+- Discovery does not do **investigation** (no symptom analysis, reproduction, root-cause hunting — investigation phase does that)
+- Discovery does not do **decision-making** (no resolving design questions, no choosing between options — discussion phase does that)
+- Discovery does not do **scope work** (no spec content, no plan content)
+
+What Discovery DOES:
+- Name the work unit
+- Figure out shape (macro routing)
+- Curate topics + per-topic routing (micro routing) where applicable
+- Read seed material (imports, inbox content) and use it to shape the conversation, NOT to extract substantive content
+- Capture intent in the journey record
+
+The discipline is recognising the difference between *"this is shaping up as a bugfix"* (Discovery's job) and *"the bug is probably in the session middleware"* (Investigation's job). Discovery makes the routing call; downstream does the work.
+
+This guardrail applies regardless of work type. It's the most important constraint on Discovery's behaviour.
+
+---
+
+### Imports & inbox handling [decided]
+
+**Context.** Today's import flow is per-work-unit, collected at start-* time, copied to `.workflows/{wu}/imports/`. Inbox items live at `.workflows/.inbox/{bugs,quickfixes,ideas}/`. Different mechanisms for similar purposes.
+
+**Decision.** Both are seed material with the same handling pattern in Discovery:
+
+**Imports** are read at Discovery's opener (across all work types). Interpretation is mode-specific:
+
+- Epic-mode: imports drive topic decomposition
+- Feature/cc-mode: imports inform single-topic shape; multi-topic content triggers epic-pivot offer
+- Bugfix-mode: imports are reference material (logs, error reports, prior tickets) — read for context, not analysed for content (would violate the shape vs content guardrail)
+- Quickfix-mode: similar — reference material
+
+**Inbox items** are similar to imports but with an implied classification hint from the source folder:
+
+- `.inbox/bugs/` → pre-seeds macro routing as bugfix (still pivot-able)
+- `.inbox/quickfixes/` → pre-seeds macro routing as quickfix (still pivot-able)
+- `.inbox/ideas/` → no pre-seed, Claude classifies from content
+- Inbox selection routes through Discovery via the `/start` path (or user picks `i`/`inbox` from `/workflow-start` menu, which still ends up in Discovery)
+
+Inbox content drives Discovery's opening exploration the same way imports do — Claude reads the content, sketches what they're picking up, asks targeted questions to confirm shape and uncover detail.
+
+**Mechanism: same as today's epic import flow, just extended across work types.**
+
+---
+
+### /workflow-start menu [decided]
+
+**Context.** `/workflow-start` is the user-facing universal entry. Today's menu has `f`/`feature`, `e`/`epic`, `b`/`bugfix`, `q`/`quickfix`, `c`/`cross-cutting`, `i`/`inbox`, `v`/`view`. Phase 17 needed to decide whether to keep these, add a new option, or collapse them.
+
+**Decision.** Keep the existing menu structure with one addition:
+
+- **`e`/`epic`, `f`/`feature`, `b`/`bugfix`, `q`/`quickfix`, `c`/`cross-cutting`** — fast paths for users who know what they want. Pre-seed Discovery's macro routing. Discovery still runs (for micro routing, topic surfacing, and pivot opportunity).
+- **New: `s`/`start`** — unknown-shape entry. Routes to Discovery with no work_type pre-set. Discovery classifies macro shape during exploration.
+- **`i`/`inbox`** — stays. Routes to Discovery via `/start` (or the inbox-item's pre-classified path) with inbox item as seed material.
+- **`v`/`view`** — stays. Completed/cancelled work units.
+
+Even when user picks a work-type fast path, Claude may suggest a pivot during Discovery (e.g. *"looks more like an epic"*). User controls the final call; Claude proposes and explains reasoning.
+
+---
+
+### Currently exploring / pending — to be filled
+
+These subtopics are open. Captured here for tracking; will get Context / Journey / Decision sections as each lands.
+
+- **Discovery loop mechanics** — what the conversation actually looks like across work types. Openers, exploration questions, shape-detection signals, routing-confirmation. *No arbitrary turn counts* — loop runs as long as needed to form a confident opinion. Currently exploring.
+- **Shape-detection heuristics** — what cues does Claude read to commit to a macro shape? Same for micro routing. Tight guidelines on what's being shaped and why. Exploring.
+- **Routing-confirmation mechanism** — when does Claude surface a routing proposal? Principles agreed: Claude must be confident before proposing, asks more questions if unsure, always explains reasoning so user can agree or push back. Mechanism details pending.
+- **AskUserTool integration** — could be a clean fit for the explicit routing-confirmation moments. Pending exploration.
+- **Macro pivot triggers** — what specific signals raise an epic-pivot offer, feature-pivot offer, etc.? Pending.
+- **Scope-down + inbox surface** — when discussing one work, noticing a separate concern, surface to inbox rather than scope-creep into the current work. Principle agreed; mechanics pending.
+- **Reasoning surfacing** — how does Claude explain why it's proposing a routing decision so the user is informed enough to agree/push back? Principle decided; convention pending.
+- **start-\* future** — collapse to one shared utility or stay as five thin model-only wrappers. Exploring.
+- **continue-\* mirror question** — does the start-* model-only move imply continue-* should also become model-only? Note that continue-* is currently user-invocable and load-bearing for user navigation back to existing work; the case for moving it to model-only is weaker. Exploring.
+- **Migration & cutover** — what happens to existing in-progress work units, what's user-visible on upgrade. Pending.
+
+---
+
+This is the working design surface. Decided subtopics are locked in this pass but can be revisited if further discussion reveals problems. Exploring/pending subtopics get worked through as conversation continues.

--- a/discovery-map/phase-17-entry-ux-redesign.md
+++ b/discovery-map/phase-17-entry-ux-redesign.md
@@ -234,7 +234,7 @@ Discovery as universal entry              [decided]
 
 Discovery loop mechanics                  [exploring]
 ├─ Opener shapes across worktypes         [decided]
-├─ Shape-detection heuristics             [exploring]
+├─ Shape-detection heuristics             [decided]
 ├─ Routing-confirmation mechanism         [exploring]
 └─ AskUserTool integration                [pending]
 
@@ -407,6 +407,87 @@ Even when user picks a work-type fast path, Claude may suggest a pivot during Di
 4. **No pre-announce of process discipline** — Claude doesn't preamble *"we're in setup mode, not problem-solving."* Discipline is enforced by behaviour (open exploratory questions, no commitments, redirects on deep dives). The user finds out *what* Discovery does by being in it; they don't need a meta-explanation upfront.
 
 The pattern is universal. The text varies for naturalness. Cross-worktype symmetry is preserved at the structural level — same opener stages, same conversational discipline, same pivot availability.
+
+---
+
+### Shape-detection heuristics [decided]
+
+**Context.** Discovery needs to figure out what kind of work the user is bringing — feature, multi-feature initiative, fix, targeted change, project-wide pattern — and for the work types that have it, the per-topic routing decision (research vs discussion). This is the listening discipline that drives everything else in the loop. Two angles needed nailing: *what signals Claude listens for*, and *how it surfaces tentative reads to the user without dropping into workflow jargon*.
+
+**Journey.** Started by sketching per-shape signal lists (bugfix-shaped vs feature-shaped vs epic-shaped, etc.) — concrete cues Claude would weight. Then hit a more important point: those bucket names (epic / feature / bugfix / quickfix / cc) are workflow internals. They mean nothing to a user who hasn't lived in the system. Saying *"this sounds like an epic"* assumes user vocabulary that often isn't there.
+
+Reframed: we're not detecting *"which bucket does this fall into."* We're detecting **what kind of work the user is actually describing**, in plain terms. The bucket names are how we route internally; the shape language we speak with the user is something else.
+
+The signals stay (substantively). The surfacing language flips.
+
+Also worked through three structural points:
+
+1. **Macro and micro signals co-emerge** — not sequential phases. A user describing *"operators do X, kitchen does Y, customers do Z"* surfaces BOTH multi-shape (macro signal) AND candidate topic seeds (micro signal) simultaneously. The macro/micro structure from the earlier subtopic is about routing OUTPUTS, not about loop sequencing. One loop, both signal flavours accumulating in parallel.
+2. **Mid-loop surfacing** — Claude shares tentative reads as patterns clearly emerge, not silently accumulating to endpoint. User gets to push back while reads are still tentative, before momentum builds.
+3. **The explicit shape question** — when shape questions are exhausted but ambiguity remains, Claude asks an explicit disambiguator (rather than continuing to fish, which would risk dropping into content territory).
+
+**Decision.** Five elements:
+
+**1. Signals are about substance, not bucket names.** Claude listens for plain shape-cues in the user's framing:
+
+| Substance signal (what's being described) | Routes to internally |
+|---|---|
+| New behaviour not present today, single coherent scope, clear actors and flows | feature |
+| Multiple distinct concerns from one description, multi-week / multi-phase shape, broader system-level reshaping, *"project"* / *"initiative"* framing | epic |
+| System-wide concern affecting multiple work units, pattern / principle / strategy definition (*"error response shape"*, *"auth strategy"*, *"logging convention"*), no customer-facing deliverable | cross-cutting |
+| Past-tense or present-broken descriptions, specific failure cases with reproducible conditions, error messages / stack traces in imports | bugfix |
+| Imperative scoped changes (*"bump the timeout"*, *"rename X to Y"*, *"add a flag"*), one-shot adjustments without behaviour debate | quickfix |
+| *"Not sure how"*, *"what's possible"* — could route research-shaped; descriptions that mix broken + new — could be bugfix-with-feature-followup | ambiguous — keep exploring |
+
+These are illustrative first-pass cues; will be tuned via real use. Hardcoding them as a strict checklist risks Claude getting trigger-happy on weak matches.
+
+**2. Surfacing language stays plain until commit.** When Claude shares a tentative read or asks for confirmation, it speaks in user-facing shape-terms:
+
+| Internal (workflow lingo) | User-facing (plain shape) |
+|---|---|
+| *"This sounds like an epic"* | *"This sounds like several distinct things — more than one feature in scope"* |
+| *"This is a feature"* | *"Sounds like a single coherent piece of work"* |
+| *"This is cross-cutting"* | *"Sounds like a pattern or principle that affects the whole project — something to define, not something to ship as a feature"* |
+| *"This is a bugfix"* | *"Sounds like something broken we're fixing rather than something new we're building"* |
+| *"This is a quickfix"* | *"Sounds like a small targeted change — adjustment rather than a whole feature"* |
+
+The bucket names only appear at the routing-commit moment (next subtopic), and even then framed naturally. Up until commit, everything is described in terms of what the user is actually doing.
+
+**3. Confidence heuristics** — Claude is *"confident enough to surface"* when:
+
+- **Multiple converging signals** point at the same shape (not just one weak hint)
+- **User framing has been consistent** across multiple turns (not switching shapes mid-conversation)
+- **Ambiguity has been resolved** — Claude has asked at least one explicit-shape question if needed, and the user's answer resolved it
+- **Pivot signals aren't lit** — Claude isn't sitting on a competing shape's signals at the same time
+
+Below this threshold, keep exploring.
+
+**4. Mid-loop surfacing** — when patterns clearly emerge, Claude shares a tentative read mid-loop rather than holding to endpoint. Examples (illustrative wording):
+
+- After several exchanges hinting at multiple concerns: *"I'm hearing a few distinct things — this might be more than one feature. Want to pull on that or stay focused?"*
+- After enough scope clarity: *"Sounds like a single coherent thing, with the routing tendency I'm reading as discussion-shaped. Anything I'm missing?"*
+- After a tangential concern surfaces: *"You mentioned X — that feels separate from what we're shaping. Surface to inbox for later?"*
+- After topic seeds start clustering: *"I'm seeing menu-management and kitchen-printers as candidate topics. Sound right or wrong shape?"*
+
+Surfacings are conversational — soft, easy for the user to redirect. Not every signal triggers a surfacing; only when there's enough to test against the user usefully.
+
+**5. The explicit shape question** — when shape questions are exhausted but ambiguity remains. Trigger: the next natural question would drop into content territory (research, decision-making, investigation) and we'd be violating the shape-vs-content guardrail. Move: ask the user directly to disambiguate.
+
+Examples (illustrative):
+
+- *"Two readings here — this could be fixing something that's currently broken, or adding something new that doesn't exist yet. Which is closer?"*
+- *"This is shaping bigger than a single feature — does it feel to you like one focused thing, or several connected things?"*
+- *"This sounds like a small targeted change, but if it touches behaviour the user sees, we should treat it as a feature instead. How does it feel from your end?"*
+
+These are the explicit disambiguators that prevent the conversation from looping forever and force a commit so we can progress.
+
+**The hardest discriminations** are the pairs at the boundaries:
+
+- **Single feature vs multi-feature** — *"is this one thing or several things stuck together?"*
+- **Building vs fixing** — *"is the behaviour missing, or is the behaviour broken?"*
+- **Quick targeted change vs feature vs bugfix** — *"is this a small adjustment, a new behaviour, or a fix?"*
+
+These are where mid-loop surfacings and explicit shape questions earn their keep.
 
 ---
 

--- a/discovery-map/phase-17-entry-ux-redesign.md
+++ b/discovery-map/phase-17-entry-ux-redesign.md
@@ -250,7 +250,7 @@ Entry surface design                      [decided]
 ├─ start-* future                         [decided]
 └─ continue-* mirror question             [decided]
 
-Migration & cutover                       [pending]
+Migration & cutover                       [decided]
 ```
 
 State key: `pending` (not yet discussed), `exploring` (active discussion), `converging` (narrowing toward decision), `decided` (locked in this pass; future refinements may revisit).
@@ -669,6 +669,54 @@ Expected pattern (implementation detail, not a decision now):
 - Continue-* is no longer defensive about migrations or knowledge check — those are guaranteed to have run at `/workflow-start`
 
 Net: real simplification of duplicated Step 0 content. Worked out concretely during implementation.
+
+---
+
+### Migration & cutover [decided]
+
+**Context.** Phase 17 is a substantial shape change — Discovery becomes universal, start-* collapses, continue-* becomes model-only. The question was: what happens to existing in-progress work units, what's user-visible on upgrade, and what data migrations are needed?
+
+**Key insight.** The change is **largely additive in terms of shape.** Existing in-progress work is past Discovery's entry point; their pipelines continue unchanged. Non-epic work types don't get a discovery map even under the new design — Discovery for feature/bugfix/quickfix/cc doesn't produce backfillable manifest state (no items, no per-topic curation manifest entries). The only Discovery artefact for those types is the session log itself, which only applies to *new* work going forward.
+
+The biggest backfill problem (epic discovery maps for legacy epics) was already solved in Phase 11 via migration 038. That ship sailed and is already deployed.
+
+**Decision.**
+
+**1. Existing in-progress work units are untouched.**
+
+They're past Discovery's relevance. They continue running through their pipeline as before. No discovery-related back-fill needed for non-epic existing work because Discovery for those types doesn't produce manifest state to backfill. For existing epics with `phases.discovery` already populated (from Phase 11), nothing changes — the structure is already there.
+
+**2. Schema change is permissive, not destructive.**
+
+The manifest CLI's `phases.discovery` validation currently rejects non-epic work types (epic-only). The change is to *allow* `phases.discovery` for all work types, not to *require* it. Existing non-epic work units don't have `phases.discovery`, and they don't need it added — they're grandfathered. New non-epic work units going forward will write the session log under `discovery/session-NNN.md` but won't populate `phases.discovery.items` (there are no items for single-topic work types).
+
+No new migration script needed. The schema change is purely permissive validation.
+
+**3. No deprecation period for start-\* / continue-\* slash commands.**
+
+Release notes flag the change. Direct invocations of `/start-feature`, `/continue-feature`, etc. fail with the standard "skill not user-invocable" behaviour. Self-healing — users adjust on first encounter.
+
+The decision rests on this codebase having effectively one user. A wider-user codebase might prefer a deprecation pattern (emit a *"moving to /workflow-start"* notice before proceeding), but the cost-benefit doesn't justify it here.
+
+**4. Active user sessions during upgrade.**
+
+Upgrades happen at-install-time (`npx agntc add ...`), not auto-pushed. Users explicitly upgrade between sessions. Mid-conversation upgrades aren't a real concern.
+
+**What's user-visible on upgrade.**
+
+For existing in-progress work:
+- Continue exactly as before — pipeline runs through to the end
+- No new discovery-map artefacts get created retroactively
+- No prompts about Discovery
+- The `/workflow-start` entry surface is still the way back in
+
+For new work after upgrade:
+- `/workflow-start` is now the only entry point (other slash commands fail)
+- Picking any menu option goes through Discovery
+- Discovery handles classification + curation + routing
+- Users feel the new flow on first new-work invocation
+
+**Summary:** the change is large in scope but small in disruption. Existing state is preserved; existing flows continue; new work goes through the new shape. No data backfill, no deprecation period, no breaking of in-progress sessions.
 
 ---
 

--- a/discovery-map/phase-17-entry-ux-redesign.md
+++ b/discovery-map/phase-17-entry-ux-redesign.md
@@ -232,11 +232,11 @@ Discovery as universal entry              [decided]
 ├─ Cross-worktype symmetry                [decided]
 └─ Shape vs content guardrail             [decided]
 
-Discovery loop mechanics                  [exploring]
+Discovery loop mechanics                  [decided]
 ├─ Opener shapes across worktypes         [decided]
 ├─ Shape-detection heuristics             [decided]
-├─ Routing-confirmation mechanism         [exploring]
-└─ AskUserTool integration                [pending]
+├─ Routing-confirmation mechanism         [decided]
+└─ AskUserTool integration                [decided]
 
 Pivot mechanics                           [exploring]
 ├─ Macro pivot triggers                   [pending]
@@ -488,6 +488,57 @@ These are the explicit disambiguators that prevent the conversation from looping
 - **Quick targeted change vs feature vs bugfix** — *"is this a small adjustment, a new behaviour, or a fix?"*
 
 These are where mid-loop surfacings and explicit shape questions earn their keep.
+
+---
+
+### Routing-confirmation mechanism [decided]
+
+**Context.** Once the loop has accumulated enough signal, Claude needs to move from *"I have an opinion"* to *"we've committed"* — for macro routing (what kind of work) and, for the work types that have it, micro routing (per-topic research vs discussion). This is the commit moment. It needs to be informative (user understands the reasoning), bidirectional (user can override), and patient (we don't rush it).
+
+**Journey.** Worked out the moment-of-commit mechanics, then realised the more important point was *when* the commit should happen at all. Early reads can be revised as conversation continues — an early *"feature"* read can become *"epic"* after more talking, and that's fine if we never committed early. The substance-focus discipline that keeps us in shape rather than content also keeps us patient on the commit: as long as Claude keeps the conversation on *"what are we doing"* rather than racing to *"which bucket,"* shape emergence is organic. Premature bucket-labelling pushes Claude to commit too early. Substance-labelling stays patient.
+
+**Decision.** Five elements:
+
+**1. State the read.** When committing, Claude says what the shape is in plain user-facing terms, with the workflow bucket name folded in naturally — not before. Example: *"This is feature-shaped — one focused thing to build. The routing tendency I'm reading is discussion since the shape is clear and the open questions are about trade-offs not unknowns."*
+
+**2. Explain the reasoning.** Per the earlier principle, the user needs to be informed enough to agree or push back. Reasoning surfaces the signals that drove the read. Should be brief — one or two sentences — but specific enough that the user knows *why*, not just *what*.
+
+**3. Invite confirmation or override.** Soft conversational invitation, or structured tool prompt, depending on confidence and stakes. AskUserTool fits cleanly here (see next subtopic).
+
+**4. Honour user override authoritatively.** If the user pushes back, Claude takes their call as final. No re-litigation. If the user redirects to a different shape, Claude adjusts without needing further justification.
+
+**5. Patience on the commit.** Even when signals have reached the surfacing threshold, hold off committing until:
+
+- Signals have **converged AND been stable** across the last few exchanges (not just hit threshold this turn)
+- Mid-loop tentative surfacings have been **confirmed or adjusted** by the user
+- The natural next move would **drop into content** if we kept exploring — we've truly run the shape conversation as far as it can go without violating the shape-vs-content guardrail
+- The user's framing has been **consistent enough** that we're not about to revert the commit in two turns
+
+This is the same patience discipline as the surfacing threshold, applied one step later in the loop. Substance-focus enables it: stay on what's being built/fixed/changed, not on which bucket it lands in, and the commit lands when it's actually ready.
+
+**Operational commit semantics:**
+
+Once routing is committed:
+- The committed shape is written to Discovery's session log (the journey record)
+- Claude transitions into shape-appropriate output (topic synthesis for epic/feature/cc, brief intent capture for bugfix/quickfix)
+- Pivots after commit are possible but expensive — they reset the synthesis. Claude treats post-commit pivots as deliberate redirects, not casual exploration
+- For epic/feature/cc, the macro commit doesn't necessarily lock micro routing yet — per-topic routing commits happen during/after synthesis
+
+The macro and micro commits can land at the same conversational moment (single-topic feature: *"feature-shaped, routing is discussion"*) or at different moments (epic: macro commit first, then per-topic routing commits during synthesis).
+
+---
+
+### AskUserTool integration [decided]
+
+**Context.** AskUserTool provides structured user input (typed answers, menus, binary confirmations). The question was where it fits in Discovery's loop — given the loop is largely conversational, tool-driven prompts could feel mechanical if misplaced.
+
+**Decision.** AskUserTool is used **where appropriate** — specifically:
+
+- **NOT for mid-loop tentative surfacings.** Those stay conversational and soft (*"I'm hearing X — want to pull on that?"*). Tool prompts in the middle of an exploratory flow break the conversational rhythm without adding clarity.
+- **OK for explicit shape questions** when implicit confidence is borderline. Quick binaries like *"is this fixing something or adding something new?"* can be cleaner as a tool prompt than as prose. Use judiciously — only when the disambiguation is genuinely binary and the user benefits from explicit framing.
+- **YES for the committed routing-commit moment.** Structured confirm-or-override locks the call cleanly without ambiguity and matches the formality of a commit. The user sees the proposed routing, the reasoning, and structured options (confirm / override-to-{alternative} / discuss-more). This is the cleanest fit.
+
+The principle: AskUserTool appears at structured decision moments, not during conversational exploration. The tool's clarity is its value at commit; that same clarity is its cost mid-loop.
 
 ---
 

--- a/discovery-map/phase-17-entry-ux-redesign.md
+++ b/discovery-map/phase-17-entry-ux-redesign.md
@@ -238,10 +238,10 @@ Discovery loop mechanics                  [decided]
 ├─ Routing-confirmation mechanism         [decided]
 └─ AskUserTool integration                [decided]
 
-Pivot mechanics                           [exploring]
-├─ Macro pivot triggers                   [pending]
-├─ Scope-down + inbox surface             [converging]
-└─ Reasoning surfacing                    [pending]
+Pivot mechanics                           [decided]
+├─ Macro pivot triggers                   [decided]
+├─ Scope-down + inbox surface             [decided]
+└─ Reasoning surfacing                    [decided]
 
 Imports & inbox handling                  [decided]
 
@@ -539,6 +539,73 @@ The macro and micro commits can land at the same conversational moment (single-t
 - **YES for the committed routing-commit moment.** Structured confirm-or-override locks the call cleanly without ambiguity and matches the formality of a commit. The user sees the proposed routing, the reasoning, and structured options (confirm / override-to-{alternative} / discuss-more). This is the cleanest fit.
 
 The principle: AskUserTool appears at structured decision moments, not during conversational exploration. The tool's clarity is its value at commit; that same clarity is its cost mid-loop.
+
+---
+
+### Macro pivot triggers [decided]
+
+**Context.** When Claude is in Discovery with a pre-seeded or tentatively-converging shape, and signals start pointing at a *different* shape, Claude needs to raise the pivot. The question was: what specifically triggers raising a pivot, and how does it differ from the normal shape-detection flow?
+
+**Decision.** The trigger pattern matches the regular shape-detection threshold (multiple converging signals, consistent framing, etc.) — just applied to the *competing* shape rather than the current one. Same patience discipline applies: don't pivot on a single weak signal; wait until the alternative shape has built actual momentum.
+
+Specifics for each common pivot path (illustrative cues; tune via real use):
+
+| Pivot direction | Cues |
+|---|---|
+| feature → epic | Multiple distinct concerns surface from what was framed as one feature; topic seeds start clustering into independent groups; user describes scope expansion mid-conversation |
+| epic → feature | Synthesis converges on one coherent topic; "multiple shapes" never quite materialises; user keeps pulling back to one core concern |
+| bugfix → feature | Described "broken" behaviour turns out to be missing-by-design rather than malfunction; user struggles to describe a working state before the bug |
+| feature → bugfix | Described "new" behaviour is actually restoring something that should already work; user mentions regression or "it used to work" |
+| quickfix → feature/bugfix | Scope discussion gets substantive; behaviour debate emerges; user starts describing how the change *should* work |
+| any → cross-cutting | Described work turns out to be defining a pattern, principle, or strategy rather than shipping a feature; no customer-facing deliverable surfaces |
+
+The pivot offer surfaces mid-loop as a tentative read (per the shape-detection mid-loop surfacing pattern). Plain language, not workflow jargon: *"This is shaping bigger than one feature — sounds like several connected things. Want to treat as a larger initiative made of multiple features?"* User confirms, declines, or redirects — Claude takes the call.
+
+Pivot offers can fire multiple times in one Discovery session. Each one is a tentative surfacing, easy to push back on.
+
+---
+
+### Scope-down + inbox surface [decided]
+
+**Context.** During Discovery for one work unit, Claude often notices a related-but-separate concern the user mentions in passing. Without a release valve, this would either (a) scope-creep into the current work unit, contaminating its shape, or (b) get lost entirely. We want a third path — surface to inbox for later, keep the current work focused.
+
+**Decision.** When Claude notices a tangential concern that doesn't fit the current shape, it surfaces a brief offer:
+
+> *"You mentioned X — that feels separate from what we're shaping. Surface to inbox for later?"*
+
+If user accepts, the mechanism reuses existing inbox capture infrastructure:
+
+- Inbox capture skill is invoked (`/workflow-log-idea`, `/workflow-log-bug`, or `/workflow-log-quickfix` — pick based on the tangential concern's shape; if uncertain, default to idea)
+- File lands in `.workflows/.inbox/{ideas,bugs,quickfixes}/` per existing capture pattern
+- Discovery's session log notes the surfacing as part of the journey record (so it's discoverable in the journey record even if the inbox file gets actioned later)
+- Conversation continues with the original work, now without scope creep
+
+The decision moment is conversational, not structured — soft surfacing, easy redirect. No AskUserTool needed.
+
+If user declines (*"no, that's actually part of this"*), Claude folds the concern into the current work. The surfacing offer is the value-add either way — surfaces the question rather than silently scope-creeping.
+
+---
+
+### Reasoning surfacing [decided]
+
+**Context.** Throughout the loop, Claude shares tentative reads (mid-loop surfacings) and committed routing offers (at the commit moment). Both require the user to be informed enough to agree or push back. The question was: how does Claude express reasoning so the user can engage with it meaningfully?
+
+**Decision.** Two principles guide reasoning surfacing:
+
+**1. Brief and concrete.** Reasoning names the specific signals that drove the read. Not *"based on the conversation"* (vague, unfalsifiable). Not *"because of multiple factors"* (no entry point for pushback). Instead: *"because you described X and Y as separate concerns and each came with substantive weight."*
+
+Brief — one or two sentences. The point is to make the read auditable, not to defend it.
+
+**2. Pull-on-able.** Reasoning surfaces in a way the user can challenge specific cues, not just accept-or-reject the whole conclusion. Saying *"because you described X and Y as separate concerns"* lets the user respond *"actually X and Y are the same thing — Y is just a subset"* — which Claude takes as an update to the read.
+
+This is the difference between *"trust me"* reasoning and *"check my work"* reasoning. Discovery uses the latter.
+
+The principle applies to:
+- Mid-loop tentative surfacings (*"I'm hearing several distinct shapes — your descriptions of X and Y feel orthogonal. Want to pull on that?"*)
+- Committed routing offers (*"This is feature-shaped — one focused thing with clear actors. Routing is discussion since you described the shape but flagged trade-off questions, not unknowns. Confirm or override?"*)
+- Pivot offers (*"Sounds like several connected things rather than one — you've sketched menu-management, kitchen-printers, and operator-analytics as distinct concerns. Want to treat as a larger initiative?"*)
+
+When Claude doesn't have enough signal to give pull-on-able reasoning, that's the trigger to keep exploring rather than surface a read — the read isn't ready yet.
 
 ---
 

--- a/discovery-map/phase-17-entry-ux-redesign.md
+++ b/discovery-map/phase-17-entry-ux-redesign.md
@@ -245,10 +245,10 @@ Pivot mechanics                           [decided]
 
 Imports & inbox handling                  [decided]
 
-Entry surface design                      [converging]
+Entry surface design                      [decided]
 ├─ /workflow-start menu                   [decided]
-├─ start-* future                         [exploring]
-└─ continue-* mirror question             [exploring]
+├─ start-* future                         [decided]
+└─ continue-* mirror question             [decided]
 
 Migration & cutover                       [pending]
 ```
@@ -606,6 +606,69 @@ The principle applies to:
 - Pivot offers (*"Sounds like several connected things rather than one — you've sketched menu-management, kitchen-printers, and operator-analytics as distinct concerns. Want to treat as a larger initiative?"*)
 
 When Claude doesn't have enough signal to give pull-on-able reasoning, that's the trigger to keep exploring rather than surface a read — the read isn't ready yet.
+
+---
+
+### start-* future [decided]
+
+**Context.** Pre-Phase-17, start-* are five user-invocable skills (one per work type), each handling: gather context, name + collision check, manifest creation, optional import collection, route to first phase. Post-Phase-17, Discovery has absorbed everything work-type-specific (the conversation, the classification, the import handling, the routing decisions). The question: do start-* skills survive as five thin wrappers, collapse into one shared utility, or disappear entirely?
+
+**Decision.** **Collapse to one shared utility.** Post-Phase-17, what's left for start-* to do is identical across all five work types except for *which downstream phase to route to* — that's a parameter, not a separate skill. Five thin wrappers that differ only in routing target = duplication for no benefit.
+
+Working name: `workflow-bootstrap` (or similar — TBD). Single skill, invoked by Discovery's terminal step with the resolved `work_type` and routing decisions. Its job:
+
+1. Create the manifest with the resolved work_type + name
+2. Copy imports to their final location (if not already there)
+3. Route to the first phase based on work_type + micro routing
+
+All three steps are work-type-aware via parameters, not via separate skills.
+
+**Frontmatter:** `user-invocable: false`. The skill is model-only — Discovery invokes it internally; users never reach it directly.
+
+---
+
+### continue-* mirror question [decided]
+
+**Context.** The question that paralleled start-*: does continue-* also collapse, or stay separated per work type? Different from start-* because continue-*'s resume logic varies meaningfully across work types — different displays, different menu options, different state aggregation. Also: Discovery doesn't have an equivalent absorber for continue-* the way it does for start-*.
+
+**Decision.** **Keep five continue-* skills, all become `user-invocable: false`.**
+
+Reasoning:
+
+- **Resume logic genuinely differs by work type.** continue-epic shows the discovery map; continue-feature shows a single-topic phase tree; continue-bugfix shows investigation state and routes accordingly; continue-quickfix shows scoping state; continue-cross-cutting handles the terminal-at-spec case. Collapsing into one skill would mean a big conditional skill with five-way display/menu logic — that's a complexity *increase*, not a decrease.
+- **No equivalent absorber.** Discovery handled all the work-type-specific *entry* logic that justified start-* collapse. There's no analogous *resume* mechanism in Discovery. Keeping continue-* per work type keeps that logic clean.
+- **The user-facing surface isn't the load-bearing part.** Bridge invocations, absorb-into-epic invocations, and manage-work-unit invocations of `/continue-epic` all keep working (model-side invocation). The only thing that goes is the user-typed `/continue-bugfix auth-flow` direct invocation — which user behaviour suggests isn't load-bearing either (users go through `/workflow-start` to navigate to existing work).
+
+**Result:** `/workflow-start` is the only user-invocable entry. For both new work (→ Discovery → bootstrap utility → first phase) AND continuing work (→ continue-* per work type, internally → phase routing), `/workflow-start` is the surface.
+
+**Text migration that follows:**
+
+Making continue-* model-only requires updating user-facing guidance text in a finite set of files:
+
+- `workflow-start/references/active-work.md` — table currently maps actions to `/continue-*` slash commands; rewrite to direct internal invocation (user sees outcome, not command)
+- `start-*/references/name-check.md` files with *"Run /continue-X to resume"* text → rewrite as *"Run /workflow-start to resume {work_unit}"* or equivalent
+- `continue-cross-cutting/references/validate-selection.md` and similar → same treatment
+- Any documentation surfaces that promise the `/continue-*` commands as user-typeable
+
+Mechanical text updates, not architectural restructuring.
+
+**Implementation note: Step 0 centralization opportunity.**
+
+With `/workflow-start` as the only user-invocable entry, Step 0 (casing conventions, migrations, knowledge check, knowledge compact) no longer needs to be defensively repeated in every entry-point skill. The full Step 0 runs once at `/workflow-start`. But continue-* invocations from the bridge happen mid-session, so some Step 0 elements need to remain available at bridge time:
+
+| Step 0 element | Needs to survive a bridge? |
+|---|---|
+| Migrations | No — idempotent and state-tracked. `/workflow-start` only. |
+| Knowledge check | No — gates session at entry; once cleared, stays cleared. `/workflow-start` only. |
+| Casing conventions | **Yes** — content authoring rules. Bridge to research/discussion/spec/etc. needs the conventions to author files correctly. |
+| Knowledge compact | No — TTL-based decay at entry boundaries. `/workflow-start` only. |
+
+Expected pattern (implementation detail, not a decision now):
+- `/workflow-start` runs full Step 0
+- Bridge invocations and continue-*'s own Step 0 are trimmed to the bridge-survival subset (casing + anything else identified later)
+- Continue-* is no longer defensive about migrations or knowledge check — those are guaranteed to have run at `/workflow-start`
+
+Net: real simplification of duplicated Step 0 content. Worked out concretely during implementation.
 
 ---
 

--- a/discovery-map/phase-17-entry-ux-redesign.md
+++ b/discovery-map/phase-17-entry-ux-redesign.md
@@ -233,7 +233,7 @@ Discovery as universal entry              [decided]
 └─ Shape vs content guardrail             [decided]
 
 Discovery loop mechanics                  [exploring]
-├─ Opener shapes across worktypes         [exploring]
+├─ Opener shapes across worktypes         [decided]
 ├─ Shape-detection heuristics             [exploring]
 ├─ Routing-confirmation mechanism         [exploring]
 └─ AskUserTool integration                [pending]
@@ -367,6 +367,46 @@ Inbox content drives Discovery's opening exploration the same way imports do —
 - **`v`/`view`** — stays. Completed/cancelled work units.
 
 Even when user picks a work-type fast path, Claude may suggest a pivot during Discovery (e.g. *"looks more like an epic"*). User controls the final call; Claude proposes and explains reasoning.
+
+---
+
+### Opener shapes across worktypes [decided]
+
+**Context.** Discovery's first turn shapes the entire conversation. With Discovery becoming universal across work types, we needed to decide whether the opener is one universal sentence or varies by entry path. First instinct was a single universal opener for cross-worktype symmetry, but that produces awkward phrasing (asking *"what's on your mind"* to someone who picked `/bugfix` from the menu is bizarre — they already told us a thing is broken).
+
+**Journey.** Landed on a model that holds the symmetry rule at the *pattern* level while letting the *specific text* phrase itself appropriately. Worked through three judgement calls along the way:
+
+1. Should the opener pre-announce that Discovery is "shape-figuring, not problem-solving"? **No** — discipline shows through behaviour. Pre-announcing the process is annoying for repeat users. Claude redirects deep dives when they happen (*"hold that thread — we'll cover it in [research / discussion / investigation]"*) rather than caveating upfront.
+2. Should workflow-start announce the handoff to Discovery? **Yes** — the workflow already has signpost conventions for phase boundaries (step markers + signpost blockquotes). Discovery's entry uses the same pattern. The signpost gives the user a clear *"we're moving into Discovery now"* moment.
+3. For `/start` entry (no pre-seed), should the opener acknowledge that explicitly? **Yes, lightly** — naturally folded into the question itself (*"we'll figure out the shape together"*). No need for a separate caveat.
+
+**Decision.** Discovery's opener has four elements, applied in sequence:
+
+1. **Phase signpost** — workflow-start → Discovery boundary marked via the established step-marker + signpost-blockquote convention. One sentence indicating what's about to happen. The signpost text may carry shape-appropriate framing (e.g. for `/start`: *"figuring out what kind of work this is, then the details inside it"*; for `e`/`epic`: *"setting up the epic — we'll pull on shape before naming topics"*). Same convention as the rest of the workflow.
+
+2. **Seed-material acknowledgment** (when imports or inbox content is present) — Claude reads the seed material and surfaces a brief sketch of what was picked up. Sketch first, then the opening question. Pattern matches today's epic-mode opener:
+
+   > Read your import(s). Here's the shape I'm picking up:
+   > 
+   >   {one-line summary}
+   >
+   > {targeted opening question}
+
+3. **Opening question, shape-appropriate** — phrased per work_type pre-seed (or fully open for `/start`). The PATTERN is universal across entry paths and work types; the SPECIFIC TEXT varies for conversational naturalness. Sketch (illustrative, not final wording):
+
+   | Entry path | Opening question |
+   |---|---|
+   | `/start` | *"Tell me what's on your mind. I'll ask open questions and we'll figure out the shape together."* |
+   | `e`/`epic` | *"Tell me about the epic. I'll ask open questions to pull on it before we synthesise topics."* |
+   | `f`/`feature` | *"Tell me about the feature."* |
+   | `b`/`bugfix` | *"What's broken?"* |
+   | `q`/`quickfix` | *"What's the change?"* |
+   | `c`/`cc` | *"Tell me about the cross-cutting concern."* |
+   | inbox | (after reading the inbox item) *"I've read your {bug/idea/quickfix}. Here's the shape I'm picking up: {sketch}. {targeted question}."* |
+
+4. **No pre-announce of process discipline** — Claude doesn't preamble *"we're in setup mode, not problem-solving."* Discipline is enforced by behaviour (open exploratory questions, no commitments, redirects on deep dives). The user finds out *what* Discovery does by being in it; they don't need a meta-explanation upfront.
+
+The pattern is universal. The text varies for naturalness. Cross-worktype symmetry is preserved at the structural level — same opener stages, same conversational discipline, same pivot availability.
 
 ---
 


### PR DESCRIPTION
## Summary

Phase 17 makes a substantive architectural shift across the workflow system:

- **Discovery becomes the universal first step** for all new work (not just epics)
- **`/workflow-start` is the sole user-invocable entry point**
- **`/start-*` skills are deleted** — their work moved into one shared utility, `workflow-bootstrap`
- **`/continue-*` skills become model-only** (still per-work-type internally, routed via `/workflow-start`)
- **Step 0 deduplicates** — full Step 0 runs once at `/workflow-start`; continue-* trim to casing-only (the bridge-survival subset)

Design discussion locked in `discovery-map/phase-17-entry-ux-redesign.md` ("Current Design" section).

## Key Changes

### Manifest schema relaxation
- 29 new assertions in `test-workflow-manifest.sh` pinning `phases.discovery` as writable for every work type (CLI already had no epic-only guard; this protects against silent schema tightening).

### Discovery becomes work-type-aware
- `workflow-discovery-entry` drops the epic-only rejection, accepts three entry modes: **Resumed** / **Pre-seeded shape** / **Classifier**. Optional `$2` forwards inbox-file path as seed material.
- `workflow-discovery-process` gains **Step 00: Classifier Pre-Resolution** — resolves work_type (classifier mode), proposes a kebab-case name, creates the manifest before Steps 0–2 read it. Existing resumed flow unchanged.
- Five new references (terse, agent-facing): `discovery-mode-overlays.md`, `opener-pattern.md`, `shape-detection.md`, `routing-commit.md`, `pivot-watchpoints.md`.
- `discovery-guidelines.md` split into shared core + cross-references; shape-vs-content guardrail tightened.
- `topic-synthesis` / `confirm-and-persist` / `conclude-discovery` gain mode dispatch: epic = multi-row map, feature/cc = single-topic, bugfix/quick-fix = brief intent + routing (no map).

### `workflow-bootstrap` utility (new)
Model-only. Discovery's conclude step invokes it with positional args (work_type, work_unit, routing). Steps: ensure-manifest, land-imports, route-to-phase (matrix dispatch).

### `start-*` skill deletion
All five start-* directories deleted. Their work has migrated:
- `gather-{type}-context.md` → Discovery's opener
- `name-check.md` → `workflow-bootstrap/references/name-check.md`
- `collect-import.md` → Discovery's import handling
- `research-gating.md` → removed (micro routing happens in Discovery)

### `workflow-start` menu
- Add `s`/`start` ambiguous-shape option to both menus
- Fast-paths (e/f/b/q/c) route to `/workflow-discovery-entry {work_type} ""` with menu pre-seed; workflow-bootstrap creates the manifest at commit
- Inbox folder-based pre-seed: bugs/ → bugfix, quickfixes/ → quick-fix, ideas/ → classifier mode. File path forwarded via `$2`.

### `continue-*` model-only + Step 0 trim
- Frontmatter flip: `user-invocable: false` on all five
- Step 0 trim: drop migrations + knowledge check; keep casing only (bridge-survival subset)

### `workflow-discussion-entry`
- Add `source=import` branch for bootstrap-routed feature/cc discussions

### Text migration
Eleven user-facing prose files rewritten so users are never told to type `/start-X` or `/continue-X`. Five internal model-side invocation sites intentionally keep `/continue-X` (the harness allows model-side invocation of `user-invocable: false` skills).

## End-to-End Flow After This PR

```
/workflow-start
  → menu pick (e/f/b/q/c/s/i)
  → /workflow-discovery-entry {work_type|""} {""} [{inbox_seed}]
  → Step 00 (classifier or pre-seeded — resolve name, create manifest)
    OR Step 0 (resume — manifest exists)
  → Discovery loop (work-type-aware synthesis at endpoint)
  → conclude-discovery
  → /workflow-bootstrap {work_type} {work_unit} {routing}
  → routed entry skill

/workflow-start (existing in-progress work)
  → continue-{type} (model-only, casing-only Step 0)
  → next phase
```

## Verification

Test-suite coverage (passing):
- 251 manifest tests (+29 new cross-work-type discovery assertions)
- All `test-discovery-*` files
- Migration 038 test (seeded text assertion updated for `/workflow-start`)
- Legacy research split tests

Audits performed:
- Verbosity — references trimmed of historical / journey / rationale prose; only direct instruction remains
- Logic flow — classifier mode (empty work_unit) wired via Step 00; inbox seed-path forwarding via `$2`
- Conventions — H1/H2/H3 headers, `**STOP.**` gates, `→ Return to caller`, reference file headers, frontmatter all match `CONVENTIONS.md`

**What this PR does NOT cover** — these are markdown skill files; the only "real" verification is installing them via `npx agntc add` into a scratch project and walking each menu option through manually. The full classifier path (`s`/`start`) has not yet been exercised against a real session. Recommend a manual walkthrough on a scratch project before relying on it in anger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)