### PR TITLE
fix: clear dangling active_session marker in discovery

### DIFF
--- a/skills/workflow-discovery/references/map-operations.md
+++ b/skills/workflow-discovery/references/map-operations.md
@@ -22,11 +22,7 @@ node .claude/skills/workflow-discovery/scripts/discovery.cjs {work_unit}
 
 Read `discovery_map` (per-topic `tier`, `lifecycle`, `routing`, `summary`, `source`) and `dismissed`. These drive validation in **B**.
 
-Set the active-session marker (idempotent — no-op if already set). The first per-op commit below will pick it up via `git add manifest.json`:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery active_session "{session_number:03d}"
-```
+The active-session marker is **not** set here — it is set lazily when an operation first writes the session log (see [template.md](template.md)), so an all-rejected or browse-only session leaves no marker.
 
 Then read the user's most recent message. Extract one or more operations. Recognised intents:
 

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -171,10 +171,9 @@ No fixed cadence — follow the conversation, not a checklist. **The loop is pur
 
    The Exploration entry is **prose, not transcript** — capture what was named, what crystallised, what was decided not to pursue. The log survives context refresh; in-context memory does not.
 
-   The lazy-creation rule applies: this may create the session log file if it doesn't exist yet — see [template.md](template.md) → *Lazy creation and finalisation*. After writing, set the active-session marker (idempotent) and commit:
+   The lazy-creation rule applies: this may create the session log file if it doesn't exist yet — see [template.md](template.md) → *Lazy creation and finalisation*, which sets the active-session marker on first creation. After writing, commit:
 
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery active_session "{session_number:03d}"
    git add -- .workflows/{work_unit}/
    git commit -m "discovery({work_unit}): exploration notes — session-{session_number:03d}"
    ```

--- a/skills/workflow-discovery/references/template.md
+++ b/skills/workflow-discovery/references/template.md
@@ -87,6 +87,14 @@ Browse-and-bail produces no file.
 
 When the file is first created, populate the header, **Description (as of session)**, **Imports**, and **Map State at Start** at the same write that adds the first content. Other sections start as `(none)`.
 
+At that same first-creation write, set the active-session marker so it always pairs with an existing log:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery active_session "{session_number:03d}"
+```
+
+The caller's own commit step stages and commits this alongside the log.
+
 The `(none)` Conclusion is the **resume-detection signal** in concert with the `phases.discovery.active_session` manifest marker (see [resume-detection](../../workflow-discovery/SKILL.md)). Always replace it at finalisation so the next entry sees a closed state.
 
 At finalisation, replace the `(none)` Conclusion with one of:


### PR DESCRIPTION
## Summary
- `map-operations.md` set the `active_session` marker **eagerly on entry**, before any operation succeeded and before any session log existed. An all-rejected (lifecycle-gated) or declined edit session left the marker pointing at a `session-NNN.md` that was never created → the next entry's resume-detection offered to resume a phantom session and tried to read a missing file.
- Fix moves marker ownership to **lazy log creation in `template.md`** (the design's stated owner — SKILL.md:223 "set by lazy log creation"), so the marker is set only when/where the log is first written. Removed the eager set in `map-operations.md` and the now-redundant explicit set in `session-loop.md`; both lazy paths already stage `manifest.json` in their commits.
- Restores the invariant **marker ⟺ existing log**, which also makes `confirm-and-persist.md`'s existing "skip clear if no log" guard correct (no absent-key `manifest delete`).

## Test plan
- New epic → discovery → confirm, then a continue-epic "Continue discovery" session where every map op is rejected/declined: no log written, **no marker left**, next entry opens cleanly (no phantom resume).
- A successful edit (or Exploration write) still creates the log **and** sets the marker (committed via the existing `git add`), so an interrupted-mid-edit session still resumes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)