### PR TITLE
fix: explore choice resumes the discovery session loop

### DIFF
--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -215,11 +215,15 @@ Ready to synthesise topics?
 
 #### If `yes`
 
-Load **[topic-synthesis.md](topic-synthesis.md)** and follow its instructions as written.
+Load **[topic-synthesis.md](topic-synthesis.md)** and follow its instructions as written. It returns a synthesis outcome:
 
-When `topic-synthesis.md` returns:
+**If the outcome is `confirmed`:**
 
 → Return to caller.
+
+**If the outcome is `explore`:**
+
+→ Return to **B. Session Loop**.
 
 #### If keep going
 

--- a/skills/workflow-discovery/references/topic-synthesis.md
+++ b/skills/workflow-discovery/references/topic-synthesis.md
@@ -79,13 +79,15 @@ Confirm to commit, or tell me what to adjust.
 
 #### If `yes`
 
-The topic set is confirmed. Hold it in conversation memory as the **working list** for Step 12 confirm-and-persist. Do not write Topics Identified to the log yet — Step 12 writes the manifest items and the log section together.
+The topic set is confirmed. Hold it in conversation memory as the **working list** for Step 12 confirm-and-persist. Do not write Topics Identified to the log yet — Step 12 writes the manifest items and the log section together. Synthesis outcome: `confirmed`.
 
 → Return to caller.
 
 #### If `explore`
 
-→ Return to caller for **B. Session Loop**.
+The user isn't ready to commit — no working list is produced. Synthesis outcome: `explore`.
+
+→ Return to caller.
 
 #### If adjust
 


### PR DESCRIPTION
## Summary
- At the synthesis gate, choosing **`e`/`explore`** ("not ready to commit") was meant to resume exploration, but `session-loop.md` C's "If yes" branch returned to caller unconditionally for any `topic-synthesis.md` return — so `explore` advanced discovery to Document Review instead of looping back to **B. Session Loop**.
- `topic-synthesis.md` now reports an explicit synthesis outcome (`confirmed` | `explore`); `session-loop.md` C branches on it (confirmed → return to caller; explore → return to **B. Session Loop**), each branch carrying its own routing per the conventions.

## Test plan
- Reach the synthesis gate, choose `e`/`explore`: exploration resumes (back into the session loop), no advance to Document Review.
- Choose `y`/`yes`: topics commit and discovery proceeds to conclusion as before.

> Stacked on #308 (base: `fix/discovery-dangling-active-session`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)