### PR TITLE
fix: entry skills fall back to gather-context when no discovery log

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -136,7 +136,7 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > Collecting the context needed before starting the discussion.
 ```
 
-#### If `work_type` is not `epic`
+#### If `work_type` is not `epic` and a discovery session log exists for this work unit
 
 Single-phase work shaped in discovery. Read the durable carrier as the seed — the manifest `description` and the latest discovery session log (`.workflows/{work_unit}/discovery/session-NNN.md`, highest-numbered) — and seed the discussion from it. Do not re-ask; live conversation context, when present, supplements the carrier.
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -160,7 +160,7 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > Collecting initial context to seed the research session.
 ```
 
-#### If `work_type` is not `epic`
+#### If `work_type` is not `epic` and a discovery session log exists for this work unit
 
 Single-phase work shaped in discovery. Read the durable carrier as the seed — the manifest `description` and the latest discovery session log (`.workflows/{work_unit}/discovery/session-NNN.md`, highest-numbered) — and seed the research session from it. Do not re-ask; live conversation context, when present, supplements the carrier.
 


### PR DESCRIPTION
## Summary
- `research-entry` and `discussion-entry` gated the durable-carrier read on `work_type != epic` **alone**, without checking a discovery session log actually exists. A non-epic work unit created before this refactor (or otherwise without a discovery log) matched the branch, read an empty carrier, said "do not re-ask", and skipped context gathering — handing a blank seed downstream.
- Added the log-existence check to the branch (mirroring `investigation-entry`'s correct pattern), keeping the `work_type` clause since these skills also serve epics. A non-epic unit with no log now falls through to the `gather-context.md` fallback. Epic behaviour unchanged.

## Test plan
- Non-epic work unit **with** a discovery session log → reads the carrier, no re-ask (as before).
- Non-epic work unit **without** a discovery log (legacy/migrated), resumed in a fresh context → falls to `gather-context.md` instead of seeding empty.
- Epic topic → unchanged (branch never fired for epics before or after).

> Stacked on #309 (base: `fix/discovery-explore-resumes-loop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)