### PR TITLE
fix: name collision keeps the user's retyped name

### DIFF
--- a/skills/workflow-discovery/references/name-resolution.md
+++ b/skills/workflow-discovery/references/name-resolution.md
@@ -68,7 +68,9 @@ Choose a different name, or resume via /workflow-start.
 
 **STOP.** Wait for user response.
 
-→ Return to **A. Suggest a Name**.
+Kebab-case the name the user gives and hold it as `work_unit` — don't re-derive the original suggestion.
+
+→ Return to **B. Conflict Check**.
 
 #### If no conflict
 


### PR DESCRIPTION
## Summary
- On a name collision, the recovery branch returned to **A. Suggest a Name**, which re-derives the suggestion from the same inbox slug / `description` — re-proposing the colliding name and **discarding the alternate the user just typed** at the collision gate (forcing a retype, or a loop if the derived name keeps colliding).
- Now the branch adopts the user-typed name (kebab-cased) and re-runs the **conflict check** on it, mirroring how A already accepts the user's own name.

## Test plan
- Hit a name collision, type `auth-v2`: it's adopted and re-checked — if free, proceeds; no re-proposal of the original colliding name.
- Type a second colliding name: collision message shows for *that* name and re-prompts (user-driven loop), with the `/workflow-start` resume hint still available.

> Stacked on #311 (base: `fix/discovery-macro-continuation-refresh`). Final PR in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)