### PR TITLE
fix: declare git/cp/mkdir tools the discovery persistence hinge runs

### DIFF
--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-discovery
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-discovery/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(mkdir -p .workflows/.inbox/.archived/), Bash(mv .workflows/.inbox/)
+allowed-tools: Bash(node .claude/skills/workflow-discovery/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(git status), Bash(git add), Bash(git commit), Bash(cp), Bash(mkdir -p .workflows/), Bash(mv .workflows/.inbox/)
 ---
 
 # Discovery


### PR DESCRIPTION
## Summary
- `workflow-discovery`'s `allowed-tools` listed the node CLIs and the inbox `mkdir`/`mv`, but the confirm-trigger / import-landing / map-operations steps run `git status`, `git add`, `git commit`, `cp` (into `imports/`), and `mkdir -p .workflows/{wu}/…` — none matched, so the work-type commit fired interactive permission prompts mid-flow.
- Added the missing tools using the codebase's broad-prefix convention (`workflow-migrate` declares `git` the same way), and broadened the inbox-only `mkdir` to `Bash(mkdir -p .workflows/)` to cover the work-unit directories the skill creates.

## Test plan
- Run a new-work discovery to the work-type commit: manifest create, import copy, session-log write, and git commit complete without permission prompts.

> Stacked on #312. Continues the review-fix pile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)