### PR TITLE
fix: run the compliance self-check for single-phase work too

### DIFF
--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -334,32 +334,11 @@ Load **[document-review.md](references/document-review.md)** and follow its inst
 
 Load **[confirm-and-persist.md](references/confirm-and-persist.md)** and follow its instructions as written.
 
-→ Proceed to **Step 13**.
+→ Proceed to **Step 14**.
 
 ---
 
-## Step 13: Compliance Self-Check
-
-> *Output the next fenced block as a code block:*
-
-```
-── Compliance Self-Check ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the session followed the discovery conventions before
-> moving on.
-```
-
-Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
-
-→ Proceed to **Step 15** (the epic topic path skips the single-phase endpoint).
-
----
-
-## Step 14: Single-Phase Endpoint
+## Step 13: Single-Phase Endpoint
 
 Reached only for single-phase work — feature, cross-cutting, bugfix, quick-fix — routed here by the confirm-trigger (Step 5). The epic topic path does not pass through here.
 
@@ -379,13 +358,36 @@ Reached only for single-phase work — feature, cross-cutting, bugfix, quick-fix
 
 Load **[first-phase-routing.md](references/first-phase-routing.md)** and follow its instructions as written.
 
+→ Proceed to **Step 14**.
+
+---
+
+## Step 14: Compliance Self-Check
+
+Reached before concluding by both paths — the epic topic path from Step 12, the single-phase endpoint from Step 13.
+
+> *Output the next fenced block as a code block:*
+
+```
+── Compliance Self-Check ────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking the session followed the discovery conventions before
+> moving on.
+```
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
 → Proceed to **Step 15**.
 
 ---
 
 ## Step 15: Conclude Discovery
 
-The single exit for every work type — epic arrives from Step 13, single-phase work from Step 14.
+The single exit for every work type — both paths arrive from the Step 14 compliance check.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-discovery/references/confirm-trigger.md
+++ b/skills/workflow-discovery/references/confirm-trigger.md
@@ -124,4 +124,4 @@ The work continues into the initial topic sketch — the same shaping, deepened.
 
 Single-phase work (feature / cross-cutting / bugfix / quick-fix). The single-phase endpoint determines the first phase, then the work concludes.
 
-→ Return to **[the skill](../SKILL.md)** for **Step 14**.
+→ Return to **[the skill](../SKILL.md)** for **Step 13**.


### PR DESCRIPTION
## Summary
- Single-phase work (feature/cross-cutting/bugfix/quick-fix) routed Step 5 → 14 → 15, **skipping the Step 13 compliance self-check** that only the epic path ran — an implicit, undocumented exemption, even though single-phase sessions also write a discovery session log.
- Swapped the two endpoint steps so compliance is the **shared penultimate step both paths flow through** before concluding: Step 13 = single-phase endpoint (first-phase routing), Step 14 = compliance (reached from Step 12 for epics, Step 13 for single-phase).
- Epic behaviour is unchanged (compliance still runs after persist, before conclude). Forward-flowing, one concern per step, no duplicated Load directive.

## Test plan
- Run a feature/bugfix/quick-fix/cross-cutting through discovery to the endpoint → the compliance self-check now runs before conclusion.
- Run an epic → compliance still runs after Step 12 persist, before Step 15 conclude (no change).

> Stacked on #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)