### PR TITLE
fix: template.md resume-detection link points at the sibling reference

### DIFF
--- a/skills/workflow-discovery/references/template.md
+++ b/skills/workflow-discovery/references/template.md
@@ -95,7 +95,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.disco
 
 The caller's own commit step stages and commits this alongside the log.
 
-The `(none)` Conclusion is the **resume-detection signal** in concert with the `phases.discovery.active_session` manifest marker (see [resume-detection](../../workflow-discovery/SKILL.md)). Always replace it at finalisation so the next entry sees a closed state.
+The `(none)` Conclusion is the **resume-detection signal** in concert with the `phases.discovery.active_session` manifest marker (see [resume-detection](resume-detection.md)). Always replace it at finalisation so the next entry sees a closed state.
 
 At finalisation, replace the `(none)` Conclusion with one of:
 


### PR DESCRIPTION
## Summary
- `template.md`'s `resume-detection` link pointed at the discovery backbone (`../../workflow-discovery/SKILL.md`) instead of the sibling `resume-detection.md` that documents the marker/Conclusion resume protocol. Now points at the sibling.
- This was also the only violation surfaced by the convention-adherence pass.

## Test plan
- Follow the link from `template.md` → lands on `resume-detection.md` (the focused reference), not the 400-line backbone.

> Stacked on #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)