### PR TITLE
fix: correct topic-discovery.md attribution header

### DIFF
--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -1,6 +1,6 @@
 # Topic Discovery
 
-*Shared reference. Loaded by `continue-epic` and `workflow-discovery`.*
+*Shared reference. Loaded by [topic-discovery-dispatch.md](topic-discovery-dispatch.md), which `continue-epic` and `workflow-bridge` run.*
 
 ---
 


### PR DESCRIPTION
## Summary
- `topic-discovery.md`'s header claimed it was loaded by `continue-epic` and `workflow-discovery`. But `workflow-discovery` loads neither topic-discovery file, and CLAUDE.md states these self-healing analyses run **not** from inside discovery.
- Its only loader is `topic-discovery-dispatch.md`, which `continue-epic` (Step 6) and `workflow-bridge` (epic-continuation §B) run. Header now points at the real loader, consistent with the dispatch file's own header.

## Test plan
- Grep confirms nothing under `skills/workflow-discovery/` references either topic-discovery file; the dispatch is the sole loader.

> Stacked on #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)