### PR TITLE
fix: make the active-session marker epic-only

### DIFF
--- a/skills/workflow-discovery/references/confirm-trigger.md
+++ b/skills/workflow-discovery/references/confirm-trigger.md
@@ -89,7 +89,7 @@ Write `.workflows/{work_unit}/discovery/session-001.md` populating the header, *
 
 This session log is the durable carrier: for single-phase types it (plus the manifest `description`) is what the first phase reads; for epic it seeds the topic synthesis. Do not KB-index it — it is shape-talk, not validated substance.
 
-Set the active-session marker:
+Set the active-session marker — only for epics, the sole work type with a resumable discovery session loop:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery active_session "001"

--- a/skills/workflow-discovery/references/first-phase-routing.md
+++ b/skills/workflow-discovery/references/first-phase-routing.md
@@ -49,11 +49,7 @@ Set `next_phase` = `scoping`.
 
 ## B. Finalise
 
-Finalise the session log carrier: replace its `(none)` **Conclusion** with a one-line note — `Routed to {next_phase}.` Clear the active-session marker:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery active_session
-```
+Finalise the session log carrier: replace its `(none)` **Conclusion** with a one-line note — `Routed to {next_phase}.` Single-phase work sets no active-session marker (it has no resumable loop), so there is nothing to clear here.
 
 Leave the commit to the conclude step — `next_phase` is held in context for it to use.
 


### PR DESCRIPTION
## Summary
- `confirm-trigger` set `active_session` for every work type, but only the **epic** discovery session loop can resume. Single-phase work got the marker set at confirm and cleared at first-phase-routing — a window where an interrupt left it dangling forever (harmless, but it pollutes the manifest).
- The marker is epic resume machinery: set it only for epics in confirm-trigger (E), and drop first-phase-routing's clear (single-phase never sets it). After this, every set/clear site is epic-only (confirm-trigger + template.md set; confirm-and-persist + resume-detection clear).

## Test plan
- New non-epic (feature/bugfix/quick-fix/cross-cutting) through discovery → no `active_session` written to the manifest at any point; interrupting before routing leaves no dangling marker.
- New epic → marker still set at confirm (committed with work-unit creation), used by resume-detection, cleared at conclusion. Unchanged.

> Stacked on #317. Final PR of the review-fix pile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)