### PR TITLE
fix: correct confirm-trigger's overstated 'no branching' header

### DIFF
--- a/skills/workflow-discovery/references/confirm-trigger.md
+++ b/skills/workflow-discovery/references/confirm-trigger.md
@@ -4,7 +4,7 @@
 
 ---
 
-The single persistence hinge. Until the work-type commit, all shaping is ephemeral — nothing is on disk. This reference fires once, at the commit, and persists everything uniformly for **every** work type: resolve the name → create the work unit → land imports → archive the inbox seed → write the session log. No work-type branching here; the only parameter is `--work-type`.
+The single persistence hinge. Until the work-type commit, all shaping is ephemeral — nothing is on disk. This reference fires once, at the commit, and persists the work unit for **every** work type: resolve the name → create it → land imports → archive the inbox seed → write the session log. Persistence is uniform except two epic-specific touches in **E** (the session log's *Map State at Start* wording and the active-session marker); routing by work type is deferred to **G**.
 
 Inputs held from earlier steps: committed `work_type`, shaped one-line `description`, `import_paths` (paths the user shared during shaping, may be empty), `inbox_seed` path (may be none).
 


### PR DESCRIPTION
## Summary
- `confirm-trigger`'s header claimed *"No work-type branching here; the only parameter is `--work-type`."* That's inaccurate: section E renders *Map State at Start* differently for epic vs single-phase (line 88), and #15 added the **epic-only active-session marker** (line 92); section G routes by type.
- Header now states the two epic-specific touches in E and that routing branches in G, instead of overclaiming uniformity.

## Test plan
- Doc-only. Read the header against sections E and G — the description now matches the actual conditional behaviour.

> Stacked on #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)