### PR TITLE
fix: remove dead source=import branches in research-entry

### DIFF
--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -63,12 +63,6 @@ Store work_unit for the handoff.
 
 Resolve filename:
 
-#### If source is `import`
-
-`resolved_filename = {topic}.md`
-
-→ Proceed to **Step 5**.
-
 #### If `topic` resolved
 
 `resolved_filename = {topic}.md`

--- a/skills/workflow-research-entry/references/invoke-skill.md
+++ b/skills/workflow-research-entry/references/invoke-skill.md
@@ -44,27 +44,6 @@ Invoke the workflow-research-process skill.
 
 No description load for `continue` — resuming an existing session, no need to re-prime. Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
-#### If source is `import`
-
-```
-Research session for: {topic}
-Work unit: {work_unit}
-
-Source: import
-Output: .workflows/{work_unit}/research/{resolved_filename}
-
-Imports tracked in manifest.imports[] and indexed into the
-knowledge base — relevant chunks will surface via the
-session-start contextual query. Starting Point stays empty.
-
-Description:
-{description text — paragraph or two, preserved as-is}
-
-Invoke the workflow-research-process skill.
-```
-
-The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
-
 #### Otherwise
 
 ```


### PR DESCRIPTION
## Summary
- `source` in `research-entry` is only ever set to `"continue"` (by `validate-phase`, the resume path) or left unset (→ `Otherwise`, the new path). **Nothing sets `source="import"`** — that was the old `start-feature` import path, dropped in phase-17.
- So both `#### If source is \`import\`` branches were unreachable: SKILL.md Step 1 (routed to Step 5, skipping context-gathering) and the `invoke-skill.md` handoff branch. Removed both.

## Test plan
- Grep confirms no remaining `source=import` references. Step 1 now branches `topic resolved` / `no topic` (both → Step 2); `invoke-skill.md` has `continue` / `Otherwise`, and its "every source branch except continue" note still holds.

> Stacked on #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)