### PR TITLE
fix: stop confirm-and-persist's source list from drifting

### DIFF
--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -42,7 +42,7 @@ Notes:
 - `init-phase` creates the item with `status: in-progress` automatically. Discovery items have no other valid status — do not pass `status` explicitly.
 - The topic name is the manifest dict key (third dot-path segment). There is no separate `name` field to set.
 - `routing` is the value confirmed by the user at the synthesis gate.
-- `source: discovery` distinguishes user-surfaced topics from later auto-additions (`research-analysis`, `gap-analysis`, `split`, `elevation`, `direct-start`, `migration-seeded`).
+- `source: discovery` marks topics the user surfaced during discovery, distinguishing them from items added later with other provenance (e.g. `research-analysis`, `gap-analysis`).
 
 → Proceed to **B. Write Topics Identified**.
 


### PR DESCRIPTION
## Summary
- `confirm-and-persist`'s inline `source` enumeration had already diverged from the canonical provenance set: it abbreviated `research-split:{parent}` → `split` and `discussion-elevation:{parent}` → `elevation`, and omitted `legacy-split:{parent}`.
- The note is only illustrative (this step writes `source discovery`), and there's no single shipped enum definition to reference (CLAUDE.md enumerates the vocabulary but doesn't ship). So it's now explicitly illustrative — `e.g.` with correct example values — which can't drift out of sync with the full set.

## Test plan
- Doc-only. The note still conveys "discovery = user-surfaced vs later auto-added provenance" without claiming an exhaustive (and stale) list.

> Stacked on #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)