### PR TITLE
fix: correct CLAUDE.md migration filename reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Contract and scaffolding templates live in `.claude/skills/create-output-format/
 3. Orchestrator handles tracking — once a migration ID appears in the log, the script never runs again
 4. Use helper functions: `report_update`, `report_skip` (display only)
 
-Migration `038-add-discovery-phase.sh` seeds discovery items for existing in-progress epics so legacy work units pick up the discovery map without manual intervention.
+Migration `038-add-inception-phase.sh` seeds the phase for existing in-progress epics (`040-rename-inception-to-discovery.sh` then renames it to `discovery`) so legacy work units pick up the discovery map without manual intervention.
 
 **Critical: Migration scripts must not use the manifest CLI**
 


### PR DESCRIPTION
## Summary
- CLAUDE.md cited migration `038-add-discovery-phase.sh`, which doesn't exist on disk. The real files are `038-add-inception-phase.sh` (seeds the phase under the historical "inception" name) and `040-rename-inception-to-discovery.sh` (renames it to `discovery`).
- Updated the reference to name both, so the dev doc matches reality.

## Test plan
- `ls skills/workflow-migrate/scripts/migrations/ | grep -E '038|040'` matches the names now in CLAUDE.md.

> Stacked on #321. (CLAUDE.md is dev-only — not shipped to installed projects.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)