### PR TITLE
fix: correct ensure-discovery-item's epic-only rationale

### DIFF
--- a/skills/workflow-shared/references/ensure-discovery-item.md
+++ b/skills/workflow-shared/references/ensure-discovery-item.md
@@ -21,7 +21,7 @@ The caller provides these via context before loading:
 
 ## A. Gate on Work Type
 
-The discovery map is epic-only. Features, bugfixes, quick-fixes, and cross-cutting work units have no discovery phase, and writing one would corrupt their manifests.
+The discovery *map* is epic-only — a multi-topic map only makes sense when there's more than one topic. Single-phase work types (feature, bugfix, quick-fix, cross-cutting) have a single topic that *is* the work unit, so there's no map item to ensure. (They still pass through the discovery phase, and `phases.discovery` is a valid manifest location for every type — there's just no map to populate here.)
 
 #### If `work_type` is `epic`
 


### PR DESCRIPTION
## Summary
- `ensure-discovery-item`'s gate (no-op for non-epics) is correct, but its rationale was stale post-phase-17. It claimed non-epics *"have no discovery phase"* (they do — discovery is the universal first phase) and that writing a discovery item *"would corrupt their manifests"* (it wouldn't — commit 1's cross-type test proves `phases.discovery` writes succeed for every work type).
- Restated accurately: the discovery **map** is epic-only because single-phase types have one topic that *is* the work unit, so there's no map item to ensure. Behaviour unchanged.

## Test plan
- Doc-only; the `#### If \`work_type\` is \`epic\`` / `Otherwise` gate is untouched. The rationale no longer contradicts the universal-first-phase model or the cross-type manifest test.

> Stacked on #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)