### PR TITLE
fix: scoping-entry actually reads the discovery session log

### DIFF
--- a/skills/workflow-scoping-entry/references/invoke-skill.md
+++ b/skills/workflow-scoping-entry/references/invoke-skill.md
@@ -10,11 +10,17 @@ This skill's purpose is now fulfilled. Construct the handoff and invoke the proc
 
 ## Handoff
 
-Read the durable carrier discovery left — the manifest `description` and the latest discovery session log (`.workflows/{work_unit}/discovery/session-NNN.md`, highest-numbered, when present) — to seed the scoping session:
+Read the durable carrier discovery left, to seed the scoping session. It has two halves — read **both**:
+
+1. The manifest `description`:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} description
 ```
+
+2. The latest discovery session log when one exists (`.workflows/{work_unit}/discovery/session-NNN.md`, highest-numbered) — read its **Exploration** so discovery's shaped context is in hand for scoping-process. A logless quick-fix (e.g. one created before phase-17) has none; scoping-process then gathers from scratch.
+
+Construct the handoff:
 
 ```
 Scoping session for: {topic}


### PR DESCRIPTION
## Summary
- The bridge's handoff promises every first-phase entry reads *"the discovery session log and the manifest description."* `research`/`discussion`/`investigation`-entry genuinely do (at their gather-context step). But `scoping-entry`'s `invoke-skill` only **mentioned** the log — the lone command read the manifest `description`, and the handoff carried only `Description:`. So for quick-fix, discovery's shaped **Exploration** was dropped and the bridge over-promised.
- Made the log read an explicit numbered step (read its Exploration when a log exists; guarded for logless / pre-phase-17 quick-fixes that gather from scratch), so the durable carrier is genuinely read and the bridge promise now holds for quick-fix too.

## Test plan
- New quick-fix shaped in discovery → bridge → scoping-entry: the latest `session-NNN.md` Exploration is read into context alongside the description before scoping-process runs.
- A logless quick-fix: the guard skips the log; scoping-process gathers from scratch (no error).

> Stacked on #323. This is the verified, localized form of review item C11 (the finding was wrong for research/discussion/investigation, right for scoping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)