### PR TITLE
fix: remove dead source branches in discussion-entry (research, gap-analysis)

### DIFF
--- a/skills/workflow-discussion-entry/references/invoke-skill.md
+++ b/skills/workflow-discussion-entry/references/invoke-skill.md
@@ -32,26 +32,6 @@ When the read returns non-empty, append the Description block shown in each sour
 
 ## Handoff
 
-#### If source is `research`
-
-```
-Discussion session for: {topic}
-Work unit: {work_unit}
-Output: {output_path}
-
-Research files:
-- .workflows/{work_unit}/research/{filename1}.md
-- .workflows/{work_unit}/research/{filename2}.md
-Topic context: {summary from analysis cache}
-
-Description:
-{description text — paragraph or two, preserved as-is}
-
-Invoke the workflow-discussion-process skill.
-```
-
-The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
-
 #### If source is `topic-provided-with-research`
 
 ```
@@ -63,26 +43,6 @@ Research files:
 - .workflows/{work_unit}/research/{filename1}.md
 - .workflows/{work_unit}/research/{filename2}.md
 Topic context: {brief orientation from user context}
-
-Description:
-{description text — paragraph or two, preserved as-is}
-
-Invoke the workflow-discussion-process skill.
-```
-
-The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
-
-#### If source is `gap-analysis`
-
-```
-Discussion session for: {topic}
-Work unit: {work_unit}
-Output: {output_path}
-
-Source discussions:
-- .workflows/{work_unit}/discussion/{discussion1}.md
-- .workflows/{work_unit}/discussion/{discussion2}.md
-Topic context: {summary from gap analysis cache}
 
 Description:
 {description text — paragraph or two, preserved as-is}


### PR DESCRIPTION
## Summary
- Same class as the C14 `source=import` dead branch. `discussion-entry` sets `source` only to `topic-provided` / `fresh` / `continue` / `topic-provided-with-research`. **Nothing sets `research` or `gap-analysis`** — those were pre-phase-17 provenances, now subsumed by `topic-provided` / `topic-provided-with-research`.
- So `invoke-skill.md`'s `#### If source is \`research\`` and `#### If source is \`gap-analysis\`` handoff branches were unreachable. Removed both.

## Test plan
- The remaining branches (`topic-provided-with-research`, `continue`, `fresh`/`topic-provided`) cover all four live `source` values; the "every source branch except continue reads the description" note still holds.
- The sibling-discussion context the `gap-analysis` branch listed is available to discussion-process via the knowledge base, not the handoff — nothing lost.

> Stacked on #324. Found via a follow-up dead-branch sweep prompted by C14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)