### PR TITLE
fix: drop dead can_start_discussion gating flag (continue-epic)

### DIFF
--- a/skills/continue-epic/scripts/discovery.cjs
+++ b/skills/continue-epic/scripts/discovery.cjs
@@ -113,7 +113,6 @@ function buildEpicDetail(cwd, manifest) {
     phases[phase] = phaseEntries;
   }
 
-  const researchItems = phaseItems(manifest, 'research');
   const discussionItems = phaseItems(manifest, 'discussion');
   const unaccountedDiscussions = [];
   for (const d of discussionItems) {
@@ -164,7 +163,6 @@ function buildEpicDetail(cwd, manifest) {
     }
   }
 
-  const hasCompletedResearch = researchItems.some(r => r.status === 'completed');
   const hasCompletedSpec = specItems.some(s => s.status === 'completed');
   const hasCompletedPlan = planItems.some(p => p.status === 'completed');
   const hasCompletedDiscussion = discussionItems.some(d => d.status === 'completed');
@@ -222,7 +220,6 @@ function buildEpicDetail(cwd, manifest) {
     imports_count: importsCount,
     analysis_caches: buildAnalysisCaches(cwd, manifest),
     gating: {
-      can_start_discussion: hasCompletedResearch,
       can_start_specification: hasCompletedDiscussion,
       can_start_planning: hasCompletedSpec,
       can_start_implementation: hasCompletedPlan,

--- a/tests/scripts/test-discovery-for-continue-epic.cjs
+++ b/tests/scripts/test-discovery-for-continue-epic.cjs
@@ -232,7 +232,6 @@ describe('continue-epic discovery', () => {
       });
       const r = discover(dir);
       const g = r.epics[0].detail.gating;
-      assert.strictEqual(g.can_start_discussion, true);
       assert.strictEqual(g.can_start_specification, true);
       assert.strictEqual(g.can_start_planning, true);
       assert.strictEqual(g.can_start_implementation, true);
@@ -249,7 +248,6 @@ describe('continue-epic discovery', () => {
       });
       const r = discover(dir);
       const g = r.epics[0].detail.gating;
-      assert.strictEqual(g.can_start_discussion, false);
       assert.strictEqual(g.can_start_specification, false);
       assert.strictEqual(g.can_start_planning, false);
     });
@@ -479,7 +477,6 @@ describe('continue-epic discovery', () => {
       createManifest(dir, 'v1', { work_type: 'epic' });
       const r = discover(dir);
       const g = r.epics[0].detail.gating;
-      assert.strictEqual(g.can_start_discussion, false);
       assert.strictEqual(g.can_start_specification, false);
       assert.strictEqual(g.can_start_planning, false);
       assert.strictEqual(g.can_start_implementation, false);


### PR DESCRIPTION
## Summary
- continue-epic's `discovery.cjs` emitted `gating.can_start_discussion` (`= hasCompletedResearch`), but **no skill consumes it** — `epic-display-and-menu` reads the four downstream siblings (`can_start_specification`/`planning`/`implementation`/`review`) but never `can_start_discussion`. Verified exhaustively: only the tests referenced it.
- Discussion availability is driven by the **discovery map's per-topic routing/lifecycle** now (the menu offers "Start discussion" from the map), not a research-gated flag — so this is superseded, not broken.
- Removed the dead chain: `can_start_discussion` + its sole feeder `hasCompletedResearch` + the now-unused `researchItems`.

## Test plan
- Dropped the three `can_start_discussion` assertions, keeping the live-sibling assertions in the same gating tests.
- `node --test tests/scripts/test-discovery-for-continue-epic.cjs` → **77/77 pass**.

> Stacked on #326. Found by extending the emitted-but-unconsumed sweep to continue-epic's `discovery.cjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)