### PR TITLE
Carry promoted inbox items through the pipeline as imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,8 @@ Work-unit-first directory structure with uniform `{topic}` in all paths (`{topic
 - State: `.workflows/{work_unit}/.state/` (per-work-unit analysis files)
 - Global state: `.workflows/.state/` (migrations, environment-setup.md)
 - Cache: `.workflows/.cache/{work_unit}/{phase}/{topic}/` (scratch files for any phase)
-- Imports: `.workflows/{work_unit}/imports/` (tracked via the `imports[]` manifest field; KB-indexed at copy time)
-- Inbox: `.workflows/.inbox/{ideas,bugs,quickfixes}/` (pre-pipeline capture; archived to `.archived/` subfolder when entering pipeline)
+- Imports: `.workflows/{work_unit}/imports/` (tracked via the `imports[]` manifest field; KB-indexed when landed — copied for user-shared files, moved for a promoted inbox seed)
+- Inbox: `.workflows/.inbox/{ideas,bugs,quickfixes}/` (pre-pipeline capture; on promotion the item is **moved** into the work unit's `imports/` — verbatim, KB-indexed, tracked in `imports[]` — so it travels through the pipeline like any import. The `.archived/` subfolder is reserved for *declined* items, not promoted ones)
 
 **Work unit lifecycle**: Each work unit has a `status` field in its manifest tracking lifecycle state:
 - `in-progress` — actively being worked on (default on creation)

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Revisit any completed phase before moving forward — refine a discussion, updat
 
 ### Inbox Capture
 
-Log ideas, bugs, and quick-fixes as you go — mid-conversation or from scratch. Say "log that as an idea" during any conversation, or invoke `/workflow-log-idea`, `/workflow-log-bug`, or `/workflow-log-quickfix` directly. Review recommendations can also be surfaced to the inbox from the verdict screen. Captured items land in `.inbox` as plain markdown files. When you're ready, `/workflow-start` shows your inbox and lets you promote items into the pipeline — pre-filling context and skipping the gather-context interview.
+Log ideas, bugs, and quick-fixes as you go — mid-conversation or from scratch. Say "log that as an idea" during any conversation, or invoke `/workflow-log-idea`, `/workflow-log-bug`, or `/workflow-log-quickfix` directly. Review recommendations can also be surfaced to the inbox from the verdict screen. Captured items land in `.inbox` as plain markdown files. When you're ready, `/workflow-start` shows your inbox and lets you promote items into the pipeline — pre-filling context and skipping the gather-context interview. The item itself isn't discarded once it's shaped: its verbatim content travels into the work unit as an import, so the exact repro, stack trace, or fully-worked idea you captured stays available to every downstream phase.
 
 ### Workflow Dashboard
 

--- a/skills/workflow-discovery/references/confirm-trigger.md
+++ b/skills/workflow-discovery/references/confirm-trigger.md
@@ -4,7 +4,7 @@
 
 ---
 
-The single persistence hinge. Until the work-type commit, all shaping is ephemeral — nothing is on disk. This reference fires once, at the commit, and persists the work unit for **every** work type: resolve the name → create it → land imports → archive the inbox seed → write the session log. Persistence is uniform except two epic-specific touches in **E** (the session log's *Map State at Start* wording and the active-session marker); routing by work type is deferred to **G**.
+The single persistence hinge. Until the work-type commit, all shaping is ephemeral — nothing is on disk. This reference fires once, at the commit, and persists the work unit for **every** work type: resolve the name → create it → land imports → land the inbox seed as an import → write the session log. Persistence is uniform except two epic-specific touches in **E** (the session log's *Map State at Start* wording and the active-session marker); routing by work type is deferred to **G**.
 
 Inputs held from earlier steps: committed `work_type`, shaped one-line `description`, `import_paths` (paths the user shared during shaping, may be empty), `inbox_seed` path (may be none).
 
@@ -44,28 +44,25 @@ The work unit already exists (defensive — should not occur after a clean name 
 
 The user shared reference files during shaping. Land them now — copied into `imports/`, tracked in `manifest.imports[]`, indexed into the knowledge base so they surface via retrieval in this and every future phase.
 
-→ Load **[import-files.md](import-files.md)** with work_unit = `{work_unit}`, import_paths = `{import_paths}`.
+→ Load **[import-files.md](import-files.md)** with work_unit = `{work_unit}`, import_paths = `{import_paths}`, mode = `copy`.
 
-→ Proceed to **D. Archive the Inbox Seed**.
+→ Proceed to **D. Land the Inbox Seed as an Import**.
 
 #### Otherwise
 
 No imports.
 
-→ Proceed to **D. Archive the Inbox Seed**.
+→ Proceed to **D. Land the Inbox Seed as an Import**.
 
-## D. Archive the Inbox Seed
+## D. Land the Inbox Seed as an Import
 
 #### If an inbox seed was the origin
 
-The seed is consumed — its substance has shaped the conversation (and is backfilled into the session log in **E**). Archive it (never delete, never copy into `imports/`). Match the folder to the seed's source (`bugs`, `quickfixes`, or `ideas`):
+The seed's substance shaped the conversation (and is backfilled into the session log in **E**), but its verbatim content — stack trace, exact repro, fully-worked idea — must persist for downstream phases too. Land it as a first-class import so it surfaces via knowledge-base retrieval in every later phase. **Move** it — the same item travels from the inbox into the work unit (not copied, not archived):
 
-```bash
-mkdir -p .workflows/.inbox/.archived/{folder}
-mv .workflows/.inbox/{folder}/{file} .workflows/.inbox/.archived/{folder}/{file}
-```
+→ Load **[import-files.md](import-files.md)** with work_unit = `{work_unit}`, import_paths = `{inbox_seed}`, mode = `move`.
 
-Archival fires at the same trigger as manifest creation — there is no window where a manifest exists but the inbox file is still pending.
+The move fires at the same trigger as manifest creation — there is no window where a manifest exists but the inbox file is still pending. (`.workflows/.inbox/.archived/` is reserved for items the user *declines*, not promoted ones.)
 
 → Proceed to **E. Write the Session Log**.
 
@@ -85,7 +82,7 @@ Ensure the directory exists and create the log from [template.md](template.md):
 mkdir -p .workflows/{work_unit}/discovery/
 ```
 
-Write `.workflows/{work_unit}/discovery/session-001.md` populating the header, **Description (as of session)** (the shaped `description`), **Imports** (the landed import paths, or `(none)`), and **Map State at Start** — `(empty — first session)` for epic, `(n/a — single-topic work)` for the single-phase types. Backfill **Exploration** with a strong-summary of the shaping conversation so far (the intent and any topic seeds — prose, not transcript). Leave **Edits**, **Topics Identified**, and **Conclusion** as `(none)`.
+Write `.workflows/{work_unit}/discovery/session-001.md` populating the header, **Description (as of session)** (the shaped `description`), **Imports** (every landed import path — the user-shared files from **C** and the promoted inbox seed from **D**, read authoritatively from `manifest.imports[]`; or `(none)`), and **Map State at Start** — `(empty — first session)` for epic, `(n/a — single-topic work)` for the single-phase types. Backfill **Exploration** with a strong-summary of the shaping conversation so far (the intent and any topic seeds — prose, not transcript). Leave **Edits**, **Topics Identified**, and **Conclusion** as `(none)`.
 
 This session log is the durable carrier: for single-phase types it (plus the manifest `description`) is what the first phase reads; for epic it seeds the topic synthesis. Do not KB-index it — it is shape-talk, not validated substance.
 
@@ -106,7 +103,7 @@ git add -- .workflows/{work_unit}/ .workflows/.inbox/
 git commit -m "discovery({work_unit}): create work unit ({work_type})"
 ```
 
-The `.workflows/.inbox/` path is staged so the inbox archival (if any) lands in the same commit.
+The `.workflows/.inbox/` path is staged so the inbox seed's removal (when one was promoted in **D**) lands in the same commit as its new home under `imports/`.
 
 → Proceed to **G. Route to the First Phase**.
 

--- a/skills/workflow-discovery/references/import-files.md
+++ b/skills/workflow-discovery/references/import-files.md
@@ -4,7 +4,7 @@
 
 ---
 
-Validate user-supplied import paths, normalise filenames, copy each file into `.workflows/{work_unit}/imports/`, push a manifest entry per file, and index each file into the knowledge base. Imports are seed material — they remain on disk for the work unit's life and surface in future sessions via knowledge-base retrieval.
+Validate import paths, normalise filenames, land each file into `.workflows/{work_unit}/imports/`, push a manifest entry per file, and index each file into the knowledge base. Imports are seed material — they remain on disk for the work unit's life and surface in future sessions via knowledge-base retrieval.
 
 ## Parameters
 
@@ -12,6 +12,7 @@ The caller provides these via context before loading:
 
 - `work_unit` — the work unit's name. Always present.
 - `import_paths` — list of file paths the user provided in the prior prompt. The list may be space- or newline-separated; the caller passes the parsed values.
+- `mode` — `copy` (default) or `move`. `copy` is for user-shared reference files, which stay where they are. `move` is for a promoted inbox seed: the source is the same item travelling into the work unit, so it is moved (the inbox copy is removed) rather than duplicated. When omitted, treat as `copy`.
 
 ## A. Validate Paths
 
@@ -53,13 +54,13 @@ For each validated path, derive a destination filename from its basename:
 4. Ensure the name ends with `.md`. If the original extension is missing or differs, append `.md`.
 5. Reject names that resolve to `.`, `..`, or begin with `.` (dotfile). Report the rejected source path and skip that file.
 
-If the normalised name collides with a file already under `.workflows/{work_unit}/imports/` **or** with a destination filename chosen earlier in this same batch, suffix the stem with `-2`, `-3`, … until the name is unique. The batch check matters when the user provides the same source path twice in one prompt — without it, the second entry would silently overwrite the first. (Re-importing the same source path across separate runs is also permitted — see **C. Copy and Track**.)
+If the normalised name collides with a file already under `.workflows/{work_unit}/imports/` **or** with a destination filename chosen earlier in this same batch, suffix the stem with `-2`, `-3`, … until the name is unique. The batch check matters when the user provides the same source path twice in one prompt — without it, the second entry would silently overwrite the first. (Re-importing the same source path across separate runs is also permitted — see **C. Land and Track**.)
 
 Hold the resulting `(source_path, destination_filename)` pairs for the next section.
 
-→ Proceed to **C. Copy and Track**.
+→ Proceed to **C. Land and Track**.
 
-## C. Copy and Track
+## C. Land and Track
 
 Ensure the imports directory exists:
 
@@ -67,22 +68,35 @@ Ensure the imports directory exists:
 mkdir -p .workflows/{work_unit}/imports/
 ```
 
-For each `(source_path, destination_filename)` pair, copy the file and push a manifest entry. Generate a fresh ISO 8601 UTC timestamp per file at copy time:
+For each `(source_path, destination_filename)` pair, land the file and push a manifest entry. Generate a fresh ISO 8601 UTC timestamp per file at land time.
+
+#### If `mode` is `move`
+
+The source is the promoted inbox seed — move it so the inbox copy is removed:
+
+```bash
+mv <source_path> .workflows/{work_unit}/imports/<destination_filename>
+node .claude/skills/workflow-manifest/scripts/manifest.cjs push {work_unit} imports '{"path":"imports/<destination_filename>","imported_at":"<iso>"}'
+```
+
+#### Otherwise (`mode` is `copy`)
+
+The source is a user-shared reference file — copy it so the original stays put:
 
 ```bash
 cp <source_path> .workflows/{work_unit}/imports/<destination_filename>
 node .claude/skills/workflow-manifest/scripts/manifest.cjs push {work_unit} imports '{"path":"imports/<destination_filename>","imported_at":"<iso>"}'
 ```
 
-Where `<iso>` is `date -u +%Y-%m-%dT%H:%M:%SZ` taken at copy time. One timestamp per file.
+Where `<iso>` is `date -u +%Y-%m-%dT%H:%M:%SZ` taken at land time. One timestamp per file.
 
-Re-importing a file that already exists at the destination path is allowed — the `cp` overwrites and the KB index call in **D** replaces existing chunks for that identity. The manifest gains a second `imports[]` entry; that minor duplication is acceptable.
+Re-importing a file that already exists at the destination path is allowed — the `cp`/`mv` overwrites and the KB index call in **D** replaces existing chunks for that identity. The manifest gains a second `imports[]` entry; that minor duplication is acceptable.
 
 → Proceed to **D. Index into KB**.
 
 ## D. Index into KB
 
-For each copied file, invoke the knowledge CLI:
+For each landed file, invoke the knowledge CLI:
 
 ```bash
 node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index .workflows/{work_unit}/imports/<destination_filename>

--- a/skills/workflow-discovery/references/opener-pattern.md
+++ b/skills/workflow-discovery/references/opener-pattern.md
@@ -26,7 +26,7 @@ No inbox seed. The opener invites the user to describe the work.
 
 ## B. Render the Opener
 
-Imports are **woven into the opener, never a standalone gate** — if the user has notes, design docs, error reports, or prior research, invite them to share the path(s) now; the no-files path costs zero extra turns. Any paths the user provides are read for shaping and held as `import_paths` for the confirm-trigger to land (imports are reference material, distinct from the inbox seed — never copy the inbox seed into `imports/`).
+Imports are **woven into the opener, never a standalone gate** — if the user has notes, design docs, error reports, or prior research, invite them to share the path(s) now; the no-files path costs zero extra turns. Any paths the user provides are read for shaping and held as `import_paths` for the confirm-trigger to land (these are *copied* — the user's originals stay put). The inbox seed, if any, is also landed as an import at the confirm-trigger, but *moved* rather than copied — see **[confirm-trigger.md](confirm-trigger.md)** section D.
 
 Render the opener matching what the caller told us.
 

--- a/tests/scripts/test-inbox-promotion.sh
+++ b/tests/scripts/test-inbox-promotion.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Inbox-promotion → import carry-through tests.
+#
+# When an inbox item (idea/bug/quick-fix logged via /workflow-log-*) is
+# promoted, discovery's confirm-trigger (section D) lands it as a first-class
+# import by MOVING .workflows/.inbox/{folder}/{file} into the work unit's
+# imports/, registering manifest.imports[], and KB-indexing it — so the
+# verbatim content travels through the pipeline and surfaces to every
+# downstream phase via the knowledge base.
+#
+# This test executes that documented promotion sequence against the real
+# manifest.cjs and knowledge.cjs CLIs and asserts the end state for every
+# inbox type (idea / bug / quick-fix) and a representative spread of resulting
+# work types (feature / epic / bugfix / quick-fix). It also runs the
+# downstream-surfacing path check — the same `knowledge query --work-unit`
+# that research/discussion/investigation/scoping perform — to confirm the
+# landed import is retrievable.
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUNDLE="$SCRIPT_DIR/../../skills/workflow-knowledge/scripts/knowledge.cjs"
+MANIFEST_JS="$SCRIPT_DIR/../../skills/workflow-manifest/scripts/manifest.cjs"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Isolate from the developer's real ~/.config/workflows/ so a real OpenAI
+# config can't leak in and break the stub-only knowledge calls.
+FAKE_HOME=$(mktemp -d)
+export HOME="$FAKE_HOME"
+trap 'rm -rf "$FAKE_HOME"' EXIT
+
+TEST_ROOT=""
+setup_project() {
+  TEST_ROOT=$(mktemp -d)
+  mkdir -p "$TEST_ROOT/.workflows/.knowledge"
+  cat > "$TEST_ROOT/.workflows/.knowledge/config.json" <<'CONF'
+{ "knowledge": { "provider": "stub", "dimensions": 128 } }
+CONF
+}
+
+teardown_project() {
+  [ -n "$TEST_ROOT" ] && rm -rf "$TEST_ROOT"
+  TEST_ROOT=""
+}
+
+# Normalise an inbox basename the way import-files.md section B does:
+# lowercase, non-[alnum.-] → '-', collapse repeated '-', ensure .md.
+# For the date-prefixed inbox names this collapses the '--' separator.
+normalise_filename() {
+  local base="$1"
+  base=$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')
+  base=$(printf '%s' "$base" | sed -E 's/[^a-z0-9.-]+/-/g; s/-+/-/g; s/^-+//; s/-+$//')
+  case "$base" in
+    *.md) ;;
+    *) base="${base}.md" ;;
+  esac
+  printf '%s' "$base"
+}
+
+# Perform the documented promotion (confirm-trigger D + import-files move mode)
+# for a single inbox item, then assert the full end state.
+#
+# Args: label folder work_type work_unit inbox_basename content query_term
+promote_and_assert() {
+  local label="$1" folder="$2" work_type="$3" work_unit="$4"
+  local basename="$5" content="$6" query_term="$7"
+
+  setup_project
+  cd "$TEST_ROOT"
+
+  # Arrange: a logged inbox item.
+  mkdir -p ".workflows/.inbox/$folder"
+  printf '%s\n' "$content" > ".workflows/.inbox/$folder/$basename"
+
+  # confirm-trigger A/B: name resolved + work unit created.
+  node "$MANIFEST_JS" init "$work_unit" --work-type "$work_type" \
+    --description "promoted from inbox" >/dev/null 2>&1
+
+  # confirm-trigger D → import-files (mode = move).
+  local dest
+  dest=$(normalise_filename "$basename")
+  mkdir -p ".workflows/$work_unit/imports/"
+  mv ".workflows/.inbox/$folder/$basename" ".workflows/$work_unit/imports/$dest"
+  node "$MANIFEST_JS" push "$work_unit" imports \
+    "{\"path\":\"imports/$dest\",\"imported_at\":\"2026-06-02T00:00:00Z\"}" >/dev/null 2>&1
+  node "$BUNDLE" index ".workflows/$work_unit/imports/$dest" >/dev/null 2>&1
+
+  # Assert: landed in imports/.
+  assert_eq "$label: file lands in imports/" "true" \
+    "$([ -f ".workflows/$work_unit/imports/$dest" ] && echo true || echo false)"
+
+  # Assert: removed from the inbox (moved, not copied).
+  assert_eq "$label: removed from .inbox/" "false" \
+    "$([ -f ".workflows/.inbox/$folder/$basename" ] && echo true || echo false)"
+
+  # Assert: NOT archived (.archived is reserved for declined items).
+  assert_eq "$label: not archived to .inbox/.archived/" "false" \
+    "$([ -e ".workflows/.inbox/.archived/$folder/$basename" ] && echo true || echo false)"
+
+  # Assert: registered in manifest.imports[].
+  local imports_json
+  imports_json=$(node "$MANIFEST_JS" get "$work_unit" imports 2>&1)
+  assert_eq "$label: manifest.imports[] has the entry" "true" \
+    "$(printf '%s' "$imports_json" | grep -qF "imports/$dest" && echo true || echo false)"
+
+  # Assert: KB-indexed and surfaces via a work-unit-scoped query — the
+  # downstream contextual-query path every consuming phase runs.
+  local query_out
+  query_out=$(node "$BUNDLE" query "$query_term" --work-unit "$work_unit" 2>&1)
+  assert_eq "$label: import surfaces via knowledge query" "false" \
+    "$(printf '%s' "$query_out" | grep -q '\[0 results\]' && echo true || echo false)"
+  assert_eq "$label: query result carries imports provenance" "true" \
+    "$(printf '%s' "$query_out" | grep -q "imports | $work_unit/" && echo true || echo false)"
+
+  teardown_project
+}
+
+echo "=== Inbox Promotion → Import Carry-Through ==="
+
+# --- bug → bugfix → investigation ---
+echo "Test: bug promoted to a bugfix"
+promote_and_assert "bug→bugfix" "bugs" "bugfix" "login-timeout" \
+  "2026-03-18--login-timeout.md" \
+  "# Login times out
+The auth callback throws RequestTimeoutError after 30s. Stack trace:
+  at refreshSession (auth/session.js:42)
+Repro: log in with an expired refresh token on a throttled connection." \
+  "RequestTimeoutError"
+
+# --- quick-fix → quick-fix → scoping ---
+echo "Test: quick-fix promoted to a quick-fix"
+promote_and_assert "quickfix→quick-fix" "quickfixes" "quick-fix" "replace-interface" \
+  "2026-03-28--replace-interface.md" \
+  "# Replace deprecated interface
+Global rename of LegacyClient to PlatformClient across the gateway module.
+Mechanical find-and-replace, no logic change." \
+  "PlatformClient"
+
+# --- idea → feature → research/discussion ---
+echo "Test: idea promoted to a feature"
+promote_and_assert "idea→feature" "ideas" "feature" "smart-retry" \
+  "2026-03-19--smart-retry.md" \
+  "# Smart retry backoff
+Idea: replace fixed retry delays with decorrelated jitter. Cap at 20s.
+Open question: how to surface retry budget exhaustion to the caller." \
+  "decorrelated"
+
+# --- idea → epic → topic curation then per-topic phases ---
+echo "Test: idea promoted to an epic"
+promote_and_assert "idea→epic" "ideas" "epic" "billing-overhaul" \
+  "2026-04-02--billing-overhaul.md" \
+  "# Billing overhaul
+Rework metering, invoicing, and dunning into one pipeline.
+Migrate legacy proration records without downtime." \
+  "dunning"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Why

When you log a bug/idea/quick-fix to the inbox and later promote it (`/workflow-start` → `i`/inbox → select), the item is a **deliberately-captured artifact** — its verbatim content (stack traces, exact repro, a fully-worked idea) matters.

Today that content was **degraded** on promotion: discovery's opener synthesised the inbox file into the carrier and the confirm-trigger `mv`'d the verbatim file to `.workflows/.inbox/.archived/`, where nothing read it again. Downstream phases got only discovery's summary.

This is a **phase-17 side-effect**, not truly pre-existing. Pre-phase-17 the `start-*` skills read the inbox file and invoked the processing skill in the **same context**, so the content was implicitly present. Phase-17's **bridge mode** (a context *clear*) severed that. This PR restores it properly: a promoted inbox item becomes a first-class **import** (verbatim, KB-indexed), surfacing to every downstream phase via the same machinery user-shared imports already use.

Stacks on #307 — targets `feat/phase-17-discovery-universal-entry` so it reviews as a clean diff on top and merges to main together.

## What changed

- **`confirm-trigger.md`** — section **D** "Archive the Inbox Seed" → **"Land the Inbox Seed as an Import"**. It now loads `import-files.md` with `mode=move`, moving `.workflows/.inbox/{folder}/{file}` into `imports/`, registering `manifest.imports[]`, and KB-indexing. Section **E** lists every landed import (user-shared + promoted seed) from `manifest.imports[]`; the commit comment reflects the move.
- **`import-files.md`** — new `mode` parameter (`copy` default for user-shared files / `move` for the promoted inbox seed). Normalisation, collision handling, KB index, and retry are preserved for both.
- **`opener-pattern.md`** — corrected the now-false "never copy the inbox seed into `imports/`" note.
- **`.archived/` is reserved for DECLINED items** — promoted items live on as imports. (An explicit decline→archived / recover flow is a deliberate follow-on, out of scope here.)
- **Docs** — `CLAUDE.md` + `README.md` inbox subsystem.

## Decisions carried from the plan

- **Move, don't copy** — the same item travels through the pipeline.
- **Uniform** across all three inbox types and every resulting work type.
- Reuse `import-files.md` adapted to move (vs `cp`).

## allowed-tools

No frontmatter change needed: discovery's existing `Bash(mv .workflows/.inbox/)` is a command-prefix match keyed on the source path (still `.workflows/.inbox/…`), so it already authorises the move into `imports/`.

## Tests

New `tests/scripts/test-inbox-promotion.sh` drives the real `manifest.cjs` + `knowledge.cjs` through the documented promotion sequence and asserts, **per inbox type (idea/bug/quick-fix) across feature/epic/bugfix/quick-fix resulting types**:

- file lands in `imports/`
- removed from `.inbox/` (moved, not copied)
- **not** archived to `.inbox/.archived/`
- registered in `manifest.imports[]`
- surfaces via `knowledge query --work-unit` with `imports` provenance — the same contextual-query downstream phases run

Full suite green (47 `.sh` + `.cjs` files).

## Deferred (open questions, off this plan)

1. Inbox/`.archived` management — explicit decline→archived and recover←archived actions.
2. Whether each first-phase entry should read work-unit imports **directly** into context vs relying on KB surfacing (esp. investigation reading the bug import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)