### PR TITLE
Make promoted imports reliably seed single-phase work (two-step retrieval)

### DIFF
--- a/skills/workflow-knowledge/references/contextual-query.md
+++ b/skills/workflow-knowledge/references/contextual-query.md
@@ -55,6 +55,8 @@ No prior context found. Proceed to the next step silently — no delay, no user 
 
 Read each chunk and weigh it against the current topic. For a chunk that looks load-bearing, read its source file (the `Source:` line) for full detail. Most results are context — one or two may be directly relevant.
 
+An **import** chunk (provenance `[imports | …]`) is different: it is raw seed the user captured for the work itself, not incidental prior context. When its `Source:` sits under *this* work unit's `imports/` and the work is single-topic (not an epic), the import is the work's own origin — **always read its full source file**, never leave it to a load-bearing judgement, and use it to seed this phase. For an epic, a broad work-unit import surfaces as the relevant slice per topic — read the full file only if the chunk points to more you need, so a wide seed doesn't swamp a narrow topic.
+
 Briefly acknowledge surfaced context to the user before the main session starts:
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/tests/scripts/test-inbox-promotion.sh
+++ b/tests/scripts/test-inbox-promotion.sh
@@ -12,9 +12,11 @@
 # manifest.cjs and knowledge.cjs CLIs and asserts the end state for every
 # inbox type (idea / bug / quick-fix) and a representative spread of resulting
 # work types (feature / epic / bugfix / quick-fix). It also runs the
-# downstream-surfacing path check — the same `knowledge query --work-unit`
-# that research/discussion/investigation/scoping perform — to confirm the
-# landed import is retrievable.
+# downstream-surfacing path check — a paraphrased, work-unit-boosted query
+# exactly like the contextual-query step every consuming phase
+# (research/discussion/investigation/scoping) runs — and confirms the result
+# carries a readable Source: path, so two-step retrieval can read the verbatim
+# import in full.
 
 set -eo pipefail
 
@@ -75,10 +77,10 @@ normalise_filename() {
 # Perform the documented promotion (confirm-trigger D + import-files move mode)
 # for a single inbox item, then assert the full end state.
 #
-# Args: label folder work_type work_unit inbox_basename content query_term
+# Args: label folder work_type work_unit inbox_basename content query_phrase
 promote_and_assert() {
   local label="$1" folder="$2" work_type="$3" work_unit="$4"
-  local basename="$5" content="$6" query_term="$7"
+  local basename="$5" content="$6" query_phrase="$7"
 
   setup_project
   cd "$TEST_ROOT"
@@ -118,14 +120,19 @@ promote_and_assert() {
   assert_eq "$label: manifest.imports[] has the entry" "true" \
     "$(printf '%s' "$imports_json" | grep -qF "imports/$dest" && echo true || echo false)"
 
-  # Assert: KB-indexed and surfaces via a work-unit-scoped query — the
-  # downstream contextual-query path every consuming phase runs.
+  # Assert: KB-indexed and surfaces via the SAME query the consuming phase
+  # runs — a paraphrased natural-language phrase (not lifted verbatim) with a
+  # work-unit BOOST (not a hard filter), exactly as contextual-query.md does.
   local query_out
-  query_out=$(node "$BUNDLE" query "$query_term" --work-unit "$work_unit" 2>&1)
-  assert_eq "$label: import surfaces via knowledge query" "false" \
+  query_out=$(node "$BUNDLE" query "$query_phrase" --boost:work-unit "$work_unit" 2>&1)
+  assert_eq "$label: import surfaces via contextual-style query" "false" \
     "$(printf '%s' "$query_out" | grep -q '\[0 results\]' && echo true || echo false)"
   assert_eq "$label: query result carries imports provenance" "true" \
     "$(printf '%s' "$query_out" | grep -q "imports | $work_unit/" && echo true || echo false)"
+  # Assert: the Source: line points at the import file, so two-step retrieval
+  # (read the source for full verbatim detail) can fire.
+  assert_eq "$label: result carries readable Source path for two-step read" "true" \
+    "$(printf '%s' "$query_out" | grep -q "Source: .workflows/$work_unit/imports/$dest" && echo true || echo false)"
 
   teardown_project
 }
@@ -140,7 +147,7 @@ promote_and_assert "bug→bugfix" "bugs" "bugfix" "login-timeout" \
 The auth callback throws RequestTimeoutError after 30s. Stack trace:
   at refreshSession (auth/session.js:42)
 Repro: log in with an expired refresh token on a throttled connection." \
-  "RequestTimeoutError"
+  "auth callback timeout when refreshing an expired session token"
 
 # --- quick-fix → quick-fix → scoping ---
 echo "Test: quick-fix promoted to a quick-fix"
@@ -149,7 +156,7 @@ promote_and_assert "quickfix→quick-fix" "quickfixes" "quick-fix" "replace-inte
   "# Replace deprecated interface
 Global rename of LegacyClient to PlatformClient across the gateway module.
 Mechanical find-and-replace, no logic change." \
-  "PlatformClient"
+  "rename the deprecated client interface in the gateway module"
 
 # --- idea → feature → research/discussion ---
 echo "Test: idea promoted to a feature"
@@ -158,7 +165,7 @@ promote_and_assert "idea→feature" "ideas" "feature" "smart-retry" \
   "# Smart retry backoff
 Idea: replace fixed retry delays with decorrelated jitter. Cap at 20s.
 Open question: how to surface retry budget exhaustion to the caller." \
-  "decorrelated"
+  "improve retry backoff delays with jitter"
 
 # --- idea → epic → topic curation then per-topic phases ---
 echo "Test: idea promoted to an epic"
@@ -167,7 +174,7 @@ promote_and_assert "idea→epic" "ideas" "epic" "billing-overhaul" \
   "# Billing overhaul
 Rework metering, invoicing, and dunning into one pipeline.
 Migrate legacy proration records without downtime." \
-  "dunning"
+  "rework the billing metering and invoicing pipeline"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Why

Stacked on #328. That PR made a promoted inbox item **durable** — moved into `imports/`, registered in `manifest.imports[]`, KB-indexed. This PR makes it reliably **reach the phase that consumes it**.

The original worry was "how can we be *sure* the import is used in processing?" The answer turned out to be: the machinery is already there, it just needed one reliability tightening — no forced direct-read, no KB strip, no migration.

## What was already in place (verified, not assumed)

- Every consuming processing skill — **research, discussion, investigation, scoping** — already runs the contextual-query step at phase start. (Investigation has it as Step 4; my earlier research mis-flagged it as missing.)
- `contextual-query.md` already documents **two-step retrieval**: query returns a snippet + a `Source:` file path, and Claude is told to read the full source file for load-bearing chunks.
- The import is KB-indexed (#328), so a work-unit-boosted query surfaces it — empirically, even a *paraphrased* query in keyword-only (BM25) mode returns the import as top hit with its `Source:` path. Early in a single-phase unit the import is the only content and the query is boosted toward it, so surfacing is robust regardless of provider.

## The one change

`contextual-query.md` §C — an **import** chunk is the work's own captured seed, not incidental prior context. When its `Source:` sits under *this* work unit's `imports/` and the work is single-topic (not an epic), **always read its full source file** to seed the phase, rather than leaving it to a "looks load-bearing" judgement.

Scoped deliberately: for an **epic**, a broad work-unit import surfaces as the relevant *slice* per topic — there it's read in full only if the chunk points to more, so a wide seed doesn't swamp a narrow topic. The epic per-topic noise concern stays solved.

## Design path (for reviewers)

We considered and rejected: (1) a forced direct-read codepath in each entry/process skill — adds special-casing and risks dumping a large import into context unconditionally; (2) stripping imports from the KB + a de-index migration — would have broken the epic case, where semantic retrieval surfacing the *relevant slice* is exactly the right mechanism. The uniform contextual-query + two-step path is the clean answer.

## Tests

`test-inbox-promotion.sh` surfacing assertion updated to mirror the real contextual query — a **paraphrased** natural-language phrase with **`--boost:work-unit`** (not a hard filter + verbatim term) — and to assert the `Source:` path is present so two-step can fire. 28/28 across all inbox types and resulting work types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)