### PR TITLE
fix(inbox): single-item tree, flag spacing, description indent

### DIFF
--- a/skills/workflow-start/references/inbox-working-set.md
+++ b/skills/workflow-start/references/inbox-working-set.md
@@ -15,12 +15,13 @@ For each item in the set, read its file and synthesise a short summary of what i
 ```
   Working Set ({count} item{s}) — actions apply to all of them
 @if(set is mixed)
+
   ⚑ Work is unavailable while the set mixes types — drop to a single
     type to enable it.
 @endif
 
 @foreach(item in working_set)
-  {branch} • {item.title} ({item.type})
+  {branch}• {item.title} ({item.type})
 @foreach(line in wrap(item.summary, 65))
   {gutter}{line}
 @endforeach
@@ -29,9 +30,10 @@ For each item in the set, read its file and synthesise a short summary of what i
 
 **Render rules:**
 
-- **Item row**: `{branch} • {item.title} ({item.type})`. `{branch}` is `┌─` for the first item, `└─` for the last, `├─` for the rest; with a single item use `└─`. The `•` is a fixed marker, not a status icon.
-- **Summary sub-lines**: hard-wrap at 65 characters, capped at **3 lines** — if it would run longer, truncate the third line with `…` (`v`/`view` shows the full text). Each line aligns under the title.
-  - **`{gutter}`**: non-last item → `│` then 4 spaces; last item → 7 spaces (no `│`). The `│` runs continuously through every sub-line of non-last items so the tree never breaks.
+- **Item row**: `{branch}• {item.title} ({item.type})`. `{branch}` is `┌─ ` for the first item, `└─ ` for the last, `├─ ` for the rest (trailing space included). **With a single item, `{branch}` is empty** — render `• {item.title}` with no connector; a lone `└─` would join nothing. The `•` is a fixed marker, not a status icon.
+- **Flag spacing**: the `⚑` block carries one blank line above and one below. The blank inside `@if` supplies the upper gap; the blank after `@endif` supplies the lower. When no flag renders, only the lower blank remains — the title-to-items gap stays a single line, never doubled.
+- **Summary sub-lines**: hard-wrap at 65 characters, capped at **3 lines** — if it would run longer, truncate the third line with `…` (`v`/`view` shows the full text). Each line is indented **two columns past the title text** so the description reads as subordinate, not aligned directly under the title.
+  - **`{gutter}`** (the template's 2-space lead precedes it): non-last item → `│` then 6 spaces; last item → 7 spaces (no `│`); single item → 4 spaces. The `│` sits under the branch character and runs continuously through every sub-line of non-last items so the tree never breaks.
 
 > *Output the next fenced block as markdown (not a code block):*
 


### PR DESCRIPTION
Three rendering fixes to the inbox working-set display.

- **Single item** → no tree connector. A lone `└─` joined nothing; the item now sits plainly under the header with just its `•` marker.
- **Flag spacing** → the `⚑` mixed-types flag now carries a blank line both above and below. When no flag renders, only the lower blank remains, so the title-to-items gap is never doubled.
- **Description indent** → summary sub-lines are indented two columns past the title text (gutters: non-last `│`+6, last 7 spaces, single 4 spaces) so they read as subordinate rather than aligning under the title.

Display-only; the menu, branch logic, and gutter spine are otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)