### PR TITLE
fix(permissions): grant workflow sub-agents write access to .workflows/

### DIFF
--- a/agents/workflow-review-task-verifier.md
+++ b/agents/workflow-review-task-verifier.md
@@ -63,6 +63,8 @@ Search the codebase:
 
 ### Step 4: Verify Tests
 
+You assess tests by **reading** them — you have no shell access and running tests is not your job. Do not attempt to execute the suite.
+
 Evaluate test coverage critically:
 - Is there a test for this task?
 - Does the test actually verify the acceptance criteria?
@@ -155,4 +157,5 @@ SUMMARY: {1 sentence}
 3. **Be specific** — include file paths and line numbers
 4. **Balanced test review** — flag both under-testing AND over-testing
 5. **Report findings** — don't fix anything, just report what you find
+6. **No test execution** — you have no shell. Judge test adequacy by reading the test code; never try to run the suite
 6. **No git writes** — writing the output file is your only file write

--- a/skills/workflow-migrate/scripts/migrations/042-allow-workflows-writes.sh
+++ b/skills/workflow-migrate/scripts/migrations/042-allow-workflows-writes.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Migration 042: Allow workflow sub-agents to write under .workflows/
+#
+# Parallel-dispatched sub-agents (analysis trio, review verifiers, discussion
+# perspectives, spec review) run as background sub-agents that cannot surface
+# permission prompts — any Write/Edit that would prompt is auto-denied, so they
+# fail to persist their artifact files. A path-scoped allow-rule resolves before
+# that auto-deny, letting them write to the workflow tree without a prompt.
+#
+# Idempotent: skips when both rules already present.
+#
+
+SETTINGS_DIR="${PROJECT_DIR:-.}/.claude"
+SETTINGS_FILE="$SETTINGS_DIR/settings.json"
+
+if [ -f "$SETTINGS_FILE" ] && node -e "
+  const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+  const allow = (s.permissions && s.permissions.allow) || [];
+  const need = ['Write(.workflows/**)', 'Edit(.workflows/**)'];
+  process.exit(need.every(r => allow.includes(r)) ? 0 : 1);
+" "$SETTINGS_FILE" 2>/dev/null; then
+  return 0
+fi
+
+mkdir -p "$SETTINGS_DIR"
+[ -f "$SETTINGS_FILE" ] || echo '{}' > "$SETTINGS_FILE"
+
+node -e "
+  const fs = require('fs');
+  const settings = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+  settings.permissions = settings.permissions || {};
+  settings.permissions.allow = settings.permissions.allow || [];
+  for (const rule of ['Write(.workflows/**)', 'Edit(.workflows/**)']) {
+    if (!settings.permissions.allow.includes(rule)) settings.permissions.allow.push(rule);
+  }
+  fs.writeFileSync(process.argv[1], JSON.stringify(settings, null, 2) + '\n');
+" "$SETTINGS_FILE"
+
+report_update

--- a/tests/scripts/test-migration-042.sh
+++ b/tests/scripts/test-migration-042.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+#
+# Tests for migration 042: allow-workflows-writes
+#
+# Run: bash tests/scripts/test-migration-042.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/042-allow-workflows-writes.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+# Read permissions.allow as a sorted JSON array (order-independent comparison).
+read_allow() {
+  node -e "const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')); console.log(JSON.stringify(((s.permissions && s.permissions.allow) || []).slice().sort()))" "$1"
+}
+
+# Count occurrences of a rule in permissions.allow.
+count_rule() {
+  node -e "const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')); const a = (s.permissions && s.permissions.allow) || []; console.log(a.filter(r => r === process.argv[2]).length)" "$1" "$2"
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-042-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Test 1: Creates settings.json from scratch with both rules ---
+test_no_settings_file() {
+  setup
+
+  source "$MIGRATION"
+
+  assert_eq "file created" "true" "$([ -f "$TEST_DIR/.claude/settings.json" ] && echo true || echo false)"
+  assert_eq "both rules present" '["Edit(.workflows/**)","Write(.workflows/**)"]' "$(read_allow "$TEST_DIR/.claude/settings.json")"
+
+  teardown
+}
+
+# --- Test 2: Merges into existing settings, preserving other content ---
+test_existing_settings_preserved() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "showClearContextOnPlanAccept": true,
+  "permissions": {
+    "allow": ["Bash(git status:*)"]
+  }
+}
+EOF
+
+  source "$MIGRATION"
+
+  assert_eq "rules merged with existing allow" '["Bash(git status:*)","Edit(.workflows/**)","Write(.workflows/**)"]' "$(read_allow "$TEST_DIR/.claude/settings.json")"
+
+  local other
+  other=$(node -e "const s = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')); console.log(s.showClearContextOnPlanAccept)" "$TEST_DIR/.claude/settings.json")
+  assert_eq "unrelated setting preserved" "true" "$other"
+
+  teardown
+}
+
+# --- Test 3: Skips (no rewrite) when both rules already present ---
+test_already_present_skips() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "permissions": {
+    "allow": ["Write(.workflows/**)", "Edit(.workflows/**)"]
+  }
+}
+EOF
+
+  local mtime_before
+  mtime_before=$(stat --format="%Y" "$TEST_DIR/.claude/settings.json" 2>/dev/null || stat -f "%m" "$TEST_DIR/.claude/settings.json")
+
+  source "$MIGRATION"
+
+  local mtime_after
+  mtime_after=$(stat --format="%Y" "$TEST_DIR/.claude/settings.json" 2>/dev/null || stat -f "%m" "$TEST_DIR/.claude/settings.json")
+  assert_eq "file not modified" "$mtime_before" "$mtime_after"
+
+  teardown
+}
+
+# --- Test 4: Adds only the missing rule when one is already present ---
+test_partial_present() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  cat > "$TEST_DIR/.claude/settings.json" <<'EOF'
+{
+  "permissions": {
+    "allow": ["Write(.workflows/**)"]
+  }
+}
+EOF
+
+  source "$MIGRATION"
+
+  assert_eq "missing rule added" '["Edit(.workflows/**)","Write(.workflows/**)"]' "$(read_allow "$TEST_DIR/.claude/settings.json")"
+  assert_eq "existing rule not duplicated" "1" "$(count_rule "$TEST_DIR/.claude/settings.json" 'Write(.workflows/**)')"
+
+  teardown
+}
+
+# --- Test 5: Idempotent — running twice yields no duplicates ---
+test_idempotent() {
+  setup
+
+  source "$MIGRATION"
+  source "$MIGRATION"
+
+  assert_eq "Write not duplicated" "1" "$(count_rule "$TEST_DIR/.claude/settings.json" 'Write(.workflows/**)')"
+  assert_eq "Edit not duplicated" "1" "$(count_rule "$TEST_DIR/.claude/settings.json" 'Edit(.workflows/**)')"
+
+  teardown
+}
+
+# --- Test 6: Creates .claude directory if missing ---
+test_no_claude_dir() {
+  setup
+
+  source "$MIGRATION"
+
+  assert_eq ".claude dir created" "true" "$([ -d "$TEST_DIR/.claude" ] && echo true || echo false)"
+  assert_eq "file created" "true" "$([ -f "$TEST_DIR/.claude/settings.json" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 042 tests..."
+echo ""
+
+test_no_settings_file
+test_existing_settings_preserved
+test_already_present_skips
+test_partial_present
+test_idempotent
+test_no_claude_dir
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

- Parallel-dispatched sub-agents (analysis trio, review verifiers, discussion perspectives, spec review) run as **background** sub-agents that cannot surface permission prompts — their `Write`/`Edit` to the workflow tree was auto-denied, so they couldn't persist their artifact files.
- **Migration 042** adds path-scoped `Write(.workflows/**)` and `Edit(.workflows/**)` allow-rules to the consumer project's `.claude/settings.json`. Allow-rules resolve **before** the background auto-deny, so this fixes the issue in every permission mode (auto included). Idempotent, preserves existing settings, creates `.claude/` + file if missing; runs automatically at `/workflow-start` Step 0.
- **Review task-verifier** is now told it has no shell and must not attempt to run the suite — it judges test adequacy by reading, so it stops trying-and-failing. Test execution stays in the foreground orchestrator where it already lives.

## Test plan

- `bash tests/scripts/test-migration-042.sh` — 11 assertions, all passing: fresh-create, merge-with-preservation of unrelated settings + existing allow entries, skip-when-present (mtime unchanged), partial-present (adds only the missing rule, no dup), idempotency (double-run, no dupes), `.claude` dir creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)