### PR TITLE
fix(entry): seed epic map topics without re-asking context

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -142,6 +142,12 @@ Single-phase work shaped in discovery. Read the durable carrier as the seed — 
 
 → Proceed to **Step 4**.
 
+#### If `work_type` is `epic` and the discovery-map item carries a `summary` or `description`
+
+The topic was shaped on the discovery map. Read the durable carrier as the seed — the `summary` and `description` on the map item (`{work_unit}.discovery.{topic}`) — and seed the discussion from it. Do not re-ask; live conversation context, when present, supplements the carrier.
+
+→ Proceed to **Step 4**.
+
 #### If discussion context is already available in conversation
 
 The caller already gathered context (problem description, motivation, constraints). Do not re-ask.

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -142,12 +142,6 @@ Single-phase work shaped in discovery. Read the durable carrier as the seed — 
 
 → Proceed to **Step 4**.
 
-#### If discussion context is already available in conversation
-
-The caller already gathered context (problem description, motivation, constraints). Do not re-ask.
-
-→ Proceed to **Step 4**.
-
 #### If `work_type` is `epic`
 
 The topic was shaped on the discovery map; its seed lives on the map item. Read it:

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -136,9 +136,27 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > Collecting the context needed before starting the discussion.
 ```
 
-#### If `work_type` is not `epic` and a discovery session log exists for this work unit
+#### If `work_type` is not `epic`
 
-Single-phase work shaped in discovery. Read the durable carrier as the seed — the manifest `description` and the latest discovery session log (`.workflows/{work_unit}/discovery/session-NNN.md`, highest-numbered) — and seed the discussion from it. Do not re-ask; live conversation context, when present, supplements the carrier.
+Single-phase work (feature, cross-cutting) shaped in discovery. The carrier has two halves — read both. First the manifest `description`:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} description
+```
+
+Then the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/session-001.md` (a not-found result means a legacy work unit with no log).
+
+**If the session log exists:**
+
+Seed the discussion from the `description` and the log's **Exploration**. Do not re-ask; live conversation context, when present, supplements the carrier.
+
+→ Proceed to **Step 4**.
+
+**Otherwise:**
+
+Legacy work unit with no discovery session log — gather context.
+
+Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
 
@@ -167,12 +185,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.disco
 ```
 
 Do not re-ask; live conversation context, when present, supplements the carrier.
-
-→ Proceed to **Step 4**.
-
-#### Otherwise
-
-Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
 

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -144,17 +144,17 @@ Single-phase work (feature, cross-cutting) shaped in discovery. The carrier has 
 node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} description
 ```
 
-Then the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/session-001.md` (a not-found result means a legacy work unit with no log).
+Then the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/session-001.md`. A legacy work unit may have no log, or a placeholder log whose **Exploration** is absent or `(none)`.
 
-**If the session log exists:**
+**If the log's `Exploration` section has content (not absent or `(none)`):**
 
-Seed the discussion from the `description` and the log's **Exploration**. Do not re-ask; live conversation context, when present, supplements the carrier.
+Seed the discussion from the `description` and that **Exploration**. Do not re-ask; live conversation context, when present, supplements the carrier.
 
 → Proceed to **Step 4**.
 
 **Otherwise:**
 
-Legacy work unit with no discovery session log — gather context.
+No usable carrier — the log is missing or has no **Exploration**. Gather context.
 
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -144,19 +144,29 @@ Single-phase work shaped in discovery. Read the durable carrier as the seed — 
 
 #### If `work_type` is `epic`
 
-The topic was shaped on the discovery map; its seed lives on the map item. Read it:
+The map item's `source` says whether the topic was shaped on the discovery map or started fresh from this entry. Read it:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} source
 ```
 
-**If the `summary` or `description` field holds content:** seed the discussion from them. Do not re-ask; live conversation context, when present, supplements them.
+**If `source` is exactly `direct-start`:**
+
+The topic was started fresh, not shaped on the map — there is no curated carrier to seed from.
+
+Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
 
-**If both are empty or absent:** the map item has no seed material — gather it.
+**Otherwise:**
 
-Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
+The topic was shaped on the discovery map — its seed lives on the map item. Read the `description` and seed the discussion from it:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} description
+```
+
+Do not re-ask; live conversation context, when present, supplements the carrier.
 
 → Proceed to **Step 4**.
 

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -142,15 +142,27 @@ Single-phase work shaped in discovery. Read the durable carrier as the seed — 
 
 → Proceed to **Step 4**.
 
-#### If `work_type` is `epic` and the discovery-map item carries a `summary` or `description`
-
-The topic was shaped on the discovery map. Read the durable carrier as the seed — the `summary` and `description` on the map item (`{work_unit}.discovery.{topic}`) — and seed the discussion from it. Do not re-ask; live conversation context, when present, supplements the carrier.
-
-→ Proceed to **Step 4**.
-
 #### If discussion context is already available in conversation
 
 The caller already gathered context (problem description, motivation, constraints). Do not re-ask.
+
+→ Proceed to **Step 4**.
+
+#### If `work_type` is `epic`
+
+The topic was shaped on the discovery map; its seed lives on the map item. Read it:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic}
+```
+
+**If the `summary` or `description` field holds content:** seed the discussion from them. Do not re-ask; live conversation context, when present, supplements them.
+
+→ Proceed to **Step 4**.
+
+**If both are empty or absent:** the map item has no seed material — gather it.
+
+Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 4**.
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -160,12 +160,6 @@ Single-phase work shaped in discovery. Read the durable carrier as the seed — 
 
 → Proceed to **Step 5**.
 
-#### If research context is already available in conversation
-
-The caller already gathered context (idea description, motivation, constraints). Do not re-ask.
-
-→ Proceed to **Step 5**.
-
 #### If `work_type` is `epic`
 
 The topic was shaped on the discovery map; its seed lives on the map item. Read it:

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -162,19 +162,29 @@ Single-phase work shaped in discovery. Read the durable carrier as the seed — 
 
 #### If `work_type` is `epic`
 
-The topic was shaped on the discovery map; its seed lives on the map item. Read it:
+The map item's `source` says whether the topic was shaped on the discovery map or started fresh from this entry. Read it:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} source
 ```
 
-**If the `summary` or `description` field holds content:** seed the research session from them. Do not re-ask; live conversation context, when present, supplements them.
+**If `source` is exactly `direct-start`:**
+
+The topic was started fresh, not shaped on the map — there is no curated carrier to seed from.
+
+Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
 
-**If both are empty or absent:** the map item has no seed material — gather it.
+**Otherwise:**
 
-Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
+The topic was shaped on the discovery map — its seed lives on the map item. Read the `description` and seed the research session from it:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} description
+```
+
+Do not re-ask; live conversation context, when present, supplements the carrier.
 
 → Proceed to **Step 5**.
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -160,6 +160,12 @@ Single-phase work shaped in discovery. Read the durable carrier as the seed — 
 
 → Proceed to **Step 5**.
 
+#### If `work_type` is `epic` and the discovery-map item carries a `summary` or `description`
+
+The topic was shaped on the discovery map. Read the durable carrier as the seed — the `summary` and `description` on the map item (`{work_unit}.discovery.{topic}`) — and seed the research session from it. Do not re-ask; live conversation context, when present, supplements the carrier.
+
+→ Proceed to **Step 5**.
+
 #### If research context is already available in conversation
 
 The caller already gathered context (idea description, motivation, constraints). Do not re-ask.

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -162,17 +162,17 @@ Single-phase work (feature, cross-cutting) shaped in discovery. The carrier has 
 node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} description
 ```
 
-Then the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/session-001.md` (a not-found result means a legacy work unit with no log).
+Then the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/session-001.md`. A legacy work unit may have no log, or a placeholder log whose **Exploration** is absent or `(none)`.
 
-**If the session log exists:**
+**If the log's `Exploration` section has content (not absent or `(none)`):**
 
-Seed the research session from the `description` and the log's **Exploration**. Do not re-ask; live conversation context, when present, supplements the carrier.
+Seed the research session from the `description` and that **Exploration**. Do not re-ask; live conversation context, when present, supplements the carrier.
 
 → Proceed to **Step 5**.
 
 **Otherwise:**
 
-Legacy work unit with no discovery session log — gather context.
+No usable carrier — the log is missing or has no **Exploration**. Gather context.
 
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -160,15 +160,27 @@ Single-phase work shaped in discovery. Read the durable carrier as the seed — 
 
 → Proceed to **Step 5**.
 
-#### If `work_type` is `epic` and the discovery-map item carries a `summary` or `description`
-
-The topic was shaped on the discovery map. Read the durable carrier as the seed — the `summary` and `description` on the map item (`{work_unit}.discovery.{topic}`) — and seed the research session from it. Do not re-ask; live conversation context, when present, supplements the carrier.
-
-→ Proceed to **Step 5**.
-
 #### If research context is already available in conversation
 
 The caller already gathered context (idea description, motivation, constraints). Do not re-ask.
+
+→ Proceed to **Step 5**.
+
+#### If `work_type` is `epic`
+
+The topic was shaped on the discovery map; its seed lives on the map item. Read it:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic}
+```
+
+**If the `summary` or `description` field holds content:** seed the research session from them. Do not re-ask; live conversation context, when present, supplements them.
+
+→ Proceed to **Step 5**.
+
+**If both are empty or absent:** the map item has no seed material — gather it.
+
+Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -154,9 +154,27 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 > Collecting initial context to seed the research session.
 ```
 
-#### If `work_type` is not `epic` and a discovery session log exists for this work unit
+#### If `work_type` is not `epic`
 
-Single-phase work shaped in discovery. Read the durable carrier as the seed — the manifest `description` and the latest discovery session log (`.workflows/{work_unit}/discovery/session-NNN.md`, highest-numbered) — and seed the research session from it. Do not re-ask; live conversation context, when present, supplements the carrier.
+Single-phase work (feature, cross-cutting) shaped in discovery. The carrier has two halves — read both. First the manifest `description`:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} description
+```
+
+Then the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/session-001.md` (a not-found result means a legacy work unit with no log).
+
+**If the session log exists:**
+
+Seed the research session from the `description` and the log's **Exploration**. Do not re-ask; live conversation context, when present, supplements the carrier.
+
+→ Proceed to **Step 5**.
+
+**Otherwise:**
+
+Legacy work unit with no discovery session log — gather context.
+
+Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
 
@@ -185,12 +203,6 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.disco
 ```
 
 Do not re-ask; live conversation context, when present, supplements the carrier.
-
-→ Proceed to **Step 5**.
-
-#### Otherwise
-
-Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
 → Proceed to **Step 5**.
 


### PR DESCRIPTION
## Problem

Picking an epic topic off the discovery map and routing it into **research** (or **discussion**) re-asked the cold-start context questions ("What's on your mind?…"), even though the topic's seed — `summary`/`description` — was already established on the discovery-map item.

## Root cause

The **Gather Context** guard in `workflow-research-entry` (Step 4) and `workflow-discussion-entry` (Step 3) had three branches:

1. `work_type is not epic` and a discovery session log exists → seed from carrier
2. context already in conversation → skip
3. **Otherwise** → ask the cold-start questions

Branch 1 explicitly excludes epics (their per-topic seed lives on the map item, not the session log). No branch covered the epic case, so epic-from-map fell through to branch 3 and re-asked. Features never hit this — their seed is the session log, caught by branch 1.

The smoking gun: `invoke-skill.md` already reads the map item's `description` at handoff for epics — so the questions were redundant with context the skill then fetches anyway.

## Fix

Add an epic carrier branch to both entry skills:

> **If `work_type` is `epic` and the discovery-map item carries a `summary` or `description`** → seed from the map item, don't re-ask.

Mirrors the existing feature carrier branch. Cold-start questions remain for genuine direct-entry (no topic, no carrier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)