### PR TITLE
feat(discovery): suggested execution order for epic topic map

### DIFF
--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -30,13 +30,13 @@ On return, `new_arrivals` is populated — section E reads it to render the call
 
 ## C. Sequence Map
 
-A new topic may have arrived without a suggested execution order — from section B's analyses, or from a prior edit. Read `needs_sequencing` from the `detail` object parsed in A.
+A new topic may have arrived without a suggested execution order — from section B's analyses, or from a prior edit. Read `needs_sequencing` from the most recent discovery `detail` (section B re-runs discovery when its analyses add topics, so it may be newer than A's).
 
 #### If `needs_sequencing` is true
 
-Load **[sequence-discovery-map.md](../../workflow-shared/references/sequence-discovery-map.md)** with work_unit = `{work_unit}`.
+→ Load **[sequence-discovery-map.md](../../workflow-shared/references/sequence-discovery-map.md)** with work_unit = `{work_unit}`.
 
-Then re-run discovery so section E sees the new order:
+On return, re-run discovery so section E sees the new order:
 
 ```bash
 node .claude/skills/workflow-continue-epic/scripts/discovery.cjs {work_unit}

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -24,11 +24,35 @@ Parse the output. Use the epic's `detail` object as the discovery data for the d
 
 A research or discussion conclusion may have changed source files since the last analysis. Read `analysis_caches` from the `detail` object parsed in A, then load **[topic-discovery-dispatch.md](../../workflow-shared/references/topic-discovery-dispatch.md)** with work_unit = `{work_unit}`, analysis_caches = `{analysis_caches}`.
 
-On return, `new_arrivals` is populated — section D reads it to render the callout above the discovery map.
+On return, `new_arrivals` is populated — section E reads it to render the callout above the discovery map.
 
-→ Proceed to **C. Check All-Done**.
+→ Proceed to **C. Sequence Map**.
 
-## C. Check All-Done
+## C. Sequence Map
+
+A new topic may have arrived without a suggested execution order — from section B's analyses, or from a prior edit. Read `needs_sequencing` from the `detail` object parsed in A.
+
+#### If `needs_sequencing` is true
+
+Load **[sequence-discovery-map.md](../../workflow-shared/references/sequence-discovery-map.md)** with work_unit = `{work_unit}`.
+
+Then re-run discovery so section E sees the new order:
+
+```bash
+node .claude/skills/workflow-continue-epic/scripts/discovery.cjs {work_unit}
+```
+
+Use the refreshed `detail` object for the remaining sections.
+
+→ Proceed to **D. Check All-Done**.
+
+#### Otherwise
+
+The map is already sequenced.
+
+→ Proceed to **D. Check All-Done**.
+
+## D. Check All-Done
 
 Using the enriched discovery data from section A, check if ALL topics across ALL phases have review status `completed`. Specifically: check if any review items exist, and if so, whether every one has `status: completed`, and no topics in earlier phases are still `in-progress`.
 
@@ -71,13 +95,13 @@ Epic Completed
 
 **If user chose `n`/`no`:**
 
-→ Proceed to **D. Display and Menu**.
+→ Proceed to **E. Display and Menu**.
 
 #### Otherwise
 
-→ Proceed to **D. Display and Menu**.
+→ Proceed to **E. Display and Menu**.
 
-## D. Display and Menu
+## E. Display and Menu
 
 > *Output the next fenced block as a code block:*
 
@@ -89,11 +113,11 @@ Epic Completed
 
 > **CHECKPOINT**: Do not proceed until the above has returned with the user's selection.
 
-→ Proceed to **E. Enter Plan Mode**.
+→ Proceed to **F. Enter Plan Mode**.
 
 ---
 
-## E. Enter Plan Mode
+## F. Enter Plan Mode
 
 Map the selection to a skill invocation using this routing table:
 

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -220,13 +220,49 @@ backfill-checks is terminal when it fires — it commits the recovery work and s
 
 Read `analysis_caches` from the most recent discovery `detail`. Load **[topic-discovery-dispatch.md](../workflow-shared/references/topic-discovery-dispatch.md)** with work_unit = `{work_unit}`, analysis_caches = `{analysis_caches}`.
 
-On return, `new_arrivals` is populated for Step 7 to render the callout.
+On return, `new_arrivals` is populated for Step 8 to render the callout.
 
 → Proceed to **Step 7**.
 
 ---
 
-## Step 7: Display State and Menu
+## Step 7: Sequence Map
+
+> *Output the next fenced block as a code block:*
+
+```
+── Sequence Map ─────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Assigning a suggested execution order to the discovery map's topics.
+```
+
+Read `needs_sequencing` from the most recent discovery `detail`.
+
+#### If `needs_sequencing` is true
+
+Load **[sequence-discovery-map.md](../workflow-shared/references/sequence-discovery-map.md)** with work_unit = `{work_unit}`.
+
+Then re-run discovery so the display sees the new order:
+
+```bash
+node .claude/skills/workflow-continue-epic/scripts/discovery.cjs {work_unit}
+```
+
+→ Proceed to **Step 8**.
+
+#### Otherwise
+
+The map is already sequenced.
+
+→ Proceed to **Step 8**.
+
+---
+
+## Step 8: Display State and Menu
 
 > *Output the next fenced block as a code block:*
 
@@ -242,11 +278,11 @@ On return, `new_arrivals` is populated for Step 7 to render the callout.
 
 Load **[epic-display-and-menu.md](references/epic-display-and-menu.md)** with new_arrivals = `{new_arrivals}`.
 
-→ Proceed to **Step 8**.
+→ Proceed to **Step 9**.
 
 ---
 
-## Step 8: Route Selection
+## Step 9: Route Selection
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -246,7 +246,7 @@ Read `needs_sequencing` from the most recent discovery `detail`.
 
 Load **[sequence-discovery-map.md](../workflow-shared/references/sequence-discovery-map.md)** with work_unit = `{work_unit}`.
 
-Then re-run discovery so the display sees the new order:
+On return, re-run discovery so the display sees the new order:
 
 ```bash
 node .claude/skills/workflow-continue-epic/scripts/discovery.cjs {work_unit}

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -712,7 +712,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{phas
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{phase}.{topic} status cancelled
 ```
 
-Drop the topic's suggested execution order so a later reactivation has no stale number — the map will renumber it cleanly on the next render:
+Drop the topic's discovery-map order so reactivation renumbers it cleanly:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{topic} order

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -101,7 +101,7 @@ Render the discovery map block at the top, then the build-phase tree (specificat
 - **Imports callout** (`{show_imports_callout}`): true only when `imports_count > 0` **and** `imports_count != discovery_map.length`. When every topic is itself an import, per-row provenance already says so on every line and the callout is redundant. Format when shown: `· {imports_count} import` for 1, `· {imports_count} imports` for 2+.
 - **Convergence callout**: rendered after the optional seed and imports callouts, before the topic rows. Always present. `⚑ Discovery in progress — {N} topics not yet decided.` when `convergence_state == 'in-progress'` (where N excludes cancelled). `✓ Discovery settled — ready for specification.` when `convergence_state == 'settled'`.
 - **New-arrivals callout** (optional): when the caller passes a non-empty `new_arrivals.research_analysis` or `new_arrivals.gap_analysis` list, render `⚑ {N} new topic(s) added to the map from {analysis}.` lines beneath the convergence callout, one per analysis with arrivals. Shown once per boot-up that added items — subsequent invocations without changes don't repeat it (the items are now part of the map). Sub-line provenance on the topic rows is the persistent surface afterwards.
-- **Tier ordering and sort**: rows are pre-sorted by the discovery script (tier rank `→ ◐ ✓ ○ ⊘`, then alphabetical within each tier). Render in the order given.
+- **Tier ordering and sort**: rows are pre-sorted by the discovery script (tier rank `→ ◐ ✓ ○ ⊘`, then suggested execution order within each tier). Render in the order given.
 - **Topic row**: `{branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]`. Single space between each segment. Lifecycle label wrapped in square brackets.
   - `{branch}`: `┌─` for the first row, `└─` for the last, `├─` for the rest. With a single row, use `└─` (no upward stroke).
 - **Lifecycle label** by tier:
@@ -295,7 +295,7 @@ Build a menu with two types of options:
    | `continue_discussion`             | `Continue "{topic:(titlecase)}" — discussion`                    |
    | `start_discussion_after_research` | `Start discussion for "{topic:(titlecase)}" — research completed`|
 
-   Discovery-topic order matches the `discovery_map` row order: tier `→`, then `◐`, then `○` (alphabetical within each tier).
+   Discovery-topic order matches the `discovery_map` row order: tier `→`, then `◐`, then `○` (suggested execution order within each tier).
 
 2. **Build-phase entries** — from `next_phase_ready` and any in-progress items in `phases.specification`/`planning`/`implementation`/`review`:
    - In-progress in build phases:
@@ -710,6 +710,12 @@ Run two manifest CLI calls to set cancelled status and preserve previous status:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{phase}.{topic} previous_status {current_status}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{phase}.{topic} status cancelled
+```
+
+Drop the topic's suggested execution order so a later reactivation has no stale number — the map will renumber it cleanly on the next render:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{topic} order
 ```
 
 Remove the cancelled topic's chunks from the knowledge base:

--- a/skills/workflow-continue-epic/scripts/discovery.cjs
+++ b/skills/workflow-continue-epic/scripts/discovery.cjs
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { loadActiveManifests, loadAllManifests, loadManifest, phaseItems, phaseData, computeTopicLifecycle, computeNextAction, computeMapSummary, computeSourceProvenance, computeAnalysisCacheStatus, TIER_RANK } = require('../../workflow-shared/scripts/discovery-utils.cjs');
+const { loadActiveManifests, loadAllManifests, loadManifest, phaseItems, phaseData, computeTopicLifecycle, computeNextAction, computeMapSummary, computeSourceProvenance, computeAnalysisCacheStatus, compareMapRows, computeNeedsSequencing } = require('../../workflow-shared/scripts/discovery-utils.cjs');
 
 const EPIC_PHASES = ['discovery', 'research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
 
@@ -187,18 +187,14 @@ function buildEpicDetail(cwd, manifest) {
         routing: item.routing || null,
         source: item.source || 'discovery',
         source_provenance,
+        order: item.order ?? null,
         lifecycle,
         tier,
         current_phase,
         next_action,
       };
     });
-    discoveryMap.sort((a, b) => {
-      const ra = TIER_RANK[a.tier] != null ? TIER_RANK[a.tier] : 99;
-      const rb = TIER_RANK[b.tier] != null ? TIER_RANK[b.tier] : 99;
-      if (ra !== rb) return ra - rb;
-      return a.name.localeCompare(b.name);
-    });
+    discoveryMap.sort(compareMapRows);
     mapSummary = computeMapSummary(discoveryMap);
     const allSettled = discoveryMap.every(t => t.lifecycle === 'decided' || t.lifecycle === 'cancelled');
     convergenceState = allSettled ? 'settled' : 'in-progress';
@@ -217,6 +213,7 @@ function buildEpicDetail(cwd, manifest) {
     reopened_discussions: reopenedDiscussions,
     discovery_map: discoveryMap,
     convergence_state: convergenceState,
+    needs_sequencing: computeNeedsSequencing(discoveryMap),
     map_summary: mapSummary,
     imports_count: importsCount,
     seeds_count: seedsCount,
@@ -323,7 +320,7 @@ function format(result) {
     }
     if (d.discovery_map && d.discovery_map.length > 0) {
       const s = d.map_summary;
-      lines.push(`    discovery_map (${s.total} topics — ${s.decided} decided, ${s.in_flight} in-flight, ${s.ready} ready, ${s.fresh} fresh, ${s.cancelled} cancelled, convergence: ${d.convergence_state}):`);
+      lines.push(`    discovery_map (${s.total} topics — ${s.decided} decided, ${s.in_flight} in-flight, ${s.ready} ready, ${s.fresh} fresh, ${s.cancelled} cancelled, convergence: ${d.convergence_state}, needs_sequencing: ${d.needs_sequencing}):`);
       for (const t of d.discovery_map) {
         let line = `      - ${t.tier} ${t.name} [${t.lifecycle}]`;
         if (t.next_action) line += ` -> ${t.next_action}`;

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -77,7 +77,7 @@ Render rules:
 
 - `tier_breakdown` — append ` — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {cancelled} cancelled` (omitting zero-count categories) only when more than one tier bucket is non-zero. When only one bucket is non-zero, omit the breakdown and render just `Discovery Map ({total} topics)`.
 - `{branch}` — `┌─` for the first row, `└─` for the last, `├─` for the rest. With a single row, use `└─` (no upward stroke).
-- Tier ordering — discovery output is already tier-sorted (`→ ◐ ✓ ○ ⊘`, alphabetical within tier). Render in the order given.
+- Tier ordering — discovery output is already tier-sorted (`→ ◐ ✓ ○ ⊘`, suggested execution order within tier). Render in the order given.
 - `lifecycle_label` by tier (wrapped in square brackets per the row template):
   - `→` — `research complete · ready for discussion`
   - `◐` — `researching` or `discussing` (use `topic.current_phase`)

--- a/skills/workflow-discovery/scripts/discovery.cjs
+++ b/skills/workflow-discovery/scripts/discovery.cjs
@@ -9,12 +9,13 @@ const {
   computeMapSummary,
   computeSourceProvenance,
   computeAnalysisCacheStatus,
-  TIER_RANK,
+  compareMapRows,
+  computeNeedsSequencing,
 } = require('../../workflow-shared/scripts/discovery-utils.cjs');
 
 function buildDiscoveryMap(manifest) {
   const discoveryItems = phaseItems(manifest, 'discovery');
-  if (discoveryItems.length === 0) return { map: [], summary: { total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, cancelled: 0 } };
+  if (discoveryItems.length === 0) return { map: [], summary: { total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, cancelled: 0 }, needs_sequencing: false };
   const map = discoveryItems.map(item => {
     const { lifecycle, tier, current_phase } = computeTopicLifecycle(manifest, item.name);
     return {
@@ -24,18 +25,14 @@ function buildDiscoveryMap(manifest) {
       routing: item.routing || null,
       source: item.source || 'discovery',
       source_provenance: computeSourceProvenance(item.source),
+      order: item.order ?? null,
       lifecycle,
       tier,
       current_phase,
     };
   });
-  map.sort((a, b) => {
-    const ra = TIER_RANK[a.tier] != null ? TIER_RANK[a.tier] : 99;
-    const rb = TIER_RANK[b.tier] != null ? TIER_RANK[b.tier] : 99;
-    if (ra !== rb) return ra - rb;
-    return a.name.localeCompare(b.name);
-  });
-  return { map, summary: computeMapSummary(map) };
+  map.sort(compareMapRows);
+  return { map, summary: computeMapSummary(map), needs_sequencing: computeNeedsSequencing(map) };
 }
 
 function findLatestSessionLog(cwd, workUnit) {
@@ -63,7 +60,7 @@ function discover(cwd, workUnit) {
   const activeSession = (typeof discoveryPhase.active_session === 'string' && discoveryPhase.active_session !== '')
     ? discoveryPhase.active_session
     : null;
-  const { map, summary } = buildDiscoveryMap(manifest);
+  const { map, summary, needs_sequencing } = buildDiscoveryMap(manifest);
   const latestSession = findLatestSessionLog(cwd, workUnit);
   const nextSessionNumber = latestSession ? latestSession.number + 1 : 1;
   const workflowsDir = path.join(cwd, '.workflows');
@@ -75,6 +72,7 @@ function discover(cwd, workUnit) {
     work_unit: workUnit,
     discovery_map: map,
     map_summary: summary,
+    needs_sequencing,
     dismissed,
     active_session: activeSession,
     analysis_caches: analysisCaches,
@@ -91,6 +89,7 @@ function format(result) {
 
   const s = result.map_summary;
   lines.push(`map_summary: ${s.total} topics — ${s.decided} decided, ${s.in_flight} in-flight, ${s.ready} ready, ${s.fresh} fresh, ${s.cancelled} cancelled`);
+  lines.push(`needs_sequencing: ${result.needs_sequencing}`);
   lines.push('');
 
   lines.push(`discovery_map (${result.discovery_map.length}):`);

--- a/skills/workflow-shared/references/sequence-discovery-map.md
+++ b/skills/workflow-shared/references/sequence-discovery-map.md
@@ -4,9 +4,9 @@
 
 ---
 
-Assign a suggested execution order across the live topics of an epic's discovery map — Claude's read of which topic to tackle first. The order is soft: it sorts the map rows and selects which item is `(recommended)`, but never gates. It is re-derived wholesale whenever a new topic lands without an order, so it is a moving target as the map grows.
+Assign a suggested execution order across the live topics of an epic's discovery map — Claude's read of which topic to tackle first. The order is soft: it sorts the map rows and selects which item is `(recommended)`, but never gates. It is re-derived wholesale — a full renumber of all live topics — whenever a new one lands without an order.
 
-Manifest-driven so it works identically from either caller. The caller fires this only when its discovery output reports `needs_sequencing: true`, then re-runs its discovery script afterward so the render sees the new order.
+Manifest-driven, so it runs identically from either caller. The caller fires it only when its discovery output reports `needs_sequencing: true`, and re-runs discovery afterward so the render picks up the new order.
 
 ## Parameters
 
@@ -22,7 +22,7 @@ A discovery map only exists for epics.
 node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} work_type
 ```
 
-#### If the value is `epic`
+#### If the work type is `epic`
 
 → Proceed to **B. Gather Live Topics**.
 
@@ -32,7 +32,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} work_
 
 ## B. Gather Live Topics
 
-Take the live topic names from the caller's most recent discovery output — every `discovery_map` row whose tier is not `⊘` (cancelled). Cancelled topics are excluded from the ordering entirely.
+Take the live topic names from the caller's most recent discovery output — every `discovery_map` row whose tier is not `⊘` (cancelled).
 
 For richer context, read each live topic's `summary` and `description` from the manifest:
 

--- a/skills/workflow-shared/references/sequence-discovery-map.md
+++ b/skills/workflow-shared/references/sequence-discovery-map.md
@@ -1,0 +1,65 @@
+# Sequence Discovery Map
+
+*Shared reference. Loaded by `workflow-continue-epic` and `workflow-bridge`.*
+
+---
+
+Assign a suggested execution order across the live topics of an epic's discovery map — Claude's read of which topic to tackle first. The order is soft: it sorts the map rows and selects which item is `(recommended)`, but never gates. It is re-derived wholesale whenever a new topic lands without an order, so it is a moving target as the map grows.
+
+Manifest-driven so it works identically from either caller. The caller fires this only when its discovery output reports `needs_sequencing: true`, then re-runs its discovery script afterward so the render sees the new order.
+
+## Parameters
+
+The caller provides this via context before loading:
+
+- `work_unit` — the epic's work unit name. Always present.
+
+## A. Gate on Work Type
+
+A discovery map only exists for epics.
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} work_type
+```
+
+#### If the value is `epic`
+
+→ Proceed to **B. Gather Live Topics**.
+
+#### Otherwise
+
+→ Return to caller.
+
+## B. Gather Live Topics
+
+Take the live topic names from the caller's most recent discovery output — every `discovery_map` row whose tier is not `⊘` (cancelled). Cancelled topics are excluded from the ordering entirely.
+
+For richer context, read each live topic's `summary` and `description` from the manifest:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} summary
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} description
+```
+
+→ Proceed to **C. Assign and Write Order**.
+
+## C. Assign and Write Order
+
+Analyse the live set holistically and decide a suggested execution order — which topic to start with, which to do next, and so on. Weigh what is foundational versus dependent, what de-risks the rest of the work, and what the user signalled as a starting point. This is a judgement call across the whole set, not a per-topic rule.
+
+Assign contiguous integers `1..N` over the live topics — `1` is the suggested first topic. Full renumber every time: close any gaps, ignore any prior `order` values. Write each one:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} order {N}
+```
+
+→ Proceed to **D. Commit**.
+
+## D. Commit
+
+```bash
+git add -- .workflows/{work_unit}/
+git commit -m "discovery({work_unit}): sequence topic map"
+```
+
+→ Return to caller.

--- a/skills/workflow-shared/scripts/discovery-utils.cjs
+++ b/skills/workflow-shared/scripts/discovery-utils.cjs
@@ -290,6 +290,24 @@ function computeAnalysisCacheStatus(manifest, workflowsDir, kind) {
 
 const TIER_RANK = { '→': 0, '◐': 1, '✓': 2, '○': 3, '⊘': 4 };
 
+// Shared row comparator for the discovery map: tier rank first, then suggested
+// execution order ascending (null orders sort last), then name as final fallback.
+function compareMapRows(a, b) {
+  const ra = TIER_RANK[a.tier] != null ? TIER_RANK[a.tier] : 99;
+  const rb = TIER_RANK[b.tier] != null ? TIER_RANK[b.tier] : 99;
+  if (ra !== rb) return ra - rb;
+  const oa = a.order == null ? Infinity : a.order;
+  const ob = b.order == null ? Infinity : b.order;
+  if (oa !== ob) return oa - ob;
+  return a.name.localeCompare(b.name);
+}
+
+// True when any live (non-cancelled) map item lacks a suggested execution order.
+// Programmatic detection — the assignment of order values stays with Claude.
+function computeNeedsSequencing(mapItems) {
+  return mapItems.some(it => it.tier !== '⊘' && it.order == null);
+}
+
 function computeTopicLifecycle(manifest, topicName) {
   const research = phaseItems(manifest, 'research').find(i => i.name === topicName);
   const discussion = phaseItems(manifest, 'discussion').find(i => i.name === topicName);
@@ -385,5 +403,7 @@ module.exports = {
   computeNextAction,
   computeMapSummary,
   computeSourceProvenance,
+  compareMapRows,
+  computeNeedsSequencing,
   TIER_RANK,
 };

--- a/tests/scripts/test-discovery-utils.cjs
+++ b/tests/scripts/test-discovery-utils.cjs
@@ -13,6 +13,7 @@ const {
   phaseStatus, phaseItems, phaseData, computeNextPhase,
   computeAnalysisCacheStatus, computeSourceProvenance,
   computeTopicLifecycle, computeNextAction, computeMapSummary,
+  compareMapRows, computeNeedsSequencing,
   TIER_RANK,
 } = require('../../skills/workflow-shared/scripts/discovery-utils.cjs');
 
@@ -1060,6 +1061,90 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.ready, 0);
       assert.strictEqual(r.fresh, 0);
       assert.strictEqual(r.cancelled, 0);
+    });
+  });
+
+  describe('computeNeedsSequencing', () => {
+    it('returns true when a live item is missing order', () => {
+      const items = [
+        { tier: '◐', order: 1 },
+        { tier: '○', order: null },
+      ];
+      assert.strictEqual(computeNeedsSequencing(items), true);
+    });
+
+    it('returns false when all live items are ordered', () => {
+      const items = [
+        { tier: '→', order: 1 },
+        { tier: '◐', order: 2 },
+        { tier: '✓', order: 3 },
+      ];
+      assert.strictEqual(computeNeedsSequencing(items), false);
+    });
+
+    it('returns false when only a cancelled item is missing order', () => {
+      const items = [
+        { tier: '◐', order: 1 },
+        { tier: '⊘', order: null },
+      ];
+      assert.strictEqual(computeNeedsSequencing(items), false);
+    });
+
+    it('treats undefined order the same as null (missing)', () => {
+      const items = [{ tier: '○' }];
+      assert.strictEqual(computeNeedsSequencing(items), true);
+    });
+
+    it('returns false for an empty map', () => {
+      assert.strictEqual(computeNeedsSequencing([]), false);
+    });
+  });
+
+  describe('compareMapRows', () => {
+    function sorted(items) {
+      return items.slice().sort(compareMapRows).map(i => i.name);
+    }
+
+    it('orders by tier rank first', () => {
+      const items = [
+        { name: 'fresh', tier: '○', order: 1 },
+        { name: 'ready', tier: '→', order: 9 },
+        { name: 'inflight', tier: '◐', order: 5 },
+      ];
+      assert.deepStrictEqual(sorted(items), ['ready', 'inflight', 'fresh']);
+    });
+
+    it('orders by order ascending within the same tier', () => {
+      const items = [
+        { name: 'c', tier: '◐', order: 3 },
+        { name: 'a', tier: '◐', order: 1 },
+        { name: 'b', tier: '◐', order: 2 },
+      ];
+      assert.deepStrictEqual(sorted(items), ['a', 'b', 'c']);
+    });
+
+    it('sorts null order last within a tier', () => {
+      const items = [
+        { name: 'unordered', tier: '○', order: null },
+        { name: 'ordered', tier: '○', order: 2 },
+      ];
+      assert.deepStrictEqual(sorted(items), ['ordered', 'unordered']);
+    });
+
+    it('falls back to name on equal order', () => {
+      const items = [
+        { name: 'zebra', tier: '◐', order: 1 },
+        { name: 'apple', tier: '◐', order: 1 },
+      ];
+      assert.deepStrictEqual(sorted(items), ['apple', 'zebra']);
+    });
+
+    it('falls back to name when both orders are null', () => {
+      const items = [
+        { name: 'beta', tier: '○', order: null },
+        { name: 'alpha', tier: '○', order: null },
+      ];
+      assert.deepStrictEqual(sorted(items), ['alpha', 'beta']);
     });
   });
 


### PR DESCRIPTION
## What

Adds a soft, non-gating **suggested order of execution** over an epic's live discovery-map topics — Claude's read of which topic to tackle first — so the epic menu can lead with "start here". The user can always ignore it; it only sorts rows and picks the `(recommended)` item, never gates.

## Design

- **One global order**, contiguous `1..N` over live (non-cancelled) topics.
- **Re-derived wholesale on every add** — no sparse numbering, no reorder ops. Lazy + deterministic: detection (`needs_sequencing`) is programmatic; assignment is Claude's.
- **Invisible** — drives sort + recommendation, never printed as a number.
- **Owned by the epic-menu render path only** — discovery/synthesis and the phase-recommendation engine are untouched (the engine inherits the suggested start for free via the new sort).

## Changes

- **discovery-utils**: shared `compareMapRows` comparator (tier rank → `order` asc, null last → name) and `computeNeedsSequencing` detection. Both exported.
- **Both discovery scripts** surface `order` + `needs_sequencing`, sort via the shared comparator.
- **New shared reference** `sequence-discovery-map.md`: the LLM step — epic-only guard, reads live topics' summary/description, assigns `1..N`, commits.
- **Wired into both render paths**: continue-epic new **Step 7 "Sequence Map"** (old 7/8 → 8/9); bridge `epic-continuation` new **section C** (old C–E → D–F). Both fire only when `needs_sequencing`, then re-run discovery to refresh.
- **Cancel** drops the topic's `order` so a later reactivation renumbers cleanly.
- **Doc-wording**: within-tier sort is "suggested execution order", not alphabetical.

## Verification

- `discovery-utils` tests extended for `computeNeedsSequencing` (live-missing → true; all-ordered → false; cancelled-only → false) and `compareMapRows` (tier precedence, order asc, null last, name fallback). Full suite: **759 pass, 0 fail**.
- Manual end-to-end against a synthetic temp epic fixture (never a real project):
  - 9 unsequenced topics → `needs_sequencing: true`, all `order: null`.
  - After assigning `1..9` → rows sort by order within tier (not alphabetical), recommended = order 1.
  - New item without order → flips true.
  - Fully-cancelled (⊘) item with order deleted → stays false (excluded); single-phase-cancelled item falling back to fresh → flips true (self-heals via renumber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)