### PR TITLE
feat(release): restore GitHub Releases via release script

### DIFF
--- a/release
+++ b/release
@@ -306,6 +306,20 @@ update_changelog() {
     rm -f "$entry_file"
 }
 
+# Preflight gate: require the GitHub CLI to be installed and authenticated.
+# Called before any mutation so a missing/unauthenticated gh aborts the release
+# loudly *before* a tag is ever created — recoverable, no stray tags left behind.
+require_github_cli() {
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "Error: gh (GitHub CLI) is not installed. Install it before releasing: https://cli.github.com" >&2
+        exit 1
+    fi
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "Error: gh is not authenticated. Run 'gh auth login' before releasing." >&2
+        exit 1
+    fi
+}
+
 perform_release() {
     local new_version=$1
     local current_version=$2
@@ -316,6 +330,10 @@ perform_release() {
         echo "Please commit or stash your changes and run the script again to release."
         exit 1
     fi
+
+    # Verify gh is ready before mutating anything, so no tag is ever pushed
+    # without the means to create its Release.
+    require_github_cli
 
     # Rebuild the knowledge CLI bundle so every tagged release ships a fresh
     # skills/workflow-knowledge/scripts/knowledge.cjs. AGNTC installs from tags
@@ -374,6 +392,21 @@ perform_release() {
 
     # Push commit and tag atomically
     git push --atomic origin HEAD "v${new_version}"
+
+    # Create the GitHub Release, reusing the already-computed notes body. The
+    # tag is already live, so a failure here is non-fatal — but the preflight
+    # gh gate makes this branch rare.
+    echo "Creating GitHub release..."
+    local notes="${body:-See CHANGELOG.md for details.}"
+    if gh release create "v${new_version}" \
+           --title "v${new_version}" \
+           --notes "$notes" \
+           --verify-tag --latest; then
+        echo "✅ GitHub release v${new_version} created"
+    else
+        echo "⚠️  GitHub release creation failed — the tag is already pushed." >&2
+        echo "    Re-run manually: gh release create v${new_version} --title v${new_version} --notes '...' --verify-tag --latest" >&2
+    fi
 
     echo -e "\n"
     echo "✅ Released v${new_version}"
@@ -434,11 +467,13 @@ main() {
             echo " 2. Update version in $VERSION_FILE"
             echo " 3. Create a new commit"
             echo " 4. Create git tag v${new_version}"
-            echo -e " 5. Push changes\n"
+            echo " 5. Push changes"
+            echo -e " 6. Create GitHub release\n"
         else
             echo " 1. Update CHANGELOG.md"
             echo " 2. Create git tag v${new_version}"
-            echo -e " 3. Push changes\n"
+            echo " 3. Push changes"
+            echo -e " 4. Create GitHub release\n"
         fi
 
         echo -n "Proceed? [Y/n] "

--- a/tests/scripts/test-release-build.sh
+++ b/tests/scripts/test-release-build.sh
@@ -100,6 +100,31 @@ exit 0
 NPMEOF
   chmod +x "$STUBS/npm"
 
+  # Stub gh: logs every call to $CALLS. `gh auth status` honors
+  # STUB_GH_AUTH_FAIL and `gh release create` honors STUB_GH_CREATE_FAIL.
+  cat > "$STUBS/gh" << 'GHEOF'
+#!/bin/bash
+echo "gh $*" >> "$CALLS"
+case "$1 $2" in
+  "auth status")
+    if [ "${STUB_GH_AUTH_FAIL:-0}" = "1" ]; then
+      echo "stub: gh not authenticated" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  "release create")
+    if [ "${STUB_GH_CREATE_FAIL:-0}" = "1" ]; then
+      echo "stub: gh release create failed" >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+GHEOF
+  chmod +x "$STUBS/gh"
+
   # Strip the main invocation so sourcing defines functions without running.
   grep -v '^main "\$@"$' "$RELEASE_SCRIPT" > "$RELEASE_FUNCS"
 
@@ -111,6 +136,7 @@ teardown() {
   cd "$REPO_DIR"
   rm -rf "$TEST_DIR"
   unset STUB_NPM_CI_FAIL STUB_NPM_BUILD_FAIL STUB_NPM_BUILD_MODIFIES
+  unset STUB_GH_AUTH_FAIL STUB_GH_CREATE_FAIL
 }
 
 # Run perform_release in a subshell with git tag/push stubbed so tests never
@@ -278,6 +304,64 @@ test_build_runs_before_tag() {
   teardown
 }
 
+# --- Test 9: happy path — gh release create runs after git push ---
+test_gh_release_created_after_push() {
+  setup
+  export STUB_NPM_BUILD_MODIFIES=1
+
+  run_release "1.0.0" "0.0.0" "none"
+
+  local calls_content push_line create_line
+  calls_content=$(cat "$CALLS")
+  push_line=$(echo "$calls_content" | awk '/^git push/ {print NR; exit}')
+  create_line=$(echo "$calls_content" | awk '/^gh release create/ {print NR; exit}')
+
+  assert_eq "both push and gh release create recorded" "true" \
+    "$([ -n "$push_line" ] && [ -n "$create_line" ] && echo true || echo false)"
+  assert_eq "gh release create runs after git push" "true" \
+    "$([ -n "$push_line" ] && [ -n "$create_line" ] && [ "$push_line" -lt "$create_line" ] && echo true || echo false)"
+  assert_eq "release created for v1.0.0" "true" "$(file_contains 'gh release create v1.0.0' "$CALLS")"
+
+  teardown
+}
+
+# --- Test 10: preflight gh-auth failure aborts before any mutation ---
+test_gh_auth_failure_aborts_before_tag() {
+  setup
+  export STUB_GH_AUTH_FAIL=1
+
+  local rc=0
+  run_release "1.0.0" "0.0.0" "none" || rc=$?
+
+  assert_eq "perform_release exits non-zero on gh auth failure" "true" \
+    "$([ "$rc" -ne 0 ] && echo true || echo false)"
+  assert_eq "npm ci was NOT invoked after gh auth failure" "false" "$(file_contains 'npm ci' "$CALLS")"
+  assert_eq "tag was NOT called after gh auth failure" "false" "$(file_contains 'git tag' "$CALLS")"
+  assert_eq "gh auth error message emitted" "true" \
+    "$(file_contains 'gh is not authenticated' "$TEST_DIR/out.log")"
+
+  teardown
+}
+
+# --- Test 11: post-push gh release create failure is non-fatal ---
+test_gh_create_failure_is_non_fatal() {
+  setup
+  export STUB_NPM_BUILD_MODIFIES=1
+  export STUB_GH_CREATE_FAIL=1
+
+  local rc=0
+  run_release "1.0.0" "0.0.0" "none" || rc=$?
+
+  assert_eq "perform_release exits 0 despite gh create failure" "0" "$rc"
+  assert_eq "tag was still pushed" "true" "$(file_contains 'git push' "$CALLS")"
+  assert_eq "warning about failed release emitted" "true" \
+    "$(file_contains 'GitHub release creation failed' "$TEST_DIR/out.log")"
+  assert_eq "manual re-run hint emitted" "true" \
+    "$(file_contains 'Re-run manually' "$TEST_DIR/out.log")"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running release-build integration tests..."
 echo ""
@@ -290,6 +374,9 @@ test_build_failure_aborts
 test_ci_failure_aborts
 test_dirty_tree_gate_fires
 test_build_runs_before_tag
+test_gh_release_created_after_push
+test_gh_auth_failure_aborts_before_tag
+test_gh_create_failure_is_non_fatal
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Context

GitHub Releases stopped at `v0.2.18` (Apr 14) after commit `097df142` removed `.github/workflows/release.yml`. Git tags kept advancing (now `v0.4.21`+). We now want Release pages for human-readable visibility.

Release creation belongs **in the local `./release` script** (the deterministic orchestrator that already holds the notes `body` in-memory at tag time) — not in CI. Single source of truth, no re-extraction.

## Changes

1. **`require_github_cli` preflight gate** — called at the top of `perform_release` (after the dirty-tree gate, before `npm ci`/build/tag). Exits loudly if gh is missing or unauthenticated, so no stray tags are ever pushed. Dry-run stays gh-free.
2. **`gh release create` after the atomic push** — reuses the already-computed `$body`. Non-fatal on failure (tag is already live) with a manual re-run hint. Preamble updated with a "Create GitHub release" line.
3. **Tests** — `gh` stub mirroring the `npm` stub + 3 cases: happy-path ordering (create after push), preflight abort before tagging (`STUB_GH_AUTH_FAIL`), non-fatal post-push create failure (`STUB_GH_CREATE_FAIL`).

## Verification

- `bash tests/scripts/test-release-build.sh` → 35 passed
- `bash tests/scripts/test-release-changelog.sh` → 10 passed
- `./release -d` dry-run → works, no gh involvement
- `gh auth status` confirmed locally

Backfill of the missing historical Releases (`v0.2.14`, `v0.3.0`+) is a throwaway local script, run separately — not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)