### PR TITLE
fix(release): survive git lock contention instead of aborting

### DIFF
--- a/release
+++ b/release
@@ -306,6 +306,69 @@ update_changelog() {
     rm -f "$entry_file"
 }
 
+# How long (seconds) to wait out a contended git lock before treating it as
+# stale and removing it. A real local index/ref mutation finishes well within
+# this window — overridable via the environment for testing.
+: "${GIT_LOCK_WAIT_SECONDS:=30}"
+
+# Run a git command, transparently surviving a contended or stale lock file.
+#
+# Git takes a lock (.git/index.lock for index ops, refs/.../*.lock for ref ops)
+# at the start of a mutation and releases it on completion. A second git caller
+# running concurrently — an editor, an auto-commit, a background agent — or a
+# process killed mid-op leaves us either racing the lock or staring at a stale
+# one. Either way the bare command aborts with "Unable to create '...lock':
+# File exists", which would break a release. This wrapper instead waits the
+# lock out silently, retrying until the holder finishes, and as a last resort
+# removes a lock that is provably stale (still present after the whole wait).
+# The caller never sees the lock error; genuine (non-lock) git failures are
+# surfaced and returned unchanged.
+git_safe() {
+    local deadline=$(( SECONDS + GIT_LOCK_WAIT_SECONDS ))
+    local out status lock_path
+
+    while true; do
+        # Combine streams so we can inspect git's diagnostics. The capture sits
+        # in an `if` condition because `set -e` would otherwise abort the whole
+        # script the moment git exits non-zero — defeating the retry entirely.
+        if out=$(git "$@" 2>&1); then status=0; else status=$?; fi
+
+        if [[ $status -eq 0 ]]; then
+            if [[ -n "$out" ]]; then printf '%s\n' "$out"; fi
+            return 0
+        fi
+
+        # Not a lock collision? Surface the real error and fail as normal.
+        if ! printf '%s' "$out" | grep -qE "Unable to create '.*\.lock'|cannot lock ref|Another git process"; then
+            if [[ -n "$out" ]]; then printf '%s\n' "$out" >&2; fi
+            return "$status"
+        fi
+
+        # Lock collision: stay quiet and wait for the holder to release it.
+        if (( SECONDS < deadline )); then
+            sleep 1
+            continue
+        fi
+
+        # Waited the full window and the lock is still here — treat as stale,
+        # remove it, and make one final attempt.
+        lock_path=$(printf '%s' "$out" | grep -oE "Unable to create '[^']*\.lock'" | head -1 | sed "s/Unable to create '//; s/'\$//")
+        if [[ -n "$lock_path" && -e "$lock_path" ]]; then
+            echo "Clearing stale git lock: $lock_path" >&2
+            rm -f "$lock_path"
+            if out=$(git "$@" 2>&1); then status=0; else status=$?; fi
+            if [[ -n "$out" ]]; then
+                if [[ $status -eq 0 ]]; then printf '%s\n' "$out"; else printf '%s\n' "$out" >&2; fi
+            fi
+            return "$status"
+        fi
+
+        # Couldn't identify a lock file to clear — surface the original error.
+        if [[ -n "$out" ]]; then printf '%s\n' "$out" >&2; fi
+        return "$status"
+    done
+}
+
 # Preflight gate: require the GitHub CLI to be installed and authenticated.
 # Called before any mutation so a missing/unauthenticated gh aborts the release
 # loudly *before* a tag is ever created — recoverable, no stray tags left behind.
@@ -356,8 +419,8 @@ perform_release() {
     local bundle_path="skills/workflow-knowledge/scripts/knowledge.cjs"
     if ! git diff --quiet -- "$bundle_path"; then
         echo "Knowledge bundle changed — committing."
-        git add "$bundle_path"
-        git commit -m "chore(release): rebuild knowledge bundle for v${new_version}"
+        git_safe add "$bundle_path"
+        git_safe commit -m "chore(release): rebuild knowledge bundle for v${new_version}"
     else
         echo "Knowledge bundle unchanged — no commit needed."
     fi
@@ -371,9 +434,9 @@ perform_release() {
 
     # Prepend the entry to CHANGELOG.md and commit it before tagging.
     update_changelog "$new_version" "$body"
-    git add CHANGELOG.md
+    git_safe add CHANGELOG.md
     if ! git diff --cached --quiet -- CHANGELOG.md; then
-        git commit -m "chore(release): update changelog for v${new_version}"
+        git_safe commit -m "chore(release): update changelog for v${new_version}"
     fi
 
     local commit_message
@@ -383,15 +446,15 @@ perform_release() {
     update_version_file "$new_version"
 
     if [[ "$VERSION_STRATEGY" != "none" ]]; then
-        git add "$VERSION_FILE"
-        git commit -m "$commit_message"
+        git_safe add "$VERSION_FILE"
+        git_safe commit -m "$commit_message"
     fi
 
     # Create annotated tag with the same message
-    git tag -a "v${new_version}" -m "$commit_message"
+    git_safe tag -a "v${new_version}" -m "$commit_message"
 
     # Push commit and tag atomically
-    git push --atomic origin HEAD "v${new_version}"
+    git_safe push --atomic origin HEAD "v${new_version}"
 
     # Create the GitHub Release, reusing the already-computed notes body. The
     # tag is already live, so a failure here is non-fatal — but the preflight

--- a/tests/scripts/test-release-git-lock.sh
+++ b/tests/scripts/test-release-git-lock.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# Tests for git_safe — the release script's git-lock-resilience wrapper.
+# Run: bash tests/scripts/test-release-git-lock.sh
+
+set -eo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RELEASE_SCRIPT="$REPO_DIR/release"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+file_contains() {
+  local pattern="$1" file="$2"
+  local content
+  content=$(cat "$file" 2>/dev/null || true)
+  case "$content" in
+    *"$pattern"*) echo true ;;
+    *) echo false ;;
+  esac
+}
+
+# A self-contained throwaway repo plus a `git` shell-function override that the
+# release functions call. git_safe invokes `git "$@"`, so overriding git as a
+# function (after sourcing) lets each case simulate lock collisions, stale
+# locks, and genuine errors without touching a real repository.
+setup() {
+  TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/release-gitlock-test.XXXXXX")
+  REPO="$TEST_DIR/repo"
+  RELEASE_FUNCS="$TEST_DIR/release-funcs.sh"
+  GIT_OVERRIDE="$TEST_DIR/git-override.sh"
+  COUNTER="$TEST_DIR/counter"
+  LOCKFILE="$TEST_DIR/index.lock"
+  ERRFILE="$TEST_DIR/err.log"
+  mkdir -p "$REPO"
+
+  cd "$REPO"
+  git init -q
+  git config user.email t@t.t
+  git config user.name t
+
+  # Strip the main invocation so sourcing defines functions without running.
+  grep -v '^main "\$@"$' "$RELEASE_SCRIPT" > "$RELEASE_FUNCS"
+
+  # git override, driven by STUB_MODE. Every invocation bumps $COUNTER so a
+  # test can assert whether git_safe retried or returned immediately.
+  cat > "$GIT_OVERRIDE" << OVREOF
+git() {
+  local n
+  n=\$(cat "$COUNTER" 2>/dev/null || echo 0)
+  echo \$((n + 1)) > "$COUNTER"
+  case "\${STUB_MODE:-ok}" in
+    ok)
+      echo "ok-stdout"; return 0 ;;
+    lock_then_ok)
+      if [ "\$n" -lt "\${STUB_FAIL_TIMES:-1}" ]; then
+        echo "fatal: Unable to create '$LOCKFILE': File exists." >&2
+        return 128
+      fi
+      echo "ok-after-retry"; return 0 ;;
+    stale)
+      if [ -e "$LOCKFILE" ]; then
+        echo "fatal: Unable to create '$LOCKFILE': File exists." >&2
+        return 128
+      fi
+      echo "ok-stale-cleared"; return 0 ;;
+    genuine)
+      echo "fatal: pathspec 'foo' did not match any files" >&2
+      return 1 ;;
+  esac
+}
+OVREOF
+}
+
+teardown() {
+  cd "$REPO_DIR"
+  rm -rf "$TEST_DIR"
+  unset STUB_MODE STUB_FAIL_TIMES GIT_LOCK_WAIT_SECONDS
+}
+
+# Run git_safe in a subshell with the override sourced. Captures stdout into
+# $STDOUT, stderr into $ERRFILE, exit status into $RC, retries into $COUNTER.
+run_git_safe() {
+  rm -f "$COUNTER"
+  set +e
+  STDOUT=$(
+    {
+      cd "$REPO"
+      source "$RELEASE_FUNCS"
+      source "$GIT_OVERRIDE"
+      git_safe add foo
+    } 2> "$ERRFILE"
+  )
+  RC=$?
+  set -e
+}
+
+# --- Test 1: Clean pass-through (no lock) ---
+test_passthrough_success() {
+  setup
+  export STUB_MODE=ok GIT_LOCK_WAIT_SECONDS=3
+  run_git_safe
+  assert_eq "clean command returns 0" "0" "$RC"
+  assert_eq "stdout is forwarded" "true" "$(case "$STDOUT" in *ok-stdout*) echo true ;; *) echo false ;; esac)"
+  assert_eq "no retry on success" "1" "$(cat "$COUNTER")"
+  teardown
+}
+
+# --- Test 2: Lock collision, then succeeds on retry (error stays silent) ---
+test_lock_then_succeeds() {
+  setup
+  export STUB_MODE=lock_then_ok STUB_FAIL_TIMES=2 GIT_LOCK_WAIT_SECONDS=10
+  run_git_safe
+  assert_eq "retried command returns 0" "0" "$RC"
+  assert_eq "success stdout forwarded" "true" "$(case "$STDOUT" in *ok-after-retry*) echo true ;; *) echo false ;; esac)"
+  assert_eq "lock error is suppressed (not surfaced)" "false" "$(file_contains "File exists" "$ERRFILE")"
+  assert_eq "it retried past the failures" "3" "$(cat "$COUNTER")"
+  teardown
+}
+
+# --- Test 3: Persistent lock is cleared as stale, then succeeds ---
+test_stale_lock_cleared() {
+  setup
+  : > "$LOCKFILE"
+  export STUB_MODE=stale GIT_LOCK_WAIT_SECONDS=2
+  run_git_safe
+  assert_eq "stale-cleared command returns 0" "0" "$RC"
+  assert_eq "stale lock file removed" "false" "$([ -e "$LOCKFILE" ] && echo true || echo false)"
+  assert_eq "logged the stale-lock clearance" "true" "$(file_contains "Clearing stale git lock" "$ERRFILE")"
+  assert_eq "final attempt stdout forwarded" "true" "$(case "$STDOUT" in *ok-stale-cleared*) echo true ;; *) echo false ;; esac)"
+  teardown
+}
+
+# --- Test 4: Genuine (non-lock) error surfaces immediately, no retry ---
+test_genuine_error_passthrough() {
+  setup
+  export STUB_MODE=genuine GIT_LOCK_WAIT_SECONDS=10
+  run_git_safe
+  assert_eq "genuine error returns non-zero" "true" "$([ "$RC" -ne 0 ] && echo true || echo false)"
+  assert_eq "genuine error is surfaced on stderr" "true" "$(file_contains "did not match any files" "$ERRFILE")"
+  assert_eq "no retry on a non-lock error" "1" "$(cat "$COUNTER")"
+  teardown
+}
+
+echo "Running release git-lock resilience tests..."
+echo
+
+test_passthrough_success
+test_lock_then_succeeds
+test_stale_lock_cleared
+test_genuine_error_passthrough
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Problem

The release script intermittently dies with `Unable to create '.git/index.lock': File exists` when a concurrent git caller (auto-commit, editor, background agent) holds the lock — leaving the release half-done. Most recently this broke the v0.4.22 release at the changelog-commit step (no tag was ever created).

## Fix

New `git_safe` wrapper around every index/ref-mutating git call in `perform_release` (add, commit, tag, push):

- **Waits out** a contended lock silently, retrying until the holder releases it (`GIT_LOCK_WAIT_SECONDS`, default 30s).
- **Clears a provably-stale lock** as a last resort — only after the full wait window elapses with the lock still present (a real local op finishes in well under a second).
- **Surfaces genuine (non-lock) git errors** unchanged and fails fast, exactly as before.

Also fixes a latent `set -e` trap: a failing command substitution in an assignment aborts the whole script, so the capture now sits in an `if` condition.

## Tests

`tests/scripts/test-release-git-lock.sh` — pass-through success, lock-then-succeed retry, stale-lock clearing, genuine-error pass-through (14 assertions). Existing `test-release-build` (35) and `test-release-changelog` (10) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)