### PR TITLE
feat(discovery): add handled lifecycle tier + migration 043

### DIFF
--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -94,14 +94,14 @@ Render the discovery map block at the top, then the build-phase tree (specificat
 
 **Discovery map display rules:**
 
-- **Tier breakdown** (`{tier_breakdown}`): when more than one tier bucket has a non-zero count, append ` — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {cancelled} cancelled` to the topic count (omitting zero-count categories). When only one bucket is non-zero — e.g. every topic in flight — the breakdown is redundant with the rows; omit it and render just `Discovery Map ({total} topics)`. Read counts from `map_summary`.
+- **Tier breakdown** (`{tier_breakdown}`): when more than one tier bucket has a non-zero count, append ` — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {handled} handled · {cancelled} cancelled` to the topic count (omitting zero-count categories). When only one bucket is non-zero — e.g. every topic in flight — the breakdown is redundant with the rows; omit it and render just `Discovery Map ({total} topics)`. Read counts from `map_summary`.
   - Example (mixed): `Discovery Map (8 topics — 2 decided · 3 in flight · 1 ready · 2 fresh)`
   - Example (single bucket): `Discovery Map (9 topics)`
 - **Seed callout** (`seeds_count > 0`): `· seeded from the inbox`.
 - **Imports callout** (`{show_imports_callout}`): true only when `imports_count > 0` **and** `imports_count != discovery_map.length`. When every topic is itself an import, per-row provenance already says so on every line and the callout is redundant. Format when shown: `· {imports_count} import` for 1, `· {imports_count} imports` for 2+.
-- **Convergence callout**: rendered after the optional seed and imports callouts, before the topic rows. Always present. `⚑ Discovery in progress — {N} topics not yet decided.` when `convergence_state == 'in-progress'` (where N excludes cancelled). `✓ Discovery settled — ready for specification.` when `convergence_state == 'settled'`.
+- **Convergence callout**: rendered after the optional seed and imports callouts, before the topic rows. Always present. `⚑ Discovery in progress — {N} topics not yet decided.` when `convergence_state == 'in-progress'` (where N excludes cancelled and handled). `✓ Discovery settled — ready for specification.` when `convergence_state == 'settled'`.
 - **New-arrivals callout** (optional): when the caller passes a non-empty `new_arrivals.research_analysis` or `new_arrivals.gap_analysis` list, render `⚑ {N} new topic(s) added to the map from {analysis}.` lines beneath the convergence callout, one per analysis with arrivals. Shown once per boot-up that added items — subsequent invocations without changes don't repeat it (the items are now part of the map). Sub-line provenance on the topic rows is the persistent surface afterwards.
-- **Tier ordering and sort**: rows are pre-sorted by the discovery script (tier rank `→ ◐ ✓ ○ ⊘`, then suggested execution order within each tier). Render in the order given.
+- **Tier ordering and sort**: rows are pre-sorted by the discovery script (tier rank `→ ◐ ✓ ○ ⊙ ⊘`, then suggested execution order within each tier). Render in the order given.
 - **Topic row**: `{branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]`. Single space between each segment. Lifecycle label wrapped in square brackets.
   - `{branch}`: `┌─` for the first row, `└─` for the last, `├─` for the rest. With a single row, use `└─` (no upward stroke).
 - **Lifecycle label** by tier:
@@ -110,6 +110,7 @@ Render the discovery map block at the top, then the build-phase tree (specificat
   - `◐` (discussing) — `discussing`
   - `✓` (decided) — `decided`
   - `○` (fresh) — `fresh · routed to {topic.routing}` (omit the ` · routed to ...` segment if `topic.routing` is null)
+  - `⊙` (handled) — `handled · research fanned out`
   - `⊘` (cancelled) — `cancelled`
 - **Summary / provenance sub-lines** — both follow the same `{gutter}` rule. Summary appears first when present; provenance below it. Source `discovery` produces no provenance line.
   - **Wrap**: hard-wrap the summary text at 65 characters before emitting. Provenance is short — no wrap needed.
@@ -237,7 +238,7 @@ Show only statuses and categories that appear in the current display. No `---` s
     Discovery tier:
       →  ready for next phase   ◐  in flight
       ✓  decided                ○  fresh
-      ⊘  cancelled
+      ⊙  handled                ⊘  cancelled
 
     Status:
       in-progress — work is ongoing
@@ -285,7 +286,7 @@ Build a menu with two types of options:
 
 **Numbered items, in order:**
 
-1. **Discovery topics** — one entry per `discovery_map` row whose `next_action` is non-null. Skip rows with tier `✓` (decided) and `⊘` (cancelled) — those have no menu entry. Label by `next_action`:
+1. **Discovery topics** — one entry per `discovery_map` row whose `next_action` is non-null. Skip rows with tier `✓` (decided), `⊙` (handled), and `⊘` (cancelled) — those have no menu entry. Label by `next_action`:
 
    | next_action                       | Label                                                            |
    |-----------------------------------|------------------------------------------------------------------|
@@ -331,7 +332,7 @@ Build a menu with two types of options:
 
 | Convergence state | Recommendation source                                               |
 |-------------------|---------------------------------------------------------------------|
-| `in-progress`     | Top of `discovery_map` — first row with non-null `next_action` (tier order: `→` first, then `◐`, then `○`). Never `✓` or `⊘`. |
+| `in-progress`     | Top of `discovery_map` — first row with non-null `next_action` (tier order: `→` first, then `◐`, then `○`). Never `✓`, `⊙`, or `⊘`. |
 | `settled`         | First build-phase `next_phase_ready` item in pipeline order (planning before implementation before review). If none, `s`/`spec` when applicable. Otherwise no recommendation. |
 
 The recommended item always appears first. Mark it `(recommended)`. After the recommended item, list remaining numbered items in their natural order (discovery topics, then build-phase items), then command options.

--- a/skills/workflow-continue-epic/scripts/discovery.cjs
+++ b/skills/workflow-continue-epic/scripts/discovery.cjs
@@ -196,7 +196,8 @@ function buildEpicDetail(cwd, manifest) {
     });
     discoveryMap.sort(compareMapRows);
     mapSummary = computeMapSummary(discoveryMap);
-    const allSettled = discoveryMap.every(t => t.lifecycle === 'decided' || t.lifecycle === 'cancelled');
+    const allSettled = discoveryMap.every(t =>
+      t.lifecycle === 'decided' || t.lifecycle === 'cancelled' || t.lifecycle === 'handled');
     convergenceState = allSettled ? 'settled' : 'in-progress';
   }
 
@@ -320,7 +321,7 @@ function format(result) {
     }
     if (d.discovery_map && d.discovery_map.length > 0) {
       const s = d.map_summary;
-      lines.push(`    discovery_map (${s.total} topics — ${s.decided} decided, ${s.in_flight} in-flight, ${s.ready} ready, ${s.fresh} fresh, ${s.cancelled} cancelled, convergence: ${d.convergence_state}, needs_sequencing: ${d.needs_sequencing}):`);
+      lines.push(`    discovery_map (${s.total} topics — ${s.decided} decided, ${s.in_flight} in-flight, ${s.ready} ready, ${s.fresh} fresh, ${s.handled} handled, ${s.cancelled} cancelled, convergence: ${d.convergence_state}, needs_sequencing: ${d.needs_sequencing}):`);
       for (const t of d.discovery_map) {
         let line = `      - ${t.tier} ${t.name} [${t.lifecycle}]`;
         if (t.next_action) line += ` -> ${t.next_action}`;

--- a/skills/workflow-discovery/references/map-operations.md
+++ b/skills/workflow-discovery/references/map-operations.md
@@ -86,7 +86,7 @@ Mark handled is non-destructive — it sets a display/convergence marker, primar
 - `handled` — `it has fanned out into discussions and stays on the map as historical anchor`
 - `cancelled` — `it has phase work in cancelled state and stays on the map as historical record`
 
-`{recovery_pointer}`: for a `handled` target, `To bring it back, say "reactivate {topic}".` For any other disallowed lifecycle, `To stop work on it, use \`a\`/\`cancel\` from the epic menu instead.`
+`{recovery_pointer}`: for a `handled` target, `Say "reactivate {topic}" to make it actionable again.` For any other disallowed lifecycle, `To stop work on it, use \`a\`/\`cancel\` from the epic menu instead.`
 
 **Marker-op rejection** — for a Mark handled op on an already-`handled` or `cancelled` topic, or a Reactivate op on a non-`handled` topic, render in a code block:
 

--- a/skills/workflow-discovery/references/map-operations.md
+++ b/skills/workflow-discovery/references/map-operations.md
@@ -33,6 +33,8 @@ Then read the user's most recent message. Extract one or more operations. Recogn
 | *"remove X"*, *"drop X"*, *"delete X"*                     | Remove            | name                   |
 | *"rename X to Y"*                                          | Rename            | old name, new name     |
 | *"change routing of X to discussion"*                      | Change routing    | name, new routing      |
+| *"mark X handled"*, *"X has fanned out"*                   | Mark handled      | name                   |
+| *"reactivate X"*, *"un-handle X"*                          | Reactivate        | name                   |
 
 If the message is ambiguous (e.g. *"fix X"*, *"that one looks wrong"*), ask one clarifying question before proceeding. No STOP gate is needed for clarification — it's part of conversational flow, not a manifest write.
 
@@ -40,6 +42,7 @@ If the message is ambiguous (e.g. *"fix X"*, *"that one looks wrong"*), ask one 
 
 - **Additive group** — a contiguous run of Edit summary operations *or* a contiguous run of Edit description operations. Each group batches into one STOP gate, one commit, one session-log entry.
 - **Destructive group** — a single Remove, Rename, or Change routing operation. Each is its own group of one with its own STOP gate and commit.
+- **Marker group** — a single Mark handled or Reactivate operation. Non-destructive (it sets or clears a display/convergence marker only), but still its own group of one with its own STOP gate and commit.
 
 Walk the groups in user order. For mixed batches, each destructive op is its own group; contiguous additive ops in between batch.
 
@@ -49,26 +52,29 @@ Walk the groups in user order. For mixed batches, each destructive op is its own
 
 Apply per-operation validation gates **before** any STOP gate. If validation fails for an operation, surface the rejection with a clear next-step pointer (don't just say "blocked") and remove the operation from its group. Continue with the rest.
 
-**Lifecycle gates** — for destructive operations (Remove, Rename, Change routing), look up the operation's target topic in `discovery_map` and read its `lifecycle` field. The operation is allowed only when:
+**Lifecycle gates** — for destructive (Remove, Rename, Change routing) and marker (Mark handled, Reactivate) operations, look up the operation's target topic in `discovery_map` and read its `lifecycle` field. The operation is allowed only when:
 
 | Operation       | Allowed lifecycles | Disallowed                                                                  |
 | --------------- | ------------------ | --------------------------------------------------------------------------- |
-| Remove          | `fresh`            | `researching`, `discussing`, `ready_for_discussion`, `decided`, `cancelled` |
+| Remove          | `fresh`            | `researching`, `discussing`, `ready_for_discussion`, `decided`, `handled`, `cancelled` |
 | Rename          | `fresh`            | all others                                                                  |
 | Change routing  | `fresh`            | all others (routing is implicit once a phase item exists)                   |
+| Mark handled    | any except `handled`, `cancelled` | `handled`, `cancelled`                                       |
+| Reactivate      | `handled`          | all others                                                                  |
 | Edit summary    | any                | —                                                                           |
 | Edit description| any                | —                                                                           |
 
 `cancelled` is also disallowed for Remove because the discovery item is the historical record of the topic ever having existed. Removal is for never-started topics only; cancel-then-vanish would erase the audit trail. The `a`/`cancel` flow in `/workflow-continue-epic` is the right tool for stopping in-flight work.
 
-Render the rejection in a code block:
+Mark handled is non-destructive — it sets a display/convergence marker, primary use being a research topic that has fanned out into differently-named discussions. It's allowed from any actionable lifecycle; only an already-`handled` or `cancelled` topic is rejected. Reactivate is its inverse — allowed on `handled` only, clearing the marker.
+
+**Destructive-op rejection** — for a Remove, Rename, or Change routing op that fails its gate, render in a code block:
 
 > *Output the next fenced block as a code block:*
 
 ```
 "{topic}" can't be {removed|renamed|re-routed} from the map —
-{lifecycle_phrase}. To stop work on it, use `a`/`cancel` from the
-epic menu instead.
+{lifecycle_phrase}. {recovery_pointer}
 ```
 
 `{lifecycle_phrase}` examples:
@@ -77,7 +83,24 @@ epic menu instead.
 - `discussing` — `discussion is in flight on it`
 - `ready_for_discussion` — `research has completed and discussion is queued`
 - `decided` — `discussion has concluded`
+- `handled` — `it has fanned out into discussions and stays on the map as historical anchor`
 - `cancelled` — `it has phase work in cancelled state and stays on the map as historical record`
+
+`{recovery_pointer}`: for a `handled` target, `To bring it back, say "reactivate {topic}".` For any other disallowed lifecycle, `To stop work on it, use \`a\`/\`cancel\` from the epic menu instead.`
+
+**Marker-op rejection** — for a Mark handled op on an already-`handled` or `cancelled` topic, or a Reactivate op on a non-`handled` topic, render in a code block:
+
+> *Output the next fenced block as a code block:*
+
+```
+"{topic}" can't be {marked handled|reactivated} — {marker_phrase}.
+```
+
+`{marker_phrase}` examples:
+
+- Mark handled on `handled` — `it's already marked handled`
+- Mark handled on `cancelled` — `it's cancelled; reactivate the phase work from the epic menu first`
+- Reactivate on a non-`handled` lifecycle — `it isn't marked handled, so there's nothing to reactivate`
 
 **Name validation** — for each Rename operation, validate the proposed name via the shared reference:
 
@@ -115,9 +138,17 @@ Walk the validated operation groups in user order. For the next pending group:
 
 → Proceed to **H. Edit Description**.
 
+#### If the group is a Mark handled operation
+
+→ Proceed to **I. Mark Handled**.
+
+#### If the group is a Reactivate operation
+
+→ Proceed to **J. Reactivate**.
+
 #### Otherwise (no groups remain)
 
-→ Proceed to **I. Done**.
+→ Proceed to **K. Done**.
 
 ## D. Edit Summary
 
@@ -446,7 +477,115 @@ git commit -m "discovery({work_unit}): edit {N} description(s)"
 
 → Return to **C. Apply** for the next group.
 
-## I. Done
+## I. Mark Handled
+
+Render the proposal:
+
+> *Output the next fenced block as a code block:*
+
+```
+Mark "{name}" handled.
+
+  It stays on the map as a historical anchor, but stops
+  prompting for a next action and no longer counts against
+  convergence. Use this when its research has fanned out into
+  other discussions. Reversible with "reactivate {name}".
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Confirm mark handled?
+
+- **`y`/`yes`**
+- **`n`/`no`**
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `no`
+
+Skip this operation. No manifest writes, no session-log entry, no commit.
+
+→ Return to **C. Apply** for the next group.
+
+#### If `yes`
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} handled true
+```
+
+Append an Edits entry to the session log. If the log doesn't exist yet, create it first from [template.md](template.md). If **Edits** currently reads `(none)`, replace it with the bullet:
+
+```markdown
+- Marked handled: {name} — {short reason}
+```
+
+Per-item commit:
+
+```bash
+git add -- .workflows/{work_unit}/manifest.json .workflows/{work_unit}/discovery/session-{session_number:03d}.md
+git commit -m "discovery({work_unit}): mark {name} handled"
+```
+
+→ Return to **C. Apply** for the next group.
+
+## J. Reactivate
+
+Render the proposal:
+
+> *Output the next fenced block as a code block:*
+
+```
+Reactivate "{name}".
+
+  Clears the handled marker. The topic returns to its
+  name-matched lifecycle and counts against convergence again.
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Confirm reactivation?
+
+- **`y`/`yes`**
+- **`n`/`no`**
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `no`
+
+Skip this operation. No manifest writes, no session-log entry, no commit.
+
+→ Return to **C. Apply** for the next group.
+
+#### If `yes`
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{name} handled
+```
+
+Append an Edits entry to the session log. If the log doesn't exist yet, create it first from [template.md](template.md). If **Edits** currently reads `(none)`, replace it with the bullet:
+
+```markdown
+- Reactivated: {name} — {short reason}
+```
+
+Per-item commit:
+
+```bash
+git add -- .workflows/{work_unit}/manifest.json .workflows/{work_unit}/discovery/session-{session_number:03d}.md
+git commit -m "discovery({work_unit}): reactivate {name}"
+```
+
+→ Return to **C. Apply** for the next group.
+
+## K. Done
 
 All operation groups have been processed.
 

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -75,14 +75,15 @@ The map exists; editing existing items is available alongside new exploration. R
 
 Render rules:
 
-- `tier_breakdown` — append ` — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {cancelled} cancelled` (omitting zero-count categories) only when more than one tier bucket is non-zero. When only one bucket is non-zero, omit the breakdown and render just `Discovery Map ({total} topics)`.
+- `tier_breakdown` — append ` — {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {handled} handled · {cancelled} cancelled` (omitting zero-count categories) only when more than one tier bucket is non-zero. When only one bucket is non-zero, omit the breakdown and render just `Discovery Map ({total} topics)`.
 - `{branch}` — `┌─` for the first row, `└─` for the last, `├─` for the rest. With a single row, use `└─` (no upward stroke).
-- Tier ordering — discovery output is already tier-sorted (`→ ◐ ✓ ○ ⊘`, suggested execution order within tier). Render in the order given.
+- Tier ordering — discovery output is already tier-sorted (`→ ◐ ✓ ○ ⊙ ⊘`, suggested execution order within tier). Render in the order given.
 - `lifecycle_label` by tier (wrapped in square brackets per the row template):
   - `→` — `research complete · ready for discussion`
   - `◐` — `researching` or `discussing` (use `topic.current_phase`)
   - `✓` — `decided`
   - `○` — `fresh · routed to {topic.routing}` (omit ` · routed to ...` if `topic.routing` is null)
+  - `⊙` — `handled · research fanned out`
   - `⊘` — `cancelled`
 
 Then frame the opener:
@@ -94,7 +95,7 @@ You can open a fresh thread — a new area of the work you want
 to sketch out — and we'll explore it the same way we did first
 time, then synthesise topics at the end. Or you can name changes
 to existing items: add, remove, rename, re-route, edit summary,
-edit description. Both in one go is fine.
+edit description, mark handled. Both in one go is fine.
 
 Say "show map" anytime to pull the map back up.
 

--- a/skills/workflow-discovery/scripts/discovery.cjs
+++ b/skills/workflow-discovery/scripts/discovery.cjs
@@ -15,7 +15,7 @@ const {
 
 function buildDiscoveryMap(manifest) {
   const discoveryItems = phaseItems(manifest, 'discovery');
-  if (discoveryItems.length === 0) return { map: [], summary: { total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, cancelled: 0 }, needs_sequencing: false };
+  if (discoveryItems.length === 0) return { map: [], summary: { total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, handled: 0, cancelled: 0 }, needs_sequencing: false };
   const map = discoveryItems.map(item => {
     const { lifecycle, tier, current_phase } = computeTopicLifecycle(manifest, item.name);
     return {
@@ -88,7 +88,7 @@ function format(result) {
   lines.push(`=== DISCOVERY DISCOVERY: ${result.work_unit} ===`);
 
   const s = result.map_summary;
-  lines.push(`map_summary: ${s.total} topics — ${s.decided} decided, ${s.in_flight} in-flight, ${s.ready} ready, ${s.fresh} fresh, ${s.cancelled} cancelled`);
+  lines.push(`map_summary: ${s.total} topics — ${s.decided} decided, ${s.in_flight} in-flight, ${s.ready} ready, ${s.fresh} fresh, ${s.handled} handled, ${s.cancelled} cancelled`);
   lines.push(`needs_sequencing: ${result.needs_sequencing}`);
   lines.push('');
 

--- a/skills/workflow-migrate/scripts/migrations/043-handled-umbrellas-and-restamp-caches.sh
+++ b/skills/workflow-migrate/scripts/migrations/043-handled-umbrellas-and-restamp-caches.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+#
+# Migration 043: Mark legacy umbrellas handled + re-stamp valid analysis caches
+#
+# Two jobs, run in order per epic work unit (Job 1 feeds Job 2):
+#
+# Job 1 — mark legacy completed-umbrella discovery items `handled`. A
+#   migration-seeded research umbrella whose content fanned out into
+#   differently-named discussions never matches a same-named discussion, so the
+#   map renders it `→ ready for discussion` forever (a false nag). Marking it
+#   `handled` makes it terminal on the map without a next action.
+#
+# Job 2 — re-stamp a *valid* analysis cache for past-discovery epics. A prior
+#   migration cleared analysis caches without re-stamping, so finished epics read
+#   "no cache → stale → one pointless forced analysis run" on re-open. Stamping a
+#   valid cache (byte-matching the read side in discovery-utils.cjs) stops the
+#   re-fire. Only when the cache is currently absent — a present cache, even a
+#   stale one, is never clobbered.
+#
+# Idempotent: Job 1 skips already-handled items; Job 2 skips present caches and
+# only writes when something changed. Only epics; only migration-seeded
+# umbrellas; honours phases.discovery.dismissed[]; in-discovery epics keep an
+# absent cache (they still run once, behind the boot-time gate).
+#
+# Point-in-time snapshot: inline node reading/writing manifest.json directly.
+# Never uses the manifest CLI or requires discovery-utils.cjs.
+#
+
+WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+
+[ -d "$WORKFLOWS_DIR" ] || return 0
+
+result=$(node -e "
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const wfDir = '$WORKFLOWS_DIR';
+
+function fileExists(p) { try { fs.accessSync(p); return true; } catch { return false; } }
+
+function md5(paths) {
+  const hash = crypto.createHash('md5');
+  for (const p of paths) {
+    try { hash.update(fs.readFileSync(p)); } catch {}
+  }
+  return hash.digest('hex');
+}
+
+function itemsOf(phase) {
+  return (phase && phase.items && typeof phase.items === 'object') ? phase.items : {};
+}
+
+const now = new Date().toISOString();
+let changedAny = false;
+
+let entries;
+try { entries = fs.readdirSync(wfDir, { withFileTypes: true }); } catch { entries = []; }
+
+for (const entry of entries) {
+  if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+
+  const wuDir = path.join(wfDir, entry.name);
+  const mPath = path.join(wuDir, 'manifest.json');
+  if (!fs.existsSync(mPath)) continue;
+
+  let m;
+  try { m = JSON.parse(fs.readFileSync(mPath, 'utf8')); } catch { continue; }
+  if (m.work_type !== 'epic') continue;
+
+  m.phases = m.phases || {};
+  const phases = m.phases;
+  phases.discovery = phases.discovery || {};
+  const discovery = phases.discovery;
+
+  const discoveryItems = itemsOf(discovery);
+  const dismissed = Array.isArray(discovery.dismissed) ? discovery.dismissed : [];
+  const researchItems = itemsOf(phases.research);
+  const discussionItems = itemsOf(phases.discussion);
+
+  let updated = false;
+
+  // --- Job 1: mark legacy completed umbrellas handled ---
+
+  const hasOtherCompletedDiscussion = Object.keys(discussionItems)
+    .some(n => (discussionItems[n] || {}).status === 'completed');
+
+  const justHandled = {};
+  for (const name of Object.keys(discoveryItems)) {
+    const item = discoveryItems[name] || {};
+    if (item.handled === true) continue;
+    const source = typeof item.source === 'string' ? item.source : '';
+    if (source.indexOf('migration-seeded') === -1) continue;
+    if (item.routing !== 'research') continue;
+    const r = researchItems[name];
+    if (!r || r.status !== 'completed') continue;
+    if (!fileExists(path.join(wuDir, 'research', name + '.md'))) continue;
+    const sameNamed = discussionItems[name];
+    if (sameNamed && sameNamed.status === 'completed') continue;
+    if (!hasOtherCompletedDiscussion) continue;
+    if (dismissed.indexOf(name) !== -1) continue;
+    item.handled = true;
+    justHandled[name] = true;
+    updated = true;
+  }
+
+  // --- Job 2: re-stamp valid caches for past-discovery epics ---
+
+  // discoveryQuiescent: every discovery item resolves to a terminal lifecycle.
+  // Mirrors computeTopicLifecycle's branch order inline, treating a just-handled
+  // or already-handled item as terminal first.
+  let discoveryQuiescent = true;
+  for (const name of Object.keys(discoveryItems)) {
+    const item = discoveryItems[name] || {};
+    if (justHandled[name] || item.handled === true) continue; // handled
+    const r = researchItems[name];
+    const d = discussionItems[name];
+    const rs = r ? r.status : null;
+    const ds = d ? d.status : null;
+    if (ds === 'completed') continue;                          // decided
+    if (rs === 'cancelled' && ds === 'cancelled') continue;    // cancelled
+    discoveryQuiescent = false;
+    break;
+  }
+
+  // pastPlanning: at least one non-cancelled, non-superseded item in planning,
+  // implementation, or review. Spec is not a stop — the planning floor.
+  let pastPlanning = false;
+  for (const ph of ['planning', 'implementation', 'review']) {
+    const items = itemsOf(phases[ph]);
+    for (const n of Object.keys(items)) {
+      const st = (items[n] || {}).status;
+      if (st !== 'cancelled' && st !== 'superseded') { pastPlanning = true; break; }
+    }
+    if (pastPlanning) break;
+  }
+
+  if (discoveryQuiescent && pastPlanning) {
+    // research cache — completed research files on disk, sorted by full path.
+    const researchCache = phases.research && phases.research.analysis_cache;
+    if (!researchCache || !researchCache.checksum) {
+      const files = [];
+      for (const n of Object.keys(researchItems)) {
+        if ((researchItems[n] || {}).status !== 'completed') continue;
+        const fp = path.join(wuDir, 'research', n + '.md');
+        if (fileExists(fp)) files.push(fp);
+      }
+      files.sort();
+      if (files.length > 0) {
+        phases.research = phases.research || {};
+        phases.research.analysis_cache = {
+          checksum: md5(files),
+          generated: now,
+          files: files.map(f => path.basename(f)).sort(),
+        };
+        updated = true;
+      }
+    }
+
+    // gap cache — completed research + completed discussion files merged then
+    // sorted by full path (read side sorts the combined list).
+    const gapCache = discovery.gap_analysis_cache;
+    if (!gapCache || !gapCache.checksum) {
+      const researchFiles = [];
+      for (const n of Object.keys(researchItems)) {
+        if ((researchItems[n] || {}).status !== 'completed') continue;
+        const fp = path.join(wuDir, 'research', n + '.md');
+        if (fileExists(fp)) researchFiles.push(fp);
+      }
+      const discussionFiles = [];
+      for (const n of Object.keys(discussionItems)) {
+        if ((discussionItems[n] || {}).status !== 'completed') continue;
+        const fp = path.join(wuDir, 'discussion', n + '.md');
+        if (fileExists(fp)) discussionFiles.push(fp);
+      }
+      const inputs = researchFiles.concat(discussionFiles);
+      inputs.sort();
+      if (inputs.length > 0) {
+        discovery.gap_analysis_cache = {
+          checksum: md5(inputs),
+          generated: now,
+          input_files: inputs.map(f => path.basename(f)).sort(),
+        };
+        updated = true;
+      }
+    }
+  }
+
+  if (updated) {
+    fs.writeFileSync(mPath, JSON.stringify(m, null, 2) + '\n');
+    changedAny = true;
+  }
+}
+
+if (changedAny) console.log('changed');
+" 2>/dev/null) || true
+
+if [ "$result" = "changed" ]; then
+  report_update
+else
+  report_skip
+fi
+
+return 0

--- a/skills/workflow-shared/references/sequence-discovery-map.md
+++ b/skills/workflow-shared/references/sequence-discovery-map.md
@@ -32,7 +32,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit} work_
 
 ## B. Gather Live Topics
 
-Take the live topic names from the caller's most recent discovery output — every `discovery_map` row whose tier is not `⊘` (cancelled).
+Take the live topic names from the caller's most recent discovery output — every `discovery_map` row whose tier is neither `⊘` (cancelled) nor `⊙` (handled). Handled topics are non-actionable — a research umbrella that fanned out — so they get no execution order, the same as cancelled.
 
 For richer context, read each live topic's `summary` and `description` from the manifest:
 

--- a/skills/workflow-shared/scripts/discovery-utils.cjs
+++ b/skills/workflow-shared/scripts/discovery-utils.cjs
@@ -288,7 +288,7 @@ function computeAnalysisCacheStatus(manifest, workflowsDir, kind) {
   return { status: 'absent', generated: null, files: [] };
 }
 
-const TIER_RANK = { '→': 0, '◐': 1, '✓': 2, '○': 3, '⊘': 4 };
+const TIER_RANK = { '→': 0, '◐': 1, '✓': 2, '○': 3, '⊙': 4, '⊘': 5 };
 
 // Shared row comparator for the discovery map: tier rank first, then suggested
 // execution order ascending (null orders sort last), then name as final fallback.
@@ -302,13 +302,23 @@ function compareMapRows(a, b) {
   return a.name.localeCompare(b.name);
 }
 
-// True when any live (non-cancelled) map item lacks a suggested execution order.
-// Programmatic detection — the assignment of order values stays with Claude.
+// True when any live (non-cancelled, non-handled) map item lacks a suggested
+// execution order. Handled topics are non-actionable — they get no order, the
+// same as cancelled. Programmatic detection — the assignment of order values
+// stays with Claude.
 function computeNeedsSequencing(mapItems) {
-  return mapItems.some(it => it.tier !== '⊘' && it.order == null);
+  return mapItems.some(it => it.tier !== '⊘' && it.tier !== '⊙' && it.order == null);
 }
 
 function computeTopicLifecycle(manifest, topicName) {
+  const discovery = phaseItems(manifest, 'discovery').find(i => i.name === topicName);
+  // Stored marker wins over name-matching: a research topic that fanned out
+  // into differently-named discussions is terminal, with no next action. Read
+  // only the item's own field — never inspect siblings or provenance.
+  if (discovery && discovery.handled === true) {
+    return { lifecycle: 'handled', tier: '⊙', current_phase: null };
+  }
+
   const research = phaseItems(manifest, 'research').find(i => i.name === topicName);
   const discussion = phaseItems(manifest, 'discussion').find(i => i.name === topicName);
 
@@ -354,19 +364,21 @@ function computeNextAction(routing, lifecycle) {
       return 'continue_discussion';
     case 'decided':
     case 'cancelled':
+    case 'handled':
     default:
       return null;
   }
 }
 
 function computeMapSummary(items) {
-  const counts = { total: items.length, decided: 0, in_flight: 0, ready: 0, fresh: 0, cancelled: 0 };
+  const counts = { total: items.length, decided: 0, in_flight: 0, ready: 0, fresh: 0, handled: 0, cancelled: 0 };
   for (const it of items) {
     switch (it.tier) {
       case '✓': counts.decided++; break;
       case '◐': counts.in_flight++; break;
       case '→': counts.ready++; break;
       case '○': counts.fresh++; break;
+      case '⊙': counts.handled++; break;
       case '⊘': counts.cancelled++; break;
     }
   }

--- a/tests/scripts/test-discovery-for-discovery.cjs
+++ b/tests/scripts/test-discovery-for-discovery.cjs
@@ -231,6 +231,33 @@ describe('workflow-discovery discovery', () => {
     assert.strictEqual(r.discovery_map[0].lifecycle, 'fresh');
   });
 
+  it('reflects handled lifecycle when the discovery item carries the handled marker', () => {
+    createManifest(dir, 'payments', {
+      work_type: 'epic',
+      phases: {
+        discovery: { items: { umbrella: { status: 'in-progress', routing: 'research', source: 'discovery', handled: true } } },
+        research:  { items: { umbrella: { status: 'completed' } } },
+      },
+    });
+    const r = discover(dir, 'payments');
+    assert.strictEqual(r.discovery_map[0].lifecycle, 'handled');
+    assert.strictEqual(r.discovery_map[0].tier, '⊙');
+    assert.strictEqual(r.discovery_map[0].current_phase, null);
+  });
+
+  it('handled item counts in the handled bucket and is excluded from sequencing', () => {
+    createManifest(dir, 'payments', {
+      work_type: 'epic',
+      phases: {
+        discovery: { items: { umbrella: { status: 'in-progress', routing: 'research', source: 'discovery', handled: true, order: null } } },
+        research:  { items: { umbrella: { status: 'completed' } } },
+      },
+    });
+    const r = discover(dir, 'payments');
+    assert.strictEqual(r.map_summary.handled, 1);
+    assert.strictEqual(r.needs_sequencing, false);
+  });
+
   // --- source_provenance ---
 
   it('source_provenance is null for source=discovery', () => {
@@ -346,7 +373,7 @@ describe('workflow-discovery discovery', () => {
     createManifest(dir, 'payments', { work_type: 'epic', phases: {} });
     const r = discover(dir, 'payments');
     assert.deepStrictEqual(r.map_summary, {
-      total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, cancelled: 0,
+      total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, handled: 0, cancelled: 0,
     });
   });
 
@@ -520,7 +547,7 @@ describe('workflow-discovery format', () => {
       },
     });
     const out = format(discover(dir, 'payments'));
-    assert.match(out, /map_summary: 2 topics — 0 decided, 0 in-flight, 0 ready, 2 fresh, 0 cancelled/);
+    assert.match(out, /map_summary: 2 topics — 0 decided, 0 in-flight, 0 ready, 2 fresh, 0 handled, 0 cancelled/);
   });
 
   it('map_summary line for empty map reads "0 topics — ..."', () => {

--- a/tests/scripts/test-discovery-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-discovery-for-workflow-continue-epic.cjs
@@ -836,6 +836,58 @@ describe('workflow-continue-epic discovery', () => {
       assert.strictEqual(d.convergence_state, 'in-progress');
     });
 
+    it('handled row renders ⊙ with no next_action', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discovery: { items: { umbrella: { routing: 'research', source: 'discovery', handled: true } } },
+          research: { items: { umbrella: { status: 'completed' } } },
+        },
+      });
+      const t = discover(dir).epics[0].detail.discovery_map[0];
+      assert.strictEqual(t.tier, '⊙');
+      assert.strictEqual(t.lifecycle, 'handled');
+      assert.strictEqual(t.next_action, null);
+    });
+
+    it('convergence: handled topic counts as terminal — settled when only handled + decided remain', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discovery: {
+            items: {
+              umbrella: { routing: 'research', source: 'discovery', handled: true },
+              decided: { routing: 'discussion', source: 'discovery' },
+            },
+          },
+          research: { items: { umbrella: { status: 'completed' } } },
+          discussion: { items: { decided: { status: 'completed' } } },
+        },
+      });
+      const d = discover(dir).epics[0].detail;
+      assert.strictEqual(d.convergence_state, 'settled');
+      assert.strictEqual(d.map_summary.handled, 1);
+    });
+
+    it('handled topic is excluded from needs_sequencing like cancelled', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discovery: {
+            items: {
+              umbrella: { routing: 'research', source: 'discovery', handled: true, order: null },
+              live: { routing: 'discussion', source: 'discovery', order: 1 },
+            },
+          },
+          research: { items: { umbrella: { status: 'completed' } } },
+          discussion: { items: { live: { status: 'in-progress' } } },
+        },
+      });
+      const d = discover(dir).epics[0].detail;
+      // Only the handled topic lacks an order; it's excluded, so no sequencing needed.
+      assert.strictEqual(d.needs_sequencing, false);
+    });
+
     it('source provenance: discovery → null', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',

--- a/tests/scripts/test-discovery-utils.cjs
+++ b/tests/scripts/test-discovery-utils.cjs
@@ -893,12 +893,18 @@ describe('discovery-utils', () => {
   });
 
   describe('TIER_RANK', () => {
-    it('orders tiers from ready → in-flight → decided → fresh → cancelled', () => {
+    it('orders tiers from ready → in-flight → decided → fresh → handled → cancelled', () => {
       assert.strictEqual(TIER_RANK['→'], 0);
       assert.strictEqual(TIER_RANK['◐'], 1);
       assert.strictEqual(TIER_RANK['✓'], 2);
       assert.strictEqual(TIER_RANK['○'], 3);
-      assert.strictEqual(TIER_RANK['⊘'], 4);
+      assert.strictEqual(TIER_RANK['⊙'], 4);
+      assert.strictEqual(TIER_RANK['⊘'], 5);
+    });
+
+    it('ranks handled just before cancelled (both non-actionable)', () => {
+      assert.ok(TIER_RANK['⊙'] < TIER_RANK['⊘']);
+      assert.ok(TIER_RANK['○'] < TIER_RANK['⊙']);
     });
   });
 
@@ -986,6 +992,60 @@ describe('discovery-utils', () => {
       const r = computeTopicLifecycle(m, 'auth');
       assert.strictEqual(r.lifecycle, 'discussing');
     });
+
+    // Build a manifest where the discovery item carries the `handled` marker,
+    // alongside whatever research/discussion statuses are supplied.
+    function loadWithHandled(name, handledValue, phaseStatuses) {
+      const phases = { discovery: { items: { [name]: { routing: 'research', handled: handledValue } } } };
+      for (const [phase, status] of Object.entries(phaseStatuses || {})) {
+        phases[phase] = { items: { [name]: { status } } };
+      }
+      createManifest(dir, 'alpha', { phases });
+      return loadManifest(dir, 'alpha');
+    }
+
+    it('handled marker beats ready_for_discussion (research completed, no discussion)', () => {
+      const m = loadWithHandled('umbrella', true, { research: 'completed' });
+      const r = computeTopicLifecycle(m, 'umbrella');
+      assert.deepStrictEqual(r, { lifecycle: 'handled', tier: '⊙', current_phase: null });
+    });
+
+    it('handled marker beats decided (same-named discussion completed)', () => {
+      const m = loadWithHandled('umbrella', true, { research: 'completed', discussion: 'completed' });
+      const r = computeTopicLifecycle(m, 'umbrella');
+      assert.strictEqual(r.lifecycle, 'handled');
+      assert.strictEqual(r.tier, '⊙');
+    });
+
+    it('absent marker falls through to name-matching', () => {
+      // No handled field at all → resolves by research/discussion statuses.
+      const m = loadWithPhases('topic', { research: 'completed' });
+      const r = computeTopicLifecycle(m, 'topic');
+      assert.strictEqual(r.lifecycle, 'ready_for_discussion');
+    });
+
+    it('handled !== true (e.g. false) falls through to name-matching', () => {
+      const m = loadWithHandled('topic', false, { research: 'completed' });
+      const r = computeTopicLifecycle(m, 'topic');
+      assert.strictEqual(r.lifecycle, 'ready_for_discussion');
+    });
+
+    it('reads only the item own field — handled on one topic does not affect another', () => {
+      createManifest(dir, 'alpha', {
+        phases: {
+          discovery: {
+            items: {
+              umbrella: { routing: 'research', handled: true },
+              sibling: { routing: 'research' },
+            },
+          },
+          research: { items: { umbrella: { status: 'completed' }, sibling: { status: 'completed' } } },
+        },
+      });
+      const m = loadManifest(dir, 'alpha');
+      assert.strictEqual(computeTopicLifecycle(m, 'umbrella').lifecycle, 'handled');
+      assert.strictEqual(computeTopicLifecycle(m, 'sibling').lifecycle, 'ready_for_discussion');
+    });
   });
 
   describe('computeNextAction', () => {
@@ -1022,6 +1082,11 @@ describe('discovery-utils', () => {
       assert.strictEqual(computeNextAction('discussion', 'cancelled'), null);
     });
 
+    it('handled → null (no next action)', () => {
+      assert.strictEqual(computeNextAction('research', 'handled'), null);
+      assert.strictEqual(computeNextAction('discussion', 'handled'), null);
+    });
+
     it('unknown lifecycle → null', () => {
       assert.strictEqual(computeNextAction('research', 'made-up'), null);
     });
@@ -1031,7 +1096,7 @@ describe('discovery-utils', () => {
     it('returns zero counts for an empty items array', () => {
       assert.deepStrictEqual(
         computeMapSummary([]),
-        { total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, cancelled: 0 },
+        { total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, handled: 0, cancelled: 0 },
       );
     });
 
@@ -1044,12 +1109,20 @@ describe('discovery-utils', () => {
         { tier: '○' },
         { tier: '○' },
         { tier: '○' },
+        { tier: '⊙' },
         { tier: '⊘' },
       ];
       assert.deepStrictEqual(
         computeMapSummary(items),
-        { total: 8, decided: 1, in_flight: 1, ready: 2, fresh: 3, cancelled: 1 },
+        { total: 9, decided: 1, in_flight: 1, ready: 2, fresh: 3, handled: 1, cancelled: 1 },
       );
+    });
+
+    it('counts the handled bucket independently of cancelled', () => {
+      const items = [{ tier: '⊙' }, { tier: '⊙' }, { tier: '⊘' }];
+      const r = computeMapSummary(items);
+      assert.strictEqual(r.handled, 2);
+      assert.strictEqual(r.cancelled, 1);
     });
 
     it('ignores items with unrecognised tier glyphs but still counts total', () => {
@@ -1088,6 +1161,22 @@ describe('discovery-utils', () => {
         { tier: '⊘', order: null },
       ];
       assert.strictEqual(computeNeedsSequencing(items), false);
+    });
+
+    it('returns false when only a handled item is missing order (excluded like cancelled)', () => {
+      const items = [
+        { tier: '◐', order: 1 },
+        { tier: '⊙', order: null },
+      ];
+      assert.strictEqual(computeNeedsSequencing(items), false);
+    });
+
+    it('returns true when a live item is missing order even alongside a handled item', () => {
+      const items = [
+        { tier: '⊙', order: null },
+        { tier: '○', order: null },
+      ];
+      assert.strictEqual(computeNeedsSequencing(items), true);
     });
 
     it('treats undefined order the same as null (missing)', () => {

--- a/tests/scripts/test-migration-043.sh
+++ b/tests/scripts/test-migration-043.sh
@@ -1,0 +1,461 @@
+#!/bin/bash
+#
+# Tests for migration 043: mark legacy umbrellas handled + re-stamp analysis caches
+#
+# Run: bash tests/scripts/test-migration-043.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/043-handled-umbrellas-and-restamp-caches.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/migration-043-test.XXXXXX")
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# Read a manifest field via node; prints the JS-stringified value.
+field() {
+  local manifest="$1" expr="$2"
+  node -e "
+    const m = JSON.parse(require('fs').readFileSync('$manifest', 'utf8'));
+    const v = (function(m){ return $expr; })(m);
+    console.log(v === undefined ? 'undefined' : v);
+  "
+}
+
+# --- Test 1: legacy umbrella marked handled ---
+test_umbrella_marked() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-a"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth talk" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-a", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } } },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  assert_eq "umbrella marked handled" "true" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.handled')"
+  teardown
+}
+
+# --- Test 2: user-authored umbrella (not migration-seeded) untouched ---
+test_user_authored_untouched() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-b"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-b", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": { "umbrella": { "source": "discovery", "routing": "research" } } },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  assert_eq "user-authored umbrella not handled" "undefined" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.handled')"
+  teardown
+}
+
+# --- Test 3: dismissed name skipped ---
+test_dismissed_skipped() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-c"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-c", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": {
+      "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } },
+      "dismissed": ["umbrella"]
+    },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  assert_eq "dismissed umbrella not handled" "undefined" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.handled')"
+  teardown
+}
+
+# --- Test 4: genuine 1:1 (same-named completed discussion) untouched ---
+test_same_named_discussion_untouched() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-d"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "umbrella talk" > "$wu/discussion/umbrella.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-d", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } } },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "umbrella": { "status": "completed" } } },
+    "planning": { "items": { "umbrella": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  assert_eq "same-named-discussion umbrella not handled" "undefined" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.handled')"
+  teardown
+}
+
+# --- Test 5: no other completed discussions → untouched ---
+test_no_other_discussions_untouched() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-e"
+  mkdir -p "$wu/research" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-e", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } } },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "planning": { "items": { "umbrella": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  assert_eq "no-other-discussion umbrella not handled" "undefined" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.handled')"
+  teardown
+}
+
+# --- Test 6: cache re-stamp when both absent + quiescent + past-planning ---
+test_cache_restamp() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-f"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research umbrella" > "$wu/research/umbrella.md"
+  echo "auth discussion" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-f", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } } },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  # Research cache present + byte-matches md5 of research/umbrella.md.
+  local research_match=$(node -e "
+    const fs = require('fs'), crypto = require('crypto');
+    const m = JSON.parse(fs.readFileSync('$wu/manifest.json', 'utf8'));
+    const c = m.phases.research.analysis_cache;
+    const exp = crypto.createHash('md5').update(fs.readFileSync('$wu/research/umbrella.md')).digest('hex');
+    console.log(!!c && c.checksum === exp);
+  ")
+  assert_eq "research cache byte-matches read side" "true" "$research_match"
+
+  # Gap cache present + byte-matches md5 of full-path-sorted [discussion/auth, research/umbrella].
+  local gap_match=$(node -e "
+    const fs = require('fs'), crypto = require('crypto');
+    const m = JSON.parse(fs.readFileSync('$wu/manifest.json', 'utf8'));
+    const c = m.phases.discovery.gap_analysis_cache;
+    const paths = ['$wu/discussion/auth.md', '$wu/research/umbrella.md'].sort();
+    const h = crypto.createHash('md5');
+    for (const p of paths) h.update(fs.readFileSync(p));
+    console.log(!!c && c.checksum === h.digest('hex'));
+  ")
+  assert_eq "gap cache byte-matches read side" "true" "$gap_match"
+
+  # files / input_files are sorted basenames.
+  assert_eq "research files basenames" "umbrella.md" "$(field "$wu/manifest.json" 'm.phases.research.analysis_cache.files.join(",")')"
+  assert_eq "gap input_files basenames" "auth.md,umbrella.md" "$(field "$wu/manifest.json" 'm.phases.discovery.gap_analysis_cache.input_files.join(",")')"
+  teardown
+}
+
+# --- Test 7: present (stale) caches not clobbered ---
+test_present_cache_not_clobbered() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-g"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-g", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": {
+      "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } },
+      "gap_analysis_cache": { "checksum": "GAPSTALE", "generated": "old", "input_files": ["gone.md"] }
+    },
+    "research": {
+      "items": { "umbrella": { "status": "completed" } },
+      "analysis_cache": { "checksum": "RESEARCHSTALE", "generated": "old", "files": ["gone.md"] }
+    },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  assert_eq "research cache not clobbered" "RESEARCHSTALE" "$(field "$wu/manifest.json" 'm.phases.research.analysis_cache.checksum')"
+  assert_eq "gap cache not clobbered" "GAPSTALE" "$(field "$wu/manifest.json" 'm.phases.discovery.gap_analysis_cache.checksum')"
+  # Job 1 still runs even with present caches.
+  assert_eq "umbrella still marked handled" "true" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.handled')"
+  teardown
+}
+
+# --- Test 8: in-discovery epic (a fresh topic remains) left with absent caches ---
+test_in_discovery_left_absent() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-h"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-h", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": {
+      "items": {
+        "umbrella": { "source": "migration-seeded", "routing": "research" },
+        "pending": { "source": "discovery", "routing": "research" }
+      }
+    },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  # Job 1 still marks the qualifying umbrella.
+  assert_eq "umbrella handled even in-discovery" "true" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.handled')"
+  # But quiescence fails (pending is fresh) → caches stay absent.
+  assert_eq "research cache stays absent" "true" "$(field "$wu/manifest.json" '!m.phases.research.analysis_cache')"
+  assert_eq "gap cache stays absent" "true" "$(field "$wu/manifest.json" '!m.phases.discovery.gap_analysis_cache')"
+  teardown
+}
+
+# --- Test 9: past-planning false (spec only) → no restamp ---
+test_past_planning_false_no_restamp() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-i"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/specification"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-i", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } } },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "specification": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  # Spec is not a stop — no planning/impl/review → no restamp.
+  assert_eq "research cache absent (spec only)" "true" "$(field "$wu/manifest.json" '!m.phases.research.analysis_cache')"
+  assert_eq "gap cache absent (spec only)" "true" "$(field "$wu/manifest.json" '!m.phases.discovery.gap_analysis_cache')"
+  # Job 1 still independent of Job 2.
+  assert_eq "umbrella handled regardless" "true" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.handled')"
+  teardown
+}
+
+# --- Test 10: zero completed inputs → stays absent (not stale) ---
+test_zero_inputs_stays_absent() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-j"
+  mkdir -p "$wu/planning"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-j", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": {} },
+    "planning": { "items": { "x": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  assert_eq "research cache absent (zero inputs)" "true" "$(field "$wu/manifest.json" '!m.phases.research || !m.phases.research.analysis_cache')"
+  assert_eq "gap cache absent (zero inputs)" "true" "$(field "$wu/manifest.json" '!m.phases.discovery.gap_analysis_cache')"
+  teardown
+}
+
+# --- Test 11: idempotency (run twice, bytes identical) ---
+test_idempotent() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-k"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-k", "work_type": "epic", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } } },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+  local after_first=$(cat "$wu/manifest.json")
+  source "$MIGRATION"
+  local after_second=$(cat "$wu/manifest.json")
+
+  assert_eq "idempotent manifest bytes" "true" "$([ "$after_first" = "$after_second" ] && echo true || echo false)"
+  teardown
+}
+
+# --- Test 12: non-epic untouched ---
+test_non_epic_untouched() {
+  setup
+  local wu="$TEST_DIR/.workflows/feat-a"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "feat-a", "work_type": "feature", "status": "in-progress",
+  "phases": {
+    "discovery": { "items": { "umbrella": { "source": "migration-seeded", "routing": "research" } } },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  local before=$(cat "$wu/manifest.json")
+  source "$MIGRATION"
+  local after=$(cat "$wu/manifest.json")
+
+  assert_eq "non-epic manifest unchanged" "true" "$([ "$before" = "$after" ] && echo true || echo false)"
+  teardown
+}
+
+# --- Test 13: no .workflows directory → no-op ---
+test_no_workflows_noop() {
+  TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/migration-043-test.XXXXXX")
+  export PROJECT_DIR="$TEST_DIR"
+  # No .workflows created.
+
+  local rc=0
+  source "$MIGRATION" || rc=$?
+  assert_eq "returns cleanly with no .workflows" "0" "$rc"
+  rm -rf "$TEST_DIR"
+}
+
+# --- Test 14: unrelated fields preserved ---
+test_unrelated_fields_preserved() {
+  setup
+  local wu="$TEST_DIR/.workflows/epic-l"
+  mkdir -p "$wu/research" "$wu/discussion" "$wu/planning"
+  echo "research" > "$wu/research/umbrella.md"
+  echo "auth" > "$wu/discussion/auth.md"
+  cat > "$wu/manifest.json" << 'JSON'
+{
+  "name": "epic-l", "work_type": "epic", "status": "in-progress",
+  "description": "keep me", "seeds": [{"path": "seeds/x.md"}],
+  "phases": {
+    "discovery": {
+      "items": { "umbrella": { "source": "migration-seeded", "routing": "research", "summary": "preserve" } },
+      "dismissed": ["ghost"]
+    },
+    "research": { "items": { "umbrella": { "status": "completed" } } },
+    "discussion": { "items": { "auth": { "status": "completed" } } },
+    "planning": { "items": { "auth": { "status": "completed" } } }
+  }
+}
+JSON
+
+  source "$MIGRATION"
+
+  assert_eq "description preserved" "keep me" "$(field "$wu/manifest.json" 'm.description')"
+  assert_eq "seeds preserved" "seeds/x.md" "$(field "$wu/manifest.json" 'm.seeds[0].path')"
+  assert_eq "summary preserved" "preserve" "$(field "$wu/manifest.json" 'm.phases.discovery.items.umbrella.summary')"
+  assert_eq "dismissed preserved" "ghost" "$(field "$wu/manifest.json" 'm.phases.discovery.dismissed.join(",")')"
+  teardown
+}
+
+test_umbrella_marked
+test_user_authored_untouched
+test_dismissed_skipped
+test_same_named_discussion_untouched
+test_no_other_discussions_untouched
+test_cache_restamp
+test_present_cache_not_clobbered
+test_in_discovery_left_absent
+test_past_planning_false_no_restamp
+test_zero_inputs_stays_absent
+test_idempotent
+test_non_epic_untouched
+test_no_workflows_noop
+test_unrelated_fields_preserved
+
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Implements **PR1** of idea #31 (discovery-map `handled` state, analysis approval gate, finished-epic cache re-stamp). Self-contained and shippable: after this, finished epics stop nagging and stop re-firing analyses.

The discovery map infers a topic's lifecycle by matching research↔discussion files **1:1 by name**, but research→discussion is inherently **1:many**. A research umbrella whose content fanned out into differently-named discussions never finds a same-named discussion → renders `→ ready_for_discussion` forever (a false nag on a finished epic). This PR adds a terminal `handled` tier and a migration that self-heals legacy umbrellas and re-stamps the analysis caches a prior migration cleared.

## What's in it

**`handled` tier end-to-end** (`⊙`)
- Stored marker `phases.discovery.items.{topic}.handled = true` — mirrors the `legacy_split_state` precedent, absent by default, backward-compatible.
- **Never live-inferred** from "has children" — `research-analysis` derives child topics without moving content, so a parent with children may still legitimately want its own discussion. Set only by the heal migration or the user.
- `computeTopicLifecycle`: handled branch at the **top** of the branch order (stored marker wins over name-matching); reads only the item's own field.
- `TIER_RANK` `⊙` ranks just before `⊘` (both non-actionable). `computeNextAction` → `null`. `computeMapSummary` gets a `handled` bucket. `computeNeedsSequencing` excludes `⊙` like `⊘`.
- Convergence predicate treats `handled` as terminal (settled).
- Render refs updated: glyph, lifecycle label (`handled · research fanned out`), key, menu/recommendation/sequencing exclusions.
- Map operations: user-settable **Mark handled** / **Reactivate**.

**Migration 043** (`043-handled-umbrellas-and-restamp-caches.sh`)
- **Job 1** — marks legacy `migration-seeded` completed-umbrella discovery items `handled` (the completed counterpart of `legacy-research-split` detection: research completed + on disk, no same-named completed discussion, ≥1 other completed discussion, not dismissed, not already handled).
- **Job 2** — re-stamps a **valid** analysis cache (research + gap) for past-discovery epics (every discovery item terminal, ≥1 non-cancelled item at the planning floor or beyond), **only when the cache is currently absent** — present caches are never clobbered. Checksums byte-match the read side in `discovery-utils.cjs` (sorted full paths, raw bytes, gap = research+discussion merged-then-sorted).
- Inline `node` reading/writing `manifest.json` directly (point-in-time snapshot rule — no manifest CLI, no `require` of discovery-utils). Idempotent; epics only; honours `dismissed[]`.

## Tests
- `test-discovery-utils.cjs`: handled marker beats `ready_for_discussion`/`decided`, absent marker falls through, tier rank, next-action, summary bucket, sequencing exclusion.
- `test-discovery-for-{workflow-continue-epic,discovery}.cjs`: handled row renders `⊙` with no next-action, convergence flips to `settled`, sequencing excludes it.
- `test-migration-043.sh` (new, 27 assertions): umbrella marked / user-authored untouched / dismissed skipped / genuine 1:1 untouched / no-other-discussions untouched / cache re-stamp byte-match / present cache not clobbered / in-discovery left absent / past-planning false → no restamp / zero inputs stays absent / idempotency / non-epic & no-`.workflows` no-op / unrelated fields preserved.

Full suite green: `774` node tests, all migration tests (incl. 043 run twice), CLI round-trip for the boolean marker verified.

> **Deploy order**: PR2 (approval gate + fan-out offer) depends on this PR and must deploy after it — PR1's migration re-stamps finished epics to `valid`, so PR2's boot-time gate only fires on in-discovery epics rather than interrupting finished ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)