### PR TITLE
feat(discovery): gate analysis candidates behind per-topic approval

### DIFF
--- a/skills/workflow-shared/references/analysis-approval-gate.md
+++ b/skills/workflow-shared/references/analysis-approval-gate.md
@@ -1,0 +1,226 @@
+# Analysis Approval Gate
+
+*Shared reference. Loaded by [topic-discovery.md](topic-discovery.md).*
+
+---
+
+Presents the candidate topics an analysis staged, gates each per-topic before anything lands on the discovery map, and writes the approved ones. The analysis (`research-analysis` or `discovery-gap-analysis`) has already staged its genuinely-new candidates to a per-analysis staging file as `status: pending`; the already-on-map and dismissed cases were resolved silently at stage time and never reach this gate.
+
+The gate is the boot-time review surface — it runs before the dashboard. Approving a candidate writes it to `phases.discovery.items.{name}`; skipping it adds the name to `phases.discovery.dismissed[]` so the analysis won't re-propose it. Deferring leaves every candidate `pending` and signals the host to skip the cache stamp, so the same staging file is re-presented next boot without re-running the analysis.
+
+## Parameters
+
+The caller provides these via context before loading:
+
+- `analysis` — `research-analysis` or `discovery-gap-analysis`.
+- `work_unit` — the epic's work unit name.
+- `tracker` — a list (initially empty) the caller surfaces as the new-topics callout. The reference appends a name only when a candidate is **approved and written**.
+- `staging_file` — path to the analysis's staging file (`.workflows/{work_unit}/.state/{analysis}-candidates.md`).
+
+On return, the reference sets `gate_outcome` to `processed` (gate ran to completion — host stamps the cache) or `deferred` (host skips the stamp).
+
+`{analysis_label}`: `Research analysis` for `research-analysis`, `Gap analysis` for `discovery-gap-analysis`. Used in the lead-in.
+
+## A. Lead-In and Defer
+
+Read `staging_file`. Count the candidate blocks with `status: pending` — call it `K`.
+
+#### If `K` is `0`
+
+Nothing to review (every candidate was pre-resolved at stage time, or already approved/skipped on a prior pass).
+
+Set `gate_outcome` to `processed`.
+
+→ Return to caller.
+
+#### If `K` is `1` or more
+
+> *Output the next fenced block as a code block:*
+
+```
+{analysis_label} surfaced {K} candidate topic(s) — review before continuing.
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Review them now?
+
+- **`r`/`review`** — Review each candidate now
+- **`d`/`defer`** — Postpone all; review next time (nothing is written)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `defer`
+
+Leave every candidate `status: pending`. Write nothing to the map. Append nothing to `tracker`.
+
+Set `gate_outcome` to `deferred`.
+
+→ Return to caller.
+
+#### If `review`
+
+→ Proceed to **B. Gate Each Candidate**.
+
+## B. Gate Each Candidate
+
+Walk the candidate blocks in staging-file order. For the next block with `status: pending`:
+
+#### If no `pending` block remains
+
+Set `gate_outcome` to `processed`.
+
+→ Return to caller.
+
+Render the candidate. `{provenance}` is `derived from research "{parent}"` when `analysis` is `research-analysis` (read `parent` from the block), or `surfaced by gap analysis` when `discovery-gap-analysis`.
+
+> *Output the next fenced block as a code block:*
+
+```
+{name:(titlecase)} [{routing}]
+  {summary}
+  {provenance}
+```
+
+Read `gate_mode` from the staging frontmatter.
+
+#### If `gate_mode` is `auto`
+
+> *Output the next fenced block as a code block:*
+
+```
+{name:(titlecase)} — approved [auto].
+```
+
+→ Proceed to **C. Write Approved Candidate**.
+
+#### If `gate_mode` is `gated`
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Add this topic to the map?
+
+- **`y`/`yes`** — Approve and add to the map
+- **`a`/`auto`** — Approve this and all remaining candidates automatically
+- **`s`/`skip`** — Skip and dismiss (won't be re-proposed)
+- **Comment** — Tell me what to change (routing, summary, or description)
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `yes`:**
+
+→ Proceed to **C. Write Approved Candidate**.
+
+**If `auto`:**
+
+Set `gate_mode: auto` in the staging frontmatter so subsequent candidates approve without a stop.
+
+→ Proceed to **C. Write Approved Candidate**.
+
+**If `skip`:**
+
+Set this block's `status: skipped` in the staging file and add the name to the dismissed list:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs push {work_unit}.discovery dismissed "{name}"
+```
+
+→ Return to **B. Gate Each Candidate**.
+
+**If comment:**
+
+Revise this block's `routing`, `summary`, or `description` in the staging file per the user's feedback. Leave `status: pending`.
+
+→ Return to **B. Gate Each Candidate**.
+
+## C. Write Approved Candidate
+
+Set this block's `status: approved` in the staging file, then write the discovery item from the block's stored fields:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{name}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} summary "{summary}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} description "{description}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} routing {routing}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} source "{source}"
+```
+
+`source` is the block's stored value verbatim — `research-analysis:{parent}` for research-analysis (provenance renders as `from {parent}`), `gap-analysis` for gap-analysis.
+
+Append `{name}` to the caller's `tracker`.
+
+#### If `analysis` is `research-analysis`
+
+→ Proceed to **D. Fan-Out Parent-Handled Offer**.
+
+#### Otherwise
+
+→ Return to **B. Gate Each Candidate**.
+
+## D. Fan-Out Parent-Handled Offer
+
+Research-analysis derives a candidate from a completed research file (its `parent`) **without moving content out of that parent** — so the parent may still legitimately want its own discussion. This offers, once per parent, to mark the parent `handled`: a fanned-out research umbrella that stays on the map but stops prompting to be discussed.
+
+Read this block's `parent`.
+
+#### If any other candidate block sharing the same `parent` has `fanout_offer` set to `marked` or `declined`
+
+The offer for this parent already ran this session. Skip it (dedup).
+
+→ Return to **B. Gate Each Candidate**.
+
+#### Otherwise
+
+Re-run discovery to read the parent's current lifecycle:
+
+```bash
+node .claude/skills/workflow-discovery/scripts/discovery.cjs {work_unit}
+```
+
+Find the `parent` row in `discovery_map`.
+
+#### If the parent is not on the map, or its lifecycle is `handled`, `decided`, or `cancelled`
+
+Not actionable — no offer. Set `fanout_offer: declined` on every block sharing this `parent` (so it isn't reconsidered).
+
+→ Return to **B. Gate Each Candidate**.
+
+#### Otherwise (parent on the map and actionable)
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Derived from research "{parent:(titlecase)}". Mark "{parent:(titlecase)}"
+handled — fanned out, keep on the map but stop prompting to discuss it?
+
+- **`y`/`yes`** — Mark "{parent:(titlecase)}" handled
+- **`n`/`no`** — Leave it actionable
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `yes`:**
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{parent} handled true
+```
+
+Set `fanout_offer: marked` on every block sharing this `parent`.
+
+→ Return to **B. Gate Each Candidate**.
+
+**If `no`:**
+
+Set `fanout_offer: declined` on every block sharing this `parent`.
+
+→ Return to **B. Gate Each Candidate**.

--- a/skills/workflow-shared/references/discovery-gap-analysis.md
+++ b/skills/workflow-shared/references/discovery-gap-analysis.md
@@ -4,16 +4,17 @@
 
 ---
 
-Identifies gap topics across completed research files and completed discussions, and adds them to the discovery map as fresh discovery items with `source: gap-analysis` provenance. The orchestrator handles the cache check; this reference is invoked only when the cache is `stale`.
+Identifies gap topics across completed research files and completed discussions, and **stages** them as candidates for per-topic approval, with `source: gap-analysis` provenance. The orchestrator ([topic-discovery.md](topic-discovery.md)) handles the cache check and invokes this reference only when the cache is `stale`; it then runs the approval gate ([analysis-approval-gate.md](analysis-approval-gate.md)) and, once the gate completes, re-enters this reference at **E. Update Cache** to stamp.
+
+This reference does not write to the discovery map directly — it resolves the no-gate cases (already-on-map, dismissed) silently at stage time and stages genuinely-new candidates for the gate to approve.
 
 ## Parameters
 
 The caller provides these via context before loading:
 
 - `work_unit` — the epic's work unit name.
-- `tracker` — a list (initially empty) for newly-added topic names. The reference appends names as items are written.
 
-**Precondition.** Collect `completed_research` and `completed_discussion` (items with `status: completed`). If both empty, return — no cache stamp, no manifest writes, no callout.
+**Precondition.** Collect `completed_research` and `completed_discussion` (items with `status: completed`). If both empty, return — no staging, no cache stamp, no manifest writes.
 
 ## A. Read Artifacts
 
@@ -81,9 +82,9 @@ Assign each candidate a `routing` value.
 
 A single analysis may emit a mix of routings — apply the criteria per candidate.
 
-→ Proceed to **D. Filter and Save**.
+→ Proceed to **D. Filter and Stage**.
 
-## D. Filter and Save
+## D. Filter and Stage
 
 Read filter inputs from the work unit's manifest:
 
@@ -94,11 +95,22 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.disco
 
 `items` is the active map (an object keyed by topic name). `dismissed` is the array of names previously removed from the map by the user.
 
-For each candidate topic from **C** (kebab-case name + summary + routing), evaluate the conditions below in order. Each branch is self-contained and concludes by moving on to the next candidate.
+Initialise the staging file fresh (overwrite any prior pass) at `.workflows/{work_unit}/.state/discovery-gap-analysis-candidates.md` with frontmatter — this reference is only invoked for staging when no pending candidates remain from a deferred run, so overwriting is safe:
+
+```markdown
+---
+work_unit: {work_unit}
+analysis: discovery-gap-analysis
+generated: {ISO timestamp}
+gate_mode: gated
+---
+```
+
+For each candidate topic from **C** (kebab-case name + summary + description + routing), evaluate the conditions below in order. The first two cases are resolved here at stage time without a gate; only genuinely-new candidates are staged for the approval gate. Each branch is self-contained and concludes by moving on to the next candidate.
 
 #### If the name is already on the active map (a key in `items`)
 
-Check if the existing item's `source` field already includes `gap-analysis`. If not, the same theme is now surfacing both via the existing source and via gap-analysis — extend the source list to record dual provenance.
+Check if the existing item's `source` field already includes `gap-analysis`. If not, the same theme is now surfacing both via the existing source and via gap-analysis — extend the source list to record dual provenance. This is a silent merge — no staging entry, no gate.
 
 Read the existing source:
 
@@ -122,37 +134,37 @@ Set source to `{existing},gap-analysis` (comma-joined):
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} source "{existing},gap-analysis"
 ```
 
-Do not change the existing item's routing. Do not add to `tracker`. Do not write a new manifest entry.
+Do not change the existing item's routing. Do not stage a candidate.
 
 #### If the name appears in `dismissed`
 
-Skip silently. The user removed this topic from the map; the dismissed semantic is "don't auto-re-propose."
+Skip silently. The user removed this topic from the map; the dismissed semantic is "don't auto-re-propose." No staging entry.
 
 #### Otherwise (new candidate)
 
-Initialise the discovery item and write its fields:
+Stage it for the approval gate by appending a block to the staging file:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{name}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} summary "{one-line summary}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} description "{paragraphs}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} routing {routing-from-C}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} source gap-analysis
+```markdown
+## {name}
+status: pending
+summary: {one-line summary}
+description: |
+  {paragraphs}
+routing: {routing-from-C}
+source: gap-analysis
 ```
 
-`routing` is the value decided per-candidate in **C** (`discussion` or `research`).
-
-`description` is a paragraph or two extracted from the gap analysis for this topic — richer context than the one-line summary, loaded by entry skills as opening context when the user later picks the topic up. Quote with single quotes; description may span multiple paragraphs.
-
-Append the name to the caller's `tracker` so the orchestrator can surface it via callout / Topic Discovery Arrivals.
+`routing` is the value decided per-candidate in **C** (`discussion` or `research`). Gap-analysis keeps the bare `gap-analysis` source (no single-parent semantics — it synthesises across artifacts) and stages no `parent` or `fanout_offer`. `description` is a paragraph or two extracted from the gap analysis for this topic — richer context than the one-line summary, loaded by entry skills as opening context when the user later picks the topic up. Do not write to the discovery map and do not append to any tracker here — the approval gate writes approved candidates and tracks them.
 
 ---
 
 Once all candidates have been evaluated:
 
-→ Proceed to **E. Update Cache**.
+→ Return to caller.
 
 ## E. Update Cache
+
+Invoked by [topic-discovery.md](topic-discovery.md) after the approval gate has run, regardless of how many candidates were approved — a decline-all pass still stamps, so the analysis won't re-fire on every boot. Not reached when the gate is deferred (the host skips this section so the staging file is re-presented next boot).
 
 Update the existing cache file at `.workflows/{work_unit}/.state/discovery-gap-analysis.md` (pure markdown, no frontmatter):
 

--- a/skills/workflow-shared/references/discovery-gap-analysis.md
+++ b/skills/workflow-shared/references/discovery-gap-analysis.md
@@ -192,6 +192,8 @@ Overwrite with the topic list:
 - **Gap type**: {cross-artifact|elevated|emergent|integration|uncovered}
 ```
 
+List every topic from **C**, even those that filtered out in **D** — the cache file is the analysis output, not the diff. If re-entered on a reuse boot where **C** did not run this session (a deferred staging file was picked up), source the topic list from the staging file's candidate blocks instead.
+
 Compute the input checksum from completed research files plus completed discussion files only:
 
 ```bash

--- a/skills/workflow-shared/references/research-analysis.md
+++ b/skills/workflow-shared/references/research-analysis.md
@@ -172,7 +172,7 @@ Overwrite with the topic list:
 - **Sources**: {filename1}.md, {filename2}.md
 ```
 
-List every topic from **B**, even those that filtered out in **D** — the cache file is the analysis output, not the diff.
+List every topic from **B**, even those that filtered out in **D** — the cache file is the analysis output, not the diff. If re-entered on a reuse boot where **B** did not run this session (a deferred staging file was picked up), source the topic list from the staging file's candidate blocks instead.
 
 Compute the input checksum from the completed research files only:
 

--- a/skills/workflow-shared/references/research-analysis.md
+++ b/skills/workflow-shared/references/research-analysis.md
@@ -4,16 +4,17 @@
 
 ---
 
-Identifies follow-up topics from completed per-topic research files and adds them to the discovery map as fresh discovery items with `source: research-analysis` provenance. The orchestrator handles the cache check; this reference is invoked only when the cache is `stale`.
+Identifies follow-up topics from completed per-topic research files and **stages** them as candidates for per-topic approval, with `source: research-analysis:{parent}` provenance. The orchestrator ([topic-discovery.md](topic-discovery.md)) handles the cache check and invokes this reference only when the cache is `stale`; it then runs the approval gate ([analysis-approval-gate.md](analysis-approval-gate.md)) and, once the gate completes, re-enters this reference at **E. Update Cache** to stamp.
+
+This reference does not write to the discovery map directly — it resolves the no-gate cases (already-on-map, dismissed) silently at stage time and stages genuinely-new candidates for the gate to approve.
 
 ## Parameters
 
 The caller provides these via context before loading:
 
 - `work_unit` — the epic's work unit name.
-- `tracker` — a list (initially empty) for newly-added topic names. The reference appends names as items are written.
 
-**Precondition.** Collect research items where `status == 'completed'`. If empty, return — no cache stamp, no manifest writes, no callout.
+**Precondition.** Collect research items where `status == 'completed'`. If empty, return — no staging, no cache stamp, no manifest writes.
 
 ## A. Identify Themes
 
@@ -31,7 +32,7 @@ Cross-reference across files — connections, contradictions, and shared concern
 
 This analysis is cached and only re-runs when completed-research content changes. Be exhaustive — this is the one opportunity to capture the full picture.
 
-For each theme, note the source file(s) that contributed to it and assess its depth: is it well-explored in the source material, or does it surface as an under-explored area that would benefit from its own research pass?
+For each theme, note the source file(s) that contributed to it and assess its depth: is it well-explored in the source material, or does it surface as an under-explored area that would benefit from its own research pass? The contributing files drive each candidate's `parent` in **B**.
 
 → Proceed to **B. Define Candidate Topics**.
 
@@ -42,6 +43,8 @@ Group the themes from A into candidate topics.
 → Load **[topic-granularity.md](topic-granularity.md)**.
 
 For each candidate topic, write a one-line summary that covers the constituent themes — used as the discovery item's `summary` field.
+
+Record each candidate's `parent` — the completed research file (filename without `.md`) that primarily contributed it. When several files contribute, pick the primary one. The parent drives `source: research-analysis:{parent}` provenance and the fan-out offer in the approval gate.
 
 Assign each candidate a `routing` value.
 
@@ -59,9 +62,9 @@ When naming topics:
 - If a topic clearly maps to an existing discussion, you MUST use that discussion's filename (without the `.md` extension) as the kebab-case topic name. E.g., if `data-schema-design.md` exists and you identify a matching topic, name it `data-schema-design` — not `database-schema-architecture` or any variation.
 - Only create new names for topics with no matching existing discussion.
 
-→ Proceed to **D. Filter and Save**.
+→ Proceed to **D. Filter and Stage**.
 
-## D. Filter and Save
+## D. Filter and Stage
 
 Read filter inputs from the work unit's manifest:
 
@@ -72,11 +75,22 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.disco
 
 `items` is the active map (an object keyed by topic name). `dismissed` is the array of names previously removed from the map by the user.
 
-For each candidate topic from **B** (kebab-case name + summary + routing), evaluate the conditions below in order. Each branch is self-contained and concludes by moving on to the next candidate.
+Initialise the staging file fresh (overwrite any prior pass) at `.workflows/{work_unit}/.state/research-analysis-candidates.md` with frontmatter — this reference is only invoked for staging when no pending candidates remain from a deferred run, so overwriting is safe:
+
+```markdown
+---
+work_unit: {work_unit}
+analysis: research-analysis
+generated: {ISO timestamp}
+gate_mode: gated
+---
+```
+
+For each candidate topic from **B** (kebab-case name + summary + description + routing + parent), evaluate the conditions below in order. The first two cases are resolved here at stage time without a gate; only genuinely-new candidates are staged for the approval gate. Each branch is self-contained and concludes by moving on to the next candidate.
 
 #### If the name is already on the active map (a key in `items`)
 
-Check if the existing item's `source` field already includes `research-analysis`. If not, the same theme is now surfacing both via the existing source and via research-analysis — extend the source list to record dual provenance.
+Check if the existing item's `source` field already includes `research-analysis`. If not, the same theme is now surfacing both via the existing source and via research-analysis — extend the source list to record dual provenance. This is a silent merge — no staging entry, no gate.
 
 Read the existing source:
 
@@ -100,37 +114,39 @@ Set source to `{existing},research-analysis` (comma-joined):
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} source "{existing},research-analysis"
 ```
 
-Do not change the existing item's routing — the user (or earlier analysis) already set it. Do not add to `tracker`. Do not write a new manifest entry.
+Do not change the existing item's routing — the user (or earlier analysis) already set it. Do not stage a candidate.
 
 #### If the name appears in `dismissed`
 
-Skip silently. The user removed this topic from the map; the dismissed semantic is "don't auto-re-propose."
+Skip silently. The user removed this topic from the map; the dismissed semantic is "don't auto-re-propose." No staging entry.
 
 #### Otherwise (new candidate)
 
-Initialise the discovery item and write its fields:
+Stage it for the approval gate by appending a block to the staging file:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{name}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} summary "{one-line summary}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} description "{paragraphs}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} routing {routing-from-B}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} source research-analysis
+```markdown
+## {name}
+status: pending
+summary: {one-line summary}
+description: |
+  {paragraphs}
+routing: {routing-from-B}
+source: research-analysis:{parent}
+parent: {parent}
+fanout_offer: pending
 ```
 
-`routing` is the value decided per-candidate in **B** (`discussion` or `research`).
-
-`description` is a paragraph or two extracted from the analysis output for this topic — richer context than the one-line summary, loaded by entry skills as opening context when the user later picks the topic up. Quote with single quotes; description may span multiple paragraphs.
-
-Append the name to the caller's `tracker` so the orchestrator can surface it via callout / Topic Discovery Arrivals.
+`routing` is the value decided per-candidate in **B** (`discussion` or `research`). `source` carries the `parent` so provenance renders as `from {parent}`. `description` is a paragraph or two extracted from the analysis output for this topic — richer context than the one-line summary, loaded by entry skills as opening context when the user later picks the topic up. Do not write to the discovery map and do not append to any tracker here — the approval gate writes approved candidates and tracks them.
 
 ---
 
 Once all candidates have been evaluated:
 
-→ Proceed to **E. Update Cache**.
+→ Return to caller.
 
 ## E. Update Cache
+
+Invoked by [topic-discovery.md](topic-discovery.md) after the approval gate has run, regardless of how many candidates were approved — a decline-all pass still stamps, so the analysis won't re-fire on every boot. Not reached when the gate is deferred (the host skips this section so the staging file is re-presented next boot).
 
 Update the existing cache file at `.workflows/{work_unit}/.state/research-analysis.md` (pure markdown, no frontmatter):
 

--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -4,9 +4,13 @@
 
 ---
 
-Drives cache-based dispatch of `research-analysis` and `discovery-gap-analysis` against an epic's discovery map. The analyses write directly to `phases.discovery.items.{topic}` with `source` provenance and respect the per-work-unit `phases.discovery.dismissed[]` list.
+Drives cache-based dispatch of `research-analysis` and `discovery-gap-analysis` against an epic's discovery map. For each stale analysis the flow is **stage → present → approve → write → stamp**: the analysis stages its genuinely-new candidates to a per-analysis staging file, the approval gate ([analysis-approval-gate.md](analysis-approval-gate.md)) presents each for per-topic approval, approved candidates are written to `phases.discovery.items.{topic}` with `source` provenance, and the cache is stamped once the gate completes. The no-gate cases (already-on-map, dismissed) are resolved silently at stage time and respect the per-work-unit `phases.discovery.dismissed[]` list.
 
-Each analysis self-gates on a precondition (research-analysis needs at least one completed research item; gap-analysis needs at least one completed research OR discussion item). When the precondition fails the analysis returns without touching cache or manifest — dispatching on `stale` is safe even when no qualifying inputs exist yet.
+The gate runs before the dashboard — it is the boot-time review surface for both callers. Hosting the orchestration here covers both boot callers (`workflow-continue-epic` Step 6 and `workflow-bridge` section B) via the shared dispatch.
+
+Each analysis self-gates on a precondition (research-analysis needs at least one completed research item; gap-analysis needs at least one completed research OR discussion item). When the precondition fails the analysis returns without staging, gating, or stamping — dispatching on `stale` is safe even when no qualifying inputs exist yet.
+
+**Decline vs defer.** Skipping every candidate (decline-all) still stamps the cache, so the analysis won't re-fire. **Deferring** at the gate leaves every candidate `pending` and does **not** stamp — the still-valid staging file is re-presented next boot rather than re-running the analysis. Keep these strictly distinct.
 
 The caller is responsible for surfacing the result — `workflow-continue-epic` shows a callout above the discovery map; `workflow-bridge` does the same on its epic-continuation display.
 
@@ -41,7 +45,7 @@ Initialise an in-conversation tracker:
 new_arrivals = { research_analysis: [], gap_analysis: [] }
 ```
 
-This tracker captures topic names added during this run, per analysis. The caller reads it after **E. Return**.
+This tracker captures topic names **approved and written** during this run, per analysis — the approval gate appends a name only when the user approves the candidate, so the caller's `⚑ N new topics` callout counts approvals, not proposals. The caller reads it after **E. Return**.
 
 → Proceed to **B. Run Research Analysis if Stale**.
 
@@ -57,9 +61,27 @@ Research-analysis runs first because gap-analysis reads its cache file as a seco
 ·· Research Analysis ····························
 ```
 
-→ Load **[research-analysis.md](research-analysis.md)** with work_unit = `{work_unit}`, tracker = `new_arrivals.research_analysis`.
+**Stage or reuse.** Check `.workflows/{work_unit}/.state/research-analysis-candidates.md`. If it exists with at least one `status: pending` candidate, the analysis was deferred on a prior boot — reuse it and skip staging. Otherwise stage fresh:
 
-On return, the tracker holds the names of any discovery items just added by research-analysis.
+→ Load **[research-analysis.md](research-analysis.md)** with work_unit = `{work_unit}`.
+
+On return (or on reuse), run the approval gate over the staged candidates:
+
+→ Load **[analysis-approval-gate.md](analysis-approval-gate.md)** with analysis = `research-analysis`, work_unit = `{work_unit}`, tracker = `new_arrivals.research_analysis`, staging_file = `.workflows/{work_unit}/.state/research-analysis-candidates.md`.
+
+On return, read `gate_outcome`.
+
+**If `gate_outcome` is `processed`:**
+
+Stamp the cache (a decline-all pass still stamps, so the analysis won't re-fire):
+
+→ Load **[research-analysis.md](research-analysis.md)** for **E. Update Cache**.
+
+→ Proceed to **C. Run Gap Analysis if Stale**.
+
+**If `gate_outcome` is `deferred`:**
+
+Leave the cache stale so the still-valid staging file is re-presented next boot.
 
 → Proceed to **C. Run Gap Analysis if Stale**.
 
@@ -79,9 +101,27 @@ No dispatch.
 ·· Gap Analysis ·································
 ```
 
-→ Load **[discovery-gap-analysis.md](discovery-gap-analysis.md)** with work_unit = `{work_unit}`, tracker = `new_arrivals.gap_analysis`.
+**Stage or reuse.** Check `.workflows/{work_unit}/.state/discovery-gap-analysis-candidates.md`. If it exists with at least one `status: pending` candidate, the analysis was deferred on a prior boot — reuse it and skip staging. Otherwise stage fresh:
 
-On return, the tracker holds the names of any discovery items just added by gap-analysis.
+→ Load **[discovery-gap-analysis.md](discovery-gap-analysis.md)** with work_unit = `{work_unit}`.
+
+On return (or on reuse), run the approval gate over the staged candidates:
+
+→ Load **[analysis-approval-gate.md](analysis-approval-gate.md)** with analysis = `discovery-gap-analysis`, work_unit = `{work_unit}`, tracker = `new_arrivals.gap_analysis`, staging_file = `.workflows/{work_unit}/.state/discovery-gap-analysis-candidates.md`.
+
+On return, read `gate_outcome`.
+
+**If `gate_outcome` is `processed`:**
+
+Stamp the cache (a decline-all pass still stamps, so the analysis won't re-fire):
+
+→ Load **[discovery-gap-analysis.md](discovery-gap-analysis.md)** for **E. Update Cache**.
+
+→ Proceed to **D. Dedupe Sources**.
+
+**If `gate_outcome` is `deferred`:**
+
+Leave the cache stale so the still-valid staging file is re-presented next boot.
 
 → Proceed to **D. Dedupe Sources**.
 
@@ -93,7 +133,7 @@ No dispatch.
 
 ## D. Dedupe Sources
 
-When both analyses surface the same kebab-case theme, the second analysis writes the discovery item with `source` already comma-joined (`research-analysis,gap-analysis`) — see each analysis's **D. Filter and Save** section.
+When both analyses surface the same kebab-case theme, research-analysis runs first; if the user approves it, the item is on the map by the time gap-analysis stages. Gap-analysis's **D. Filter and Stage** then takes the already-on-map branch and silently merges the source (`research-analysis:{parent},gap-analysis`) instead of staging a duplicate.
 
 If a name appears in both `new_arrivals.research_analysis` and `new_arrivals.gap_analysis`, treat it as a research-analysis arrival only for caller-side display purposes (single callout entry, single Topic Discovery Arrivals bullet). The manifest already records the comma-joined source.
 

--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -75,7 +75,7 @@ On return, read `gate_outcome`.
 
 Stamp the cache (a decline-all pass still stamps, so the analysis won't re-fire):
 
-→ Load **[research-analysis.md](research-analysis.md)** for **E. Update Cache**.
+→ Load **[research-analysis.md](research-analysis.md)** for **E. Update Cache** and follow its instructions. When it returns:
 
 → Proceed to **C. Run Gap Analysis if Stale**.
 
@@ -115,7 +115,7 @@ On return, read `gate_outcome`.
 
 Stamp the cache (a decline-all pass still stamps, so the analysis won't re-fire):
 
-→ Load **[discovery-gap-analysis.md](discovery-gap-analysis.md)** for **E. Update Cache**.
+→ Load **[discovery-gap-analysis.md](discovery-gap-analysis.md)** for **E. Update Cache** and follow its instructions. When it returns:
 
 → Proceed to **D. Dedupe Sources**.
 


### PR DESCRIPTION
## Summary

Implements **PR2** of idea #31 — the analysis approval gate, point-A provenance, and the fan-out parent-handled offer.

> **Stacked on #342 (PR1).** Base is `feat/discovery-handled-tier-migration-043`. **Merge PR1 first** — the fan-out offer writes the `handled` marker that only PR1 teaches the system to read, and PR1's migration re-stamps finished epics to `valid` so this PR's boot-time gate fires only on in-discovery epics rather than interrupting finished ones.

The topic-discovery analyses (`research-analysis`, `discovery-gap-analysis`) previously wrote every derived topic straight to the discovery map with no approval. Now each **stages** its genuinely-new candidates and the user approves them **per-topic** before anything lands.

## Flow

Per stale analysis: **stage → present → approve → write → stamp**.

- **`analysis-approval-gate.md`** (new shared ref): boot-time lead-in summary; top-level **defer**; per-candidate gate (`y` / `a` auto / `s` skip→dismiss / **Comment** adjust); writes approved candidates to `phases.discovery.items.{name}`; appends the tracker only on **approve + written** (the `⚑ N new topics` callout counts approvals, not proposals); fan-out parent-handled offer (research-analysis only).
- **`research-analysis.md` / `discovery-gap-analysis.md` §D**: write-direct → write-staging. The no-gate cases (already-on-map source merge, dismissed skip) are pre-resolved silently at stage time; only genuinely-new candidates are staged as `pending`. §E (cache stamp) is now invoked post-gate by the host.
- **Provenance (point A)**: research-analysis records `source: research-analysis:{parent}` (renders `from {parent}` via `computeSourceProvenance`); gap-analysis keeps bare `gap-analysis`.
- **Fan-out offer**: after a candidate is approved, offers once per `{parent}` (deduped via `fanout_offer`) to mark the parent `handled` — only when the parent is on the map and actionable (not already handled/decided/cancelled). The only auto-with-consent path; still user-confirmed.
- **`topic-discovery.md`** hosts the orchestration for both boot callers (continue-epic Step 6 + bridge §B): stage-or-reuse a deferred staging file → gate → stamp when processed.

## Decline vs defer (kept strictly distinct)

- **Decline-all** (skip every candidate) → **stamps** the cache, so the analysis won't re-fire.
- **Defer** (postpone at gate start) → leaves all candidates `pending`, does **not** stamp → the still-valid staging file is re-presented next boot rather than re-running the analysis.

## Staging file

`.workflows/{work_unit}/.state/{research-analysis|discovery-gap-analysis}-candidates.md` — YAML frontmatter (`work_unit`, `analysis`, `generated`, `gate_mode`) + one `## {kebab-name}` block per candidate (`status`, `summary`, `description`, `routing`, `source`, and research-analysis-only `parent` + `fanout_offer`). On-disk so the gate survives context refresh; mirrors the implementation analysis-loop staging pattern.

## Verification

These are Claude-followed markdown references — no executable surface. Verified by walking the gate end-to-end against staged fixtures: approve (writes + tracker + fan-out), decline-all (stamps, dismisses, no map writes), defer (no stamp, staging reused next boot), zero-candidate (stamps), and fan-out dedup (one offer per parent, only for actionable on-map parents). All internal routing targets resolve. Existing test suite unaffected (no code changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)