### PR TITLE
[renderer] Design log: render-shape survey + decisions

### DIFF
--- a/ideas/deterministic-tree-and-menu-renderer.md
+++ b/ideas/deterministic-tree-and-menu-renderer.md
@@ -103,6 +103,19 @@ Low for data integrity (purely cosmetic — nothing corrupts), **medium for UX a
 
 ---
 
+## Update — PR #344 (epic-dashboard stage grouping)
+
+After this idea was written, PR #344 restructured `epic-display-and-menu.md`. Relevant to this proposal:
+
+- **The motivating bug persists.** The summary is still hard-wrapped at 65 chars; the gutter grew 7 → 9 (the map moved under a stage divider), so overflow is now at **74 cols**, not 72. The restructure did not touch the wrap budget. The immediate sub-fix (subtract gutter from budget) is still outstanding — and now even more clearly worth doing independently of the renderer.
+- **Several flagged drifts were hand-fixed** — dangling `└─` build sub-rows now nest properly; first-row `┌─` dropped for the discovery map (tree hangs off its header via `├─`); sub-headers uppercased. This is the survey's thesis demonstrated: per-file, by hand, correct only when watched.
+- **A composition layer appeared** — three `── DISCOVERY/DEFINITION/DELIVERY ──` stage dividers (Family 1) now wrap the trees (Family 3). The dashboard is now a multi-primitive composite — see **3B-composite** below.
+- **A new genuine tree** — the build-phase render gained a real `{child_gutter}`/`{child_branch}`, so `epic-display-and-menu.md` now holds two continuous-gutter trees sharing one mechanism (see **3B-v**). Best beachhead for the renderer.
+
+The survey below has been updated to reflect this state.
+
+---
+
 # Render-Shape Survey
 
 The section above is the *why*. This is the **survey**: every structured-ASCII shape Claude is currently instructed to hand-draw across the skills, grouped into families, with the distinct variants, observed drift, and candidate canonical forms. These canonical forms are *candidates for discussion*, not decisions. Schema design stays out of scope (per the note above) — this is what a schema would have to absorb.
@@ -121,11 +134,12 @@ Volume note: section headers ≈176 occurrences, dotted gates ≈326 (paired), b
 Near-perfectly consistent already. Pure presentation with trivial input (usually one string). Highest reasoning-tax-per-character to draw by hand (padding/centering/dash-counting), lowest input cost to feed a renderer. Strong, low-risk first targets.
 
 ### 1A. Section header — `── Label ──`
-Padded to ~50 cols total. ~176 occurrences across ~54 files. Title Case labels.
+Padded to ~50 cols total (PR #344's epic-dashboard stage dividers fix this at **49 chars** — `── DISCOVERY ──`, `── DEFINITION ──`, `── DELIVERY ──` — and use it as top-level structural grouping, not just a section break). ~176 occurrences across ~54 files. Title Case labels (the stage dividers are UPPERCASE).
 ```
 ── Resume Detection ─────────────────────────────
+── DISCOVERY ────────────────────────────────────
 ```
-- **Drift:** total width not actually enforced — varies with label length because it's hand-counted. Same class of bug as the tree wrap: a width that's "supposed to be" fixed but is eyeballed.
+- **Drift:** total width not actually enforced — varies with label length because it's hand-counted (the 49 vs ~50 split is itself an instance). Same class of bug as the tree wrap: a width that's "supposed to be" fixed but is eyeballed.
 - **Candidate canonical:** `signpost --label "Resume Detection" [--width 50]` → dashes computed to fill.
 
 ### 1B. Dotted gate — `· · · · · · · · · · · ·`
@@ -221,22 +235,22 @@ Continuing "Auth Flow" — planning.
 
 ## Family 3 — Lists vs Trees  (the important distinction)
 
-Biggest finding: **most "trees" are not trees.** They're flat lists with a single `└─` sub-row. True tree logic (continuous `│` gutter across siblings and wrapped sub-lines, last-sibling math) is needed by only **four** renders. Separating these is the key scoping decision.
+Biggest finding: **most "trees" are not trees.** They're flat lists with a single `└─` sub-row. True tree logic (continuous `│` gutter across siblings and wrapped sub-lines, last-sibling math) is needed by **five** renders (one of which, the epic build-phase tree, graduated out of the flat-list bucket in PR #344 when its sub-rows were given a proper `│/├─/└─` gutter). Separating these is the key scoping decision.
 
 ### 3A. Flat list + single sub-row  — *NOT a tree*  [script-backed]
-`N. Name` then one `└─ detail` line. No `│`, no sibling continuity. Used by: `select-*.md` (all 5 types), `active-work.md`, `view-completed.md`, planning `define-tasks.md`, legacy-split themes, dependency lists (`resolve-dependencies.md`, `check-dependencies.md`), spec overview (`display-*.md`).
+`N. Name` then one `└─ detail` line. No `│`, no sibling continuity. Used by: `select-*.md` (all 5 types), `active-work.md`, `view-completed.md`, planning `define-tasks.md`, legacy-split themes, dependency lists (`resolve-dependencies.md`, `check-dependencies.md`), spec overview (`display-*.md`). (The epic dashboard's build-phase render used to live here too — PR #344 promoted it to a genuine tree, now 3B-v.)
 ```
 1. Auth Flow
    └─ Planning, in-progress
 ```
-- **Drift:** indent is 2-space in dependency renders, 3-space elsewhere; multiple sub-rows sometimes all use `└─` where `├─`/`└─` is correct.
+- **Drift:** indent is 2-space in dependency renders, 3-space elsewhere; multiple sub-rows sometimes all use `└─` where `├─`/`└─` is correct (exactly the dangling-`└─` defect #344 just hand-fixed in the epic dashboard — and which will recur elsewhere until a renderer owns it).
 - These don't need the tree renderer. A `list` form (item + optional sub-rows) covers them. Cheap.
 
 ### 3B. Genuine trees — continuous gutter  [script-backed]
-Four renders. All share `┌─ ├─ └─` branch grammar, a leading status glyph, and a `│`+indent gutter that must stay continuous. Where the renderer earns its keep.
+Five renders. All share `├─ └─` branch grammar (some still use `┌─`; see below), a leading status glyph, and a `│`+indent gutter that must stay continuous. Where the renderer earns its keep.
 
-**3B-i. Discovery map** — `workflow-continue-epic/.../epic-display-and-menu.md`, `workflow-discovery/.../session-loop.md`
-Tier glyph (`→ ◐ ✓ ○ ⊙ ⊘`) + name + `[lifecycle]`, with **wrapped summary + provenance sub-lines** under each row hung off the `│` gutter. **The render with the motivating bug** (summary hard-wrapped at 65 chars + 7-char gutter = 72 cols → terminal soft-wrap orphans the gutter).
+**3B-i. Discovery map** — `workflow-continue-epic/.../epic-display-and-menu.md` (now under the `── DISCOVERY ──` stage, header `RESEARCH & DISCUSSION`), `workflow-discovery/.../session-loop.md`
+Tier glyph (`→ ◐ ✓ ○ ⊙ ⊘`) + name + `[lifecycle]`, with **wrapped summary + provenance sub-lines** under each row hung off the `│` gutter. **The render with the motivating bug, still unfixed as of PR #344** (summary still hard-wrapped at 65 chars; gutter grew from 7 → **9 chars** when the map moved under the stage divider, so 65 + 9 = **74 cols** → terminal soft-wrap still orphans the gutter). First row now `├─` (was `┌─`) so the list hangs off the header.
 ```
   ├─ ◐ Ai Content Engine [researching]
   │      AI imagery (enhancement-only v1), description
@@ -278,15 +292,30 @@ Bullet `•` (not a status glyph) + `(type)`, **wrapped summary max 3 lines + el
          single item gets no connector glyph
 ```
 
+**3B-v. Epic build-phase tree** — `workflow-continue-epic/.../epic-display-and-menu.md` (under the `── DEFINITION ──` and `── DELIVERY ──` stages)
+Uppercase phase sub-header (`SPECIFICATION`, `PLANNING`, `IMPLEMENTATION`, `REVIEW`) + count summary, with items branching off it (`├─`/`└─`), and child sub-rows (spec sources, implementation progress) nested via a formal `{child_gutter}` + `{child_branch}`. Graduated from flat-list (3A) in PR #344. **Shares the exact gutter machinery as 3B-i in the same file** — the strongest single argument for a shared tree renderer.
+```
+  SPECIFICATION (2 completed)
+  ├─ ✓ User Authentication
+  │  ├─ ← Auth Flows [incorporated]
+  │  └─ ← Session Mgmt [pending]
+  └─ ○ Admin Panel
+     └─ Phase 2, 4 task(s) completed
+```
+- `{child_gutter}` — non-last item: `2sp │ 2sp`; last item: `5sp`. `{child_branch}`: `├─` non-final, `└─` final/only. Items hang off the sub-header (no `┌─`).
+
 **Structural variation the tree renderer must absorb (from 3B):**
 - Glyph source: tier set / state set / bullet / none — pluggable leading symbol.
-- Special first row `┌─` (discovery, discussion, inbox) vs none.
-- Wrapped multi-line bodies (discovery, inbox) vs single-line nodes (discussion, dependency).
-- Nesting: 1 level (discovery, inbox) vs 2 levels (discussion, dependency).
-- Gutter width drift: discovery uses `│`+6 spaces; discussion uses `│`+2. **Normalise.**
+- **Hang-off-header vs free-standing first row:** discovery map (3B-i) and build trees (3B-v) now use `├─`/sole `└─` to tick up into a header label — **never `┌─`** (normalised in #344). Discussion map (3B-ii) and inbox (3B-iv) still open with `┌─`. The renderer should make "hang off header" the default; `┌─` the opt-in.
+- Wrapped multi-line bodies (discovery, inbox) vs single-line nodes (discussion, dependency, build).
+- Nesting: 1 level (discovery, inbox) vs 2 levels (discussion, dependency, build).
+- **Gutter width drift (now across three trees):** discovery body gutter `2sp │ 6sp` (9); discussion child `│`+2; build child `2sp │ 2sp`. Same concept, three widths. **Normalise.**
 - Single-item / last-sibling / last-line edge cases.
 - Marker rows that aren't nodes (`↑ Elevated`, source `←`, promotion `→`).
-- Body wrap budget **must subtract the gutter** — the bug. Width is intentionally narrow; renderer enforces, never widens or defers to terminal.
+- Body wrap budget **must subtract the gutter** — the bug, still live after #344 (65 + 9 = 74). Width is intentionally narrow; renderer enforces, never widens or defers to terminal.
+
+### 3B-composite. The epic dashboard is now a multi-primitive render
+PR #344 restructured `epic-display-and-menu.md` so the whole dashboard is **Family 1 signposts wrapping Family 3 trees**: three `── DISCOVERY/DEFINITION/DELIVERY ──` dividers (49-char section headers, see 1A), each followed by a header/sub-header and a tree. One render composes a box cap (`●──●` title), three dividers, two genuine trees, and several sub-headers. This is the clearest real example that the renderer is **composed primitives assembled into a dashboard**, not one schema per shape — and the obvious migration beachhead (one high-value file, two trees + three dividers, already hand-normalised to copy byte-for-byte).
 
 ### 3C. Documentation trees — `├──` 3-dash filesystem diagrams  [static, OUT OF SCOPE]
 `output-formats/{tick,linear,local-markdown}/about.md`. Static docs illustrating directory/issue layout, not per-session data-driven renders. Different glyph (`├──` 3-dash + 4-space). **Exclude from the renderer** — prose, not output.

--- a/ideas/deterministic-tree-and-menu-renderer.md
+++ b/ideas/deterministic-tree-and-menu-renderer.md
@@ -130,6 +130,13 @@ The model, agreed in discussion. Implementation flows from these.
 
 **Still open** (don't block the start): the exact reasoning-surface field set per skill (settled by the spike); the menu `description` sub-line (5th form vs row option); whether the reasoning surface stays labeled text or becomes JSON (tied to the broader code-based-orchestration push — out of scope here).
 
+## Build log
+
+- **Core + signpost slice** (shipped) — `skills/workflow-render/render.cjs` as library+CLI: shared `fillTo`/`wrap`/`wrapWithPrefix` core (budget = `width − prefix.length`, the single home of the gutter bug) + `signpost` (step/sub-step markers) + `box` (phase title). Proven byte-exact against live hand-drawn markers/borders; surfaced a real 50-vs-49 sub-step drift the renderer normalises.
+- **Tree spike → GO** (shipped) — `renderTree` (discovery-map shape) on the same core. Reproduces the documented hand-drawn rows **byte-for-byte**; the 74-col gutter-orphan bug is now structurally impossible (every body line stays within width at 49/58/65). The spike validated the whole approach, so `renderTree` is kept, not thrown away.
+  - **Finding — header-row overflow is inherent.** A long `label [lifecycle]` header row can't wrap without breaking glyph alignment, so it can exceed the width (the hand-drawn version overruns identically). The renderer guarantees only the wrappable *body* lines fit. Mitigation (truncating long labels) is a separate decision.
+  - **Decision deferred to wiring — tree content width.** 49 (consistent with the 49-wide dividers/markers) vs ~65 (current text density). The renderer is correct at any width; this is a visual-density call made when `discovery.cjs` is wired up.
+
 ---
 
 # Render-Shape Survey

--- a/ideas/deterministic-tree-and-menu-renderer.md
+++ b/ideas/deterministic-tree-and-menu-renderer.md
@@ -100,3 +100,250 @@ Survey every tree- and menu-shaped render across the workflow skills, catalogue 
 ## Severity
 
 Low for data integrity (purely cosmetic — nothing corrupts), **medium for UX and recurring cost**. The visible breakage is intermittent and terminal-width-dependent, so it'll keep resurfacing unpredictably and reads as a quality defect each time. The deeper cost is the per-render reasoning/token tax of hand-drawing layout across dozens of skills, every invocation, forever — which is the real reason to make it deterministic.
+
+---
+
+# Render-Shape Survey
+
+The section above is the *why*. This is the **survey**: every structured-ASCII shape Claude is currently instructed to hand-draw across the skills, grouped into families, with the distinct variants, observed drift, and candidate canonical forms. These canonical forms are *candidates for discussion*, not decisions. Schema design stays out of scope (per the note above) — this is what a schema would have to absorb.
+
+## How to read this
+
+Two axes matter for the renderer, not just shape:
+
+1. **Shape family** — signpost, menu, list, tree, legend.
+2. **Where the input comes from** — does a script already hold the data (e.g. `discovery.cjs`), or does Claude compose it contextually? This decides whether the renderer kills the per-render reasoning or just relocates it. Marked **[script-backed]** / **[Claude-composed]** per shape.
+
+Volume note: section headers ≈176 occurrences, dotted gates ≈326 (paired), bullet boxes ≈59, `├─`-using files ≈28. The high-volume, high-consistency families (signposts, gates) are the cheapest wins; the trees are the highest-variation and where the bug lives.
+
+## Family 1 — Signposts, gates & banners  [Claude-composed, fixed-shape]
+
+Near-perfectly consistent already. Pure presentation with trivial input (usually one string). Highest reasoning-tax-per-character to draw by hand (padding/centering/dash-counting), lowest input cost to feed a renderer. Strong, low-risk first targets.
+
+### 1A. Section header — `── Label ──`
+Padded to ~50 cols total. ~176 occurrences across ~54 files. Title Case labels.
+```
+── Resume Detection ─────────────────────────────
+```
+- **Drift:** total width not actually enforced — varies with label length because it's hand-counted. Same class of bug as the tree wrap: a width that's "supposed to be" fixed but is eyeballed.
+- **Candidate canonical:** `signpost --label "Resume Detection" [--width 50]` → dashes computed to fill.
+
+### 1B. Dotted gate — `· · · · · · · · · · · ·`
+12 middle-dots, always paired around an interactive prompt. ~326 occurrences (163 pairs). Extremely consistent.
+```
+· · · · · · · · · · · ·
+{prompt + options}
+· · · · · · · · · · · ·
+```
+- **Candidate canonical:** `gate` emits the rule; the prompt body between the rules is still Claude's. (Or a single `gate --open/--close`.)
+
+### 1C. Bullet box banner — `●───...───●`
+Two widths: short (~50, status/error headers, ~59 occ.) and long (~65, the `workflow-start` ASCII-art welcome).
+```
+●───────────────────────────────────────────────●
+  Knowledge Base Error
+●───────────────────────────────────────────────●
+```
+- **Candidate canonical:** `box --title "Knowledge Base Error" [--width 50]`. Long variant is the same shape at a different width — one form, parameterised.
+
+### 1D. Framed content box — `╭─ Finding N: … ──╮ / ╰──╯`
+Wraps diff blocks in review-findings flows. Two prefixes seen (`Finding {N}:`, `Resurfacing:`).
+```
+╭─ Finding {N}: {Brief Title} ──────────────────────╮
+{diff}
+╰───────────────────────────────────────────────────╯
+```
+- Low volume (6 occ.). Same `box` primitive with rounded corners + a body passthrough.
+
+### 1E. Callout line — `⚑ {label}`
+Single glyph + label, no padding. ~28 occ. Warning/precondition callouts. Trivial; arguably not worth a command — just document the glyph, leave inline.
+
+### 1F. Solid separator — `────…`
+One occurrence. Full-width rule. Folds into the `box`/`signpost` dash logic.
+
+**Family-1 normalisation:** all six reduce to **one dash/width engine** (fill-to-width with optional centred label and optional corner glyphs). Section header, bullet box, framed box, solid rule are the *same primitive* with different end-caps. Cheapest, highest-volume win; has its own latent width-drift bug (1A) worth fixing regardless.
+
+## Family 2 — Selection menus  [mixed]
+
+Four genuinely distinct forms (survey found ~8 variants; six are drift or composition of these four). Input is a list of `{key, label, suffix?}` rows — cheap for Claude to hand over **[Claude-composed]**, except epic/spec menus whose rows mirror manifest state **[script-backed, could be fed from the data script]**.
+
+### 2A. Numbered-items + lettered-commands  (dominant, ~60%)
+Numbered continuations, blank line, then letter commands. `active-work.md`, `empty-state.md`, all `select-*.md`.
+```
+What would you like to do?
+
+- **`1`** — Continue "Auth Flow" — feature, planning
+- **`2`** — Continue "Login Bug" — bugfix, investigation
+
+- **`s`/`start`** — Start something new
+- **`f`/`feature`** — Start new feature
+- **`m`/`manage`** — Manage a work unit
+
+Select an option:
+```
+
+### 2B. Simple numbered select (grouped, `b`/`back`)
+Continuous numbering across category sections; minimal labels. `manage-work-unit.md`, `view-completed.md`.
+```
+Features:
+  1. Auth Flow
+  2. Billing
+Bugfixes:
+  3. Login Bug
+
+Select a work unit (enter number, or **`b`/`back`**):
+```
+
+### 2C. Multi-select numbered (comma-separated)
+Inbox add/drop, `start-from-inbox.md`.
+```
+1. Item A (idea, 2026-06-01)
+2. Item B (bug, 2026-06-02)
+
+Add which? (enter number(s), comma-separated, or **`b`/`back`**)
+```
+
+### 2D. Letter decision menu (y/n/r/b)
+2–4 letter options under a context line; no explicit "Select an option". `revisit-phase.md`, `*-continuation.md`, soft-gates.
+```
+Continuing "Auth Flow" — planning.
+
+- **`y`/`yes`** — Proceed to implementation
+- **`r`/`revisit`** — Revisit an earlier phase
+```
+
+**Drift to normalise:**
+- Phase-selection menu uses a **numbered** "Back" instead of `b`/`back`. → make back always `b`/`back`.
+- `(recommended)` vs `*(recommended)*` (italic) — pick one.
+- Recommended-first menus add backtick-wrapped multi-line descriptions — decide whether that's a 5th form or a row option (`description`) on 2A.
+
+**Family-2 normalisation:** one `menu` command with a row list + a mode flag (`single` | `multi` | `letter`), optional grouping header per row, optional `recommended` and `suffix` per row, and a standard prompt line. Covers ~95%.
+
+## Family 3 — Lists vs Trees  (the important distinction)
+
+Biggest finding: **most "trees" are not trees.** They're flat lists with a single `└─` sub-row. True tree logic (continuous `│` gutter across siblings and wrapped sub-lines, last-sibling math) is needed by only **four** renders. Separating these is the key scoping decision.
+
+### 3A. Flat list + single sub-row  — *NOT a tree*  [script-backed]
+`N. Name` then one `└─ detail` line. No `│`, no sibling continuity. Used by: `select-*.md` (all 5 types), `active-work.md`, `view-completed.md`, planning `define-tasks.md`, legacy-split themes, dependency lists (`resolve-dependencies.md`, `check-dependencies.md`), spec overview (`display-*.md`).
+```
+1. Auth Flow
+   └─ Planning, in-progress
+```
+- **Drift:** indent is 2-space in dependency renders, 3-space elsewhere; multiple sub-rows sometimes all use `└─` where `├─`/`└─` is correct.
+- These don't need the tree renderer. A `list` form (item + optional sub-rows) covers them. Cheap.
+
+### 3B. Genuine trees — continuous gutter  [script-backed]
+Four renders. All share `┌─ ├─ └─` branch grammar, a leading status glyph, and a `│`+indent gutter that must stay continuous. Where the renderer earns its keep.
+
+**3B-i. Discovery map** — `workflow-continue-epic/.../epic-display-and-menu.md`, `workflow-discovery/.../session-loop.md`
+Tier glyph (`→ ◐ ✓ ○ ⊙ ⊘`) + name + `[lifecycle]`, with **wrapped summary + provenance sub-lines** under each row hung off the `│` gutter. **The render with the motivating bug** (summary hard-wrapped at 65 chars + 7-char gutter = 72 cols → terminal soft-wrap orphans the gutter).
+```
+  ├─ ◐ Ai Content Engine [researching]
+  │      AI imagery (enhancement-only v1), description
+  │      generation, per-tenant tone primitive
+  │      from exploration
+  └─ ◐ Menu And Admin [researching]
+         Business-side menu modelling, admin shell
+         from exploration
+```
+
+**3B-ii. Discussion map** — `workflow-discussion-process/.../discussion-session.md`
+State glyph (`○ ◐ → ✓`) + name + `[state]`, **two-level nesting** (parent → children, no grandchildren), `↑ Elevated: …` marker rows. No wrapped bodies.
+```
+  ┌─ ✓ Subsystem Prefix Taxonomy [decided]
+  ├─ → Decision-Point INFO Line Shape [converging]
+  │  ├─ ✓ Field Order [decided]
+  │  └─ ◐ Truncation Rules [exploring]
+  ├─ ↑ Elevated: Log Aggregation Backend
+  └─ ○ Rollout Sequencing [pending]
+```
+
+**3B-iii. Epic dependency / phase detail** — `workflow-continue-epic/.../display-epic-map.md`
+Status glyph + name, sub-rows for sources (`←`) and promotions (`→`), `│` phase continuation.
+```
+  ├─ ✓ User Authentication
+  │  ├─ ← Auth Flows Discussion
+  │  └─ ← Session Management Discussion
+  └─ ○ Admin Panel
+     └─ Phase 2, 4 task(s) completed
+```
+
+**3B-iv. Inbox working set** — `workflow-start/.../inbox-working-set.md`
+Bullet `•` (not a status glyph) + `(type)`, **wrapped summary max 3 lines + ellipsis**, and a **single-item special case** (lone item renders no branch glyph). Same `│`+gutter wrap concern as the discovery map.
+```
+  ┌─ • Item One (idea)
+  │      Summary that wraps to a second line if needed,
+  │      max 3 lines with ellipsis…
+  └─ • Item Three (quickfix)
+         single item gets no connector glyph
+```
+
+**Structural variation the tree renderer must absorb (from 3B):**
+- Glyph source: tier set / state set / bullet / none — pluggable leading symbol.
+- Special first row `┌─` (discovery, discussion, inbox) vs none.
+- Wrapped multi-line bodies (discovery, inbox) vs single-line nodes (discussion, dependency).
+- Nesting: 1 level (discovery, inbox) vs 2 levels (discussion, dependency).
+- Gutter width drift: discovery uses `│`+6 spaces; discussion uses `│`+2. **Normalise.**
+- Single-item / last-sibling / last-line edge cases.
+- Marker rows that aren't nodes (`↑ Elevated`, source `←`, promotion `→`).
+- Body wrap budget **must subtract the gutter** — the bug. Width is intentionally narrow; renderer enforces, never widens or defers to terminal.
+
+### 3C. Documentation trees — `├──` 3-dash filesystem diagrams  [static, OUT OF SCOPE]
+`output-formats/{tick,linear,local-markdown}/about.md`. Static docs illustrating directory/issue layout, not per-session data-driven renders. Different glyph (`├──` 3-dash + 4-space). **Exclude from the renderer** — prose, not output.
+
+## Shared vocabulary (consistent — renderer config, not per-call reasoning)
+
+### Glyph table (one meaning per context; no collisions found)
+```
+Discovery tier:  →ready-next  ◐in-flight  ✓decided  ○fresh  ⊙handled  ⊘cancelled
+Discussion state: ○pending   ◐exploring  →converging ✓decided
+Markers:         ↑elevated   ←source     →promoted
+Alert:           ⚑
+Decoration:      ● (box caps)
+```
+Discovery and discussion share `○ ◐ → ✓` with semantically aligned meanings — safe.
+
+### Suffix grammar (bracket type signals metadata type — consistent)
+```
+[]  status / state           [in-progress] [decided] [extracted, reopened]
+()  metadata                 (recommended) (was: {status}) (3 of 5 sources extracted)
+·   provenance / routing     · {format}   · routed to research   · seeded from the inbox
+—   phase / progress / block — implementation (Phase 2, Task 3)   — blocked by {plan}:{task}
+:   cross-plan task ref      {plan}:{task}
+```
+
+### Legend / Key blocks
+Several near-identical `Key:` blocks (spec-entry display-*.md, epic display) listing the subset of glyphs/statuses in play. **Candidate:** a `legend` command that emits the canonical block for a given vocabulary subset — removes the copy-paste drift between the five spec-entry variants.
+
+## Cross-cutting observations
+
+1. **The system is already remarkably consistent.** Most drift is mechanical (indent width, dash count, `└─` vs `├─`, italic vs plain `(recommended)`) — exactly the class of error a renderer eliminates by construction.
+2. **The latent width bug isn't unique to the tree.** Section headers (1A) and boxes (1C) also rely on hand-counted widths that aren't enforced. Same fix, same primitive.
+3. **The four families collapse toward shared primitives**, not one schema:
+   - a **width/dash engine** (signposts, boxes, rules) — Family 1
+   - a **wrap-with-prefix primitive** (`budget = width − prefixWidth`) — the root of the bug, shared by trees and wrapped lists
+   - a **menu** form — Family 2
+   - a **tree** form (4 real trees) over the wrap primitive — Family 3B
+   - **vocab/legend** as config, not logic
+4. **Scope ladder by payoff/risk:**
+   - Cheapest, safest, highest volume: **signposts/gates/boxes** (Family 1) + the width-drift fix.
+   - High value, contained: **menus** (Family 2, 4 forms).
+   - Highest value + where the bug lives + most variation: **the 4 real trees** (3B). Feed from the data scripts that already hold the rows.
+   - Skip: doc filesystem trees (3C), maybe the bare `⚑` callout (1E).
+
+## Open questions (for decision, not yet decided)
+
+- **Tree input source** — data-script emits the renderer IR directly (kills reasoning) vs Claude adapts script output per render (relocates it). Leaning: data-script emits IR.
+- **Recommended-description menus** — 5th menu form, or a `description` option on the numbered form?
+- **One CLI, subcommands** (`signpost`/`box`/`menu`/`list`/`tree`/`legend`) over a shared wrap+width core — vs separate tools. Leaning: one CLI, shared core.
+- **Where it lives** — new shared script home under `skills/` (alongside `manifest.cjs`/`knowledge.cjs` conventions) vs the `bash-toolkit/lib` shared dir.
+- **Display contract** — Claude re-emits the block verbatim in its reply (output tokens unchanged, reasoning saved). Confirmed acceptable.
+
+## Relevant files (call-site index)
+
+- **Trees (real):** `workflow-continue-epic/references/{epic-display-and-menu,display-epic-map}.md`, `workflow-discussion-process/references/discussion-session.md`, `workflow-discovery/references/session-loop.md`, `workflow-start/references/inbox-working-set.md`
+- **Lists (sub-row, not trees):** `workflow-continue-*/references/select-*.md`, `workflow-start/references/{active-work,view-completed}.md`, `workflow-planning-process/references/{define-tasks,resolve-dependencies}.md`, `workflow-implementation-entry/references/check-dependencies.md`, `workflow-legacy-research-split/references/dialog.md`, `workflow-specification-entry/references/display-*.md`
+- **Menus:** `workflow-start/references/{active-work,empty-state,manage-work-unit,inbox-working-set,start-from-inbox,absorb-into-epic,inbox-archived}.md`, `workflow-continue-*/references/{select-*,revisit-phase}.md`, `workflow-bridge/references/*-continuation.md`, `workflow-specification-entry/references/display-specs-menu.md`
+- **Signposts/gates/boxes:** ~54 SKILL.md + references for `── ──`; ~40 reference files for `· · ·`; `workflow-knowledge/references/knowledge-check.md`, `workflow-start/SKILL.md` (boxes); `*/process-review-findings.md`, `spec-construction.md` (framed)
+- **Legends/vocab:** `workflow-specification-entry/references/display-*.md`, `workflow-continue-epic/references/epic-display-and-menu.md`
+- **Out of scope:** `workflow-planning-process/references/output-formats/{tick,linear,local-markdown}/about.md` (doc filesystem trees)

--- a/ideas/deterministic-tree-and-menu-renderer.md
+++ b/ideas/deterministic-tree-and-menu-renderer.md
@@ -116,6 +116,22 @@ The survey below has been updated to reflect this state.
 
 ---
 
+# Design Decisions (locked 2026-06-04)
+
+The model, agreed in discussion. Implementation flows from these.
+
+1. **One render library + CLI, in-repo under `skills/`.** A single shared renderer (e.g. `skills/workflow-render/scripts/render.cjs`) exposing per-shape functions (`renderSignpost`, `renderBox`, `renderMenu`, `renderList`, `renderTree`, `renderLegend`) over **one shared wrap/width/gutter core** — the single home of the budget math, so the wrap bug can exist in only one place. It is **both a library and a CLI**: scripts `require()` it in-process; Claude invokes the CLI via Bash for trivial shapes. Ships via AGNTC, no build step.
+2. **Caller owns the data.** Whoever holds the data calls the renderer. Claude calls the CLI directly for trivial-input shapes (signpost, box, simple menu). Data-backed shapes (the trees) are rendered by the data script (`discovery.cjs`), which already collates the manifest — it `require()`s the renderer and calls `renderTree()` **in-process**. Claude never assembles tree JSON.
+3. **One run, one source, two outputs — no double invocation.** `discovery.cjs` runs once: reads manifest → builds one structured object → from that object emits BOTH (a) the finished **display block** (by calling the render lib in-process) and (b) the thinned **reasoning data**. One process, one `stdout`, two clearly-demarcated sections. Drawing moves out of the prompt into the renderer; `format()` no longer asks Claude to draw — it concatenates a finished block + the data.
+4. **Two surfaces, one source of truth.** *Display surface* (the pretty tree — for the user, emitted verbatim) and *reasoning surface* (labeled data — for Claude's decisions) are two projections of the one structured object, so they can't drift. Fields that exist **only to draw the tree** (summary text, provenance, exact glyph) leave the reasoning surface once code draws the tree; what stays is only what the skill branches on (lifecycle/gating, routing, counts, next-action, blocked/deps). The dump thins; for some items it may vanish.
+5. **The tree is write-only-to-the-user (hard rule).** Claude must never read the rendered tree back to extract a decision — that re-introduces the fragile ASCII-parsing this exists to kill. Decision data always comes from the reasoning surface. `stdout` is demarcated so Claude knows which block to display vs reason about.
+6. **Display contract** — Claude re-emits the rendered block verbatim in its reply. Output tokens ~unchanged; the win is reasoning cost + correctness + one source of truth.
+7. **First slice → spike.** Build the **core + `signpost`** end-to-end first (prove the run→emit-verbatim loop, simplest shape). Then a **throwaway discovery-map spike**: render the map from `discovery.cjs` state and diff byte-for-byte against the hand-drawn block. The spike is the **go/no-go decider** for the whole effort, and doubles as the empirical test of which fields the reasoning surface keeps (= what continue-epic actually branches on).
+
+**Still open** (don't block the start): the exact reasoning-surface field set per skill (settled by the spike); the menu `description` sub-line (5th form vs row option); whether the reasoning surface stays labeled text or becomes JSON (tied to the broader code-based-orchestration push — out of scope here).
+
+---
+
 # Render-Shape Survey
 
 The section above is the *why*. This is the **survey**: every structured-ASCII shape Claude is currently instructed to hand-draw across the skills, grouped into families, with the distinct variants, observed drift, and candidate canonical forms. These canonical forms are *candidates for discussion*, not decisions. Schema design stays out of scope (per the note above) — this is what a schema would have to absorb.
@@ -360,13 +376,13 @@ Several near-identical `Key:` blocks (spec-entry display-*.md, epic display) lis
    - Highest value + where the bug lives + most variation: **the 4 real trees** (3B). Feed from the data scripts that already hold the rows.
    - Skip: doc filesystem trees (3C), maybe the bare `⚑` callout (1E).
 
-## Open questions (for decision, not yet decided)
+## Open questions
 
-- **Tree input source** — data-script emits the renderer IR directly (kills reasoning) vs Claude adapts script output per render (relocates it). Leaning: data-script emits IR.
+Most of the original open questions are now resolved — see **Design Decisions (locked 2026-06-04)** above (packaging, location, tree input, caller model, display contract). What remains:
+
+- **Reasoning-surface field set** per consuming skill — which fields stay vs leave once code draws the tree. Settled empirically by the first-slice spike (= what continue-epic actually branches on).
 - **Recommended-description menus** — 5th menu form, or a `description` option on the numbered form?
-- **One CLI, subcommands** (`signpost`/`box`/`menu`/`list`/`tree`/`legend`) over a shared wrap+width core — vs separate tools. Leaning: one CLI, shared core.
-- **Where it lives** — new shared script home under `skills/` (alongside `manifest.cjs`/`knowledge.cjs` conventions) vs the `bash-toolkit/lib` shared dir.
-- **Display contract** — Claude re-emits the block verbatim in its reply (output tokens unchanged, reasoning saved). Confirmed acceptable.
+- **Reasoning surface format** — stays labeled text vs becomes JSON. Tied to the broader code-based-orchestration push; out of scope for the renderer itself.
 
 ## Relevant files (call-site index)
 

--- a/ideas/discovery-architecture-spec.md
+++ b/ideas/discovery-architecture-spec.md
@@ -1,0 +1,192 @@
+# Discovery / Projection Architecture Spec (Draft)
+
+Status: **draft for mark-up.** Companion to [deterministic-tree-and-menu-renderer.md](deterministic-tree-and-menu-renderer.md). That doc covers the renderer (built). This doc covers the *integration* — how each skill's discovery script, the data it holds, and the deterministic renders fit together cleanly. Written to be handed to an implementing agent once the open decisions (§9) are settled.
+
+---
+
+## 1. Goal
+
+Two outcomes, one architecture:
+
+1. **Deterministic display.** Trees, menus, and signposts are computed by code and emitted verbatim — never hand-drawn in skill prose. (The renderer that does this is already built; see §3.)
+2. **Less per-skill boilerplate.** Today each skill's `discovery.cjs` re-implements its own phase looping, detail-building, and text formatting. Move the *generic* machinery to one place; keep each skill's *specifics* declared in that skill.
+
+The guiding constraint, in the user's words: **do not centralise skill-specific knowledge.** A central blob of "every skill's data structures woven into logic" is the thing to avoid. Each skill must remain the single, legible place where *what that skill needs* is declared.
+
+## 2. The anchor pattern — mirror the manifest CLI
+
+The manifest CLI is the model to copy:
+
+> The **manifest CLI** is a *generic read layer*. It holds zero skill knowledge; each skill supplies the **dot-paths** it wants (`get <wu>.specification.<topic> status`).
+
+Do the same for shaping + rendering:
+
+> A **generic engine** — also zero skill knowledge; each skill supplies a **declaration** (schema) describing the data it needs and how to render it.
+
+So skill-specific knowledge lives *in the skill*, declared next to where it's used. The central code is a dumb interpreter + the renderer. Open one skill's discovery script → see everything that skill needs, in one place.
+
+## 3. What already exists (do not rebuild)
+
+- **`skills/workflow-render/scripts/render.cjs`** — generic layout primitives, pure, no domain knowledge:
+  - `signpost(label, {style})`, `box(title)` — Family-1 shapes.
+  - `renderTree(nodes, {width})` — recursive `{ title, body?, children? }` tree. Owns branch glyphs, the continuous `│` gutter, and wrap-with-gutter-budget (the original bug is structurally impossible). Width default 72.
+  - `wrap` / `wrapWithPrefix` / `fillTo` — the core. **`wrapWithPrefix` is the single home of the gutter-budget math.**
+- **`skills/workflow-render/scripts/conventions.cjs`** — domain composition: `title({glyph,label,tag})`, `tag()`, `derivedFrom()` (the `↳` line), `discoveryGlyph()` + the tier vocabulary, `titlecase()`.
+- These are sound and tested (PRs #348, #351). The renderer is the **presentation layer** below; this spec is about everything above it.
+
+## 4. The layers
+
+```
+┌── PER SKILL ────────────────────────────────────────────────┐
+│  SKILL .md      ── invoke ──▶  scripts/discovery.cjs         │
+│  emits verbatim / reads        (thin: holds the skill's      │
+│                                 schema; delegates to engine) │
+└──────────────────────────────┬──────────────────────────────┘
+                               ▼
+┌── ENGINE  (central, generic — workflow-shared or workflow-data) ──┐
+│   run({ skill, command, params }):                          │
+│     1. load the calling skill's schema                      │
+│     2. read manifest per schema (data layer)                │
+│     3. apply the schema's derive() functions                │
+│     4. if command is a VIEW → render it                     │
+│     5. return reasoning text  OR  a finished display block  │
+└───────────────┬───────────────┬───────────────┬────────────┘
+        data    │      display   │      display  │
+        ┌───────▼──────┐  ┌──────▼──────┐  ┌─────▼─────┐
+        │ dump / data  │  │  dashboard  │  │   menu    │   ◀ projections
+        └──────────────┘  └──────┬──────┘  └─────┬─────┘
+                                 ▼               ▼
+                   ┌─────────────────────────────────┐
+                   │ render.cjs + conventions.cjs     │   ◀ presentation (built)
+                   └─────────────────────────────────┘
+```
+
+- **Data layer** — reads the project-level manifest into the `detail` object. The generic builder replaces each skill's bespoke `buildXDetail()`; the irreducible computations stay as skill functions (see §7).
+- **Projection layer** — deterministic views off the one `detail`, produced *on demand* (one command → one output): `dump`/`data` (reasoning text), `dashboard` (display block), `menu` (display/actions).
+- **Presentation** — already built.
+
+## 5. Two kinds of output (the surfaces)
+
+Everything is text on stdout, but two distinct kinds:
+
+| Surface | Commands | Claude does | Today |
+|---|---|---|---|
+| **Reasoning** | `overview`, `data` | **reads** the labelled text to decide (selection, gating, routing) | the data dump on `main` |
+| **Display** | `dashboard`, `menu` | **emits verbatim** in a code block | hand-drawn in the `.md` |
+
+Hard rule (carried from the renderer doc): **the display is write-only-to-the-user.** Never parse a rendered tree to extract a decision — decision data comes from the reasoning surface.
+
+## 6. Invocation mechanics (grounded in the codebase — not invented)
+
+Two mechanisms exist in the tree today; they do **not** mix:
+
+1. **`!`…`` dynamic insertion** — runs at skill **load**, injects stdout. **Always parameterless.** All six in the codebase are `discovery.cjs` with no args. It **cannot** interpolate `{work_unit}`. → used for the head-of-skill **overview**.
+2. **Plain ```bash``` block with `{work_unit}`** — Claude runs it as a tool call, substituting the variable. ~14 exist (Step 7 re-run, backfill, bridge, …). → used for every **scoped** call.
+
+Consequence — the command surface must split along that line:
+
+| Need | Invocation | Mechanism |
+|---|---|---|
+| head overview (all units, for selection) | `discovery.cjs` | `!` auto-insert (load) |
+| scoped reasoning data | `discovery.cjs data {work_unit}` | manual bash |
+| rendered dashboard | `discovery.cjs dashboard {work_unit}` | manual bash |
+| rendered menu | `discovery.cjs menu {work_unit}` | manual bash |
+
+**The deterministic render is a manual bash call at the display step.** Today the display reference hand-draws from the in-context `detail` (no display-time invocation); the new model adds one scoped manual call where the display is emitted — the same pattern as the existing `discovery.cjs {work_unit}` re-run. There is no magic variable insertion.
+
+## 7. The skill schema — epic strawman (grounded in the live `detail`)
+
+The current `buildEpicDetail` returns (verbatim from `main`):
+
+```
+{ phases, in_progress, completed, cancelled, next_phase_ready,
+  unaccounted_discussions, reopened_discussions, discovery_map,
+  convergence_state, needs_sequencing, map_summary,
+  imports_count, seeds_count, analysis_caches, gating }
+```
+
+A skill's discovery script would *declare* this rather than imperatively build it. Strawman (illustrative, not final):
+
+```js
+// skills/workflow-continue-epic/scripts/discovery.cjs
+module.exports = defineDiscovery({
+  phases: ['discovery','research','discussion','specification','planning','implementation','review'],
+
+  // regular shape — declarative
+  enrich: {
+    specification: ['sources'],            // → entry.sources
+    planning:      ['format','deps'],      // → entry.format, deps_blocking
+    implementation:['progress'],           // → current_phase, completed_tasks
+  },
+
+  // irreducible algorithms — plain functions, defined HERE in the skill,
+  // referenced by the schema; NEVER absorbed into the engine
+  derive: {
+    discoveryMap:     buildDiscoveryMap,   // tier/lifecycle/provenance per topic
+    nextPhaseReady:   computeNextPhaseReady,
+    gating:           computeGates,
+    // unaccounted/reopened discussions, map_summary, convergence_state, …
+  },
+
+  // views the engine renders on demand; the node-mapping (epic-specific) is here
+  views: {
+    data: dumpDefault,                     // labelled reasoning text (≈ today's format())
+    dashboard: state => layout(
+      box(state.name),
+      stage('DISCOVERY',  tree(state.discoveryMap, t => ({
+        title: title({ glyph: t.tier, label: titlecase(t.name), tag: lifecycleLabel(t) }),
+        body:  [t.summary, t.provenance && derivedFrom(t.provenance)].filter(Boolean),
+      })), { callouts: stageMetaCallouts(state) }),
+      stage('DEFINITION', phaseTrees(state, ['specification','planning'])),
+      stage('DELIVERY',   phaseTrees(state, ['implementation','review'])),
+    ),
+    menu: state => actionMenu(state.nextPhaseReady /* + lifecycle actions */),
+  },
+});
+```
+
+Everything epic-specific (`buildDiscoveryMap`, `lifecycleLabel`, the dashboard layout, the menu mapping) sits in the epic skill. The engine never learns what an epic is.
+
+### Engine contract
+
+```
+run({ skill, command, params }):
+  schema  = require(skill's discovery declaration)
+  detail  = buildDetail(manifest, schema)        // generic loop + schema.enrich + schema.derive
+  switch command:
+    'data'      → stdout: dumpDefault(detail)            // reasoning
+    'dashboard' → stdout: schema.views.dashboard(detail) // display, via render.cjs
+    'menu'      → stdout: schema.views.menu(detail)      // display
+    (no command, no params) → stdout: overview(all units) // the head `!` insert
+```
+
+## 8. Two flavours — decide in §9
+
+- **(A) Declarative schema → generic engine** (above). Cleanest separation; risk is the schema growing into a DSL. Mitigation: keep it declarative only for the regular shape; push all real logic into `derive`/view functions that live in the skill.
+- **(B) Rich shared toolkit, skill composes.** No schema *format*; the skill's script imports a strong toolkit (manifest reads + transforms + renderer) and composes it imperatively. Same outcome (knowledge in-skill, central generic), less machinery, slightly more imperative scripts.
+
+Recommendation: **prototype the epic in flavour (A) on paper first**; if the schema reads clean and the `derive` escape-hatch sits comfortably, take (A); if it feels like a framework, fall back to (B). (Same empirical move that de-risked the renderer.)
+
+## 9. Open decisions (resolve before building)
+
+1. **Flavour** — declarative schema (A) vs rich toolkit (B).
+2. **Central location** — extend `workflow-shared/scripts/` (already home to `discovery-utils.cjs`) vs a new `workflow-data` skill.
+3. **Language** — JS + JSDoc typedefs (lean: gives the `detail`/node contracts, low friction) vs full TypeScript. **No bundling needed either way** — pure, no npm deps, `require`d directly like `discovery-utils` (unlike `knowledge.cjs`, which bundles only for its deps). No classes.
+4. **`data`/`dump` format** — stays labelled text, or becomes structured (JSON Claude reads)?
+5. **Menu** — how much is code-generated vs Claude-built? (The render is deterministic; the *routing* of the user's choice stays in the `.md`.)
+6. **Per-skill `discovery.cjs` consolidation order** — epic first as the reference; then one skill at a time.
+
+## 10. Migration principles
+
+- **Keep the renderer core** (#348/#351) — it's the presentation layer, unchanged.
+- **Build the engine + the epic schema as the first consumer**, validated against fixtures (this repo has no `.workflows/`, so tests use realistic `detail` fixtures, as the spike did).
+- **Behaviour-preserving** — the `data`/`overview` reasoning output stays byte-stable during migration so the many reasoning consumers don't break. Display is allowed to change only where we intend it (the renderer's `↳` provenance, 8-col gutter, width-72 wrap — already agreed).
+- **One skill at a time.** Epic proves the shape; feature/bugfix/quickfix/cross-cutting/start follow.
+- **Skills' `.md` stay thin** — a scoped call + "emit verbatim" / "read to route," no layout prose.
+
+## 11. Explicitly out of scope here
+
+- The renderer internals (done).
+- Rewriting all discovery scripts at once (incremental only).
+- Changing the manifest schema or the manifest CLI.
+- The no-discovery-map epic branch and recommendation logic — port after the main path proves out.


### PR DESCRIPTION
## Summary

Long-lived **design log** for the deterministic renderer (idea #32). Holds the idea, the full render-shape survey, and the locked design decisions in `ideas/deterministic-tree-and-menu-renderer.md`. Stays open and is appended to as the feature progresses; merges last.

- The motivating bug, root cause, and the short-wrap rationale.
- Survey of every fixed-shape render across the skills (signposts/gates, menus, lists-vs-trees, vocab/legends) — variants, drift, candidate canonical forms.
- Locked decisions: one render library+CLI in-repo; caller-owns-data; one-run/one-source/two-outputs (display vs reasoning); tree is write-only-to-user; first slice = core+signpost, then a discovery-map spike as go/no-go.

Code ships in separate stacked PRs (PR1: core + signpost slice).

## Test plan

Docs only — no code in this PR.