### PR TITLE
[renderer] Tree shape — discovery-map renderer (spike → keeper)

### DIFF
--- a/skills/workflow-render/SKILL.md
+++ b/skills/workflow-render/SKILL.md
@@ -56,24 +56,43 @@ Word-wrap `text` so that `prefix + line` stays within `width`; every line carrie
 
 ### `tree [--width N]` (reads a JSON node array on stdin)
 
-A continuous-gutter tree — the discovery-map shape. The data-owner (e.g. `discovery.cjs`) builds the node array and pipes it in; Claude does not assemble it.
+A continuous-gutter tree. Pure layout — it knows nothing about glyphs, tags, or provenance; the caller composes those into the strings (see **Conventions** below). The data-owner (e.g. `discovery.cjs`) builds the node array and pipes it in; Claude does not assemble it.
 
 ```bash
-echo '[{"glyph":"◐","label":"Ai Content Engine","tag":"researching","summary":"…","provenance":"from exploration"}]' \
-  | render tree --width 72
+echo '[{"title":"◐ Ai Content Engine [researching]","body":["summary…","↳ From exploration"],
+       "children":[{"title":"✓ Field Order [decided]"}]}]' | render tree --width 72
 ```
 
-Each node is `{ glyph?, label, tag?, summary?, provenance? }`. Rows hang off the header via `├─` (or sole `└─`) — never `┌─`. The `summary` wraps beneath the row under a continuous `│` gutter (dropped on the last row); the budget already subtracts the gutter, so it can never orphan. The `provenance` renders as a distinct `↳ `-marked line (first letter capitalised) so it reads as "derived from", not a continuation of the summary. Default width is 72; pass `--width` / `{ width }` to override. Header rows (`├─ glyph Label [tag]`) are single-line and data-determined — a long label+tag is not wrapped (wrapping would break glyph alignment).
+Each node is `{ title, body?: string[], children?: node[] }`:
+- **`title`** — the one-line header row, already composed (`glyph label [tag]`). Rows hang off whatever header precedes them via `├─` (or sole `└─`) — never `┌─`.
+- **`body`** — paragraphs beneath the row; each wraps independently under a continuous `│` gutter (dropped on the last sibling). The budget already subtracts the gutter, so body can never orphan.
+- **`children`** — nested nodes, same shape, recursively; the gutter accumulates at every depth.
 
-## Library API
+Default width is 72 (`--width` / `{ width }` to override). `title` is single-line and data-determined — a long one isn't wrapped (wrapping would break glyph alignment).
+
+## Conventions — `scripts/conventions.cjs`
+
+The domain-aware layer: it knows what workflow content should *look* like (the glyph vocabulary, the `[tag]` format, the `↳` derived-from line) and produces the plain strings the renderer lays out. Keeps format normalised in one place while the renderer stays domain-free. Grown as call sites are wired.
 
 ```js
-const { signpost, box, wrap, wrapWithPrefix, fillTo, WIDTH } =
+const { title, tag, derivedFrom, capitalise, discoveryGlyph } =
+  require('.../skills/workflow-render/scripts/conventions.cjs');
+
+title({ glyph, label, tag })   // → "◐ Menu And Admin [researching]" (a node title)
+tag('decided')                 // → "[decided]"
+derivedFrom('from exploration')// → "↳ From exploration"
+discoveryGlyph('researching')  // → "◐"  (tier → canonical symbol)
+```
+
+## Library API — `scripts/render.cjs`
+
+```js
+const { signpost, box, renderTree, wrap, wrapWithPrefix, fillTo, WIDTH } =
   require('.../skills/workflow-render/scripts/render.cjs');
 
 signpost(label, { style, width })          // → string (one line)
 box(title, { width })                       // → string (block, trailing blank)
-renderTree(nodes, { width })                // → string (discovery-map tree)
+renderTree(nodes, { width })                // → string (recursive tree)
 wrapWithPrefix(text, { width, prefix })     // → string[] (each line prefixed)
 wrap(text, budget)                          // → string[] (segments ≤ budget)
 fillTo(head, fillChar, width)               // → string (head padded to width)
@@ -83,4 +102,4 @@ fillTo(head, fillChar, width)               // → string (head padded to width)
 
 ## Tests
 
-`tests/scripts/test-render.cjs` (run `node --test tests/scripts/test-render.cjs`). Add a test alongside any change to `render.cjs`.
+`tests/scripts/test-render.cjs` (run `node --test tests/scripts/test-render.cjs`). Add a test alongside any change to `render.cjs` or `conventions.cjs`.

--- a/skills/workflow-render/SKILL.md
+++ b/skills/workflow-render/SKILL.md
@@ -63,7 +63,7 @@ echo '[{"glyph":"◐","label":"Ai Content Engine","tag":"researching","summary":
   | render tree --width 72
 ```
 
-Each node is `{ glyph?, label, tag?, summary?, provenance? }`. Rows hang off the header via `├─` (or sole `└─`) — never `┌─`. The `summary` wraps beneath the row under a continuous `│` gutter (dropped on the last row); the budget already subtracts the gutter, so it can never orphan. The `provenance` renders as a distinct `· `-marked line (first letter capitalised) so it reads as metadata, not a continuation of the summary. Default width is 72; pass `--width` / `{ width }` to override. Header rows (`├─ glyph Label [tag]`) are single-line and data-determined — a long label+tag is not wrapped (wrapping would break glyph alignment).
+Each node is `{ glyph?, label, tag?, summary?, provenance? }`. Rows hang off the header via `├─` (or sole `└─`) — never `┌─`. The `summary` wraps beneath the row under a continuous `│` gutter (dropped on the last row); the budget already subtracts the gutter, so it can never orphan. The `provenance` renders as a distinct `↳ `-marked line (first letter capitalised) so it reads as "derived from", not a continuation of the summary. Default width is 72; pass `--width` / `{ width }` to override. Header rows (`├─ glyph Label [tag]`) are single-line and data-determined — a long label+tag is not wrapped (wrapping would break glyph alignment).
 
 ## Library API
 

--- a/skills/workflow-render/SKILL.md
+++ b/skills/workflow-render/SKILL.md
@@ -54,6 +54,17 @@ render box "Planning Overview"
 
 Word-wrap `text` so that `prefix + line` stays within `width`; every line carries the prefix (the gutter/indent). The wrap budget is `width − prefix.length` — this is the primitive trees and wrapped lists build on. Utility/inspection command; in code, call `wrapWithPrefix` directly.
 
+### `tree [--width N]` (reads a JSON node array on stdin)
+
+A continuous-gutter tree — the discovery-map shape. The data-owner (e.g. `discovery.cjs`) builds the node array and pipes it in; Claude does not assemble it.
+
+```bash
+echo '[{"glyph":"◐","label":"Ai Content Engine","tag":"researching","body":["summary…","from exploration"]}]' \
+  | render tree --width 65
+```
+
+Each node is `{ glyph?, label, tag?, body?: string[] }`. Rows hang off the header via `├─` (or sole `└─`) — never `┌─`. Body lines wrap beneath each row under a continuous `│` gutter (dropped on the last row); the wrap budget already subtracts the gutter, so a body line can never orphan. Header rows (`├─ glyph Label [tag]`) are single-line and data-determined — a long label+tag is not wrapped (wrapping would break glyph alignment).
+
 ## Library API
 
 ```js
@@ -62,6 +73,7 @@ const { signpost, box, wrap, wrapWithPrefix, fillTo, WIDTH } =
 
 signpost(label, { style, width })          // → string (one line)
 box(title, { width })                       // → string (block, trailing blank)
+renderTree(nodes, { width })                // → string (discovery-map tree)
 wrapWithPrefix(text, { width, prefix })     // → string[] (each line prefixed)
 wrap(text, budget)                          // → string[] (segments ≤ budget)
 fillTo(head, fillChar, width)               // → string (head padded to width)

--- a/skills/workflow-render/SKILL.md
+++ b/skills/workflow-render/SKILL.md
@@ -59,11 +59,11 @@ Word-wrap `text` so that `prefix + line` stays within `width`; every line carrie
 A continuous-gutter tree — the discovery-map shape. The data-owner (e.g. `discovery.cjs`) builds the node array and pipes it in; Claude does not assemble it.
 
 ```bash
-echo '[{"glyph":"◐","label":"Ai Content Engine","tag":"researching","body":["summary…","from exploration"]}]' \
-  | render tree --width 65
+echo '[{"glyph":"◐","label":"Ai Content Engine","tag":"researching","summary":"…","provenance":"from exploration"}]' \
+  | render tree --width 72
 ```
 
-Each node is `{ glyph?, label, tag?, body?: string[] }`. Rows hang off the header via `├─` (or sole `└─`) — never `┌─`. Body lines wrap beneath each row under a continuous `│` gutter (dropped on the last row); the wrap budget already subtracts the gutter, so a body line can never orphan. Header rows (`├─ glyph Label [tag]`) are single-line and data-determined — a long label+tag is not wrapped (wrapping would break glyph alignment).
+Each node is `{ glyph?, label, tag?, summary?, provenance? }`. Rows hang off the header via `├─` (or sole `└─`) — never `┌─`. The `summary` wraps beneath the row under a continuous `│` gutter (dropped on the last row); the budget already subtracts the gutter, so it can never orphan. The `provenance` renders as a distinct `· `-marked line (first letter capitalised) so it reads as metadata, not a continuation of the summary. Default width is 72; pass `--width` / `{ width }` to override. Header rows (`├─ glyph Label [tag]`) are single-line and data-determined — a long label+tag is not wrapped (wrapping would break glyph alignment).
 
 ## Library API
 

--- a/skills/workflow-render/scripts/conventions.cjs
+++ b/skills/workflow-render/scripts/conventions.cjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain-aware composition helpers for workflow renders.
+//
+// These know what workflow content should LOOK like — the glyph vocabulary,
+// the `[tag]` suffix format, the `↳` derived-from line — and produce the plain
+// strings that the generic renderer (render.cjs) lays out. Keeping conventions
+// here, separate from layout, means the format is normalised in one place while
+// the renderer stays domain-free.
+//
+// This layer grows as call sites are wired; only add what a real consumer needs.
+// ---------------------------------------------------------------------------
+
+// Upper-case the first character (the rest is left untouched).
+function capitalise(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+// `[term]` — the item status / lifecycle suffix.
+function tag(term) {
+  return `[${term}]`;
+}
+
+// `↳ Derived-from` line — provenance, capitalised. Feeds a tree node's body[].
+function derivedFrom(text) {
+  return '↳ ' + capitalise(String(text).trim());
+}
+
+// Compose a tree node's title from its parts: `glyph label [tag]`. Any part may
+// be omitted. Single space between segments; the tag is bracketed.
+function title({ glyph, label, tag: term } = {}) {
+  const parts = [];
+  if (glyph) parts.push(glyph);
+  if (label) parts.push(label);
+  let line = parts.join(' ');
+  if (term) line += (line ? ' ' : '') + tag(term);
+  return line;
+}
+
+// Discovery-tier glyph vocabulary — the single source of the tier symbol set.
+const DISCOVERY_GLYPH = {
+  ready_for_discussion: '→',
+  researching: '◐',
+  discussing: '◐',
+  decided: '✓',
+  fresh: '○',
+  handled: '⊙',
+  cancelled: '⊘',
+};
+
+function discoveryGlyph(tier) {
+  return DISCOVERY_GLYPH[tier] || '';
+}
+
+module.exports = { capitalise, tag, derivedFrom, title, discoveryGlyph, DISCOVERY_GLYPH };

--- a/skills/workflow-render/scripts/render.cjs
+++ b/skills/workflow-render/scripts/render.cjs
@@ -149,10 +149,12 @@ function renderSiblings(nodes, prefix, width, out) {
     if (!node || !node.title) throw new Error(`renderTree: node ${i} needs a title`);
     const isLast = i === nodes.length - 1;
     out.push(prefix + (isLast ? '└─ ' : '├─ ') + node.title);
-    // Continuation gutters. The last sibling drops the │ (blank) so nothing
-    // dangles below └─. Body hangs under the row; children branch one step in.
-    const bodyPrefix = prefix + (isLast ? ' ' : '│') + '      ';
+    // Sub-content lives one level in. The last sibling drops the │ (blank) so
+    // nothing dangles below └─. Children branch at `childPrefix`; body has no
+    // branch, so it indents by the branch width (3) to land at the same content
+    // column — body text and child rows align.
     const childPrefix = prefix + (isLast ? '   ' : '│  ');
+    const bodyPrefix = childPrefix + '   ';
     for (const para of node.body || []) {
       for (const wl of wrapWithPrefix(para, { width, prefix: bodyPrefix })) out.push(wl);
     }

--- a/skills/workflow-render/scripts/render.cjs
+++ b/skills/workflow-render/scripts/render.cjs
@@ -110,58 +110,56 @@ function box(title, { width = WIDTH } = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Shapes: tree (continuous-gutter)
+// Shapes: tree (continuous-gutter, recursive)
 // ---------------------------------------------------------------------------
 
-// Upper-case the first character (display polish; the rest is left untouched).
-function capitalise(s) {
-  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
-}
-
-// Render a flat list of nodes as a continuous-gutter tree — the discovery-map
-// shape. Each row hangs off its header via `├─` (or sole `└─`); never `┌─`.
-// Beneath each row: the wrapped `summary`, then the `provenance` as a distinct
-// `↳ `-marked line so it reads as "derived from", not a continuation of the
-// summary. Every sub-line carries the gutter so the `│` runs unbroken.
+// Render nodes as a continuous-gutter tree. PURE LAYOUT: branch glyphs (├─/└─,
+// never ┌─ — the list hangs off whatever header precedes it), a continuous │
+// gutter at every depth, body word-wrap with the gutter subtracted from the
+// budget, and recursion for children. It knows nothing about glyphs, tags, or
+// provenance — the caller composes those into the strings (see conventions.cjs).
 //
-//   ├─ ◐ Ai Content Engine [researching]
-//   │      summary text wrapped to the budget…
-//   │      …continuation, gutter intact
-//   │      ↳ From exploration
-//   └─ ◐ Menu And Admin [researching]
-//          summary, last row drops the │
-//          ↳ From exploration
+//   ├─ ◐ Ai Content Engine [researching]      ← title (caller-composed line)
+//   │      summary text wrapped to the budget…  ← body[0]
+//   │      ↳ From exploration                   ← body[1]
+//   ├─ → Decision-Point INFO Line Shape
+//   │  ├─ ✓ Field Order                         ← child
+//   │  └─ ◐ Truncation Rules
+//   └─ ◐ Menu And Admin [researching]           ← last sibling drops the │
 //
-// node: { glyph?, label, tag?, summary?, provenance? }
-// The summary wrap budget is `width − 9` (the 9-char gutter), so a summary line
-// can never overflow `width` — the gutter-orphan bug is structurally impossible.
+// node: { title, body?: string[], children?: node[] }
+//   title    — the one-line header row (glyph + label + tag already baked in)
+//   body     — paragraphs beneath the row; each wraps independently
+//   children — nested nodes, same shape, recursively
+//
+// Every sub-line carries the accumulated gutter, so the │ runs unbroken at any
+// depth; the body wrap budget is width − gutter, so body can never orphan.
 function renderTree(nodes, { width = 72 } = {}) {
   if (!Array.isArray(nodes) || nodes.length === 0) {
     throw new Error('renderTree: nodes must be a non-empty array');
   }
-  const lines = [];
+  const out = [];
+  renderSiblings(nodes, '  ', width, out);
+  return out.join('\n') + '\n';
+}
+
+// `prefix` is the accumulated gutter that precedes this level's branch glyphs.
+function renderSiblings(nodes, prefix, width, out) {
   nodes.forEach((node, i) => {
-    if (!node || !node.label) throw new Error(`renderTree: node ${i} needs a label`);
+    if (!node || !node.title) throw new Error(`renderTree: node ${i} needs a title`);
     const isLast = i === nodes.length - 1;
-    let head = `  ${isLast ? '└─' : '├─'} `;
-    if (node.glyph) head += `${node.glyph} `;
-    head += node.label;
-    if (node.tag) head += ` [${node.tag}]`;
-    lines.push(head);
-    // Gutter: 2-space indent aligns under the row; non-last keeps the │, the
-    // last row drops it (9 spaces) so nothing dangles below └─. Both 9 wide,
-    // so the body text lands at the same column either way.
-    const gutter = isLast ? ' '.repeat(9) : '  │' + ' '.repeat(6);
-    if (node.summary) {
-      for (const wl of wrapWithPrefix(node.summary, { width, prefix: gutter })) {
-        lines.push(wl);
-      }
+    out.push(prefix + (isLast ? '└─ ' : '├─ ') + node.title);
+    // Continuation gutters. The last sibling drops the │ (blank) so nothing
+    // dangles below └─. Body hangs under the row; children branch one step in.
+    const bodyPrefix = prefix + (isLast ? ' ' : '│') + '      ';
+    const childPrefix = prefix + (isLast ? '   ' : '│  ');
+    for (const para of node.body || []) {
+      for (const wl of wrapWithPrefix(para, { width, prefix: bodyPrefix })) out.push(wl);
     }
-    if (node.provenance) {
-      lines.push(gutter + '↳ ' + capitalise(node.provenance));
+    if (node.children && node.children.length) {
+      renderSiblings(node.children, childPrefix, width, out);
     }
   });
-  return lines.join('\n') + '\n';
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/workflow-render/scripts/render.cjs
+++ b/skills/workflow-render/scripts/render.cjs
@@ -121,16 +121,16 @@ function capitalise(s) {
 // Render a flat list of nodes as a continuous-gutter tree — the discovery-map
 // shape. Each row hangs off its header via `├─` (or sole `└─`); never `┌─`.
 // Beneath each row: the wrapped `summary`, then the `provenance` as a distinct
-// `· `-marked line so it reads as metadata, not a continuation of the summary.
-// Every sub-line carries the gutter so the `│` runs unbroken down the tree.
+// `↳ `-marked line so it reads as "derived from", not a continuation of the
+// summary. Every sub-line carries the gutter so the `│` runs unbroken.
 //
 //   ├─ ◐ Ai Content Engine [researching]
 //   │      summary text wrapped to the budget…
 //   │      …continuation, gutter intact
-//   │      · From exploration
+//   │      ↳ From exploration
 //   └─ ◐ Menu And Admin [researching]
 //          summary, last row drops the │
-//          · From exploration
+//          ↳ From exploration
 //
 // node: { glyph?, label, tag?, summary?, provenance? }
 // The summary wrap budget is `width − 9` (the 9-char gutter), so a summary line
@@ -158,7 +158,7 @@ function renderTree(nodes, { width = 72 } = {}) {
       }
     }
     if (node.provenance) {
-      lines.push(gutter + '· ' + capitalise(node.provenance));
+      lines.push(gutter + '↳ ' + capitalise(node.provenance));
     }
   });
   return lines.join('\n') + '\n';

--- a/skills/workflow-render/scripts/render.cjs
+++ b/skills/workflow-render/scripts/render.cjs
@@ -113,22 +113,29 @@ function box(title, { width = WIDTH } = {}) {
 // Shapes: tree (continuous-gutter)
 // ---------------------------------------------------------------------------
 
+// Upper-case the first character (display polish; the rest is left untouched).
+function capitalise(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
 // Render a flat list of nodes as a continuous-gutter tree — the discovery-map
 // shape. Each row hangs off its header via `├─` (or sole `└─`); never `┌─`.
-// Node body lines (summary, provenance) wrap beneath the row, every line
-// carrying the gutter so the `│` runs unbroken down the whole tree.
+// Beneath each row: the wrapped `summary`, then the `provenance` as a distinct
+// `· `-marked line so it reads as metadata, not a continuation of the summary.
+// Every sub-line carries the gutter so the `│` runs unbroken down the tree.
 //
 //   ├─ ◐ Ai Content Engine [researching]
 //   │      summary text wrapped to the budget…
 //   │      …continuation, gutter intact
-//   │      from exploration
+//   │      · From exploration
 //   └─ ◐ Menu And Admin [researching]
 //          summary, last row drops the │
+//          · From exploration
 //
-// node: { glyph?, label, tag?, body?: string[] }
-// The wrap budget is `width − 9` (the 9-char gutter), so a body line can never
-// overflow `width` — the gutter-orphan bug is structurally impossible.
-function renderTree(nodes, { width = 65 } = {}) {
+// node: { glyph?, label, tag?, summary?, provenance? }
+// The summary wrap budget is `width − 9` (the 9-char gutter), so a summary line
+// can never overflow `width` — the gutter-orphan bug is structurally impossible.
+function renderTree(nodes, { width = 72 } = {}) {
   if (!Array.isArray(nodes) || nodes.length === 0) {
     throw new Error('renderTree: nodes must be a non-empty array');
   }
@@ -145,10 +152,13 @@ function renderTree(nodes, { width = 65 } = {}) {
     // last row drops it (9 spaces) so nothing dangles below └─. Both 9 wide,
     // so the body text lands at the same column either way.
     const gutter = isLast ? ' '.repeat(9) : '  │' + ' '.repeat(6);
-    for (const body of node.body || []) {
-      for (const wl of wrapWithPrefix(body, { width, prefix: gutter })) {
+    if (node.summary) {
+      for (const wl of wrapWithPrefix(node.summary, { width, prefix: gutter })) {
         lines.push(wl);
       }
+    }
+    if (node.provenance) {
+      lines.push(gutter + '· ' + capitalise(node.provenance));
     }
   });
   return lines.join('\n') + '\n';

--- a/skills/workflow-render/scripts/render.cjs
+++ b/skills/workflow-render/scripts/render.cjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
+const fs = require('fs');
+
 // ---------------------------------------------------------------------------
 // Deterministic renderer for fixed-shape workflow output.
 //
@@ -108,10 +110,55 @@ function box(title, { width = WIDTH } = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// Shapes: tree (continuous-gutter)
+// ---------------------------------------------------------------------------
+
+// Render a flat list of nodes as a continuous-gutter tree — the discovery-map
+// shape. Each row hangs off its header via `├─` (or sole `└─`); never `┌─`.
+// Node body lines (summary, provenance) wrap beneath the row, every line
+// carrying the gutter so the `│` runs unbroken down the whole tree.
+//
+//   ├─ ◐ Ai Content Engine [researching]
+//   │      summary text wrapped to the budget…
+//   │      …continuation, gutter intact
+//   │      from exploration
+//   └─ ◐ Menu And Admin [researching]
+//          summary, last row drops the │
+//
+// node: { glyph?, label, tag?, body?: string[] }
+// The wrap budget is `width − 9` (the 9-char gutter), so a body line can never
+// overflow `width` — the gutter-orphan bug is structurally impossible.
+function renderTree(nodes, { width = 65 } = {}) {
+  if (!Array.isArray(nodes) || nodes.length === 0) {
+    throw new Error('renderTree: nodes must be a non-empty array');
+  }
+  const lines = [];
+  nodes.forEach((node, i) => {
+    if (!node || !node.label) throw new Error(`renderTree: node ${i} needs a label`);
+    const isLast = i === nodes.length - 1;
+    let head = `  ${isLast ? '└─' : '├─'} `;
+    if (node.glyph) head += `${node.glyph} `;
+    head += node.label;
+    if (node.tag) head += ` [${node.tag}]`;
+    lines.push(head);
+    // Gutter: 2-space indent aligns under the row; non-last keeps the │, the
+    // last row drops it (9 spaces) so nothing dangles below └─. Both 9 wide,
+    // so the body text lands at the same column either way.
+    const gutter = isLast ? ' '.repeat(9) : '  │' + ' '.repeat(6);
+    for (const body of node.body || []) {
+      for (const wl of wrapWithPrefix(body, { width, prefix: gutter })) {
+        lines.push(wl);
+      }
+    }
+  });
+  return lines.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
 // Exports (library use)
 // ---------------------------------------------------------------------------
 
-module.exports = { WIDTH, fillTo, wrap, wrapWithPrefix, signpost, box };
+module.exports = { WIDTH, fillTo, wrap, wrapWithPrefix, signpost, box, renderTree };
 
 // ---------------------------------------------------------------------------
 // CLI (Claude / shell use) — guarded so `require()` never runs it.
@@ -157,8 +204,15 @@ function runCli(argv) {
       process.stdout.write(lines.join('\n') + '\n');
       break;
     }
+    case 'tree': {
+      // Reads a JSON node array from stdin (the data-owner builds it).
+      const input = fs.readFileSync(0, 'utf8');
+      const treeWidth = opts.width !== undefined ? width : undefined;
+      process.stdout.write(renderTree(JSON.parse(input), treeWidth ? { width: treeWidth } : {}));
+      break;
+    }
     default:
-      die(`Unknown command "${command || ''}"\nCommands: signpost, box, wrap`);
+      die(`Unknown command "${command || ''}"\nCommands: signpost, box, wrap, tree`);
   }
 }
 

--- a/tests/scripts/test-render.cjs
+++ b/tests/scripts/test-render.cjs
@@ -13,22 +13,22 @@ const {
   renderTree,
 } = require('../../skills/workflow-render/scripts/render.cjs');
 
-// A realistic discovery-map fixture: three topics, mixed tiers, wrapped bodies.
+// A realistic discovery-map fixture: three topics, mixed tiers, wrapped summaries.
 const MAP = [
   {
     glyph: '◐', label: 'Ai Content Engine', tag: 'researching',
-    body: [
-      'AI imagery (enhancement-only v1), description generation, per-tenant tone / base-knowledge primitive, allowance + overage cost shape',
-      'from exploration',
-    ],
+    summary: 'AI imagery (enhancement-only v1), description generation, per-tenant tone / base-knowledge primitive, allowance + overage cost shape',
+    provenance: 'from exploration',
   },
   {
     glyph: '→', label: 'Legal And Regulatory', tag: 'research complete · ready for discussion',
-    body: ['Data residency, GDPR, age-gating for the competition flows', 'from research-analysis'],
+    summary: 'Data residency, GDPR, age-gating for the competition flows',
+    provenance: 'from research-analysis',
   },
   {
     glyph: '◐', label: 'Menu And Admin', tag: 'researching',
-    body: ['Business-side menu modelling, admin shell (Filament vs custom Vue/Nuxt), JustEat import, staff/roles', 'from exploration'],
+    summary: 'Business-side menu modelling, admin shell (Filament vs custom Vue/Nuxt), JustEat import, staff/roles',
+    provenance: 'from exploration',
   },
 ];
 
@@ -177,12 +177,20 @@ describe('render shape: renderTree (discovery map)', () => {
     // they can't wrap without breaking glyph alignment, so they're exempt (the
     // hand-drawn version overruns identically). Only the wrappable body lines
     // are guaranteed to fit — that's where the bug was.
-    for (const width of [49, 58, 65]) {
+    for (const width of [49, 58, 72]) {
       for (const l of renderTree(MAP, { width }).split('\n')) {
         if (/^ {2}[├└]─ /.test(l) || l === '') continue; // header row / trailing
         assert.ok(l.length <= width, `width ${width}: body "${l}" (${l.length}) overruns`);
       }
     }
+  });
+
+  it('renders provenance as a distinct · -marked, capitalised line', () => {
+    const out = renderTree(MAP, { width: 72 });
+    assert.ok(out.includes('  │      · From exploration'), 'non-last provenance: gutter + marker + capitalised');
+    assert.ok(out.includes('         · From exploration'), 'last provenance: 9-space gutter + marker + capitalised');
+    assert.ok(out.includes('· From research-analysis'), 'capitalises whatever the provenance is');
+    assert.ok(!out.includes('from exploration'), 'no lowercase provenance leaks through');
   });
 
   it('runs the │ unbroken under non-last topics, drops it under the last', () => {

--- a/tests/scripts/test-render.cjs
+++ b/tests/scripts/test-render.cjs
@@ -10,7 +10,27 @@ const {
   wrapWithPrefix,
   signpost,
   box,
+  renderTree,
 } = require('../../skills/workflow-render/scripts/render.cjs');
+
+// A realistic discovery-map fixture: three topics, mixed tiers, wrapped bodies.
+const MAP = [
+  {
+    glyph: '◐', label: 'Ai Content Engine', tag: 'researching',
+    body: [
+      'AI imagery (enhancement-only v1), description generation, per-tenant tone / base-knowledge primitive, allowance + overage cost shape',
+      'from exploration',
+    ],
+  },
+  {
+    glyph: '→', label: 'Legal And Regulatory', tag: 'research complete · ready for discussion',
+    body: ['Data residency, GDPR, age-gating for the competition flows', 'from research-analysis'],
+  },
+  {
+    glyph: '◐', label: 'Menu And Admin', tag: 'researching',
+    body: ['Business-side menu modelling, admin shell (Filament vs custom Vue/Nuxt), JustEat import, staff/roles', 'from exploration'],
+  },
+];
 
 describe('render core: fillTo', () => {
   it('pads a head out to the target width', () => {
@@ -126,5 +146,70 @@ describe('render shape: box (phase title)', () => {
 
   it('rejects an empty title', () => {
     assert.throws(() => box(''));
+  });
+});
+
+describe('render shape: renderTree (discovery map)', () => {
+  it('reproduces the documented row lines byte-for-byte', () => {
+    const lines = renderTree(MAP, { width: 65 }).split('\n');
+    assert.strictEqual(lines[0], '  ├─ ◐ Ai Content Engine [researching]');
+    assert.strictEqual(
+      lines.find((l) => l.includes('Legal And Regulatory')),
+      '  ├─ → Legal And Regulatory [research complete · ready for discussion]'
+    );
+    assert.strictEqual(
+      lines.find((l) => l.includes('Menu And Admin')),
+      '  └─ ◐ Menu And Admin [researching]'
+    );
+  });
+
+  it('hangs off the header — first row ├─, last └─, never ┌─', () => {
+    const out = renderTree(MAP, { width: 65 });
+    assert.ok(out.startsWith('  ├─ '));
+    assert.ok(!out.includes('┌─'));
+    const rows = out.split('\n').filter((l) => /^ {2}[├└]─ /.test(l));
+    assert.strictEqual(rows.length, 3);
+    assert.ok(rows[rows.length - 1].startsWith('  └─ '));
+  });
+
+  it('keeps every BODY line within the width (gutter-orphan bug is impossible)', () => {
+    // Header rows (`├─ glyph Name [tag]`) are single-line and data-determined —
+    // they can't wrap without breaking glyph alignment, so they're exempt (the
+    // hand-drawn version overruns identically). Only the wrappable body lines
+    // are guaranteed to fit — that's where the bug was.
+    for (const width of [49, 58, 65]) {
+      for (const l of renderTree(MAP, { width }).split('\n')) {
+        if (/^ {2}[├└]─ /.test(l) || l === '') continue; // header row / trailing
+        assert.ok(l.length <= width, `width ${width}: body "${l}" (${l.length}) overruns`);
+      }
+    }
+  });
+
+  it('runs the │ unbroken under non-last topics, drops it under the last', () => {
+    const lines = renderTree(MAP, { width: 65 }).split('\n').filter(Boolean);
+    let currentIsLast = false;
+    for (const l of lines) {
+      const m = l.match(/^ {2}([├└])─ /);
+      if (m) { currentIsLast = m[1] === '└'; continue; }
+      // body sub-line
+      if (currentIsLast) {
+        assert.ok(/^ {9}\S/.test(l), `last-topic sub-line should be 9 spaces then text: "${l}"`);
+        assert.ok(!l.includes('│'), `last topic must not carry the bar: "${l}"`);
+      } else {
+        assert.strictEqual(l[2], '│', `non-last sub-line must carry the bar at col 2: "${l}"`);
+        assert.ok(l.startsWith('  │      '), `non-last gutter must be 2sp │ 6sp: "${l}"`);
+      }
+    }
+  });
+
+  it('single node uses a sole └─', () => {
+    const out = renderTree([{ glyph: '○', label: 'Only One', tag: 'fresh' }], { width: 49 });
+    assert.ok(out.startsWith('  └─ ○ Only One [fresh]'));
+    assert.ok(!out.includes('├─') && !out.includes('┌─'));
+  });
+
+  it('rejects an empty node list and a label-less node', () => {
+    assert.throws(() => renderTree([]));
+    assert.throws(() => renderTree([{ glyph: '○' }]));
   });
 });

--- a/tests/scripts/test-render.cjs
+++ b/tests/scripts/test-render.cjs
@@ -185,11 +185,11 @@ describe('render shape: renderTree (discovery map)', () => {
     }
   });
 
-  it('renders provenance as a distinct · -marked, capitalised line', () => {
+  it('renders provenance as a distinct ↳ -marked, capitalised line', () => {
     const out = renderTree(MAP, { width: 72 });
-    assert.ok(out.includes('  │      · From exploration'), 'non-last provenance: gutter + marker + capitalised');
-    assert.ok(out.includes('         · From exploration'), 'last provenance: 9-space gutter + marker + capitalised');
-    assert.ok(out.includes('· From research-analysis'), 'capitalises whatever the provenance is');
+    assert.ok(out.includes('  │      ↳ From exploration'), 'non-last provenance: gutter + arrow + capitalised');
+    assert.ok(out.includes('         ↳ From exploration'), 'last provenance: 9-space gutter + arrow + capitalised');
+    assert.ok(out.includes('↳ From research-analysis'), 'capitalises whatever the provenance is');
     assert.ok(!out.includes('from exploration'), 'no lowercase provenance leaks through');
   });
 

--- a/tests/scripts/test-render.cjs
+++ b/tests/scripts/test-render.cjs
@@ -13,23 +13,45 @@ const {
   renderTree,
 } = require('../../skills/workflow-render/scripts/render.cjs');
 
-// A realistic discovery-map fixture: three topics, mixed tiers, wrapped summaries.
+const {
+  capitalise,
+  tag,
+  derivedFrom,
+  title,
+  discoveryGlyph,
+} = require('../../skills/workflow-render/scripts/conventions.cjs');
+
+// A realistic discovery-map fixture, composed via the conventions layer (proving
+// the split: conventions builds the strings, the renderer lays them out).
 const MAP = [
   {
-    glyph: '◐', label: 'Ai Content Engine', tag: 'researching',
-    summary: 'AI imagery (enhancement-only v1), description generation, per-tenant tone / base-knowledge primitive, allowance + overage cost shape',
-    provenance: 'from exploration',
+    title: title({ glyph: discoveryGlyph('researching'), label: 'Ai Content Engine', tag: 'researching' }),
+    body: [
+      'AI imagery (enhancement-only v1), description generation, per-tenant tone / base-knowledge primitive, allowance + overage cost shape',
+      derivedFrom('from exploration'),
+    ],
   },
   {
-    glyph: '→', label: 'Legal And Regulatory', tag: 'research complete · ready for discussion',
-    summary: 'Data residency, GDPR, age-gating for the competition flows',
-    provenance: 'from research-analysis',
+    title: title({ glyph: discoveryGlyph('ready_for_discussion'), label: 'Legal And Regulatory', tag: 'research complete · ready for discussion' }),
+    body: ['Data residency, GDPR, age-gating for the competition flows', derivedFrom('from research-analysis')],
   },
   {
-    glyph: '◐', label: 'Menu And Admin', tag: 'researching',
-    summary: 'Business-side menu modelling, admin shell (Filament vs custom Vue/Nuxt), JustEat import, staff/roles',
-    provenance: 'from exploration',
+    title: title({ glyph: discoveryGlyph('researching'), label: 'Menu And Admin', tag: 'researching' }),
+    body: ['Business-side menu modelling, admin shell (Filament vs custom Vue/Nuxt), JustEat import, staff/roles', derivedFrom('from exploration')],
   },
+];
+
+// A discussion-map fixture exercising nesting (children).
+const DISCUSSION = [
+  { title: '✓ Subsystem Prefix Taxonomy [decided]' },
+  {
+    title: '→ Decision-Point INFO Line Shape [converging]',
+    children: [
+      { title: '✓ Field Order [decided]' },
+      { title: '◐ Truncation Rules [exploring]' },
+    ],
+  },
+  { title: '○ Rollout Sequencing [pending]' },
 ];
 
 describe('render core: fillTo', () => {
@@ -211,13 +233,51 @@ describe('render shape: renderTree (discovery map)', () => {
   });
 
   it('single node uses a sole └─', () => {
-    const out = renderTree([{ glyph: '○', label: 'Only One', tag: 'fresh' }], { width: 49 });
+    const out = renderTree([{ title: '○ Only One [fresh]' }], { width: 49 });
     assert.ok(out.startsWith('  └─ ○ Only One [fresh]'));
     assert.ok(!out.includes('├─') && !out.includes('┌─'));
   });
 
-  it('rejects an empty node list and a label-less node', () => {
+  it('nests children with an accumulating gutter (discussion-map shape)', () => {
+    const lines = renderTree(DISCUSSION, { width: 72 }).split('\n');
+    // Parent is a non-last sibling, so its children sit under a continued │.
+    assert.ok(lines.includes('  ├─ → Decision-Point INFO Line Shape [converging]'));
+    assert.ok(lines.includes('  │  ├─ ✓ Field Order [decided]'), 'non-last child branches under the parent bar');
+    assert.ok(lines.includes('  │  └─ ◐ Truncation Rules [exploring]'), 'last child uses └─, parent bar still runs');
+    // Last top-level sibling drops its own bar.
+    assert.ok(lines.includes('  └─ ○ Rollout Sequencing [pending]'));
+    assert.ok(!renderTree(DISCUSSION).includes('┌─'));
+  });
+
+  it('rejects an empty node list and a title-less node', () => {
     assert.throws(() => renderTree([]));
-    assert.throws(() => renderTree([{ glyph: '○' }]));
+    assert.throws(() => renderTree([{ body: ['orphan'] }]));
+  });
+});
+
+describe('conventions (domain composition layer)', () => {
+  it('tag wraps in square brackets', () => {
+    assert.strictEqual(tag('decided'), '[decided]');
+  });
+
+  it('capitalise upper-cases only the first character', () => {
+    assert.strictEqual(capitalise('from exploration'), 'From exploration');
+    assert.strictEqual(capitalise(''), '');
+  });
+
+  it('derivedFrom builds a capitalised ↳ line', () => {
+    assert.strictEqual(derivedFrom('from research-analysis'), '↳ From research-analysis');
+  });
+
+  it('title composes glyph + label + [tag], omitting absent parts', () => {
+    assert.strictEqual(title({ glyph: '◐', label: 'Menu And Admin', tag: 'researching' }), '◐ Menu And Admin [researching]');
+    assert.strictEqual(title({ label: 'No Glyph', tag: 'pending' }), 'No Glyph [pending]');
+    assert.strictEqual(title({ label: 'Bare' }), 'Bare');
+  });
+
+  it('discoveryGlyph maps tiers to the canonical symbol set', () => {
+    assert.strictEqual(discoveryGlyph('decided'), '✓');
+    assert.strictEqual(discoveryGlyph('fresh'), '○');
+    assert.strictEqual(discoveryGlyph('unknown-tier'), '');
   });
 });

--- a/tests/scripts/test-render.cjs
+++ b/tests/scripts/test-render.cjs
@@ -209,8 +209,8 @@ describe('render shape: renderTree (discovery map)', () => {
 
   it('renders provenance as a distinct ↳ -marked, capitalised line', () => {
     const out = renderTree(MAP, { width: 72 });
-    assert.ok(out.includes('  │      ↳ From exploration'), 'non-last provenance: gutter + arrow + capitalised');
-    assert.ok(out.includes('         ↳ From exploration'), 'last provenance: 9-space gutter + arrow + capitalised');
+    assert.ok(out.includes('  │     ↳ From exploration'), 'non-last provenance: gutter + arrow + capitalised');
+    assert.ok(out.includes('        ↳ From exploration'), 'last provenance: 8-space gutter + arrow + capitalised');
     assert.ok(out.includes('↳ From research-analysis'), 'capitalises whatever the provenance is');
     assert.ok(!out.includes('from exploration'), 'no lowercase provenance leaks through');
   });
@@ -221,13 +221,13 @@ describe('render shape: renderTree (discovery map)', () => {
     for (const l of lines) {
       const m = l.match(/^ {2}([├└])─ /);
       if (m) { currentIsLast = m[1] === '└'; continue; }
-      // body sub-line
+      // body sub-line — aligns one level in (8-wide gutter)
       if (currentIsLast) {
-        assert.ok(/^ {9}\S/.test(l), `last-topic sub-line should be 9 spaces then text: "${l}"`);
+        assert.ok(/^ {8}\S/.test(l), `last-topic sub-line should be 8 spaces then text: "${l}"`);
         assert.ok(!l.includes('│'), `last topic must not carry the bar: "${l}"`);
       } else {
         assert.strictEqual(l[2], '│', `non-last sub-line must carry the bar at col 2: "${l}"`);
-        assert.ok(l.startsWith('  │      '), `non-last gutter must be 2sp │ 6sp: "${l}"`);
+        assert.ok(l.startsWith('  │     '), `non-last gutter must be 2sp │ 5sp: "${l}"`);
       }
     }
   });


### PR DESCRIPTION
## Summary

Stacked on #348. Adds `renderTree` — the first genuine continuous-gutter tree, on the shared `wrapWithPrefix` core. This was the go/no-go spike for the whole renderer; it came out clean, so the code is kept.

- Branch glyphs `├─`/`└─` (hangs off the header, never `┌─`), leading tier glyph, `name [lifecycle]`, wrapped summary/provenance sub-lines under a continuous `│` gutter (dropped on the last row).
- Wrap budget subtracts the 9-char gutter → the 74-col gutter-orphan bug (the original motivation) is **structurally impossible**.
- CLI `tree` reads a JSON node array on stdin (the data-owner builds it; Claude never assembles tree JSON); `renderTree` exported for in-process use.

## Spike findings

- **GO.** Structural rows reproduce the documented hand-drawn map **byte-for-byte**; every body line stays within width at 49/58/65.
- **Header-row overflow is inherent** — a long `label [lifecycle]` row (e.g. 70 cols) can't wrap without breaking glyph alignment; the hand-drawn version overruns identically. Mitigation (truncation) is a separate decision.
- **Open: tree content width** — 49 (consistent with the 49-wide dividers/markers) vs ~65 (current text density). Renderer is correct at any width; this is a visual-density call for the wiring step.

## Test plan

- `node --test tests/scripts/test-render.cjs` — 23 tests (6 new for the tree: byte-exact rows, hang-off-header, body-within-width across widths, continuous/dropped gutter, single-node `└─`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)