### PR TITLE
[renderer] Wire epic dashboard to the deterministic renderer

### DIFF
--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -31,109 +31,13 @@ No work started yet.
 
 #### If `discovery_map` is non-empty
 
-Group every phase under three stage dividers: **DISCOVERY** (the research & discussion map), **DEFINITION** (specification, planning), and **DELIVERY** (implementation, review).
+Run the discovery render command and emit its output to the user **verbatim, inside a code block** — it is the complete, deterministically-rendered state display (the bullet-bordered title, the three `── DISCOVERY / DEFINITION / DELIVERY ──` stage dividers, the research-and-discussion map, and the build-phase trees, with all gutters and wrapping already correct). Do not redraw, reflow, re-wrap, or annotate it.
 
-> *Output the next fenced block as a code block:*
-
-```
-●───────────────────────────────────────────────●
-  {work_unit:(titlecase)}
-●───────────────────────────────────────────────●
-
-── DISCOVERY ────────────────────────────────────
-
-  RESEARCH & DISCUSSION ({total} topics{status_suffix})
-@foreach(topic in discovery_map)
-  {branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]
-@if(topic.summary)
-@foreach(line in wrap(topic.summary, 65))
-  {gutter}{line}
-@endforeach
-@endif
-@if(topic.source_provenance)
-  {gutter}{topic.source_provenance}
-@endif
-@endforeach
-
-@if(specification.items or planning.items)
-── DEFINITION ───────────────────────────────────
-
-@foreach(phase in [specification, planning])
-@if(phase.items)
-  {phase:(uppercase)} ({phase.count_summary})
-@foreach(item in phase.items)
-  {item_branch} {item.name:(titlecase)} [{item.status}]@if(phase == planning and item.format) · {item.format}@endif
-@if(phase == specification and item.sources)
-@foreach(source in item.sources)
-  {child_gutter}{child_branch} {source.topic:(titlecase)} [{source.status}]
-@endforeach
-@endif
-@endforeach
-
-@endif
-@endforeach
-@endif
-@if(implementation.items or review.items)
-── DELIVERY ─────────────────────────────────────
-
-@foreach(phase in [implementation, review])
-@if(phase.items)
-  {phase:(uppercase)} ({phase.count_summary})
-@foreach(item in phase.items)
-  {item_branch} {item.name:(titlecase)} [{item.status}]
-@if(phase == implementation and item.current_phase)
-  {child_gutter}└─ Phase {item.current_phase}, {item.completed_tasks.length} task(s) completed
-@else
-@if(phase == implementation and item.completed_tasks)
-  {child_gutter}└─ {item.completed_tasks.length} task(s) completed
-@endif
-@endif
-@endforeach
-
-@endif
-@endforeach
-@endif
+```bash
+node .claude/skills/workflow-continue-epic/scripts/discovery.cjs render {work_unit}
 ```
 
-**Stage and tree display rules:**
-
-The display groups every phase under three stage dividers — **DISCOVERY** (research & discussion, the map), **DEFINITION** (specification, planning), **DELIVERY** (implementation, review). Each divider is flush to the code block's left edge and padded to 49 characters, matching step-marker width (`── DISCOVERY ───…`). A blank line follows each divider before its content; a blank line separates stages.
-
-- **Stage presence**: the DISCOVERY divider always renders here (the map is non-empty). Render the DEFINITION divider only when `specification` or `planning` has items; the DELIVERY divider only when `implementation` or `review` has items.
-- **Stage-meta callouts**: when present, render between the DISCOVERY divider's blank line and the `RESEARCH & DISCUSSION` header, each on its own 2-space-indented line, followed by a blank line. Omit the trailing blank line (and all callouts) when none apply.
-  - Seed (`seeds_count > 0`): `· seeded from the inbox`
-  - Imports (`show_imports_callout`): `· {imports_count} import` for 1, `· {imports_count} imports` for 2+. True only when `imports_count > 0` **and** `imports_count != discovery_map.length` (when every topic is itself an import, per-row provenance already says so).
-  - New arrivals: `⚑ {N} new topic(s) added to the map from research-analysis.` and/or `⚑ {N} new topic(s) added to the map from gap-analysis.`, one per analysis in `new_arrivals` with a non-empty list. Shown once per boot-up that added items; the topic rows' provenance sub-lines are the persistent surface afterwards.
-- **Discovery header**: `RESEARCH & DISCUSSION ({total} topics{status_suffix})`. The topic tree branches directly off this line — no blank between.
-  - `{status_suffix}`: ` · all decided` when `convergence_state == 'settled'`. Otherwise ` · {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {handled} handled · {cancelled} cancelled`, omitting zero-count categories. Read counts from `map_summary`.
-- **Topic rows** are pre-sorted by the discovery script (tier rank `→ ◐ ✓ ○ ⊙ ⊘`, then suggested execution order). Render in order. Row: `{branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]`, single space between segments.
-  - `{branch}`: `├─` for every row except the last; `└─` for the last (or only) row. Never `┌─` — the leading `├─` (or sole `└─`) ticks upward into the header so the list hangs off it.
-  - **Lifecycle label** by tier: `→` (ready_for_discussion) `research complete · ready for discussion`; `◐` (researching) `researching` or (discussing) `discussing`; `✓` (decided) `decided`; `○` (fresh) `fresh · routed to {topic.routing}` (omit ` · routed to …` if `topic.routing` is null); `⊙` (handled) `handled · research fanned out`; `⊘` (cancelled) `cancelled`.
-  - **Summary / provenance sub-lines** via `{gutter}`. Summary first (hard-wrapped at 65 chars), provenance below it. Source `discovery` produces no provenance line.
-    - `{gutter}` — **non-last topic**: 2 spaces, `│`, 6 spaces; **last topic**: 9 spaces. Both land sub-line text at the same column, two columns right of the topic name. The `│` runs continuously through every sub-line of every non-last topic so the tree never breaks; the last topic drops it so nothing dangles below `└─`.
-    - **Example** (non-last topic, summary wraps onto three lines, provenance below):
-      ```
-        ├─ ◐ Ai Content Engine [researching]
-        │      AI imagery (enhancement-only v1), description
-        │      generation, per-tenant tone / base-knowledge
-        │      primitive, allowance + overage cost shape
-        │      from exploration
-      ```
-    - **Example** (last topic — same shape, no `│`):
-      ```
-        └─ ◐ Menu And Admin [researching]
-               Business-side menu modelling, admin shell (Filament vs
-               custom Vue/Nuxt), JustEat import, staff/roles
-               from exploration
-      ```
-- **Build-phase sub-headers**: `{phase:(uppercase)} ({phase.count_summary})` — the phase name uppercased (`SPECIFICATION`, `PLANNING`, `IMPLEMENTATION`, `REVIEW`) with a parenthetical count summary combining the statuses present (e.g. `(2 completed)`, `(3 completed, 1 cancelled)`; omit zero counts). The item tree branches directly off the sub-header. Blank line between sub-headers within a stage.
-- **Item rows** (`{item_branch}`): `├─` for non-final items, `└─` for the final item in the phase. Planning items append ` · {format}` after the status.
-- **Item sub-rows** — specification sources, implementation progress — branch beneath their item via `{child_gutter}` + `{child_branch}`:
-  - `{child_gutter}` — under a **non-last item**: 2 spaces, `│`, 2 spaces; under the **last item**: 5 spaces. Both land the child branch at the same column, under the item name.
-  - `{child_branch}`: `├─` for non-final children, `└─` for the final (or only) child.
-  - Specification source status: `[incorporated]` or `[pending]` from the manifest. Implementation shows `Phase {N}, {M} task(s) completed` when in-progress with `current_phase`, else `{M} task(s) completed` (always a single `└─` child).
-- **Promoted items** render with `[promoted]` in the display but not the menu. **Cancelled items** show `[cancelled]`. Phases with no items don't appear.
-- **No trailing recommendation callout** in this code block — build-phase recommendations attach to menu entries (see **C. Menu**).
+If `new_arrivals` has items for this boot-up, pass it as a JSON second argument so the "new topics added" callouts render — `… render {work_unit} '{"research_analysis":["topic-name"],"gap_analysis":[]}'`. Omit the argument entirely when there are none.
 
 After the render block, run the **Plans Not Ready Check** below; it applies to both this branch and the otherwise branch.
 
@@ -180,7 +84,9 @@ Group the phases under the same three stage dividers. This branch has no map —
 
 **Display rules:**
 
-- Stage dividers, uppercase sub-headers, count summaries, and tree grammar (`{item_branch}`, `{child_gutter}`, `{child_branch}`) follow the **Stage and tree display rules** above. Render a stage divider only when at least one of its mapped phases has items; blank line after each divider, between sub-headers, and between stages.
+- **Stage dividers** are `── {STAGE} ──` padded to 49 characters; render one only when a mapped phase has items, with a blank line after each divider and between stages. **Sub-headers** are the phase name uppercased + `({count_summary})` (statuses present, zeros omitted); blank line between sub-headers within a stage.
+- **Item rows** (`{item_branch}`): `├─` for non-final items, `└─` for the final item. Planning items append ` · {format}` after the status. Never `┌─`.
+- **Item sub-rows** branch beneath their item via `{child_gutter}` (2 spaces + `│` + 2 spaces under a non-last item; 5 spaces under the last) + `{child_branch}` (`├─` non-final, `└─` final): specification sources as `← {source.topic:(titlecase)} [{source.status}]`; implementation as `Phase {N}, {M} task(s) completed` when in-progress with `current_phase`, else `{M} task(s) completed`.
 - Pending discussion topics from research count as siblings when determining the final item in the discussion phase.
 - Phases with no items don't appear. No trailing blank line after the last stage (the code block ends after the last item, or the recommendation if present).
 

--- a/skills/workflow-continue-epic/scripts/discovery.cjs
+++ b/skills/workflow-continue-epic/scripts/discovery.cjs
@@ -368,8 +368,29 @@ function format(result) {
 }
 
 if (require.main === module) {
-  const workUnit = process.argv[2] || undefined;
-  process.stdout.write(format(discover(process.cwd(), workUnit)));
+  const args = process.argv.slice(2);
+
+  // `render <work_unit> [new_arrivals_json]` — emit the finished dashboard block
+  // for one epic (the display surface). Default output stays the data dump (the
+  // reasoning surface), untouched, for every other consumer.
+  if (args[0] === 'render') {
+    const { renderEpicDashboard } = require('./epic-dashboard.cjs');
+    const workUnit = args[1];
+    const newArrivals = args[2] ? JSON.parse(args[2]) : {};
+    const epic = discover(process.cwd(), workUnit).epics.find(e => e.name === workUnit);
+    if (!epic) {
+      process.stderr.write(`render: no active epic "${workUnit}"\n`);
+      process.exit(1);
+    }
+    if (!epic.detail.discovery_map || epic.detail.discovery_map.length === 0) {
+      process.stderr.write(`render: "${workUnit}" has no discovery map (caller handles that case)\n`);
+      process.exit(1);
+    }
+    process.stdout.write(renderEpicDashboard(epic, { newArrivals }));
+  } else {
+    const workUnit = args[0] || undefined;
+    process.stdout.write(format(discover(process.cwd(), workUnit)));
+  }
 }
 
 module.exports = { discover, format };

--- a/skills/workflow-continue-epic/scripts/epic-dashboard.cjs
+++ b/skills/workflow-continue-epic/scripts/epic-dashboard.cjs
@@ -1,0 +1,134 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Epic dashboard renderer.
+//
+// Assembles the epic state display — the box title, the three stage dividers
+// (DISCOVERY / DEFINITION / DELIVERY), and one tree per phase — from a
+// `buildEpicDetail`-shaped object. Layout comes from the generic renderer
+// (render.cjs); content conventions from conventions.cjs; the epic-specific
+// composition (lifecycle labels, count summaries, source/progress rows) lives
+// here. The data-owner (discovery.cjs) calls this in-process and emits the
+// finished block; nothing about the tree shape is left to the model.
+// ---------------------------------------------------------------------------
+
+const { box, signpost, renderTree } = require('../../workflow-render/scripts/render.cjs');
+const { title, tag, derivedFrom, titlecase } = require('../../workflow-render/scripts/conventions.cjs');
+
+// --- epic-specific content composition ---------------------------------------
+
+// Discovery lifecycle → the `[label]` text, by lifecycle (tier supplies the glyph).
+function lifecycleLabel(lifecycle, routing) {
+  switch (lifecycle) {
+    case 'ready_for_discussion': return 'research complete · ready for discussion';
+    case 'researching': return 'researching';
+    case 'discussing': return 'discussing';
+    case 'decided': return 'decided';
+    case 'handled': return 'handled · research fanned out';
+    case 'cancelled': return 'cancelled';
+    case 'fresh': return routing ? `fresh · routed to ${routing}` : 'fresh';
+    default: return lifecycle;
+  }
+}
+
+// The discovery header's count suffix, from map_summary + convergence_state.
+function statusSuffix(detail) {
+  if (detail.convergence_state === 'settled') return ' · all decided';
+  const s = detail.map_summary || {};
+  const buckets = [
+    [s.decided, 'decided'], [s.in_flight, 'in flight'], [s.ready, 'ready'],
+    [s.fresh, 'fresh'], [s.handled, 'handled'], [s.cancelled, 'cancelled'],
+  ];
+  const parts = buckets.filter(([n]) => n > 0).map(([n, label]) => `${n} ${label}`);
+  return parts.length ? ' · ' + parts.join(' · ') : '';
+}
+
+// A build phase's `(N completed, M cancelled)` count summary; omits zero counts.
+const STATUS_ORDER = ['completed', 'in-progress', 'cancelled', 'promoted'];
+function countSummary(items) {
+  const counts = {};
+  for (const it of items) counts[it.status] = (counts[it.status] || 0) + 1;
+  const ordered = [...STATUS_ORDER, ...Object.keys(counts).filter((k) => !STATUS_ORDER.includes(k))];
+  const parts = ordered.filter((k) => counts[k]).map((k) => `${counts[k]} ${k}`);
+  return `(${parts.join(', ')})`;
+}
+
+// A specification source sub-row: `← Auth Flows [incorporated]`.
+function sourceRow(src) {
+  return `← ${titlecase(src.topic || src.name)} ${tag(src.status || 'pending')}`;
+}
+
+// An implementation progress sub-row.
+function implProgress(item) {
+  const n = Array.isArray(item.completed_tasks) ? item.completed_tasks.length : 0;
+  if (item.current_phase != null) return `Phase ${item.current_phase}, ${n} task(s) completed`;
+  if (n > 0) return `${n} task(s) completed`;
+  return null;
+}
+
+// --- node builders -----------------------------------------------------------
+
+function discoveryNodes(map) {
+  return map.map((t) => {
+    const body = [];
+    if (t.summary) body.push(t.summary);
+    if (t.source_provenance) body.push(derivedFrom(t.source_provenance));
+    return {
+      title: title({ glyph: t.tier, label: titlecase(t.name), tag: lifecycleLabel(t.lifecycle, t.routing) }),
+      ...(body.length ? { body } : {}),
+    };
+  });
+}
+
+function buildNodes(items, phase) {
+  return items.map((it) => {
+    let line = title({ label: titlecase(it.name), tag: it.status });
+    if (phase === 'planning' && it.format) line += ` · ${it.format}`;
+    const node = { title: line };
+    if (phase === 'specification' && Array.isArray(it.sources) && it.sources.length) {
+      node.children = it.sources.map((src) => ({ title: sourceRow(src) }));
+    }
+    if (phase === 'implementation') {
+      const prog = implProgress(it);
+      if (prog) node.children = [{ title: prog }];
+    }
+    return node;
+  });
+}
+
+// --- assembly ----------------------------------------------------------------
+
+// Append a stage's sub-header + tree blocks for each phase that has items.
+function pushStage(out, detail, divider, phases, width) {
+  const present = phases.filter((p) => detail.phases[p] && detail.phases[p].length);
+  if (!present.length) return;
+  out.push('', signpost(divider), '');
+  present.forEach((phase, idx) => {
+    out.push(`  ${phase.toUpperCase()} ${countSummary(detail.phases[phase])}`);
+    out.push(renderTree(buildNodes(detail.phases[phase], phase), { width }).replace(/\n$/, ''));
+    if (idx < present.length - 1) out.push('');
+  });
+}
+
+// `epic` is a `discover()` epic entry: { name, detail }.
+function renderEpicDashboard(epic, { width = 72 } = {}) {
+  const detail = epic.detail;
+  const out = [];
+  out.push(box(titlecase(epic.name)).replace(/\n+$/, ''));
+
+  // DISCOVERY — always present here (the map is non-empty).
+  out.push('', signpost('DISCOVERY'), '');
+  out.push(`  RESEARCH & DISCUSSION (${detail.map_summary.total} topics${statusSuffix(detail)})`);
+  out.push(renderTree(discoveryNodes(detail.discovery_map), { width }).replace(/\n$/, ''));
+
+  pushStage(out, detail, 'DEFINITION', ['specification', 'planning'], width);
+  pushStage(out, detail, 'DELIVERY', ['implementation', 'review'], width);
+
+  return out.join('\n') + '\n';
+}
+
+module.exports = {
+  renderEpicDashboard,
+  lifecycleLabel, statusSuffix, countSummary, sourceRow, implProgress,
+  discoveryNodes, buildNodes,
+};

--- a/skills/workflow-continue-epic/scripts/epic-dashboard.cjs
+++ b/skills/workflow-continue-epic/scripts/epic-dashboard.cjs
@@ -96,6 +96,24 @@ function buildNodes(items, phase) {
   });
 }
 
+// Stage-meta callout lines shown between the DISCOVERY divider and the header:
+// seed / imports provenance (from the manifest) and new-arrival notices (passed
+// in by the caller for the current boot-up).
+function stageMetaCallouts(detail, newArrivals) {
+  const lines = [];
+  if (detail.seeds_count > 0) lines.push('· seeded from the inbox');
+  const imp = detail.imports_count || 0;
+  const mapLen = (detail.discovery_map || []).length;
+  if (imp > 0 && imp !== mapLen) lines.push(`· ${imp} ${imp === 1 ? 'import' : 'imports'}`);
+  const na = newArrivals || {};
+  for (const [key, label] of [['research_analysis', 'research-analysis'], ['gap_analysis', 'gap-analysis']]) {
+    if (Array.isArray(na[key]) && na[key].length) {
+      lines.push(`⚑ ${na[key].length} new topic(s) added to the map from ${label}.`);
+    }
+  }
+  return lines;
+}
+
 // --- assembly ----------------------------------------------------------------
 
 // Append a stage's sub-header + tree blocks for each phase that has items.
@@ -110,14 +128,20 @@ function pushStage(out, detail, divider, phases, width) {
   });
 }
 
-// `epic` is a `discover()` epic entry: { name, detail }.
-function renderEpicDashboard(epic, { width = 72 } = {}) {
+// `epic` is a `discover()` epic entry: { name, detail }. Requires a non-empty
+// discovery_map (the brand-new and no-map cases are handled by the caller).
+function renderEpicDashboard(epic, { width = 72, newArrivals = {} } = {}) {
   const detail = epic.detail;
   const out = [];
   out.push(box(titlecase(epic.name)).replace(/\n+$/, ''));
 
   // DISCOVERY — always present here (the map is non-empty).
   out.push('', signpost('DISCOVERY'), '');
+  const callouts = stageMetaCallouts(detail, newArrivals);
+  if (callouts.length) {
+    for (const c of callouts) out.push('  ' + c);
+    out.push('');
+  }
   out.push(`  RESEARCH & DISCUSSION (${detail.map_summary.total} topics${statusSuffix(detail)})`);
   out.push(renderTree(discoveryNodes(detail.discovery_map), { width }).replace(/\n$/, ''));
 
@@ -130,5 +154,5 @@ function renderEpicDashboard(epic, { width = 72 } = {}) {
 module.exports = {
   renderEpicDashboard,
   lifecycleLabel, statusSuffix, countSummary, sourceRow, implProgress,
-  discoveryNodes, buildNodes,
+  stageMetaCallouts, discoveryNodes, buildNodes,
 };

--- a/skills/workflow-render/scripts/conventions.cjs
+++ b/skills/workflow-render/scripts/conventions.cjs
@@ -18,6 +18,15 @@ function capitalise(s) {
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
 }
 
+// Title-case a kebab/space name: "ai-content-engine" → "Ai Content Engine".
+function titlecase(s) {
+  return String(s)
+    .split(/[-\s]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
 // `[term]` — the item status / lifecycle suffix.
 function tag(term) {
   return `[${term}]`;
@@ -54,4 +63,4 @@ function discoveryGlyph(tier) {
   return DISCOVERY_GLYPH[tier] || '';
 }
 
-module.exports = { capitalise, tag, derivedFrom, title, discoveryGlyph, DISCOVERY_GLYPH };
+module.exports = { capitalise, titlecase, tag, derivedFrom, title, discoveryGlyph, DISCOVERY_GLYPH };

--- a/tests/scripts/test-epic-dashboard.cjs
+++ b/tests/scripts/test-epic-dashboard.cjs
@@ -1,0 +1,105 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  renderEpicDashboard,
+  lifecycleLabel,
+  statusSuffix,
+  countSummary,
+  sourceRow,
+  implProgress,
+} = require('../../skills/workflow-continue-epic/scripts/epic-dashboard.cjs');
+
+// A realistic discover() epic entry (the shape buildEpicDetail produces).
+const EPIC = {
+  name: 'quiz-competition-v1',
+  detail: {
+    discovery_map: [
+      { name: 'game-and-content-engine', tier: '◐', lifecycle: 'researching', routing: null,
+        summary: 'Quiz content pipeline, AI-assisted question generation, media handling, difficulty calibration across rounds',
+        source_provenance: 'from exploration' },
+      { name: 'synchronous-round-engine', tier: '→', lifecycle: 'ready_for_discussion', routing: null,
+        summary: 'Real-time round orchestration, fastest-cumulative-time scoring, reconnection handling',
+        source_provenance: 'from research-analysis' },
+      { name: 'leaderboards', tier: '○', lifecycle: 'fresh', routing: 'research',
+        summary: 'Per-competition and global ranking surfaces', source_provenance: null },
+    ],
+    map_summary: { total: 3, decided: 0, in_flight: 1, ready: 1, fresh: 1, handled: 0, cancelled: 0 },
+    convergence_state: 'in-progress',
+    phases: {
+      specification: [
+        { name: 'user-authentication', status: 'completed',
+          sources: [{ topic: 'auth-flows', status: 'incorporated' }, { topic: 'session-management', status: 'pending' }] },
+        { name: 'admin-panel', status: 'completed' },
+      ],
+      implementation: [
+        { name: 'core-gameplay', status: 'in-progress', current_phase: 2, completed_tasks: ['t1', 't2', 't3', 't4'] },
+        { name: 'reporting', status: 'completed', completed_tasks: ['a', 'b', 'c', 'd', 'e', 'f'] },
+      ],
+    },
+  },
+};
+
+describe('epic-dashboard: composition helpers', () => {
+  it('lifecycleLabel maps each lifecycle (routing only on fresh)', () => {
+    assert.strictEqual(lifecycleLabel('ready_for_discussion'), 'research complete · ready for discussion');
+    assert.strictEqual(lifecycleLabel('researching'), 'researching');
+    assert.strictEqual(lifecycleLabel('decided'), 'decided');
+    assert.strictEqual(lifecycleLabel('handled'), 'handled · research fanned out');
+    assert.strictEqual(lifecycleLabel('fresh', 'research'), 'fresh · routed to research');
+    assert.strictEqual(lifecycleLabel('fresh', null), 'fresh');
+  });
+
+  it('statusSuffix builds the count tail, omitting zeros / collapsing when settled', () => {
+    assert.strictEqual(statusSuffix(EPIC.detail), ' · 1 in flight · 1 ready · 1 fresh');
+    assert.strictEqual(statusSuffix({ convergence_state: 'settled' }), ' · all decided');
+  });
+
+  it('countSummary omits zero counts, completed first', () => {
+    assert.strictEqual(countSummary(EPIC.detail.phases.specification), '(2 completed)');
+    assert.strictEqual(countSummary(EPIC.detail.phases.implementation), '(1 completed, 1 in-progress)');
+  });
+
+  it('sourceRow and implProgress compose the sub-rows', () => {
+    assert.strictEqual(sourceRow({ topic: 'auth-flows', status: 'incorporated' }), '← Auth Flows [incorporated]');
+    assert.strictEqual(implProgress({ current_phase: 2, completed_tasks: ['a', 'b'] }), 'Phase 2, 2 task(s) completed');
+    assert.strictEqual(implProgress({ completed_tasks: ['a', 'b', 'c'] }), '3 task(s) completed');
+    assert.strictEqual(implProgress({ completed_tasks: [] }), null);
+  });
+});
+
+describe('epic-dashboard: full render', () => {
+  const out = renderEpicDashboard(EPIC, { width: 72 });
+
+  it('renders the box title (titlecased)', () => {
+    assert.ok(out.includes('  Quiz Competition V1'));
+  });
+
+  it('renders the three stage dividers at 49 chars', () => {
+    for (const stage of ['DISCOVERY', 'DEFINITION', 'DELIVERY']) {
+      const line = out.split('\n').find((l) => l.startsWith(`── ${stage} `));
+      assert.ok(line, `${stage} divider present`);
+      assert.strictEqual([...line].length, 49, `${stage} divider is 49 wide`);
+    }
+  });
+
+  it('renders the discovery header with status suffix and topic rows', () => {
+    assert.ok(out.includes('  RESEARCH & DISCUSSION (3 topics · 1 in flight · 1 ready · 1 fresh)'));
+    assert.ok(out.includes('  ├─ ◐ Game And Content Engine [researching]'));
+    assert.ok(out.includes('  └─ ○ Leaderboards [fresh · routed to research]'));
+    assert.ok(out.includes('     ↳ From research-analysis') || out.includes('↳ From research-analysis'));
+  });
+
+  it('renders build phases with sub-headers, source rows and progress rows', () => {
+    assert.ok(out.includes('  SPECIFICATION (2 completed)'));
+    assert.ok(out.includes('  │  ├─ ← Auth Flows [incorporated]'));
+    assert.ok(out.includes('  IMPLEMENTATION (1 completed, 1 in-progress)'));
+    assert.ok(out.includes('  │  └─ Phase 2, 4 task(s) completed'));
+  });
+
+  it('never emits ┌─', () => {
+    assert.ok(!out.includes('┌─'));
+  });
+});

--- a/tests/scripts/test-epic-dashboard.cjs
+++ b/tests/scripts/test-epic-dashboard.cjs
@@ -10,6 +10,7 @@ const {
   countSummary,
   sourceRow,
   implProgress,
+  stageMetaCallouts,
 } = require('../../skills/workflow-continue-epic/scripts/epic-dashboard.cjs');
 
 // A realistic discover() epic entry (the shape buildEpicDetail produces).
@@ -101,5 +102,37 @@ describe('epic-dashboard: full render', () => {
 
   it('never emits ┌─', () => {
     assert.ok(!out.includes('┌─'));
+  });
+});
+
+describe('epic-dashboard: stage-meta callouts', () => {
+  it('emits seed + import callouts from manifest counts', () => {
+    assert.deepStrictEqual(
+      stageMetaCallouts({ seeds_count: 1, imports_count: 2, discovery_map: [{}, {}, {}] }, {}),
+      ['· seeded from the inbox', '· 2 imports']
+    );
+  });
+
+  it('omits the import callout when every topic is itself an import', () => {
+    assert.deepStrictEqual(
+      stageMetaCallouts({ seeds_count: 0, imports_count: 3, discovery_map: [{}, {}, {}] }, {}),
+      []
+    );
+  });
+
+  it('emits a new-arrival notice per analysis with items', () => {
+    assert.deepStrictEqual(
+      stageMetaCallouts({ discovery_map: [] }, { research_analysis: ['a', 'b'], gap_analysis: [] }),
+      ['⚑ 2 new topic(s) added to the map from research-analysis.']
+    );
+  });
+
+  it('renders callouts between the DISCOVERY divider and the header', () => {
+    const epic = { name: 'x', detail: { ...EPIC.detail, seeds_count: 1 } };
+    const lines = renderEpicDashboard(epic, { width: 72 }).split('\n');
+    const di = lines.findIndex((l) => l.startsWith('── DISCOVERY'));
+    const hi = lines.findIndex((l) => l.includes('RESEARCH & DISCUSSION'));
+    assert.ok(di >= 0 && hi > di);
+    assert.ok(lines.slice(di, hi).includes('  · seeded from the inbox'));
   });
 });


### PR DESCRIPTION
## Summary

Stacked on #351. Makes the epic state display render via the deterministic renderer instead of being hand-drawn inline.

- **`epic-dashboard.cjs`** (new) — `renderEpicDashboard(epic)` assembles the entire dashboard (box title, three stage dividers, one tree per phase, stage-meta callouts) from a `buildEpicDetail`-shaped object, using the generic renderer (#351) + conventions. Epic-specific composition (lifecycle labels, count summaries, `←` source rows, impl progress, seed/import/new-arrival callouts) lives here; `titlecase()` added to conventions.
- **`discovery.cjs`** — new `render <work_unit> [new_arrivals_json]` command that emits the finished block (the *display* surface) in-process; the default data-dump output (the *reasoning* surface) is untouched, so every other consumer is unaffected.
- **`epic-display-and-menu.md`** — the "non-empty map" branch drops from ~103 lines (hand-drawn template + the whole "Stage and tree display rules") to 7: run the command, emit verbatim. **Net −94 lines of prose.** The no-map "Otherwise" branch is kept self-contained (still hand-drawn; wiring it + its recommendation logic is a follow-up).

Intentional visual changes from the old hand-drawing (all previously agreed): `↳ From …` provenance, 8-col body gutter, width-72 wrapping with the gutter-orphan bug now impossible.

## Test plan

- `node --test tests/scripts/test-render.cjs tests/scripts/test-epic-dashboard.cjs` — 43 tests (renderer + epic-dashboard: helpers, full render, callouts).
- Renders the full dashboard from a realistic `buildEpicDetail` fixture; the `render` command errors cleanly when the work unit isn't an active epic.
- Note: end-to-end against a live `.workflows/` manifest is not exercised here (this repo has none); the data path reuses the battle-tested `discover()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)