### PR TITLE
fix(pivot): seed discovery map item when converting feature to epic

### DIFF
--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -195,6 +195,22 @@ Re-index all completed artifacts so their chunks carry the new `work_type: epic`
 
 Load **[reindex-work-unit.md](../../workflow-knowledge/references/reindex-work-unit.md)** with work_unit = `{selected.name}`.
 
+Register the feature's topic on the discovery map (topic name = work unit name). Leave `summary` and `description` unset — `summary-backfill.md` fills them on the next `/workflow-continue-epic` entry.
+
+Check whether the feature did research:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.research
+```
+
+Create the map item — `routing` is `research` if it exists, otherwise `discussion`:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {selected.name}.discovery.{selected.name}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {selected.name}.discovery.{selected.name} routing {research|discussion}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {selected.name}.discovery.{selected.name} source discovery
+```
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```


### PR DESCRIPTION
## Summary

- Feature→epic pivot changed `work_type` but never registered the feature's topic on the epic's discovery map. The topic stayed visible in the dashboard via the per-phase join, but was absent from map-summary counts, convergence state, the dismissed-list flow, and future discovery sessions — the same gap `absorb-into-epic.md` already guards against in its Register Discovery Item step.
- The pivot branch in `manage-work-unit.md` now seeds the map item, mirroring the canonical `confirm-and-persist` creator: `init-phase` the discovery item (topic = work unit name), route `research`/`discussion` by whether research exists, set `source: discovery`, and leave `summary`/`description` unset so the next `/workflow-continue-epic` entry routes to `summary-backfill.md` for review.

## Test plan

- Verified the manifest CLI sequence (`init-phase` → `set routing` → `set source`) produces a valid discovery item against a temp manifest; `init-phase`'s auto `status: in-progress` is the documented correct shape for discovery items (`confirm-and-persist.md:42`).
- Confirmed against CONVENTIONS.md: inline `{research|discussion}` placeholder with value explained in prose matches the canonical creator; no new `source` enum value introduced (mirrors default `discovery`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)