### PR TITLE
fix(absorb): set source=discovery explicitly on registered discovery item

### DIFF
--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -389,7 +389,7 @@ The feature has nothing to move.
 
 The absorbed topic must exist in the target epic's discovery map. The map is built from `phases.discovery.items` — without an discovery entry, the topic is invisible to the workflow-continue-epic display, subsequent discovery sessions, map-summary counts, and the dismissed-list flow.
 
-Routing reflects the work already done on the feature. `summary` and `description` are left unset — `source` defaults to `discovery` at render time, and the next `/workflow-continue-epic` entry will detect the missing fields and route to `summary-backfill.md` so the user can review derived values.
+Routing reflects the work already done on the feature. `source` is set to `discovery`; `summary` and `description` are left unset — the next `/workflow-continue-epic` entry detects the missing fields and routes to `summary-backfill.md` so the user can review derived values.
 
 #### If `has_research` is `true`
 
@@ -398,6 +398,7 @@ Set `routing` to `research`:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.discovery.{topic}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discovery.{topic} routing research
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discovery.{topic} source discovery
 ```
 
 → Proceed to **K. Cleanup**.
@@ -409,6 +410,7 @@ Set `routing` to `discussion`:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.discovery.{topic}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discovery.{topic} routing discussion
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discovery.{topic} source discovery
 ```
 
 → Proceed to **K. Cleanup**.


### PR DESCRIPTION
## Summary

- Absorb's Register Discovery Item step (`absorb-into-epic.md` §J) relied on the render-time default for `source`, leaving the field unset on the manifest.
- `map-operations.md` rename reads `source` directly via `get …discovery.{old} source`, so an absorbed topic would carry an empty `source` through a rename.
- Set `source: discovery` explicitly on both routing branches, matching the canonical `confirm-and-persist` creator so all three discovery-item creators (confirm-and-persist, pivot, absorb) are consistent. Renders identically to the prior default.

## Test plan

- No behavioural change to display (`computeSourceProvenance` treats unset and `discovery` identically); the fix makes the field present for downstream reads like rename.
- Prose updated to reflect explicit setting ("`source` is set to `discovery`" rather than "defaults at render time").

🤖 Generated with [Claude Code](https://claude.com/claude-code)