### PR TITLE
feat(spec): auto gate mode for spec construction loop

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -554,7 +554,7 @@ Entry-point skills that invoke processing skills use this exact blockquote to pr
 
 ### Auto-Mode Gates
 
-Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STOP gates. This pattern is used in implementation (task + fix gates), planning (task list approval + task authoring + review findings), and specification (review findings).
+Per-item approval gates can offer `a`/`auto` to let the user bypass repeated STOP gates. This pattern is used in implementation (task + fix gates), planning (task list approval + task authoring + review findings), and specification (construction + review findings).
 
 **Manifest tracking**: Gate modes are stored in the manifest via CLI (`gated` or `auto`). This ensures they survive context refresh.
 

--- a/skills/workflow-specification-entry/references/handoffs/continue-completed.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue-completed.md
@@ -4,9 +4,10 @@
 
 ---
 
-Before invoking the skill, reset `finding_gate_mode` to `gated` via manifest CLI:
+Before invoking the skill, reset `finding_gate_mode` and `construction_gate_mode` to `gated` via manifest CLI:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} finding_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} construction_gate_mode gated
 ```
 Commit if changed: `spec({work_unit}): reset gate mode`
 

--- a/skills/workflow-specification-entry/references/handoffs/continue.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue.md
@@ -4,9 +4,10 @@
 
 ---
 
-Before invoking the skill, reset `finding_gate_mode` to `gated` via manifest CLI:
+Before invoking the skill, reset `finding_gate_mode` and `construction_gate_mode` to `gated` via manifest CLI:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} finding_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} construction_gate_mode gated
 ```
 Commit if changed: `spec({work_unit}): reset gate mode`
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -59,7 +59,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 2. **Read all tracking and state files** for the current topic — the specification file, review tracking files, or any working documents this skill creates. These are your source of truth for progress.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
-5. **Check `finding_gate_mode`** via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.specification.{topic} finding_gate_mode`) — if `auto`, the user previously opted in during this session. Preserve this value.
+5. **Check `finding_gate_mode` and `construction_gate_mode`** via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.specification.{topic} finding_gate_mode` and `... construction_gate_mode`) — if either is `auto`, the user previously opted in during this session. Preserve that value.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 

--- a/skills/workflow-specification-process/references/initialize-specification.md
+++ b/skills/workflow-specification-process/references/initialize-specification.md
@@ -14,6 +14,7 @@ Create the specification file at `.workflows/{work_unit}/specification/{topic}/s
    node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.specification.{topic}
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} review_cycle 0
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} finding_gate_mode gated
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} construction_gate_mode gated
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} date $(date +%Y-%m-%d)
    ```
 3. Add all sources with `status: pending` via manifest CLI:

--- a/skills/workflow-specification-process/references/session-setup.md
+++ b/skills/workflow-specification-process/references/session-setup.md
@@ -4,10 +4,11 @@
 
 ---
 
-Reset `finding_gate_mode` to `gated` via manifest CLI:
+Reset `finding_gate_mode` and `construction_gate_mode` to `gated` via manifest CLI:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} finding_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} construction_gate_mode gated
 ```
 
 → Return to caller.

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -25,6 +25,8 @@ When working with multiple sources, search each one — information about a sing
 
 ### Context Resurfacing
 
+This gate stays gated even when `construction_gate_mode` is `auto` — it changes already-approved content, so it always stops for confirmation.
+
 When extraction reveals information that affects **already-logged topics**, resurface them immediately. Even mid-discussion — interrupt, flag what you found, and discuss whether it changes anything.
 
 If it does: summarize what's changing in the chat, then present the changes as a diff view. The summary is for discussion only — the specification just gets the clean replacement.
@@ -86,7 +88,7 @@ Better to resurface and confirm "already covered" than let something slip past.
 
 ## B. Synthesize and Present
 
-Present your understanding to the user **in the format it would appear in the specification**:
+Present your understanding to the user **in the format it would appear in the specification** (shown in both modes):
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -96,7 +98,23 @@ Here's what I understand about [topic] based on the reference material. This is 
 [content as rendered markdown]
 ```
 
-Then, **separately from the content above** (clear visual break):
+Then check `construction_gate_mode` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.specification.{topic} construction_gate_mode`).
+
+#### If `construction_gate_mode` is `auto`
+
+**CRITICAL**: Auto removes only the approval STOP — process one topic at a time (extract → present → log → commit → next). Never generate multiple topics, or the whole specification, in a single pass. Commit after each topic.
+
+> *Output the next fenced block as a code block:*
+
+```
+{Topic Name} — added to specification.
+```
+
+→ Proceed to **E. Log and Commit**.
+
+#### If `construction_gate_mode` is `gated`
+
+**Separately from the content above** (clear visual break) — content and choices must be visually distinct:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -105,13 +123,26 @@ Then, **separately from the content above** (clear visual break):
 Record this to the specification verbatim?
 
 - **`y`/`yes`** — Add exactly as shown, no modifications
+- **`a`/`auto`** — Add this and all remaining topics automatically
 - **Tell me what to change** — Revise before recording
 · · · · · · · · · · · ·
 ```
 
-Content and choices must be visually distinct (not run together).
+**STOP.** Wait for user response.
 
-> **CHECKPOINT**: After presenting, you MUST STOP and wait for the user's response. Do NOT proceed to logging. Do NOT present the next topic. WAIT.
+#### If `yes`
+
+→ Proceed to **E. Log and Commit**.
+
+#### If `auto`
+
+Set `construction_gate_mode` to `auto` via manifest CLI (`node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} construction_gate_mode auto`).
+
+→ Proceed to **E. Log and Commit**.
+
+#### If the user provides feedback
+
+→ Proceed to **C. Discuss and Refine**.
 
 ---
 

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -110,8 +110,6 @@ Skip the menu and STOP. The content presented above is logged exactly as shown â
 
 #### If `construction_gate_mode` is `gated`
 
-**Separately from the content above** (clear visual break) â€” content and choices must be visually distinct:
-
 > *Output the next fenced block as markdown (not a code block):*
 
 ```

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -102,6 +102,8 @@ Then check `construction_gate_mode` via manifest CLI (`node .claude/skills/workf
 
 #### If `construction_gate_mode` is `auto`
 
+The full content block above is still presented exactly as in gated mode — auto changes **nothing** about what is shown. The only difference is that no approval menu or STOP follows; after presenting the content, append the one-line confirmation below and proceed.
+
 **CRITICAL**: Auto removes only the approval STOP — process one topic at a time (extract → present → log → commit → next). Never generate multiple topics, or the whole specification, in a single pass. Commit after each topic.
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -102,15 +102,9 @@ Then check `construction_gate_mode` via manifest CLI (`node .claude/skills/workf
 
 #### If `construction_gate_mode` is `auto`
 
-The full content block above is still presented exactly as in gated mode — auto changes **nothing** about what is shown. The only difference is that no approval menu or STOP follows; after presenting the content, append the one-line confirmation below and proceed.
+Skip the menu and STOP. The content presented above is logged exactly as shown — auto adds no output of its own.
 
 **CRITICAL**: Auto removes only the approval STOP — process one topic at a time (extract → present → log → commit → next). Never generate multiple topics, or the whole specification, in a single pass. Commit after each topic.
-
-> *Output the next fenced block as a code block:*
-
-```
-{Topic Name} — added to specification.
-```
 
 → Proceed to **E. Log and Commit**.
 

--- a/skills/workflow-specification-process/references/specification-format.md
+++ b/skills/workflow-specification-process/references/specification-format.md
@@ -34,6 +34,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.speci
 | `date` | Spec creation — today's date; update on each commit |
 | `review_cycle` | Starts at 0; incremented each review cycle. Missing field treated as 0. |
 | `finding_gate_mode` | Spec creation → `gated`; user opts in → `auto` |
+| `construction_gate_mode` | Spec creation → `gated`; user opts in → `auto` |
 | `sources` | Spec creation — all sources as `pending`; updated as extraction completes |
 
 ---


### PR DESCRIPTION
## Summary

Spec **review** already has an auto mode (`finding_gate_mode`); the **construction** loop (Step 5, where the spec body is written topic-by-topic) had no auto option — every topic stopped for explicit `y`/`yes`. This adds a per-phase `construction_gate_mode` gate, mirroring the established `finding_gate_mode` / planning `author_gate_mode` pattern.

Auto removes **only** the approval STOP. The per-topic cycle — exhaustive-extract → present → log → **commit** → next — is preserved exactly; the per-topic commit is the structural anti-batch boundary against lossy single-pass generation. Content is still rendered in chat in both modes (audience-effect + audit trail). The Context Resurfacing gate stays gated always (it changes already-approved content).

## Changes

- `spec-construction.md` — stage B split into present + gate-mode branch (auto / gated / yes / auto-opt-in / feedback); CRITICAL anti-batch rule in auto branch; Context Resurfacing note that it stays gated.
- `initialize-specification.md`, `session-setup.md`, `continue.md`, `continue-completed.md` — init + reset `construction_gate_mode` to `gated` alongside `finding_gate_mode`.
- `specification-format.md` — document the field.
- `SKILL.md` resume protocol — preserve either gate mode if `auto`.
- `CONVENTIONS.md` — update auto-mode-gates catalog.

No CLI change (`manifest.cjs:377` validates any `*_gate_mode` generically), no migration (missing field reads as `gated`), no new tests (pure skill-markdown, consistent with how `finding_gate_mode`/`author_gate_mode` shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)