### PR TITLE
Incoming: create-topic CLI + plan & design docs

### DIFF
--- a/incoming/design.md
+++ b/incoming/design.md
@@ -1,0 +1,172 @@
+# Incoming: Off-Topic Surfacing + Shared Topic-Creation Infra
+
+**Status:** In progress
+
+Design log for the Incoming initiative. Its own stacked-PR effort, independent of the discovery-map
+work. This doc is the durable scope reference; decisions are appended as the PR stack progresses.
+
+## Purpose
+
+When an off-topic concern surfaces mid research or discussion, there is today **no clean way to
+record it against the topic it actually belongs to**. The only moves are *fission* (elevation §F /
+research-split spawn a brand-new sibling) or burying it in the current artefact. There is no way to
+route a concern into an **existing** topic on the discovery map, and the spawn paths don't even
+check whether a matching topic already exists — so they create duplicates.
+
+**Incoming** lets an off-topic concern land in an `## Incoming` section of a *target* topic's
+artefact (existing or new — landing is uniform). The target's own processing skill drains Incoming
+into its working map when that topic's phase next runs. Symmetric across research and discussion. A
+topic can't conclude with a non-empty Incoming.
+
+Building it surfaced that the "create a topic" sequence is **already duplicated across six call
+sites** and is non-atomic (multi-command, with explicit "stop before commit to recover" prose
+because a mid-sequence failure half-builds a topic). The feature therefore ships on top of extracted,
+hardened shared infra: an atomic `create-topic` CLI command + a `create-topic.md` shared reference.
+
+**Outcome:** off-topic concerns are never lost and never pollute the wrong artefact; topic creation
+is atomic and defined once; existing spawn behaviour is unchanged.
+
+## Locked design (decided with user)
+
+- **Storage:** Incoming lives in the **target's artefact file**, an `## Incoming` section. A `fresh`
+  target with no file yet → landing creates a seed artefact stub. Artefact-only; **not** a manifest
+  array (hybrid was explicitly rejected).
+- **Surfacing is dumb + symmetric:** the landing step writes **only** `## Incoming`. It never injects
+  into the target's Discussion Map / research threads. Folding Incoming → working map is the
+  *consuming* process's job, identically on both sides.
+- **Reopen on decided:** landing on a `completed` (decided) target also flips its phase-item status
+  `completed → in-progress`. Lifecycle recomputes to actionable automatically
+  (`discovery-utils.cjs` `computeTopicLifecycle` reads live status).
+- **Drain = remove:** when the consuming process folds an entry in, it **deletes** that subsection
+  from `## Incoming` (clean for KB indexing; git history is the audit trail).
+- **Conclusion gate:** a research/discussion topic cannot conclude while `## Incoming` ≠ `(none)`.
+- **Provenance:** new source value `incoming:{origin}`. Renders "from {origin}" for free via
+  `discovery-utils.cjs` `computeSourceProvenance` (splits `{x}:{y}` → label `y`). Multi-source
+  comma-accumulation already handled.
+- **Non-epic (feature/bugfix/quick-fix):** stays single-topic, no exceptions. An off-topic concern →
+  **ignore**, **surface to inbox** (`workflow-log-idea`), or **pivot to epic** then use the main
+  flow. No Incoming section on single-topic artefacts.
+- **Coexist with extraction:** keep extraction for already-written drift (research-split moves real
+  content out of a file); Incoming is for conversational concerns not yet written up.
+
+## Component 1 — `create-topic` CLI command (atomic)
+
+`skills/workflow-manifest/scripts/manifest.cjs`. Mirrors `cmdInitPhase`'s lock/atomic pattern: one
+`withLock` → `readManifest` → in-memory mutations → single `writeManifestAtomic`.
+
+```
+create-topic <work-unit>.<topic> [--phase research|discussion] --routing <r> --source <src> [--summary s] [--description d]
+```
+
+- First positional is a **two-segment** dotted path `wu.topic` (the discovery item it addresses) — a
+  deliberate divergence from `init-phase`'s three-segment `wu.phase.topic` (phase is a flag here, not
+  a path segment).
+- Always creates the **discovery** item with `routing`/`source` (required) + `summary`/`description`
+  (optional) on the discovery item.
+- `--phase` additionally creates `phases.{phase}.items.{topic} = {status:'in-progress'}` — status
+  only (preserves the existing asymmetry: the four fields live on the discovery item).
+- `--summary`/`--description` truly omittable (key absent, not `""`).
+- **Errors if either target item already exists** (checked before any write) — removes the
+  half-built-topic hazard outright.
+- `--phase` and `--routing` validated against `research`/`discussion`.
+
+## Component 2 — `create-topic.md` shared reference
+
+`skills/workflow-shared/references/create-topic.md` encodes the **common core** only: name-validation
+loop, idempotent `pull dismissed`, the `create-topic` CLI call, no commit (returns dirty to caller).
+
+Stays site-specific: artefact creation/templates, originating-side markers, summary/description
+generation, commit messages + staged paths, post-action prompts, trigger/offer gates.
+
+**Behaviour-preservation note:** §F and research-split today pull dismissed *only* on
+`matches-dismissed`; the shared reference pulls *unconditionally*. Observably identical — `pull` is a
+no-op when the name is absent, and on the `ok` path the name is never in dismissed.
+
+## Component 3 — Incoming (the new behaviour)
+
+**Substrate:** `## Incoming` with a `(none)` placeholder in both templates; `initialize-*` seed it;
+new `drain-incoming.md` + `incoming-landing.md` shared references; `incoming:{origin}` provenance.
+
+**Landing** (`incoming-landing.md`): recompute target lifecycle at landing time (never cached). New →
+`create-topic --phase {routing}`; fresh → plain `init-phase`; in-flight/decided → append `### {concern}`
+subsection + reopen if completed. If the resolved target is the current topic, route to normal
+subtopic handling, not Incoming.
+
+Entry shape:
+```
+### {concern}
+*From: {origin} · {phase} · {date}*
+
+{concern as captured}
+```
+
+**Drain** (`drain-incoming.md`): runs once at session start (before the loop, regardless of the
+findings check), invoked from both initialize and resume/reopen paths. Discussion → `pending`
+subtopics; research → seed threads in the body. Delete each folded subsection; reset to `(none)`.
+
+**Conclusion gate:** `conclude-{discussion,research}.md` block with a `⚑` callout when `## Incoming` ≠
+`(none)`. `document-review.md` gains an Incoming-consistency check on both sides.
+
+**Reopen-bridge hazard — verified as already handled, no guard added.** Re-concluding a reopened
+topic re-fires the pipeline bridge. This is epic-only (single-topic never lands an Incoming entry, so
+it never reopens via Incoming). For epics the specification phase already treats a discussion that
+regressed to `in-progress` as a first-class `[extracted, reopened]` source and offers
+re-incorporation (`workflow-specification-entry` `display-groupings.md` / `display-single-grouped.md`)
+— the bridge re-firing into the epic menu is the *designed* path. So no warning is added; `conclude-*`
+just carries a one-line note. KB re-index on re-conclude is safe (idempotent — replaces chunks).
+
+## PR stack
+
+- **PR 0** — this design-log doc (long-lived, merge last).
+- **PR 1** — `create-topic` CLI + tests.
+- **PR 2** — `create-topic.md` shared ref + migrate full-spawn sites (§F, topic-splitting).
+- **PR 3** — migrate discovery-only sites (confirm-and-persist, ensure-discovery-item, analysis-approval-gate).
+- **PR 4** — Incoming substrate (templates, initialize-*, stubs, CLAUDE.md provenance).
+- **PR 5** — Incoming landing (full incoming-landing.md, trigger wiring, non-epic routing).
+- **PR 6** — drain + conclusion gate + reopen guard.
+
+PRs 1–3 are a behaviour-preserving no-op refactor. Only PRs 4–6 introduce new behaviour.
+
+| PR | Branch | Base | GitHub |
+|---|---|---|---|
+| 0 | `idea/incoming-pr-0-design` | `main` | #359 |
+| 1 | `idea/incoming-pr-1-create-topic-cli` | `main` | #360 |
+| 2 | `idea/incoming-pr-2-shared-ref` | PR 1 | #361 |
+| 3 | `idea/incoming-pr-3-discovery-only` | PR 2 | #362 |
+| 4 | `idea/incoming-pr-4-substrate` | PR 3 | #363 |
+| 5 | `idea/incoming-pr-5-landing` | PR 4 | #364 |
+| 6 | `idea/incoming-pr-6-drain-gate` | PR 5 | #365 |
+
+## Decisions taken during implementation
+
+- **Entry From-line dropped `session {NNN}`.** Research and discussion track no session number
+  anywhere, so the line is `origin · phase · date`. Detection keys on the `## Incoming` heading,
+  the `(none)` placeholder, and `### ` subsections — not the From line — so this is safe.
+- **Shared-ref output vars renamed to avoid caller collisions.** `create-topic.md` returns
+  `created_topic` (§F already binds `{topic}` to the parent); `incoming-landing.md` returns
+  `landed_topic`.
+- **Research Incoming lives in `epic-session.md` §C (Topic Awareness)**, the conversational-concern
+  home — kept deliberately distinct from §D's written-drift split. Non-epic research routing
+  (log / pivot / ignore) added to `feature-session.md`.
+- **Drain commits its own changes** (`{phase}({wu}/{topic}): drain incoming`) rather than folding
+  into an initialize/resume commit, and is invoked **once** at the session step (discussion Step 5,
+  research Step 6) — both fresh and resume/reopen funnel through it; a fresh `(none)` artefact no-ops.
+- **No reopen-bridge guard.** Verification showed the epic specification phase already handles a
+  reopened (regressed-to-`in-progress`) source via its `[extracted, reopened]` state and re-analysis
+  offer, and single-topic types never reopen via Incoming. An initial `⚑` warning was added and then
+  removed — it was redundant for epics and a false positive on the shared non-epic conclude path.
+- **Refactor (PRs 2–3) leaves one non-semantic diff:** discovery-item key order
+  (`status,routing,source,summary,description` from `create-topic` vs the old sequential `set`
+  order). Values identical.
+
+## Verification
+
+- CLI: `bash tests/scripts/test-workflow-manifest.sh` green incl. new create-topic cases; manual runs
+  against a temp `.workflows/` fixture for full-spawn, discovery-only, duplicate-error, omitted-field,
+  missing-flag paths.
+- Refactor no-op: diff resulting `manifest.json` + artefact before vs after migration on a temp
+  fixture — byte-identical (modulo intended content); commit messages/staged paths unchanged.
+- Incoming e2e (temp epic fixture): land new/fresh/decided targets; drain folds + removes; conclude
+  blocked on non-empty Incoming; non-epic offers inbox/pivot/ignore with no Incoming section.
+- Lifecycle/provenance: `discovery.cjs <wu>` renders reopened target actionable, shows "from {origin}".
+- KB safety: stub creation triggers no `knowledge index`; index only at conclude (idempotent on re-conclude).

--- a/incoming/plan-original.md
+++ b/incoming/plan-original.md
@@ -1,0 +1,272 @@
+# Plan: Incoming — off-topic topic surfacing + shared topic-creation infra
+
+## Context
+
+In the agentic-workflows system, when an off-topic concern surfaces mid research/discussion,
+there is today **no clean way to record it against the topic it actually belongs to**. The only
+moves are *fission* (elevation §F / research-split spawn a brand-new sibling) or burying it in the
+current artefact. There is no way to route a concern into an **existing** topic on the discovery
+map, and the spawn paths don't even check whether a matching topic already exists (so they create
+duplicates).
+
+This plan adds **Incoming**: an off-topic concern lands in an `## Incoming` section of a *target*
+topic's artefact (existing or new — landing is uniform); the target's own processing skill drains
+Incoming into its working map when that topic's phase next runs. Symmetric across research and
+discussion. A topic can't conclude with a non-empty Incoming.
+
+Building it surfaced that the "create a topic" sequence is **already duplicated across 6 call
+sites** and is non-atomic (multi-command, with explicit "stop before commit to recover" prose
+because a mid-sequence failure half-builds a topic). So the feature ships on top of extracted,
+hardened shared infra: an atomic `create-topic` CLI command + a `create-topic.md` shared reference.
+
+Outcome: off-topic concerns are never lost and never pollute the wrong artefact; topic creation is
+atomic and defined once; existing spawn behaviour is unchanged.
+
+---
+
+## Hard Constraints (non-negotiable)
+
+1. **CONVENTIONS.md is strictly followed on every skill-file edit.** Human review happens at the
+   end; convention errors there elongate the release. Before editing ANY `skills/**/SKILL.md` or
+   `skills/**/references/**/*.md`, re-read CONVENTIONS.md in full (do not pattern-match from siblings).
+   Per-PR compliance checklist is in the **Convention Compliance** section below — run it before each PR.
+
+2. **PRs 1–3 (creation infra) are a behaviour-preserving no-op refactor.** Code moves; the observable
+   logic process is unchanged. No new behaviour, no "while I'm here" improvements. The only acceptable
+   consolidation is one that is *observably identical* (documented explicitly for the reviewer — see
+   the dismissed-pull note in PR 2).
+
+3. **Only the Incoming system (PRs 4–6) introduces new behaviour.** Keep new behaviour out of the
+   refactor PRs entirely so review can treat them as "did this preserve behaviour?" vs "is this new
+   behaviour correct?".
+
+4. **Write as if authored fresh** (CONVENTIONS.md Prose Economy). When adding Incoming to existing
+   files: no `(new)` markers, no "formerly/now" notes, no migration backstory. Files must read as
+   though the feature was always there. The refactor must leave migrated files reading natively, not
+   as "code that was moved here".
+
+---
+
+## Locked Design (decided with user — do not re-litigate)
+
+- **Storage:** Incoming lives in the **target's artefact file**, an `## Incoming` section. A `fresh`
+  target with no file yet → landing creates a seed artefact stub. (Artefact-only; **not** a manifest
+  array — hybrid was explicitly rejected.)
+- **Surfacing is dumb + symmetric:** the landing step writes **only** `## Incoming`. It never injects
+  into the target's Discussion Map / research threads. Folding Incoming → working map is the
+  *consuming* process's job, identically on both sides.
+- **Reopen on decided:** landing on a `completed` (decided) target also flips its phase-item status
+  `completed → in-progress`. Lifecycle recomputes to actionable automatically
+  (`discovery-utils.cjs:313 computeTopicLifecycle` reads live status — verified).
+- **Drain = remove:** when the consuming process folds an entry in, it **deletes** that subsection
+  from `## Incoming` (clean for KB indexing; git history is the audit trail).
+- **Conclusion gate:** a research/discussion topic cannot conclude while `## Incoming` ≠ `(none)`.
+- **Provenance:** new source value `incoming:{origin}`. Renders "from {origin}" for free via
+  `discovery-utils.cjs:388 computeSourceProvenance` (splits `{x}:{y}` → label `y` — verified).
+  Multi-source comma-accumulation already handled.
+- **Non-epic (feature/bugfix/quick-fix):** stays single-topic, no exceptions. An off-topic concern →
+  **ignore**, **surface to inbox** (`workflow-log-idea`, already exists), or **pivot to epic** then
+  use the main flow. No Incoming section on single-topic artefacts.
+- **Coexist with extraction:** keep extraction for already-written drift (research-split moves real
+  content out of a file); Incoming is for conversational concerns not yet written up.
+
+---
+
+## Component 1 — `create-topic` CLI command (atomic)
+
+`skills/workflow-manifest/scripts/manifest.cjs`. Mirror `cmdInitPhase` (line 710) lock/atomic pattern:
+one `withLock` → `readManifest` → in-memory mutations → single `writeManifestAtomic`.
+
+**Signature:**
+```
+create-topic <work-unit>.<topic> [--phase research|discussion] --routing <r> --source <src> [--summary s] [--description d]
+```
+
+- First positional is a **two-segment** dotted path `wu.topic` (the discovery item it addresses).
+  This is a deliberate divergence from `init-phase`'s three-segment `wu.phase.topic` — the phase is a
+  flag here, not a path segment. Parse it directly (split on first dot; reject further dots, mirroring
+  the `name.includes('.')` guard in `cmdInit` line 501). Document the divergence in the function's doc
+  comment so a maintainer doesn't "fix" it.
+- Always creates the **discovery** item `phases.discovery.items.{topic} = {status:'in-progress'}` and
+  sets `routing`/`source` (required) and `summary`/`description` (optional) **on the discovery item**.
+- `--phase` additionally creates `phases.{phase}.items.{topic} = {status:'in-progress'}` — status only,
+  no other fields (preserves the existing asymmetry: the four fields live on the discovery item, the
+  phase item carries status). Assert this in the doc comment.
+- `--routing` and `--source` **required** (no safe default — every call site sets a different source).
+  `--summary`/`--description` **truly omittable** (key absent, not `""`) — `ensure-discovery-item.md`
+  creates routing+source-only items and a later backfill distinguishes absent from empty.
+- **Errors if either target item already exists** (mirror `cmdInitPhase` line 728 `die`). Check both
+  targets *before* writing. This removes the half-built-topic hazard outright.
+- Dispatch switch (~line 1036): add `case 'create-topic': cmdCreateTopic(args); break;`.
+- Usage string (line 1033): add `create-topic` to the command list.
+- `--phase` value validated against `VALID_PHASES` (line 15) restricted to `research`/`discussion`;
+  `--routing` likewise.
+
+**Tests** — `tests/scripts/test-workflow-manifest.sh` (run_cli / assert_equals harness, lines 40–113):
+full-spawn (with `--phase`), discovery-only (no `--phase`), omitted summary/description (assert key
+absent), duplicate-discovery error, duplicate-phase error, missing-required-flag (`--routing`,
+`--source`) errors, atomicity (a failing run leaves manifest unchanged).
+
+**`pull dismissed` stays OUT of `create-topic`** — it's a separate idempotent command, kept in the
+shared reference before the create-topic call (folding it in would couple concerns and complicate the
+atomic write).
+
+---
+
+## Component 2 — `create-topic.md` shared reference + migrate spawn sites
+
+New `skills/workflow-shared/references/create-topic.md`. Encodes the **common core** only:
+
+1. Name-validation loop — load `topic-name-validation.md` with `work_unit`/`proposed_name`, loop on
+   `collision-active` until `ok`/`matches-dismissed`/cancel.
+2. `pull {wu}.discovery dismissed "{topic}"` (idempotent no-op if absent).
+3. The `create-topic` CLI call with the four fields + optional `--phase`.
+4. **No commit** — returns dirty to caller (mirrors `ensure-discovery-item.md:96`), so the caller's
+   commit covers artefact + manifest together.
+
+**Stays site-specific (NOT in the shared reference):** artefact creation (different templates;
+research-split additionally moves content verbatim out of the source file and deletes it), the
+originating-side marker (§F's `↑ Elevated:` row; research-split has none), summary/description
+*generation*, commit message + staged paths (§F: one topic; split: N topics, stages whole
+`research/` dir), the post-action user prompt (split's "which topic to continue with?" STOP; §F just
+returns), and the trigger/offer gates (`e`/`k`, `y`/`n`).
+
+**Behaviour-preservation note for the reviewer (PR 2):** §F and research-split today pull dismissed
+*only* on `matches-dismissed`; the shared reference pulls *unconditionally*. This is **observably
+identical** — `pull` is a no-op when the name is absent, and on the `ok` path the name is never in
+dismissed. Call this out explicitly in the PR description as the single intentional consolidation.
+
+**Migration targets (PR 2, full-spawn):** `discussion-process/references/discussion-session.md` §F
+(steps 1, 4) and `research-process/references/topic-splitting.md` (steps 1, 4).
+
+**Migration targets (PR 3, discovery-only):** `discovery/references/confirm-and-persist.md`,
+`shared/references/ensure-discovery-item.md`, `shared/references/analysis-approval-gate.md` — these
+call `create-topic` *without* `--phase`. Split from PR 2 so the omittable-field path reviews
+independently.
+
+---
+
+## Component 3 — Incoming (the new behaviour)
+
+### Substrate (PR 4)
+- Add `## Incoming` with a `(none)` placeholder to **both** templates:
+  `discussion-process/references/template.md` (after Discussion Map, before first subtopic) and
+  `research-process/references/template.md` (after Starting Point). **Pin the exact heading
+  (`## Incoming`) and exact placeholder (`(none)`)** — the conclusion gate and drain detect against
+  these literals.
+- Update `initialize-discussion.md` and `initialize-research.md` to seed the section as `(none)`.
+- New `shared/references/drain-incoming.md` — the consuming-side primitive (see Drain below).
+- New `shared/references/incoming-landing.md` — the landing primitive (see Landing below).
+- Provenance docs: add `incoming:{origin}` to `CLAUDE.md` (the authoritative source enumeration,
+  ~line 106). No code change (`discovery-utils.cjs` handles `{x}:{y}` generically). Optionally update
+  the `discovery-map/` design-log doc (secondary — historical record).
+
+### Landing — `incoming-landing.md` (PR 5)
+Recompute the target's lifecycle **at landing time, never cached** (lifecycle is live; a target
+elevated earlier in the same session must resolve correctly). Three cases:
+
+- **New** (not on map) → `create-topic.md` with `--phase {routing}`, `--source incoming:{origin}`;
+  create artefact stub from template with the Incoming entry.
+- **Fresh** (discovery item exists, no phase work) → plain `init-phase {wu}.{phase}.{topic}`
+  (per the discovery item's `routing`) + create artefact stub. **Not** `create-topic` (it errors on
+  the existing discovery item — correct).
+- **In-flight / decided** (artefact exists) → append the `### {concern}` subsection to `## Incoming`;
+  if the phase item is `completed`, `set {wu}.{phase}.{topic} status in-progress` (reopen).
+
+Incoming entry shape (pin this):
+```
+### {concern}
+*From: {origin} · {phase} · session {NNN} · {date}*
+
+{concern as captured}
+```
+
+**Target resolution:** match the concern against the live discovery map (`discovery.cjs` output).
+If the resolved target **is the current topic itself**, this is not Incoming — route to normal
+subtopic handling (discussion: add to Discussion Map; research: a thread), do not land. Incoming is
+strictly for a *different* target.
+
+**Wiring the trigger:** `discussion-session.md` §F gains an Incoming branch (target new/existing)
+alongside elevate/keep; research `epic-session.md` D / `topic-splitting.md` gains the
+conversational-concern → Incoming path, kept distinct from the existing drift-extraction split.
+
+### Drain — `drain-incoming.md` (PR 6)
+Runs **once at session start**, before the loop and before "check for findings" (that step is skipped
+on the first iteration; drain must run regardless, and must not reshuffle the map mid-turn). Invoked
+from BOTH the initialize path (fresh start) and the resume/reopen path (a reopened decided topic
+resumes, it doesn't initialise) — that's why drain is its own shared reference.
+
+- **Discussion:** each `### {concern}` → a `pending` subtopic on the Discussion Map.
+- **Research:** each `### {concern}` → folded into Starting Point / body as a seed thread (research
+  has no formal map; the freeform body is the home).
+- After folding each entry, **delete its subsection**; reset `## Incoming` to `(none)` when empty.
+  Include the drained map in the same initial/resume commit.
+
+### Conclusion gate (PR 6)
+In `conclude-discussion.md` and `conclude-research.md`, before setting status `completed`: read the
+artefact's `## Incoming` section; if it is not exactly `(none)`, **block** with a `⚑` callout
+(CONVENTIONS.md Callout Flag) and return to the session loop. Mirror the existing review-cycle safety
+net format in `discussion-session.md` §G. Add an Incoming-consistency check to `document-review.md`
+(both sides) the way it already audits Open Threads drift, to catch placeholder drift.
+
+### Known risk to handle explicitly (PR 6)
+**Reopen-bridge hazard.** Re-concluding a reopened *decided* topic re-fires the pipeline bridge
+(`conclude-discussion.md` terminal bridge invocation). If a downstream phase (specification+) already
+consumed the first conclusion, the bridge re-triggers into it. The reopen path must detect existing
+downstream phase work and handle it (at minimum surface a `⚑` warning to the user before
+re-concluding; ideally the bridge already no-ops when downstream work exists — verify and document).
+KB re-index on re-conclude is safe (idempotent, replaces chunks — verified).
+
+---
+
+## PR Stack (managed with the `stack` CLI)
+
+Linear stack, bottom → top. PRs 1–3 are the no-op infra and merge on their own merit even if the
+Incoming PRs iterate. All `manifest.cjs` + test changes live in PR 1 so the test file isn't touched
+twice. Use `stack sync --dry-run` before any sync and `stack merge` (dry-run by default) per the
+pr-stacked skill; squash-merge, descendants rebase onto main after each merge.
+
+- **PR 0 (design-log, long-lived):** design doc following the `discovery-map/phase-NN-*.md`
+  convention (next sequential number). Branch off main, open the PR early so it sits ready, keep
+  logging decisions to it as the stack progresses, **merge last**.
+- **PR 1 — `create-topic` CLI + tests.** `manifest.cjs` (cmdCreateTopic, dispatch, usage),
+  `tests/scripts/test-workflow-manifest.sh`. Pure addition; breaks nothing.
+- **PR 2 — `create-topic.md` shared ref + migrate full-spawn sites.** `shared/references/create-topic.md`,
+  `discussion-session.md` §F, `topic-splitting.md`. Behaviour-preserving (note the dismissed-pull
+  consolidation). Depends on PR 1.
+- **PR 3 — migrate discovery-only sites.** `confirm-and-persist.md`, `ensure-discovery-item.md`,
+  `analysis-approval-gate.md`. Behaviour-preserving. Depends on PR 2.
+- **PR 4 — Incoming substrate.** both `template.md`, `initialize-discussion.md`,
+  `initialize-research.md`, new `drain-incoming.md` + `incoming-landing.md` (stubs/contracts),
+  `CLAUDE.md` provenance. Depends on PR 1 (uses create-topic in landing contract) — stack on PR 3.
+- **PR 5 — Incoming landing.** `incoming-landing.md` (full), trigger wiring in `discussion-session.md`
+  + research `epic-session.md`/`topic-splitting.md`, non-epic routing (inbox/pivot/ignore). Depends
+  on PR 4.
+- **PR 6 — drain + conclusion gate + reopen guard.** `drain-incoming.md` (full) invoked from
+  initialize + resume/reopen paths, `conclude-discussion.md`/`conclude-research.md` gate,
+  `document-review.md` consistency check (both), reopen-bridge guard. Depends on PR 4 + PR 5.
+
+---
+
+## Convention Compliance (run before EACH skill-file PR)
+
+- Re-read CONVENTIONS.md in full before editing.
+- Every user-facing fenced block preceded by a rendering instruction (`> *Output the next fenced block as a code block:*` / `... as markdown ...`); model-instruction blocks (bash, paths) exempt.
+- Menus: `· · · · · · · · · · · ·` framing, command options first (backtick shorthand) + one prompt option last (plain bold, "Tell me…" directive), `— description`, single source of truth.
+- STOP gates: exactly `**STOP.** Wait for user response.` / terminal variant.
+- Headings: H2 sections, H4 `#### If`/`#### Otherwise` conditionals (lowercase, backticked values), every branch self-routes.
+- Navigation: only `→ Proceed to` / `→ Return to`; reference headers `*Reference for **[skill](../SKILL.md)***`; `→ Return to caller.` default exit; no link before internal routing.
+- Callout `⚑` at 2-space indent for the conclusion-gate block.
+- Status terms in `[brackets]`; reopened state uses `reopened` vocabulary where displayed.
+- Prose economy: no `(new)`, no historical/migration notes, no WHY where WHAT suffices; files read as authored fresh.
+
+---
+
+## Verification
+
+- **CLI:** `bash tests/scripts/test-workflow-manifest.sh` — all green, including new create-topic cases. Manually run `node skills/workflow-manifest/scripts/manifest.cjs create-topic …` against a temp `.workflows/` fixture (never a real project — copy to a temp dir) for full-spawn, discovery-only, duplicate-error, omitted-field, and missing-flag paths; inspect resulting `manifest.json`.
+- **Refactor (PRs 2–3) is a no-op:** for each migrated site, diff the *resulting manifest.json* and artefact produced by an end-to-end run before vs after migration on a temp fixture — they must be byte-identical (modulo intended content). Confirm commit messages/staged paths unchanged.
+- **Incoming end-to-end** (temp epic fixture): (a) land a concern on a new target → discovery+phase items + stub with `## Incoming` entry, source `incoming:{origin}`; (b) land on fresh target → phase item + stub; (c) land on decided target → appended entry + status flipped to `in-progress`, lifecycle recomputes to `discussing`/`researching` via `discovery.cjs`; (d) start that target's session → drain folds entries into map/threads and removes them, `## Incoming` back to `(none)`; (e) attempt conclude with a non-empty Incoming → blocked; (f) non-epic → inbox/pivot/ignore offered, no Incoming section created.
+- **Lifecycle/provenance:** `node skills/workflow-discovery/scripts/discovery.cjs <wu>` renders the reopened target as actionable and shows "from {origin}".
+- **KB safety:** confirm stub creation triggers no `knowledge index`; index only fires at conclude (idempotent on re-conclude).
+- **Conventions:** spot-check each edited skill file against the checklist; the final human review should find zero convention drift.

--- a/incoming/plan.md
+++ b/incoming/plan.md
@@ -1,0 +1,96 @@
+# Plan v2: Incoming — corrected & execution-ready
+
+The original plan is preserved verbatim at **[plan-original.md](plan-original.md)** and remains the
+authoritative spec for the locked design, hard constraints, and component details. The design log is
+at **[design.md](design.md)**. This document is the corrected **delta**: what's done, what the first
+attempt got wrong, the discipline for the redo, and the specific corrections to fold into the
+original plan. Read all three before executing.
+
+## Status
+
+- **create-topic CLI + tests** — DONE (this PR). Atomic `create-topic` command in `manifest.cjs`,
+  full test coverage, SKILL.md API entry. Verified by `tests/scripts/test-workflow-manifest.sh`.
+- **Everything else** (shared `create-topic.md`, call-site migrations, Incoming substrate / landing /
+  drain / conclusion gate) — TO DO, rewritten from scratch. The first attempt's skill-file work was
+  binned for sloppiness; nothing from it is carried forward except the design knowledge below.
+
+## What the first attempt got wrong — do not repeat
+
+- **Inlined conditional branches into running prose** (`If it returns cancelled, … → Return … Otherwise
+  continue`) instead of structured conditionals. This was pervasive and is the single biggest defect.
+- **Coasted on memory** instead of re-reading CONVENTIONS.md per file — the exact thing the doc warns
+  against.
+- **Over-explained** — WHY where WHAT suffices; padded purpose, parameter, and case bodies.
+- **Volume over correctness** — a five-PR blast with no per-file convention check before opening each.
+
+## Execution discipline (mandatory for every skill-file PR)
+
+- **Re-read CONVENTIONS.md in full before each PR.** Check every construct in every touched file
+  against it. Do not pattern-match from sibling files.
+- **Conditionals are never inline in prose.** Top-level branches in a lettered section use H4
+  `#### If` / `#### Otherwise`. Nested or post-STOP branches use bold `**If …:**`. Every branch sits on
+  its own line and carries its own `→` routing instruction. No `If X … → do Y. Otherwise Z` sentences.
+- **Prose economy.** Cut WHY when WHAT suffices. No historical/migration notes. Write as if authored
+  fresh. Keep every instruction the agent needs — and nothing more.
+- **One PR at a time.** Run the compliance self-check (`workflow-shared/references/compliance-check.md`)
+  on each touched file before opening the PR. Do not start the next PR until the current one is clean.
+
+## Corrections to the original plan (apply these during the redo)
+
+1. **No reopen-bridge guard.** The original plan's PR 6 "Known risk" called for detecting downstream
+   work and warning before re-concluding a reopened topic. Resolved: **do nothing.** The reopen case is
+   epic-only (single-topic never lands an Incoming entry), and the specification phase already treats a
+   discussion that regressed to `in-progress` as a first-class `[extracted, reopened]` source and offers
+   re-incorporation (`workflow-specification-entry` `display-groupings.md` / `display-single-grouped.md`).
+   Re-firing the bridge into the epic menu is the designed path. No guard, no warning — at most a
+   one-line note that re-conclusion is already handled downstream.
+
+2. **Entry From-line drops `session {NNN}`.** Research and discussion track no session number anywhere,
+   so the pinned shape is:
+   ```
+   ### {concern}
+   *From: {origin} · {phase} · {date}*
+
+   {concern as captured}
+   ```
+   Detection keys on the `## Incoming` heading, the `(none)` placeholder, and the `### ` subsections —
+   not the From line.
+
+3. **Target resolution skips `handled` and `cancelled` rows.** Those lifecycles have `current_phase:
+   null` (verified in `discovery-utils.cjs` `computeTopicLifecycle`), so landing logic that dereferences
+   `current_phase` for the artefact path breaks on them. The trigger sites (discussion §F, research §C)
+   resolve a concern only to a live topic (or a new name); `incoming-landing` therefore only ever
+   classifies new / fresh / actionable (`researching`, `ready_for_discussion`, `discussing`, `decided`)
+   targets — all of which have a real artefact or are `fresh`.
+
+4. **Shared-ref output variables avoid caller collisions.** `create-topic.md` returns `created_topic`
+   (the validated name); `incoming-landing.md` returns `landed_topic`. Both avoid clashing with a
+   caller's own `{topic}` (e.g. §F binds `{topic}` to the parent discussion).
+
+5. **Drain owns its commit and runs once at the session-start step.** `drain-incoming.md` folds the
+   `## Incoming` entries, clears the section to `(none)`, and commits
+   `{phase}({work_unit}/{topic}): drain incoming`. Wire it into the session-start step (discussion
+   Step 5 / research Step 6) — both the fresh and the resume/reopen paths funnel through there, so one
+   invocation covers both; a fresh `(none)` artefact is a no-op.
+
+6. **The refactor leaves one non-semantic diff.** Migrating the create sites onto `create-topic` changes
+   the discovery-item key order (`status, routing, source, summary, description` from the CLI vs the old
+   sequential `set` order). Values are identical. Call it out in the refactor PR so a reviewer doesn't
+   read it as a behaviour change.
+
+## Remaining PR breakdown (redo — each its own PR, in order)
+
+Scope and behaviour-preservation requirements are unchanged from the original plan; apply the
+corrections above as you go.
+
+1. **`create-topic.md` shared ref + migrate full-spawn sites** — `discussion-session.md` §F (elevation),
+   `research-process/.../topic-splitting.md`. Behaviour-preserving refactor.
+2. **Migrate discovery-only sites** — `confirm-and-persist.md`, `ensure-discovery-item.md`,
+   `analysis-approval-gate.md`. Behaviour-preserving refactor.
+3. **Incoming substrate** — `## Incoming` (`(none)`) in both templates, `initialize-*` seeding,
+   `drain-incoming.md` + `incoming-landing.md` (contracts), `CLAUDE.md` `incoming:{origin}` provenance.
+4. **Incoming landing + trigger wiring** — full `incoming-landing.md` (correction #3), epic triggers
+   (discussion §F, research §C), non-epic routing (`log` / `pivot` / `ignore`). Entry shape per #2.
+5. **Drain + conclusion gate** — full `drain-incoming.md` (correction #5), conclusion gate in
+   `conclude-{discussion,research}.md`, Incoming-consistency check in `document-review.md` (both).
+   **No reopen guard** (correction #1).

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -73,6 +73,9 @@ $MANIFEST set {work_unit}.{phase}.{topic} field.path value
 $MANIFEST delete {work_unit}.{phase}.{topic} field.path
 $MANIFEST init-phase {work_unit}.{phase}.{topic}
 
+# Atomic topic creation (2-segment path — phase is a flag, not a segment):
+$MANIFEST create-topic {work_unit}.{topic} [--phase research|discussion] --routing r --source s [--summary "..."] [--description "..."]
+
 # Wildcard (3 segments, * as topic):
 $MANIFEST get {work_unit}.{phase}.* [field.path]
 $MANIFEST exists {work_unit}.{phase}.* [field.path]
@@ -247,6 +250,21 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase <name>.dis
 ```
 
 Errors if item/phase already exists.
+
+### `create-topic`
+
+Atomically create a discovery-map topic and, optionally, its initial phase item — one lock, one write, no half-built state. The first positional is a **2-segment** `<name>.<topic>` path (the phase is a flag, not a path segment).
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-topic <name>.<topic> \
+  [--phase research|discussion] --routing <research|discussion> --source <src> \
+  [--summary "..."] [--description "..."]
+```
+
+- Always creates `phases.discovery.items.<topic>` with `status`, `routing`, `source`, and `summary`/`description` when supplied.
+- `--phase` additionally creates `phases.<phase>.items.<topic>` with `{ "status": "in-progress" }` (status only — the descriptor fields stay on the discovery item).
+- `--routing` and `--source` are required. `--summary`/`--description` are omittable — when absent the key is not written at all.
+- Errors if either the discovery item or the `--phase` item already exists (both checked before any write).
 
 ### `push`
 

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -73,8 +73,8 @@ $MANIFEST set {work_unit}.{phase}.{topic} field.path value
 $MANIFEST delete {work_unit}.{phase}.{topic} field.path
 $MANIFEST init-phase {work_unit}.{phase}.{topic}
 
-# Atomic topic creation (2-segment path — phase is a flag, not a segment):
-$MANIFEST create-topic {work_unit}.{topic} [--phase research|discussion] --routing r --source s [--summary "..."] [--description "..."]
+# Atomic epic discovery-map topic spawn (2-segment path — phase is a flag, not a segment):
+$MANIFEST create-discovery-topic {work_unit}.{topic} [--phase research|discussion] --routing r --source s [--summary "..."] [--description "..."]
 
 # Wildcard (3 segments, * as topic):
 $MANIFEST get {work_unit}.{phase}.* [field.path]
@@ -251,12 +251,12 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase <name>.dis
 
 Errors if item/phase already exists.
 
-### `create-topic`
+### `create-discovery-topic`
 
-Atomically create a discovery-map topic and, optionally, its initial phase item — one lock, one write, no half-built state. The first positional is a **2-segment** `<name>.<topic>` path (the phase is a flag, not a path segment).
+Atomically spawn a new topic onto an epic's discovery map and, optionally, seed its initial phase item — one lock, one write, no half-built state. The first positional is a **2-segment** `<name>.<topic>` path (the phase is a flag, not a path segment). Epic-only by intent (the discovery map exists only for epics); single-topic types create their topic via `init` + a single `init-phase` and never call this. The work_type gate lives in the callers.
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs create-topic <name>.<topic> \
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic <name>.<topic> \
   [--phase research|discussion] --routing <research|discussion> --source <src> \
   [--summary "..."] [--description "..."]
 ```

--- a/skills/workflow-manifest/scripts/manifest.cjs
+++ b/skills/workflow-manifest/scripts/manifest.cjs
@@ -737,13 +737,20 @@ function cmdInitPhase(args) {
   process.stdout.write(`Initialized ${phase} phase for "${topic}" in "${workUnit}"\n`);
 }
 
-// create-topic <work-unit>.<topic> [--phase research|discussion]
+// create-discovery-topic <work-unit>.<topic> [--phase research|discussion]
 //              --routing <r> --source <src> [--summary s] [--description d]
 //
-// Atomically create a discovery-map topic and, optionally, its initial phase
-// item. One withLock → readManifest → in-memory mutation → single
-// writeManifestAtomic, so a mid-sequence failure can never leave a half-built
-// topic (the hazard the multi-command sequence this replaces was prone to).
+// Atomically spawn a new topic onto an epic's discovery map and, optionally,
+// seed its initial phase item. One withLock → readManifest → in-memory mutation
+// → single writeManifestAtomic, so a mid-sequence failure can never leave a
+// half-built topic (the hazard the multi-command sequence this replaces was
+// prone to).
+//
+// EPIC-ONLY by intent: the discovery map exists only for epics, so this is the
+// epic topic-spawn primitive. Single-topic types (feature/bugfix/quick-fix)
+// create their topic via `init` (the work unit IS the topic) plus a single
+// `init-phase` for the first phase — they never call this. The work_type gate
+// lives in the callers, not here; this command is a dumb primitive.
 //
 // DIVERGENCE FROM init-phase: the first positional is a TWO-segment `wu.topic`
 // path, not init-phase's three-segment `wu.phase.topic`. The phase is a flag
@@ -763,9 +770,9 @@ function cmdInitPhase(args) {
 //
 // Errors if either the discovery item or the --phase item already exists (both
 // checked before any write).
-function cmdCreateTopic(args) {
+function cmdCreateDiscoveryTopic(args) {
   const usage =
-    'Usage: create-topic <work-unit>.<topic> [--phase research|discussion] ' +
+    'Usage: create-discovery-topic <work-unit>.<topic> [--phase research|discussion] ' +
     '--routing <research|discussion> --source <src> [--summary s] [--description d]';
 
   let pathArg = null;
@@ -1149,7 +1156,7 @@ function cmdResolve(args) {
 const [command, ...args] = process.argv.slice(2);
 
 if (!command) {
-  die('Usage: manifest.cjs <command> [args]\nCommands: init, get, set, delete, list, init-phase, create-topic, push, pull, exists, key-of, project, resolve');
+  die('Usage: manifest.cjs <command> [args]\nCommands: init, get, set, delete, list, init-phase, create-discovery-topic, push, pull, exists, key-of, project, resolve');
 }
 
 switch (command) {
@@ -1159,7 +1166,7 @@ switch (command) {
   case 'delete':   cmdDelete(args); break;
   case 'list':     cmdList(args); break;
   case 'init-phase': cmdInitPhase(args); break;
-  case 'create-topic': cmdCreateTopic(args); break;
+  case 'create-discovery-topic': cmdCreateDiscoveryTopic(args); break;
   case 'push':     cmdPush(args); break;
   case 'pull':     cmdPull(args); break;
   case 'exists':   cmdExists(args); break;

--- a/skills/workflow-manifest/scripts/manifest.cjs
+++ b/skills/workflow-manifest/scripts/manifest.cjs
@@ -737,6 +737,125 @@ function cmdInitPhase(args) {
   process.stdout.write(`Initialized ${phase} phase for "${topic}" in "${workUnit}"\n`);
 }
 
+// create-topic <work-unit>.<topic> [--phase research|discussion]
+//              --routing <r> --source <src> [--summary s] [--description d]
+//
+// Atomically create a discovery-map topic and, optionally, its initial phase
+// item. One withLock → readManifest → in-memory mutation → single
+// writeManifestAtomic, so a mid-sequence failure can never leave a half-built
+// topic (the hazard the multi-command sequence this replaces was prone to).
+//
+// DIVERGENCE FROM init-phase: the first positional is a TWO-segment `wu.topic`
+// path, not init-phase's three-segment `wu.phase.topic`. The phase is a flag
+// (`--phase`), never a path segment — a topic is created against exactly one
+// discovery item and at most one phase. Do not "fix" this to three segments.
+// We split on the first dot and reject any further dots, mirroring the
+// `name.includes('.')` guard in cmdInit.
+//
+// ASYMMETRY (preserved deliberately): the four descriptor fields
+// (routing, source, summary, description) live ONLY on the discovery item. The
+// phase item created by --phase carries `status` only — no other fields.
+//
+// --routing and --source are REQUIRED (no safe default — every call site sets a
+// different source). --summary and --description are truly omittable: when
+// absent the key is not written at all (not ""), so a later backfill can
+// distinguish "never set" from "set to empty".
+//
+// Errors if either the discovery item or the --phase item already exists (both
+// checked before any write).
+function cmdCreateTopic(args) {
+  const usage =
+    'Usage: create-topic <work-unit>.<topic> [--phase research|discussion] ' +
+    '--routing <research|discussion> --source <src> [--summary s] [--description d]';
+
+  let pathArg = null;
+  let phase = null;
+  let routing = null;
+  let source = null;
+  let summary = null;
+  let description = null;
+  let hasSummary = false;
+  let hasDescription = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--phase' && i + 1 < args.length) {
+      phase = args[++i];
+    } else if (a === '--routing' && i + 1 < args.length) {
+      routing = args[++i];
+    } else if (a === '--source' && i + 1 < args.length) {
+      source = args[++i];
+    } else if (a === '--summary' && i + 1 < args.length) {
+      summary = args[++i];
+      hasSummary = true;
+    } else if (a === '--description' && i + 1 < args.length) {
+      description = args[++i];
+      hasDescription = true;
+    } else if (!pathArg) {
+      pathArg = a;
+    }
+  }
+
+  if (!pathArg) die(usage);
+
+  // Two-segment path: wu.topic (NOT wu.phase.topic). Split on the first dot;
+  // reject any further dots — mirrors cmdInit's name.includes('.') guard.
+  const dot = pathArg.indexOf('.');
+  if (dot === -1) die(`Invalid path "${pathArg}". Expected: <work-unit>.<topic>`);
+  const workUnit = pathArg.slice(0, dot);
+  const topic = pathArg.slice(dot + 1);
+  if (!workUnit || !topic) die(`Invalid path "${pathArg}". Expected: <work-unit>.<topic>`);
+  if (topic.includes('.')) die(`Topic "${topic}" must not contain dots`);
+
+  if (!routing) die('--routing is required');
+  if (!source) die('--source is required');
+
+  const PHASE_CHOICES = ['research', 'discussion'];
+  if (!PHASE_CHOICES.includes(routing)) {
+    die(`--routing must be one of: ${PHASE_CHOICES.join(', ')}`);
+  }
+  if (phase !== null && !PHASE_CHOICES.includes(phase)) {
+    die(`--phase must be one of: ${PHASE_CHOICES.join(', ')}`);
+  }
+
+  requireWorkUnit(workUnit);
+
+  withLock(workUnit, () => {
+    const manifest = readManifest(workUnit);
+
+    if (!manifest.phases) manifest.phases = {};
+    if (!manifest.phases.discovery) manifest.phases.discovery = {};
+    if (!manifest.phases.discovery.items) manifest.phases.discovery.items = {};
+
+    // Check BOTH targets before writing anything.
+    if (manifest.phases.discovery.items[topic]) {
+      die(`Discovery item "${topic}" already exists in "${workUnit}"`);
+    }
+    if (phase !== null) {
+      if (!manifest.phases[phase]) manifest.phases[phase] = {};
+      if (!manifest.phases[phase].items) manifest.phases[phase].items = {};
+      if (manifest.phases[phase].items[topic]) {
+        die(`Item "${topic}" already exists in phase "${phase}" of "${workUnit}"`);
+      }
+    }
+
+    const discoveryItem = { status: 'in-progress', routing, source };
+    if (hasSummary) discoveryItem.summary = summary;
+    if (hasDescription) discoveryItem.description = description;
+    manifest.phases.discovery.items[topic] = discoveryItem;
+
+    if (phase !== null) {
+      manifest.phases[phase].items[topic] = { status: 'in-progress' };
+    }
+
+    writeManifestAtomic(workUnit, manifest);
+  });
+
+  process.stdout.write(
+    `Created topic "${topic}" in "${workUnit}" (discovery${phase ? ` + ${phase}` : ''})\n`
+  );
+}
+
 function cmdPush(args) {
   // Project manifest routing: push project.field.path <value>
   const proj = parseProjectPath(args[0]);
@@ -1030,7 +1149,7 @@ function cmdResolve(args) {
 const [command, ...args] = process.argv.slice(2);
 
 if (!command) {
-  die('Usage: manifest.cjs <command> [args]\nCommands: init, get, set, delete, list, init-phase, push, pull, exists, key-of, project, resolve');
+  die('Usage: manifest.cjs <command> [args]\nCommands: init, get, set, delete, list, init-phase, create-topic, push, pull, exists, key-of, project, resolve');
 }
 
 switch (command) {
@@ -1040,6 +1159,7 @@ switch (command) {
   case 'delete':   cmdDelete(args); break;
   case 'list':     cmdList(args); break;
   case 'init-phase': cmdInitPhase(args); break;
+  case 'create-topic': cmdCreateTopic(args); break;
   case 'push':     cmdPush(args); break;
   case 'pull':     cmdPull(args); break;
   case 'exists':   cmdExists(args); break;

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -710,14 +710,14 @@ assert_exit_nonzero "Invalid phase in init-phase rejected" init-phase bad-phase-
 echo ""
 
 # ============================================================================
-# CREATE-TOPIC TESTS
+# CREATE-DISCOVERY-TOPIC TESTS
 # ============================================================================
 
-echo -e "${YELLOW}Test: create-topic full spawn (with --phase) creates both items${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic full spawn (with --phase) creates both items${NC}"
 setup_fixture
 run_cli init ct-full --work-type epic --description "Create topic" >/dev/null 2>&1
-output=$(run_cli create-topic ct-full.auth --phase discussion --routing discussion --source "incoming:billing" --summary "Auth concern" --description "Longer context")
-assert_contains "$output" "Created topic" "create-topic full spawn reports creation"
+output=$(run_cli create-discovery-topic ct-full.auth --phase discussion --routing discussion --source "incoming:billing" --summary "Auth concern" --description "Longer context")
+assert_contains "$output" "Created topic" "create-discovery-topic full spawn reports creation"
 assert_equals "$(run_cli_stdout get ct-full.discovery.auth status)" "in-progress" "discovery item status in-progress"
 assert_equals "$(run_cli_stdout get ct-full.discovery.auth routing)" "discussion" "discovery item routing set"
 assert_equals "$(run_cli_stdout get ct-full.discovery.auth source)" "incoming:billing" "discovery item source set"
@@ -729,66 +729,66 @@ assert_equals "$(run_cli_stdout exists ct-full.discussion.auth routing)" "false"
 
 echo ""
 
-echo -e "${YELLOW}Test: create-topic discovery-only (no --phase) creates only discovery item${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic discovery-only (no --phase) creates only discovery item${NC}"
 setup_fixture
 run_cli init ct-disc --work-type epic --description "Create topic" >/dev/null 2>&1
-run_cli create-topic ct-disc.search --routing research --source direct-start >/dev/null 2>&1
+run_cli create-discovery-topic ct-disc.search --routing research --source direct-start >/dev/null 2>&1
 assert_equals "$(run_cli_stdout get ct-disc.discovery.search routing)" "research" "discovery-only routing set"
 assert_equals "$(run_cli_stdout get ct-disc.discovery.search source)" "direct-start" "discovery-only source set"
 assert_equals "$(run_cli_stdout exists ct-disc.research.search)" "false" "no phase item created without --phase"
 
 echo ""
 
-echo -e "${YELLOW}Test: create-topic omits summary/description as absent keys (not empty string)${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic omits summary/description as absent keys (not empty string)${NC}"
 setup_fixture
 run_cli init ct-omit --work-type epic --description "Create topic" >/dev/null 2>&1
-run_cli create-topic ct-omit.thread --routing research --source incoming:perf >/dev/null 2>&1
+run_cli create-discovery-topic ct-omit.thread --routing research --source incoming:perf >/dev/null 2>&1
 assert_equals "$(run_cli_stdout exists ct-omit.discovery.thread summary)" "false" "summary key absent when omitted"
 assert_equals "$(run_cli_stdout exists ct-omit.discovery.thread description)" "false" "description key absent when omitted"
 
 echo ""
 
-echo -e "${YELLOW}Test: create-topic rejects duplicate discovery item${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic rejects duplicate discovery item${NC}"
 setup_fixture
 run_cli init ct-dup --work-type epic --description "Create topic" >/dev/null 2>&1
-run_cli create-topic ct-dup.auth --routing discussion --source x >/dev/null 2>&1
-assert_exit_nonzero "duplicate discovery item rejected" create-topic ct-dup.auth --routing discussion --source y
+run_cli create-discovery-topic ct-dup.auth --routing discussion --source x >/dev/null 2>&1
+assert_exit_nonzero "duplicate discovery item rejected" create-discovery-topic ct-dup.auth --routing discussion --source y
 
 echo ""
 
-echo -e "${YELLOW}Test: create-topic rejects when phase item already exists${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic rejects when phase item already exists${NC}"
 setup_fixture
 run_cli init ct-dupphase --work-type epic --description "Create topic" >/dev/null 2>&1
 # Phase item present, discovery item absent → duplicate-phase guard must fire.
 run_cli init-phase ct-dupphase.discussion.auth >/dev/null 2>&1
-assert_exit_nonzero "duplicate phase item rejected" create-topic ct-dupphase.auth --phase discussion --routing discussion --source x
+assert_exit_nonzero "duplicate phase item rejected" create-discovery-topic ct-dupphase.auth --phase discussion --routing discussion --source x
 
 echo ""
 
-echo -e "${YELLOW}Test: create-topic requires --routing and --source${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic requires --routing and --source${NC}"
 setup_fixture
 run_cli init ct-req --work-type epic --description "Create topic" >/dev/null 2>&1
-assert_exit_nonzero "missing --routing rejected" create-topic ct-req.foo --source x
-assert_exit_nonzero "missing --source rejected" create-topic ct-req.bar --routing research
+assert_exit_nonzero "missing --routing rejected" create-discovery-topic ct-req.foo --source x
+assert_exit_nonzero "missing --source rejected" create-discovery-topic ct-req.bar --routing research
 
 echo ""
 
-echo -e "${YELLOW}Test: create-topic validates --routing and --phase values${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic validates --routing and --phase values${NC}"
 setup_fixture
 run_cli init ct-val --work-type epic --description "Create topic" >/dev/null 2>&1
-assert_exit_nonzero "invalid --routing rejected" create-topic ct-val.foo --routing planning --source x
-assert_exit_nonzero "invalid --phase rejected" create-topic ct-val.bar --phase planning --routing research --source x
+assert_exit_nonzero "invalid --routing rejected" create-discovery-topic ct-val.foo --routing planning --source x
+assert_exit_nonzero "invalid --phase rejected" create-discovery-topic ct-val.bar --phase planning --routing research --source x
 
 echo ""
 
-echo -e "${YELLOW}Test: create-topic rejects three-segment path${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic rejects three-segment path${NC}"
 setup_fixture
 run_cli init ct-path --work-type epic --description "Create topic" >/dev/null 2>&1
-assert_exit_nonzero "three-segment path rejected" create-topic ct-path.discussion.foo --routing research --source x
+assert_exit_nonzero "three-segment path rejected" create-discovery-topic ct-path.discussion.foo --routing research --source x
 
 echo ""
 
-echo -e "${YELLOW}Test: create-topic is atomic — a failing run leaves the manifest unchanged${NC}"
+echo -e "${YELLOW}Test: create-discovery-topic is atomic — a failing run leaves the manifest unchanged${NC}"
 setup_fixture
 run_cli init ct-atomic --work-type epic --description "Create topic" >/dev/null 2>&1
 run_cli init-phase ct-atomic.discussion.auth >/dev/null 2>&1
@@ -796,9 +796,9 @@ before=$(cat "$TEST_DIR/.workflows/ct-atomic/manifest.json")
 # Discovery item does not exist yet, but the discussion phase item does → the
 # duplicate-phase guard fires AFTER the discovery existence check but BEFORE any
 # write. The discovery item must NOT be left behind.
-run_cli create-topic ct-atomic.auth --phase discussion --routing discussion --source x >/dev/null 2>&1 || true
+run_cli create-discovery-topic ct-atomic.auth --phase discussion --routing discussion --source x >/dev/null 2>&1 || true
 after=$(cat "$TEST_DIR/.workflows/ct-atomic/manifest.json")
-assert_equals "$after" "$before" "manifest byte-identical after failed create-topic"
+assert_equals "$after" "$before" "manifest byte-identical after failed create-discovery-topic"
 assert_equals "$(run_cli_stdout exists ct-atomic.discovery.auth)" "false" "no half-built discovery item after failure"
 
 echo ""

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -710,6 +710,100 @@ assert_exit_nonzero "Invalid phase in init-phase rejected" init-phase bad-phase-
 echo ""
 
 # ============================================================================
+# CREATE-TOPIC TESTS
+# ============================================================================
+
+echo -e "${YELLOW}Test: create-topic full spawn (with --phase) creates both items${NC}"
+setup_fixture
+run_cli init ct-full --work-type epic --description "Create topic" >/dev/null 2>&1
+output=$(run_cli create-topic ct-full.auth --phase discussion --routing discussion --source "incoming:billing" --summary "Auth concern" --description "Longer context")
+assert_contains "$output" "Created topic" "create-topic full spawn reports creation"
+assert_equals "$(run_cli_stdout get ct-full.discovery.auth status)" "in-progress" "discovery item status in-progress"
+assert_equals "$(run_cli_stdout get ct-full.discovery.auth routing)" "discussion" "discovery item routing set"
+assert_equals "$(run_cli_stdout get ct-full.discovery.auth source)" "incoming:billing" "discovery item source set"
+assert_equals "$(run_cli_stdout get ct-full.discovery.auth summary)" "Auth concern" "discovery item summary set"
+assert_equals "$(run_cli_stdout get ct-full.discovery.auth description)" "Longer context" "discovery item description set"
+assert_equals "$(run_cli_stdout get ct-full.discussion.auth status)" "in-progress" "phase item status in-progress"
+# Phase item carries status only — no descriptor fields leak onto it.
+assert_equals "$(run_cli_stdout exists ct-full.discussion.auth routing)" "false" "phase item has no routing field"
+
+echo ""
+
+echo -e "${YELLOW}Test: create-topic discovery-only (no --phase) creates only discovery item${NC}"
+setup_fixture
+run_cli init ct-disc --work-type epic --description "Create topic" >/dev/null 2>&1
+run_cli create-topic ct-disc.search --routing research --source direct-start >/dev/null 2>&1
+assert_equals "$(run_cli_stdout get ct-disc.discovery.search routing)" "research" "discovery-only routing set"
+assert_equals "$(run_cli_stdout get ct-disc.discovery.search source)" "direct-start" "discovery-only source set"
+assert_equals "$(run_cli_stdout exists ct-disc.research.search)" "false" "no phase item created without --phase"
+
+echo ""
+
+echo -e "${YELLOW}Test: create-topic omits summary/description as absent keys (not empty string)${NC}"
+setup_fixture
+run_cli init ct-omit --work-type epic --description "Create topic" >/dev/null 2>&1
+run_cli create-topic ct-omit.thread --routing research --source incoming:perf >/dev/null 2>&1
+assert_equals "$(run_cli_stdout exists ct-omit.discovery.thread summary)" "false" "summary key absent when omitted"
+assert_equals "$(run_cli_stdout exists ct-omit.discovery.thread description)" "false" "description key absent when omitted"
+
+echo ""
+
+echo -e "${YELLOW}Test: create-topic rejects duplicate discovery item${NC}"
+setup_fixture
+run_cli init ct-dup --work-type epic --description "Create topic" >/dev/null 2>&1
+run_cli create-topic ct-dup.auth --routing discussion --source x >/dev/null 2>&1
+assert_exit_nonzero "duplicate discovery item rejected" create-topic ct-dup.auth --routing discussion --source y
+
+echo ""
+
+echo -e "${YELLOW}Test: create-topic rejects when phase item already exists${NC}"
+setup_fixture
+run_cli init ct-dupphase --work-type epic --description "Create topic" >/dev/null 2>&1
+# Phase item present, discovery item absent → duplicate-phase guard must fire.
+run_cli init-phase ct-dupphase.discussion.auth >/dev/null 2>&1
+assert_exit_nonzero "duplicate phase item rejected" create-topic ct-dupphase.auth --phase discussion --routing discussion --source x
+
+echo ""
+
+echo -e "${YELLOW}Test: create-topic requires --routing and --source${NC}"
+setup_fixture
+run_cli init ct-req --work-type epic --description "Create topic" >/dev/null 2>&1
+assert_exit_nonzero "missing --routing rejected" create-topic ct-req.foo --source x
+assert_exit_nonzero "missing --source rejected" create-topic ct-req.bar --routing research
+
+echo ""
+
+echo -e "${YELLOW}Test: create-topic validates --routing and --phase values${NC}"
+setup_fixture
+run_cli init ct-val --work-type epic --description "Create topic" >/dev/null 2>&1
+assert_exit_nonzero "invalid --routing rejected" create-topic ct-val.foo --routing planning --source x
+assert_exit_nonzero "invalid --phase rejected" create-topic ct-val.bar --phase planning --routing research --source x
+
+echo ""
+
+echo -e "${YELLOW}Test: create-topic rejects three-segment path${NC}"
+setup_fixture
+run_cli init ct-path --work-type epic --description "Create topic" >/dev/null 2>&1
+assert_exit_nonzero "three-segment path rejected" create-topic ct-path.discussion.foo --routing research --source x
+
+echo ""
+
+echo -e "${YELLOW}Test: create-topic is atomic — a failing run leaves the manifest unchanged${NC}"
+setup_fixture
+run_cli init ct-atomic --work-type epic --description "Create topic" >/dev/null 2>&1
+run_cli init-phase ct-atomic.discussion.auth >/dev/null 2>&1
+before=$(cat "$TEST_DIR/.workflows/ct-atomic/manifest.json")
+# Discovery item does not exist yet, but the discussion phase item does → the
+# duplicate-phase guard fires AFTER the discovery existence check but BEFORE any
+# write. The discovery item must NOT be left behind.
+run_cli create-topic ct-atomic.auth --phase discussion --routing discussion --source x >/dev/null 2>&1 || true
+after=$(cat "$TEST_DIR/.workflows/ct-atomic/manifest.json")
+assert_equals "$after" "$before" "manifest byte-identical after failed create-topic"
+assert_equals "$(run_cli_stdout exists ct-atomic.discovery.auth)" "false" "no half-built discovery item after failure"
+
+echo ""
+
+# ============================================================================
 # PUSH TESTS
 # ============================================================================
 

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -716,11 +716,11 @@ echo ""
 echo -e "${YELLOW}Test: create-discovery-topic full spawn (with --phase) creates both items${NC}"
 setup_fixture
 run_cli init ct-full --work-type epic --description "Create topic" >/dev/null 2>&1
-output=$(run_cli create-discovery-topic ct-full.auth --phase discussion --routing discussion --source "incoming:billing" --summary "Auth concern" --description "Longer context")
+output=$(run_cli create-discovery-topic ct-full.auth --phase discussion --routing discussion --source "reroute:billing" --summary "Auth concern" --description "Longer context")
 assert_contains "$output" "Created topic" "create-discovery-topic full spawn reports creation"
 assert_equals "$(run_cli_stdout get ct-full.discovery.auth status)" "in-progress" "discovery item status in-progress"
 assert_equals "$(run_cli_stdout get ct-full.discovery.auth routing)" "discussion" "discovery item routing set"
-assert_equals "$(run_cli_stdout get ct-full.discovery.auth source)" "incoming:billing" "discovery item source set"
+assert_equals "$(run_cli_stdout get ct-full.discovery.auth source)" "reroute:billing" "discovery item source set"
 assert_equals "$(run_cli_stdout get ct-full.discovery.auth summary)" "Auth concern" "discovery item summary set"
 assert_equals "$(run_cli_stdout get ct-full.discovery.auth description)" "Longer context" "discovery item description set"
 assert_equals "$(run_cli_stdout get ct-full.discussion.auth status)" "in-progress" "phase item status in-progress"
@@ -742,7 +742,7 @@ echo ""
 echo -e "${YELLOW}Test: create-discovery-topic omits summary/description as absent keys (not empty string)${NC}"
 setup_fixture
 run_cli init ct-omit --work-type epic --description "Create topic" >/dev/null 2>&1
-run_cli create-discovery-topic ct-omit.thread --routing research --source incoming:perf >/dev/null 2>&1
+run_cli create-discovery-topic ct-omit.thread --routing research --source reroute:perf >/dev/null 2>&1
 assert_equals "$(run_cli_stdout exists ct-omit.discovery.thread summary)" "false" "summary key absent when omitted"
 assert_equals "$(run_cli_stdout exists ct-omit.discovery.thread description)" "false" "description key absent when omitted"
 


### PR DESCRIPTION
Foundation PR for the **Incoming** feature (off-topic concern surfacing + shared topic-creation infra). Based on `main`.

This PR carries the one solid, self-contained piece of the work plus the durable planning artefacts. The rest of the feature (the skill-file work) was binned for not meeting the project's authoring conventions and will be redone cleanly, one PR at a time, per the corrected plan included here.

## Contents

**Code (verify by running tests, no prose review needed):**
- `create-topic` — atomic CLI command in `manifest.cjs` (one locked read→mutate→write, mirrors `cmdInitPhase`). Creates the discovery item (`routing`/`source` required, `summary`/`description` omittable) and optionally a `--phase` item; errors if either target exists, checked before any write. Two-segment `wu.topic` path documented in the doc comment.
- Tests in `tests/scripts/test-workflow-manifest.sh` — full-spawn, discovery-only, omitted-field, duplicate-discovery/phase, missing-flag, bad-value, three-segment rejection, atomicity. Suite green (277).
- `workflow-manifest/SKILL.md` API entry.

**Docs (`incoming/`):**
- `plan-original.md` — the approved plan, copied **verbatim** so it survives context loss.
- `design.md` — design log with decisions taken during the first attempt.
- `plan.md` — corrected, execution-ready delta: the fixes we found (no reopen guard, dropped `session NNN`, null `current_phase` handling, output-var naming, drain commit/placement) plus the convention discipline for the redo.

## Why the rest was binned

The skill-file PRs inlined conditionals into prose and over-explained against the project's authoring conventions. Rather than review/patch a mess, that work is dropped and re-specified in `incoming/plan.md` for a disciplined redo. The design thinking is preserved in the three docs above — nothing was lost except the bad prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#360** 👈 current
2. #366
3. #367
4. #368
5. #369
6. #370
7. #371
<!-- stack:links:end -->