### PR TITLE
PR 2 — create-topic.md shared ref + migrate full-spawn sites

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -169,41 +169,28 @@ During organic discussion, a subtopic may grow beyond the scope of the current t
 
 #### If `elevate`
 
-1. Pick a kebab-case name reflecting the elevated concern. Surface it to the user for confirmation. Then validate:
-
-   → Load **[topic-name-validation.md](../../workflow-shared/references/topic-name-validation.md)** with work_unit = `{work_unit}`, proposed_name = `{new-topic}`.
-
-   On `collision-active`, re-prompt for an alternative and re-validate — loop until `ok` or `matches-dismissed`, or the user cancels the elevation. On `matches-dismissed`, proceed (the dismissed entry is pulled in step 4). On `ok`, proceed.
+1. Pick a kebab-case name reflecting the elevated concern. Surface it to the user for confirmation.
 
 2. Generate a one-sentence summary of the elevated concern (drawn from the context that triggered elevation). This becomes the discovery item's `summary` field. Generate a paragraph or two of richer context in the same turn — this becomes the `description` field, loaded by discussion-entry as opening context when the user later picks the elevated topic up.
 
-3. Create the seed discussion file at `.workflows/{work_unit}/discussion/{new-topic}.md` with:
+3. → Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new-topic}`, phase = `discussion`, routing = `discussion`, source = `discussion-elevation:{topic}`, summary = `{summary}`, description = `{description}`.
+
+   `routing: discussion` because elevation fires inside a discussion session. `source: discussion-elevation:{topic}` is historical provenance; no cascade.
+
+   **If `result` is `cancelled`:** the user dropped the elevation — nothing was written.
+
+   → Return to **B. Session Loop**.
+
+   **Otherwise** the topic was created (`{created_topic}` holds the validated name). Continue.
+
+4. Create the seed discussion file at `.workflows/{work_unit}/discussion/{created_topic}.md` with:
    - Context section capturing what prompted the topic and any initial thinking from the current discussion
    - A Discussion Map with initial subtopics derived from what's been discussed so far
    - No decisions — those happen in the new discussion
 
-4. Write manifest items — discussion first, then discovery. If validation returned `matches-dismissed`, pull from the dismissed list first:
+5. Update the current Discussion Map — replace the subtopic row with `↑ Elevated: {created_topic:(titlecase)}` in the same slot (same branch, same gutter if it was a child). See **E. Status Display** for the marker rules.
 
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{new-topic}"
-   ```
-
-   Then:
-
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discussion.{new-topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{new-topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new-topic} routing discussion
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new-topic} summary "{one-line summary}"
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new-topic} description "{paragraphs}"
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new-topic} source "discussion-elevation:{topic}"
-   ```
-
-   `routing: discussion` because elevation fires inside a discussion session. `source: discussion-elevation:{parent_topic}` is historical provenance; no cascade.
-
-5. Update the current Discussion Map — replace the subtopic row with `↑ Elevated: {new-topic:(titlecase)}` in the same slot (same branch, same gutter if it was a child). See **E. Status Display** for the marker rules.
-
-6. Commit: `discussion({work_unit}/{topic}): elevate {new-topic} to separate discussion`
+6. Commit: `discussion({work_unit}/{topic}): elevate {created_topic} to separate discussion`
 
 → Return to **B. Session Loop**.
 

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -37,34 +37,19 @@ Want to split these into separate research files?
 
 For each split topic:
 
-1. Pick a kebab-case name from the thread's content (e.g. `image-moderation`, `kitchen-utensils`). Surface it to the user for confirmation. Then validate:
+1. Pick a kebab-case name from the thread's content (e.g. `image-moderation`, `kitchen-utensils`). Surface it to the user for confirmation.
 
-   → Load **[topic-name-validation.md](../../workflow-shared/references/topic-name-validation.md)** with work_unit = `{work_unit}`, proposed_name = `{new_topic}`.
+2. Generate a one-sentence summary of the extracted content (drawn from the thread itself). This becomes the discovery item's `summary` field, used in map renders. Generate a paragraph or two of richer context in the same turn — this becomes the `description` field, loaded by entry skills as opening context when the user later picks the topic up.
 
-   On `collision-active`, re-prompt for an alternative and re-validate — loop until `ok` or `matches-dismissed`, or the user abandons this thread. On `matches-dismissed`, proceed (the dismissed entry is pulled in step 4). On `ok`, proceed.
-
-2. Create `.workflows/{work_unit}/research/{new_topic}.md` using **[template.md](template.md)**. Move content verbatim from the source file — reword only for flow and readability, no summarisation. Remove the extracted content from the source file.
-
-3. Generate a one-sentence summary of the extracted content (drawn from the thread itself). This becomes the discovery item's `summary` field, used in map renders. Generate a paragraph or two of richer context in the same turn — this becomes the `description` field, loaded by entry skills as opening context when the user later picks the topic up.
-
-4. Write manifest items — research first, then discovery. If the validation returned `matches-dismissed`, pull from the dismissed list first:
-
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{new_topic}"
-   ```
-
-   Then:
-
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.research.{new_topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{new_topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new_topic} routing research
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new_topic} summary "{one-line summary}"
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new_topic} description "{paragraphs}"
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new_topic} source "research-split:{parent_topic}"
-   ```
+3. → Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new_topic}`, phase = `research`, routing = `research`, source = `research-split:{parent_topic}`, summary = `{summary}`, description = `{description}`.
 
    `routing: research` because the split fires inside a research session — research is where the new topic enters the pipeline. `source: research-split:{parent_topic}` is historical provenance; the parent's later state changes don't cascade.
+
+   **If `result` is `cancelled`:** the user abandoned this thread — nothing was written. Skip it and continue with the next thread.
+
+   **Otherwise** the topic was created (`{created_topic}` holds the validated name). Continue.
+
+4. Create `.workflows/{work_unit}/research/{created_topic}.md` using **[template.md](template.md)**. Move content verbatim from the source file — reword only for flow and readability, no summarisation. Remove the extracted content from the source file.
 
 Once all accepted threads have been processed, single commit covering the manifest writes and the new research files:
 

--- a/skills/workflow-shared/references/create-topic.md
+++ b/skills/workflow-shared/references/create-topic.md
@@ -1,0 +1,94 @@
+# Create Topic
+
+*Shared reference. Loaded by `workflow-discussion-process`, `workflow-research-process`, `workflow-discovery`, and any flow that adds a topic to an epic's discovery map.*
+
+---
+
+Validates a proposed topic name, clears any matching dismissed entry, and atomically creates the discovery-map item (and, when a phase is given, that phase's item). The caller has already picked the name and generated any summary/description — this reference owns the validate → pull → create core only. It writes the manifest but does **not** commit; the caller's commit covers the manifest writes alongside the artefact it creates.
+
+## Parameters
+
+The caller provides these via context before loading:
+
+- `work_unit` — the epic's work unit name. Always present.
+- `proposed_name` — the caller's kebab-case topic name. May change if the validation loop re-prompts.
+- `routing` — the literal `research` or `discussion` (the discovery item's initial intent).
+- `source` — the provenance string written to the discovery item (e.g. `discussion-elevation:{parent}`, `research-split:{parent}`, `direct-start`, `incoming:{origin}`).
+- `phase` — optional. The literal `research` or `discussion` to also create a phase item. Omit to create the discovery item only.
+- `summary` — optional one-line summary for the discovery item.
+- `description` — optional paragraph or two of richer context for the discovery item.
+
+After return, the caller reads these from conversation memory:
+
+- `result` — `created` (manifest written, dirty, ready for the caller's commit) or `cancelled` (nothing written; caller handles abandonment).
+- `created_topic` — the final validated topic name (the caller uses it for the artefact path, marker, and commit).
+
+## A. Validate the Name
+
+→ Load **[topic-name-validation.md](topic-name-validation.md)** with work_unit = `{work_unit}`, proposed_name = `{proposed_name}`.
+
+Read `result` from the validation reference.
+
+#### If `result` is `collision-active`
+
+The name is taken. Re-prompt the user for an alternative, then re-validate.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+That name is already on the map.
+
+- **`c`/`cancel`** — Drop this topic
+- **Pick another** — Tell me a different name to use
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `cancel`:**
+
+Set `result = "cancelled"`.
+
+→ Return to caller.
+
+**If pick another:**
+
+Set `proposed_name` to the user's name (normalised to kebab-case).
+
+→ Return to **A. Validate the Name**.
+
+#### Otherwise
+
+The validation returned `ok` or `matches-dismissed`. Set `created_topic` to the validated name.
+
+→ Proceed to **B. Clear Dismissed**.
+
+## B. Clear Dismissed
+
+User-explicit spawns bypass the dismissed list. Pull the name unconditionally — a no-op when it is absent or the list does not exist:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{created_topic}"
+```
+
+→ Proceed to **C. Create the Topic**.
+
+## C. Create the Topic
+
+Run `create-topic`. Include `--phase {phase}` only when `phase` is set; include `--summary` / `--description` only when those values are present:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-topic {work_unit}.{created_topic} \
+  --phase {phase} \
+  --routing {routing} \
+  --source "{source}" \
+  --summary "{summary}" \
+  --description "{description}"
+```
+
+The discovery item lands with `status`, `routing`, `source`, and any `summary`/`description`; `--phase` additionally creates that phase's item with status only. The write is atomic — a single locked write, no half-built state.
+
+Set `result = "created"`. The manifest is dirty; the caller's commit covers it.
+
+→ Return to caller.


### PR DESCRIPTION
Second PR in the **Incoming** stack (design log: #359). **Behaviour-preserving no-op refactor** — code moves, observable logic is unchanged.

Stacked on PR 1 (#360). Review against that branch.

## What changes

New `skills/workflow-shared/references/create-topic.md` encodes the topic-creation **core** once:
1. Name-validation loop (`topic-name-validation.md`, re-prompt on collision until ok / matches-dismissed / cancel)
2. Unconditional `pull dismissed` (idempotent)
3. The atomic `create-topic` CLI call (+ optional `--phase`)
4. No commit — returns dirty to the caller

Two **full-spawn** sites migrate onto it:
- `discussion-session.md` §F — topic elevation
- `topic-splitting.md` — research split

## What stays site-specific (not in the shared ref)

Name picking + confirmation, summary/description **generation**, artefact creation (split additionally moves content verbatim out of the source file), the `↑ Elevated:` marker, commit message + staged paths, and the split's post-action "which topic to continue with?" prompt.

## The single intentional consolidation (observably identical)

§F and research-split previously pulled dismissed **only** on `matches-dismissed`; the shared reference pulls **unconditionally**. This is observably identical — `pull` is a no-op when the name is absent, and on the `ok` path the name is never in the dismissed list.

## Notes for review

- The shared ref returns `created_topic` (the validated name) to avoid colliding with §F's `{topic}` (the parent).
- The only resulting-manifest difference is **non-semantic key order** on the discovery item (`status,routing,source,summary,description` from `create-topic` vs the old sequential `set` order). Values are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #360
2. **#361** 👈 current
3. #362
4. #363
5. #364
6. #365
<!-- stack:links:end -->