### PR TITLE
PR 3 — migrate discovery-only sites onto create-topic.md

### DIFF
--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -22,29 +22,17 @@ No new topics — this is an edits-only or browse-only session.
 
 For each topic on the working list, in synthesised order:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{topic}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} summary "{one-line summary}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} description "{paragraphs}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} routing {research|discussion}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} source discovery
-```
+→ Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{topic}`, routing = `{routing}`, source = `discovery`, summary = `{summary}`, description = `{description}`.
 
-The `pull` is a no-op if the name isn't in the dismissed list.
-
-Summary and description come from the synthesis — derived from the exploration in topic-synthesis. Quote shell values with single quotes if they contain `[]`, `{}`, `~`, or backticks. Description may span paragraphs.
-
-If any command fails, surface the error and stop before the commit so the user can recover.
+Summary and description come from the synthesis — derived from the exploration in topic-synthesis. Description may span paragraphs.
 
 Notes:
 
-- `init-phase` creates the item with `status: in-progress` automatically. Discovery items have no other valid status — do not pass `status` explicitly.
 - The topic name is the manifest dict key (third dot-path segment). There is no separate `name` field to set.
 - `routing` is the value confirmed by the user at the synthesis gate.
 - `source: discovery` marks topics the user surfaced during discovery, distinguishing them from items added later with other provenance (e.g. `research-analysis`, `gap-analysis`).
 
-→ Proceed to **B. Write Topics Identified**.
+Once every topic is persisted, → Proceed to **B. Write Topics Identified**.
 
 ## B. Write Topics Identified
 

--- a/skills/workflow-shared/references/analysis-approval-gate.md
+++ b/skills/workflow-shared/references/analysis-approval-gate.md
@@ -143,15 +143,9 @@ Revise this block's `routing`, `summary`, or `description` in the staging file p
 
 ## C. Write Approved Candidate
 
-Set this block's `status: approved` in the staging file, then write the discovery item from the block's stored fields:
+Set this block's `status: approved` in the staging file, then create the discovery item from the block's stored fields:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{name}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} summary "{summary}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} description "{description}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} routing {routing}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} source "{source}"
-```
+→ Load **[create-topic.md](create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{name}`, routing = `{routing}`, source = `{source}`, summary = `{summary}`, description = `{description}`.
 
 `source` is the block's stored value verbatim — `research-analysis:{parent}` for research-analysis (provenance renders as `from {parent}`), `gap-analysis` for gap-analysis.
 

--- a/skills/workflow-shared/references/create-topic.md
+++ b/skills/workflow-shared/references/create-topic.md
@@ -87,6 +87,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs create-topic {work_un
   --description "{description}"
 ```
 
+Single-quote any `--summary`/`--description` value that contains backticks, `$`, `[]`, `{}`, or `~` — they are shell-active inside the double quotes shown above.
+
 The discovery item lands with `status`, `routing`, `source`, and any `summary`/`description`; `--phase` additionally creates that phase's item with status only. The write is atomic — a single locked write, no half-built state.
 
 Set `result = "created"`. The manifest is dirty; the caller's commit covers it.

--- a/skills/workflow-shared/references/ensure-discovery-item.md
+++ b/skills/workflow-shared/references/ensure-discovery-item.md
@@ -45,54 +45,14 @@ The topic is already on the map. Nothing to do — fall through to the caller's 
 
 #### If output is empty (item does not exist)
 
-→ Proceed to **C. Check Dismissed and Pull**.
+→ Proceed to **C. Create Discovery Item**.
 
-## C. Check Dismissed and Pull
+## C. Create Discovery Item
 
-Most epics never dismiss anything, so the dismissed list is usually absent. Read it directly — empty stdout means the list is absent:
+The item does not exist. Create it via the shared topic-creation core, which pulls the name from the dismissed list (a no-op when absent) and writes the discovery item atomically. Pass `summary`/`description` only when the caller supplied non-empty values — omit the parameter otherwise so the key is left absent:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery dismissed
-```
+→ Load **[create-topic.md](create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{topic}`, routing = `{routing}`, source = `direct-start`, summary = `{summary}`, description = `{description}`.
 
-#### If output is empty (no dismissed list)
-
-Nothing to pull.
-
-→ Proceed to **D. Create Discovery Item**.
-
-#### Otherwise
-
-If `{topic}` appears in the returned JSON array, pull it (user-explicit spawns bypass dismissal):
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{topic}"
-```
-
-→ Proceed to **D. Create Discovery Item**.
-
-## D. Create Discovery Item
-
-Initialise the item and set provenance fields:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} routing {routing}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} source direct-start
-```
-
-If `summary` was supplied and is non-empty, write it:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} summary "{summary}"
-```
-
-If `description` was supplied and is non-empty, write it (multi-paragraph values are fine):
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} description "{description}"
-```
-
-No commit here — the manifest writes are folded into the next commit produced by the calling phase's process.
+No commit here — the manifest write is folded into the next commit produced by the calling phase's process.
 
 → Return to caller.


### PR DESCRIPTION
Third PR in the **Incoming** stack (design log: #359). **Behaviour-preserving no-op refactor.** Stacked on PR 2 (#361).

## What changes

The three sites that create a discovery item **without** a phase item now route through the shared `create-topic.md` core:
- `workflow-discovery/references/confirm-and-persist.md` — discovery synthesis batch write
- `workflow-shared/references/ensure-discovery-item.md` — direct-entry (keeps its existence-gate / work-type no-op; only the create step moves)
- `workflow-shared/references/analysis-approval-gate.md` — approved analysis candidates

## Why it's behaviour-preserving

At each site the name is already fresh or de-duped before the create step:
- **analysis-approval-gate** resolves on-map and dismissed cases silently at *stage* time — they never reach the gate.
- **confirm-and-persist** writes freshly-synthesised topics that aren't on the map yet.
- **ensure-discovery-item** guards on existence first (no-op early return) before creating.

So the shared validation loop returns `ok` and never re-prompts — the only behavioural addition is the **unconditional dismissed-pull no-op** (same consolidation noted in PR 2).

## Bonus from atomicity

`confirm-and-persist.md` drops its *"If any command fails… stop before the commit so the user can recover"* prose — the half-built-topic hazard it guarded against is gone now the write is atomic. Also carries confirm-and-persist's shell-quoting safety note into the shared reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #360
2. #361
3. **#362** 👈 current
4. #363
5. #364
6. #365
<!-- stack:links:end -->