### PR TITLE
PR 5 — Incoming landing + trigger wiring

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -144,61 +144,90 @@ Don't render the map after every exchange — do it at meaningful transitions. I
 
 ---
 
-## F. Topic Elevation
+## F. Off-Topic Concerns
 
-**This section applies to epic work types only.** For features and bugfixes (single-topic), subtopics stay on the map regardless of scope. Note any out-of-scope concerns in the Summary section for the user to consider separately.
+During organic discussion a concern may surface that doesn't belong under the current topic — a sibling that wants its own discussion now, or something that belongs to a different topic entirely.
 
-During organic discussion, a subtopic may grow beyond the scope of the current topic — it starts needing its own decisions, its own options exploration, its own trade-offs. When this happens, it's a sibling topic, not a subtopic.
+**Heuristic**: If a concern would need its own set of decisions, its own perspective agents, its own full exploration — it's a sibling. If it belongs to a *different* topic but isn't ready to spin off, it's an Incoming concern — note it against that topic for it to pick up later. If it's a detail that informs a decision within the current topic — it's a subtopic. Example: "How do we handle token refresh?" within an auth discussion = subtopic. "What's our caching strategy?" surfacing during auth because tokens need caching = sibling.
 
-**Heuristic**: If a concern would need its own set of decisions, its own perspective agents, its own full exploration — it's a sibling. If it's a detail that informs a decision within the current topic — it's a subtopic. Example: "How do we handle token refresh?" within an auth discussion = subtopic. "What's our caching strategy?" surfacing during auth because tokens need caching = sibling.
+#### If work type is not `epic`
 
-**When you identify a potential sibling:**
+Single-topic work types (feature, bugfix, quick-fix) have no sibling map — the topic *is* the work unit.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-**{concern}** is expanding beyond a subtopic — it has its own decisions and trade-offs.
+**{concern}** is beyond this topic's scope.
 
-- **`e`/`elevate`** — Seed as a separate discussion topic
+- **`l`/`log`** — Capture it as an idea in the inbox for later
+- **`p`/`pivot`** — Convert this work to an epic so it can hold the concern as its own topic
+- **`i`/`ignore`** — Note it in the Summary and move on
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `log`:** capture the concern via the `workflow-log-idea` skill so it lands in the inbox for later triage. → Return to **B. Session Loop**.
+
+**If `pivot`:** note the concern in the Summary so it isn't lost, then tell the user they can pivot this work to an epic from the manage menu (`p`/`pivot`) and route the concern as a topic from there. → Return to **B. Session Loop**.
+
+**If `ignore`:** note the concern in the Summary section for the user to consider separately, and continue. → Return to **B. Session Loop**.
+
+#### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**{concern}** is beyond this subtopic's scope.
+
+- **`e`/`elevate`** — Spin it off into its own discussion now
+- **`i`/`incoming`** — Note it against the topic it belongs to, for that topic to pick up later
 - **`k`/`keep`** — Keep it as a subtopic here
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-#### If `elevate`
+**If `elevate`:**
 
 1. Pick a kebab-case name reflecting the elevated concern. Surface it to the user for confirmation.
 
 2. Generate a one-sentence summary of the elevated concern (drawn from the context that triggered elevation). This becomes the discovery item's `summary` field. Generate a paragraph or two of richer context in the same turn — this becomes the `description` field, loaded by discussion-entry as opening context when the user later picks the elevated topic up.
 
-3. → Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new-topic}`, phase = `discussion`, routing = `discussion`, source = `discussion-elevation:{topic}`, summary = `{summary}`, description = `{description}`.
+3. Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new-topic}`, phase = `discussion`, routing = `discussion`, source = `discussion-elevation:{topic}`, summary = `{summary}`, description = `{description}`. `routing: discussion` because elevation fires inside a discussion session; `source: discussion-elevation:{topic}` is historical provenance, no cascade. If it returns `cancelled`, the user dropped the elevation — → Return to **B. Session Loop**. Otherwise `{created_topic}` holds the validated name; continue.
 
-   `routing: discussion` because elevation fires inside a discussion session. `source: discussion-elevation:{topic}` is historical provenance; no cascade.
-
-   **If `result` is `cancelled`:** the user dropped the elevation — nothing was written.
-
-   → Return to **B. Session Loop**.
-
-   **Otherwise** the topic was created (`{created_topic}` holds the validated name). Continue.
-
-4. Create the seed discussion file at `.workflows/{work_unit}/discussion/{created_topic}.md` with:
-   - Context section capturing what prompted the topic and any initial thinking from the current discussion
-   - A Discussion Map with initial subtopics derived from what's been discussed so far
-   - No decisions — those happen in the new discussion
+4. Create the seed discussion file at `.workflows/{work_unit}/discussion/{created_topic}.md` with a Context section capturing what prompted the topic, a Discussion Map with initial subtopics derived from what's been discussed so far, and no decisions (those happen in the new discussion).
 
 5. Update the current Discussion Map — replace the subtopic row with `↑ Elevated: {created_topic:(titlecase)}` in the same slot (same branch, same gutter if it was a child). See **E. Status Display** for the marker rules.
 
-6. Commit: `discussion({work_unit}/{topic}): elevate {created_topic} to separate discussion`
+6. Commit: `discussion({work_unit}/{topic}): elevate {created_topic} to separate discussion`.
 
 → Return to **B. Session Loop**.
 
-#### If `keep`
+**If `incoming`:**
 
-Leave it as a subtopic on the map.
+1. Identify the topic the concern belongs to. Read the live map:
+
+   ```bash
+   node .claude/skills/workflow-discovery/scripts/discovery.cjs {work_unit}
+   ```
+
+   Propose the matching existing topic, or a new kebab-case name when none fits, and confirm the target with the user. If the target is the current topic (`{topic}`), it's a detail of this discussion, not Incoming — add it to the Discussion Map as a `pending` subtopic and → Return to **B. Session Loop**.
+
+2. Load **[incoming-landing.md](../../workflow-shared/references/incoming-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{concern}`, origin = `{topic}`, phase = `discussion`, date = `{today}`. If it returns `cancelled`, nothing landed — → Return to **B. Session Loop**. Otherwise the concern landed in `{landed_topic}`'s `## Incoming`.
+
+3. The current Discussion Map is unchanged — Incoming routes the concern away from this topic, it doesn't mark it. Commit:
+
+   ```bash
+   git add -- .workflows/{work_unit}/
+   git commit -m "discussion({work_unit}/{topic}): route concern to {landed_topic} incoming"
+   ```
 
 → Return to **B. Session Loop**.
+
+**If `keep`:** leave it as a subtopic on the map. → Return to **B. Session Loop**.
 
 ---
 

--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -24,7 +24,43 @@ Per-topic session with topic awareness and convergence routing.
 
 ## C. Topic Awareness
 
-When working in a specific topic file and content drifts to another topic's scope, flag it and offer to switch to that topic's file or note it for later. Don't silently let content accumulate in the wrong file.
+When a concern surfaces that belongs to a *different* topic — raised in conversation, not yet written into this file — flag it rather than letting it accumulate here. (Sustained *written* drift over multiple exchanges is the separate split signal — see **D. Convergence Routing**.)
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**{concern}** belongs to a different topic, not this one.
+
+- **`i`/`incoming`** — Note it against that topic for it to pick up later
+- **`k`/`keep`** — Keep exploring here for now
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `incoming`:**
+
+1. Identify the topic the concern belongs to. Read the live map:
+
+   ```bash
+   node .claude/skills/workflow-discovery/scripts/discovery.cjs {work_unit}
+   ```
+
+   Propose the matching existing topic, or a new kebab-case name when none fits, and confirm the target with the user. If the target is the current topic, it's not Incoming — fold it into this research file as a thread and → Return to **B. Session Loop**.
+
+2. Load **[incoming-landing.md](../../workflow-shared/references/incoming-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{concern}`, origin = `{topic}`, phase = `research`, date = `{today}`. If it returns `cancelled`, nothing landed — → Return to **B. Session Loop**. Otherwise the concern landed in `{landed_topic}`'s `## Incoming`.
+
+3. Commit:
+
+   ```bash
+   git add -- .workflows/{work_unit}/
+   git commit -m "research({work_unit}/{topic}): route concern to {landed_topic} incoming"
+   ```
+
+→ Return to **B. Session Loop**.
+
+**If `keep`:** keep exploring here. If written material keeps accumulating off-topic over multiple exchanges, the split path in **D. Convergence Routing** moves it out. → Return to **B. Session Loop**.
 
 ---
 

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -66,3 +66,29 @@ Check for agent completion. When all agents have returned, delegate surfacing to
 → Load **[topic-completion.md](topic-completion.md)** and follow its instructions as written.
 
 → Return to **B. Session Loop**.
+
+---
+
+## E. Off-Topic Concerns
+
+When a concern surfaces that's beyond this topic's scope, a single-topic work type has no other topic to route it to.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**{concern}** is beyond this topic's scope.
+
+- **`l`/`log`** — Capture it as an idea in the inbox for later
+- **`p`/`pivot`** — Convert this work to an epic so it can hold the concern as its own topic
+- **`i`/`ignore`** — Note it in the research file and move on
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `log`:** capture the concern via the `workflow-log-idea` skill so it lands in the inbox for later triage. → Return to **B. Session Loop**.
+
+**If `pivot`:** note the concern in the research file so it isn't lost, then tell the user they can pivot this work to an epic from the manage menu (`p`/`pivot`) and route the concern as a topic from there. → Return to **B. Session Loop**.
+
+**If `ignore`:** note the concern in the research file for the user to consider separately, and continue. → Return to **B. Session Loop**.

--- a/skills/workflow-shared/references/incoming-landing.md
+++ b/skills/workflow-shared/references/incoming-landing.md
@@ -8,17 +8,23 @@ Lands an off-topic concern in a target topic's `## Incoming` section so the targ
 
 Epic-only. Single-topic work types (feature, bugfix, quick-fix) have no second topic to route to — their callers handle an off-topic concern by ignoring it, surfacing it to the inbox, or pivoting to an epic, and never load this reference.
 
+The caller has already confirmed the target is a **different** topic from the current one (a concern that belongs to the current topic is normal subtopic work, not Incoming). This reference writes the manifest and artefact but does **not** commit — the caller's commit covers them.
+
 ## Parameters
 
 The caller provides these via context before loading:
 
 - `work_unit` — the epic. Always present.
-- `target` — the destination topic the concern belongs to (may or may not exist yet).
+- `target` — the destination topic the concern belongs to (an existing map name, or a new kebab-case name the caller proposes).
 - `concern` — the off-topic concern as captured.
 - `origin` — the topic the concern surfaced in (the current session's topic).
-- `phase` — the current phase, `research` or `discussion` (recorded in the entry; also the `routing` for a target that has to be created).
-- `session` — the current session number.
+- `phase` — the current session's phase, `research` or `discussion` (recorded in the entry, and the routing for a brand-new target).
 - `date` — today's date.
+
+After return, the caller reads these from conversation memory:
+
+- `result` — `landed` (entry written; manifest/artefact dirty, ready for the caller's commit) or `cancelled` (a new target's name was dropped; nothing written).
+- `landed_topic` — the final target name (a new target may have been renamed during validation).
 
 ## Incoming Entry Shape
 
@@ -26,19 +32,93 @@ Each landed concern is appended to the target artefact's `## Incoming` section a
 
 ```
 ### {concern}
-*From: {origin} · {phase} · session {NNN} · {date}*
+*From: {origin} · {phase} · {date}*
 
 {concern as captured}
 ```
 
-## Behaviour Contract
+## A. Classify the Target
 
-Target resolution is computed against the **live** discovery map at landing time, never cached — a target elevated earlier in the same session must resolve correctly. Three cases, by the target's current lifecycle:
+Resolution is computed against the **live** map at landing time, never cached — a target elevated or created earlier in the same session must resolve correctly:
 
-- **New** (not on the map) — create the target via `create-topic` with `--phase {phase}` and `--source incoming:{origin}`, then create its artefact stub from the template carrying the entry.
-- **Fresh** (a discovery item exists but no phase work) — `init-phase` the target's phase per its `routing` and create the artefact stub. `create-topic` is **not** used here — it errors on the existing discovery item.
-- **In-flight or decided** (an artefact exists) — append the entry to its `## Incoming`. When the phase item is `completed`, also flip it back to `in-progress` (reopen) so the target recomputes to actionable.
+```bash
+node .claude/skills/workflow-discovery/scripts/discovery.cjs {work_unit}
+```
 
-If the resolved target **is the current topic itself**, this is not Incoming — the caller routes it to normal subtopic handling instead and never lands it. Incoming is strictly for a different target.
+Find the row whose `name` is `target` in `discovery_map`.
 
-The full case-by-case procedure and the trigger wiring that loads this reference are specified where the session flows invoke it.
+#### If no row matches
+
+The target is not on the map.
+
+→ Proceed to **B. New Target**.
+
+#### If the row's `lifecycle` is `fresh`
+
+A discovery item exists but no research or discussion work has started.
+
+→ Proceed to **C. Fresh Target**.
+
+#### Otherwise
+
+An artefact already exists (the row's `current_phase` names it).
+
+→ Proceed to **D. Existing Target**.
+
+## B. New Target
+
+Create the target via the shared topic-creation core, routed at the current phase:
+
+→ Load **[create-topic.md](create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{target}`, phase = `{phase}`, routing = `{phase}`, source = `incoming:{origin}`.
+
+**If `result` is `cancelled`:** the user dropped the new target — nothing was written.
+
+→ Return to caller.
+
+**Otherwise** the topic was created (`{created_topic}` holds the validated name). Set `landed_topic = {created_topic}`.
+
+Create the artefact stub at `.workflows/{work_unit}/{phase}/{created_topic}.md` from the `{phase}` template — [discussion template](../../workflow-discussion-process/references/template.md) or [research template](../../workflow-research-process/references/template.md). Write the concern into its `## Incoming` section using the entry shape above, replacing the `(none)` placeholder. Leave the rest of the stub as the bare template (its Context / Starting Point fill in when the target is picked up).
+
+Set `result = "landed"`.
+
+→ Return to caller.
+
+## C. Fresh Target
+
+The discovery item exists; read its `routing` from the map row. Create that phase's item:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.{routing}.{target}
+```
+
+Create the artefact stub at `.workflows/{work_unit}/{routing}/{target}.md` from the `{routing}` template — [discussion template](../../workflow-discussion-process/references/template.md) or [research template](../../workflow-research-process/references/template.md). Write the concern into its `## Incoming` section using the entry shape above, replacing the `(none)` placeholder.
+
+Set `landed_topic = {target}` and `result = "landed"`.
+
+→ Return to caller.
+
+## D. Existing Target
+
+The live artefact is the map row's `current_phase` file: `.workflows/{work_unit}/{current_phase}/{target}.md`.
+
+Append the concern as a `### {concern}` subsection under that file's `## Incoming` heading, using the entry shape above. If the section is the `(none)` placeholder, replace it with the entry; otherwise add the entry below the existing ones.
+
+#### If the row's `lifecycle` is `decided` or `ready_for_discussion`
+
+The `current_phase` item is `completed` — reopen it so the target recomputes to actionable:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{current_phase}.{target} status in-progress
+```
+
+→ Proceed to the return below.
+
+#### Otherwise
+
+The `current_phase` item is already `in-progress` — no reopen needed.
+
+→ Proceed to the return below.
+
+Set `landed_topic = {target}` and `result = "landed"`.
+
+→ Return to caller.


### PR DESCRIPTION
Fifth PR in the **Incoming** stack (design log: #359). New behaviour. Stacked on PR 4 (#363).

## What lands

**`incoming-landing.md` (full)** — the landing primitive. Classifies the target against the **live** discovery map at landing time (never cached), then:
- **New** (not on map) → `create-topic --phase {phase} --source incoming:{origin}` + artefact stub carrying the entry.
- **Fresh** (discovery item, no phase work) → `init-phase` per the item's `routing` + stub.
- **Existing** (`current_phase` artefact exists) → append the `### {concern}` entry to its `## Incoming`; if that phase item is `completed` (`decided` / `ready_for_discussion`), flip it to `in-progress` (reopen) so the target recomputes to actionable.

If the resolved target **is the current topic**, it's normal subtopic work — the caller folds it in and never lands.

**Trigger wiring:**
- `discussion-session.md` §F → "Off-Topic Concerns": **epic** offers `elevate` / `incoming` / `keep`; **non-epic** offers `log` (inbox via `workflow-log-idea`) / `pivot` / `ignore`.
- research `epic-session.md` §C offers `incoming` / `keep` for a *conversational* concern — kept distinct from §D's *written-drift* split.
- research `feature-session.md` gains the non-epic `log` / `pivot` / `ignore` handler.

Incoming routes a concern **away** from the current artefact — no elevation marker, no change to the current map. The target drains it when its phase next runs (PR 6).

## Deviation from plan (noted for the design log)

The pinned entry shape dropped `session {NNN}` — research and discussion track no session number anywhere, so the From line is `origin · phase · date`. Detection keys on the `## Incoming` heading + `(none)` placeholder + `### ` subsections, not the From line, so this is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #360
2. #361
3. #362
4. #363
5. **#364** 👈 current
6. #365
<!-- stack:links:end -->