### PR TITLE
PR 6 — drain + conclusion gate + reopen guard

### DIFF
--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -177,6 +177,8 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 > explore edge cases, and capture decisions as we go.
 ```
 
+Load **[drain-incoming.md](../workflow-shared/references/drain-incoming.md)** with work_unit = `{work_unit}`, topic = `{topic}`, phase = `discussion`.
+
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.
 
 *Knowledge-base nudge — before committing to a direction on a new subtopic, or when a decision might echo one made elsewhere, run a quick query. See **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)**.*

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -21,13 +21,27 @@ Conclude this discussion and mark as completed?
 
 #### If `yes`
 
-1. Ensure the Summary section is populated — Key Insights, Open Threads, Current State
-2. Set discussion status to completed via manifest CLI:
+1. **Incoming gate.** Read the `## Incoming` section of `.workflows/{work_unit}/discussion/{topic}.md`. If it is not exactly `(none)`, the topic has undrained concerns and cannot conclude:
+
+   > *Output the next fenced block as a code block:*
+
+   ```
+     ⚑ This discussion has undrained Incoming concerns.
+       Fold them into the Discussion Map and resolve them
+       before concluding.
+   ```
+
+   → Return to **[the skill](../SKILL.md)** for **Step 5**.
+
+   Otherwise the section is `(none)` — continue.
+
+2. Ensure the Summary section is populated — Key Insights, Open Threads, Current State
+3. Set discussion status to completed via manifest CLI:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discussion.{topic} status completed
    ```
-3. Final commit
-4. Index the completed artifact into the knowledge base:
+4. Final commit
+5. Index the completed artifact into the knowledge base:
 
 ```bash
 node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index .workflows/{work_unit}/discussion/{topic}.md
@@ -43,7 +57,31 @@ If the index command fails, display the error but do not block — the artifact 
   The artifact is saved. Indexing can be retried later.
 ```
 
-5. Invoke the bridge:
+Re-indexing a previously-concluded topic is safe — `index` replaces the topic's chunks rather than duplicating them.
+
+6. **Reopen-bridge guard.** Check whether any downstream phase already holds work for this topic:
+
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.specification.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.planning.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.implementation.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.review.{topic}
+   ```
+
+   **If any returns `true`:** this topic was concluded before, reopened by an Incoming landing, and is now re-concluding. A downstream phase already consumed the earlier conclusion — invoking the bridge re-enters it. Warn before proceeding:
+
+   > *Output the next fenced block as a code block:*
+
+   ```
+     ⚑ This topic already has downstream phase work.
+       Re-concluding re-triggers the pipeline bridge into it.
+       Review the downstream artefact against the new
+       decisions for consistency.
+   ```
+
+   **If all return `false`:** first conclusion — no downstream work. Continue.
+
+7. Invoke the bridge:
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -57,31 +57,9 @@ If the index command fails, display the error but do not block — the artifact 
   The artifact is saved. Indexing can be retried later.
 ```
 
-Re-indexing a previously-concluded topic is safe — `index` replaces the topic's chunks rather than duplicating them.
+Re-indexing a previously-concluded topic is safe — `index` replaces the topic's chunks rather than duplicating them. Re-concluding a topic that an Incoming concern reopened needs no special handling here: the specification phase already detects a regressed source and surfaces it as `[extracted, reopened]`, offering re-incorporation — the bridge re-firing into the epic menu is the designed path.
 
-6. **Reopen-bridge guard.** Check whether any downstream phase already holds work for this topic:
-
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.specification.{topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.planning.{topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.implementation.{topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.review.{topic}
-   ```
-
-   **If any returns `true`:** this topic was concluded before, reopened by an Incoming landing, and is now re-concluding. A downstream phase already consumed the earlier conclusion — invoking the bridge re-enters it. Warn before proceeding:
-
-   > *Output the next fenced block as a code block:*
-
-   ```
-     ⚑ This topic already has downstream phase work.
-       Re-concluding re-triggers the pipeline bridge into it.
-       Review the downstream artefact against the new
-       decisions for consistency.
-   ```
-
-   **If all return `false`:** first conclusion — no downstream work. Continue.
-
-7. Invoke the bridge:
+6. Invoke the bridge:
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -31,6 +31,7 @@ Pull the current state fresh into context — don't rely on your memory of what 
 - The **Discussion Map** and every subtopic's state
 - Each subtopic section (Context → Options → Journey → Decision)
 - The **Summary** section (Key Insights, Open Threads, Current State)
+- The **Incoming** section
 
 → Proceed to **B. Compare and Reconcile**.
 
@@ -44,11 +45,14 @@ Walk the conversation against the document and check three dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user pushback, competing options understated to make the chosen one look cleaner, or a subtopic marked `decided` on the Discussion Map when it was really `converging`. Check the Discussion Map itself for drift — child subtopics absorbed into a parent decision when they weren't fully resolved, Open Threads in the Summary that don't match what was actually left unresolved in the conversation.
 
+4. **Incoming consistency** — the `## Incoming` section should read exactly `(none)` by conclusion: the drain folds any entries into the Discussion Map at session start, and the conclusion gate blocks while it is non-empty. If an entry is still present, it was never drained — fold it into the Discussion Map as a `pending` subtopic and clear it (see [drain-incoming.md](../../workflow-shared/references/drain-incoming.md)). If the `(none)` placeholder is missing or malformed, restore it.
+
 **Apply the reconciliation.** For each finding:
 
 - Gap → add the missing substance to the discussion file at the appropriate place (subtopic section, Journey, or Summary)
 - Hallucination → remove or correct to match what was discussed
 - Drift → rewrite to faithfully reflect the conversation; correct Discussion Map states where needed
+- Incoming → fold any stray entry into the Discussion Map and reset the section to `(none)`; restore the placeholder if it drifted
 
 Commit the changes with a descriptive message (e.g., `docs(discussion): capture undocumented trade-off thread`, `docs(discussion): correct drift on caching decision`, `docs(discussion): soften Map state to converging`).
 

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -200,6 +200,8 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 > No decisions needed at this stage.
 ```
 
+Load **[drain-incoming.md](../workflow-shared/references/drain-incoming.md)** with work_unit = `{work_unit}`, topic = `{topic}`, phase = `research`.
+
 Load **[route-session.md](references/route-session.md)** and follow its instructions as written.
 
 *Knowledge-base nudge — if a thread feels familiar, or you're about to re-tread ground that might have been covered in another work unit, run a quick query before proceeding. See **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)**.*

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -39,31 +39,9 @@ If the index command fails, display the error but do not block — the artifact 
   The artifact is saved. Indexing can be retried later.
 ```
 
-Re-indexing a previously-concluded topic is safe — `index` replaces the topic's chunks rather than duplicating them.
+Re-indexing a previously-concluded topic is safe — `index` replaces the topic's chunks rather than duplicating them. Re-concluding a topic that an Incoming concern reopened needs no special handling here: the downstream phase already detects a regressed source on re-entry — the bridge re-firing into the epic menu is the designed path.
 
-5. **Reopen-bridge guard.** Check whether any downstream phase already holds work for this topic:
-
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.discussion.{topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.specification.{topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.planning.{topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.implementation.{topic}
-   ```
-
-   **If any returns `true`:** this topic was concluded before, reopened by an Incoming landing, and is now re-concluding. A downstream phase already consumed the earlier conclusion — invoking the bridge re-enters it. Warn before proceeding:
-
-   > *Output the next fenced block as a code block:*
-
-   ```
-     ⚑ This topic already has downstream phase work.
-       Re-concluding re-triggers the pipeline bridge into it.
-       Review the downstream artefact against the new
-       findings for consistency.
-   ```
-
-   **If all return `false`:** first conclusion — no downstream work. Continue.
-
-6. Closure signpost:
+5. Closure signpost:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -72,7 +50,7 @@ Re-indexing a previously-concluded topic is safe — `index` replaces the topic'
 > to make decisions about architecture and approach.
 ```
 
-7. Invoke the `/workflow-bridge` skill:
+6. Invoke the `/workflow-bridge` skill:
    ```
    Pipeline bridge for: {work_unit}
    Completed phase: research

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -4,12 +4,26 @@
 
 ---
 
-1. Set research status to completed:
+1. **Incoming gate.** Read the `## Incoming` section of `.workflows/{work_unit}/research/{topic}.md`. If it is not exactly `(none)`, the topic has undrained concerns and cannot conclude:
+
+   > *Output the next fenced block as a code block:*
+
+   ```
+     ⚑ This research has undrained Incoming concerns.
+       Fold them into the research body and resolve them
+       before concluding.
+   ```
+
+   → Return to **[the skill](../SKILL.md)** for **Step 6**.
+
+   Otherwise the section is `(none)` — continue.
+
+2. Set research status to completed:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.research.{topic} status completed
    ```
-2. Final commit: `research({work_unit}): complete {topic} research`
-3. Index the completed artifact into the knowledge base:
+3. Final commit: `research({work_unit}): complete {topic} research`
+4. Index the completed artifact into the knowledge base:
 
 ```bash
 node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index .workflows/{work_unit}/research/{topic}.md
@@ -25,7 +39,31 @@ If the index command fails, display the error but do not block — the artifact 
   The artifact is saved. Indexing can be retried later.
 ```
 
-4. Closure signpost:
+Re-indexing a previously-concluded topic is safe — `index` replaces the topic's chunks rather than duplicating them.
+
+5. **Reopen-bridge guard.** Check whether any downstream phase already holds work for this topic:
+
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.discussion.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.specification.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.planning.{topic}
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.implementation.{topic}
+   ```
+
+   **If any returns `true`:** this topic was concluded before, reopened by an Incoming landing, and is now re-concluding. A downstream phase already consumed the earlier conclusion — invoking the bridge re-enters it. Warn before proceeding:
+
+   > *Output the next fenced block as a code block:*
+
+   ```
+     ⚑ This topic already has downstream phase work.
+       Re-concluding re-triggers the pipeline bridge into it.
+       Review the downstream artefact against the new
+       findings for consistency.
+   ```
+
+   **If all return `false`:** first conclusion — no downstream work. Continue.
+
+6. Closure signpost:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -34,7 +72,7 @@ If the index command fails, display the error but do not block — the artifact 
 > to make decisions about architecture and approach.
 ```
 
-5. Invoke the `/workflow-bridge` skill:
+7. Invoke the `/workflow-bridge` skill:
    ```
    Pipeline bridge for: {work_unit}
    Completed phase: research

--- a/skills/workflow-research-process/references/document-review.md
+++ b/skills/workflow-research-process/references/document-review.md
@@ -41,11 +41,14 @@ Walk the conversation against the document and check three dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user views, tradeoffs reframed beyond what the conversation supported, or context omitted that changes how a position should read.
 
+4. **Incoming consistency** — the `## Incoming` section should read exactly `(none)` by conclusion: the drain folds any entries into the body as seed threads at session start, and the conclusion gate blocks while it is non-empty. If an entry is still present, it was never drained — fold it into the body and clear it (see [drain-incoming.md](../../workflow-shared/references/drain-incoming.md)). If the `(none)` placeholder is missing or malformed, restore it.
+
 **Apply the reconciliation.** For each finding:
 
 - Gap → add the missing substance to the research file at the appropriate place
 - Hallucination → remove or correct to match what was discussed
 - Drift → rewrite to faithfully reflect the conversation
+- Incoming → fold any stray entry into the body and reset the section to `(none)`; restore the placeholder if it drifted
 
 Commit the changes with a descriptive message (e.g., `docs(research): capture undocumented tradeoff thread`, `docs(research): correct drift on storage preference`).
 

--- a/skills/workflow-shared/references/drain-incoming.md
+++ b/skills/workflow-shared/references/drain-incoming.md
@@ -4,7 +4,7 @@
 
 ---
 
-Folds any entries in the current topic artefact's `## Incoming` section into the session's working map, then clears the section. Runs **once at session start** — before the session loop and before the first "check for findings" step — so a concern that landed while the topic was idle is picked up before any work begins, and the map is never reshuffled mid-turn. Invoked from both the initialize path (fresh start) and the resume/reopen path (a reopened decided topic resumes rather than initialises), which is why it is its own reference.
+Folds any entries in the current topic artefact's `## Incoming` section into the session's working map, then clears the section. Runs **once at session start** — before the session loop and before its first "check for findings" step — so a concern that landed while the topic was idle is picked up before any work begins, and the map is never reshuffled mid-turn. Both the fresh-start path and the resume/reopen path reach the session step, so a single invocation there covers both: on a fresh artefact the section is `(none)` and the drain is a no-op; on resume or after a reopen it folds whatever landed.
 
 ## Parameters
 
@@ -12,19 +12,41 @@ The caller provides these via context before loading:
 
 - `work_unit` — the work unit. Always present.
 - `topic` — the current topic whose artefact is being drained.
-- `phase` — the current phase, `research` or `discussion` (selects how entries fold in).
+- `phase` — the current phase, `research` or `discussion`. Selects the artefact and how entries fold in.
 
-## Drain Contract
+## A. Read the Section
 
-Read the topic artefact's `## Incoming` section.
+The artefact is `.workflows/{work_unit}/{phase}/{topic}.md`. Read its `## Incoming` section.
 
-- When it is exactly `(none)`, there is nothing to drain — return.
-- Otherwise, for each `### {concern}` subsection:
-  - **Discussion** — add the concern to the Discussion Map as a `pending` subtopic.
-  - **Research** — fold the concern into the body as a seed thread (research has no formal map; the freeform body is its home).
-  - After folding an entry, **delete its subsection** from `## Incoming`. When the last entry is removed, reset the section to `(none)`.
-- Include the drained map and the cleared `## Incoming` in the same initial / resume commit the caller is about to make.
+#### If the section is exactly `(none)`
 
-The full folding procedure is specified where the session flows invoke it.
+Nothing landed — no drain needed.
+
+→ Return to caller.
+
+#### Otherwise
+
+→ Proceed to **B. Fold Each Entry**.
+
+## B. Fold Each Entry
+
+Each landed concern is a `### {concern}` subsection. For each, in order:
+
+**If `phase` is `discussion`:** add the concern to the Discussion Map as a `pending` subtopic, so it enters the session as something to explore.
+
+**If `phase` is `research`:** fold the concern into the body as a seed thread — research has no formal map, so the freeform body (near the Starting Point) is its home.
+
+After folding an entry, **delete its `### {concern}` subsection** from `## Incoming`. The git history is the audit trail. When the last entry is removed, reset the section body to `(none)`.
+
+→ Proceed to **C. Commit**.
+
+## C. Commit
+
+Commit the folded working map and the cleared section together:
+
+```bash
+git add -- .workflows/{work_unit}/{phase}/{topic}.md
+git commit -m "{phase}({work_unit}/{topic}): drain incoming"
+```
 
 → Return to caller.


### PR DESCRIPTION
Final PR in the **Incoming** stack (design log: #359). Stacked on PR 5 (#364). Completes the consuming side.

## What lands

**`drain-incoming.md` (full)** — at session start, fold each `### {concern}` from `## Incoming` into the working map (discussion → `pending` subtopic; research → seed thread in the body), delete the folded subsection, reset to `(none)`, commit. Wired into both session-start steps (discussion **Step 5**, research **Step 6**). A single invocation covers fresh **and** resume/reopen — both funnel through the session step; a fresh `(none)` artefact no-ops (no commit).

**Conclusion gate** — `conclude-discussion.md` / `conclude-research.md` block with a `⚑` callout when `## Incoming` ≠ `(none)`, returning to the session step to drain before completing.

**`document-review.md` (both)** — a fourth reconciliation check audits Incoming consistency the way it already audits Open Threads drift: fold a stray entry, restore a drifted placeholder. Gives a third safety layer (drain → review → gate).

**Reopen handling — no guard, by design.** The reopen-via-Incoming case is **epic-only** (single-topic never lands an Incoming entry). For epics, the specification phase already treats a discussion that regressed to `in-progress` as a first-class `[extracted, reopened]` source and offers re-incorporation — re-firing the bridge into the epic menu is the *designed* path. An initial `⚑` warning was added then removed (redundant for epics, false-positive on the shared non-epic conclude path). `conclude-*` carries a one-line note instead. KB re-index on re-conclude is idempotent (replaces the topic's chunks).

## Layering

`drain` (session start) → `document-review` Incoming check → `conclude` gate. Three backstops, so a stray entry is caught and folded well before it could block conclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)