### PR TITLE
Incoming: shared create-topic.md + migrate full-spawn sites

### DIFF
--- a/incoming/design.md
+++ b/incoming/design.md
@@ -21,7 +21,7 @@ topic can't conclude with a non-empty Incoming.
 Building it surfaced that the "create a topic" sequence is **already duplicated across six call
 sites** and is non-atomic (multi-command, with explicit "stop before commit to recover" prose
 because a mid-sequence failure half-builds a topic). The feature therefore ships on top of extracted,
-hardened shared infra: an atomic `create-topic` CLI command + a `create-topic.md` shared reference.
+hardened shared infra: an atomic `create-discovery-topic` CLI command + a `create-discovery-topic.md` shared reference.
 
 **Outcome:** off-topic concerns are never lost and never pollute the wrong artefact; topic creation
 is atomic and defined once; existing spawn behaviour is unchanged.
@@ -49,18 +49,21 @@ is atomic and defined once; existing spawn behaviour is unchanged.
 - **Coexist with extraction:** keep extraction for already-written drift (research-split moves real
   content out of a file); Incoming is for conversational concerns not yet written up.
 
-## Component 1 — `create-topic` CLI command (atomic)
+## Component 1 — `create-discovery-topic` CLI command (atomic)
 
 `skills/workflow-manifest/scripts/manifest.cjs`. Mirrors `cmdInitPhase`'s lock/atomic pattern: one
 `withLock` → `readManifest` → in-memory mutations → single `writeManifestAtomic`.
 
 ```
-create-topic <work-unit>.<topic> [--phase research|discussion] --routing <r> --source <src> [--summary s] [--description d]
+create-discovery-topic <work-unit>.<topic> [--phase research|discussion] --routing <r> --source <src> [--summary s] [--description d]
 ```
 
 - First positional is a **two-segment** dotted path `wu.topic` (the discovery item it addresses) — a
   deliberate divergence from `init-phase`'s three-segment `wu.phase.topic` (phase is a flag here, not
   a path segment).
+- **Epic-only by intent** — the discovery map exists only for epics, so this is the epic topic-spawn
+  primitive. Single-topic types create their topic via `init` + a single `init-phase`. The work_type
+  gate lives in the callers; the CLI stays a dumb primitive.
 - Always creates the **discovery** item with `routing`/`source` (required) + `summary`/`description`
   (optional) on the discovery item.
 - `--phase` additionally creates `phases.{phase}.items.{topic} = {status:'in-progress'}` — status
@@ -70,10 +73,10 @@ create-topic <work-unit>.<topic> [--phase research|discussion] --routing <r> --s
   half-built-topic hazard outright.
 - `--phase` and `--routing` validated against `research`/`discussion`.
 
-## Component 2 — `create-topic.md` shared reference
+## Component 2 — `create-discovery-topic.md` shared reference
 
-`skills/workflow-shared/references/create-topic.md` encodes the **common core** only: name-validation
-loop, idempotent `pull dismissed`, the `create-topic` CLI call, no commit (returns dirty to caller).
+`skills/workflow-shared/references/create-discovery-topic.md` encodes the **common core** only: name-validation
+loop, idempotent `pull dismissed`, the `create-discovery-topic` CLI call, no commit (returns dirty to caller).
 
 Stays site-specific: artefact creation/templates, originating-side markers, summary/description
 generation, commit messages + staged paths, post-action prompts, trigger/offer gates.
@@ -88,7 +91,7 @@ no-op when the name is absent, and on the `ok` path the name is never in dismiss
 new `drain-incoming.md` + `incoming-landing.md` shared references; `incoming:{origin}` provenance.
 
 **Landing** (`incoming-landing.md`): recompute target lifecycle at landing time (never cached). New →
-`create-topic --phase {routing}`; fresh → plain `init-phase`; in-flight/decided → append `### {concern}`
+`create-discovery-topic --phase {routing}`; fresh → plain `init-phase`; in-flight/decided → append `### {concern}`
 subsection + reopen if completed. If the resolved target is the current topic, route to normal
 subtopic handling, not Incoming.
 
@@ -119,8 +122,8 @@ just carries a one-line note. KB re-index on re-conclude is safe (idempotent —
 
 Scope per PR:
 
-- **PR 1** — `create-topic` CLI + tests (also carries this design log).
-- **PR 2** — `create-topic.md` shared ref + migrate full-spawn sites (§F, topic-splitting).
+- **PR 1** — `create-discovery-topic` CLI + tests (also carries this design log).
+- **PR 2** — `create-discovery-topic.md` shared ref + migrate full-spawn sites (§F, topic-splitting).
 - **PR 3** — migrate discovery-only sites (confirm-and-persist, ensure-discovery-item, analysis-approval-gate).
 - **PR 4** — Incoming substrate (templates, initialize-*, stubs, CLAUDE.md provenance).
 - **PR 5** — Incoming landing (full incoming-landing.md, trigger wiring, non-epic routing).
@@ -149,7 +152,11 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
 - **Entry From-line dropped `session {NNN}`.** Research and discussion track no session number
   anywhere, so the line is `origin · phase · date`. Detection keys on the `## Incoming` heading,
   the `(none)` placeholder, and `### ` subsections — not the From line — so this is safe.
-- **Shared-ref output vars renamed to avoid caller collisions.** `create-topic.md` returns
+- **`create-topic` renamed to `create-discovery-topic`.** The command (and its `create-topic.md`
+  shared ref → `create-discovery-topic.md`) spawns a topic onto an epic's discovery map; the old name
+  read as a universal "create any topic". Single-topic types create their topic via `init` + a single
+  `init-phase` and never call it, so the name now states the real epic-only scope.
+- **Shared-ref output vars renamed to avoid caller collisions.** `create-discovery-topic.md` returns
   `created_topic` (§F already binds `{topic}` to the parent); `incoming-landing.md` returns
   `landed_topic`.
 - **Research Incoming lives in `epic-session.md` §C (Topic Awareness)**, the conversational-concern
@@ -163,12 +170,12 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
   offer, and single-topic types never reopen via Incoming. An initial `⚑` warning was added and then
   removed — it was redundant for epics and a false positive on the shared non-epic conclude path.
 - **Refactor (PRs 2–3) leaves one non-semantic diff:** discovery-item key order
-  (`status,routing,source,summary,description` from `create-topic` vs the old sequential `set`
+  (`status,routing,source,summary,description` from `create-discovery-topic` vs the old sequential `set`
   order). Values identical.
 
 ## Verification
 
-- CLI: `bash tests/scripts/test-workflow-manifest.sh` green incl. new create-topic cases; manual runs
+- CLI: `bash tests/scripts/test-workflow-manifest.sh` green incl. new create-discovery-topic cases; manual runs
   against a temp `.workflows/` fixture for full-spawn, discovery-only, duplicate-error, omitted-field,
   missing-flag paths.
 - Refactor no-op: diff resulting `manifest.json` + artefact before vs after migration on a temp

--- a/incoming/design.md
+++ b/incoming/design.md
@@ -117,7 +117,9 @@ just carries a one-line note. KB re-index on re-conclude is safe (idempotent —
 
 ## PR stack
 
-- **PR 0** — this design-log doc (long-lived, merge last).
+Scope per PR:
+
+- **PR 0** — this design-log doc.
 - **PR 1** — `create-topic` CLI + tests.
 - **PR 2** — `create-topic.md` shared ref + migrate full-spawn sites (§F, topic-splitting).
 - **PR 3** — migrate discovery-only sites (confirm-and-persist, ensure-discovery-item, analysis-approval-gate).
@@ -127,15 +129,21 @@ just carries a one-line note. KB re-index on re-conclude is safe (idempotent —
 
 PRs 1–3 are a behaviour-preserving no-op refactor. Only PRs 4–6 introduce new behaviour.
 
-| PR | Branch | Base | GitHub |
-|---|---|---|---|
-| 0 | `idea/incoming-pr-0-design` | `main` | #359 |
-| 1 | `idea/incoming-pr-1-create-topic-cli` | `main` | #360 |
-| 2 | `idea/incoming-pr-2-shared-ref` | PR 1 | #361 |
-| 3 | `idea/incoming-pr-3-discovery-only` | PR 2 | #362 |
-| 4 | `idea/incoming-pr-4-substrate` | PR 3 | #363 |
-| 5 | `idea/incoming-pr-5-landing` | PR 4 | #364 |
-| 6 | `idea/incoming-pr-6-drain-gate` | PR 5 | #365 |
+**Execution: per-PR redo.** A first pass built the whole stack in one go and violated the authoring
+conventions, so the work is being redone one PR at a time. The first-pass PRs #359 and #361–#365 are
+**closed**; only #360 (PR 1, CLI) is kept. The design log no longer ships as its own PR (#359 closed)
+— it rides on PR 1's branch and flows down the redo stack. From PR 2 onward each PR is re-cut fresh on
+top of its redone parent, on a new branch (old closed branches are left in place).
+
+| PR | Branch | Base | GitHub | State |
+|---|---|---|---|---|
+| 0 | (rides on PR 1's branch) | — | #359 | closed — superseded |
+| 1 | `idea/incoming-pr-1-create-topic-cli` | `main` | #360 | open |
+| 2 | `idea/incoming-pr-2-shared-create-topic` | PR 1 | #366 | open — redo (old #361 closed) |
+| 3 | _to re-cut_ | PR 2 | — | pending (old #362 closed) |
+| 4 | _to re-cut_ | PR 3 | — | pending (old #363 closed) |
+| 5 | _to re-cut_ | PR 4 | — | pending (old #364 closed) |
+| 6 | _to re-cut_ | PR 5 | — | pending (old #365 closed) |
 
 ## Decisions taken during implementation
 

--- a/incoming/design.md
+++ b/incoming/design.md
@@ -119,8 +119,7 @@ just carries a one-line note. KB re-index on re-conclude is safe (idempotent —
 
 Scope per PR:
 
-- **PR 0** — this design-log doc.
-- **PR 1** — `create-topic` CLI + tests.
+- **PR 1** — `create-topic` CLI + tests (also carries this design log).
 - **PR 2** — `create-topic.md` shared ref + migrate full-spawn sites (§F, topic-splitting).
 - **PR 3** — migrate discovery-only sites (confirm-and-persist, ensure-discovery-item, analysis-approval-gate).
 - **PR 4** — Incoming substrate (templates, initialize-*, stubs, CLAUDE.md provenance).
@@ -131,14 +130,14 @@ PRs 1–3 are a behaviour-preserving no-op refactor. Only PRs 4–6 introduce ne
 
 **Execution: per-PR redo.** A first pass built the whole stack in one go and violated the authoring
 conventions, so the work is being redone one PR at a time. The first-pass PRs #359 and #361–#365 are
-**closed**; only #360 (PR 1, CLI) is kept. The design log no longer ships as its own PR (#359 closed)
-— it rides on PR 1's branch and flows down the redo stack. From PR 2 onward each PR is re-cut fresh on
-top of its redone parent, on a new branch (old closed branches are left in place).
+**closed** (their branches deleted); only #360 (PR 1, CLI) is kept. There is no standalone design-log
+PR — the original PR 0 (#359) was deleted and this design log now lives on **PR 1's branch**, merging
+to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone parent, on a new branch
+(old closed branches are left in place).
 
 | PR | Branch | Base | GitHub | State |
 |---|---|---|---|---|
-| 0 | (rides on PR 1's branch) | — | #359 | closed — superseded |
-| 1 | `idea/incoming-pr-1-create-topic-cli` | `main` | #360 | open |
+| 1 | `idea/incoming-pr-1-create-topic-cli` | `main` | #360 | open — carries design log |
 | 2 | `idea/incoming-pr-2-shared-create-topic` | PR 1 | #366 | open — redo (old #361 closed) |
 | 3 | _to re-cut_ | PR 2 | — | pending (old #362 closed) |
 | 4 | _to re-cut_ | PR 3 | — | pending (old #363 closed) |

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -173,7 +173,7 @@ During organic discussion, a subtopic may grow beyond the scope of the current t
 
 2. Generate a one-sentence summary of the elevated concern (drawn from the context that triggered elevation) for the discovery item's `summary` field. Generate a paragraph or two of richer context in the same turn for the `description` field, loaded by discussion-entry as opening context when the user later picks the elevated topic up.
 
-→ Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new-topic}`, phase = `discussion`, routing = `discussion`, source = `discussion-elevation:{topic}`, summary = `{summary}`, description = `{description}`.
+→ Load **[create-discovery-topic.md](../../workflow-shared/references/create-discovery-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new-topic}`, phase = `discussion`, routing = `discussion`, source = `discussion-elevation:{topic}`, summary = `{summary}`, description = `{description}`.
 
 **If `result` is `cancelled`:**
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -169,41 +169,26 @@ During organic discussion, a subtopic may grow beyond the scope of the current t
 
 #### If `elevate`
 
-1. Pick a kebab-case name reflecting the elevated concern. Surface it to the user for confirmation. Then validate:
+1. Pick a kebab-case name reflecting the elevated concern. Surface it to the user for confirmation.
 
-   → Load **[topic-name-validation.md](../../workflow-shared/references/topic-name-validation.md)** with work_unit = `{work_unit}`, proposed_name = `{new-topic}`.
+2. Generate a one-sentence summary of the elevated concern (drawn from the context that triggered elevation) for the discovery item's `summary` field. Generate a paragraph or two of richer context in the same turn for the `description` field, loaded by discussion-entry as opening context when the user later picks the elevated topic up.
 
-   On `collision-active`, re-prompt for an alternative and re-validate — loop until `ok` or `matches-dismissed`, or the user cancels the elevation. On `matches-dismissed`, proceed (the dismissed entry is pulled in step 4). On `ok`, proceed.
+→ Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new-topic}`, phase = `discussion`, routing = `discussion`, source = `discussion-elevation:{topic}`, summary = `{summary}`, description = `{description}`.
 
-2. Generate a one-sentence summary of the elevated concern (drawn from the context that triggered elevation). This becomes the discovery item's `summary` field. Generate a paragraph or two of richer context in the same turn — this becomes the `description` field, loaded by discussion-entry as opening context when the user later picks the elevated topic up.
+**If `result` is `cancelled`:**
 
-3. Create the seed discussion file at `.workflows/{work_unit}/discussion/{new-topic}.md` with:
+→ Return to **B. Session Loop**.
+
+**Otherwise:**
+
+3. Create the seed discussion file at `.workflows/{work_unit}/discussion/{created_topic}.md` with:
    - Context section capturing what prompted the topic and any initial thinking from the current discussion
    - A Discussion Map with initial subtopics derived from what's been discussed so far
    - No decisions — those happen in the new discussion
 
-4. Write manifest items — discussion first, then discovery. If validation returned `matches-dismissed`, pull from the dismissed list first:
+4. Update the current Discussion Map — replace the subtopic row with `↑ Elevated: {created_topic:(titlecase)}` in the same slot (same branch, same gutter if it was a child). See **E. Status Display** for the marker rules.
 
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{new-topic}"
-   ```
-
-   Then:
-
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discussion.{new-topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{new-topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new-topic} routing discussion
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new-topic} summary "{one-line summary}"
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new-topic} description "{paragraphs}"
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new-topic} source "discussion-elevation:{topic}"
-   ```
-
-   `routing: discussion` because elevation fires inside a discussion session. `source: discussion-elevation:{parent_topic}` is historical provenance; no cascade.
-
-5. Update the current Discussion Map — replace the subtopic row with `↑ Elevated: {new-topic:(titlecase)}` in the same slot (same branch, same gutter if it was a child). See **E. Status Display** for the marker rules.
-
-6. Commit: `discussion({work_unit}/{topic}): elevate {new-topic} to separate discussion`
+5. Commit: `discussion({work_unit}/{topic}): elevate {created_topic} to separate discussion`
 
 → Return to **B. Session Loop**.
 

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -37,34 +37,19 @@ Want to split these into separate research files?
 
 For each split topic:
 
-1. Pick a kebab-case name from the thread's content (e.g. `image-moderation`, `kitchen-utensils`). Surface it to the user for confirmation. Then validate:
+1. Pick a kebab-case name from the thread's content (e.g. `image-moderation`, `kitchen-utensils`). Surface it to the user for confirmation.
 
-   → Load **[topic-name-validation.md](../../workflow-shared/references/topic-name-validation.md)** with work_unit = `{work_unit}`, proposed_name = `{new_topic}`.
+2. Generate a one-sentence summary of the extracted content (drawn from the thread itself) for the discovery item's `summary` field, used in map renders. Generate a paragraph or two of richer context in the same turn for the `description` field, loaded by entry skills as opening context when the user later picks the topic up.
 
-   On `collision-active`, re-prompt for an alternative and re-validate — loop until `ok` or `matches-dismissed`, or the user abandons this thread. On `matches-dismissed`, proceed (the dismissed entry is pulled in step 4). On `ok`, proceed.
+→ Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new_topic}`, phase = `research`, routing = `research`, source = `research-split:{parent_topic}`, summary = `{summary}`, description = `{description}`.
 
-2. Create `.workflows/{work_unit}/research/{new_topic}.md` using **[template.md](template.md)**. Move content verbatim from the source file — reword only for flow and readability, no summarisation. Remove the extracted content from the source file.
+**If `result` is `cancelled`:**
 
-3. Generate a one-sentence summary of the extracted content (drawn from the thread itself). This becomes the discovery item's `summary` field, used in map renders. Generate a paragraph or two of richer context in the same turn — this becomes the `description` field, loaded by entry skills as opening context when the user later picks the topic up.
+Abandon this thread and continue the loop with the next.
 
-4. Write manifest items — research first, then discovery. If the validation returned `matches-dismissed`, pull from the dismissed list first:
+**Otherwise:**
 
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{new_topic}"
-   ```
-
-   Then:
-
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.research.{new_topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{new_topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new_topic} routing research
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new_topic} summary "{one-line summary}"
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new_topic} description "{paragraphs}"
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{new_topic} source "research-split:{parent_topic}"
-   ```
-
-   `routing: research` because the split fires inside a research session — research is where the new topic enters the pipeline. `source: research-split:{parent_topic}` is historical provenance; the parent's later state changes don't cascade.
+3. Create `.workflows/{work_unit}/research/{created_topic}.md` using **[template.md](template.md)**. Move content verbatim from the source file — reword only for flow and readability, no summarisation. Remove the extracted content from the source file. Continue the loop with the next.
 
 Once all accepted threads have been processed, single commit covering the manifest writes and the new research files:
 

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -41,7 +41,7 @@ For each split topic:
 
 2. Generate a one-sentence summary of the extracted content (drawn from the thread itself) for the discovery item's `summary` field, used in map renders. Generate a paragraph or two of richer context in the same turn for the `description` field, loaded by entry skills as opening context when the user later picks the topic up.
 
-→ Load **[create-topic.md](../../workflow-shared/references/create-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new_topic}`, phase = `research`, routing = `research`, source = `research-split:{parent_topic}`, summary = `{summary}`, description = `{description}`.
+→ Load **[create-discovery-topic.md](../../workflow-shared/references/create-discovery-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{new_topic}`, phase = `research`, routing = `research`, source = `research-split:{parent_topic}`, summary = `{summary}`, description = `{description}`.
 
 **If `result` is `cancelled`:**
 

--- a/skills/workflow-shared/references/create-discovery-topic.md
+++ b/skills/workflow-shared/references/create-discovery-topic.md
@@ -1,4 +1,4 @@
-# Create Topic
+# Create Discovery Topic
 
 *Shared reference. Loaded by `workflow-discussion-process` (topic elevation) and `workflow-research-process` (research split), and any flow that spawns a new discovery-map topic.*
 
@@ -77,7 +77,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.disc
 Create the discovery item and, when `phase` is set, its phase item in one atomic call:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs create-topic {work_unit}.{created_topic} --routing {routing} --source "{source}" --phase {phase} --summary "{summary}" --description "{description}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {work_unit}.{created_topic} --routing {routing} --source "{source}" --phase {phase} --summary "{summary}" --description "{description}"
 ```
 
 Assemble the flags as follows:

--- a/skills/workflow-shared/references/create-topic.md
+++ b/skills/workflow-shared/references/create-topic.md
@@ -35,6 +35,8 @@ The rejection is already rendered by topic-name-validation.md. Offer the choice:
 
 ```
 · · · · · · · · · · · ·
+How would you like to proceed?
+
 - **`c`/`cancel`** — Abandon creating this topic
 - **Pick another** — Tell me a different name
 · · · · · · · · · · · ·
@@ -62,7 +64,7 @@ Set `created_topic` to the validated `proposed_name`.
 
 ## B. Clear Dismissed
 
-Pull the name from the dismissed list — a no-op when it is absent. User-explicit spawns bypass dismissal, so this clears any stale entry before the write:
+Pull the name from the dismissed list — a no-op when it is absent, so it always runs:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{created_topic}"

--- a/skills/workflow-shared/references/create-topic.md
+++ b/skills/workflow-shared/references/create-topic.md
@@ -1,0 +1,92 @@
+# Create Topic
+
+*Shared reference. Loaded by `workflow-discussion-process` (topic elevation) and `workflow-research-process` (research split), and any flow that spawns a new discovery-map topic.*
+
+---
+
+Validates a proposed topic name, clears any matching dismissed entry, then writes the discovery item and — when a `phase` is given — its initial phase item in one atomic CLI call. The caller owns the user-facing framing around the new topic (seed file creation, map markers, the commit); this reference owns only the validate → create sequence and reports back through `result`.
+
+## Parameters
+
+The caller provides these via context before loading:
+
+- `work_unit` — the epic's work unit name. Always present.
+- `proposed_name` — the topic name the caller has picked and confirmed with the user. Always present.
+- `routing` — the literal `research` or `discussion`. The new topic's initial routing intent.
+- `source` — the provenance string for the discovery item (e.g. `research-split:{parent}`, `discussion-elevation:{parent}`).
+- `phase` — optional, `research` or `discussion`. When set, the matching phase item is created alongside the discovery item.
+- `summary` — optional one-line summary. Written only when provided and non-empty.
+- `description` — optional paragraph or two of richer context. Written only when provided and non-empty.
+
+After return, the caller reads these from conversation memory:
+
+- `result` — `created` (topic written) or `cancelled` (user abandoned at the collision prompt).
+- `created_topic` — the validated topic name. A distinct variable from any caller-side `{topic}`, so it never collides with a parent topic the caller is already tracking.
+
+## A. Validate the Name
+
+→ Load **[topic-name-validation.md](topic-name-validation.md)** with work_unit = `{work_unit}`, proposed_name = `{proposed_name}`.
+
+#### If `result` is `collision-active`
+
+The rejection is already rendered by topic-name-validation.md. Offer the choice:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+- **`c`/`cancel`** — Abandon creating this topic
+- **Pick another** — Tell me a different name
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `cancel`:**
+
+Set `result = cancelled`.
+
+→ Return to caller.
+
+**If pick another:**
+
+Set `proposed_name` to the new name.
+
+→ Return to **A. Validate the Name**.
+
+#### Otherwise
+
+Set `created_topic` to the validated `proposed_name`.
+
+→ Proceed to **B. Clear Dismissed**.
+
+## B. Clear Dismissed
+
+Pull the name from the dismissed list — a no-op when it is absent. User-explicit spawns bypass dismissal, so this clears any stale entry before the write:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{created_topic}"
+```
+
+→ Proceed to **C. Create the Topic**.
+
+## C. Create the Topic
+
+Create the discovery item and, when `phase` is set, its phase item in one atomic call:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-topic {work_unit}.{created_topic} --routing {routing} --source "{source}" --phase {phase} --summary "{summary}" --description "{description}"
+```
+
+Assemble the flags as follows:
+
+- `--routing {routing}` and `--source "{source}"` — always included.
+- `--phase {phase}` — included only when `phase` is set.
+- `--summary "{summary}"` — included only when `summary` is present and non-empty.
+- `--description "{description}"` — included only when `description` is present and non-empty.
+
+Single-quote any value containing characters zsh would interpret — backticks, `$`, `[]`, `{}`, `~` — so the shell passes it through literally.
+
+Set `result = created`. No commit here — the caller folds this write into its own commit.
+
+→ Return to caller.


### PR DESCRIPTION
Second of the per-PR Incoming redo. Extracts the shared *prose* core for spawning a discovery-map topic into a new `skills/workflow-shared/references/create-topic.md`, and migrates the two **full-spawn** call sites onto it.

Stacked on #360 (the `create-topic` CLI). Base is `idea/incoming-pr-1-create-topic-cli`; retarget to `main` once #360 merges.

## What changed

- **New** `skills/workflow-shared/references/create-topic.md` — `## Parameters` + lettered sections: **A. Validate the Name** (loads `topic-name-validation.md`, collision menu with cancel/pick-another), **B. Clear Dismissed** (unconditional `pull`), **C. Create the Topic** (single atomic `create-topic` call). Returns `result` (`created`|`cancelled`) and `created_topic`.
- **Migrated** `discussion-session.md` §F (topic elevation) — replaced the inline validation loop + 7-command manifest write with one `Load create-topic.md`; reordered so validation runs before the seed file is written.
- **Migrated** `topic-splitting.md` (research split) — same swap per thread; reordered so a cancel leaves no orphan research file.

## Behaviour preservation

Same observable manifest, artefacts, and commits. The **only** consolidation: both sites previously pulled dismissed *only* on `matches-dismissed`; the shared reference pulls **unconditionally**. `pull` is a no-op when the name is absent, and on the `ok` path the name is never on the dismissed list — so the resulting manifest is identical.

Verified on a throwaway fixture: `create-topic` with elevation params and with split params yields a discovery item `{status, routing, source, summary?, description?}` and phase item `{status}` matching the old `init-phase`+`set` output modulo discovery-item key order. `test-workflow-manifest.sh` stays green (277/277, CLI untouched). Diffs grepped for mid-sentence `→ Return`/`→ Proceed` — none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #360
2. **#366** 👈 current
3. #367
4. #368
5. #369
6. #370
7. #371
<!-- stack:links:end -->