### PR TITLE
PR 3 — migrate discovery-only topic creation onto the create-discovery-topic CLI

### DIFF
--- a/incoming/design.md
+++ b/incoming/design.md
@@ -142,7 +142,7 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
 |---|---|---|---|---|
 | 1 | `idea/incoming-pr-1-create-topic-cli` | `main` | #360 | open — carries design log |
 | 2 | `idea/incoming-pr-2-shared-create-topic` | PR 1 | #366 | open — redo (old #361 closed) |
-| 3 | `idea/incoming-pr-3-discovery-direct-cli` | PR 2 | — | open — redo (old #362 closed) |
+| 3 | `idea/incoming-pr-3-discovery-direct-cli` | PR 2 | #367 | open — redo (old #362 closed) |
 | 4 | _to re-cut_ | PR 3 | — | pending (old #363 closed) |
 | 5 | _to re-cut_ | PR 4 | — | pending (old #364 closed) |
 | 6 | _to re-cut_ | PR 5 | — | pending (old #365 closed) |

--- a/incoming/design.md
+++ b/incoming/design.md
@@ -124,7 +124,7 @@ Scope per PR:
 
 - **PR 1** — `create-discovery-topic` CLI + tests (also carries this design log).
 - **PR 2** — `create-discovery-topic.md` shared ref + migrate full-spawn sites (§F, topic-splitting).
-- **PR 3** — migrate discovery-only sites (confirm-and-persist, ensure-discovery-item, analysis-approval-gate).
+- **PR 3** — migrate discovery-only sites onto the CLI directly (confirm-and-persist §A, ensure-discovery-item §D, analysis-approval-gate §C, absorb-into-epic §J, manage-work-unit pivot).
 - **PR 4** — Incoming substrate (templates, initialize-*, stubs, CLAUDE.md provenance).
 - **PR 5** — Incoming landing (full incoming-landing.md, trigger wiring, non-epic routing).
 - **PR 6** — drain + conclusion gate + reopen guard.
@@ -142,7 +142,7 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
 |---|---|---|---|---|
 | 1 | `idea/incoming-pr-1-create-topic-cli` | `main` | #360 | open — carries design log |
 | 2 | `idea/incoming-pr-2-shared-create-topic` | PR 1 | #366 | open — redo (old #361 closed) |
-| 3 | _to re-cut_ | PR 2 | — | pending (old #362 closed) |
+| 3 | `idea/incoming-pr-3-discovery-direct-cli` | PR 2 | — | open — redo (old #362 closed) |
 | 4 | _to re-cut_ | PR 3 | — | pending (old #363 closed) |
 | 5 | _to re-cut_ | PR 4 | — | pending (old #364 closed) |
 | 6 | _to re-cut_ | PR 5 | — | pending (old #365 closed) |
@@ -169,6 +169,14 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
   reopened (regressed-to-`in-progress`) source via its `[extracted, reopened]` state and re-analysis
   offer, and single-topic types never reopen via Incoming. An initial `⚑` warning was added and then
   removed — it was redundant for epics and a false positive on the shared non-epic conclude path.
+- **PR 3's discovery-only sites call the `create-discovery-topic` CLI directly, not the shared ref.**
+  The ref (`create-discovery-topic.md`) is the *interactive* full-spawn helper — its section A renders a
+  collision menu with `**STOP.**` and has no flag to suppress it. The discovery-only sites are
+  non-interactive and several require a silent idempotent no-op (`ensure-discovery-item` §B), which the
+  ref's collision menu would break. Routing them through it would inject STOP gates that never existed.
+  Post-CLI the create is one line, so a wrapping ref would be parameter boilerplate with no instruction
+  density. Net: ref = interactive human-naming sites; CLI = non-interactive programmatic sites.
+  (`map-operations.md` §F is a topic *rename*, not a fresh spawn — deliberately excluded.)
 - **Refactor (PRs 2–3) leaves one non-semantic diff:** discovery-item key order
   (`status,routing,source,summary,description` from `create-discovery-topic` vs the old sequential `set`
   order). Values identical.

--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -24,11 +24,7 @@ For each topic on the working list, in synthesised order:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{topic}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} summary "{one-line summary}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} description "{paragraphs}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} routing {research|discussion}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} source discovery
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {work_unit}.{topic} --routing {research|discussion} --source discovery --summary "{one-line summary}" --description "{paragraphs}"
 ```
 
 The `pull` is a no-op if the name isn't in the dismissed list.
@@ -39,8 +35,7 @@ If any command fails, surface the error and stop before the commit so the user c
 
 Notes:
 
-- `init-phase` creates the item with `status: in-progress` automatically. Discovery items have no other valid status — do not pass `status` explicitly.
-- The topic name is the manifest dict key (third dot-path segment). There is no separate `name` field to set.
+- The topic name is the manifest dict key (the `{topic}` path segment). There is no separate `name` field to set.
 - `routing` is the value confirmed by the user at the synthesis gate.
 - `source: discovery` marks topics the user surfaced during discovery, distinguishing them from items added later with other provenance (e.g. `research-analysis`, `gap-analysis`).
 

--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -29,7 +29,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topi
 
 The `pull` is a no-op if the name isn't in the dismissed list.
 
-Summary and description come from the synthesis — derived from the exploration in topic-synthesis. Quote shell values with single quotes if they contain `[]`, `{}`, `~`, or backticks. Description may span paragraphs.
+Summary and description come from the synthesis — derived from the exploration in topic-synthesis. Single-quote any value containing characters zsh would interpret — backticks, `$`, `[]`, `{}`, `~`. Description may span paragraphs.
 
 If any command fails, surface the error and stop before the commit so the user can recover.
 

--- a/skills/workflow-shared/references/analysis-approval-gate.md
+++ b/skills/workflow-shared/references/analysis-approval-gate.md
@@ -143,14 +143,10 @@ Revise this block's `routing`, `summary`, or `description` in the staging file p
 
 ## C. Write Approved Candidate
 
-Set this block's `status: approved` in the staging file, then write the discovery item from the block's stored fields:
+Set this block's `status: approved` in the staging file, then write the discovery item from the block's stored fields in one atomic call:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{name}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} summary "{summary}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} description "{description}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} routing {routing}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{name} source "{source}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {work_unit}.{name} --routing {routing} --source "{source}" --summary "{summary}" --description "{description}"
 ```
 
 `source` is the block's stored value verbatim — `research-analysis:{parent}` for research-analysis (provenance renders as `from {parent}`), `gap-analysis` for gap-analysis.

--- a/skills/workflow-shared/references/ensure-discovery-item.md
+++ b/skills/workflow-shared/references/ensure-discovery-item.md
@@ -73,25 +73,19 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.disc
 
 ## D. Create Discovery Item
 
-Initialise the item and set provenance fields:
+Create the item with its routing and `source: direct-start` in one atomic call:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discovery.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} routing {routing}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} source direct-start
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {work_unit}.{topic} --routing {routing} --source direct-start --summary "{summary}" --description "{description}"
 ```
 
-If `summary` was supplied and is non-empty, write it:
+Assemble the flags as follows:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} summary "{summary}"
-```
+- `--routing {routing}` and `--source direct-start` — always included.
+- `--summary "{summary}"` — included only when `summary` was supplied and is non-empty.
+- `--description "{description}"` — included only when `description` was supplied and is non-empty (multi-paragraph values are fine).
 
-If `description` was supplied and is non-empty, write it (multi-paragraph values are fine):
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} description "{description}"
-```
+Single-quote any value containing characters zsh would interpret — backticks, `$`, `[]`, `{}`, `~`.
 
 No commit here — the manifest writes are folded into the next commit produced by the calling phase's process.
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -396,9 +396,7 @@ Routing reflects the work already done on the feature. `source` is set to `disco
 Set `routing` to `research`:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.discovery.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discovery.{topic} routing research
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discovery.{topic} source discovery
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {target_epic}.{topic} --routing research --source discovery
 ```
 
 → Proceed to **K. Cleanup**.
@@ -408,9 +406,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.dis
 Set `routing` to `discussion`:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {target_epic}.discovery.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discovery.{topic} routing discussion
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {target_epic}.discovery.{topic} source discovery
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {target_epic}.{topic} --routing discussion --source discovery
 ```
 
 → Proceed to **K. Cleanup**.

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -206,9 +206,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name
 Create the map item — `routing` is `research` if it exists, otherwise `discussion`:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {selected.name}.discovery.{selected.name}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {selected.name}.discovery.{selected.name} routing {research|discussion}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {selected.name}.discovery.{selected.name} source discovery
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {selected.name}.{selected.name} --routing {research|discussion} --source discovery
 ```
 
 > *Output the next fenced block as markdown (not a code block):*


### PR DESCRIPTION
Third of the per-PR Incoming redo. Stacks on **PR 2** (`idea/incoming-pr-2-shared-create-topic`, #366). Design log: `incoming/design.md`.

## What

Finishes the consolidation started in PR 1 (CLI) and PR 2 (full-spawn sites on the shared ref) by migrating the five **discovery-only** creation sites — those that write a `phases.discovery.items.{topic}` entry with **no `--phase`** — off their `init-phase` + `set` chains onto a single atomic `create-discovery-topic` call:

- `workflow-discovery/references/confirm-and-persist.md` §A (synthesis loop) — `--source discovery` + summary + description
- `workflow-shared/references/ensure-discovery-item.md` §D (idempotent single) — `--source direct-start`, optional summary/description
- `workflow-shared/references/analysis-approval-gate.md` §C (post-approval loop) — `--source "{source}"` verbatim (`research-analysis:{parent}` / `gap-analysis`)
- `workflow-start/references/absorb-into-epic.md` §J (both H4 branches) — `--source discovery`
- `workflow-start/references/manage-work-unit.md` (feature→epic pivot) — `--source discovery`

**Behaviour-preserving refactor.** Same resulting manifest item, same idempotency, same error-on-exists, same interactivity, same commits. The win is atomicity (one locked write replacing a 3–6 command sequence that could half-build a topic).

## Approach — direct CLI, not the shared ref

The shared ref (`create-discovery-topic.md`) is the **interactive** full-spawn helper: section A renders a collision menu with `**STOP.**` and no flag to suppress it. These sites are non-interactive, and `ensure-discovery-item` §B requires a silent idempotent no-op the collision menu would break. Routing them through the ref would inject STOP gates that never existed. Post-CLI the create is one line, so a wrapping ref would be parameter boilerplate with no instruction density. See the new decision-log entry in `incoming/design.md`.

## Out of scope

`map-operations.md` §F is a topic **rename** (delete old key → recreate, preserving fields), semantically distinct from a fresh spawn — deliberately excluded. The only remaining discovery-item `init-phase`+`set` chain lives there.

## Verification

- `bash tests/scripts/test-workflow-manifest.sh` — 277/277 green (CLI untouched; suite already covers discovery-only no-`--phase`, omitted summary/description as absent keys, duplicate rejection, atomicity).
- Behaviour-preservation on a throwaway temp epic fixture: each site's call shape produces a `phases.discovery.items.{topic}` matching the pre-migration item (`status, routing, source` + summary/description present-or-absent per site); no `--phase` → no phase item created; duplicate rejection preserved.
- Residual-chain grep: no `init-phase {…}.discovery` + `set … routing` chains remain in the five files.
- Convention check: CONVENTIONS.md re-read; assembly notes (not inline conditionals) beside command blocks; H4 branches preserved; no new STOP gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #360
2. #366
3. **#367** 👈 current
4. #368
5. #369
6. #370
7. #371
<!-- stack:links:end -->