### PR TITLE
Incoming PR 6 — drain + conclusion gate (Triage)

### DIFF
--- a/incoming/design.md
+++ b/incoming/design.md
@@ -137,7 +137,7 @@ Scope per PR:
 - **PR 3** — migrate discovery-only sites onto the CLI directly (confirm-and-persist §A, ensure-discovery-item §D, analysis-approval-gate §C, absorb-into-epic §J, manage-work-unit pivot).
 - **PR 4** — Incoming substrate: templates + initialize-* seed `## Incoming (none)`; CLAUDE.md + test declare `incoming:{origin}` provenance. (Stub *creation* on a fresh target is landing-time — PR 5.)
 - **PR 5** — Incoming landing: `incoming-landing.md` (classify target → new / fresh / existing+reopen), caller-side target resolution with an ambiguity menu, trigger wiring (discussion §F, epic-research §C), non-epic routing (feature §E).
-- **PR 6** — drain + conclusion gate + reopen guard.
+- **PR 6** — drain (`drain-triage.md`, folded in at the session step) + conclusion gate + document-review Triage check. No reopen guard (dropped per the prior decision).
 - **PR 7** — make the off-topic `pivot` option real: extract the feature→epic conversion core (set `work_type epic`, reindex, register the discovery-map topic, `create-discovery-topic`) from `manage-work-unit.md` into a shared `pivot-to-epic.md`; `manage-work-unit` loads it (no behaviour change). Wire the off-topic `pivot` (feature §E, discussion §F non-epic) to load it, then land the triggering concern as a topic. Today `pivot` only points the user at the manage menu — a no-op the off-topic menu shouldn't pretend to perform.
 
 PRs 1–3 are a behaviour-preserving no-op refactor. Only PRs 4–7 introduce new behaviour.
@@ -156,7 +156,7 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
 | 3 | `idea/incoming-pr-3-discovery-direct-cli` | PR 2 | #367 | open — redo (old #362 closed) |
 | 4 | `idea/incoming-pr-4-template-substrate` | PR 3 | #368 | open — redo (old #363 closed) |
 | 5 | `idea/incoming-pr-5-incoming-landing` | PR 4 | #369 | open — redo (old #364 closed) |
-| 6 | _to re-cut_ | PR 5 | — | pending (old #365 closed) |
+| 6 | `idea/incoming-pr-6-drain-and-gate` | PR 5 | — | open — redo (old #365 closed) |
 | 7 | _to cut_ | PR 6 | — | pending — make off-topic `pivot` real |
 
 ## Decisions taken during implementation
@@ -220,6 +220,22 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
 - **Refactor (PRs 2–3) leaves one non-semantic diff:** discovery-item key order
   (`status,routing,source,summary,description` from `create-discovery-topic` vs the old sequential `set`
   order). Values identical.
+- **PR 6 drain runs at the SKILL.md session step**, not inside the session reference — discussion Step 5
+  (before `discussion-session.md` loads), research Step 6 (before `route-session.md` loads). `topic`/`work_unit`
+  are already bound there (the prior Contextual Query step operates on the topic), and the research insertion
+  sits above `route-session`'s epic/feature fan-out so one call covers both. Invoked once per session: a fresh
+  `(none)` artefact no-ops, resume/reopen folds whatever landed.
+- **Drain preserves the full rerouted context, not a bare map row.** Discussion → `pending` subtopic on the
+  Discussion Map + a seeded `## {title}` section (entry body as initial Context); research → a `### {title}`
+  seed thread in the freeform body. Then delete the drained subsection; reset to `(none)` when the last is gone.
+- **Conclusion gate is a backstop placed before the conclude action.** Drain at session start normally empties
+  Triage first, so the gate fires only when a concern lands in *this* topic mid-session (a reroute after drain
+  ran). On non-empty Triage it renders a `⚑` callout and returns to the session step (Step 5 / Step 6), which
+  re-runs drain and folds the late arrival.
+- **PR 6 adapts, not replays, closed #365.** Same shape (drain + gate + document-review check) but renamed to
+  Triage / `drain-triage.md`, and the reopen guard is dropped — the epic specification phase already handles a
+  regressed-to-`in-progress` source via its `[extracted, reopened]` state, and single-topic types never reopen
+  via Triage. #365's reopen `⚑` was added then removed as redundant / a false positive.
 
 ## Verification
 

--- a/incoming/design.md
+++ b/incoming/design.md
@@ -156,7 +156,7 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
 | 3 | `idea/incoming-pr-3-discovery-direct-cli` | PR 2 | #367 | open — redo (old #362 closed) |
 | 4 | `idea/incoming-pr-4-template-substrate` | PR 3 | #368 | open — redo (old #363 closed) |
 | 5 | `idea/incoming-pr-5-incoming-landing` | PR 4 | #369 | open — redo (old #364 closed) |
-| 6 | `idea/incoming-pr-6-drain-and-gate` | PR 5 | — | open — redo (old #365 closed) |
+| 6 | `idea/incoming-pr-6-drain-and-gate` | PR 5 | #370 | open — redo (old #365 closed) |
 | 7 | _to cut_ | PR 6 | — | pending — make off-topic `pivot` real |
 
 ## Decisions taken during implementation

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -177,6 +177,8 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 > explore edge cases, and capture decisions as we go.
 ```
 
+Load **[drain-triage.md](../workflow-shared/references/drain-triage.md)** with work_unit = `{work_unit}`, topic = `{topic}`, phase = `discussion`.
+
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.
 
 *Knowledge-base nudge — before committing to a direction on a new subtopic, or when a decision might echo one made elsewhere, run a quick query. See **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)**.*

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -4,7 +4,22 @@
 
 ---
 
-When the discussion session returns here (either through natural convergence or user-initiated conclusion):
+When the discussion session returns here (either through natural convergence or user-initiated conclusion), first check the `## Triage` section of `.workflows/{work_unit}/discussion/{topic}.md`.
+
+**If `## Triage` is not `(none)`:**
+
+A concern was rerouted into this topic after drain ran this session. It must be folded before concluding.
+
+> *Output the next fenced block as a code block:*
+
+```
+  ⚑ Triage not empty — {N} rerouted concern(s) awaiting fold.
+    Returning to the session to drain and explore them before concluding.
+```
+
+→ Return to **[the skill](../SKILL.md)** for **Step 5**.
+
+**If `## Triage` is `(none)`:**
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -31,6 +31,7 @@ Pull the current state fresh into context — don't rely on your memory of what 
 - The **Discussion Map** and every subtopic's state
 - Each subtopic section (Context → Options → Journey → Decision)
 - The **Summary** section (Key Insights, Open Threads, Current State)
+- The **Triage** section — it must read `(none)` by conclusion
 
 → Proceed to **B. Compare and Reconcile**.
 
@@ -44,11 +45,14 @@ Walk the conversation against the document and check three dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user pushback, competing options understated to make the chosen one look cleaner, or a subtopic marked `decided` on the Discussion Map when it was really `converging`. Check the Discussion Map itself for drift — child subtopics absorbed into a parent decision when they weren't fully resolved, Open Threads in the Summary that don't match what was actually left unresolved in the conversation.
 
+4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the working content — a `pending` subtopic on the Discussion Map plus a seeded `## {title}` section — and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
+
 **Apply the reconciliation.** For each finding:
 
 - Gap → add the missing substance to the discussion file at the appropriate place (subtopic section, Journey, or Summary)
 - Hallucination → remove or correct to match what was discussed
 - Drift → rewrite to faithfully reflect the conversation; correct Discussion Map states where needed
+- Undrained Triage entry → fold into the Discussion Map and a subtopic section, then reset `## Triage` to `(none)`; restore the placeholder if it drifted
 
 Commit the changes with a descriptive message (e.g., `docs(discussion): capture undocumented trade-off thread`, `docs(discussion): correct drift on caching decision`, `docs(discussion): soften Map state to converging`).
 

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -200,6 +200,8 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 > No decisions needed at this stage.
 ```
 
+Load **[drain-triage.md](../workflow-shared/references/drain-triage.md)** with work_unit = `{work_unit}`, topic = `{topic}`, phase = `research`.
+
 Load **[route-session.md](references/route-session.md)** and follow its instructions as written.
 
 *Knowledge-base nudge — if a thread feels familiar, or you're about to re-tread ground that might have been covered in another work unit, run a quick query before proceeding. See **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)**.*

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -4,6 +4,23 @@
 
 ---
 
+First check the `## Triage` section of `.workflows/{work_unit}/research/{topic}.md`.
+
+**If `## Triage` is not `(none)`:**
+
+A concern was rerouted into this topic after drain ran this session. It must be folded before concluding.
+
+> *Output the next fenced block as a code block:*
+
+```
+  ⚑ Triage not empty — {N} rerouted concern(s) awaiting fold.
+    Returning to the session to drain and explore them before concluding.
+```
+
+→ Return to **[the skill](../SKILL.md)** for **Step 6**.
+
+**If `## Triage` is `(none)`:**
+
 1. Set research status to completed:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.research.{topic} status completed

--- a/skills/workflow-research-process/references/document-review.md
+++ b/skills/workflow-research-process/references/document-review.md
@@ -27,7 +27,7 @@ Read the research document(s) in full:
 - Feature: `.workflows/{work_unit}/research/{topic}.md`
 - Epic: all files in `.workflows/{work_unit}/research/` relevant to the current topic
 
-Pull the current state fresh into context — don't rely on your memory of what you wrote earlier.
+Pull the current state fresh into context — don't rely on your memory of what you wrote earlier. Include the `## Triage` section — it must read `(none)` by conclusion.
 
 → Proceed to **B. Compare and Reconcile**.
 
@@ -41,11 +41,14 @@ Walk the conversation against the document and check three dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user views, tradeoffs reframed beyond what the conversation supported, or context omitted that changes how a position should read.
 
+4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the research body as a seed thread and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
+
 **Apply the reconciliation.** For each finding:
 
 - Gap → add the missing substance to the research file at the appropriate place
 - Hallucination → remove or correct to match what was discussed
 - Drift → rewrite to faithfully reflect the conversation
+- Undrained Triage entry → fold into the research body as a seed thread, then reset `## Triage` to `(none)`; restore the placeholder if it drifted
 
 Commit the changes with a descriptive message (e.g., `docs(research): capture undocumented tradeoff thread`, `docs(research): correct drift on storage preference`).
 

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -1,0 +1,65 @@
+# Drain Triage
+
+*Shared reference. Loaded by `workflow-discussion-process` (Step 5) and `workflow-research-process` (Step 6) at the session step, before the session loop runs.*
+
+---
+
+Folds the current topic's `## Triage` entries — concerns rerouted here from other topics — into its working content, then resets the section to `(none)`. Runs once per session, before the loop. A fresh `(none)` artefact is a no-op; a resume or reopen folds whatever landed since the topic last ran.
+
+The fold preserves the **full** rerouted context — each entry becomes real working material the session explores, not a bare map row. The conclusion gate backstops this: a topic cannot conclude while its `## Triage` ≠ `(none)`.
+
+## Parameters
+
+The caller provides these via context before loading:
+
+- `work_unit` — the epic. Always present.
+- `topic` — the current topic, whose artefact is drained.
+- `phase` — `discussion` or `research`. Selects the artefact path and the fold shape.
+
+## A. Read
+
+Read the `## Triage` section of `.workflows/{work_unit}/{phase}/{topic}.md`.
+
+#### If it holds exactly `(none)`
+
+Nothing landed. No-op — do not commit, surface nothing.
+
+→ Return to caller.
+
+#### Otherwise
+
+The section holds one or more `### {title}` entries (shape pinned in [triage-landing.md](triage-landing.md)).
+
+→ Proceed to **B. Fold Each Entry**.
+
+## B. Fold Each Entry
+
+For each `### {title}` subsection under `## Triage`, carry its **full body** (everything below the `*From: ...*` line) into the topic's working content:
+
+**If `phase` is `discussion`:**
+
+- Add `{title}` to the Discussion Map as a `pending` subtopic (`○ {title} [pending]`).
+- Create a `## {title}` subtopic section with the entry body written in as its `### Context`, so the session explores it from there.
+
+**If `phase` is `research`:**
+
+- Fold the entry body into the freeform research body as a seed thread under a `### {title}` heading, so the session picks it up from there.
+
+Delete each drained `### {title}` subsection from `## Triage`. When the last entry is removed, reset the section to its `(none)` placeholder.
+
+Surface that concerns arrived from elsewhere:
+
+> *Output the next fenced block as a code block:*
+
+```
+  ⚑ Drained {N} rerouted concern(s) into this topic:
+    {title}, {title}
+```
+
+→ Proceed to **C. Commit**.
+
+## C. Commit
+
+Commit the drained artefact with message `{phase}({work_unit}/{topic}): drain triage`.
+
+→ Return to caller.


### PR DESCRIPTION
Sixth of the per-PR Incoming redo. Stacks on PR 5 (#369). Design log: `incoming/design.md`.

## What

PR 5 made reroute *write* concerns into a target topic's `## Triage` section, but nothing *consumed* them. PR 6 closes the loop:

- **Drain** — at the session step (discussion Step 5, research Step 6, before the session loads), fold the current topic's `## Triage` entries into its working content, then reset to `(none)`. Preserves the full rerouted context: discussion → `pending` subtopic + seeded `## {title}` section; research → `### {title}` seed thread in the body. Commits its own change `{phase}({wu}/{topic}): drain triage`. No-op on a fresh `(none)` artefact.
- **Conclusion gate** — a backstop before the conclude action: a topic cannot conclude while `## Triage` ≠ `(none)`; on a late mid-session arrival it renders a `⚑` callout and returns to the session step, which re-runs drain.
- **Document-review check** — a 4th "Triage consistency" dimension on both sides verifies Triage drained to `(none)` by conclusion.

Adapts (not replays) closed #365: renamed to Triage / `drain-triage.md`, reopen guard dropped per prior decision.

## Files

- `skills/workflow-shared/references/drain-triage.md` (new)
- `skills/workflow-{discussion,research}-process/SKILL.md` — wire drain into the session step
- `skills/workflow-{discussion,research}-process/references/conclude-*.md` — gate
- `skills/workflow-{discussion,research}-process/references/document-review.md` — Triage consistency dimension
- `incoming/design.md` — rides forward (scope, stack row, decision log)

## Verification

- `bash tests/scripts/test-workflow-manifest.sh` → 277 passed, 0 failed
- `node tests/scripts/test-discovery-utils.cjs` → green
- No code paths touched; markdown skill-flow only. `drain-incoming.md` absent; no `## Incoming`/`incoming:`/`elevate` reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #360
2. #366
3. #367
4. #368
5. #369
6. **#370** 👈 current
7. #371
<!-- stack:links:end -->