### PR TITLE
Incoming PR 7 — make off-topic pivot real

### DIFF
--- a/incoming/design.md
+++ b/incoming/design.md
@@ -157,7 +157,7 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
 | 4 | `idea/incoming-pr-4-template-substrate` | PR 3 | #368 | open — redo (old #363 closed) |
 | 5 | `idea/incoming-pr-5-incoming-landing` | PR 4 | #369 | open — redo (old #364 closed) |
 | 6 | `idea/incoming-pr-6-drain-and-gate` | PR 5 | #370 | open — redo (old #365 closed) |
-| 7 | _to cut_ | PR 6 | — | pending — make off-topic `pivot` real |
+| 7 | `idea/incoming-pr-7-pivot-to-epic` | PR 6 | #371 | open — make off-topic `pivot` real |
 
 ## Decisions taken during implementation
 

--- a/incoming/design.md
+++ b/incoming/design.md
@@ -265,6 +265,13 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
   `proposed_name` + `concern` as named variables; `triage-landing.md` → `create-discovery-topic.md` →
   `topic-name-validation.md` already own kebab normalisation, the live-map collision check, and the
   pick-another/cancel loop (with its own STOP). No separate confirm gate in the caller.
+- **Reroute handoffs aligned with pivot for consistency.** The pre-existing reroute paths
+  (`discussion-session.md` §F `Otherwise`, `epic-session.md` §C) handed off to `triage-landing.md` with a
+  "Gather the full context…" non-action step and a `concern = {concern and its full context}` prose flag. Both
+  reworded to bind `concern` as a named variable and pass `concern = {concern}` — matching the pivot handoff so
+  the same operation reads the same way across the off-topic flow. Prose-only; behaviour unchanged. Target
+  *resolution* (step 1: propose/confirm an existing topic, candidate menu) is left as-is — a genuine interactive
+  choice, not the redundant name-confirm the pivot path dropped.
 
 ## Verification
 

--- a/incoming/design.md
+++ b/incoming/design.md
@@ -236,6 +236,23 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
   Triage / `drain-triage.md`, and the reopen guard is dropped — the epic specification phase already handles a
   regressed-to-`in-progress` source via its `[extracted, reopened]` state, and single-topic types never reopen
   via Triage. #365's reopen `⚑` was added then removed as redundant / a false positive.
+- **PR 7 extracts the conversion core, it doesn't rewrite it.** `pivot-to-epic.md` lifts `manage-work-unit.md`'s
+  pivot steps verbatim (set `work_type epic` → reindex → register the topic on the discovery map via the
+  `create-discovery-topic` CLI direct, `--source discovery`). `manage-work-unit` now just loads it; its
+  continue/back menu (which already carries the "converted from feature to epic" line) is unchanged. Behaviour
+  is byte-identical.
+- **`pivot-to-epic.md` stays commitless.** `manage-work-unit`'s pivot block never committed (the continue/back
+  menu or the subsequent continue-epic entry carries the change forward), so the extracted core preserves that:
+  it writes the manifest and returns dirty. Each caller owns its commit — `manage-work-unit` keeps not
+  committing; the off-topic callers commit conversion + landing together.
+- **Off-topic pivot reuses `triage-landing.md` to land the concern.** After the conversion the situation is
+  exactly the epic reroute case — a concern bound for a new topic — so the off-topic `pivot` branch (feature
+  `feature-session.md` §E, discussion `discussion-session.md` §F non-epic) proposes + confirms a kebab name,
+  gathers full context, and loads `triage-landing.md` (new-target path) rather than inventing a second landing
+  mechanism. This preserves full context (into the new topic's `## Triage`, drained when it next runs) instead
+  of dropping a bare map row. The current topic's session then continues; the new topic waits on the map for
+  `continue-epic`. A `cancelled` name-validation leaves the pivot standing and notes the concern in the
+  current artefact.
 
 ## Verification
 

--- a/incoming/design.md
+++ b/incoming/design.md
@@ -253,6 +253,18 @@ to main with it. From PR 2 onward each PR is re-cut fresh on top of its redone p
   of dropping a bare map row. The current topic's session then continues; the new topic waits on the map for
   `continue-epic`. A `cancelled` name-validation leaves the pivot standing and notes the concern in the
   current artefact.
+- **Off-topic `pivot` is gated to `feature` only.** `feature-session.md` §E and `discussion-session.md` §F
+  (non-epic) are reached by exactly `feature` and `cross-cutting` (bugfix/quick-fix have no research or
+  discussion phase). `pivot` (feature→epic) is the wrong tool for cross-cutting: cross-cutting is the terminal,
+  define-only, project-level tier that work is promoted *to* (`promote-to-cross-cutting.md`), not converted away
+  from into a buildable epic. So the `p`/`pivot` menu line is wrapped in `@if(work_type == 'feature')`; a
+  cross-cutting off-topic concern uses `log` (→ inbox → its own standalone unit later) or `ignore`. This also
+  matches `manage-work-unit.md`'s existing `work_type == 'feature'` gate on pivot. (Also corrected §F's intro
+  parenthetical, which wrongly listed bugfix/quick-fix as the non-epic types reaching discussion.)
+- **Name confirmation/clash is delegated, not re-implemented.** The off-topic pivot's step 2 only derives
+  `proposed_name` + `concern` as named variables; `triage-landing.md` → `create-discovery-topic.md` →
+  `topic-name-validation.md` already own kebab normalisation, the live-map collision check, and the
+  pick-another/cancel loop (with its own STOP). No separate confirm gate in the caller.
 
 ## Verification
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -242,9 +242,9 @@ Note the concern in the Summary section for the user to consider separately, and
 
    A chosen candidate is the target; `new` means propose a kebab-case name and confirm it. If the resolved target is the current topic (`{topic}`), it's a detail of this discussion, not a reroute — add it to the Discussion Map as a `pending` subtopic and → Return to **B. Session Loop**.
 
-2. Gather the full context discussed about the concern — everything worked out so far, not a one-line summary. The target topic picks this up cold, so it needs the whole thing.
+2. Record the concern with the full context discussed about it as `concern` — the target topic picks it up cold.
 
-3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{concern and its full context}`, origin = `{topic}`, phase = `discussion`, date = `{today}`. If `result` is `cancelled`, nothing landed — → Return to **B. Session Loop**. Otherwise the concern landed in `{landed_topic}`'s `## Triage`.
+3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{concern}`, origin = `{topic}`, phase = `discussion`, date = `{today}`. If `result` is `cancelled`, nothing landed — → Return to **B. Session Loop**. Otherwise the concern landed in `{landed_topic}`'s `## Triage`.
 
 4. The current Discussion Map is unchanged — rerouting sends the concern away from this topic, it doesn't mark it. Commit:
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -173,9 +173,9 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 
 1. Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{work_unit}`. The work unit is now an epic with this topic on its discovery map.
 
-2. Propose a kebab-case topic name for the concern and confirm it with the user. Gather the full context discussed about the concern — everything worked out so far, not a one-line summary; the new topic picks it up cold.
+2. From the context you already have, derive two values: `proposed_name` — a kebab-case topic name for the concern; and `concern` — the concern with the full context discussed about it.
 
-3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern and its full context}`, origin = `{topic}`, phase = `discussion`, date = `{today}`. If `result` is `cancelled`, the topic wasn't created — note the concern in the Summary so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic.
+3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern}`, origin = `{topic}`, phase = `discussion`, date = `{today}`. It validates the name against the map and, on a clash, prompts to pick another or cancel. If `result` is `cancelled`, the topic wasn't created — note the concern in the Summary so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic.
 
 4. Commit the conversion and the landing:
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -147,7 +147,7 @@ During organic discussion a concern may surface that doesn't belong under the cu
 
 #### If work type is not `epic`
 
-Single-topic work types (feature, bugfix, quick-fix) have no other topic to route to — the topic *is* the work unit.
+Single-topic work types (feature, cross-cutting) have no other topic to route to — the topic *is* the work unit.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -156,7 +156,9 @@ Single-topic work types (feature, bugfix, quick-fix) have no other topic to rout
 **{concern}** is beyond this topic's scope.
 
 - **`l`/`log`** — Capture it as an idea in the inbox for later
+@if(work_type == 'feature')
 - **`p`/`pivot`** — Convert this work to an epic so it can hold the concern as its own topic
+@endif
 - **`i`/`ignore`** — Note it in the Summary and move on
 · · · · · · · · · · · ·
 ```

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -171,7 +171,7 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 
 **If `pivot`:**
 
-1. Convert this work to an epic — load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{work_unit}`. The work unit is now an epic with this topic on its discovery map.
+1. Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{work_unit}`. The work unit is now an epic with this topic on its discovery map.
 
 2. Propose a kebab-case topic name for the concern and confirm it with the user. Gather the full context discussed about the concern — everything worked out so far, not a one-line summary; the new topic picks it up cold.
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -171,7 +171,25 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 
 **If `pivot`:**
 
-Note the concern in the Summary so it isn't lost, then tell the user they can pivot this work to an epic from the manage menu (`p`/`pivot`) and route the concern as a topic from there.
+1. Convert this work to an epic — load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{work_unit}`. The work unit is now an epic with this topic on its discovery map.
+
+2. Propose a kebab-case topic name for the concern and confirm it with the user. Gather the full context discussed about the concern — everything worked out so far, not a one-line summary; the new topic picks it up cold.
+
+3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern and its full context}`, origin = `{topic}`, phase = `discussion`, date = `{today}`. If `result` is `cancelled`, the topic wasn't created — note the concern in the Summary so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic.
+
+4. Commit the conversion and the landing:
+
+   ```bash
+   git add -- .workflows/{work_unit}/
+   git commit -m "discussion({work_unit}/{topic}): pivot to epic"
+   ```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> This work is now an epic — continuing here with the current topic.
+> The concern is preserved for its own handling later.
+```
 
 → Return to **B. Session Loop**.
 

--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -65,9 +65,9 @@ When a concern surfaces that belongs to a *different* topic — raised in conver
 
    A chosen candidate is the target; `new` means propose a kebab-case name and confirm it. If the resolved target is the current topic, it's not a reroute — fold it into this research file as a thread and → Return to **B. Session Loop**.
 
-2. Gather the full context discussed about the concern — everything raised so far, not a one-line summary. The target topic picks this up cold, so it needs the whole thing.
+2. Record the concern with the full context discussed about it as `concern` — the target topic picks it up cold.
 
-3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{concern and its full context}`, origin = `{topic}`, phase = `research`, date = `{today}`. If `result` is `cancelled`, nothing landed — → Return to **B. Session Loop**. Otherwise the concern landed in `{landed_topic}`'s `## Triage`.
+3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{concern}`, origin = `{topic}`, phase = `research`, date = `{today}`. If `result` is `cancelled`, nothing landed — → Return to **B. Session Loop**. Otherwise the concern landed in `{landed_topic}`'s `## Triage`.
 
 4. Commit:
 

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -80,7 +80,9 @@ When a concern surfaces that's beyond this topic's scope, a single-topic work ty
 **{concern}** is beyond this topic's scope.
 
 - **`l`/`log`** — Capture it as an idea in the inbox for later
+@if(work_type == 'feature')
 - **`p`/`pivot`** — Convert this work to an epic so it can hold the concern as its own topic
+@endif
 - **`i`/`ignore`** — Note it in the research file and move on
 · · · · · · · · · · · ·
 ```

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -95,7 +95,25 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 
 **If `pivot`:**
 
-Note the concern in the research file so it isn't lost, then tell the user they can pivot this work to an epic from the manage menu (`p`/`pivot`) and route the concern as a topic from there.
+1. Convert this work to an epic — load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{work_unit}`. The work unit is now an epic with this topic on its discovery map.
+
+2. Propose a kebab-case topic name for the concern and confirm it with the user. Gather the full context discussed about the concern — everything worked out so far, not a one-line summary; the new topic picks it up cold.
+
+3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern and its full context}`, origin = `{topic}`, phase = `research`, date = `{today}`. If `result` is `cancelled`, the topic wasn't created — note the concern in the research file so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic.
+
+4. Commit the conversion and the landing:
+
+   ```bash
+   git add -- .workflows/{work_unit}/
+   git commit -m "research({work_unit}/{topic}): pivot to epic"
+   ```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> This work is now an epic — continuing here with the current topic.
+> The concern is preserved for its own handling later.
+```
 
 → Return to **B. Session Loop**.
 

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -95,7 +95,7 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 
 **If `pivot`:**
 
-1. Convert this work to an epic — load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{work_unit}`. The work unit is now an epic with this topic on its discovery map.
+1. Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{work_unit}`. The work unit is now an epic with this topic on its discovery map.
 
 2. Propose a kebab-case topic name for the concern and confirm it with the user. Gather the full context discussed about the concern — everything worked out so far, not a one-line summary; the new topic picks it up cold.
 

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -97,9 +97,9 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 
 1. Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{work_unit}`. The work unit is now an epic with this topic on its discovery map.
 
-2. Propose a kebab-case topic name for the concern and confirm it with the user. Gather the full context discussed about the concern — everything worked out so far, not a one-line summary; the new topic picks it up cold.
+2. From the context you already have, derive two values: `proposed_name` — a kebab-case topic name for the concern; and `concern` — the concern with the full context discussed about it.
 
-3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern and its full context}`, origin = `{topic}`, phase = `research`, date = `{today}`. If `result` is `cancelled`, the topic wasn't created — note the concern in the research file so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic.
+3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern}`, origin = `{topic}`, phase = `research`, date = `{today}`. It validates the name against the map and, on a clash, prompts to pick another or cancel. If `result` is `cancelled`, the topic wasn't created — note the concern in the research file so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic.
 
 4. Commit the conversion and the landing:
 

--- a/skills/workflow-shared/references/pivot-to-epic.md
+++ b/skills/workflow-shared/references/pivot-to-epic.md
@@ -24,7 +24,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_
 
 Re-index so every completed chunk carries the new `work_type: epic`:
 
-→ Load **[reindex-work-unit.md](../workflow-knowledge/references/reindex-work-unit.md)** with work_unit = `{work_unit}`.
+→ Load **[reindex-work-unit.md](../../workflow-knowledge/references/reindex-work-unit.md)** with work_unit = `{work_unit}`.
 
 → Proceed to **C. Register the Topic on the Discovery Map**.
 

--- a/skills/workflow-shared/references/pivot-to-epic.md
+++ b/skills/workflow-shared/references/pivot-to-epic.md
@@ -1,0 +1,49 @@
+# Pivot to Epic
+
+*Shared reference. Loaded by `workflow-start` (manage menu), `workflow-research-process`, and `workflow-discussion-process` (off-topic pivot) to convert a single-topic feature into an epic.*
+
+---
+
+Converts a feature work unit into an epic: flips its `work_type`, re-indexes its completed artifacts so chunk metadata stays in sync, and registers its single topic on the new discovery map. Mechanical only — the caller owns the user-facing framing and the commit (this reference writes the manifest but does **not** commit).
+
+## Parameters
+
+The caller provides this via context before loading:
+
+- `work_unit` — the feature being converted. Its single topic shares the work unit's name.
+
+## A. Convert the Work Type
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_type epic
+```
+
+→ Proceed to **B. Re-Index Completed Artifacts**.
+
+## B. Re-Index Completed Artifacts
+
+Re-index so every completed chunk carries the new `work_type: epic`:
+
+→ Load **[reindex-work-unit.md](../workflow-knowledge/references/reindex-work-unit.md)** with work_unit = `{work_unit}`.
+
+→ Proceed to **C. Register the Topic on the Discovery Map**.
+
+## C. Register the Topic on the Discovery Map
+
+The feature's single topic (topic name = work unit name) joins the discovery map. Leave `summary` and `description` unset — `summary-backfill.md` fills them on the next `/workflow-continue-epic` entry.
+
+Determine routing from whether the feature did research:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.research
+```
+
+Create the map item — `routing` is `research` if the research phase exists, otherwise `discussion`:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {work_unit}.{work_unit} --routing {research|discussion} --source discovery
+```
+
+No commit here — the caller frames the conversion and folds this write into its own commit.
+
+→ Return to caller.

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -187,27 +187,7 @@ Commit: `workflow({selected.name}): mark as completed`
 
 #### If user chose `p`/`pivot`
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {selected.name} work_type epic
-```
-
-Re-index all completed artifacts so their chunks carry the new `work_type: epic`:
-
-Load **[reindex-work-unit.md](../../workflow-knowledge/references/reindex-work-unit.md)** with work_unit = `{selected.name}`.
-
-Register the feature's topic on the discovery map (topic name = work unit name). Leave `summary` and `description` unset — `summary-backfill.md` fills them on the next `/workflow-continue-epic` entry.
-
-Check whether the feature did research:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {selected.name}.research
-```
-
-Create the map item — `routing` is `research` if it exists, otherwise `discussion`:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {selected.name}.{selected.name} --routing {research|discussion} --source discovery
-```
+Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{selected.name}`.
 
 > *Output the next fenced block as markdown (not a code block):*
 


### PR DESCRIPTION
Seventh and final PR of the Incoming redo. Stacks on PR 6 (#370). Design log: `incoming/design.md`.

## What

The off-topic `pivot` option was a no-op — it noted the concern and pointed the user at the manage menu. This makes it real, in two halves.

**Refactor (no behaviour change):** extract `manage-work-unit.md`'s feature→epic conversion core into a shared `pivot-to-epic.md` — set `work_type epic` → reindex completed artifacts → register the topic on the discovery map (`create-discovery-topic` CLI, `--source discovery`). `manage-work-unit` now loads it; its continue/back menu (already carrying "converted from feature to epic") is unchanged. Stays commitless, exactly as before.

**New wiring:** the off-topic `pivot` branch (`feature-session.md` §E, `discussion-session.md` §F non-epic) now:
1. Loads `pivot-to-epic.md` → the work unit is now an epic with its original topic on the map.
2. Proposes + confirms a kebab name for the concern, gathers full context, and loads `triage-landing.md` (new-target path) → the concern lands as its **own new topic** (full context into its `## Triage`, drained when it next runs). Cancelled name-validation leaves the pivot standing and notes the concern in the current artefact.
3. Commits conversion + landing together; the current topic's session continues; the new topic waits on the map for `continue-epic`.

Reusing `triage-landing` is deliberate — after the pivot the situation is exactly the epic reroute case, so it preserves full context rather than dropping a bare map row.

## Files

- `skills/workflow-shared/references/pivot-to-epic.md` (new)
- `skills/workflow-start/references/manage-work-unit.md` — extract core → Load
- `skills/workflow-research-process/references/feature-session.md` — §E pivot wiring
- `skills/workflow-discussion-process/references/discussion-session.md` — §F pivot wiring
- `incoming/design.md` — rides forward (decision log; stack row)

## Verification

- `bash tests/scripts/test-workflow-manifest.sh` → 277 passed, 0 failed
- `node tests/scripts/test-discovery-utils.cjs` → green
- Markdown skill-flow only; no code paths touched. `manage-work-unit` pivot is a byte-identical no-op refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #360
2. #366
3. #367
4. #368
5. #369
6. #370
7. **#371** 👈 current
<!-- stack:links:end -->