### PR TITLE
Spec groupings as manifest `proposed` items (PR1 of 3)

### DIFF
--- a/skills/workflow-continue-epic/references/display-epic-map.md
+++ b/skills/workflow-continue-epic/references/display-epic-map.md
@@ -14,7 +14,7 @@ Display two complementary views of the epic's cross-phase progress: a compact su
 
 Before rendering, derive the pipeline data from the discovery `detail` object. This section is not displayed to the user.
 
-**Pipeline definition:** Each specification topic defines a pipeline. The pipeline name is the spec topic name. Additional virtual rows exist for unassigned discussions and promoted items.
+**Pipeline definition:** Each specification topic that has been started (status other than `proposed`) defines a pipeline. The pipeline name is the spec topic name. Additional virtual rows exist for unassigned discussions, proposed groupings, and promoted items.
 
 **Per-pipeline data:**
 
@@ -30,9 +30,11 @@ Before rendering, derive the pipeline data from the discovery `detail` object. T
 
 **Unassigned row:** From `unaccounted_discussions`. Count of unaccounted discussions. `{N}✓` if all completed, `{N}◐` if any in-progress. Only the `disc` column is populated.
 
+**Proposed row:** Spec items with status `proposed`. Show `proposed` in the spec column (spanning onward). Only the `disc` column (source count, from the proposed item's sources) and `spec` column are populated.
+
 **Promoted row:** Spec items with status `promoted`. Show `promoted` in the spec column. Only the `disc` column (source count) and `spec` column are populated.
 
-**Pipeline ordering:** Completed pipelines first (all phases ✓), then in-progress (earliest active phase first), then not-started.
+**Pipeline ordering:** Completed pipelines first (all phases ✓), then in-progress (earliest active phase first), then not-started. Proposed and promoted rows follow the started pipelines.
 
 **Phase-level status icon** (for detail view headers): `✓` if all items in that phase are completed, `◐` if any are in-progress or some are completed but not all, `○` if no items are completed. When pending topics from research exist, include them in the discussion count.
 
@@ -72,6 +74,9 @@ Before rendering, derive the pipeline data from the discovery `detail` object. T
 @foreach(pipeline in pipelines)
   {pipeline.name:(left-padded)}  {disc}  {spec}  {plan}  {impl}  {rev}
 @endforeach
+@foreach(prop in proposed)
+  {prop.name:(left-padded)}  {disc}  proposed
+@endforeach
 @if(has_promoted)
   {promoted.name:(left-padded)}  {disc}  promoted
 @endif
@@ -95,7 +100,7 @@ Before rendering, derive the pipeline data from the discovery `detail` object. T
 - Pipeline names left-aligned, padded to the longest pipeline name + 2 spaces before the first column
 - Status cells use icons: `✓`, `◐`, `○`. Discussion column prefixes with count: `3✓`, `2◐`
 - Blank cells (phase doesn't exist for this pipeline) use empty space
-- `promoted` spans from the spec column onward
+- `proposed` and `promoted` each span from the spec column onward
 - Blank line between the research summary and the column headers
 - If no specification items exist, show the "No pipelines yet" message. Still show unassigned discussion count if applicable.
 
@@ -147,6 +152,7 @@ Before rendering, derive the pipeline data from the discovery `detail` object. T
 - Status icons before item names: `✓` completed, `◐` in-progress, `○` not started
 - Tree grammar: `├─` non-final, `└─` final within each phase
 - Specification items show source discussions as `← {source-topic}` sub-items using tree grammar
+- Proposed spec items use the `○` icon with a `[proposed]` suffix after the name; their source discussions still render as `← {source-topic}` sub-items
 - Promoted items show `→ promoted to {work_unit}` as a sub-item
 - Implementation items show progress as a sub-item when in-progress
 - Blank line between phase sections

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -126,13 +126,13 @@ The display groups every phase under three stage dividers — **DISCOVERY** (res
                custom Vue/Nuxt), JustEat import, staff/roles
                from exploration
       ```
-- **Build-phase sub-headers**: `{phase:(uppercase)} ({phase.count_summary})` — the phase name uppercased (`SPECIFICATION`, `PLANNING`, `IMPLEMENTATION`, `REVIEW`) with a parenthetical count summary combining the statuses present (e.g. `(2 completed)`, `(3 completed, 1 cancelled)`; omit zero counts). The item tree branches directly off the sub-header. Blank line between sub-headers within a stage.
-- **Item rows** (`{item_branch}`): `├─` for non-final items, `└─` for the final item in the phase. Planning items append ` · {format}` after the status.
+- **Build-phase sub-headers**: `{phase:(uppercase)} ({phase.count_summary})` — the phase name uppercased (`SPECIFICATION`, `PLANNING`, `IMPLEMENTATION`, `REVIEW`) with a parenthetical count summary combining the statuses present (e.g. `(2 completed)`, `(1 proposed, 2 completed)`, `(3 completed, 1 cancelled)`; omit zero counts). The item tree branches directly off the sub-header. Blank line between sub-headers within a stage.
+- **Item rows** (`{item_branch}`): `├─` for non-final items, `└─` for the final item in the phase. Planning items append ` · {format}` after the status. Within the specification phase, order proposed items first (analyzed groupings awaiting a start), then the remaining items in their existing order.
 - **Item sub-rows** — specification sources, implementation progress — branch beneath their item via `{child_gutter}` + `{child_branch}`:
   - `{child_gutter}` — under a **non-last item**: 2 spaces, `│`, 2 spaces; under the **last item**: 5 spaces. Both land the child branch at the same column, under the item name.
   - `{child_branch}`: `├─` for non-final children, `└─` for the final (or only) child.
   - Specification source status: `[incorporated]` or `[pending]` from the manifest. Implementation shows `Phase {N}, {M} task(s) completed` when in-progress with `current_phase`, else `{M} task(s) completed` (always a single `└─` child).
-- **Promoted items** render with `[promoted]` in the display but not the menu. **Cancelled items** show `[cancelled]`. Phases with no items don't appear.
+- **Promoted items** render with `[promoted]` in the display but not the menu. **Proposed specs** render with `[proposed]` in the display but are not offered as menu items. **Cancelled items** show `[cancelled]`. Phases with no items don't appear.
 - **No trailing recommendation callout** in this code block — build-phase recommendations attach to menu entries (see **C. Menu**).
 
 After the render block, run the **Plans Not Ready Check** below; it applies to both this branch and the otherwise branch.
@@ -240,6 +240,7 @@ Show only statuses and categories that appear in the current display. No `---` s
       ⊙  handled                ⊘  cancelled
 
     Status:
+      proposed    — analyzed grouping, not yet started
       in-progress — work is ongoing
       completed   — phase or implementation done
       cancelled   — topic removed from active work
@@ -261,6 +262,7 @@ Show only categories present in the current display: include the Discovery tier 
 ```
   Key:
     Status:
+      proposed    — analyzed grouping, not yet started
       in-progress — work is ongoing
       completed   — phase or implementation done
       cancelled   — topic removed from active work

--- a/skills/workflow-continue-epic/scripts/discovery.cjs
+++ b/skills/workflow-continue-epic/scripts/discovery.cjs
@@ -77,8 +77,13 @@ function buildEpicDetail(cwd, manifest) {
           ? item.sources
           : Object.entries(item.sources).map(([topic, data]) => ({ topic, ...data }));
         entry.sources = sourcesArr;
-        for (const src of sourcesArr) {
-          allSourcedDiscussions.add(src.topic || src.name);
+        // A discussion that appears only in a proposed grouping is still
+        // legitimately "not yet in a spec" — skip proposed items' sources so
+        // those discussions stay in unaccounted_discussions.
+        if (item.status !== 'proposed') {
+          for (const src of sourcesArr) {
+            allSourcedDiscussions.add(src.topic || src.name);
+          }
         }
       }
 

--- a/skills/workflow-manifest/SKILL.md
+++ b/skills/workflow-manifest/SKILL.md
@@ -407,13 +407,15 @@ The CLI validates structural values to prevent invalid state:
 | Item `status` (discussion)     | `in-progress`, `completed`                         |
 | Item `status` (investigation)  | `in-progress`, `completed`                         |
 | Item `status` (scoping)        | `in-progress`, `completed`                         |
-| Item `status` (specification)  | `in-progress`, `completed`, `superseded`, `promoted` |
+| Item `status` (specification)  | `proposed`, `in-progress`, `completed`, `superseded`, `promoted`, `cancelled` |
 | Item `status` (planning)       | `in-progress`, `completed`                         |
 | Item `status` (implementation) | `in-progress`, `completed`                         |
 | Item `status` (review)         | `in-progress`, `completed`                         |
 | Gate modes (`*_gate_mode`)     | `gated`, `auto`                                    |
 
 Status is always tracked at the item level (`phases.{phase}.items.{topic}.status`), never at the phase level.
+
+A specification item with status `proposed` is an analyzed grouping not yet started — it carries `sources.{disc}.status` rows but has no specification file on disk and no `review_cycle`/gate fields. Starting it flips the status to `in-progress`.
 
 ## Output Conventions
 

--- a/skills/workflow-manifest/scripts/manifest.cjs
+++ b/skills/workflow-manifest/scripts/manifest.cjs
@@ -24,7 +24,7 @@ const VALID_PHASE_STATUSES = {
   discussion:     ['in-progress', 'completed', 'cancelled'],
   investigation:  ['in-progress', 'completed', 'cancelled'],
   scoping:        ['in-progress', 'completed', 'cancelled'],
-  specification:  ['in-progress', 'completed', 'superseded', 'promoted', 'cancelled'],
+  specification:  ['proposed', 'in-progress', 'completed', 'superseded', 'promoted', 'cancelled'],
   planning:       ['in-progress', 'completed', 'cancelled'],
   implementation: ['in-progress', 'completed', 'cancelled'],
   review:         ['in-progress', 'completed', 'cancelled'],

--- a/skills/workflow-shared/scripts/discovery-utils.cjs
+++ b/skills/workflow-shared/scripts/discovery-utils.cjs
@@ -104,9 +104,9 @@ function phaseStatus(manifest, phase) {
     if (keys.length === 0) return null;
     if (keys.length === 1) {
       const status = (p.items[keys[0]] || {}).status || null;
-      return (status === 'cancelled' || status === 'superseded') ? null : status;
+      return (status === 'cancelled' || status === 'superseded' || status === 'proposed') ? null : status;
     }
-    const statuses = keys.map(k => (p.items[k] || {}).status).filter(s => s && s !== 'cancelled' && s !== 'superseded');
+    const statuses = keys.map(k => (p.items[k] || {}).status).filter(s => s && s !== 'cancelled' && s !== 'superseded' && s !== 'proposed');
     if (statuses.length === 0) return null;
     if (statuses.every(s => s === 'completed')) return 'completed';
     if (statuses.some(s => s === 'in-progress')) return 'in-progress';

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -80,7 +80,7 @@ Parse the discovery output to understand:
 
 **From `specifications` array:** Each specification's name, work_unit, status, work_type, sources, and superseded_by (if applicable). Specifications with `status: superseded` should be noted but excluded from active counts.
 
-**From `cache` section:** `entries` array — each entry has `status` (valid/stale), `reason`, `generated`, `anchored_names`. Empty array if no cache exists.
+**From `cache` section:** `entries` array — each entry has `status` (valid/stale), `reason`, `generated`. Empty array if no cache exists.
 
 **From `current_state`:** `completed_count`, `spec_count` (materialized, file-backed), `proposed_count`, `has_discussions`, `has_completed`, `has_specs`, `has_proposed`, and other counts/booleans for routing.
 

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -82,7 +82,7 @@ Parse the discovery output to understand:
 
 **From `cache` section:** `entries` array — each entry has `status` (valid/stale), `reason`, `generated`, `anchored_names`. Empty array if no cache exists.
 
-**From `current_state`:** `completed_count`, `spec_count`, `has_discussions`, `has_completed`, `has_specs`, and other counts/booleans for routing.
+**From `current_state`:** `completed_count`, `spec_count` (materialized, file-backed), `proposed_count`, `has_discussions`, `has_completed`, `has_specs`, `has_proposed`, and other counts/booleans for routing.
 
 **IMPORTANT**: Use ONLY this script for discovery. Do NOT run additional bash commands (ls, head, cat, etc.) to gather state.
 

--- a/skills/workflow-specification-entry/references/analysis-flow.md
+++ b/skills/workflow-specification-entry/references/analysis-flow.md
@@ -50,12 +50,12 @@ Group discussions into specifications where each grouping represents a **coheren
 
 ### Preserve Anchored Names
 
-**CRITICAL**: Check the `cache.anchored_names` from discovery state. These are grouping names that have existing specifications.
+**Anchors** are existing specification items whose status is anything other than `proposed` — `in-progress`, `completed`, `superseded`, or `promoted` — from the discovery `specifications` array. They are specs the user has already started or finished; reconcile preserves them. Proposed items are not anchors — they are freely regenerated.
 
 When forming groupings:
-- If a grouping contains a majority of the same discussions as an anchored name's spec, you MUST reuse that anchored name
+- If a grouping contains a majority of the same discussions as an anchor's sources, you MUST reuse that anchor's topic name
 - Only create new names for genuinely new groupings with no overlap
-- If an anchored spec's discussions are now scattered across multiple new groupings, note this as a **naming conflict** to present to the user
+- If an anchor's discussions are now scattered across multiple new groupings, note this as a **naming conflict** to present to the user
 
 ### Identify Cross-Grouping Hand-offs
 
@@ -79,24 +79,64 @@ Phrase the query as a natural-language description of the grouping's concern, no
 
 Treat hits as **candidate** consult references — a hit from a discussion outside this grouping that names a correction it owes is worth promoting onto the receiving grouping. **Advisory only**: never auto-add, never gate. You decide which candidates to record; the user confirms at the grouping menu.
 
-→ Proceed to **C. Save to Cache**.
+→ Proceed to **C. Reconcile Proposed Groupings**.
 
 ---
 
-## C. Save to Cache
+## C. Reconcile Proposed Groupings
 
-Write cache metadata to manifest:
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discussion analysis_cache.checksum "{checksum from current_state.discussions_checksum}"
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discussion analysis_cache.generated "{ISO date}"
-```
+Persist the analysis by reconciling the manifest's specification items against the freshly-formed groupings. The manifest is the source of truth: each purely-proposed grouping becomes a `proposed` specification item carrying its members as `pending` sources and **no file on disk**. Every mutation uses `set`/`delete` — never `init-phase`. Anchors are preserved; proposed items are freely regenerated.
+
+Work through these steps in order:
+
+1. **Snapshot existing items.** Read the current specification items and their sources:
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs get '{work_unit}.specification.*' status
+   ```
+   Partition them into **anchors** (status ∉ `proposed`) and **existing-proposed** (status `proposed`). Read sources per item as needed (`get {work_unit}.specification.{name} sources`).
+
+2. **Map groupings to anchors.** For each freshly-formed grouping that substantially overlaps an anchor's sources (a majority of members shared), rename it in memory to the anchor's topic key. This splits the groupings into **maps-to-anchor** and **purely-proposed**.
+
+3. **Augment anchors.** For each grouping mapped to an anchor, add any member discussion not already in that anchor's sources:
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{anchor} sources.{discussion}.status pending
+   ```
+   Never change an anchor's `status`. Never prune or overwrite an anchor's existing sources.
+
+4. **Compute the target proposed set.** The target names are the kebab-case names of the **purely-proposed** groupings. An independent discussion is a grouping of one — it becomes a proposed item too, so it is startable and visible.
+
+5. **Delete stale proposed.** For each existing-proposed item whose name is not in the target set, remove the whole item:
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.specification items.{name}
+   ```
+
+6. **Collision guard.** If a target proposed name equals an existing anchor key, do NOT write `proposed` over it. Surface it as a **naming conflict** to the user and drop or rename the colliding target. This protects the invariant — an anchor is never overwritten by a proposed item.
+
+7. **Upsert proposed.** For each surviving target name:
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{name} status proposed
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{name} sources.{discussion}.status pending
+   ```
+   Set one `sources.{discussion}.status pending` per grouping member. For an existing-proposed item being regenerated, prune any source no longer in the grouping (allowed only on proposed items, never anchors):
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.specification.{name} sources.{old-discussion}
+   ```
+   A **rename** of a proposed grouping is just delete-old (step 5) plus upsert-new — lossless, since a proposed item holds no file or extraction.
+
+→ Proceed to **D. Write the Cache**.
+
+---
+
+## D. Write the Cache
+
+Write the cache **after** all manifest mutations. The checksum is written last — a mid-reconcile crash then leaves a stale checksum, forcing a clean re-reconcile on the next run.
 
 Create the cache directory if needed:
 ```bash
 mkdir -p .workflows/{work_unit}/.state
 ```
 
-Write to `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md` (pure markdown, no frontmatter):
+Write to `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md` (pure markdown, no frontmatter) — the manifest holds the authoritative grouping→source mapping, so this file carries only coupling/rationale and consult-slice hints:
 
 ```markdown
 # Discussion Consolidation Analysis
@@ -124,5 +164,13 @@ Write to `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md` (p
 ```
 
 The `**Consult**` line is per-grouping — one line per consult reference, omitted entirely when a grouping owes none. List sources under each grouping as bullets; consult references stay on their own `**Consult**` line so they are never mistaken for sources.
+
+Write the cache metadata to the manifest last:
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discussion analysis_cache.checksum "{checksum from current_state.discussions_checksum}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discussion analysis_cache.generated "{ISO date}"
+```
+
+Commit the whole reconcile as one commit: `spec({work_unit}): reconcile proposed groupings`
 
 → Load **[display-groupings.md](display-groupings.md)** and follow its instructions as written.

--- a/skills/workflow-specification-entry/references/confirm-create.md
+++ b/skills/workflow-specification-entry/references/confirm-create.md
@@ -45,6 +45,8 @@ Proceed?
 
 #### If any source discussion has an individual spec
 
+`has_individual_spec` is computed proposed-blind — a discussion that appears only in a proposed grouping does not count as having an individual spec, so a proposed item never lands here for supersession.
+
 Note the supersession (`has_individual_spec: true`):
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-specification-entry/references/confirm-unify.md
+++ b/skills/workflow-specification-entry/references/confirm-unify.md
@@ -6,6 +6,8 @@
 
 Unify folds every completed discussion into the unified spec as a full **source**, so any cross-grouping consult reference is absorbed by wholesale extraction. There is no separate consult-reference block on the unify path.
 
+"Existing specifications to incorporate" lists only materialized specs (status not `proposed`) — reconcile removed the other proposed items as deletes when the unified item was created, so only started/completed specs are superseded.
+
 ## A. Display Confirmation
 
 #### If existing specifications will be superseded

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -4,7 +4,7 @@
 
 ---
 
-Prompted when multiple completed discussions exist, no specifications exist, and cache is none or stale.
+Prompted when multiple completed discussions exist, no specifications or proposed groupings exist, and cache is none or stale.
 
 ## A. Display
 

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -47,8 +47,8 @@ No `---` separator before these messages.
 
 ```
 > What happens next. Your discussions will be analyzed for natural
-> groupings to determine how they should be organized into specifications.
-> Results are cached and reused until discussions change.
+> groupings. Each grouping becomes a proposed specification you can
+> start when ready. Results are cached and reused until discussions change.
 
 · · · · · · · · · · · ·
 Proceed with analysis?

--- a/skills/workflow-specification-entry/references/display-groupings.md
+++ b/skills/workflow-specification-entry/references/display-groupings.md
@@ -4,7 +4,7 @@
 
 ---
 
-Shows when cache is valid (directly from routing) or after analysis completes. This is the most content-rich display.
+Shows when proposed groupings exist (directly from routing) or after analysis completes. This is the most content-rich display.
 
 ## A. Load Groupings
 

--- a/skills/workflow-specification-entry/references/display-groupings.md
+++ b/skills/workflow-specification-entry/references/display-groupings.md
@@ -8,7 +8,9 @@ Shows when cache is valid (directly from routing) or after analysis completes. T
 
 ## A. Load Groupings
 
-Load groupings from `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md`. Parse the `### {Name}` headings and their discussion lists. Parse each grouping's `**Consult**` lines too — each names a consult reference the grouping owes (a sibling discussion read narrowly for corrections, not a source).
+Each grouping is a specification item from the discovery `specifications` array — proposed items and materialized specs alike. The item *is* the grouping: its `sources` are the grouping's discussions, its `status` drives the verb, its `consult_references` are the consult slices it owes.
+
+For consult-slice **hints** (the human-readable "which slice / why"), read `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md` if present and match each grouping's `**Consult**` lines by name. The manifest holds the authoritative grouping→source mapping; the `.md` only enriches consult descriptions.
 
 → Proceed to **B. Determine Discussion Status**.
 
@@ -16,35 +18,24 @@ Load groupings from `.workflows/{work_unit}/.state/discussion-consolidation-anal
 
 ## B. Determine Discussion Status
 
-For each grouping, convert the name to kebab-case and check if a matching specification exists in the discovery `specifications` array.
+The item *is* the grouping — there is no name-matching step. Determine each discussion's status from the item's `status` and `sources`.
 
-#### If a matching spec exists
+#### If the item status is `proposed`
 
-For each discussion in the grouping:
-- Look up in the spec's `sources` array (by `name` field)
-- If found → use the source's `status` (`incorporated` → `extracted`, `pending` → `pending`)
-- If NOT found → status is `pending` (new source not yet in spec)
-
-Spec status: show actual status with extraction count `({X} of {Y} sources extracted)`.
-
-**Regressed sources:** After processing the grouping's discussions, check the spec's
-`sources` array from discovery. For any source where `discussion_status` is neither
-`completed` nor `not-found`, and the source is not already in the grouping:
-- Add it to the discussion tree with status `[extracted, reopened]`
-
-These represent sources that were incorporated but whose discussions have since
-regressed to in-progress. Sources with `discussion_status: "not-found"` (deleted
-discussions) are silently skipped — there is nothing actionable.
-
-**Extraction count:** Y = count of unique discussions in (spec sources ∪ grouping members). X = count of those with `incorporated` status in spec sources. This ensures regressed sources that dropped out of the grouping still count toward Y.
-
-**Consult references:** For each `**Consult**` entry on the grouping, look it up in the spec's `consult_references` array (by `name`). If found → use its `status` (`pending` or `addressed`). If not found → status is `pending` (declared in the analysis but not yet registered on the spec).
+The grouping has no spec yet. Each source discussion's status is `ready`. Each consult reference's status is `pending`. Spec status: `none`.
 
 → Proceed to **C. Display**.
 
 #### Otherwise
 
-For each discussion: status is `ready`. For each `**Consult**` entry on the grouping: status is `pending`. Spec status: `none`.
+The item is a materialized spec (`in-progress` or `completed`). For each source in the item's `sources` array:
+- `incorporated` + `discussion_status: completed` or `not-found` → `extracted`
+- `incorporated` + `discussion_status: other` (e.g. `in-progress`) → `extracted, reopened`
+- `pending` → `pending`
+
+Spec status: show the item's actual status with extraction count `({X} of {Y} sources extracted)`. Y = count of unique discussions in the item's sources; X = count of those with `incorporated` status. Sources with `discussion_status: "not-found"` (deleted discussions) are silently skipped.
+
+**Consult references:** For each entry on the item's `consult_references` array, use its `status` (`pending` or `addressed`).
 
 → Proceed to **C. Display**.
 
@@ -130,13 +121,13 @@ specification, choose "Re-analyze" and provide guidance.
 
 ## D. Menu
 
-Present one numbered menu entry per grouping. The verb and description depend on the grouping's spec state:
+Present one numbered menu entry per grouping. The verb and description depend on the item's status:
 
-- No spec exists → **Start** "{Name}" — {N} ready discussions
-- Spec is `in-progress` with pending sources → **Continue** "{Name}" — {N} source(s) pending extraction
-- Spec is `in-progress` with all extracted → **Continue** "{Name}" — all sources extracted
-- Spec is `completed` with no pending sources → **Refine** "{Name}" — completed spec
-- Spec is `completed` with pending sources → **Continue** "{Name}" — {N} new source(s) to extract
+- Status `proposed` → **Start** "{Name}" — {N} ready discussions
+- Status `in-progress` with pending sources → **Continue** "{Name}" — {N} source(s) pending extraction
+- Status `in-progress` with all extracted → **Continue** "{Name}" — all sources extracted
+- Status `completed` with no pending sources → **Refine** "{Name}" — completed spec
+- Status `completed` with pending sources → **Continue** "{Name}" — {N} new source(s) to extract
 
 When the grouping has pending consult references, append `— {N} consult ref(s) pending` to its description. Do not change the verb — consult references gate completion but never introduce a new action.
 
@@ -177,7 +168,17 @@ Every meta option (Unify, Re-analyze) MUST include its description lines.
 
 #### If user picks `Unify all`
 
-Update the cache: rewrite `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all completed discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
+Reconcile the manifest to a single proposed grouping immediately, so it never lags the cache. The target proposed set is `{unified}`:
+1. Delete every existing proposed item (reconcile step 5 — none survive into the target set).
+2. Upsert `unified` as a proposed item with every completed discussion as a `pending` source (reconcile step 7):
+   ```bash
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.unified status proposed
+   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.unified sources.{discussion}.status pending
+   ```
+
+Then rewrite `.workflows/{work_unit}/.state/discussion-consolidation-analysis.md` with a single "Unified" grouping containing all completed discussions. Keep the same checksum, update the generated timestamp. Add note: `Custom groupings confirmed by user (unified).`
+
+Commit: `spec({work_unit}): reconcile proposed groupings`
 
 Spec name: "Unified". Sources: all completed discussions.
 

--- a/skills/workflow-specification-entry/references/display-specs-menu.md
+++ b/skills/workflow-specification-entry/references/display-specs-menu.md
@@ -4,7 +4,7 @@
 
 ---
 
-Shows when multiple completed discussions exist, specifications exist, and cache is none or stale. Displays existing specs from discovery manifest data (NOT from cache), lists unassigned discussions, and offers analysis or continue options.
+Shows when materialized specifications exist and no proposed groupings remain (every grouping has already been started). Displays existing specs from discovery manifest data (NOT from cache), lists unassigned discussions, and offers analysis or continue options.
 
 ## A. Display
 
@@ -93,6 +93,12 @@ Key:
 ### Cache-Aware Message
 
 No `---` separator before these messages.
+
+#### If cache status is `valid`
+
+The grouping analysis is current and every grouping has been started. No message.
+
+→ Proceed to **B. Menu**.
 
 #### If cache status is `none`
 

--- a/skills/workflow-specification-entry/references/handoffs/create-with-incorporation.md
+++ b/skills/workflow-specification-entry/references/handoffs/create-with-incorporation.md
@@ -23,7 +23,7 @@ Output: .workflows/{work_unit}/specification/{topic}/specification.md
 
 Context: This consolidates multiple sources. The existing specification should be incorporated - extract and adapt its content alongside the discussion material. The result should be a unified specification, not a simple merge.
 
-After the specification is complete, mark the incorporated specs as superseded via manifest CLI:
+After the specification is complete, mark the incorporated specs as superseded via manifest CLI — only specs whose status is not `proposed`:
 
     set {source-work-unit}.specification.{source-topic} status superseded
     set {source-work-unit}.specification.{source-topic} superseded_by {work_unit}
@@ -32,4 +32,4 @@ After the specification is complete, mark the incorporated specs as superseded v
 Invoke the workflow-specification-process skill.
 ```
 
-Omit the `Consult references` block when the grouping owes none.
+Omit the `Consult references` block when the grouping owes none. A proposed grouping is never an "existing specification to incorporate" — it has no file; absorbing it is a delete handled by reconcile, not a supersede.

--- a/skills/workflow-specification-entry/references/handoffs/unify-with-incorporation.md
+++ b/skills/workflow-specification-entry/references/handoffs/unify-with-incorporation.md
@@ -22,7 +22,7 @@ Output: .workflows/{work_unit}/specification/unified/specification.md
 
 Context: This consolidates all discussions into a single unified specification. The existing specifications should be incorporated - extract and adapt their content alongside the discussion material.
 
-After the unified specification is complete, mark the incorporated specs as superseded via manifest CLI:
+After the unified specification is complete, mark the incorporated specs as superseded via manifest CLI — only specs whose status is not `proposed`:
 
     set {source-work-unit}.specification.{source-topic} status superseded
     set {source-work-unit}.specification.{source-topic} superseded_by unified
@@ -30,3 +30,5 @@ After the unified specification is complete, mark the incorporated specs as supe
 ---
 Invoke the workflow-specification-process skill.
 ```
+
+A proposed grouping is never an "existing specification to incorporate" — it has no file; reconcile already removed the other proposed items as deletes when the unified item was created.

--- a/skills/workflow-specification-entry/references/route-scenario.md
+++ b/skills/workflow-specification-entry/references/route-scenario.md
@@ -4,20 +4,30 @@
 
 ---
 
-Based on discovery state, load exactly ONE reference file:
+Based on discovery state, load exactly ONE reference file. Evaluate the branches in order and take the first that matches.
 
 #### If `completed_count` == 1
 
 → Load **[display-single.md](display-single.md)** and follow its instructions as written.
 
-#### If cache status is `valid`
+#### If `proposed_count` > 0
+
+Proposed items *are* the groupings — load them from the manifest.
 
 → Load **[display-groupings.md](display-groupings.md)** and follow its instructions as written.
 
-#### If `spec_count` == 0 and cache is `none` or `stale`
+#### If cache status is `valid` and `proposed_count` == 0 and `spec_count` == 0
+
+The analysis ran but its groupings were never reconciled into proposed items (an in-flight epic with a valid checksum from before proposed items existed). Re-run the analysis to materialize them.
+
+→ Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions as written.
+
+#### If `spec_count` == 0 and `proposed_count` == 0 and cache is `none` or `stale`
 
 → Load **[display-analyze.md](display-analyze.md)** and follow its instructions as written.
 
 #### Otherwise
+
+Materialized specs exist — offer analysis plus continue/refine. Mixed states (some specs started, some not yet) land here.
 
 → Load **[display-specs-menu.md](display-specs-menu.md)** and follow its instructions as written.

--- a/skills/workflow-specification-entry/references/validate-phase.md
+++ b/skills/workflow-specification-entry/references/validate-phase.md
@@ -4,17 +4,25 @@
 
 ---
 
-Check if a specification already exists for this work unit.
+Read the specification item's status from the manifest — not the file on disk. A `proposed` grouping has no file yet but is a real item:
 
-Read `.workflows/{work_unit}/specification/{topic}/specification.md` if it exists.
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.specification.{topic} status
+```
 
-#### If specification doesn't exist
+#### If the output is empty
 
-Set verb = "Creating".
+The item does not exist. Set verb = "Creating".
 
 → Return to caller.
 
-#### If specification exists with status `in-progress`
+#### If the status is `proposed`
+
+The grouping exists as a proposed item; the process skill flips it to in-progress on entry. Set verb = "Creating".
+
+→ Return to caller.
+
+#### If the status is `in-progress`
 
 > *Output the next fenced block as a code block:*
 
@@ -26,7 +34,7 @@ Set verb = "Continuing".
 
 → Return to caller.
 
-#### If specification exists with status `completed`
+#### If the status is `completed`
 
 Reset to in-progress:
 

--- a/skills/workflow-specification-entry/scripts/discovery.cjs
+++ b/skills/workflow-specification-entry/scripts/discovery.cjs
@@ -25,10 +25,13 @@ function discover(cwd, workUnit) {
       if (item.status === 'completed') completedCount++;
       else if (item.status === 'in-progress') inProgressCount++;
 
-      // Check if this discussion has an individual spec via sources
+      // Check if this discussion has an individual spec via sources. Proposed
+      // groupings are not individual specs — ignore them so the single-discussion
+      // path and grouping "matching spec" logic stay correct.
       let hasIndividualSpec = false;
       let specStatus = '';
       for (const si of specItemsList) {
+        if (si.status === 'proposed') continue;
         if (si.sources && si.sources[item.name]) {
           hasIndividualSpec = true;
           specStatus = si.status || '';
@@ -45,21 +48,31 @@ function discover(cwd, workUnit) {
   }
 
   // --- Specifications ---
+  // Classify by status, not file presence. Materialized specs
+  // (in-progress/completed/promoted) are file-backed and count toward spec_count.
+  // Proposed groupings live only in the manifest — no file on disk — and count
+  // toward proposed_count. Both land in specifications[].
   const specifications = [];
   let specCount = 0;
+  let proposedCount = 0;
 
   for (const m of manifests) {
     const specItemsList = phaseItems(m, 'specification');
     const discItemsList = phaseItems(m, 'discussion');
 
     for (const item of specItemsList) {
-      const specFile = path.join(workflowsDir, m.name, 'specification', item.name, 'specification.md');
-      if (!fileExists(specFile)) continue;
-
       const status = item.status || 'in-progress';
       if (status === 'superseded' || status === 'cancelled') continue;
 
-      specCount++;
+      const isProposed = status === 'proposed';
+      if (isProposed) {
+        proposedCount++;
+      } else {
+        const specFile = path.join(workflowsDir, m.name, 'specification', item.name, 'specification.md');
+        if (!fileExists(specFile)) continue;
+        specCount++;
+      }
+
       const spec = {
         name: item.name, work_unit: m.name, status,
         work_type: m.work_type,
@@ -154,9 +167,11 @@ function discover(cwd, workUnit) {
       completed_count: completedCount,
       in_progress_count: inProgressCount,
       spec_count: specCount,
+      proposed_count: proposedCount,
       has_discussions: discCount > 0,
       has_completed: completedCount > 0,
       has_specs: specCount > 0,
+      has_proposed: proposedCount > 0,
     },
   };
 }
@@ -211,7 +226,7 @@ function format(result) {
   lines.push('=== STATE ===');
   const cs = result.current_state;
   lines.push(`discussions: ${cs.discussion_count} (${cs.completed_count} completed, ${cs.in_progress_count} in-progress)`);
-  lines.push(`specs: ${cs.spec_count}, has_discussions: ${cs.has_discussions}, has_completed: ${cs.has_completed}`);
+  lines.push(`specs: ${cs.spec_count}, proposed: ${cs.proposed_count}, has_discussions: ${cs.has_discussions}, has_completed: ${cs.has_completed}`);
   if (cs.discussions_checksum) lines.push(`checksum: ${cs.discussions_checksum}`);
 
   return lines.join('\n') + '\n';

--- a/skills/workflow-specification-entry/scripts/discovery.cjs
+++ b/skills/workflow-specification-entry/scripts/discovery.cjs
@@ -1,8 +1,7 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
-const { loadActiveManifests, phaseItems, phaseData, listFiles, listDirs, filesChecksum, fileExists } = require('../../workflow-shared/scripts/discovery-utils.cjs');
+const { loadActiveManifests, phaseItems, phaseData, listFiles, filesChecksum, fileExists } = require('../../workflow-shared/scripts/discovery-utils.cjs');
 
 function discover(cwd, workUnit) {
   const allManifests = loadActiveManifests(cwd);
@@ -124,25 +123,9 @@ function discover(cwd, workUnit) {
       reason = 'no discussions to compare';
     }
 
-    // Extract anchored names (grouping headings with existing specs)
-    const anchoredNames = [];
-    const cacheFile = path.join(workflowsDir, m.name, '.state', 'discussion-consolidation-analysis.md');
-    try {
-      const content = fs.readFileSync(cacheFile, 'utf8');
-      const headings = content.match(/^### .+$/gm) || [];
-      for (const h of headings) {
-        const cleanName = h.replace(/^### /, '').replace(/\s*\(.*\)/, '').toLowerCase().replace(/\s+/g, '-');
-        const specDir = path.join(workflowsDir, m.name, 'specification');
-        if (fileExists(path.join(specDir, cleanName, 'specification.md'))) {
-          anchoredNames.push(cleanName);
-        }
-      }
-    } catch {}
-
     cacheEntries.push({
       work_unit: m.name, status, reason,
       checksum: cache.checksum, generated: cache.generated || 'unknown',
-      anchored_names: anchoredNames,
     });
   }
 
@@ -216,9 +199,6 @@ function format(result) {
   } else {
     for (const c of result.cache.entries) {
       lines.push(`  ${c.work_unit}: ${c.status} (${c.reason})`);
-      if (c.anchored_names.length > 0) {
-        lines.push(`    anchored: ${c.anchored_names.join(', ')}`);
-      }
     }
   }
   lines.push('');

--- a/skills/workflow-specification-process/references/initialize-specification.md
+++ b/skills/workflow-specification-process/references/initialize-specification.md
@@ -4,23 +4,65 @@
 
 ---
 
+## A. Create the Specification File
+
 → Load **[specification-format.md](specification-format.md)** and follow its instructions as written.
 
-Create the specification file at `.workflows/{work_unit}/specification/{topic}/specification.md`:
+Create the file at `.workflows/{work_unit}/specification/{topic}/specification.md` using the body template (title + specification section + working notes section).
 
-1. Use the body template from specification-format.md (title + specification section + working notes section)
-2. Register specification and initialize state via manifest CLI:
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.specification.{topic}
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} review_cycle 0
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} finding_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} construction_gate_mode gated
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} date $(date +%Y-%m-%d)
-   ```
-3. Add all sources with `status: pending` via manifest CLI:
-   ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} sources.{source-name}.status pending
-   ```
+Write the file **before** any manifest change. If a crash interrupts here the item stays `proposed` with a file on disk — the resume path recovers it on the next run via restart.
+
+→ Proceed to **B. Register or Flip the Item**.
+
+---
+
+## B. Register or Flip the Item
+
+Read the manifest item status:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.specification.{topic} status
+```
+
+#### If the output is empty
+
+The item is genuinely new (feature/bugfix, or a fresh single-discussion create). Register it, then add every source with `status: pending`:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.specification.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} sources.{source-name}.status pending
+```
+
+→ Proceed to **C. Set Review State**.
+
+#### If the status is `proposed`
+
+The grouping already exists as a proposed item — flip it to in-progress. Never run `init-phase`; the item exists and `init-phase` errors on an existing item:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} status in-progress
+```
+
+The proposed item already carries its grouping's sources as `pending` rows. For any source in this session not already present, add it — never overwrite an existing row:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} sources.{source-name}.status pending
+```
+
+→ Proceed to **C. Set Review State**.
+
+---
+
+## C. Set Review State
+
+Set review state and gate modes (both branches):
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} review_cycle 0
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} finding_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} construction_gate_mode gated
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} date $(date +%Y-%m-%d)
+```
 
 Commit: `spec({work_unit}): initialize specification`
 

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -167,7 +167,9 @@ If the index command fails, display the error but do not block — the artifact 
 
 If any of your sources were **existing specifications** (as opposed to discussions, research, or other reference material), these have now been consolidated into the new specification.
 
-1. Mark each source specification as superseded via manifest CLI:
+Only supersede sources whose status is **not** `proposed`. A proposed source is an analyzed grouping with no specification file — absorbing it is a delete handled by reconcile, never a supersede.
+
+1. Mark each non-proposed source specification as superseded via manifest CLI:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{source-topic} status superseded
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{source-topic} superseded_by {topic}

--- a/tests/scripts/test-discovery-for-specification.cjs
+++ b/tests/scripts/test-discovery-for-specification.cjs
@@ -184,23 +184,10 @@ describe('workflow-specification-entry discovery', () => {
     assert.strictEqual(r.current_state.in_progress_count, 1);
   });
 
-  it('detects valid cache with anchored names from manifest', () => {
+  it('detects valid cache from manifest checksum', () => {
     const crypto = require('crypto');
-
-    createManifest(dir, 'auth', {
-      work_type: 'feature',
-      phases: {
-        discussion: {
-          analysis_cache: { checksum: null, generated: '2026-01-01' },
-          items: { auth: { status: 'completed' } },
-        },
-      },
-    });
-    createFile(dir, '.workflows/auth/discussion/auth.md', '# Auth');
-
     const checksum = crypto.createHash('md5').update('# Auth').digest('hex');
 
-    // Update manifest with correct checksum
     createManifest(dir, 'auth', {
       work_type: 'feature',
       phases: {
@@ -210,16 +197,12 @@ describe('workflow-specification-entry discovery', () => {
         },
       },
     });
-
-    // Cache file is pure markdown (no frontmatter)
-    createFile(dir, '.workflows/auth/.state/discussion-consolidation-analysis.md',
-      '### Auth\nContent here');
-    createFile(dir, '.workflows/auth/specification/auth/specification.md', '# Spec');
+    createFile(dir, '.workflows/auth/discussion/auth.md', '# Auth');
 
     const r = discover(dir);
     assert.strictEqual(r.cache.entries.length, 1);
     assert.strictEqual(r.cache.entries[0].status, 'valid');
-    assert.ok(r.cache.entries[0].anchored_names.includes('auth'));
+    assert.strictEqual(r.cache.entries[0].anchored_names, undefined);
   });
 
   it('returns empty cache entries when none exists', () => {

--- a/tests/scripts/test-discovery-for-specification.cjs
+++ b/tests/scripts/test-discovery-for-specification.cjs
@@ -471,4 +471,102 @@ describe('workflow-specification-entry format', () => {
     const out = format(discover(dir));
     assert.ok(out.includes('checksum: '));
   });
+
+  describe('proposed groupings', () => {
+    it('counts a proposed spec item (no file) in proposed_count, not spec_count', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { 'auth-design': { status: 'completed' }, 'data-model': { status: 'completed' } } },
+          specification: {
+            items: {
+              'auth-grouping': {
+                status: 'proposed',
+                sources: { 'auth-design': { status: 'pending' } },
+              },
+            },
+          },
+        },
+      });
+      // No spec file on disk for the proposed item — must still be counted.
+      const r = discover(dir);
+      assert.strictEqual(r.current_state.proposed_count, 1);
+      assert.strictEqual(r.current_state.has_proposed, true);
+      assert.strictEqual(r.current_state.spec_count, 0);
+      const spec = r.specifications.find(s => s.name === 'auth-grouping');
+      assert.ok(spec, 'proposed item present in specifications[]');
+      assert.strictEqual(spec.status, 'proposed');
+      assert.strictEqual(spec.sources.length, 1);
+      assert.strictEqual(spec.sources[0].name, 'auth-design');
+      assert.strictEqual(spec.sources[0].status, 'pending');
+    });
+
+    it('proposed source does not set has_individual_spec', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { 'auth-design': { status: 'completed' } } },
+          specification: {
+            items: {
+              'auth-grouping': { status: 'proposed', sources: { 'auth-design': { status: 'pending' } } },
+            },
+          },
+        },
+      });
+      const r = discover(dir);
+      const disc = r.discussions.find(d => d.name === 'auth-design');
+      assert.strictEqual(disc.has_individual_spec, false);
+    });
+
+    it('single completed discussion in a proposed item still has no individual spec', () => {
+      createManifest(dir, 'solo', {
+        work_type: 'feature',
+        phases: {
+          discussion: { items: { solo: { status: 'completed' } } },
+          specification: {
+            items: { solo: { status: 'proposed', sources: { solo: { status: 'pending' } } } },
+          },
+        },
+      });
+      const r = discover(dir);
+      assert.strictEqual(r.current_state.completed_count, 1);
+      assert.strictEqual(r.discussions[0].has_individual_spec, false);
+      assert.strictEqual(r.current_state.proposed_count, 1);
+      assert.strictEqual(r.current_state.spec_count, 0);
+    });
+
+    it('mixed proposed and materialized specs count separately (R11 routing inputs)', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { 'auth-design': { status: 'completed' }, 'data-model': { status: 'completed' } } },
+          specification: {
+            items: {
+              'auth-spec': { status: 'in-progress', sources: { 'auth-design': { status: 'extracted' } } },
+              'data-grouping': { status: 'proposed', sources: { 'data-model': { status: 'pending' } } },
+            },
+          },
+        },
+      });
+      createFile(dir, '.workflows/v1/specification/auth-spec/specification.md', '# Auth Spec');
+      const r = discover(dir);
+      assert.strictEqual(r.current_state.spec_count, 1);
+      assert.strictEqual(r.current_state.proposed_count, 1);
+      assert.strictEqual(r.specifications.length, 2);
+    });
+
+    it('proposed item is included even without a spec file (file not required)', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          specification: { items: { grp: { status: 'proposed', sources: { d: { status: 'pending' } } } } },
+        },
+      });
+      const r = discover(dir);
+      assert.strictEqual(r.specifications.length, 1);
+      assert.strictEqual(r.specifications[0].status, 'proposed');
+      assert.strictEqual(r.current_state.spec_count, 0);
+      assert.strictEqual(r.current_state.proposed_count, 1);
+    });
+  });
 });

--- a/tests/scripts/test-discovery-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-discovery-for-workflow-continue-epic.cjs
@@ -1080,6 +1080,53 @@ describe('workflow-continue-epic discovery', () => {
       assert.strictEqual(d.gating.can_start_planning, true);
     });
   });
+
+  describe('proposed groupings', () => {
+    it('keeps a proposed item source in unaccounted_discussions (R1)', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { auth: { status: 'completed' }, payments: { status: 'completed' } } },
+          specification: {
+            items: {
+              'auth-spec': { status: 'in-progress', sources: [{ topic: 'auth', status: 'incorporated' }] },
+              'payments-grouping': { status: 'proposed', sources: { payments: { status: 'pending' } } },
+            },
+          },
+        },
+      });
+      const r = discover(dir);
+      // payments lives only in a proposed grouping → still "not yet in a spec".
+      assert.deepStrictEqual(r.epics[0].detail.unaccounted_discussions, ['payments']);
+    });
+
+    it('does not mark a proposed spec as next_phase_ready (R2)', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          specification: { items: { 'auth-grouping': { status: 'proposed', sources: { auth: { status: 'pending' } } } } },
+        },
+      });
+      const r = discover(dir);
+      assert.strictEqual(r.epics[0].detail.next_phase_ready.length, 0);
+      assert.strictEqual(r.epics[0].detail.gating.can_start_planning, false);
+    });
+
+    it('includes a proposed spec item in phases.specification for display', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          specification: { items: { 'auth-grouping': { status: 'proposed', sources: { auth: { status: 'pending' } } } } },
+        },
+      });
+      const r = discover(dir);
+      const specPhase = r.epics[0].detail.phases.specification;
+      assert.ok(specPhase, 'specification phase present');
+      const item = specPhase.find(i => i.name === 'auth-grouping');
+      assert.strictEqual(item.status, 'proposed');
+      assert.ok(item.sources, 'proposed item carries sources for display');
+    });
+  });
 });
 
 describe('workflow-continue-epic format', () => {

--- a/tests/scripts/test-discovery-utils.cjs
+++ b/tests/scripts/test-discovery-utils.cjs
@@ -252,6 +252,30 @@ describe('discovery-utils', () => {
       assert.strictEqual(phaseStatus({ phases: { discussion: { items: {} } } }, 'discussion'), null);
     });
 
+    it('returns null for a single proposed spec item', () => {
+      assert.strictEqual(phaseStatus({
+        phases: { specification: { items: { auth: { status: 'proposed' } } } },
+      }, 'specification'), null);
+    });
+
+    it('returns null when every spec item is proposed', () => {
+      assert.strictEqual(phaseStatus({
+        phases: { specification: { items: { a: { status: 'proposed' }, b: { status: 'proposed' } } } },
+      }, 'specification'), null);
+    });
+
+    it('ignores proposed when aggregating — proposed + completed → completed', () => {
+      assert.strictEqual(phaseStatus({
+        phases: { specification: { items: { a: { status: 'proposed' }, b: { status: 'completed' } } } },
+      }, 'specification'), 'completed');
+    });
+
+    it('ignores proposed when aggregating — proposed + in-progress → in-progress', () => {
+      assert.strictEqual(phaseStatus({
+        phases: { specification: { items: { a: { status: 'proposed' }, b: { status: 'in-progress' } } } },
+      }, 'specification'), 'in-progress');
+    });
+
     it('returns null for phase with flat status but no items', () => {
       assert.strictEqual(phaseStatus({ phases: { discussion: { status: 'completed' } } }, 'discussion'), null);
     });

--- a/tests/scripts/test-knowledge-cli.sh
+++ b/tests/scripts/test-knowledge-cli.sh
@@ -1754,6 +1754,20 @@ status_output=$(run_kb status 2>&1)
 assert_eq "bulk index skipped cancelled wu" "true" "$(echo "$status_output" | grep -q 'cancelled-wu' && echo false || echo true)"
 teardown_project
 
+# --- Test 80b: Bulk index skips proposed spec items (status filter) ---
+echo "Test 80b: Bulk index skips proposed spec items"
+setup_project
+create_work_unit "prop-wu" "epic" "Proposed groupings"
+write_stub_config
+# Spec file present on disk to prove it is the STATUS filter that skips it,
+# not the missing-file guard.
+create_spec_file "prop-wu" "auth-grouping"
+cd "$TEST_ROOT" && node "$MANIFEST_JS" set prop-wu.specification.auth-grouping status proposed >/dev/null 2>&1
+run_kb index >/dev/null 2>&1
+status_output=$(run_kb status 2>&1)
+assert_eq "bulk index skipped proposed spec" "true" "$(echo "$status_output" | grep -q 'auth-grouping' && echo false || echo true)"
+teardown_project
+
 # --- Test 81: pending-removal queue survives writes + drain works ---
 echo "Test 81: Pending removal queue"
 setup_project

--- a/tests/scripts/test-workflow-manifest.sh
+++ b/tests/scripts/test-workflow-manifest.sh
@@ -1702,6 +1702,91 @@ assert_equals "$prev_exists" "false" "previous_status deleted after reactivation
 echo ""
 
 # ============================================================================
+# PROPOSED STATUS TESTS (spec groupings)
+# ============================================================================
+
+echo -e "${YELLOW}Test: proposed accepted as valid status for specification${NC}"
+setup_fixture
+run_cli init prop-spec --work-type epic --description "Proposed spec" >/dev/null 2>&1
+run_cli set prop-spec.specification.auth-flow status proposed >/dev/null 2>&1
+output=$(run_cli_stdout get prop-spec.specification.auth-flow status)
+
+assert_equals "$output" "proposed" "Specification accepts proposed status"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: bogus specification status rejected${NC}"
+setup_fixture
+run_cli init bogus-spec --work-type epic --description "Bogus" >/dev/null 2>&1
+assert_exit_nonzero "Invalid specification status rejected" \
+    set bogus-spec.specification.auth-flow status bogus
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: init-phase fails on an existing item (flip contract)${NC}"
+setup_fixture
+run_cli init flip-spec --work-type epic --description "Flip" >/dev/null 2>&1
+run_cli set flip-spec.specification.auth-flow status proposed >/dev/null 2>&1
+assert_exit_nonzero "init-phase rejects an existing proposed item" \
+    init-phase flip-spec.specification.auth-flow
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: upsert proposed item builds the exact shape${NC}"
+setup_fixture
+run_cli init upsert-spec --work-type epic --description "Upsert" >/dev/null 2>&1
+run_cli set upsert-spec.specification.auth-flow status proposed >/dev/null 2>&1
+run_cli set upsert-spec.specification.auth-flow sources.auth-design.status pending >/dev/null 2>&1
+run_cli set upsert-spec.specification.auth-flow sources.session-mgmt.status pending >/dev/null 2>&1
+status=$(run_cli_stdout get upsert-spec.specification.auth-flow status)
+src1=$(run_cli_stdout get upsert-spec.specification.auth-flow sources.auth-design.status)
+src2=$(run_cli_stdout get upsert-spec.specification.auth-flow sources.session-mgmt.status)
+rc_exists=$(run_cli_stdout exists upsert-spec.specification.auth-flow review_cycle)
+
+assert_equals "$status" "proposed" "Proposed item status set"
+assert_equals "$src1" "pending" "First source pending"
+assert_equals "$src2" "pending" "Second source pending"
+assert_equals "$rc_exists" "false" "Proposed item carries no review_cycle (invariant)"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: delete whole proposed spec item${NC}"
+setup_fixture
+run_cli init del-spec --work-type epic --description "Delete" >/dev/null 2>&1
+run_cli set del-spec.specification.auth-flow status proposed >/dev/null 2>&1
+run_cli set del-spec.specification.auth-flow sources.auth-design.status pending >/dev/null 2>&1
+run_cli delete del-spec.specification items.auth-flow >/dev/null 2>&1
+exists_after=$(run_cli_stdout exists del-spec.specification.auth-flow)
+
+assert_equals "$exists_after" "false" "Whole proposed item removed by delete items.{topic}"
+
+echo ""
+
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: flip proposed to in-progress preserves sources${NC}"
+setup_fixture
+run_cli init flip2-spec --work-type epic --description "Flip2" >/dev/null 2>&1
+run_cli set flip2-spec.specification.auth-flow status proposed >/dev/null 2>&1
+run_cli set flip2-spec.specification.auth-flow sources.auth-design.status pending >/dev/null 2>&1
+run_cli set flip2-spec.specification.auth-flow status in-progress >/dev/null 2>&1
+status=$(run_cli_stdout get flip2-spec.specification.auth-flow status)
+src=$(run_cli_stdout get flip2-spec.specification.auth-flow sources.auth-design.status)
+
+assert_equals "$status" "in-progress" "Flip sets in-progress"
+assert_equals "$src" "pending" "Flip preserves source rows"
+
+echo ""
+
+# ============================================================================
 # DISCOVERY PHASE TESTS
 # ============================================================================
 


### PR DESCRIPTION
PR1 of the 3-PR spec-groupings stack (plan: #373 / `idea/spec-groupings-pr-0-plan`). Promotes spec groupings from a cache-only representation to real `specification.{topic}` manifest items carrying a new `proposed` status — the vehicle the project already treats as authoritative.

## Summary
- **Data model**: new `proposed` spec status (`{ status: "proposed", sources: { <disc>: { status: "pending" } } }`, no file on disk). Invariant: `proposed` ⇒ no `specification.md`, no `review_cycle`/gate fields. The cache `.md` + checksum are kept (slimmed to coupling/rationale + consult-slice hints).
- **Producer**: `analysis-flow.md` §C swaps the cache-only save for an idempotent reconcile (snapshot → anchor-map → augment → delete-stale → collision-guard → upsert → cache-last). Anchors (started/completed specs) are preserved; proposed items are freely regenerated.
- **Consumers**: spec-entry and continue-epic discovery classify by status not file presence; proposed items are counted (`proposed_count`/`has_proposed`), surfaced in `specifications[]`, rendered as `[proposed]` in the epic state tree + map, and are startable. The flip (`proposed`→`in-progress`) lives in `initialize-specification.md` and uses `set status`, never `init-phase`.
- **Risk neutralisations**: R1 (proposed sources stay unaccounted), R2 (proposed never plan-ready), R5 (never supersede a proposed source), R7 (proposed ≠ individual spec), R8 (`phaseStatus` ignores proposed), R10 (`init-phase` dies on proposed → flip via `set`), R11 (mixed states route to specs-menu, not re-analysis).

**Boundary (intended transitional state):** proposed specs appear in epic state/map with `[proposed]`, but the epic menu still recommends planning and does not offer them as numbered items (PR2), and the spec menu order is unchanged (PR3). Strictly better than today (visibility), not broken.

## Test plan
- New `node:test` / bash coverage: manifest (`proposed` accepted, bogus rejected, `init-phase` refuses existing item, upsert shape, whole-item delete, flip preserves sources), `discovery-utils.phaseStatus` (proposed-only → null; mixed → completed/in-progress), spec-entry discovery (proposed counted not in `spec_count`, present in `specifications[]`, `has_individual_spec` ignores proposed, mixed counts), epic discovery (R1/R2 + display), and KB reindex skips proposed.
- Full suite green: `node tests/scripts/test-discovery-for-specification.cjs`, `test-discovery-utils.cjs`, `test-discovery-for-workflow-continue-epic.cjs`, `bash tests/scripts/test-workflow-manifest.sh`, `test-knowledge-cli.sh` — plus every other `tests/scripts/*` (exit 0).
- End-to-end smoke on a temp-dir `.workflows/` fixture copy: 3 completed discussions → reconcile writes proposed items (no files) → `proposed_count` correct → all discussions stay unaccounted, none plan-ready → start one grouping flips it to `in-progress` (sources preserved, `init-phase` refused) → re-analysis preserves the anchor and reconciles the rest cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #373
2. **#374** 👈 current
3. #375
4. #376
5. #377
<!-- stack:links:end -->