### PR TITLE
Epic menu intelligence — act on proposed specs (PR2 of 3)

### DIFF
--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -82,7 +82,7 @@ Parse the discovery output to understand:
   - `in_progress` - items currently in-progress (name + phase)
   - `completed` - items that are completed (name + phase)
   - `next_phase_ready` - items ready for the next phase (name + action + label)
-  - `unaccounted_discussions` - completed discussions not sourced in any spec
+  - `unaccounted_discussions` - completed discussions not grouped into any spec item (proposed or materialized)
   - `reopened_discussions` - in-progress discussions that are sourced in a spec
   - `discovery_map` - per-topic lifecycle for the discovery/research/discussion span (tier-sorted; empty when no discovery items exist)
   - `convergence_state` - `'in-progress'` | `'settled'` | `null` (when no map)
@@ -308,10 +308,11 @@ Invoke the appropriate skill based on the user's menu selection. Match by **pref
 | Continue {topic} — planning | `/workflow-planning-entry epic {work_unit} {topic}` |
 | Continue {topic} — implementation | `/workflow-implementation-entry epic {work_unit} {topic}` |
 | Continue {topic} — review | `/workflow-review-entry epic {work_unit} {topic}` |
+| Start specification for {topic} | `/workflow-specification-entry epic {work_unit} {topic}` |
 | Start planning for {topic} | `/workflow-planning-entry epic {work_unit} {topic}` |
 | Start implementation of {topic} | `/workflow-implementation-entry epic {work_unit} {topic}` |
 | Start review for {topic} | `/workflow-review-entry epic {work_unit} {topic}` |
-| Start specification | `/workflow-specification-entry epic {work_unit}` |
+| Analyze / regroup discussions | `/workflow-specification-entry epic {work_unit}` |
 | Start new discussion topic | `/workflow-discussion-entry epic {work_unit}` |
 | Start new research | `/workflow-research-entry epic {work_unit}` |
 | Continue discovery | `/workflow-discovery epic {work_unit}` |

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -307,14 +307,17 @@ Build a menu with two types of options:
      - Implementation in-progress without progress: `Continue "{topic:(titlecase)}" — implementation [in-progress]`
      - Review in-progress: `Continue "{topic:(titlecase)}" — review [in-progress]`
    - From `next_phase_ready`:
+     - Proposed grouping: `Start specification for "{topic:(titlecase)}" — grouping ready`
      - Completed spec with no plan: `Start planning for "{topic:(titlecase)}" — spec completed`
      - Completed plan with no implementation:
        - If `blocked`: shown but not selectable — `Start implementation of "{topic:(titlecase)}" — blocked by {dep_topic}:{internal_id}`
        - Otherwise: `Start implementation of "{topic:(titlecase)}" — plan completed`
      - Completed implementation with no review: `Start review for "{topic:(titlecase)}" — implementation completed`
 
+   Order build-phase entries by pipeline position: specification entries first (earliest in the pipeline), then planning, implementation, review.
+
 **Command options:**
-- **`s`/`spec`** — Start specification — {N} discussion(s) not yet in a spec (only shown if `gating.can_start_specification` is true and `unaccounted_discussions` has items)
+- **`s`/`spec`** — Analyze / regroup discussions (only shown if `gating.can_start_specification` is true). Description adapts: `— {N} discussion(s) not yet grouped` when `unaccounted_discussions` is non-empty, else `— review or regroup specifications`
 - **`d`/`discuss`** — Start a discussion on a new topic (always present)
 - **`r`/`research`** — Start research on a new topic (always present)
 - **`i`/`discovery`** — Continue discovery (always present when `discovery_map` is non-empty)
@@ -334,7 +337,7 @@ Build a menu with two types of options:
 | Convergence state | Recommendation source                                               |
 |-------------------|---------------------------------------------------------------------|
 | `in-progress`     | Top of `discovery_map` — first row with non-null `next_action` (tier order: `→` first, then `◐`, then `○`). Never `✓`, `⊙`, or `⊘`. |
-| `settled`         | First build-phase `next_phase_ready` item in pipeline order (planning before implementation before review). If none, `s`/`spec` when applicable. Otherwise no recommendation. |
+| `settled`         | First build-phase `next_phase_ready` item in pipeline order (specification before planning before implementation before review). A proposed spec's `start_specification` therefore outranks any `start_planning`. If none, `s`/`spec` when applicable. Otherwise no recommendation. |
 
 The recommended item always appears first. Mark it `(recommended)`. After the recommended item, list remaining numbered items in their natural order (discovery topics, then build-phase items), then command options.
 
@@ -352,9 +355,10 @@ What would you like to do?
 - **`2`** — Continue "AI Image Generation" — research
 - **`3`** — Continue "Tenant Onboarding" — discussion
 - **`4`** — Start research for "Customer Portal"
-- **`5`** — Start planning for "Roles And Permissions" — spec completed
+- **`5`** — Start specification for "Billing Grouping" — grouping ready
+- **`6`** — Start planning for "Roles And Permissions" — spec completed
 
-- **`s`/`spec`** — Start specification — 2 discussion(s) not yet in a spec
+- **`s`/`spec`** — Analyze / regroup discussions — 2 discussion(s) not yet grouped
 - **`d`/`discuss`** — Start a discussion on a new topic
 - **`r`/`research`** — Start research on a new topic
 - **`i`/`discovery`** — Continue discovery
@@ -381,7 +385,8 @@ Recreate with actual items from discovery.
   - Implementation in-progress with progress: `Continue "{topic:(titlecase)}" — implementation (Phase {N}, Task {M})`
   - Implementation in-progress without progress: `Continue "{topic:(titlecase)}" — implementation [in-progress]`
   - Other phases: `Continue "{topic:(titlecase)}" — {phase} [in-progress]`
-- Next-phase-ready items from `next_phase_ready` in discovery output:
+- Next-phase-ready items from `next_phase_ready` in discovery output (order specification entries first, then planning, implementation, review):
+  - Proposed grouping: `Start specification for "{topic:(titlecase)}" — grouping ready`
   - Completed spec with no plan: `Start planning for "{topic:(titlecase)}" — spec completed`
   - Completed plan with no implementation:
     - If `blocked`: show but mark as not selectable: `Start implementation of "{topic:(titlecase)}" — blocked by {dep_topic}:{internal_id}`
@@ -389,7 +394,7 @@ Recreate with actual items from discovery.
   - Completed implementation with no review: `Start review for "{topic:(titlecase)}" — implementation completed`
 
 **Command options** — entry-point actions that launch a flow handling its own selection. Use letter shortcuts (first letter of command; second letter if disambiguation needed):
-- **`s`/`spec`** — Start specification — {N} discussion(s) not yet in a spec (only shown if `gating.can_start_specification` is true and `unaccounted_discussions` has items)
+- **`s`/`spec`** — Analyze / regroup discussions (only shown if `gating.can_start_specification` is true). Description adapts: `— {N} discussion(s) not yet grouped` when `unaccounted_discussions` is non-empty, else `— review or regroup specifications`
 - **`d`/`discuss`** — Start new discussion (always present)
 - **`r`/`research`** — Start new research (always present)
 - **`c`/`completed`** — Resume a completed topic (only shown when `completed` items exist)
@@ -404,6 +409,7 @@ Recreate with actual items from discovery.
 - No "Start specification" unless `gating.can_start_specification` is true
 
 **Ordering:** The recommended item always appears first. Mark one item as `(recommended)` based on phase completion state:
+- A proposed grouping exists (a `start_specification` entry in `next_phase_ready`) → first proposed spec "(recommended)"
 - All discussions completed, no specifications exist → `s`/`spec` (recommended)
 - All plannable specifications completed, some without plans → first plannable spec "(recommended)"
 - All plans completed (and deps satisfied), some without implementations → first implementable plan "(recommended)"
@@ -422,12 +428,12 @@ After the recommended item, list remaining numbered items, then command options.
 · · · · · · · · · · · ·
 What would you like to do?
 
-- **`1`** — Start implementation of "Notifications" — plan completed (recommended)
+- **`1`** — Start specification for "Billing Grouping" — grouping ready (recommended)
 - **`2`** — Continue "Auth Flow" — discussion [in-progress]
 - **`3`** — Continue "Caching" — planning [in-progress]
 - **`4`** — Start planning for "User Profiles" — spec completed
 - **`5`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
-- **`s`/`spec`** — Start specification — 3 discussion(s) not yet in a spec
+- **`s`/`spec`** — Analyze / regroup discussions — 3 discussion(s) not yet grouped
 - **`d`/`discuss`** — Start new discussion
 - **`r`/`research`** — Start new research
 - **`c`/`completed`** — Resume a completed topic
@@ -522,7 +528,7 @@ Set selection to `Continue discovery`. The caller routes this to `/workflow-disc
 |---------------------|-----------|--------------|
 | discussion (new or continue) | research items exist with some in-progress | "{N} of {M} research topics still in-progress. Topic analysis works best with all research available." |
 | specification (new or continue) | discussion items exist with some in-progress | "{N} of {M} discussions still in-progress. Grouping analysis works best with all discussions available." |
-| planning | specification items exist with some in-progress | "{N} of {M} specifications still in-progress. Cross-cutting dependencies are easier to identify with all completed." |
+| planning | specification items exist with some in-progress or proposed | "{N} of {M} specifications not yet completed. Completing all specifications first helps identify cross-cutting dependencies." |
 | implementation | planning items exist with some in-progress | "{N} of {M} plans still in-progress. Task dependencies across plans may be missed." |
 
 **If a soft gate condition matches:**
@@ -573,10 +579,11 @@ Store the selected action, phase, and topic (if applicable). Match the user's se
 | Continue {topic} — planning | planning | {topic} |
 | Continue {topic} — implementation | implementation | {topic} |
 | Continue {topic} — review | review | {topic} |
+| Start specification for {topic} | specification | {topic} |
 | Start planning for {topic} | planning | {topic} |
 | Start implementation of {topic} | implementation | {topic} |
 | Start review for {topic} | review | {topic} |
-| Start specification | specification | — |
+| Analyze / regroup discussions | specification | — |
 | Start new discussion | discussion | — |
 | Start new research | research | — |
 | Continue discovery | discovery | — |

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -191,7 +191,8 @@ Group the phases under the same three stage dividers. This branch has no map —
 | In-progress items across multiple phases | No recommendation |
 | Some research in-progress, some completed | "Consider completing remaining research before starting discussion. Topic analysis works best with all research available." |
 | Some discussions in-progress, some completed | "Consider completing remaining discussions before starting specification. The grouping analysis works best with all discussions available." |
-| All discussions completed, specs not started | "All discussions are completed. Specification will analyze and group them." |
+| Proposed groupings exist (specs with status `proposed`) | "{N} analyzed grouping(s) ready to specify. Start them before planning to surface cross-cutting dependencies." |
+| All discussions completed, no specification items exist | "All discussions are completed. Specification will analyze and group them." |
 | Some specs completed, some in-progress | "Completing all specifications before planning helps identify cross-cutting dependencies." |
 | Some plans completed, some in-progress | "Completing all plans before implementation helps surface task dependencies across plans." |
 | Reopened discussion that's a source in a spec | "{Spec} specification sources the reopened {Discussion} discussion. Once that discussion concludes, the specification will need revisiting to extract new content." |

--- a/skills/workflow-continue-epic/scripts/discovery.cjs
+++ b/skills/workflow-continue-epic/scripts/discovery.cjs
@@ -58,6 +58,7 @@ function buildAnalysisCaches(cwd, manifest) {
 function buildEpicDetail(cwd, manifest) {
   const phases = {};
   const allSourcedDiscussions = new Set();
+  const groupedDiscussions = new Set();
   const completedItems = [];
   const inProgressItems = [];
   const cancelledItems = [];
@@ -77,9 +78,15 @@ function buildEpicDetail(cwd, manifest) {
           ? item.sources
           : Object.entries(item.sources).map(([topic, data]) => ({ topic, ...data }));
         entry.sources = sourcesArr;
-        // A discussion that appears only in a proposed grouping is still
-        // legitimately "not yet in a spec" — skip proposed items' sources so
-        // those discussions stay in unaccounted_discussions.
+        // groupedDiscussions tracks every spec item's sources (proposed
+        // included) — a discussion in any spec item is "grouped", which is
+        // what unaccounted_discussions now measures.
+        for (const src of sourcesArr) {
+          groupedDiscussions.add(src.topic || src.name);
+        }
+        // allSourcedDiscussions tracks only materialized items' sources —
+        // a proposed grouping has nothing extracted, so its sources can't
+        // be "reopened". Reopened detection reads this set.
         if (item.status !== 'proposed') {
           for (const src of sourcesArr) {
             allSourcedDiscussions.add(src.topic || src.name);
@@ -121,7 +128,7 @@ function buildEpicDetail(cwd, manifest) {
   const discussionItems = phaseItems(manifest, 'discussion');
   const unaccountedDiscussions = [];
   for (const d of discussionItems) {
-    if (d.status === 'completed' && !allSourcedDiscussions.has(d.name)) {
+    if (d.status === 'completed' && !groupedDiscussions.has(d.name)) {
       unaccountedDiscussions.push(d.name);
     }
   }
@@ -136,6 +143,16 @@ function buildEpicDetail(cwd, manifest) {
   const specItems = phaseItems(manifest, 'specification');
   const planItems = phaseItems(manifest, 'planning');
   const implItems = phaseItems(manifest, 'implementation');
+
+  // Proposed groupings are actionable from the epic menu — surface them as
+  // start_specification. Pushed before start_planning so they precede it in
+  // pipeline order (spec → planning), which the settled-state recommendation
+  // reads.
+  for (const s of specItems) {
+    if (s.status === 'proposed') {
+      nextPhaseReady.push({ name: s.name, action: 'start_specification', label: 'grouping ready' });
+    }
+  }
 
   const planTopics = new Set(planItems.filter(i => i.status !== 'cancelled').map(i => i.name));
   for (const s of specItems) {

--- a/skills/workflow-planning-entry/references/validate-spec.md
+++ b/skills/workflow-planning-entry/references/validate-spec.md
@@ -38,6 +38,22 @@ The specification must be completed before planning can begin.
 
 **STOP.** Do not proceed — terminal condition.
 
+#### If specification exists and status is `proposed`
+
+> *Output the next fenced block as a code block:*
+
+```
+Specification Not Started
+
+"{topic:(titlecase)}" is a proposed grouping — the specification
+hasn't been started yet.
+
+Start the specification first, then return to planning once it
+completes.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
 #### If specification exists and status is `completed`
 
 → Return to caller.

--- a/tests/scripts/test-discovery-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-discovery-for-workflow-continue-epic.cjs
@@ -1081,26 +1081,8 @@ describe('workflow-continue-epic discovery', () => {
     });
   });
 
-  describe('proposed groupings', () => {
-    it('keeps a proposed item source in unaccounted_discussions (R1)', () => {
-      createManifest(dir, 'v1', {
-        work_type: 'epic',
-        phases: {
-          discussion: { items: { auth: { status: 'completed' }, payments: { status: 'completed' } } },
-          specification: {
-            items: {
-              'auth-spec': { status: 'in-progress', sources: [{ topic: 'auth', status: 'incorporated' }] },
-              'payments-grouping': { status: 'proposed', sources: { payments: { status: 'pending' } } },
-            },
-          },
-        },
-      });
-      const r = discover(dir);
-      // payments lives only in a proposed grouping → still "not yet in a spec".
-      assert.deepStrictEqual(r.epics[0].detail.unaccounted_discussions, ['payments']);
-    });
-
-    it('does not mark a proposed spec as next_phase_ready (R2)', () => {
+  describe('proposed groupings — menu intelligence', () => {
+    it('surfaces a proposed spec as start_specification in next_phase_ready', () => {
       createManifest(dir, 'v1', {
         work_type: 'epic',
         phases: {
@@ -1108,7 +1090,73 @@ describe('workflow-continue-epic discovery', () => {
         },
       });
       const r = discover(dir);
-      assert.strictEqual(r.epics[0].detail.next_phase_ready.length, 0);
+      const ready = r.epics[0].detail.next_phase_ready;
+      const entry = ready.find(n => n.action === 'start_specification' && n.name === 'auth-grouping');
+      assert.ok(entry, 'proposed spec surfaced as a start_specification entry');
+    });
+
+    it('orders start_specification before start_planning in next_phase_ready', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          specification: {
+            items: {
+              'done-spec': { status: 'completed' },
+              'auth-grouping': { status: 'proposed', sources: { auth: { status: 'pending' } } },
+            },
+          },
+        },
+      });
+      const r = discover(dir);
+      const ready = r.epics[0].detail.next_phase_ready;
+      const specIdx = ready.findIndex(n => n.action === 'start_specification');
+      const planIdx = ready.findIndex(n => n.action === 'start_planning');
+      assert.ok(specIdx >= 0 && planIdx >= 0, 'both entries present');
+      // Settled-state recommendation reads the first entry in pipeline order;
+      // a proposed spec must outrank a completed spec's start_planning.
+      assert.ok(specIdx < planIdx, 'start_specification precedes start_planning');
+    });
+
+    it('treats a proposed-grouped discussion as accounted — unaccounted = ungrouped only', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { auth: { status: 'completed' }, payments: { status: 'completed' } } },
+          specification: {
+            items: {
+              'payments-grouping': { status: 'proposed', sources: { payments: { status: 'pending' } } },
+            },
+          },
+        },
+      });
+      const r = discover(dir);
+      // payments is grouped into a proposed spec → accounted. auth is in no
+      // spec item at all → ungrouped, the new meaning of unaccounted.
+      assert.deepStrictEqual(r.epics[0].detail.unaccounted_discussions, ['auth']);
+    });
+
+    it('does not mark an in-progress discussion sourced only by a proposed item as reopened', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { auth: { status: 'in-progress' } } },
+          specification: { items: { 'auth-grouping': { status: 'proposed', sources: { auth: { status: 'pending' } } } } },
+        },
+      });
+      const r = discover(dir);
+      // Reopened stays materialized-only — a proposed grouping has nothing
+      // extracted to revisit.
+      assert.deepStrictEqual(r.epics[0].detail.reopened_discussions, []);
+    });
+
+    it('keeps can_start_planning false when the only spec is proposed', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          specification: { items: { 'auth-grouping': { status: 'proposed', sources: { auth: { status: 'pending' } } } } },
+        },
+      });
+      const r = discover(dir);
       assert.strictEqual(r.epics[0].detail.gating.can_start_planning, false);
     });
 


### PR DESCRIPTION
Stacks on #374 (PR1). Part of the spec-groupings stack (`spec-groupings/plan.md`, "PR 2 — Epic menu intelligence"); fixes the design doc's problems 1, 2, and 4. **Review/merge #374 first.**

PR1 promoted spec groupings to real `specification.{topic}` items with a `proposed` status — they render in the epic tree/map, and the spec subsystem can start them — but the epic menu stayed passive. PR2 makes proposed specs actionable from the menu.

## Summary
- **Producer** (`discovery.cjs`): proposed specs surface in `next_phase_ready` as `start_specification`, ordered before `start_planning` so the settled-state recommendation ranks finishing specs ahead of planning. `unaccounted_discussions` shifts to mean **ungrouped** (discussions in no spec item, proposed included) — removing PR1's double-count. `reopened_discussions` and gating stay materialized-only / completed-gated.
- **Menu** (`epic-display-and-menu.md`): numbered `Start specification for "{topic}"` entries (both branches), recommendation precedence prepends specification, planning soft-gate fires on in-progress **or** proposed, and `s`/`spec` is relabelled "Analyze / regroup discussions" — always shown when `can_start_specification`, with an adaptive ungrouped-count description. The new label avoids a routing prefix-collision with the numbered entries. Map-less recommendation callouts are now proposed-aware too.
- **Routing & defensive** (`SKILL.md`, `validate-spec.md`): Step 9 route row + relabelled command row; Step 1 doc reworded; planning-entry gains a terminal stop for a `proposed`-status spec.

## Test plan
- `test-discovery-for-workflow-continue-epic.cjs` — new `proposed groupings — menu intelligence` block (start_specification surfaced, precedence ordering, unaccounted=ungrouped, reopened unaffected, gating unchanged); reversed the two PR1 invariant tests. 90 pass.
- Re-ran `test-discovery-for-specification.cjs` (32), `test-discovery-utils.cjs` (152), `test-workflow-manifest.sh` (289) — all green, untouched.
- Manual end-to-end smoke on a temp `.workflows` fixture: proposed spec surfaces as `start_specification`, precedes `start_planning`, `unaccounted` = ungrouped only, `can_start_planning` tracks only the completed spec.
- Recommendation/label/gate rendering is skill prose (not unit-testable); the tests lock the discovery-script data those rules consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #373
2. #374
3. **#375** 👈 current
4. #376
5. #377
<!-- stack:links:end -->