### PR TITLE
PR3 — Spec menu reorder + manage-completed-specs submenu

### DIFF
--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -625,7 +625,7 @@ Which topic would you like to resume?
 
 - **`1`** — Resume "{item.name:(titlecase)}" — {item.phase}
 - **`2`** — ...
-- **`{N}`** — Back to main menu
+- **`b`/`back`** — Return to menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -635,7 +635,7 @@ List all completed items across all phases.
 
 **STOP.** Wait for user response.
 
-#### If user chose `Back to main menu`
+#### If user chose `back`
 
 → Return to **C. Menu**.
 

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -132,7 +132,7 @@ The display groups every phase under three stage dividers — **DISCOVERY** (res
   - `{child_gutter}` — under a **non-last item**: 2 spaces, `│`, 2 spaces; under the **last item**: 5 spaces. Both land the child branch at the same column, under the item name.
   - `{child_branch}`: `├─` for non-final children, `└─` for the final (or only) child.
   - Specification source status: `[incorporated]` or `[pending]` from the manifest. Implementation shows `Phase {N}, {M} task(s) completed` when in-progress with `current_phase`, else `{M} task(s) completed` (always a single `└─` child).
-- **Promoted items** render with `[promoted]` in the display but not the menu. **Proposed specs** render with `[proposed]` in the display but are not offered as menu items. **Cancelled items** show `[cancelled]`. Phases with no items don't appear.
+- **Promoted items** render with `[promoted]` in the display but not the menu. **Proposed specs** render with `[proposed]` and surface in the menu as `Start specification` entries (see **C. Menu**). **Cancelled items** show `[cancelled]`. Phases with no items don't appear.
 - **No trailing recommendation callout** in this code block — build-phase recommendations attach to menu entries (see **C. Menu**).
 
 After the render block, run the **Plans Not Ready Check** below; it applies to both this branch and the otherwise branch.

--- a/skills/workflow-specification-entry/references/display-completed-specs.md
+++ b/skills/workflow-specification-entry/references/display-completed-specs.md
@@ -1,0 +1,43 @@
+# Completed Specifications
+
+*Reference for **[workflow-specification-entry](../SKILL.md)***
+
+---
+
+Loaded from the primary spec menu when the user picks `c`/`completed`. Lists the concluded specs — `status: completed` with `has_pending_sources: false` — from the discovery `specifications[]` array. These have no pending work, so each is a flat one-line Refine entry; no tree.
+
+> *Output the next fenced block as a code block:*
+
+```
+Completed Specifications
+```
+
+Present one numbered entry per concluded spec, in `specifications[]` order, then a `back` command option.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Which completed specification would you like to refine?
+
+- **`1`** — Refine "Auth Flow" — completed
+- **`2`** — Refine "Data Model" — completed
+- **`b`/`back`** — Return to the specifications menu
+
+Select an option:
+· · · · · · · · · · · ·
+```
+
+Recreate with actual specs from discovery.
+
+**STOP.** Wait for user response.
+
+#### If user picks a spec
+
+The selected spec and its sources become the context for confirmation.
+
+→ Load **[confirm-and-handoff.md](confirm-and-handoff.md)** and follow its instructions as written.
+
+#### If user picks `b`/`back`
+
+→ Return to caller.

--- a/skills/workflow-specification-entry/references/display-groupings.md
+++ b/skills/workflow-specification-entry/references/display-groupings.md
@@ -43,7 +43,9 @@ Spec status: show the item's actual status with extraction count `({X} of {Y} so
 
 ## C. Display
 
-All items are first-class — every grouping (including single-discussion entries) is a numbered item.
+The tree and menu render only **actionable** groupings — every item except the concluded ones (`status: completed` with `has_pending_sources: false`). Concluded specs move to the `c`/`completed` submenu so finished work doesn't crowd the work-first list. Render actionable items in the discovery script's `specifications[]` order (already sorted proposed → in-progress → completed-with-pending). The numbered tree and the menu options must use the same ordering and numbering — they map 1:1.
+
+All actionable items are first-class — every grouping (including single-discussion entries) is a numbered item.
 
 > *Output the next fenced block as a code block:*
 
@@ -121,13 +123,14 @@ specification, choose "Re-analyze" and provide guidance.
 
 ## D. Menu
 
-Present one numbered menu entry per grouping. The verb and description depend on the item's status:
+Present one numbered menu entry per **actionable** grouping — the same set the tree showed, in the same order. The verb and description depend on the item's status:
 
 - Status `proposed` → **Start** "{Name}" — {N} ready discussions
 - Status `in-progress` with pending sources → **Continue** "{Name}" — {N} source(s) pending extraction
 - Status `in-progress` with all extracted → **Continue** "{Name}" — all sources extracted
-- Status `completed` with no pending sources → **Refine** "{Name}" — completed spec
 - Status `completed` with pending sources → **Continue** "{Name}" — {N} new source(s) to extract
+
+Concluded groupings (`completed` with no pending sources) are not numbered here — they live behind `c`/`completed`.
 
 When the grouping has pending consult references, append `— {N} consult ref(s) pending` to its description. Do not change the verb — consult references gate completion but never introduce a new action.
 
@@ -136,7 +139,11 @@ After all grouping entries, append meta options:
 - **Unify all** (only when 2+ groupings exist) — all discussions combined into one specification instead of following the recommended groupings. If specs exist, note they will be incorporated and superseded.
 - **Re-analyze groupings** (always) — current groupings are discarded and rebuilt. If specs exist, existing names are preserved. User can provide guidance in the next step.
 
-**Example assembled menu** (2 groupings, specs exist):
+Then, after the numbered and meta options, append the command option (only when `concluded_count > 0`):
+
+- **`c`/`completed`** — Manage completed specifications — {concluded_count} completed
+
+**Example assembled menu** (2 actionable groupings, 1 concluded spec):
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -152,19 +159,27 @@ After all grouping entries, append meta options:
    `specification names are preserved. You can provide guidance`
    `in the next step.`
 
+- **`c`/`completed`** — Manage completed specifications — 1 completed
+
 Select an option:
 · · · · · · · · · · · ·
 ```
 
 Recreate with actual topics and states from discovery.
 
-Every meta option (Unify, Re-analyze) MUST include its description lines.
+Every meta option (Unify, Re-analyze) MUST include its description lines. Omit the `c`/`completed` option when `concluded_count` is 0.
 
 **STOP.** Wait for user response.
 
 #### If user picks a grouping
 
 → Load **[confirm-and-handoff.md](confirm-and-handoff.md)** and follow its instructions as written.
+
+#### If user picks `c`/`completed`
+
+→ Load **[display-completed-specs.md](display-completed-specs.md)** and follow its instructions as written.
+
+→ Return to **D. Menu**.
 
 #### If user picks `Unify all`
 

--- a/skills/workflow-specification-entry/references/display-specs-menu.md
+++ b/skills/workflow-specification-entry/references/display-specs-menu.md
@@ -8,6 +8,8 @@ Shows when materialized specifications exist and no proposed groupings remain (e
 
 ## A. Display
 
+The tree and menu render only **actionable** specs — every spec except the concluded ones (`status: completed` with `has_pending_sources: false`). Concluded specs move to the `c`/`completed` submenu. Render actionable specs in the discovery script's `specifications[]` order (already sorted in-progress → completed-with-pending). The numbered tree and the menu options use the same ordering and numbering.
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -16,11 +18,17 @@ Shows when materialized specifications exist and no proposed groupings remain (e
 ●───────────────────────────────────────────────●
 
 {N} completed discussions found. {M} specifications exist.
+```
 
+#### If actionable specs exist
+
+> *Output the next fenced block as a code block:*
+
+```
 Existing specifications:
 ```
 
-For each non-superseded specification from discovery output, display as nested tree:
+For each actionable specification from discovery output, display as nested tree:
 
 > *Output the next fenced block as a code block:*
 
@@ -33,6 +41,14 @@ For each non-superseded specification from discovery output, display as nested t
    └─ Consult:
       ├─ {ref-name} [{status:[pending|addressed]}]
       └─ ...
+```
+
+#### If no actionable specs remain (every spec is concluded)
+
+> *Output the next fenced block as a code block:*
+
+```
+All specifications are completed — see Manage completed specifications.
 ```
 
 Determine discussion status from the spec's `sources` array:
@@ -125,15 +141,20 @@ have changed since it was created. Re-analysis is required.
 
 ## B. Menu
 
-List "Analyze for groupings (recommended)" first, then one entry per existing non-superseded specification. The verb depends on the spec's state:
+List "Analyze for groupings (recommended)" first, then one numbered entry per **actionable** spec — the same set the tree showed, in the same order. The verb depends on the spec's state:
 
 - Spec is `in-progress` → **Continue** "{Name}" — in-progress
 - Spec is `completed` with pending sources → **Continue** "{Name}" — {N} source(s) pending extraction
-- Spec is `completed` with no pending sources → **Refine** "{Name}" — completed
+
+Concluded specs (`completed` with no pending sources) are not numbered here — they live behind `c`/`completed`.
 
 When the spec has pending consult references, append `— {N} consult ref(s) pending` to its description. The verb is unchanged — consult references gate completion but introduce no new action.
 
-**Example assembled menu** (2 specs exist):
+After the numbered options, append the command option (only when `concluded_count > 0`):
+
+- **`c`/`completed`** — Manage completed specifications — {concluded_count} completed
+
+**Example assembled menu** (1 actionable spec, 1 concluded spec):
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -144,7 +165,25 @@ When the spec has pending consult references, append `— {N} consult ref(s) pen
    `specification names are preserved. You can provide guidance`
    `in the next step.`
 - **`2`** — Continue "Auth Flow" — in-progress
-- **`3`** — Refine "Data Model" — completed
+
+- **`c`/`completed`** — Manage completed specifications — 1 completed
+
+Select an option:
+· · · · · · · · · · · ·
+```
+
+When no actionable specs remain (every spec is concluded), the menu shows only Analyze and `c`/`completed`:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+- **`1`** — Analyze for groupings (recommended)
+   `All discussions are analyzed for natural groupings. Existing`
+   `specification names are preserved. You can provide guidance`
+   `in the next step.`
+
+- **`c`/`completed`** — Manage completed specifications — 2 completed
 
 Select an option:
 · · · · · · · · · · · ·
@@ -152,7 +191,7 @@ Select an option:
 
 Recreate with actual topics and states from discovery.
 
-Menu descriptions are wrapped in backticks to visually distinguish them from the choice labels.
+Menu descriptions are wrapped in backticks to visually distinguish them from the choice labels. Omit the `c`/`completed` option when `concluded_count` is 0.
 
 **STOP.** Wait for user response.
 
@@ -165,8 +204,14 @@ rm .workflows/{work_unit}/.state/discussion-consolidation-analysis.md
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions as written.
 
-#### If user picks `Continue` or `Refine` for a spec
+#### If user picks `Continue` for a spec
 
 The selected spec and its sources become the context for confirmation.
 
 → Load **[confirm-and-handoff.md](confirm-and-handoff.md)** and follow its instructions as written.
+
+#### If user picks `c`/`completed`
+
+→ Load **[display-completed-specs.md](display-completed-specs.md)** and follow its instructions as written.
+
+→ Return to **B. Menu**.

--- a/skills/workflow-specification-entry/scripts/discovery.cjs
+++ b/skills/workflow-specification-entry/scripts/discovery.cjs
@@ -3,6 +3,15 @@
 const path = require('path');
 const { loadActiveManifests, phaseItems, phaseData, listFiles, filesChecksum, fileExists } = require('../../workflow-shared/scripts/discovery-utils.cjs');
 
+// Actionable-first ordering rank for the spec menu. Lower sorts earlier:
+// proposed → in-progress → completed-with-pending → concluded → other/promoted.
+function specSortRank(spec) {
+  if (spec.status === 'proposed') return 0;
+  if (spec.status === 'in-progress') return 1;
+  if (spec.status === 'completed') return spec.has_pending_sources ? 2 : 3;
+  return 4;
+}
+
 function discover(cwd, workUnit) {
   const allManifests = loadActiveManifests(cwd);
   const manifests = workUnit
@@ -95,9 +104,21 @@ function discover(cwd, workUnit) {
         });
       }
 
+      spec.has_pending_sources = (spec.sources || []).some(s => s.status === 'pending');
+
       specifications.push(spec);
     }
   }
+
+  // Actionable specs first, concluded specs last. Stable within each tier
+  // (insertion order preserved), so the menu reads work-first.
+  specifications.sort((a, b) => specSortRank(a) - specSortRank(b));
+
+  // Concluded = completed with every source extracted. Drives the
+  // "Manage completed specifications" submenu gate.
+  const concludedCount = specifications.filter(
+    s => s.status === 'completed' && !s.has_pending_sources
+  ).length;
 
   // --- Cache (discussion-consolidation-analysis from manifest) ---
   const cacheEntries = [];
@@ -151,6 +172,7 @@ function discover(cwd, workUnit) {
       in_progress_count: inProgressCount,
       spec_count: specCount,
       proposed_count: proposedCount,
+      concluded_count: concludedCount,
       has_discussions: discCount > 0,
       has_completed: completedCount > 0,
       has_specs: specCount > 0,
@@ -178,7 +200,7 @@ function format(result) {
     lines.push('  (none)');
   } else {
     for (const s of result.specifications) {
-      lines.push(`  ${s.name}: ${s.status}, type=${s.work_type}`);
+      lines.push(`  ${s.name}: ${s.status}, type=${s.work_type}, has_pending_sources=${s.has_pending_sources}`);
       if (s.sources) {
         for (const src of s.sources) {
           lines.push(`    source: ${src.name} (${src.status}, discussion: ${src.discussion_status})`);
@@ -206,7 +228,7 @@ function format(result) {
   lines.push('=== STATE ===');
   const cs = result.current_state;
   lines.push(`discussions: ${cs.discussion_count} (${cs.completed_count} completed, ${cs.in_progress_count} in-progress)`);
-  lines.push(`specs: ${cs.spec_count}, proposed: ${cs.proposed_count}, has_discussions: ${cs.has_discussions}, has_completed: ${cs.has_completed}`);
+  lines.push(`specs: ${cs.spec_count}, proposed: ${cs.proposed_count}, concluded: ${cs.concluded_count}, has_discussions: ${cs.has_discussions}, has_completed: ${cs.has_completed}`);
   if (cs.discussions_checksum) lines.push(`checksum: ${cs.discussions_checksum}`);
 
   return lines.join('\n') + '\n';

--- a/tests/scripts/test-discovery-for-specification.cjs
+++ b/tests/scripts/test-discovery-for-specification.cjs
@@ -455,6 +455,142 @@ describe('workflow-specification-entry format', () => {
     assert.ok(out.includes('checksum: '));
   });
 
+  describe('spec menu reorder', () => {
+    // Builds an epic with four spec items in shuffled insertion order:
+    // concluded, completed-with-pending, proposed, in-progress. Files exist for
+    // every materialized (non-proposed) spec so they pass the fileExists gate.
+    function reorderFixture() {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: {
+            items: {
+              'd-concluded': { status: 'completed' },
+              'd-pending-a': { status: 'completed' },
+              'd-pending-b': { status: 'completed' },
+              'd-proposed': { status: 'completed' },
+              'd-wip': { status: 'completed' },
+            },
+          },
+          specification: {
+            items: {
+              'concluded-spec': {
+                status: 'completed',
+                sources: { 'd-concluded': { status: 'incorporated' } },
+              },
+              'pending-spec': {
+                status: 'completed',
+                sources: {
+                  'd-pending-a': { status: 'incorporated' },
+                  'd-pending-b': { status: 'pending' },
+                },
+              },
+              'proposed-grp': {
+                status: 'proposed',
+                sources: { 'd-proposed': { status: 'pending' } },
+              },
+              'wip-spec': {
+                status: 'in-progress',
+                sources: { 'd-wip': { status: 'extracted' } },
+              },
+            },
+          },
+        },
+      });
+      createFile(dir, '.workflows/v1/specification/concluded-spec/specification.md', '# Concluded');
+      createFile(dir, '.workflows/v1/specification/pending-spec/specification.md', '# Pending');
+      createFile(dir, '.workflows/v1/specification/wip-spec/specification.md', '# Wip');
+    }
+
+    it('has_pending_sources false when all sources incorporated', () => {
+      reorderFixture();
+      const r = discover(dir);
+      const spec = r.specifications.find(s => s.name === 'concluded-spec');
+      assert.strictEqual(spec.has_pending_sources, false);
+    });
+
+    it('has_pending_sources true when a source is pending', () => {
+      reorderFixture();
+      const r = discover(dir);
+      const spec = r.specifications.find(s => s.name === 'pending-spec');
+      assert.strictEqual(spec.has_pending_sources, true);
+    });
+
+    it('has_pending_sources true for a proposed grouping', () => {
+      reorderFixture();
+      const r = discover(dir);
+      const spec = r.specifications.find(s => s.name === 'proposed-grp');
+      assert.strictEqual(spec.has_pending_sources, true);
+    });
+
+    it('has_pending_sources false for a spec with no sources', () => {
+      createManifest(dir, 'auth', {
+        work_type: 'feature',
+        phases: {
+          discussion: { items: { auth: { status: 'completed' } } },
+          specification: { items: { auth: { status: 'in-progress' } } },
+        },
+      });
+      createFile(dir, '.workflows/auth/specification/auth/specification.md', '# Spec');
+      const r = discover(dir);
+      assert.strictEqual(r.specifications[0].has_pending_sources, false);
+    });
+
+    it('sorts specifications actionable-first (proposed, in-progress, completed+pending, concluded)', () => {
+      reorderFixture();
+      const r = discover(dir);
+      const order = r.specifications.map(s => s.name);
+      assert.deepStrictEqual(order, ['proposed-grp', 'wip-spec', 'pending-spec', 'concluded-spec']);
+    });
+
+    it('concluded_count counts only completed specs with no pending sources', () => {
+      reorderFixture();
+      const r = discover(dir);
+      assert.strictEqual(r.current_state.concluded_count, 1);
+    });
+
+    it('concluded_count is zero when no spec is concluded', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          discussion: { items: { 'd-prop': { status: 'completed' }, 'd-wip': { status: 'completed' } } },
+          specification: {
+            items: {
+              'prop': { status: 'proposed', sources: { 'd-prop': { status: 'pending' } } },
+              'wip': { status: 'in-progress', sources: { 'd-wip': { status: 'extracted' } } },
+            },
+          },
+        },
+      });
+      createFile(dir, '.workflows/v1/specification/wip/specification.md', '# Wip');
+      const r = discover(dir);
+      assert.strictEqual(r.current_state.concluded_count, 0);
+    });
+
+    it('format STATE block shows concluded count', () => {
+      reorderFixture();
+      const out = format(discover(dir));
+      assert.ok(out.includes('concluded: 1'));
+    });
+
+    it('format spec lines carry has_pending_sources', () => {
+      reorderFixture();
+      const out = format(discover(dir));
+      assert.ok(out.includes('concluded-spec: completed, type=epic, has_pending_sources=false'));
+      assert.ok(out.includes('pending-spec: completed, type=epic, has_pending_sources=true'));
+    });
+
+    it('format prints specs in sorted order', () => {
+      reorderFixture();
+      const out = format(discover(dir));
+      const iProposed = out.indexOf('proposed-grp:');
+      const iWip = out.indexOf('wip-spec:');
+      const iPending = out.indexOf('pending-spec:');
+      const iConcluded = out.indexOf('concluded-spec:');
+      assert.ok(iProposed < iWip && iWip < iPending && iPending < iConcluded);
+    });
+  });
+
   describe('proposed groupings', () => {
     it('counts a proposed spec item (no file) in proposed_count, not spec_count', () => {
       createManifest(dir, 'v1', {


### PR DESCRIPTION
**PR3 of the 3-PR spec-groupings stack.** Stacked on PR2 (#375); the `stack` CLI infers the chain from base branches and handles merge order + rebasing.

## What

The primary spec selection menu was flat — truly-concluded specs (status `completed`, all sources extracted — the Refine state) intermixed with, or sat above, work still to do. This makes the primary menu show only **actionable** specs ordered work-first, and relocates **concluded** specs behind a `c`/`completed` "Manage completed specifications" submenu — mirroring the epic `c`/`completed` → §F precedent.

**Concluded** = `status === 'completed' && !has_pending_sources`. Everything else is actionable.

## Changes

- **`discovery.cjs`** (producer, single source, unit-tested):
  - `has_pending_sources` per spec (any source still `pending`)
  - `specifications[]` sorted actionable-first: `proposed → in-progress → completed-with-pending → concluded → other`
  - `current_state.concluded_count` gates the submenu
  - `format()` emits both for the prose to parse
- **`display-groupings.md` / `display-specs-menu.md`**: primary tree + menu render only actionable specs in the producer's order; drop the Refine line; add the gated `c`/`completed` command option (Load submenu → Return to menu). `display-specs-menu` gains an all-concluded edge note.
- **`display-completed-specs.md`** (new): flat Refine list + `b`/`back`, routes through `confirm-and-handoff` which already resolves completed+all-extracted → Refining.

## Out of scope

Single-discussion auto-create path, `confirm-*`/`route-scenario`/verb rule (reused as-is), epic-side changes (all PR1/PR2).

## Tests

New `spec menu reorder` block in `test-discovery-for-specification.cjs` locks `has_pending_sources`, sort order, `concluded_count`, and `format()` output. Menu rendering is skill prose (not unit-tested, consistent with PR2).

Verification:
- `test-discovery-for-specification.cjs` — 42 pass
- `test-discovery-for-workflow-continue-epic.cjs` — 90 pass
- `test-discovery-utils.cjs` — 152 pass
- `test-workflow-manifest.sh` — 289 pass
- Manual smoke on a temp `.workflows/` fixture: ordering, `has_pending_sources`, and `concluded_count == 1` all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #373
2. #374
3. #375
4. **#376** 👈 current
5. #377
<!-- stack:links:end -->