### PR TITLE
PR4 — Use b/back in revisit-phase + bridge continuation menus

### DIFF
--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -145,7 +145,7 @@ Which phase would you like to revisit?
 
 - **`1`** — {phase:(titlecase)} — completed
 - **`2`** — ...
-- **`{N}`** — Back
+- **`b`/`back`** — Return to the previous menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -155,7 +155,7 @@ List only completed phases that come before `next_phase`.
 
 **STOP.** Wait for user response.
 
-#### If user chose Back
+#### If user chose `back`
 
 → Return to **D. Offer Revisit**.
 

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -93,7 +93,7 @@ Which phase would you like to revisit?
 
 - **`1`** — {phase:(titlecase)} — completed
 - **`2`** — ...
-- **`{N}`** — Back
+- **`b`/`back`** — Return to the previous menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -103,7 +103,7 @@ List only completed phases that come before `next_phase`.
 
 **STOP.** Wait for user response.
 
-#### If user chose Back
+#### If user chose `back`
 
 → Return to **C. Offer Revisit**.
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -146,7 +146,7 @@ Which phase would you like to revisit?
 
 - **`1`** — {phase:(titlecase)} — completed
 - **`2`** — ...
-- **`{N}`** — Back
+- **`b`/`back`** — Return to the previous menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -156,7 +156,7 @@ List only completed phases that come before `next_phase`.
 
 **STOP.** Wait for user response.
 
-#### If user chose Back
+#### If user chose `back`
 
 → Return to **D. Offer Revisit**.
 

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -143,7 +143,7 @@ Which phase would you like to revisit?
 
 - **`1`** — {phase:(titlecase)} — completed
 - **`2`** — ...
-- **`{N}`** — Back
+- **`b`/`back`** — Return to the previous menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -153,7 +153,7 @@ List only completed phases that come before `next_phase`.
 
 **STOP.** Wait for user response.
 
-#### If user chose Back
+#### If user chose `back`
 
 → Return to **D. Offer Revisit**.
 

--- a/skills/workflow-continue-bugfix/references/revisit-phase.md
+++ b/skills/workflow-continue-bugfix/references/revisit-phase.md
@@ -54,7 +54,7 @@ Which phase would you like to revisit?
 
 - **`1`** — {phase:(titlecase)} — completed
 - **`2`** — ...
-- **`{N}`** — Back
+- **`b`/`back`** — Return to the previous menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -64,7 +64,7 @@ List only phases from `completed_phases`.
 
 **STOP.** Wait for user response.
 
-#### If user chose Back
+#### If user chose `back`
 
 → Return to **B. Proceed or Revisit**.
 

--- a/skills/workflow-continue-cross-cutting/references/revisit-phase.md
+++ b/skills/workflow-continue-cross-cutting/references/revisit-phase.md
@@ -54,7 +54,7 @@ Which phase would you like to revisit?
 
 - **`1`** — {phase:(titlecase)} — completed
 - **`2`** — ...
-- **`{N}`** — Back
+- **`b`/`back`** — Return to the previous menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -64,7 +64,7 @@ List only phases from `completed_phases`.
 
 **STOP.** Wait for user response.
 
-#### If user chose Back
+#### If user chose `back`
 
 → Return to **B. Proceed or Revisit**.
 

--- a/skills/workflow-continue-feature/references/revisit-phase.md
+++ b/skills/workflow-continue-feature/references/revisit-phase.md
@@ -70,7 +70,7 @@ Which phase would you like to revisit?
 
 - **`1`** — {phase:(titlecase)} — completed
 - **`2`** — ...
-- **`{N}`** — Back
+- **`b`/`back`** — Return to the previous menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -80,7 +80,7 @@ List only phases from `completed_phases`.
 
 **STOP.** Wait for user response.
 
-#### If user chose Back
+#### If user chose `back`
 
 → Return to **B. Proceed or Revisit**.
 

--- a/skills/workflow-continue-quickfix/references/revisit-phase.md
+++ b/skills/workflow-continue-quickfix/references/revisit-phase.md
@@ -54,7 +54,7 @@ Which phase would you like to revisit?
 
 - **`1`** — {phase:(titlecase)} — completed
 - **`2`** — ...
-- **`{N}`** — Back
+- **`b`/`back`** — Return to the previous menu
 
 Select an option:
 · · · · · · · · · · · ·
@@ -64,7 +64,7 @@ List only phases from `completed_phases`.
 
 **STOP.** Wait for user response.
 
-#### If user chose Back
+#### If user chose `back`
 
 → Return to **B. Proceed or Revisit**.
 


### PR DESCRIPTION
**PR4, stacked on PR3.** A small menu-convention cleanup that fell out of the PR3 review.

## What

The "Which phase would you like to revisit?" menus used a numbered `{N} — Back` option. This converts them to the `b`/`back` command form (handler keys on `` `back` ``), matching the epic resume/cancel/reactivate menus, the epic §F resume-completed menu (aligned in PR3), and the new completed-specs submenu. The `b`/`back` form disambiguates the back option from the numbered phase list.

8 files, 2 lines each (menu option + handler heading); **routing targets unchanged**:

- `workflow-continue-{feature,bugfix,quickfix,cross-cutting}/references/revisit-phase.md`
- `workflow-bridge/references/{feature,bugfix,quickfix,cross-cutting}-continuation.md`

## Why a separate PR

This is orthogonal to the spec-groupings feature (one-PR-per-change), so it sits on top of the stack rather than bundled into PR3.

## Tests

None — prose-only skill-reference changes. Verified no leftover `{N} — Back` or `If user chose Back` remains anywhere under `skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #373
2. #374
3. #375
4. #376
5. **#377** 👈 current
<!-- stack:links:end -->