### PR TITLE
fix(continue-epic): unblock plans when dependency tasks complete

### DIFF
--- a/skills/workflow-continue-epic/scripts/discovery.cjs
+++ b/skills/workflow-continue-epic/scripts/discovery.cjs
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { loadActiveManifests, loadAllManifests, loadManifest, phaseItems, phaseData, computeTopicLifecycle, computeNextAction, computeMapSummary, computeSourceProvenance, computeAnalysisCacheStatus, compareMapRows, computeNeedsSequencing } = require('../../workflow-shared/scripts/discovery-utils.cjs');
+const { loadActiveManifests, loadAllManifests, phaseItems, computeTopicLifecycle, computeNextAction, computeMapSummary, computeSourceProvenance, computeAnalysisCacheStatus, compareMapRows, computeNeedsSequencing } = require('../../workflow-shared/scripts/discovery-utils.cjs');
 
 const EPIC_PHASES = ['discovery', 'research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
 
@@ -16,7 +16,7 @@ function lastCompletedPhaseEpic(manifest) {
   return last;
 }
 
-function resolveDeps(cwd, manifest, planItem) {
+function resolveDeps(manifest, planItem) {
   const externalDepsObj = (planItem.external_dependencies && typeof planItem.external_dependencies === 'object' && !Array.isArray(planItem.external_dependencies))
     ? planItem.external_dependencies
     : {};
@@ -31,10 +31,12 @@ function resolveDeps(cwd, manifest, planItem) {
       depsSatisfied = false;
       depsBlocking.push({ topic: dep.topic, reason: 'dependency unresolved' });
     } else if (dep.state === 'resolved' && dep.internal_id) {
-      const depManifest = loadManifest(cwd, dep.topic);
-      const depImpl = depManifest ? phaseData(depManifest, 'implementation') : {};
+      // Dep topics live in the same work unit — read the implementation item
+      // from this manifest. A completed implementation satisfies the dep even
+      // if the referenced task was skipped or its ID is stale.
+      const depImpl = phaseItems(manifest, 'implementation').find(i => i.name === dep.topic) || {};
       const completedTasks = Array.isArray(depImpl.completed_tasks) ? depImpl.completed_tasks : [];
-      if (!completedTasks.includes(dep.internal_id)) {
+      if (depImpl.status !== 'completed' && !completedTasks.includes(dep.internal_id)) {
         depsSatisfied = false;
         depsBlocking.push({ topic: dep.topic, internal_id: dep.internal_id, reason: 'task not yet completed' });
       }
@@ -97,7 +99,7 @@ function buildEpicDetail(cwd, manifest) {
       // Enrich planning items with format and dependency data
       if (phase === 'planning') {
         if (item.format) entry.format = item.format;
-        const { deps_satisfied, deps_blocking } = resolveDeps(cwd, manifest, item);
+        const { deps_satisfied, deps_blocking } = resolveDeps(manifest, item);
         entry.deps_satisfied = deps_satisfied;
         if (deps_blocking.length > 0) entry.deps_blocking = deps_blocking;
       }
@@ -165,7 +167,7 @@ function buildEpicDetail(cwd, manifest) {
   for (const p of planItems) {
     if (p.status === 'completed' && !implTopics.has(p.name)) {
       // Check deps before marking as ready for implementation
-      const { deps_satisfied, deps_blocking } = resolveDeps(cwd, manifest, p);
+      const { deps_satisfied, deps_blocking } = resolveDeps(manifest, p);
       if (deps_satisfied) {
         nextPhaseReady.push({ name: p.name, action: 'start_implementation', label: 'plan completed' });
       } else {

--- a/skills/workflow-implementation-entry/references/check-dependencies.md
+++ b/skills/workflow-implementation-entry/references/check-dependencies.md
@@ -16,17 +16,18 @@ Evaluate each dependency and collect any that are blocking into a list:
 
 - **`state: satisfied_externally`** — skip, not blocking
 - **`state: unresolved`** — add to the blocking list
-- **`state: resolved`** — check whether the referenced task has been completed:
+- **`state: resolved`** — check the dependency topic's implementation status and completed tasks:
 
 ```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.implementation.{dep_topic} status
 node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.implementation.{dep_topic} completed_tasks
 ```
 
-**If `internal_id` is in the completed tasks list:**
+**If status is `completed`, or `internal_id` is in the completed tasks list:**
 
-Skip, not blocking.
+Skip, not blocking. A completed implementation satisfies the dependency even if the referenced task was skipped.
 
-**If `internal_id` is not in the list, or the implementation entry does not exist:**
+**If status is not `completed` and `internal_id` is not in the list, or the implementation entry does not exist:**
 
 Add to the blocking list.
 

--- a/tests/scripts/test-discovery-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-discovery-for-workflow-continue-epic.cjs
@@ -371,6 +371,196 @@ describe('workflow-continue-epic discovery', () => {
     });
   });
 
+  describe('external dependencies', () => {
+    it('unresolved dependency blocks the plan', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          planning: {
+            items: {
+              billing: {
+                status: 'completed',
+                external_dependencies: { auth: { description: 'User context', state: 'unresolved' } },
+              },
+            },
+          },
+        },
+      });
+      const plan = discover(dir).epics[0].detail.phases.planning[0];
+      assert.strictEqual(plan.deps_satisfied, false);
+      assert.deepStrictEqual(plan.deps_blocking, [{ topic: 'auth', reason: 'dependency unresolved' }]);
+    });
+
+    it('resolved dependency with task in same-manifest completed_tasks is satisfied', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          planning: {
+            items: {
+              auth: { status: 'completed' },
+              billing: {
+                status: 'completed',
+                external_dependencies: { auth: { description: 'User context', state: 'resolved', internal_id: 'auth-1-3' } },
+              },
+            },
+          },
+          implementation: {
+            items: {
+              auth: { status: 'in-progress', completed_tasks: ['auth-1-1', 'auth-1-2', 'auth-1-3'] },
+            },
+          },
+        },
+      });
+      const plan = discover(dir).epics[0].detail.phases.planning.find(p => p.name === 'billing');
+      assert.strictEqual(plan.deps_satisfied, true);
+      assert.strictEqual(plan.deps_blocking, undefined);
+    });
+
+    it('resolved dependency blocks while the task is incomplete', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          planning: {
+            items: {
+              billing: {
+                status: 'completed',
+                external_dependencies: { auth: { description: 'User context', state: 'resolved', internal_id: 'auth-1-3' } },
+              },
+            },
+          },
+          implementation: {
+            items: {
+              auth: { status: 'in-progress', completed_tasks: ['auth-1-1'] },
+            },
+          },
+        },
+      });
+      const plan = discover(dir).epics[0].detail.phases.planning[0];
+      assert.strictEqual(plan.deps_satisfied, false);
+      assert.deepStrictEqual(plan.deps_blocking, [{ topic: 'auth', internal_id: 'auth-1-3', reason: 'task not yet completed' }]);
+    });
+
+    it('completed implementation satisfies the dependency even when the task id is absent', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          planning: {
+            items: {
+              billing: {
+                status: 'completed',
+                external_dependencies: { auth: { description: 'User context', state: 'resolved', internal_id: 'auth-9-9' } },
+              },
+            },
+          },
+          implementation: {
+            items: {
+              auth: { status: 'completed', completed_tasks: ['auth-1-1'] },
+            },
+          },
+        },
+      });
+      const plan = discover(dir).epics[0].detail.phases.planning[0];
+      assert.strictEqual(plan.deps_satisfied, true);
+    });
+
+    it('resolved dependency blocks when the dep topic has no implementation entry', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          planning: {
+            items: {
+              billing: {
+                status: 'completed',
+                external_dependencies: { auth: { description: 'User context', state: 'resolved', internal_id: 'auth-1-3' } },
+              },
+            },
+          },
+        },
+      });
+      const plan = discover(dir).epics[0].detail.phases.planning[0];
+      assert.strictEqual(plan.deps_satisfied, false);
+    });
+
+    it('satisfied_externally dependency never blocks', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          planning: {
+            items: {
+              billing: {
+                status: 'completed',
+                external_dependencies: { auth: { description: 'User context', state: 'satisfied_externally' } },
+              },
+            },
+          },
+        },
+      });
+      const plan = discover(dir).epics[0].detail.phases.planning[0];
+      assert.strictEqual(plan.deps_satisfied, true);
+    });
+
+    it('resolved dependency without internal_id blocks as missing task reference', () => {
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          planning: {
+            items: {
+              billing: {
+                status: 'completed',
+                external_dependencies: { auth: { description: 'User context', state: 'resolved' } },
+              },
+            },
+          },
+        },
+      });
+      const plan = discover(dir).epics[0].detail.phases.planning[0];
+      assert.strictEqual(plan.deps_satisfied, false);
+      assert.deepStrictEqual(plan.deps_blocking, [{ topic: 'auth', reason: 'resolved dependency missing task reference' }]);
+    });
+
+    it('next_phase_ready marks start_implementation blocked only while deps are unmet', () => {
+      // Three-topic chain: cli-presentation implemented; mint-release-tool
+      // depends on its task (met); commit-command depends on both (one unmet).
+      createManifest(dir, 'v1', {
+        work_type: 'epic',
+        phases: {
+          planning: {
+            items: {
+              'cli-presentation': { status: 'completed' },
+              'mint-release-tool': {
+                status: 'completed',
+                external_dependencies: {
+                  'cli-presentation': { description: 'Presentation layer', state: 'resolved', internal_id: 'cli-presentation-1-1' },
+                },
+              },
+              'commit-command': {
+                status: 'completed',
+                external_dependencies: {
+                  'cli-presentation': { description: 'Presentation layer', state: 'resolved', internal_id: 'cli-presentation-3-1' },
+                  'mint-release-tool': { description: 'Shared engine', state: 'resolved', internal_id: 'mint-release-tool-2-1' },
+                },
+              },
+            },
+          },
+          implementation: {
+            items: {
+              'cli-presentation': { status: 'completed', completed_tasks: ['cli-presentation-1-1', 'cli-presentation-3-1'] },
+            },
+          },
+        },
+      });
+      const ready = discover(dir).epics[0].detail.next_phase_ready;
+      const mint = ready.find(n => n.name === 'mint-release-tool');
+      const commit = ready.find(n => n.name === 'commit-command');
+      assert.strictEqual(mint.action, 'start_implementation');
+      assert.strictEqual(mint.blocked, undefined);
+      assert.strictEqual(commit.blocked, true);
+      assert.deepStrictEqual(commit.deps_blocking, [
+        { topic: 'mint-release-tool', internal_id: 'mint-release-tool-2-1', reason: 'task not yet completed' },
+      ]);
+    });
+  });
+
   describe('edge cases', () => {
     it('sources using name field instead of topic', () => {
       createManifest(dir, 'v1', {


### PR DESCRIPTION
## Summary
- `resolveDeps` in the epic discovery script looked up a dependency topic's `completed_tasks` via `loadManifest(cwd, dep.topic)` — treating the topic as a work unit. No `.workflows/{topic}/manifest.json` exists for epic topics, so every resolved dependency reported "task not yet completed" forever; blocked plans never unblocked, even after the dependency topic's implementation completed. The epic menu and the bridge both render from this script, so the block appeared everywhere.
- Read the dependency's implementation item from the same work-unit manifest, and treat a completed implementation as satisfying the dependency even when the referenced task id is absent (skipped task or stale reference). The same fallback is mirrored in the implementation-entry dependency gate (`check-dependencies.md`).
- Dependencies now gate on implementation (task-level), as designed — review never blocks downstream topics.

## Test plan
- Added an `external dependencies` suite to `tests/scripts/test-discovery-for-workflow-continue-epic.cjs` covering all dependency states, the no-implementation-entry case, the completed-implementation fallback, and the `next_phase_ready` blocked flag for a three-topic chain (one dep met, one unmet).
- `node --test tests/scripts/test-discovery-*.cjs tests/scripts/test-ensure-discovery-item.cjs tests/scripts/test-absorb-into-epic.cjs` — 528 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)