### PR TITLE
fix(discovery): epic vanishes from active work after first topic review

### DIFF
--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -54,9 +54,15 @@ The map is already sequenced.
 
 ## D. Check All-Done
 
-Using the enriched discovery data from section A, check if ALL topics across ALL phases have review status `completed`. Specifically: check if any review items exist, and if so, whether every one has `status: completed`, and no topics in earlier phases are still `in-progress`.
+Phase statuses aggregate only the topics present in each phase, so a completed review phase alone does not mean the epic is finished — topics may not have reached review yet. Using the enriched discovery `detail`, the epic is all-done only when every condition holds:
 
-#### If all topics have completed review
+- review items exist and every non-cancelled one has `status: completed`
+- `next_phase_ready` is empty (no topic is awaiting its next phase)
+- `in_progress` is empty
+- `unaccounted_discussions` is empty
+- `convergence_state` is `settled` (or `null` when the epic has no discovery map)
+
+#### If all conditions hold
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-shared/scripts/discovery-utils.cjs
+++ b/skills/workflow-shared/scripts/discovery-utils.cjs
@@ -142,6 +142,12 @@ function computeNextPhase(manifest) {
   }
 
   if (ps('review') === 'completed') {
+    // Phase aggregation only covers topics that have reached the phase. For
+    // an epic, one topic completing review must not mark the whole epic done
+    // — completion is the explicit status flip, never derived.
+    if (wt === 'epic') {
+      return { next_phase: 'review', phase_label: 'review completed for current topics' };
+    }
     return { next_phase: 'done', phase_label: 'pipeline complete' };
   }
   if (ps('review') === 'in-progress') {

--- a/tests/scripts/test-discovery-for-start.cjs
+++ b/tests/scripts/test-discovery-for-start.cjs
@@ -68,6 +68,37 @@ describe('workflow-start discovery', () => {
     assert.strictEqual(r.features.count, 0);
   });
 
+  it('epic stays active when one topic completes review with others mid-pipeline', () => {
+    createManifest(dir, 'mint', {
+      work_type: 'epic',
+      phases: {
+        planning: {
+          items: {
+            'cli-presentation': { status: 'completed' },
+            'mint-release-tool': { status: 'completed' },
+            'commit-command': { status: 'completed' },
+          },
+        },
+        implementation: { items: { 'cli-presentation': { status: 'completed' } } },
+        review: { items: { 'cli-presentation': { status: 'completed' } } },
+      },
+    });
+    const r = discover(dir);
+    assert.strictEqual(r.state.has_any_work, true);
+    assert.strictEqual(r.state.epic_count, 1);
+    assert.strictEqual(r.epics.work_units[0].name, 'mint');
+  });
+
+  it('epic with completed status is not listed as active', () => {
+    createManifest(dir, 'shipped', {
+      work_type: 'epic',
+      status: 'completed',
+      phases: { review: { items: { a: { status: 'completed' } } } },
+    });
+    const r = discover(dir);
+    assert.strictEqual(r.state.epic_count, 0);
+  });
+
   it('skips archived work units', () => {
     createManifest(dir, 'old', { work_type: 'feature', status: 'completed' });
     createManifest(dir, 'active', { work_type: 'feature' });

--- a/tests/scripts/test-discovery-utils.cjs
+++ b/tests/scripts/test-discovery-utils.cjs
@@ -336,6 +336,30 @@ describe('discovery-utils', () => {
       assert.strictEqual(r.next_phase, 'done');
     });
 
+    it('epic: not done when one topic completes review with others mid-pipeline', () => {
+      const r = computeNextPhase({
+        work_type: 'epic',
+        phases: {
+          planning: { items: { 'cli-presentation': { status: 'completed' }, 'mint-release-tool': { status: 'completed' } } },
+          implementation: { items: { 'cli-presentation': { status: 'completed' } } },
+          review: { items: { 'cli-presentation': { status: 'completed' } } },
+        },
+      });
+      assert.strictEqual(r.next_phase, 'review');
+      assert.strictEqual(r.phase_label, 'review completed for current topics');
+    });
+
+    it('epic: never phase-derives done — completion is the explicit status flip', () => {
+      const r = computeNextPhase({
+        work_type: 'epic',
+        phases: {
+          implementation: { items: { a: { status: 'completed' }, b: { status: 'completed' } } },
+          review: { items: { a: { status: 'completed' }, b: { status: 'completed' } } },
+        },
+      });
+      assert.notStrictEqual(r.next_phase, 'done');
+    });
+
     it('returns review when implementation completed', () => {
       const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { implementation: { items: { test: { status: 'completed' } } } } });
       assert.strictEqual(r.next_phase, 'review');


### PR DESCRIPTION
## Summary
- `computeNextPhase` derived `done` from `phaseStatus('review') === 'completed'`, but phase statuses aggregate only the topics *present* in a phase. For an epic, the first topic to finish review made the whole epic read "pipeline complete": `workflow-start`'s discovery dropped it from the active list (`next_phase === 'done'` skip) while its manifest status was still `in-progress` — so it appeared nowhere and the epic menu became unreachable.
- Epics now never phase-derive `done`. Epic completion is the explicit status flip (bridge all-done confirm or the manage menu), which already removes the unit from active loading. When the review aggregate reads completed, an epic now returns `next_phase: review` with label `review completed for current topics`. Epic dashboard/menu rendering is untouched — `workflow-start` displays epics via `active_phases` and routes by work type.
- The bridge's all-done check (`epic-continuation.md` section D) had the same flaw — "all review items completed + nothing in-progress" holds after one topic when everything else is merely *waiting*. It now also requires empty `next_phase_ready`, empty `in_progress`, empty `unaccounted_discussions`, and a settled discovery map before offering to mark the epic completed.

## Test plan
- New `computeNextPhase` tests: epic with one topic through review and others mid-pipeline stays at `review` (not `done`); epic never phase-derives `done` even with every present topic reviewed; existing feature/quick-fix `done` tests unchanged.
- New `workflow-start` discovery tests: the reported shape (3 plans, 1 implemented, 1 reviewed) stays in the active list; an epic with explicit `status: completed` stays excluded.
- `node --test tests/scripts/test-discovery-*.cjs` plus adjacent suites — 522+ pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)