### PR TITLE
feat(engine): epic dashboard beachhead — domain projections, action-key routing, adapter on the gateway

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -44,6 +44,16 @@ or:
 
 Code blocks are used for informational displays (overviews, status, keys, phase titles, step markers) — they preserve indentation for tree structures and aligned lists. Markdown is used for interactive elements (menus, prompts) and signpost blockquotes where bold formatting is needed. When content benefits from rendered formatting (headings, checkboxes, bold) and indentation control isn't needed, prefer markdown rendering even for informational displays.
 
+### Engine Output Sections
+
+Skills that render state via an engine/adapter call (e.g. `discovery.cjs view {work_unit}`) receive one snapshot in three demarcated sections. The section markers carry their own handling instruction, and the skill file restates it at the call site:
+
+- `=== DATA … ===` — reasoning surface. Read it to decide (flags, counts, the `ACTIONS` key table); never display or restate it, and never parse the rendered sections below for decisions.
+- `=== DISPLAY … ===` — emit verbatim **as a code block**. Indentation-dependent content (trees, aligned columns) breaks under markdown rendering.
+- `=== MENU … ===` — emit verbatim **as markdown (not a code block)** so option formatting (bold, backticks) renders.
+
+A section is everything beneath its marker up to the next marker; the marker lines themselves are never emitted. Section content is emitted byte-for-byte — never redrawn, reflowed, trimmed, or re-derived. Routing uses the `ACTIONS` entry's `action`/`route` values, never label text.
+
 ### Phase Titles
 
 Bullet-bordered box. One per skill invocation. Serves as the top-level anchor telling the user where they are. Always followed by a blank line before any subsequent content.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node build/knowledge.build.js",
     "knowledge:repl": "node scripts/knowledge-repl.js",
     "typecheck": "tsc -p tsconfig.json",
-    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs"
+    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs"
   },
   "devDependencies": {
     "@msgpack/msgpack": "3.1.3",

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -296,27 +296,8 @@ Load **[epic-display-and-menu.md](references/epic-display-and-menu.md)** with ne
 > Handing off to the selected phase for this epic.
 ```
 
-Invoke the appropriate skill based on the user's menu selection. Match by **prefix** — labels may carry a trailing context segment (e.g., `— research completed`, `— spec completed`, `(Phase 2, Task 3)`) which doesn't change the routing target.
+Invoke the `route` stored for the user's selection — the selected `ACTIONS` entry's route from epic-display-and-menu.md (e.g. `/workflow-discussion-entry epic {work_unit} {topic}`). Selections with route `(internal)` resolve inside that reference and never reach this step.
 
-| Menu option | Invoke |
-|-------------|--------|
-| Start research for {topic} | `/workflow-research-entry epic {work_unit} {topic}` |
-| Start discussion for {topic} | `/workflow-discussion-entry epic {work_unit} {topic}` |
-| Continue {topic} — discussion | `/workflow-discussion-entry epic {work_unit} {topic}` |
-| Continue {topic} — research | `/workflow-research-entry epic {work_unit} {topic}` |
-| Continue {topic} — specification | `/workflow-specification-entry epic {work_unit} {topic}` |
-| Continue {topic} — planning | `/workflow-planning-entry epic {work_unit} {topic}` |
-| Continue {topic} — implementation | `/workflow-implementation-entry epic {work_unit} {topic}` |
-| Continue {topic} — review | `/workflow-review-entry epic {work_unit} {topic}` |
-| Start specification for {topic} | `/workflow-specification-entry epic {work_unit} {topic}` |
-| Start planning for {topic} | `/workflow-planning-entry epic {work_unit} {topic}` |
-| Start implementation of {topic} | `/workflow-implementation-entry epic {work_unit} {topic}` |
-| Start review for {topic} | `/workflow-review-entry epic {work_unit} {topic}` |
-| Analyze / regroup discussions | `/workflow-specification-entry epic {work_unit}` |
-| Start new discussion topic | `/workflow-discussion-entry epic {work_unit}` |
-| Start new research | `/workflow-research-entry epic {work_unit}` |
-| Continue discovery | `/workflow-discovery epic {work_unit}` |
-
-Skills receive positional arguments: `$0` = work_type (`epic`), `$1` = work_unit, `$2` = topic (when provided). "Continue discovery" routes to the discovery skill, which detects the existing work unit and re-shapes the map (existing-epic mode) — workflow-continue-epic navigates; discovery owns the shaping.
+Skills receive positional arguments: `$0` = work_type (`epic`), `$1` = work_unit, `$2` = topic (when provided). The `continue_discovery` route hands to the discovery skill, which detects the existing work unit and re-shapes the map (existing-epic mode) — workflow-continue-epic navigates; discovery owns the shaping.
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -32,7 +32,7 @@ The output is one snapshot in three demarcated sections:
 - **DISPLAY** — the dashboard and key. Emit verbatim as a code block. Never redraw, reflow, or trim it.
 - **MENU** — the selection menu. Emit verbatim as markdown (not a code block).
 
-Emit the DISPLAY section, then the MENU section.
+Emit the DISPLAY section, then the MENU section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -5,460 +5,48 @@
 ---
 
 Display the full phase-by-phase breakdown for the selected epic, then present an interactive menu of actionable items. The caller is responsible for providing:
-- Discovery output from `workflow-continue-epic/scripts/discovery.cjs` (the `detail` object for the selected epic)
 - `work_unit` — the epic's work unit name
-- `new_arrivals` (optional) — tracker from `topic-discovery.md` listing topic names added during this boot-up, per analysis. Used to render the "new topics added" callout above the Discovery Map. Empty / absent means no callout.
+- `new_arrivals` (optional) — tracker from `topic-discovery.md` listing topic names added during this boot-up, per analysis. Drives the "new topics added" callout above the Discovery Map. Empty / absent means no callout.
 
-This reference collects the user's selection and returns control to the caller. The caller decides what to do with the selection (invoke a skill directly, enter plan mode, etc.).
-
----
-
-## A. State Display
-
-#### If no phases have items (brand-new epic)
-
-> *Output the next fenced block as a code block:*
-
-```
-●───────────────────────────────────────────────●
-  {work_unit:(titlecase)}
-●───────────────────────────────────────────────●
-
-No work started yet.
-```
-
-→ Proceed to **C. Menu**.
-
-#### If `discovery_map` is non-empty
-
-Group every phase under three stage dividers: **DISCOVERY** (the research & discussion map), **DEFINITION** (specification, planning), and **DELIVERY** (implementation, review).
-
-> *Output the next fenced block as a code block:*
-
-```
-●───────────────────────────────────────────────●
-  {work_unit:(titlecase)}
-●───────────────────────────────────────────────●
-
-── DISCOVERY ────────────────────────────────────
-
-  RESEARCH & DISCUSSION ({total} topics{status_suffix})
-@foreach(topic in discovery_map)
-  {branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]
-@if(topic.summary)
-@foreach(line in wrap(topic.summary, 65))
-  {gutter}{line}
-@endforeach
-@endif
-@if(topic.source_provenance)
-  {gutter}{topic.source_provenance}
-@endif
-@endforeach
-
-@if(specification.items or planning.items)
-── DEFINITION ───────────────────────────────────
-
-@foreach(phase in [specification, planning])
-@if(phase.items)
-  {phase:(uppercase)} ({phase.count_summary})
-@foreach(item in phase.items)
-  {item_branch} {item.name:(titlecase)} [{item.status}]@if(phase == planning and item.format) · {item.format}@endif
-@if(phase == specification and item.sources)
-@foreach(source in item.sources)
-  {child_gutter}{child_branch} {source.topic:(titlecase)} [{source.status}]
-@endforeach
-@endif
-@endforeach
-
-@endif
-@endforeach
-@endif
-@if(implementation.items or review.items)
-── DELIVERY ─────────────────────────────────────
-
-@foreach(phase in [implementation, review])
-@if(phase.items)
-  {phase:(uppercase)} ({phase.count_summary})
-@foreach(item in phase.items)
-  {item_branch} {item.name:(titlecase)} [{item.status}]
-@if(phase == implementation and item.current_phase)
-  {child_gutter}└─ Phase {item.current_phase}, {item.completed_tasks.length} task(s) completed
-@else
-@if(phase == implementation and item.completed_tasks)
-  {child_gutter}└─ {item.completed_tasks.length} task(s) completed
-@endif
-@endif
-@endforeach
-
-@endif
-@endforeach
-@endif
-```
-
-**Stage and tree display rules:**
-
-The display groups every phase under three stage dividers — **DISCOVERY** (research & discussion, the map), **DEFINITION** (specification, planning), **DELIVERY** (implementation, review). Each divider is flush to the code block's left edge and padded to 49 characters, matching step-marker width (`── DISCOVERY ───…`). A blank line follows each divider before its content; a blank line separates stages.
-
-- **Stage presence**: the DISCOVERY divider always renders here (the map is non-empty). Render the DEFINITION divider only when `specification` or `planning` has items; the DELIVERY divider only when `implementation` or `review` has items.
-- **Stage-meta callouts**: when present, render between the DISCOVERY divider's blank line and the `RESEARCH & DISCUSSION` header, each on its own 2-space-indented line, followed by a blank line. Omit the trailing blank line (and all callouts) when none apply.
-  - Seed (`seeds_count > 0`): `· seeded from the inbox`
-  - Imports (`show_imports_callout`): `· {imports_count} import` for 1, `· {imports_count} imports` for 2+. True only when `imports_count > 0` **and** `imports_count != discovery_map.length` (when every topic is itself an import, per-row provenance already says so).
-  - New arrivals: `⚑ {N} new topic(s) added to the map from research-analysis.` and/or `⚑ {N} new topic(s) added to the map from gap-analysis.`, one per analysis in `new_arrivals` with a non-empty list. Shown once per boot-up that added items; the topic rows' provenance sub-lines are the persistent surface afterwards.
-- **Discovery header**: `RESEARCH & DISCUSSION ({total} topics{status_suffix})`. The topic tree branches directly off this line — no blank between.
-  - `{status_suffix}`: ` · all decided` when `convergence_state == 'settled'`. Otherwise ` · {decided} decided · {in_flight} in flight · {ready} ready · {fresh} fresh · {handled} handled · {cancelled} cancelled`, omitting zero-count categories. Read counts from `map_summary`.
-- **Topic rows** are pre-sorted by the discovery script (tier rank `→ ◐ ✓ ○ ⊙ ⊘`, then suggested execution order). Render in order. Row: `{branch} {topic.tier} {topic.name:(titlecase)} [{lifecycle_label}]`, single space between segments.
-  - `{branch}`: `├─` for every row except the last; `└─` for the last (or only) row. Never `┌─` — the leading `├─` (or sole `└─`) ticks upward into the header so the list hangs off it.
-  - **Lifecycle label** by tier: `→` (ready_for_discussion) `research complete · ready for discussion`; `◐` (researching) `researching` or (discussing) `discussing`; `✓` (decided) `decided`; `○` (fresh) `fresh · routed to {topic.routing}` (omit ` · routed to …` if `topic.routing` is null); `⊙` (handled) `handled · research fanned out`; `⊘` (cancelled) `cancelled`.
-  - **Summary / provenance sub-lines** via `{gutter}`. Summary first (hard-wrapped at 65 chars), provenance below it. Source `discovery` produces no provenance line.
-    - `{gutter}` — **non-last topic**: 2 spaces, `│`, 6 spaces; **last topic**: 9 spaces. Both land sub-line text at the same column, two columns right of the topic name. The `│` runs continuously through every sub-line of every non-last topic so the tree never breaks; the last topic drops it so nothing dangles below `└─`.
-    - **Example** (non-last topic, summary wraps onto three lines, provenance below):
-      ```
-        ├─ ◐ Ai Content Engine [researching]
-        │      AI imagery (enhancement-only v1), description
-        │      generation, per-tenant tone / base-knowledge
-        │      primitive, allowance + overage cost shape
-        │      from exploration
-      ```
-    - **Example** (last topic — same shape, no `│`):
-      ```
-        └─ ◐ Menu And Admin [researching]
-               Business-side menu modelling, admin shell (Filament vs
-               custom Vue/Nuxt), JustEat import, staff/roles
-               from exploration
-      ```
-- **Build-phase sub-headers**: `{phase:(uppercase)} ({phase.count_summary})` — the phase name uppercased (`SPECIFICATION`, `PLANNING`, `IMPLEMENTATION`, `REVIEW`) with a parenthetical count summary combining the statuses present (e.g. `(2 completed)`, `(1 proposed, 2 completed)`, `(3 completed, 1 cancelled)`; omit zero counts). The item tree branches directly off the sub-header. Blank line between sub-headers within a stage.
-- **Item rows** (`{item_branch}`): `├─` for non-final items, `└─` for the final item in the phase. Planning items append ` · {format}` after the status. Within the specification phase, order proposed items first (analyzed groupings awaiting a start), then the remaining items in their existing order.
-- **Item sub-rows** — specification sources, implementation progress — branch beneath their item via `{child_gutter}` + `{child_branch}`:
-  - `{child_gutter}` — under a **non-last item**: 2 spaces, `│`, 2 spaces; under the **last item**: 5 spaces. Both land the child branch at the same column, under the item name.
-  - `{child_branch}`: `├─` for non-final children, `└─` for the final (or only) child.
-  - Specification source status: `[incorporated]` or `[pending]` from the manifest. Implementation shows `Phase {N}, {M} task(s) completed` when in-progress with `current_phase`, else `{M} task(s) completed` (always a single `└─` child).
-- **Promoted items** render with `[promoted]` in the display but not the menu. **Proposed specs** render with `[proposed]` and surface in the menu as `Start specification` entries (see **C. Menu**). **Cancelled items** show `[cancelled]`. Phases with no items don't appear.
-- **No trailing recommendation callout** in this code block — build-phase recommendations attach to menu entries (see **C. Menu**).
-
-After the render block, run the **Plans Not Ready Check** below; it applies to both this branch and the otherwise branch.
-
-→ Proceed to **B. Key**.
-
-#### Otherwise
-
-Group the phases under the same three stage dividers. This branch has no map — research and discussion render as flat phase trees under the DISCOVERY divider. Stage → phase mapping: **DISCOVERY** → research, discussion; **DEFINITION** → specification, planning; **DELIVERY** → implementation, review.
-
-> *Output the next fenced block as a code block:*
-
-```
-●───────────────────────────────────────────────●
-  {work_unit:(titlecase)}
-●───────────────────────────────────────────────●
-
-@foreach(stage in [DISCOVERY, DEFINITION, DELIVERY] where any mapped phase has items)
-── {stage} ──────────────────────────────────────
-
-@foreach(phase in stage where phase.items)
-  {phase:(uppercase)} ({phase.count_summary})
-@foreach(item in phase.items)
-  {item_branch} {item.name:(titlecase)} [{item.status}]@if(phase == planning and item.format) · {item.format}@endif
-@if(phase == specification and item.sources)
-@foreach(source in item.sources)
-  {child_gutter}{child_branch} {source.topic:(titlecase)} [{source.status}]
-@endforeach
-@endif
-@if(phase == implementation and item.current_phase)
-  {child_gutter}└─ Phase {item.current_phase}, {item.completed_tasks.length} task(s) completed
-@else
-@if(phase == implementation and item.completed_tasks)
-  {child_gutter}└─ {item.completed_tasks.length} task(s) completed
-@endif
-@endif
-@endforeach
-
-@endforeach
-@endforeach
-@if(recommendation)
-  ⚑ {recommendation text}
-@endif
-```
-
-**Display rules:**
-
-- Stage dividers, uppercase sub-headers, count summaries, and tree grammar (`{item_branch}`, `{child_gutter}`, `{child_branch}`) follow the **Stage and tree display rules** above. Render a stage divider only when at least one of its mapped phases has items; blank line after each divider, between sub-headers, and between stages.
-- Pending discussion topics from research count as siblings when determining the final item in the discussion phase.
-- Phases with no items don't appear. No trailing blank line after the last stage (the code block ends after the last item, or the recommendation if present).
-
-**Recommendations:** Check the following conditions in order. Show the first that applies as a `⚑`-prefixed line after the last stage, separated by a blank line. If the recommendation text is long, wrap it across two lines (both 2-space indented, only the first has `⚑`). If none apply, no recommendation.
-
-| Condition | Recommendation |
-|-----------|---------------|
-| In-progress items across multiple phases | No recommendation |
-| Some research in-progress, some completed | "Consider completing remaining research before starting discussion. Topic analysis works best with all research available." |
-| Some discussions in-progress, some completed | "Consider completing remaining discussions before starting specification. The grouping analysis works best with all discussions available." |
-| Proposed groupings exist (specs with status `proposed`) | "{N} analyzed grouping(s) ready to specify. Start them before planning to surface cross-cutting dependencies." |
-| All discussions completed, no specification items exist | "All discussions are completed. Specification will analyze and group them." |
-| Some specs completed, some in-progress | "Completing all specifications before planning helps identify cross-cutting dependencies." |
-| Some plans completed, some in-progress | "Completing all plans before implementation helps surface task dependencies across plans." |
-| Reopened discussion that's a source in a spec | "{Spec} specification sources the reopened {Discussion} discussion. Once that discussion concludes, the specification will need revisiting to extract new content." |
-
-After the render block, run the **Plans Not Ready Check** below.
-
-→ Proceed to **B. Key**.
+This reference collects the user's selection and returns control to the caller. The caller decides what to do with the selection (invoke a skill directly, enter plan mode, etc.). Sections D–F additionally read per-item state (statuses, completed, cancelled) from the most recent labelled discovery output in context.
 
 ---
 
-**Plans Not Ready Check** (shared post-render check, used by both populated branches above): check for plans with `deps_blocking` entries. If any exist, show in a separate code block:
+## A. State Display and Menu
 
-> *Output the next fenced block as a code block:*
+Render the epic snapshot:
 
-```
-⚑ Plans not ready for implementation:
-  These plans have unresolved dependencies that must be
-  addressed first.
-
-@foreach(plan in plans_with_deps_blocking)
-  {topic:(titlecase)}
-@foreach(dep in plan.deps_blocking)
-  └─ Blocked by @if(dep.internal_id) {dep_topic}:{internal_id} @else {dep_topic} @endif
-@endforeach
-
-@endforeach
+```bash
+node .claude/skills/workflow-continue-epic/scripts/discovery.cjs view {work_unit}
 ```
 
-Use the `deps_blocking` array from the planning phase items. Show each blocking dependency with its cross-plan task reference using colon notation (`{plan}:{internal_id}`) when an `internal_id` is present. Omit this block entirely if no plans are blocked.
+When `new_arrivals` has any names, pass the tracker as a JSON argument instead:
 
----
-
-## B. Key
-
-Show only statuses and categories that appear in the current display. No `---` separator before this section.
-
-#### If `discovery_map` is non-empty
-
-> *Output the next fenced block as a code block:*
-
-```
-  Key:
-    Discovery tier:
-      →  ready for next phase   ◐  in flight
-      ✓  decided                ○  fresh
-      ⊙  handled                ⊘  cancelled
-
-    Status:
-      proposed    — analyzed grouping, not yet started
-      in-progress — work is ongoing
-      completed   — phase or implementation done
-      cancelled   — topic removed from active work
-      promoted    — moved to its own cross-cutting work unit
-
-    Blocking reason:
-      blocked by {plan}:{task} — depends on another plan's task
-      blocked by {plan}        — dependency unresolved
+```bash
+node .claude/skills/workflow-continue-epic/scripts/discovery.cjs view {work_unit} '{"research_analysis":["{topic}", "{topic}"],"gap_analysis":[]}'
 ```
 
-Show only categories present in the current display: include the Discovery tier block whenever `discovery_map` has entries; include the Status block when `phases` (specification onwards) has items; include the Blocking reason block when any plan has `deps_blocking`.
+The output is one snapshot in three demarcated sections:
 
-→ Proceed to **C. Menu**.
+- **DATA** — reasoning surface: state flags, `phase_counts` (in-progress / proposed / total per phase), and the `ACTIONS` table — one line per menu key, `key  action  topic  → route`, with `(recommended)` / `(blocked: …)` markers. Reason from it; never display or restate it.
+- **DISPLAY** — the dashboard and key. Emit verbatim as a code block. Never redraw, reflow, or trim it.
+- **MENU** — the selection menu. Emit verbatim as markdown (not a code block).
 
-#### Otherwise
-
-> *Output the next fenced block as a code block:*
-
-```
-  Key:
-    Status:
-      proposed    — analyzed grouping, not yet started
-      in-progress — work is ongoing
-      completed   — phase or implementation done
-      cancelled   — topic removed from active work
-      promoted    — moved to its own cross-cutting work unit
-
-    Blocking reason:
-      blocked by {plan}:{task} — depends on another plan's task
-      blocked by {plan}        — dependency unresolved
-```
-
-→ Proceed to **C. Menu**.
-
----
-
-## C. Menu
-
-Build a menu with two types of options:
-
-**Numbered items** — topic-targeting actions where you're selecting a specific topic. Use sequential numbers. The set differs based on whether the epic uses a discovery map.
-
-#### If `discovery_map` is non-empty
-
-**Numbered items, in order:**
-
-1. **Discovery topics** — one entry per `discovery_map` row whose `next_action` is non-null. Skip rows with tier `✓` (decided), `⊙` (handled), and `⊘` (cancelled) — those have no menu entry. Label by `next_action`:
-
-   | next_action                       | Label                                                            |
-   |-----------------------------------|------------------------------------------------------------------|
-   | `start_research`                  | `Start research for "{topic:(titlecase)}"`                       |
-   | `start_discussion`                | `Start discussion for "{topic:(titlecase)}"`                     |
-   | `continue_research`               | `Continue "{topic:(titlecase)}" — research`                      |
-   | `continue_discussion`             | `Continue "{topic:(titlecase)}" — discussion`                    |
-   | `start_discussion_after_research` | `Start discussion for "{topic:(titlecase)}" — research completed`|
-
-   Discovery-topic order matches the `discovery_map` row order: tier `→`, then `◐`, then `○` (suggested execution order within each tier).
-
-2. **Build-phase entries** — from `next_phase_ready` and any in-progress items in `phases.specification`/`planning`/`implementation`/`review`:
-   - In-progress in build phases:
-     - Specification in-progress: `Continue "{topic:(titlecase)}" — specification [in-progress]`
-     - Planning in-progress: `Continue "{topic:(titlecase)}" — planning [in-progress]`
-     - Implementation in-progress with progress: `Continue "{topic:(titlecase)}" — implementation (Phase {N}, Task {M})`
-     - Implementation in-progress without progress: `Continue "{topic:(titlecase)}" — implementation [in-progress]`
-     - Review in-progress: `Continue "{topic:(titlecase)}" — review [in-progress]`
-   - From `next_phase_ready`:
-     - Proposed grouping: `Start specification for "{topic:(titlecase)}" — grouping ready`
-     - Completed spec with no plan: `Start planning for "{topic:(titlecase)}" — spec completed`
-     - Completed plan with no implementation:
-       - If `blocked`: shown but not selectable — `Start implementation of "{topic:(titlecase)}" — blocked by {dep_topic}:{internal_id}`
-       - Otherwise: `Start implementation of "{topic:(titlecase)}" — plan completed`
-     - Completed implementation with no review: `Start review for "{topic:(titlecase)}" — implementation completed`
-
-   Order build-phase entries by pipeline position: specification entries first (earliest in the pipeline), then planning, implementation, review.
-
-**Command options:**
-- **`s`/`spec`** — Analyze / regroup discussions (only shown if `gating.can_start_specification` is true). Description adapts: `— {N} discussion(s) not yet grouped` when `unaccounted_discussions` is non-empty, else `— review or regroup specifications`
-- **`d`/`discuss`** — Start a discussion on a new topic (always present)
-- **`r`/`research`** — Start research on a new topic (always present)
-- **`i`/`discovery`** — Continue discovery (always present when `discovery_map` is non-empty)
-- **`c`/`completed`** — Resume a completed topic (only shown when `completed` items exist)
-- **`a`/`cancel`** — Cancel a topic (phase work) (only shown when non-cancelled, non-promoted items exist in any phase)
-- **`e`/`reactivate`** — Reactivate a cancelled topic (only shown when `cancelled` items exist in discovery output)
-- **`m`/`map`** — View pipeline map (always present when at least one phase has items)
-
-**Phase-forward gating** (build-phase entries only):
-- No "Start planning" unless `gating.can_start_planning` is true
-- No "Start implementation" unless `gating.can_start_implementation` is true
-- No "Start review" unless `gating.can_start_review` is true
-- No "Start specification" unless `gating.can_start_specification` is true
-
-**Ordering and recommendation** — evaluate by `convergence_state`:
-
-| Convergence state | Recommendation source                                               |
-|-------------------|---------------------------------------------------------------------|
-| `in-progress`     | Top of `discovery_map` — first row with non-null `next_action` (tier order: `→` first, then `◐`, then `○`). Never `✓`, `⊙`, or `⊘`. |
-| `settled`         | First build-phase `next_phase_ready` item in pipeline order (specification before planning before implementation before review). A proposed spec's `start_specification` therefore outranks any `start_planning`. If none, `s`/`spec` when applicable. Otherwise no recommendation. |
-
-The recommended item always appears first. Mark it `(recommended)`. After the recommended item, list remaining numbered items in their natural order (discovery topics, then build-phase items), then command options.
-
-**Promoted items:** Items with `[promoted]` status are shown in the state display but are **not listed in the menu** — they've been moved to their own cross-cutting work unit and are no longer actionable in this epic.
-
-**Blocked items:** Items marked `blocked` in `next_phase_ready` are shown in the menu but are **not selectable**. If the user picks a blocked item, explain why it's blocked and re-present the menu.
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-What would you like to do?
-
-- **`1`** — Start discussion for "Kitchen Hardware" — research completed (recommended)
-- **`2`** — Continue "AI Image Generation" — research
-- **`3`** — Continue "Tenant Onboarding" — discussion
-- **`4`** — Start research for "Customer Portal"
-- **`5`** — Start specification for "Billing Grouping" — grouping ready
-- **`6`** — Start planning for "Roles And Permissions" — spec completed
-
-- **`s`/`spec`** — Analyze / regroup discussions — 2 discussion(s) not yet grouped
-- **`d`/`discuss`** — Start a discussion on a new topic
-- **`r`/`research`** — Start research on a new topic
-- **`i`/`discovery`** — Continue discovery
-- **`c`/`completed`** — Resume a completed topic
-- **`a`/`cancel`** — Cancel a topic (phase work)
-- **`e`/`reactivate`** — Reactivate a cancelled topic
-- **`m`/`map`** — View pipeline map
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-Recreate with actual items from discovery.
+Emit the DISPLAY section, then the MENU section.
 
 **STOP.** Wait for user response.
 
-→ Proceed to **D. Handle Selection**.
-
-#### Otherwise
-
-**Numbered items** — topic-targeting actions where you're selecting a specific topic. Use sequential numbers. These include:
-- Continue items: any item with status `in-progress` in any phase
-  - Planning in-progress: `Continue "{topic:(titlecase)}" — planning [in-progress]`
-  - Implementation in-progress with progress: `Continue "{topic:(titlecase)}" — implementation (Phase {N}, Task {M})`
-  - Implementation in-progress without progress: `Continue "{topic:(titlecase)}" — implementation [in-progress]`
-  - Other phases: `Continue "{topic:(titlecase)}" — {phase} [in-progress]`
-- Next-phase-ready items from `next_phase_ready` in discovery output (order specification entries first, then planning, implementation, review):
-  - Proposed grouping: `Start specification for "{topic:(titlecase)}" — grouping ready`
-  - Completed spec with no plan: `Start planning for "{topic:(titlecase)}" — spec completed`
-  - Completed plan with no implementation:
-    - If `blocked`: show but mark as not selectable: `Start implementation of "{topic:(titlecase)}" — blocked by {dep_topic}:{internal_id}`
-    - Otherwise: `Start implementation of "{topic:(titlecase)}" — plan completed`
-  - Completed implementation with no review: `Start review for "{topic:(titlecase)}" — implementation completed`
-
-**Command options** — entry-point actions that launch a flow handling its own selection. Use letter shortcuts (first letter of command; second letter if disambiguation needed):
-- **`s`/`spec`** — Analyze / regroup discussions (only shown if `gating.can_start_specification` is true). Description adapts: `— {N} discussion(s) not yet grouped` when `unaccounted_discussions` is non-empty, else `— review or regroup specifications`
-- **`d`/`discuss`** — Start new discussion (always present)
-- **`r`/`research`** — Start new research (always present)
-- **`c`/`completed`** — Resume a completed topic (only shown when `completed` items exist)
-- **`a`/`cancel`** — Cancel a topic (only shown when non-cancelled, non-promoted items exist in any phase)
-- **`e`/`reactivate`** — Reactivate a cancelled topic (only shown when `cancelled` items exist in discovery output)
-- **`m`/`map`** — View epic dependency map (always present when at least one phase has items)
-
-**Phase-forward gating:**
-- No "Start planning" unless `gating.can_start_planning` is true
-- No "Start implementation" unless `gating.can_start_implementation` is true
-- No "Start review" unless `gating.can_start_review` is true
-- No "Start specification" unless `gating.can_start_specification` is true
-
-**Ordering:** The recommended item always appears first. Mark one item as `(recommended)` based on phase completion state:
-- A proposed grouping exists (a `start_specification` entry in `next_phase_ready`) → first proposed spec "(recommended)"
-- All discussions completed, no specifications exist → `s`/`spec` (recommended)
-- All plannable specifications completed, some without plans → first plannable spec "(recommended)"
-- All plans completed (and deps satisfied), some without implementations → first implementable plan "(recommended)"
-- All implementations completed, some without reviews → first reviewable implementation "(recommended)"
-- Otherwise → no recommendation (complete in-progress work first)
-
-After the recommended item, list remaining numbered items, then command options.
-
-**Promoted items:** Items with `[promoted]` status are shown in the state display but are **not listed in the menu** — they've been moved to their own cross-cutting work unit and are no longer actionable in this epic.
-
-**Blocked items:** Items marked `blocked` in `next_phase_ready` are shown in the menu but are **not selectable**. If the user picks a blocked item, explain why it's blocked and re-present the menu.
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-What would you like to do?
-
-- **`1`** — Start specification for "Billing Grouping" — grouping ready (recommended)
-- **`2`** — Continue "Auth Flow" — discussion [in-progress]
-- **`3`** — Continue "Caching" — planning [in-progress]
-- **`4`** — Start planning for "User Profiles" — spec completed
-- **`5`** — Start implementation of "Reporting" — blocked by core-features:core-2-3
-- **`s`/`spec`** — Analyze / regroup discussions — 3 discussion(s) not yet grouped
-- **`d`/`discuss`** — Start new discussion
-- **`r`/`research`** — Start new research
-- **`c`/`completed`** — Resume a completed topic
-- **`a`/`cancel`** — Cancel a topic
-- **`e`/`reactivate`** — Reactivate a cancelled topic
-- **`m`/`map`** — View epic dependency map
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-Recreate with actual items from discovery.
-
-**STOP.** Wait for user response.
-
-→ Proceed to **D. Handle Selection**.
+→ Proceed to **B. Handle Selection**.
 
 ---
 
-## D. Handle Selection
+## B. Handle Selection
 
-#### If user chose a blocked item
+Match the user's input to its `ACTIONS` entry by `key` — a number, or a command option's letter / long form. Every decision below reads the entry's `action` value, never its label text.
 
-Explain which dependencies are blocking and how to resolve them:
+#### If the selected entry carries a `(blocked: …)` marker
+
+The item is shown for visibility but not selectable. Explain what blocks it, using the marker's `{dep}:{task} — {reason}` detail:
 
 > *Output the next fenced block as a code block:*
 
@@ -491,46 +79,40 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.plann
 
 Commit the change.
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
 **If user chose `back`:**
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
-#### If user chose `m`/`map`
+#### If `action` is `view_map`
 
 Load **[display-epic-map.md](display-epic-map.md)** and follow its instructions as written.
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
-#### If user chose `i`/`discovery`
+#### If `action` is `resume_completed`
 
-Set selection to `Continue discovery`. The caller routes this to `/workflow-discovery` for the work unit (no topic argument) — the discovery skill re-shapes the map in existing-epic mode.
+→ Proceed to **D. Resume Completed**.
 
-→ Return to caller.
+#### If `action` is `cancel_topic`
 
-#### If user chose `c`/`completed`
+→ Proceed to **E. Cancel Topic**.
 
-→ Proceed to **F. Resume Completed**.
+#### If `action` is `reactivate_topic`
 
-#### If user chose `a`/`cancel`
-
-→ Proceed to **H. Cancel Topic**.
-
-#### If user chose `e`/`reactivate`
-
-→ Proceed to **I. Reactivate Topic**.
+→ Proceed to **F. Reactivate Topic**.
 
 #### Otherwise
 
-**Soft gate check** — before routing, check if the user's selection conflicts with a phase-completion recommendation. These are advisory, not blocking. The conditions use the `phases` data from discovery to count in-progress vs total items.
+**Soft gate check** — before routing, check whether the selection conflicts with a phase-completion recommendation. Advisory, not blocking. Read the counts from `phase_counts` in DATA.
 
-| User selected phase | Condition | Gate message |
-|---------------------|-----------|--------------|
-| discussion (new or continue) | research items exist with some in-progress | "{N} of {M} research topics still in-progress. Topic analysis works best with all research available." |
-| specification (new or continue) | discussion items exist with some in-progress | "{N} of {M} discussions still in-progress. Grouping analysis works best with all discussions available." |
-| planning | specification items exist with some in-progress or proposed | "{N} of {M} specifications not yet completed. Completing all specifications first helps identify cross-cutting dependencies." |
-| implementation | planning items exist with some in-progress | "{N} of {M} plans still in-progress. Task dependencies across plans may be missed." |
+| Selected `action` | Condition | Gate message |
+|-------------------|-----------|--------------|
+| `start_discussion` · `start_discussion_after_research` · `continue_discussion` · `new_discussion` | research items exist with some in-progress | "{N} of {M} research topics still in-progress. Topic analysis works best with all research available." |
+| `start_specification` · `continue_specification` · `analyze_discussions` | discussion items exist with some in-progress | "{N} of {M} discussions still in-progress. Grouping analysis works best with all discussions available." |
+| `start_planning` · `continue_planning` | specification items exist with some in-progress or proposed | "{N} of {M} specifications not yet completed. Completing all specifications first helps identify cross-cutting dependencies." |
+| `start_implementation` · `continue_implementation` | planning items exist with some in-progress | "{N} of {M} plans still in-progress. Task dependencies across plans may be missed." |
 
 **If a soft gate condition matches:**
 
@@ -548,52 +130,33 @@ now is safe, but may require rework.
 · · · · · · · · · · · ·
 ```
 
-Gate messages are self-contained first lines. For "N of M in-progress" conditions, compose the count prefix into the message (e.g., "3 of 5 research topics still in-progress. Discussion topic analysis works best with all research available.").
+Gate messages are self-contained first lines. Compose the count prefix into the message (e.g., "3 of 5 research topics still in-progress. Topic analysis works best with all research available.").
 
 **STOP.** Wait for user response.
 
 **If user chose `back`:**
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
 **If user chose `yes`:**
 
-→ Proceed to **E. Route Selection**.
+→ Proceed to **C. Route Selection**.
 
 **If no soft gate condition matches:**
 
-→ Proceed to **E. Route Selection**.
+→ Proceed to **C. Route Selection**.
 
 ---
 
-## E. Route Selection
+## C. Route Selection
 
-Store the selected action, phase, and topic (if applicable). Match the user's selection to a routing entry by **prefix** — selection labels may carry a trailing context segment (e.g., `Start discussion for "X" — research completed`, `Continue "Y" — implementation (Phase 2, Task 3)`) which doesn't change the routing target.
-
-| Selection | Phase | Topic |
-|-----------|-------|-------|
-| Start research for {topic} | research | {topic} |
-| Start discussion for {topic} | discussion | {topic} |
-| Continue {topic} — discussion | discussion | {topic} |
-| Continue {topic} — research | research | {topic} |
-| Continue {topic} — specification | specification | {topic} |
-| Continue {topic} — planning | planning | {topic} |
-| Continue {topic} — implementation | implementation | {topic} |
-| Continue {topic} — review | review | {topic} |
-| Start specification for {topic} | specification | {topic} |
-| Start planning for {topic} | planning | {topic} |
-| Start implementation of {topic} | implementation | {topic} |
-| Start review for {topic} | review | {topic} |
-| Analyze / regroup discussions | specification | — |
-| Start new discussion | discussion | — |
-| Start new research | research | — |
-| Continue discovery | discovery | — |
+Store the selected entry's `action`, `topic`, and `route`. The route is the exact skill invocation for this selection (e.g. `/workflow-discussion-entry epic {work_unit} {topic}`). Entries with route `(internal)` never reach this section — their flows resolve in **B. Handle Selection**.
 
 → Return to caller.
 
 ---
 
-## F. Resume Completed
+## D. Resume Completed
 
 Display all completed items across all phases and let the user select one to resume.
 
@@ -637,17 +200,17 @@ List all completed items across all phases.
 
 #### If user chose `back`
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
 #### If user chose a topic
 
-Store the selected phase and topic.
+Store the selected phase and topic. The route is `/workflow-{phase}-entry epic {work_unit} {topic}`.
 
 → Return to caller.
 
 ---
 
-## H. Cancel Topic
+## E. Cancel Topic
 
 Display all non-cancelled, non-promoted items across all phases, grouped by phase.
 
@@ -689,7 +252,7 @@ Recreate with actual items from discovery.
 
 #### If user chose `back`
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
 #### If user chose a numbered topic
 
@@ -711,7 +274,7 @@ cancelled. You can reactivate it later.
 
 **If user chose `no`:**
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
 **If user chose `yes`:**
 
@@ -752,11 +315,11 @@ Commit the change.
 Cancelled "{topic:(titlecase)}" in {phase}.
 ```
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
 ---
 
-## I. Reactivate Topic
+## F. Reactivate Topic
 
 Display all cancelled items across all phases, grouped by phase.
 
@@ -798,7 +361,7 @@ Recreate with actual items from discovery.
 
 #### If user chose `back`
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.
 
 #### If user chose a numbered topic
 
@@ -845,4 +408,4 @@ Commit the change.
 Reactivated "{topic:(titlecase)}" in {phase}. Status restored to {previous_status}.
 ```
 
-→ Return to **C. Menu**.
+→ Return to **A. State Display and Menu**.

--- a/skills/workflow-continue-epic/scripts/discovery.cjs
+++ b/skills/workflow-continue-epic/scripts/discovery.cjs
@@ -1,9 +1,20 @@
 'use strict';
 
-const path = require('path');
-const { loadActiveManifests, loadAllManifests, phaseItems, computeTopicLifecycle, computeNextAction, computeMapSummary, computeSourceProvenance, computeAnalysisCacheStatus, compareMapRows, computeNeedsSequencing } = require('../../workflow-shared/scripts/discovery-utils.cjs');
+// ---------------------------------------------------------------------------
+// Adapter (read gateway) for workflow-continue-epic. Thin by design: detail
+// building lives in the engine's domain ring; this script selects which
+// engine answers the skill's flow needs and sections the output.
+//
+//   discovery.cjs               → labelled dump, all active epics (head insert)
+//   discovery.cjs {work_unit}   → labelled dump, one epic (scoped re-runs)
+//   discovery.cjs view {work_unit} [new_arrivals_json]
+//                               → DATA + DISPLAY + MENU snapshot (Step 8)
+// ---------------------------------------------------------------------------
 
-const EPIC_PHASES = ['discovery', 'research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
+const engine = require('../../workflow-engine/scripts/lib.cjs');
+const { loadActiveManifests, loadAllManifests, phaseItems } = require('../../workflow-shared/scripts/discovery-utils.cjs');
+
+const EPIC_PHASES = engine.detail.EPIC_PHASES;
 
 function lastCompletedPhaseEpic(manifest) {
   let last = null;
@@ -14,242 +25,6 @@ function lastCompletedPhaseEpic(manifest) {
     }
   }
   return last;
-}
-
-function resolveDeps(manifest, planItem) {
-  const externalDepsObj = (planItem.external_dependencies && typeof planItem.external_dependencies === 'object' && !Array.isArray(planItem.external_dependencies))
-    ? planItem.external_dependencies
-    : {};
-
-  const externalDeps = Object.entries(externalDepsObj).map(([depTopic, d]) => ({ topic: depTopic, ...d }));
-  let depsSatisfied = true;
-  const depsBlocking = [];
-
-  for (const dep of externalDeps) {
-    if (dep.state === 'satisfied_externally') continue;
-    if (dep.state === 'unresolved') {
-      depsSatisfied = false;
-      depsBlocking.push({ topic: dep.topic, reason: 'dependency unresolved' });
-    } else if (dep.state === 'resolved' && dep.internal_id) {
-      // Dep topics live in the same work unit — read the implementation item
-      // from this manifest. A completed implementation satisfies the dep even
-      // if the referenced task was skipped or its ID is stale.
-      const depImpl = phaseItems(manifest, 'implementation').find(i => i.name === dep.topic) || {};
-      const completedTasks = Array.isArray(depImpl.completed_tasks) ? depImpl.completed_tasks : [];
-      if (depImpl.status !== 'completed' && !completedTasks.includes(dep.internal_id)) {
-        depsSatisfied = false;
-        depsBlocking.push({ topic: dep.topic, internal_id: dep.internal_id, reason: 'task not yet completed' });
-      }
-    } else if (dep.state === 'resolved' && !dep.internal_id) {
-      depsSatisfied = false;
-      depsBlocking.push({ topic: dep.topic, reason: 'resolved dependency missing task reference' });
-    }
-  }
-
-  return { deps_satisfied: depsSatisfied, deps_blocking: depsBlocking };
-}
-
-function buildAnalysisCaches(cwd, manifest) {
-  const workflowsDir = path.join(cwd, '.workflows');
-  return {
-    research_analysis: computeAnalysisCacheStatus(manifest, workflowsDir, 'research-analysis'),
-    gap_analysis: computeAnalysisCacheStatus(manifest, workflowsDir, 'gap-analysis'),
-  };
-}
-
-function buildEpicDetail(cwd, manifest) {
-  const phases = {};
-  const allSourcedDiscussions = new Set();
-  const groupedDiscussions = new Set();
-  const completedItems = [];
-  const inProgressItems = [];
-  const cancelledItems = [];
-  const nextPhaseReady = [];
-
-  for (const phase of EPIC_PHASES) {
-    if (phase === 'discovery') continue;
-    const items = phaseItems(manifest, phase);
-    if (items.length === 0) continue;
-
-    const phaseEntries = [];
-    for (const item of items) {
-      const entry = { name: item.name, status: item.status || 'unknown' };
-
-      if (phase === 'specification' && item.sources) {
-        const sourcesArr = Array.isArray(item.sources)
-          ? item.sources
-          : Object.entries(item.sources).map(([topic, data]) => ({ topic, ...data }));
-        entry.sources = sourcesArr;
-        // groupedDiscussions tracks every spec item's sources (proposed
-        // included) — a discussion in any spec item is "grouped", which is
-        // what unaccounted_discussions now measures.
-        for (const src of sourcesArr) {
-          groupedDiscussions.add(src.topic || src.name);
-        }
-        // allSourcedDiscussions tracks only materialized items' sources —
-        // a proposed grouping has nothing extracted, so its sources can't
-        // be "reopened". Reopened detection reads this set.
-        if (item.status !== 'proposed') {
-          for (const src of sourcesArr) {
-            allSourcedDiscussions.add(src.topic || src.name);
-          }
-        }
-      }
-
-      // Enrich planning items with format and dependency data
-      if (phase === 'planning') {
-        if (item.format) entry.format = item.format;
-        const { deps_satisfied, deps_blocking } = resolveDeps(manifest, item);
-        entry.deps_satisfied = deps_satisfied;
-        if (deps_blocking.length > 0) entry.deps_blocking = deps_blocking;
-      }
-
-      // Enrich implementation items with progress data
-      if (phase === 'implementation') {
-        if (item.current_phase != null && item.current_phase !== '~') entry.current_phase = item.current_phase;
-        if (Array.isArray(item.completed_phases) && item.completed_phases.length > 0) entry.completed_phases = item.completed_phases;
-        if (Array.isArray(item.completed_tasks) && item.completed_tasks.length > 0) entry.completed_tasks = item.completed_tasks;
-      }
-
-      phaseEntries.push(entry);
-
-      if (item.status === 'in-progress') {
-        inProgressItems.push({ name: item.name, phase });
-      }
-      if (item.status === 'completed') {
-        completedItems.push({ name: item.name, phase });
-      }
-      if (item.status === 'cancelled') {
-        cancelledItems.push({ name: item.name, phase, previous_status: item.previous_status || null });
-      }
-    }
-
-    phases[phase] = phaseEntries;
-  }
-
-  const discussionItems = phaseItems(manifest, 'discussion');
-  const unaccountedDiscussions = [];
-  for (const d of discussionItems) {
-    if (d.status === 'completed' && !groupedDiscussions.has(d.name)) {
-      unaccountedDiscussions.push(d.name);
-    }
-  }
-
-  const reopenedDiscussions = [];
-  for (const d of discussionItems) {
-    if (d.status === 'in-progress' && allSourcedDiscussions.has(d.name)) {
-      reopenedDiscussions.push(d.name);
-    }
-  }
-
-  const specItems = phaseItems(manifest, 'specification');
-  const planItems = phaseItems(manifest, 'planning');
-  const implItems = phaseItems(manifest, 'implementation');
-
-  // Proposed groupings are actionable from the epic menu — surface them as
-  // start_specification. Pushed before start_planning so they precede it in
-  // pipeline order (spec → planning), which the settled-state recommendation
-  // reads.
-  for (const s of specItems) {
-    if (s.status === 'proposed') {
-      nextPhaseReady.push({ name: s.name, action: 'start_specification', label: 'grouping ready' });
-    }
-  }
-
-  const planTopics = new Set(planItems.filter(i => i.status !== 'cancelled').map(i => i.name));
-  for (const s of specItems) {
-    if (s.status === 'completed' && !planTopics.has(s.name)) {
-      nextPhaseReady.push({ name: s.name, action: 'start_planning', label: 'spec completed' });
-    }
-  }
-
-  const implTopics = new Set(implItems.filter(i => i.status !== 'cancelled').map(i => i.name));
-  for (const p of planItems) {
-    if (p.status === 'completed' && !implTopics.has(p.name)) {
-      // Check deps before marking as ready for implementation
-      const { deps_satisfied, deps_blocking } = resolveDeps(manifest, p);
-      if (deps_satisfied) {
-        nextPhaseReady.push({ name: p.name, action: 'start_implementation', label: 'plan completed' });
-      } else {
-        nextPhaseReady.push({
-          name: p.name, action: 'start_implementation', label: 'plan completed',
-          blocked: true, deps_blocking,
-        });
-      }
-    }
-  }
-
-  const reviewItems = phaseItems(manifest, 'review');
-  const reviewTopics = new Set(reviewItems.filter(i => i.status !== 'cancelled').map(i => i.name));
-  for (const i of implItems) {
-    if (i.status === 'completed' && !reviewTopics.has(i.name)) {
-      nextPhaseReady.push({ name: i.name, action: 'start_review', label: 'implementation completed' });
-    }
-  }
-
-  const hasCompletedSpec = specItems.some(s => s.status === 'completed');
-  const hasCompletedPlan = planItems.some(p => p.status === 'completed');
-  const hasCompletedDiscussion = discussionItems.some(d => d.status === 'completed');
-  const hasCompletedImpl = implItems.some(i => i.status === 'completed');
-
-  const discoveryItems = phaseItems(manifest, 'discovery');
-  let discoveryMap = [];
-  let convergenceState = null;
-  let mapSummary = null;
-  if (discoveryItems.length > 0) {
-    discoveryMap = discoveryItems.map(item => {
-      const { lifecycle, tier, current_phase } = computeTopicLifecycle(manifest, item.name);
-      const next_action = computeNextAction(item.routing, lifecycle);
-      const source_provenance = computeSourceProvenance(item.source);
-      const summaryText = typeof item.summary === 'string' && item.summary.trim() ? item.summary : null;
-      const descriptionText = typeof item.description === 'string' && item.description.trim() ? item.description : null;
-      return {
-        name: item.name,
-        summary_present: summaryText !== null,
-        summary: summaryText,
-        description_present: descriptionText !== null,
-        routing: item.routing || null,
-        source: item.source || 'discovery',
-        source_provenance,
-        order: item.order ?? null,
-        lifecycle,
-        tier,
-        current_phase,
-        next_action,
-      };
-    });
-    discoveryMap.sort(compareMapRows);
-    mapSummary = computeMapSummary(discoveryMap);
-    const allSettled = discoveryMap.every(t =>
-      t.lifecycle === 'decided' || t.lifecycle === 'cancelled' || t.lifecycle === 'handled');
-    convergenceState = allSettled ? 'settled' : 'in-progress';
-  }
-
-  const importsCount = Array.isArray(manifest.imports) ? manifest.imports.length : 0;
-  const seedsCount = Array.isArray(manifest.seeds) ? manifest.seeds.length : 0;
-
-  return {
-    phases,
-    in_progress: inProgressItems,
-    completed: completedItems,
-    cancelled: cancelledItems,
-    next_phase_ready: nextPhaseReady,
-    unaccounted_discussions: unaccountedDiscussions,
-    reopened_discussions: reopenedDiscussions,
-    discovery_map: discoveryMap,
-    convergence_state: convergenceState,
-    needs_sequencing: computeNeedsSequencing(discoveryMap),
-    map_summary: mapSummary,
-    imports_count: importsCount,
-    seeds_count: seedsCount,
-    analysis_caches: buildAnalysisCaches(cwd, manifest),
-    gating: {
-      can_start_specification: hasCompletedDiscussion,
-      can_start_planning: hasCompletedSpec,
-      can_start_implementation: hasCompletedPlan,
-      can_start_review: hasCompletedImpl,
-    },
-  };
 }
 
 function discover(cwd, workUnit) {
@@ -273,7 +48,7 @@ function discover(cwd, workUnit) {
     epics.push({
       name: m.name,
       active_phases: activePhases,
-      detail: buildEpicDetail(cwd, m),
+      detail: engine.detail.epicDetail(cwd, m),
     });
   }
 
@@ -391,9 +166,68 @@ function format(result) {
   return lines.join('\n') + '\n';
 }
 
+// One snapshot for Step 8: reasoning DATA (flags + the ACTIONS table), the
+// rendered dashboard + key (DISPLAY), and the menu (MENU).
+function view(workUnit, newArrivalsJson) {
+  const result = discover(process.cwd(), workUnit);
+  const e = result.epics[0];
+  if (!e) {
+    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active epic with this name' });
+  }
+  const d = e.detail;
+
+  let newArrivals = {};
+  if (newArrivalsJson) {
+    try { newArrivals = JSON.parse(newArrivalsJson); } catch { /* ignore malformed tracker */ }
+  }
+
+  const menu = engine.project.epicMenu(e.name, d);
+
+  const dataLines = [];
+  dataLines.push(`work_unit: ${e.name}`);
+  dataLines.push(`convergence: ${d.convergence_state || 'none'}`);
+  dataLines.push(`needs_sequencing: ${d.needs_sequencing}`);
+  dataLines.push(`analysis_caches: research_analysis=${d.analysis_caches.research_analysis.status}, gap_analysis=${d.analysis_caches.gap_analysis.status}`);
+  const phaseNames = Object.keys(d.phases);
+  if (phaseNames.length > 0) {
+    dataLines.push('phase_counts:');
+    for (const phase of phaseNames) {
+      const items = d.phases[phase];
+      const inProgress = items.filter(i => i.status === 'in-progress').length;
+      const proposed = items.filter(i => i.status === 'proposed').length;
+      const segments = [`${inProgress} in-progress`];
+      if (proposed > 0) segments.push(`${proposed} proposed`);
+      dataLines.push(`  ${phase}: ${segments.join(', ')} / ${items.length} total`);
+    }
+  } else {
+    dataLines.push('phase_counts: (none)');
+  }
+  dataLines.push(`unaccounted_discussions: ${d.unaccounted_discussions.join(', ') || '(none)'}`);
+  dataLines.push(`reopened_discussions: ${d.reopened_discussions.join(', ') || '(none)'}`);
+  dataLines.push('ACTIONS (key  action  topic  → route):');
+  for (const k of menu.keys) {
+    let line = `  ${k.key}  ${k.action}  ${k.topic || '—'}  → ${k.route || '(internal)'}`;
+    if (k.recommended) line += '  (recommended)';
+    if (k.blocked) line += `  (blocked: ${(k.deps_blocking || []).map(b => b.topic + (b.internal_id ? ':' + b.internal_id : '') + ' — ' + b.reason).join('; ')})`;
+    dataLines.push(line);
+  }
+
+  const display = engine.project.epicDashboard(e.name, d, { newArrivals });
+  const key = engine.project.epicKey(d);
+
+  return [
+    engine.gateway.dataBlock(dataLines.join('\n')),
+    engine.gateway.displayBlock(key ? display + '\n' + key : display),
+    engine.gateway.menuBlock(menu.rendered),
+  ].join('\n');
+}
+
 if (require.main === module) {
-  const workUnit = process.argv[2] || undefined;
-  process.stdout.write(format(discover(process.cwd(), workUnit)));
+  engine.gateway.runGateway({
+    index: () => format(discover(process.cwd())),
+    view,
+    fallback: (workUnit) => format(discover(process.cwd(), workUnit)),
+  });
 }
 
 module.exports = { discover, format };

--- a/skills/workflow-engine/SKILL.md
+++ b/skills/workflow-engine/SKILL.md
@@ -49,6 +49,14 @@ engine.conventions.title({ glyph, label, tag })   // → "◐ Menu And Admin [re
 engine.conventions.tag('decided')                 // → "[decided]"
 engine.conventions.derivedFrom('from exploration')// → "↳ From exploration"
 engine.conventions.discoveryGlyph('researching')  // → "◐"
+engine.conventions.titlecase('auth-flow')         // → "Auth Flow"
+engine.conventions.TREE_WIDTH                     // 65 — tree content width incl. gutter
+
+// domain: detail builders + projections
+engine.detail.epicDetail(cwd, manifest)           // → EpicDetail (the one structured object per epic)
+engine.project.epicDashboard(wu, detail, { newArrivals }) // → dashboard display block
+engine.project.epicKey(detail)                    // → Key block ('' for a brand-new epic)
+engine.project.epicMenu(wu, detail)               // → { keys, rendered } — keys carry action + route
 
 // gateway: adapter harness
 engine.gateway.runGateway(handlers)               // argv verb dispatch → stdout
@@ -76,4 +84,4 @@ The .md's prescribed call names the verb (`discovery.cjs view {work_unit}`) — 
 
 ## Tests
 
-`tests/scripts/test-render.cjs` and `tests/scripts/test-engine-gateway.cjs` (run `node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.
+`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, and `tests/scripts/test-engine-epic-projections.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.

--- a/skills/workflow-engine/scripts/domain/conventions.cjs
+++ b/skills/workflow-engine/scripts/domain/conventions.cjs
@@ -12,10 +12,24 @@
 // This layer grows as call sites are wired; only add what a real consumer needs.
 // ---------------------------------------------------------------------------
 
+// Tree content width: total rendered width INCLUDING the gutter — the
+// deliberate narrow-wrap choice (narrow reads well on mobile / split panes,
+// and pre-empts terminal soft-wrap orphaning the │ gutter). Dividers, boxes,
+// and markers stay at the kernel's canonical 49; trees wrap to this.
+const TREE_WIDTH = 65;
+
 // Upper-case the first character (the rest is left untouched).
 /** @param {string} s */
 function capitalise(s) {
   return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+// Human-readable display name (the `(titlecase)` casing hint): split on
+// hyphens and underscores, capitalise the first letter of each word, join
+// with spaces. `auth-flow` → `Auth Flow`.
+/** @param {string} s */
+function titlecase(s) {
+  return String(s).split(/[-_\s]+/).filter(Boolean).map(capitalise).join(' ');
 }
 
 // `[term]` — the item status / lifecycle suffix.
@@ -58,4 +72,4 @@ function discoveryGlyph(tier) {
   return DISCOVERY_GLYPH[/** @type {keyof typeof DISCOVERY_GLYPH} */ (tier)] || '';
 }
 
-module.exports = { capitalise, tag, derivedFrom, title, discoveryGlyph, DISCOVERY_GLYPH };
+module.exports = { TREE_WIDTH, capitalise, titlecase, tag, derivedFrom, title, discoveryGlyph, DISCOVERY_GLYPH };

--- a/skills/workflow-engine/scripts/domain/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/epic.cjs
@@ -1,0 +1,383 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: the epic detail — the one structured object every epic
+// projection and reasoning surface derives from.
+//
+// Reads the work unit's manifest (already loaded by the caller) and computes
+// per-phase items, lifecycle joins, gating, next-phase readiness, and the
+// discovery map. Pure over its inputs: same manifest, same answer. Shared
+// manifest semantics come from workflow-shared/discovery-utils — never
+// duplicated here.
+// ---------------------------------------------------------------------------
+
+const path = require('path');
+const {
+  phaseItems,
+  computeTopicLifecycle,
+  computeNextAction,
+  computeMapSummary,
+  computeSourceProvenance,
+  computeAnalysisCacheStatus,
+  compareMapRows,
+  computeNeedsSequencing,
+} = require('../../../workflow-shared/scripts/discovery-utils.cjs');
+
+const EPIC_PHASES = ['discovery', 'research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
+
+/**
+ * @typedef {object} SpecSource
+ * @property {string} [topic]  source discussion name (object-format sources)
+ * @property {string} [name]   source discussion name (legacy array format)
+ * @property {string} [status] `incorporated` | `pending`
+ */
+
+/**
+ * @typedef {object} DepBlocking
+ * @property {string} topic          the plan this dependency points at
+ * @property {string} [internal_id]  cross-plan task reference
+ * @property {string} reason         why the dependency blocks
+ */
+
+/**
+ * @typedef {object} PhaseEntry
+ * @property {string} name
+ * @property {string} status
+ * @property {SpecSource[]} [sources]          specification items
+ * @property {string} [format]                 planning items
+ * @property {boolean} [deps_satisfied]        planning items
+ * @property {DepBlocking[]} [deps_blocking]   planning items with unmet deps
+ * @property {string|number} [current_phase]   implementation items
+ * @property {string[]} [completed_phases]     implementation items
+ * @property {string[]} [completed_tasks]      implementation items
+ */
+
+/**
+ * @typedef {object} ItemRef
+ * @property {string} name
+ * @property {string} phase
+ * @property {string|null} [previous_status]   cancelled items only
+ */
+
+/**
+ * @typedef {object} NextPhaseEntry
+ * @property {string} name
+ * @property {string} action  `start_specification` | `start_planning` | `start_implementation` | `start_review`
+ * @property {string} label
+ * @property {boolean} [blocked]
+ * @property {DepBlocking[]} [deps_blocking]
+ */
+
+/**
+ * @typedef {object} MapRow
+ * @property {string} name
+ * @property {boolean} summary_present
+ * @property {string|null} summary
+ * @property {boolean} description_present
+ * @property {string|null} routing
+ * @property {string} source
+ * @property {string|null} source_provenance
+ * @property {number|null} order
+ * @property {string} lifecycle  `fresh` | `researching` | `ready_for_discussion` | `discussing` | `decided` | `handled` | `cancelled`
+ * @property {string} tier       `→` | `◐` | `✓` | `○` | `⊙` | `⊘`
+ * @property {string|null} current_phase
+ * @property {string|null} next_action
+ */
+
+/**
+ * @typedef {object} MapSummary
+ * @property {number} total
+ * @property {number} decided
+ * @property {number} in_flight
+ * @property {number} ready
+ * @property {number} fresh
+ * @property {number} handled
+ * @property {number} cancelled
+ */
+
+/**
+ * @typedef {object} AnalysisCache
+ * @property {string} status  `valid` | `stale` | `absent`
+ * @property {string|null} generated
+ * @property {string[]} files
+ * @property {string} [reason]
+ */
+
+/**
+ * @typedef {object} EpicDetail
+ * @property {Record<string, PhaseEntry[]>} phases  build phases with items (discovery excluded)
+ * @property {ItemRef[]} in_progress
+ * @property {ItemRef[]} completed
+ * @property {ItemRef[]} cancelled
+ * @property {NextPhaseEntry[]} next_phase_ready
+ * @property {string[]} unaccounted_discussions
+ * @property {string[]} reopened_discussions
+ * @property {MapRow[]} discovery_map
+ * @property {string|null} convergence_state  `in-progress` | `settled` | null (no map)
+ * @property {boolean} needs_sequencing
+ * @property {MapSummary|null} map_summary
+ * @property {number} imports_count
+ * @property {number} seeds_count
+ * @property {{research_analysis: AnalysisCache, gap_analysis: AnalysisCache}} analysis_caches
+ * @property {{can_start_specification: boolean, can_start_planning: boolean, can_start_implementation: boolean, can_start_review: boolean}} gating
+ */
+
+/**
+ * Resolve a planning item's external dependencies against this manifest's
+ * implementation items.
+ * @param {object} manifest
+ * @param {PhaseEntry & {external_dependencies?: object}} planItem
+ * @returns {{deps_satisfied: boolean, deps_blocking: DepBlocking[]}}
+ */
+function resolveDeps(manifest, planItem) {
+  const externalDepsObj = (planItem.external_dependencies && typeof planItem.external_dependencies === 'object' && !Array.isArray(planItem.external_dependencies))
+    ? planItem.external_dependencies
+    : {};
+
+  const externalDeps = Object.entries(externalDepsObj).map(([depTopic, d]) => ({ topic: depTopic, ...d }));
+  let depsSatisfied = true;
+  const depsBlocking = [];
+
+  for (const dep of externalDeps) {
+    if (dep.state === 'satisfied_externally') continue;
+    if (dep.state === 'unresolved') {
+      depsSatisfied = false;
+      depsBlocking.push({ topic: dep.topic, reason: 'dependency unresolved' });
+    } else if (dep.state === 'resolved' && dep.internal_id) {
+      // Dep topics live in the same work unit — read the implementation item
+      // from this manifest. A completed implementation satisfies the dep even
+      // if the referenced task was skipped or its ID is stale.
+      const depImpl = phaseItems(manifest, 'implementation').find(i => i.name === dep.topic) || {};
+      const completedTasks = Array.isArray(depImpl.completed_tasks) ? depImpl.completed_tasks : [];
+      if (depImpl.status !== 'completed' && !completedTasks.includes(dep.internal_id)) {
+        depsSatisfied = false;
+        depsBlocking.push({ topic: dep.topic, internal_id: dep.internal_id, reason: 'task not yet completed' });
+      }
+    } else if (dep.state === 'resolved' && !dep.internal_id) {
+      depsSatisfied = false;
+      depsBlocking.push({ topic: dep.topic, reason: 'resolved dependency missing task reference' });
+    }
+  }
+
+  return { deps_satisfied: depsSatisfied, deps_blocking: depsBlocking };
+}
+
+/**
+ * @param {string} cwd
+ * @param {object} manifest
+ * @returns {{research_analysis: AnalysisCache, gap_analysis: AnalysisCache}}
+ */
+function buildAnalysisCaches(cwd, manifest) {
+  const workflowsDir = path.join(cwd, '.workflows');
+  return {
+    research_analysis: computeAnalysisCacheStatus(manifest, workflowsDir, 'research-analysis'),
+    gap_analysis: computeAnalysisCacheStatus(manifest, workflowsDir, 'gap-analysis'),
+  };
+}
+
+/**
+ * Build the full epic detail for one work unit's manifest.
+ * @param {string} cwd       project root (the directory containing `.workflows/`)
+ * @param {object} manifest  the work unit's parsed manifest.json
+ * @returns {EpicDetail}
+ */
+function epicDetail(cwd, manifest) {
+  /** @type {Record<string, PhaseEntry[]>} */
+  const phases = {};
+  const allSourcedDiscussions = new Set();
+  const groupedDiscussions = new Set();
+  const completedItems = [];
+  const inProgressItems = [];
+  const cancelledItems = [];
+  /** @type {NextPhaseEntry[]} */
+  const nextPhaseReady = [];
+
+  for (const phase of EPIC_PHASES) {
+    if (phase === 'discovery') continue;
+    const items = phaseItems(manifest, phase);
+    if (items.length === 0) continue;
+
+    const phaseEntries = [];
+    for (const item of items) {
+      /** @type {PhaseEntry} */
+      const entry = { name: item.name, status: item.status || 'unknown' };
+
+      if (phase === 'specification' && item.sources) {
+        const sourcesArr = Array.isArray(item.sources)
+          ? item.sources
+          : Object.entries(item.sources).map(([topic, data]) => ({ topic, ...data }));
+        entry.sources = sourcesArr;
+        // groupedDiscussions tracks every spec item's sources (proposed
+        // included) — a discussion in any spec item is "grouped", which is
+        // what unaccounted_discussions now measures.
+        for (const src of sourcesArr) {
+          groupedDiscussions.add(src.topic || src.name);
+        }
+        // allSourcedDiscussions tracks only materialized items' sources —
+        // a proposed grouping has nothing extracted, so its sources can't
+        // be "reopened". Reopened detection reads this set.
+        if (item.status !== 'proposed') {
+          for (const src of sourcesArr) {
+            allSourcedDiscussions.add(src.topic || src.name);
+          }
+        }
+      }
+
+      // Enrich planning items with format and dependency data
+      if (phase === 'planning') {
+        if (item.format) entry.format = item.format;
+        const { deps_satisfied, deps_blocking } = resolveDeps(manifest, item);
+        entry.deps_satisfied = deps_satisfied;
+        if (deps_blocking.length > 0) entry.deps_blocking = deps_blocking;
+      }
+
+      // Enrich implementation items with progress data
+      if (phase === 'implementation') {
+        if (item.current_phase != null && item.current_phase !== '~') entry.current_phase = item.current_phase;
+        if (Array.isArray(item.completed_phases) && item.completed_phases.length > 0) entry.completed_phases = item.completed_phases;
+        if (Array.isArray(item.completed_tasks) && item.completed_tasks.length > 0) entry.completed_tasks = item.completed_tasks;
+      }
+
+      phaseEntries.push(entry);
+
+      if (item.status === 'in-progress') {
+        inProgressItems.push({ name: item.name, phase });
+      }
+      if (item.status === 'completed') {
+        completedItems.push({ name: item.name, phase });
+      }
+      if (item.status === 'cancelled') {
+        cancelledItems.push({ name: item.name, phase, previous_status: item.previous_status || null });
+      }
+    }
+
+    phases[phase] = phaseEntries;
+  }
+
+  const discussionItems = phaseItems(manifest, 'discussion');
+  const unaccountedDiscussions = [];
+  for (const d of discussionItems) {
+    if (d.status === 'completed' && !groupedDiscussions.has(d.name)) {
+      unaccountedDiscussions.push(d.name);
+    }
+  }
+
+  const reopenedDiscussions = [];
+  for (const d of discussionItems) {
+    if (d.status === 'in-progress' && allSourcedDiscussions.has(d.name)) {
+      reopenedDiscussions.push(d.name);
+    }
+  }
+
+  const specItems = phaseItems(manifest, 'specification');
+  const planItems = phaseItems(manifest, 'planning');
+  const implItems = phaseItems(manifest, 'implementation');
+
+  // Proposed groupings are actionable from the epic menu — surface them as
+  // start_specification. Pushed before start_planning so they precede it in
+  // pipeline order (spec → planning), which the settled-state recommendation
+  // reads.
+  for (const s of specItems) {
+    if (s.status === 'proposed') {
+      nextPhaseReady.push({ name: s.name, action: 'start_specification', label: 'grouping ready' });
+    }
+  }
+
+  const planTopics = new Set(planItems.filter(i => i.status !== 'cancelled').map(i => i.name));
+  for (const s of specItems) {
+    if (s.status === 'completed' && !planTopics.has(s.name)) {
+      nextPhaseReady.push({ name: s.name, action: 'start_planning', label: 'spec completed' });
+    }
+  }
+
+  const implTopics = new Set(implItems.filter(i => i.status !== 'cancelled').map(i => i.name));
+  for (const p of planItems) {
+    if (p.status === 'completed' && !implTopics.has(p.name)) {
+      // Check deps before marking as ready for implementation
+      const { deps_satisfied, deps_blocking } = resolveDeps(manifest, p);
+      if (deps_satisfied) {
+        nextPhaseReady.push({ name: p.name, action: 'start_implementation', label: 'plan completed' });
+      } else {
+        nextPhaseReady.push({
+          name: p.name, action: 'start_implementation', label: 'plan completed',
+          blocked: true, deps_blocking,
+        });
+      }
+    }
+  }
+
+  const reviewItems = phaseItems(manifest, 'review');
+  const reviewTopics = new Set(reviewItems.filter(i => i.status !== 'cancelled').map(i => i.name));
+  for (const i of implItems) {
+    if (i.status === 'completed' && !reviewTopics.has(i.name)) {
+      nextPhaseReady.push({ name: i.name, action: 'start_review', label: 'implementation completed' });
+    }
+  }
+
+  const hasCompletedSpec = specItems.some(s => s.status === 'completed');
+  const hasCompletedPlan = planItems.some(p => p.status === 'completed');
+  const hasCompletedDiscussion = discussionItems.some(d => d.status === 'completed');
+  const hasCompletedImpl = implItems.some(i => i.status === 'completed');
+
+  const discoveryItems = phaseItems(manifest, 'discovery');
+  /** @type {MapRow[]} */
+  let discoveryMap = [];
+  let convergenceState = null;
+  let mapSummary = null;
+  if (discoveryItems.length > 0) {
+    discoveryMap = discoveryItems.map(item => {
+      const { lifecycle, tier, current_phase } = computeTopicLifecycle(manifest, item.name);
+      const next_action = computeNextAction(item.routing, lifecycle);
+      const source_provenance = computeSourceProvenance(item.source);
+      const summaryText = typeof item.summary === 'string' && item.summary.trim() ? item.summary : null;
+      const descriptionText = typeof item.description === 'string' && item.description.trim() ? item.description : null;
+      return {
+        name: item.name,
+        summary_present: summaryText !== null,
+        summary: summaryText,
+        description_present: descriptionText !== null,
+        routing: item.routing || null,
+        source: item.source || 'discovery',
+        source_provenance,
+        order: item.order ?? null,
+        lifecycle,
+        tier,
+        current_phase,
+        next_action,
+      };
+    });
+    discoveryMap.sort(compareMapRows);
+    mapSummary = computeMapSummary(discoveryMap);
+    const allSettled = discoveryMap.every(t =>
+      t.lifecycle === 'decided' || t.lifecycle === 'cancelled' || t.lifecycle === 'handled');
+    convergenceState = allSettled ? 'settled' : 'in-progress';
+  }
+
+  const importsCount = Array.isArray(manifest.imports) ? manifest.imports.length : 0;
+  const seedsCount = Array.isArray(manifest.seeds) ? manifest.seeds.length : 0;
+
+  return {
+    phases,
+    in_progress: inProgressItems,
+    completed: completedItems,
+    cancelled: cancelledItems,
+    next_phase_ready: nextPhaseReady,
+    unaccounted_discussions: unaccountedDiscussions,
+    reopened_discussions: reopenedDiscussions,
+    discovery_map: discoveryMap,
+    convergence_state: convergenceState,
+    needs_sequencing: computeNeedsSequencing(discoveryMap),
+    map_summary: mapSummary,
+    imports_count: importsCount,
+    seeds_count: seedsCount,
+    analysis_caches: buildAnalysisCaches(cwd, manifest),
+    gating: {
+      can_start_specification: hasCompletedDiscussion,
+      can_start_planning: hasCompletedSpec,
+      can_start_implementation: hasCompletedPlan,
+      can_start_review: hasCompletedImpl,
+    },
+  };
+}
+
+module.exports = { EPIC_PHASES, epicDetail };

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -1,0 +1,621 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: epic projections — the dashboard, key, and menu views over one
+// EpicDetail (see ../epic.cjs).
+//
+// Deterministic: same detail, same string. The dashboard groups every phase
+// under the three-D stage dividers (DISCOVERY / DEFINITION / DELIVERY); the
+// menu carries machine action keys so skills route on keys, never on labels.
+// Layout goes through the kernel renderer — no character arithmetic here.
+// ---------------------------------------------------------------------------
+
+const { signpost, box, renderTree, wrap } = require('../../kernel/render.cjs');
+const { TREE_WIDTH, titlecase, title, derivedFrom, discoveryGlyph } = require('../conventions.cjs');
+
+/** @typedef {import('../epic.cjs').EpicDetail} EpicDetail */
+/** @typedef {import('../epic.cjs').MapRow} MapRow */
+/** @typedef {import('../epic.cjs').PhaseEntry} PhaseEntry */
+/** @typedef {import('../epic.cjs').NextPhaseEntry} NextPhaseEntry */
+/** @typedef {import('../epic.cjs').DepBlocking} DepBlocking */
+
+/**
+ * @typedef {object} NewArrivals
+ * @property {string[]} [research_analysis]  topic names added by research-analysis this boot-up
+ * @property {string[]} [gap_analysis]       topic names added by gap-analysis this boot-up
+ */
+
+/**
+ * @typedef {object} MenuKey
+ * @property {string} key             what the user types (`1`, `2`, …, `s`, `m`, …)
+ * @property {string} [word]          long form of a command option (`spec`, `map`, …)
+ * @property {string} action          machine action key — skills route on this, never the label
+ * @property {string|null} topic
+ * @property {string|null} route      skill invocation, or null for internal flows
+ * @property {string} label
+ * @property {boolean} [recommended]
+ * @property {boolean} [blocked]
+ * @property {DepBlocking[]} [deps_blocking]
+ */
+
+const BUILD_PHASES = ['specification', 'planning', 'implementation', 'review'];
+
+const STAGES = [
+  { name: 'DISCOVERY', phases: ['research', 'discussion'] },
+  { name: 'DEFINITION', phases: ['specification', 'planning'] },
+  { name: 'DELIVERY', phases: ['implementation', 'review'] },
+];
+
+const STATUS_ORDER = ['proposed', 'in-progress', 'completed', 'cancelled', 'promoted'];
+
+const PHASE_ENTRY_SKILL = {
+  research: 'workflow-research-entry',
+  discussion: 'workflow-discussion-entry',
+  specification: 'workflow-specification-entry',
+  planning: 'workflow-planning-entry',
+  implementation: 'workflow-implementation-entry',
+  review: 'workflow-review-entry',
+};
+
+const ACTION_PHASE = {
+  start_research: 'research',
+  continue_research: 'research',
+  start_discussion: 'discussion',
+  start_discussion_after_research: 'discussion',
+  continue_discussion: 'discussion',
+  start_specification: 'specification',
+  continue_specification: 'specification',
+  start_planning: 'planning',
+  continue_planning: 'planning',
+  start_implementation: 'implementation',
+  continue_implementation: 'implementation',
+  start_review: 'review',
+  continue_review: 'review',
+};
+
+const START_GATE = {
+  start_specification: 'can_start_specification',
+  start_planning: 'can_start_planning',
+  start_implementation: 'can_start_implementation',
+  start_review: 'can_start_review',
+};
+
+// ---------------------------------------------------------------------------
+// Shared composition helpers
+// ---------------------------------------------------------------------------
+
+/** @param {MapRow} row */
+function lifecycleLabel(row) {
+  switch (row.lifecycle) {
+    case 'ready_for_discussion': return 'research complete · ready for discussion';
+    case 'researching': return 'researching';
+    case 'discussing': return 'discussing';
+    case 'decided': return 'decided';
+    case 'handled': return 'handled · research fanned out';
+    case 'cancelled': return 'cancelled';
+    default: return row.routing ? `fresh · routed to ${row.routing}` : 'fresh';
+  }
+}
+
+/** Count summary for a phase sub-header — statuses present, zero counts omitted. @param {PhaseEntry[]} items */
+function countSummary(items) {
+  /** @type {Map<string, number>} */
+  const counts = new Map();
+  for (const it of items) counts.set(it.status, (counts.get(it.status) || 0) + 1);
+  const ordered = [
+    ...STATUS_ORDER.filter((s) => counts.has(s)),
+    ...[...counts.keys()].filter((s) => !STATUS_ORDER.includes(s)),
+  ];
+  return ordered.map((s) => `${counts.get(s)} ${s}`).join(', ');
+}
+
+/** @param {SpecSourceLike} src @typedef {{topic?: string, name?: string, status?: string}} SpecSourceLike */
+function sourceName(src) {
+  return src.topic || src.name || '';
+}
+
+/** Cross-plan dep reference — `{plan}:{task}` when the task id is known. @param {DepBlocking} dep */
+function depRef(dep) {
+  return dep.internal_id ? `${dep.topic}:${dep.internal_id}` : dep.topic;
+}
+
+/** Spec phase shows proposed items first, then the rest in existing order. @param {string} phase @param {PhaseEntry[]} items */
+function displayOrder(phase, items) {
+  if (phase !== 'specification') return items;
+  return [...items.filter((i) => i.status === 'proposed'), ...items.filter((i) => i.status !== 'proposed')];
+}
+
+/** Build the tree nodes for one build/flat phase. @param {string} phase @param {PhaseEntry[]} items */
+function phaseNodes(phase, items) {
+  return displayOrder(phase, items).map((item) => {
+    let head = title({ label: titlecase(item.name), tag: item.status });
+    if (phase === 'planning' && item.format) head += ` · ${item.format}`;
+    /** @type {{title: string}[]} */
+    const children = [];
+    if (phase === 'specification' && Array.isArray(item.sources)) {
+      for (const src of item.sources) {
+        children.push({ title: title({ label: titlecase(sourceName(src)), tag: src.status || 'pending' }) });
+      }
+    }
+    if (phase === 'implementation') {
+      const tasks = Array.isArray(item.completed_tasks) ? item.completed_tasks.length : 0;
+      if (item.current_phase != null) {
+        children.push({ title: `Phase ${item.current_phase}, ${tasks} task(s) completed` });
+      } else if (tasks > 0) {
+        children.push({ title: `${tasks} task(s) completed` });
+      }
+    }
+    return children.length ? { title: head, children } : { title: head };
+  });
+}
+
+/** Sub-header + item tree for one phase. @param {string} phase @param {PhaseEntry[]} items */
+function phaseBlock(phase, items) {
+  return `  ${phase.toUpperCase()} (${countSummary(items)})\n`
+    + renderTree(phaseNodes(phase, items), { width: TREE_WIDTH });
+}
+
+/** ⚑ callout wrapped under the flag — continuation lines align with the text. @param {string} text */
+function flaggedCallout(text) {
+  return wrap(text, TREE_WIDTH - 4)
+    .map((seg, i) => (i === 0 ? '  ⚑ ' : '    ') + seg)
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard
+// ---------------------------------------------------------------------------
+
+/** @param {EpicDetail} detail */
+function mapStatusSuffix(detail) {
+  if (detail.convergence_state === 'settled') return ' · all decided';
+  const s = detail.map_summary;
+  if (!s) return '';
+  const parts = [];
+  if (s.decided) parts.push(`${s.decided} decided`);
+  if (s.in_flight) parts.push(`${s.in_flight} in flight`);
+  if (s.ready) parts.push(`${s.ready} ready`);
+  if (s.fresh) parts.push(`${s.fresh} fresh`);
+  if (s.handled) parts.push(`${s.handled} handled`);
+  if (s.cancelled) parts.push(`${s.cancelled} cancelled`);
+  return parts.length ? ' · ' + parts.join(' · ') : '';
+}
+
+/** Stage-meta callouts above the map header (seeds / imports / new arrivals). @param {EpicDetail} detail @param {NewArrivals} newArrivals */
+function stageMetaCallouts(detail, newArrivals) {
+  const lines = [];
+  if (detail.seeds_count > 0) lines.push('  · seeded from the inbox');
+  const showImports = detail.imports_count > 0 && detail.imports_count !== detail.discovery_map.length;
+  if (showImports) lines.push(`  · ${detail.imports_count} import${detail.imports_count === 1 ? '' : 's'}`);
+  for (const [field, label] of [['research_analysis', 'research-analysis'], ['gap_analysis', 'gap-analysis']]) {
+    const names = newArrivals[/** @type {'research_analysis'|'gap_analysis'} */ (field)];
+    if (Array.isArray(names) && names.length > 0) {
+      lines.push(`  ⚑ ${names.length} new topic(s) added to the map from ${label}.`);
+    }
+  }
+  return lines;
+}
+
+/** Discovery-map topic rows as kernel tree nodes. @param {EpicDetail} detail */
+function mapNodes(detail) {
+  return detail.discovery_map.map((row) => {
+    const body = [];
+    if (row.summary) body.push(row.summary);
+    if (row.source_provenance) body.push(derivedFrom(row.source_provenance));
+    const node = {
+      title: title({ glyph: discoveryGlyph(row.lifecycle), label: titlecase(row.name), tag: lifecycleLabel(row) }),
+    };
+    return body.length ? { ...node, body } : node;
+  });
+}
+
+/** First-matching recommendation for the no-map dashboard, or null. @param {EpicDetail} detail */
+function displayRecommendation(detail) {
+  const research = detail.phases.research || [];
+  const discussion = detail.phases.discussion || [];
+  const spec = detail.phases.specification || [];
+  const plan = detail.phases.planning || [];
+
+  const inProgressPhases = new Set(detail.in_progress.map((i) => i.phase));
+  if (inProgressPhases.size > 1) return null;
+  if (research.some((i) => i.status === 'in-progress') && research.some((i) => i.status === 'completed')) {
+    return 'Consider completing remaining research before starting discussion. Topic analysis works best with all research available.';
+  }
+  if (discussion.some((i) => i.status === 'in-progress') && discussion.some((i) => i.status === 'completed')) {
+    return 'Consider completing remaining discussions before starting specification. The grouping analysis works best with all discussions available.';
+  }
+  const proposed = spec.filter((i) => i.status === 'proposed');
+  if (proposed.length > 0) {
+    return `${proposed.length} analyzed grouping(s) ready to specify. Start them before planning to surface cross-cutting dependencies.`;
+  }
+  if (discussion.length > 0 && discussion.every((i) => i.status === 'completed') && spec.length === 0) {
+    return 'All discussions are completed. Specification will analyze and group them.';
+  }
+  if (spec.some((i) => i.status === 'completed') && spec.some((i) => i.status === 'in-progress')) {
+    return 'Completing all specifications before planning helps identify cross-cutting dependencies.';
+  }
+  if (plan.some((i) => i.status === 'completed') && plan.some((i) => i.status === 'in-progress')) {
+    return 'Completing all plans before implementation helps surface task dependencies across plans.';
+  }
+  for (const name of detail.reopened_discussions) {
+    const owner = spec.find((s) => (s.sources || []).some((src) => sourceName(src) === name));
+    if (owner) {
+      return `${titlecase(owner.name)} specification sources the reopened ${titlecase(name)} discussion. `
+        + 'Once that discussion concludes, the specification will need revisiting to extract new content.';
+    }
+  }
+  return null;
+}
+
+/** Plans-not-ready ⚑ block, or null when no plan is blocked. @param {EpicDetail} detail */
+function plansNotReadyBlock(detail) {
+  const blocked = (detail.phases.planning || [])
+    .filter((p) => Array.isArray(p.deps_blocking) && p.deps_blocking.length > 0);
+  if (blocked.length === 0) return null;
+  const parts = [
+    '⚑ Plans not ready for implementation:\n'
+    + '  These plans have unresolved dependencies that must be\n'
+    + '  addressed first.',
+  ];
+  for (const p of blocked) {
+    parts.push(
+      `  ${titlecase(p.name)}\n`
+      + renderTree((p.deps_blocking || []).map((dep) => ({ title: `Blocked by ${depRef(dep)}` })), { width: TREE_WIDTH })
+    );
+  }
+  return parts.join('\n\n').replace(/\n+$/, '');
+}
+
+/**
+ * Section A — the epic state display. One code-block string: box cap, stage
+ * dividers, map/phase trees, recommendation, and the plans-not-ready block.
+ * @param {string} workUnit
+ * @param {EpicDetail} detail
+ * @param {{newArrivals?: NewArrivals}} [opts]
+ * @returns {string}
+ */
+function epicDashboard(workUnit, detail, opts = {}) {
+  const newArrivals = opts.newArrivals || {};
+  const hasMap = detail.discovery_map.length > 0;
+  const phaseNames = Object.keys(detail.phases);
+
+  // Brand-new epic — nothing started anywhere.
+  if (!hasMap && phaseNames.length === 0) {
+    return box(titlecase(workUnit)) + 'No work started yet.';
+  }
+
+  /** @type {string[]} stage blocks, each ending with a single \n */
+  const stages = [];
+
+  if (hasMap) {
+    let block = signpost('DISCOVERY') + '\n\n';
+    const callouts = stageMetaCallouts(detail, newArrivals);
+    if (callouts.length > 0) block += callouts.join('\n') + '\n\n';
+    const total = detail.map_summary ? detail.map_summary.total : detail.discovery_map.length;
+    block += `  RESEARCH & DISCUSSION (${total} topics${mapStatusSuffix(detail)})\n`;
+    block += renderTree(mapNodes(detail), { width: TREE_WIDTH });
+    stages.push(block);
+  }
+
+  for (const stage of STAGES) {
+    if (hasMap && stage.name === 'DISCOVERY') continue; // the map is the DISCOVERY stage
+    const populated = stage.phases.filter((p) => (detail.phases[p] || []).length > 0);
+    if (populated.length === 0) continue;
+    stages.push(
+      signpost(stage.name) + '\n\n'
+      + populated.map((p) => phaseBlock(p, detail.phases[p])).join('\n')
+    );
+  }
+
+  let out = box(titlecase(workUnit)) + stages.join('\n');
+
+  if (!hasMap) {
+    const rec = displayRecommendation(detail);
+    if (rec) out += '\n' + flaggedCallout(rec) + '\n';
+  }
+
+  const notReady = plansNotReadyBlock(detail);
+  if (notReady) out += '\n' + notReady + '\n';
+
+  return out.replace(/\n+$/, '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Key
+// ---------------------------------------------------------------------------
+
+const KEY_TIER =
+  '    Discovery tier:\n'
+  + '      →  ready for next phase   ◐  in flight\n'
+  + '      ✓  decided                ○  fresh\n'
+  + '      ⊙  handled                ⊘  cancelled';
+
+const KEY_STATUS =
+  '    Status:\n'
+  + '      proposed    — analyzed grouping, not yet started\n'
+  + '      in-progress — work is ongoing\n'
+  + '      completed   — phase or implementation done\n'
+  + '      cancelled   — topic removed from active work\n'
+  + '      promoted    — moved to its own cross-cutting work unit';
+
+const KEY_BLOCKING =
+  '    Blocking reason:\n'
+  + '      blocked by {plan}:{task} — depends on another plan\'s task\n'
+  + '      blocked by {plan}        — dependency unresolved';
+
+/**
+ * Section B — the Key block, showing only categories present in the display.
+ * Empty string for a brand-new epic (the key is skipped on that branch).
+ * @param {EpicDetail} detail
+ * @returns {string}
+ */
+function epicKey(detail) {
+  const hasMap = detail.discovery_map.length > 0;
+  const phaseNames = Object.keys(detail.phases);
+  if (!hasMap && phaseNames.length === 0) return '';
+
+  const anyBlocked = (detail.phases.planning || [])
+    .some((p) => Array.isArray(p.deps_blocking) && p.deps_blocking.length > 0);
+  const blocks = [];
+  if (hasMap) {
+    blocks.push(KEY_TIER);
+    if (BUILD_PHASES.some((p) => (detail.phases[p] || []).length > 0)) blocks.push(KEY_STATUS);
+  } else {
+    blocks.push(KEY_STATUS);
+  }
+  if (anyBlocked) blocks.push(KEY_BLOCKING);
+  return '  Key:\n' + blocks.join('\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// Menu
+// ---------------------------------------------------------------------------
+
+/** @param {string} action @param {string} workUnit @param {string} topic */
+function topicRoute(action, workUnit, topic) {
+  return `/${PHASE_ENTRY_SKILL[/** @type {keyof typeof ACTION_PHASE} */ (ACTION_PHASE[action])]} epic ${workUnit} ${topic}`;
+}
+
+/** @param {string} action @param {string} name */
+function discoveryEntryLabel(action, name) {
+  const t = titlecase(name);
+  switch (action) {
+    case 'start_research': return `Start research for "${t}"`;
+    case 'start_discussion': return `Start discussion for "${t}"`;
+    case 'continue_research': return `Continue "${t}" — research`;
+    case 'continue_discussion': return `Continue "${t}" — discussion`;
+    default: return `Start discussion for "${t}" — research completed`; // start_discussion_after_research
+  }
+}
+
+/** @param {string} phase @param {PhaseEntry} item */
+function continueLabel(phase, item) {
+  const t = titlecase(item.name);
+  if (phase === 'implementation' && item.current_phase != null) {
+    const tasks = Array.isArray(item.completed_tasks) ? item.completed_tasks.length : 0;
+    return `Continue "${t}" — implementation (Phase ${item.current_phase}, Task ${tasks})`;
+  }
+  return `Continue "${t}" — ${phase} [in-progress]`;
+}
+
+/** @param {NextPhaseEntry} n */
+function startVerbLabel(n) {
+  const t = titlecase(n.name);
+  if (n.action === 'start_implementation') {
+    if (n.blocked) {
+      return `Start implementation of "${t}" — blocked by ${(n.deps_blocking || []).map(depRef).join(', ')}`;
+    }
+    return `Start implementation of "${t}" — ${n.label}`;
+  }
+  const phase = ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (n.action)];
+  return `Start ${phase} for "${t}" — ${n.label}`;
+}
+
+/** Continue entries for one phase's in-progress items. @param {string} workUnit @param {EpicDetail} detail @param {string} phase @returns {MenuKey[]} */
+function continueEntries(workUnit, detail, phase) {
+  return (detail.phases[phase] || [])
+    .filter((item) => item.status === 'in-progress')
+    .map((item) => ({
+      key: '',
+      action: `continue_${phase}`,
+      topic: item.name,
+      route: topicRoute(`continue_${phase}`, workUnit, item.name),
+      label: continueLabel(phase, item),
+    }));
+}
+
+/** Gated start entries for one phase from next_phase_ready. @param {string} workUnit @param {EpicDetail} detail @param {string} phase @returns {MenuKey[]} */
+function startEntries(workUnit, detail, phase) {
+  /** @type {MenuKey[]} */
+  const out = [];
+  for (const n of detail.next_phase_ready) {
+    if (ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (n.action)] !== phase) continue;
+    const gate = START_GATE[/** @type {keyof typeof START_GATE} */ (n.action)];
+    if (gate && !detail.gating[/** @type {keyof EpicDetail['gating']} */ (gate)]) continue;
+    /** @type {MenuKey} */
+    const entry = {
+      key: '',
+      action: n.action,
+      topic: n.name,
+      route: topicRoute(n.action, workUnit, n.name),
+      label: startVerbLabel(n),
+    };
+    if (n.blocked) {
+      entry.blocked = true;
+      entry.deps_blocking = n.deps_blocking;
+    }
+    out.push(entry);
+  }
+  return out;
+}
+
+/** Command options with presence conditions and adaptive descriptions. @param {string} workUnit @param {EpicDetail} detail @param {boolean} hasMap @returns {MenuKey[]} */
+function commandOptions(workUnit, detail, hasMap) {
+  /** @type {MenuKey[]} */
+  const opts = [];
+  if (detail.gating.can_start_specification) {
+    const desc = detail.unaccounted_discussions.length > 0
+      ? `${detail.unaccounted_discussions.length} discussion(s) not yet grouped`
+      : 'review or regroup specifications';
+    opts.push({
+      key: 's', word: 'spec', action: 'analyze_discussions', topic: null,
+      route: `/workflow-specification-entry epic ${workUnit}`,
+      label: `Analyze / regroup discussions — ${desc}`,
+    });
+  }
+  opts.push({
+    key: 'd', word: 'discuss', action: 'new_discussion', topic: null,
+    route: `/workflow-discussion-entry epic ${workUnit}`,
+    label: hasMap ? 'Start a discussion on a new topic' : 'Start new discussion',
+  });
+  opts.push({
+    key: 'r', word: 'research', action: 'new_research', topic: null,
+    route: `/workflow-research-entry epic ${workUnit}`,
+    label: hasMap ? 'Start research on a new topic' : 'Start new research',
+  });
+  if (hasMap) {
+    opts.push({
+      key: 'i', word: 'discovery', action: 'continue_discovery', topic: null,
+      route: `/workflow-discovery epic ${workUnit}`,
+      label: 'Continue discovery',
+    });
+  }
+  if (detail.completed.length > 0) {
+    opts.push({ key: 'c', word: 'completed', action: 'resume_completed', topic: null, route: null, label: 'Resume a completed topic' });
+  }
+  const cancellable = Object.values(detail.phases)
+    .some((items) => items.some((i) => i.status !== 'cancelled' && i.status !== 'promoted'));
+  if (cancellable) {
+    opts.push({ key: 'a', word: 'cancel', action: 'cancel_topic', topic: null, route: null, label: hasMap ? 'Cancel a topic (phase work)' : 'Cancel a topic' });
+  }
+  if (detail.cancelled.length > 0) {
+    opts.push({ key: 'e', word: 'reactivate', action: 'reactivate_topic', topic: null, route: null, label: 'Reactivate a cancelled topic' });
+  }
+  if (Object.keys(detail.phases).length > 0) {
+    opts.push({ key: 'm', word: 'map', action: 'view_map', topic: null, route: null, label: hasMap ? 'View pipeline map' : 'View epic dependency map' });
+  }
+  return opts;
+}
+
+/** All live (non-cancelled, non-promoted) items of one phase. @param {EpicDetail} detail @param {string} phase */
+function liveItems(detail, phase) {
+  return (detail.phases[phase] || []).filter((i) => i.status !== 'cancelled' && i.status !== 'promoted');
+}
+
+/**
+ * Pick the recommended entry. Returns the entry to move first, or marks the
+ * `s` command option, or neither (no recommendation).
+ * @param {EpicDetail} detail @param {MenuKey[]} numbered @param {MenuKey[]} options @param {boolean} hasMap
+ * @returns {MenuKey|null}
+ */
+function pickRecommendation(detail, numbered, options, hasMap) {
+  const sOption = options.find((o) => o.action === 'analyze_discussions');
+
+  if (hasMap) {
+    if (detail.convergence_state === 'in-progress') {
+      // Top of the map — the first discovery entry mirrors the first map row
+      // with a non-null next_action (tier order: → first, then ◐, then ○).
+      const discoveryActions = ['start_research', 'start_discussion', 'continue_research', 'continue_discussion', 'start_discussion_after_research'];
+      return numbered.find((e) => discoveryActions.includes(e.action)) || null;
+    }
+    // settled — first build-phase next_phase_ready entry in pipeline order
+    const build = numbered.find((e) => e.action.startsWith('start_') && !e.blocked
+      && BUILD_PHASES.includes(ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (e.action)]));
+    if (build) return build;
+    if (sOption) sOption.recommended = true;
+    return null;
+  }
+
+  // No-map branch — recommendation by phase completion state.
+  const proposedEntry = numbered.find((e) => e.action === 'start_specification');
+  if (proposedEntry) return proposedEntry;
+
+  const discussion = detail.phases.discussion || [];
+  if (discussion.length > 0 && discussion.every((i) => i.status === 'completed')
+      && (detail.phases.specification || []).length === 0 && sOption) {
+    sOption.recommended = true;
+    return null;
+  }
+
+  const specs = liveItems(detail, 'specification');
+  const planEntry = numbered.find((e) => e.action === 'start_planning');
+  if (specs.length > 0 && specs.every((i) => i.status === 'completed') && planEntry) return planEntry;
+
+  const plans = liveItems(detail, 'planning');
+  const implEntry = numbered.find((e) => e.action === 'start_implementation' && !e.blocked);
+  if (plans.length > 0 && plans.every((i) => i.status === 'completed') && implEntry) return implEntry;
+
+  const impls = liveItems(detail, 'implementation');
+  const reviewEntry = numbered.find((e) => e.action === 'start_review');
+  if (impls.length > 0 && impls.every((i) => i.status === 'completed') && reviewEntry) return reviewEntry;
+
+  return null;
+}
+
+/**
+ * Section C — the interactive menu. `keys` carries the machine action keys
+ * (skills route on these); `rendered` is the dotted-gate markdown block.
+ * @param {string} workUnit
+ * @param {EpicDetail} detail
+ * @returns {{keys: MenuKey[], rendered: string}}
+ */
+function epicMenu(workUnit, detail) {
+  const hasMap = detail.discovery_map.length > 0;
+
+  /** @type {MenuKey[]} */
+  let numbered = [];
+
+  if (hasMap) {
+    // Discovery topics — one entry per map row with a non-null next_action
+    // (✓/⊙/⊘ rows have none), in map order.
+    for (const row of detail.discovery_map) {
+      if (!row.next_action) continue;
+      numbered.push({
+        key: '',
+        action: row.next_action,
+        topic: row.name,
+        route: topicRoute(row.next_action, workUnit, row.name),
+        label: discoveryEntryLabel(row.next_action, row.name),
+      });
+    }
+    // Build-phase entries by pipeline position — continues, then gated starts.
+    for (const phase of BUILD_PHASES) {
+      numbered.push(...continueEntries(workUnit, detail, phase));
+      numbered.push(...startEntries(workUnit, detail, phase));
+    }
+  } else {
+    // Continue items — any in-progress item in any phase, pipeline order.
+    for (const phase of ['research', 'discussion', ...BUILD_PHASES]) {
+      numbered.push(...continueEntries(workUnit, detail, phase));
+    }
+    // Next-phase-ready items — specification first, then planning,
+    // implementation, review.
+    for (const phase of BUILD_PHASES) {
+      numbered.push(...startEntries(workUnit, detail, phase));
+    }
+  }
+
+  const options = commandOptions(workUnit, detail, hasMap);
+
+  const recommended = pickRecommendation(detail, numbered, options, hasMap);
+  if (recommended) {
+    recommended.recommended = true;
+    numbered = [recommended, ...numbered.filter((e) => e !== recommended)];
+  }
+
+  numbered.forEach((e, i) => { e.key = String(i + 1); });
+
+  const lines = ['· · · · · · · · · · · ·', 'What would you like to do?', ''];
+  for (const e of numbered) {
+    lines.push(`- **\`${e.key}\`** — ${e.label}${e.recommended ? ' (recommended)' : ''}`);
+  }
+  if (hasMap && numbered.length > 0 && options.length > 0) lines.push('');
+  for (const o of options) {
+    lines.push(`- **\`${o.key}\`/\`${o.word}\`** — ${o.label}${o.recommended ? ' (recommended)' : ''}`);
+  }
+  lines.push('', 'Select an option:', '· · · · · · · · · · · ·');
+
+  return { keys: [...numbered, ...options], rendered: lines.join('\n') };
+}
+
+module.exports = { epicDashboard, epicKey, epicMenu };

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -8,15 +8,28 @@
 // Rings:
 //   engine.render       kernel — pure layout (no workflow vocabulary)
 //   engine.conventions  domain — workflow glyphs, tags, title composition
+//   engine.detail       domain — detail builders (the one structured object per work unit)
+//   engine.project      domain — projections (dashboard / key / menu views over a detail)
 //   engine.gateway      adapter harness — verb dispatch + output sections
 //
-// Domain queries (`engine.detail.*`), projections (`engine.project.*`), and
-// transitions grow here as call sites migrate — added when a real consumer
-// lands, never speculatively.
+// Domain queries, projections, and transitions grow here as call sites
+// migrate — added when a real consumer lands, never speculatively.
 // ---------------------------------------------------------------------------
 
 const render = require('./kernel/render.cjs');
 const conventions = require('./domain/conventions.cjs');
 const gateway = require('./gateway.cjs');
+const epic = require('./domain/epic.cjs');
+const epicProjections = require('./domain/projections/epic.cjs');
 
-module.exports = { render, conventions, gateway };
+module.exports = {
+  render,
+  conventions,
+  gateway,
+  detail: { epicDetail: epic.epicDetail, EPIC_PHASES: epic.EPIC_PHASES },
+  project: {
+    epicDashboard: epicProjections.epicDashboard,
+    epicKey: epicProjections.epicKey,
+    epicMenu: epicProjections.epicMenu,
+  },
+};

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -1,0 +1,426 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const { setupFixture, cleanupFixture, createManifest } = require('./discovery-test-utils.cjs');
+const { discover } = require('../../skills/workflow-continue-epic/scripts/discovery.cjs');
+const { epicDashboard, epicKey, epicMenu } = require('../../skills/workflow-engine/scripts/domain/projections/epic.cjs');
+const { TREE_WIDTH } = require('../../skills/workflow-engine/scripts/domain/conventions.cjs');
+
+// Golden tests: byte-exact expected strings for the epic dashboard, key, and
+// menu projections. Fixtures go through real manifests in temp dirs (the same
+// shapes the discovery tests produce), except the gating/blocked menu fixture,
+// which hand-builds a detail to reach states a manifest can't (a start entry
+// surviving while its gate is closed).
+
+/** Build a detail from a manifest in a temp fixture dir. */
+function detailFor(dir, name, manifest) {
+  createManifest(dir, name, manifest);
+  return discover(dir, name).epics[0].detail;
+}
+
+describe('epic projections: dashboard (map branch)', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  // A summary containing a token longer than the wrap budget — the renderer
+  // must hard-split it rather than let it overflow the gutter.
+  const LONG_TOKEN_SUMMARY = 'Receipt printing, KDS handoff, and the fastest-cumulative-time-tiebreak-resolution-policy-and-offline-sync token that cannot break';
+
+  function mapDetail() {
+    return detailFor(dir, 'quiz-competition-v1', {
+      work_type: 'epic',
+      seeds: [{ path: 'seeds/x.md', source: 'inbox:idea' }],
+      imports: [{ path: 'imports/a.md' }],
+      phases: {
+        discovery: {
+          items: {
+            'kitchen-hardware': { routing: 'research', source: 'discovery', order: 1, summary: LONG_TOKEN_SUMMARY },
+            'menu-admin': { routing: 'discussion', source: 'research-split:exploration', order: 2, summary: 'Business-side menu modelling, admin shell (Filament vs custom Vue/Nuxt), JustEat import, staff/roles' },
+          },
+        },
+        research: { items: { 'kitchen-hardware': { status: 'completed' } } },
+        specification: { items: { 'roles-and-permissions': { status: 'completed', sources: { 'menu-admin': { status: 'incorporated' }, 'auth-flow': { status: 'pending' } } } } },
+        planning: { items: { 'roles-and-permissions': { status: 'completed', format: 'tick' } } },
+        implementation: { items: { 'roles-and-permissions': { status: 'in-progress', current_phase: 2, completed_tasks: ['r-1-1', 'r-1-2', 'r-2-1'] } } },
+      },
+    });
+  }
+
+  const EXPECTED_DASHBOARD = [
+    '●───────────────────────────────────────────────●',
+    '  Quiz Competition V1',
+    '●───────────────────────────────────────────────●',
+    '',
+    '── DISCOVERY ────────────────────────────────────',
+    '',
+    '  · seeded from the inbox',
+    '  · 1 import',
+    '  ⚑ 1 new topic(s) added to the map from research-analysis.',
+    '',
+    '  RESEARCH & DISCUSSION (2 topics · 1 ready · 1 fresh)',
+    '  ├─ → Kitchen Hardware [research complete · ready for discussion]',
+    '  │     Receipt printing, KDS handoff, and the',
+    '  │     fastest-cumulative-time-tiebreak-resolution-policy-and-of',
+    '  │     fline-sync token that cannot break',
+    '  └─ ○ Menu Admin [fresh · routed to discussion]',
+    '        Business-side menu modelling, admin shell (Filament vs',
+    '        custom Vue/Nuxt), JustEat import, staff/roles',
+    '        ↳ From exploration',
+    '',
+    '── DEFINITION ───────────────────────────────────',
+    '',
+    '  SPECIFICATION (1 completed)',
+    '  └─ Roles And Permissions [completed]',
+    '     ├─ Menu Admin [incorporated]',
+    '     └─ Auth Flow [pending]',
+    '',
+    '  PLANNING (1 completed)',
+    '  └─ Roles And Permissions [completed] · tick',
+    '',
+    '── DELIVERY ─────────────────────────────────────',
+    '',
+    '  IMPLEMENTATION (1 in-progress)',
+    '  └─ Roles And Permissions [in-progress]',
+    '     └─ Phase 2, 3 task(s) completed',
+    '',
+  ].join('\n');
+
+  it('renders the map-branch dashboard byte-for-byte (callouts, stages, trees)', () => {
+    const out = epicDashboard('quiz-competition-v1', mapDetail(), {
+      newArrivals: { research_analysis: ['menu-admin'], gap_analysis: [] },
+    });
+    assert.strictEqual(out, EXPECTED_DASHBOARD);
+  });
+
+  it('keeps every body line within TREE_WIDTH and the │ gutter unbroken', () => {
+    const out = epicDashboard('quiz-competition-v1', mapDetail(), {
+      newArrivals: { research_analysis: ['menu-admin'], gap_analysis: [] },
+    });
+    const lines = out.split('\n');
+    const start = lines.indexOf('  ├─ → Kitchen Hardware [research complete · ready for discussion]');
+    const end = lines.indexOf('        ↳ From exploration');
+    assert.ok(start > 0 && end > start, 'map tree rows present');
+    let underLast = false;
+    for (const l of lines.slice(start, end + 1)) {
+      const m = l.match(/^ {2}([├└])─ /);
+      if (m) { underLast = m[1] === '└'; continue; }
+      // body sub-line — within the budget, gutter intact
+      assert.ok(l.length <= TREE_WIDTH, `body "${l}" (${l.length}) overruns ${TREE_WIDTH}`);
+      if (underLast) {
+        assert.ok(!l.includes('│'), `last topic must not carry the bar: "${l}"`);
+      } else {
+        assert.strictEqual(l[2], '│', `non-last sub-line must carry the bar: "${l}"`);
+      }
+    }
+  });
+
+  it('omits the callout block when no stage-meta applies', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: { discovery: { items: { topic: { routing: 'research', source: 'discovery', order: 1 } } } },
+    });
+    assert.strictEqual(
+      epicDashboard('v1', d),
+      [
+        '●───────────────────────────────────────────────●',
+        '  V1',
+        '●───────────────────────────────────────────────●',
+        '',
+        '── DISCOVERY ────────────────────────────────────',
+        '',
+        '  RESEARCH & DISCUSSION (1 topics · 1 fresh)',
+        '  └─ ○ Topic [fresh · routed to research]',
+        '',
+      ].join('\n')
+    );
+  });
+});
+
+describe('epic projections: dashboard (no-map and brand-new branches)', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('renders the no-map branch with a wrapped ⚑ recommendation', () => {
+    const d = detailFor(dir, 'auth-overhaul', {
+      work_type: 'epic',
+      phases: {
+        research: { items: { 'market-analysis': { status: 'in-progress' }, 'competitor-scan': { status: 'completed' } } },
+        discussion: { items: { 'auth-flow': { status: 'completed' } } },
+      },
+    });
+    assert.strictEqual(
+      epicDashboard('auth-overhaul', d),
+      [
+        '●───────────────────────────────────────────────●',
+        '  Auth Overhaul',
+        '●───────────────────────────────────────────────●',
+        '',
+        '── DISCOVERY ────────────────────────────────────',
+        '',
+        '  RESEARCH (1 in-progress, 1 completed)',
+        '  ├─ Market Analysis [in-progress]',
+        '  └─ Competitor Scan [completed]',
+        '',
+        '  DISCUSSION (1 completed)',
+        '  └─ Auth Flow [completed]',
+        '',
+        '  ⚑ Consider completing remaining research before starting',
+        '    discussion. Topic analysis works best with all research',
+        '    available.',
+        '',
+      ].join('\n')
+    );
+  });
+
+  it('appends the plans-not-ready block after the stages', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        planning: { items: { billing: { status: 'completed', external_dependencies: { auth: { description: 'd', state: 'unresolved' } } } } },
+      },
+    });
+    const out = epicDashboard('v1', d);
+    assert.ok(out.endsWith([
+      '⚑ Plans not ready for implementation:',
+      '  These plans have unresolved dependencies that must be',
+      '  addressed first.',
+      '',
+      '  Billing',
+      '  └─ Blocked by auth',
+      '',
+    ].join('\n')));
+  });
+
+  it('renders the brand-new-epic branch', () => {
+    const d = detailFor(dir, 'fresh-epic', { work_type: 'epic' });
+    assert.strictEqual(
+      epicDashboard('fresh-epic', d),
+      [
+        '●───────────────────────────────────────────────●',
+        '  Fresh Epic',
+        '●───────────────────────────────────────────────●',
+        '',
+        'No work started yet.',
+      ].join('\n')
+    );
+  });
+});
+
+describe('epic projections: key', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  const TIER = [
+    '    Discovery tier:',
+    '      →  ready for next phase   ◐  in flight',
+    '      ✓  decided                ○  fresh',
+    '      ⊙  handled                ⊘  cancelled',
+  ].join('\n');
+  const STATUS = [
+    '    Status:',
+    '      proposed    — analyzed grouping, not yet started',
+    '      in-progress — work is ongoing',
+    '      completed   — phase or implementation done',
+    '      cancelled   — topic removed from active work',
+    '      promoted    — moved to its own cross-cutting work unit',
+  ].join('\n');
+  const BLOCKING = [
+    '    Blocking reason:',
+    "      blocked by {plan}:{task} — depends on another plan's task",
+    '      blocked by {plan}        — dependency unresolved',
+  ].join('\n');
+
+  it('map with no build items shows only the Discovery tier block', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: { discovery: { items: { topic: { routing: 'research', source: 'discovery', order: 1 } } } },
+    });
+    assert.strictEqual(epicKey(d), '  Key:\n' + TIER);
+  });
+
+  it('map + build items + blocked plan shows all three categories', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discovery: { items: { topic: { routing: 'research', source: 'discovery', order: 1 } } },
+        planning: { items: { billing: { status: 'completed', external_dependencies: { auth: { description: 'd', state: 'unresolved' } } } } },
+      },
+    });
+    assert.strictEqual(epicKey(d), '  Key:\n' + TIER + '\n\n' + STATUS + '\n\n' + BLOCKING);
+  });
+
+  it('no-map branch shows the Status block without the tier block', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: { discussion: { items: { auth: { status: 'in-progress' } } } },
+    });
+    assert.strictEqual(epicKey(d), '  Key:\n' + STATUS);
+  });
+
+  it('brand-new epic produces no key (section B is skipped on that branch)', () => {
+    const d = detailFor(dir, 'fresh', { work_type: 'epic' });
+    assert.strictEqual(epicKey(d), '');
+  });
+});
+
+describe('epic projections: menu', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  // Hand-built detail: a settled map plus a next_phase_ready set that includes
+  // a gated-out start_planning and a blocked start_implementation. Mirrors the
+  // discovery detail shape exactly; built by hand because a real manifest
+  // can't hold a start_planning entry while its gate is closed.
+  function settledDetail() {
+    return {
+      phases: {
+        specification: [
+          { name: 'auth-spec', status: 'in-progress' },
+          { name: 'billing-grouping', status: 'proposed', sources: [{ topic: 'menu-admin', status: 'pending' }] },
+        ],
+        planning: [
+          { name: 'reporting', status: 'completed', deps_satisfied: false, deps_blocking: [{ topic: 'core-features', internal_id: 'core-2-3', reason: 'task not yet completed' }] },
+        ],
+      },
+      in_progress: [{ name: 'auth-spec', phase: 'specification' }],
+      completed: [{ name: 'reporting', phase: 'planning' }],
+      cancelled: [],
+      next_phase_ready: [
+        { name: 'billing-grouping', action: 'start_specification', label: 'grouping ready' },
+        { name: 'user-profiles', action: 'start_planning', label: 'spec completed' },
+        {
+          name: 'reporting', action: 'start_implementation', label: 'plan completed',
+          blocked: true, deps_blocking: [{ topic: 'core-features', internal_id: 'core-2-3', reason: 'task not yet completed' }],
+        },
+      ],
+      unaccounted_discussions: ['payments', 'menu-admin'],
+      reopened_discussions: [],
+      discovery_map: [
+        { name: 'menu-admin', summary_present: true, summary: 'x', description_present: true, routing: 'discussion', source: 'discovery', source_provenance: null, order: 1, lifecycle: 'decided', tier: '✓', current_phase: 'discussion', next_action: null },
+      ],
+      convergence_state: 'settled',
+      needs_sequencing: false,
+      map_summary: { total: 1, decided: 1, in_flight: 0, ready: 0, fresh: 0, handled: 0, cancelled: 0 },
+      imports_count: 0,
+      seeds_count: 0,
+      analysis_caches: {
+        research_analysis: { status: 'absent', generated: null, files: [] },
+        gap_analysis: { status: 'absent', generated: null, files: [] },
+      },
+      gating: {
+        can_start_specification: true,
+        can_start_planning: false, // gates the user-profiles start_planning out
+        can_start_implementation: true,
+        can_start_review: true,
+      },
+    };
+  }
+
+  it('orders the recommendation first, filters gated starts, flags blocked entries', () => {
+    const menu = epicMenu('quiz-competition-v1', settledDetail());
+    assert.strictEqual(menu.rendered, [
+      '· · · · · · · · · · · ·',
+      'What would you like to do?',
+      '',
+      '- **`1`** — Start specification for "Billing Grouping" — grouping ready (recommended)',
+      '- **`2`** — Continue "Auth Spec" — specification [in-progress]',
+      '- **`3`** — Start implementation of "Reporting" — blocked by core-features:core-2-3',
+      '',
+      '- **`s`/`spec`** — Analyze / regroup discussions — 2 discussion(s) not yet grouped',
+      '- **`d`/`discuss`** — Start a discussion on a new topic',
+      '- **`r`/`research`** — Start research on a new topic',
+      '- **`i`/`discovery`** — Continue discovery',
+      '- **`c`/`completed`** — Resume a completed topic',
+      '- **`a`/`cancel`** — Cancel a topic (phase work)',
+      '- **`m`/`map`** — View pipeline map',
+      '',
+      'Select an option:',
+      '· · · · · · · · · · · ·',
+    ].join('\n'));
+  });
+
+  it('keys carry actions, topics, routes, and the recommended/blocked flags', () => {
+    const { keys } = epicMenu('quiz-competition-v1', settledDetail());
+    assert.deepStrictEqual(
+      keys.map((k) => [k.key, k.action, k.topic, k.route]),
+      [
+        ['1', 'start_specification', 'billing-grouping', '/workflow-specification-entry epic quiz-competition-v1 billing-grouping'],
+        ['2', 'continue_specification', 'auth-spec', '/workflow-specification-entry epic quiz-competition-v1 auth-spec'],
+        ['3', 'start_implementation', 'reporting', '/workflow-implementation-entry epic quiz-competition-v1 reporting'],
+        ['s', 'analyze_discussions', null, '/workflow-specification-entry epic quiz-competition-v1'],
+        ['d', 'new_discussion', null, '/workflow-discussion-entry epic quiz-competition-v1'],
+        ['r', 'new_research', null, '/workflow-research-entry epic quiz-competition-v1'],
+        ['i', 'continue_discovery', null, '/workflow-discovery epic quiz-competition-v1'],
+        ['c', 'resume_completed', null, null],
+        ['a', 'cancel_topic', null, null],
+        ['m', 'view_map', null, null],
+      ]
+    );
+    assert.strictEqual(keys[0].recommended, true);
+    assert.strictEqual(keys[2].blocked, true);
+    assert.deepStrictEqual(keys[2].deps_blocking, [{ topic: 'core-features', internal_id: 'core-2-3', reason: 'task not yet completed' }]);
+    assert.ok(!keys.some((k) => k.action === 'start_planning'), 'gated start_planning never surfaces');
+  });
+
+  it('in-progress map recommends the top discovery row; ✓/⊙/⊘ rows get no entry', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discovery: {
+          items: {
+            ready: { routing: 'research', source: 'discovery', order: 1 },
+            decided: { routing: 'discussion', source: 'discovery', order: 2 },
+            umbrella: { routing: 'research', source: 'discovery', handled: true },
+            dropped: { routing: 'research', source: 'discovery' },
+          },
+        },
+        research: {
+          items: {
+            ready: { status: 'completed' },
+            umbrella: { status: 'completed' },
+            dropped: { status: 'cancelled' },
+          },
+        },
+        discussion: {
+          items: {
+            decided: { status: 'completed' },
+            dropped: { status: 'cancelled' },
+          },
+        },
+      },
+    });
+    const { keys, rendered } = epicMenu('v1', d);
+    const numbered = keys.filter((k) => /^\d+$/.test(k.key));
+    assert.deepStrictEqual(
+      numbered.map((k) => [k.key, k.action, k.topic]),
+      [['1', 'start_discussion_after_research', 'ready']]
+    );
+    assert.strictEqual(numbered[0].recommended, true);
+    assert.ok(rendered.includes('- **`1`** — Start discussion for "Ready" — research completed (recommended)'));
+    assert.ok(rendered.includes('- **`e`/`reactivate`** — Reactivate a cancelled topic'), 'cancelled items exist');
+    assert.ok(!rendered.includes('Umbrella'), 'handled row has no menu entry');
+    assert.ok(!rendered.includes('Dropped'), 'cancelled row has no menu entry');
+  });
+
+  it('brand-new epic menu offers only the always-present command options', () => {
+    const d = detailFor(dir, 'fresh', { work_type: 'epic' });
+    const { keys, rendered } = epicMenu('fresh', d);
+    assert.deepStrictEqual(keys.map((k) => k.key), ['d', 'r']);
+    assert.strictEqual(rendered, [
+      '· · · · · · · · · · · ·',
+      'What would you like to do?',
+      '',
+      '- **`d`/`discuss`** — Start new discussion',
+      '- **`r`/`research`** — Start new research',
+      '',
+      'Select an option:',
+      '· · · · · · · · · · · ·',
+    ].join('\n'));
+  });
+});


### PR DESCRIPTION
## What

PR 2 of the engine stack (stacked on #383 — Phase 1 of the build sequence in `ideas/deterministic-tree-and-menu-renderer.md` on `feat/renderer`). The beachhead: the epic dashboard read path moves from prose into the engine.

- **`domain/epic.cjs`** — `epicDetail` ported from the continue-epic adapter (shared fns still from `discovery-utils`; behaviour identical).
- **`domain/projections/epic.cjs`** — `epicDashboard` / `epicKey` / `epicMenu`: the entire section A–C of `epic-display-and-menu.md` as code, including stage dividers, the discovery-map tree (wrap budget enforced — the original gutter-orphan bug is now structurally impossible), build-phase trees, gating, recommendation, and the menu with machine **action keys** + routes.
- **Adapter on the gateway** — `discovery.cjs` = `runGateway({ index, fallback, view })`. `index`/`fallback` outputs **byte-identical** to before (verified by diff on fixtures; the 98-test discovery suite passes UNCHANGED). `view {wu}` emits the demarcated DATA / DISPLAY / MENU snapshot.
- **`epic-display-and-menu.md`: 848 → 411 lines** — sections A–C are now call → emit verbatim → STOP → route on the selected key's `action`/`route`. The 16-row label-prefix routing table in SKILL.md Step 9 is gone. Soft gates read `phase_counts` from DATA. Resume/cancel/reactivate flows unchanged.
- **`TREE_WIDTH = 65`** (total rendered width incl. gutter) — the deliberate narrow-wrap choice, now a named constant.

## Display changes (intentional, per the design log)

8-col body gutter (was 9), `↳ From …` provenance lines, plans-not-ready + Key merged into the one DISPLAY block, proper `├─`/`└─` for multi-dep blocked plans.

## Judgment calls to review

- `(Phase {N}, Task {M})`: M = completed-task count (the .md leaves M undefined).
- Blocked menu entries are skipped as recommendation candidates (unstated in the .md; recommending a non-selectable item seemed wrong).
- `s`/`spec` keeps its menu position when recommended (a command option can't move to slot 1); gains `(recommended)`.
- No-map branch: phantom 'pending discussion topics from research count as siblings' rule dropped — no row template exists for unrendered siblings.

## Tests

`npm test` 55 pass (incl. new byte-golden projection suite with a 67-char unbreakable-token wrap case); discovery suite 98 pass unchanged; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. **#384** 👈 current
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->