### PR TITLE
feat(engine): discussion map into the manifest — engine map commands, adapter display, migration 046

### DIFF
--- a/agents/workflow-discussion-review.md
+++ b/agents/workflow-discussion-review.md
@@ -20,11 +20,12 @@ You receive via the orchestrator's prompt:
 ## Your Process
 
 1. **Read the discussion file** completely before beginning assessment
-2. **Assess coverage** — are there subtopics still `pending` or `exploring` that should have progressed? Are there obvious adjacent concerns never mentioned on the Discussion Map? (Security, error handling, scalability, observability, migration, rollback — depending on the domain)
-3. **Assess decision quality** — does each decision have rationale? Were alternatives explored? Are trade-offs acknowledged? Is confidence appropriate?
-4. **Assess depth** — are there shallow areas? Are edge cases identified? Were false paths documented?
-5. **Identify gaps** — implicit assumptions never validated, external dependencies not acknowledged, questions the participants should be asking but haven't
-6. **Write findings** to the output file path via the `.txt`-then-rename mechanism (see Output File Format)
+2. **Read the Discussion Map** — subtopic states live in the work unit's manifest, not the discussion file. From the discussion file path `.workflows/{work_unit}/discussion/{topic}.md`, read `.workflows/{work_unit}/manifest.json` → `phases.discussion.items.{topic}.subtopics` (states: `pending`, `exploring`, `converging`, `decided`, `deferred`)
+3. **Assess coverage** — are there subtopics still `pending` or `exploring` that should have progressed? Are there obvious adjacent concerns never mentioned on the Discussion Map? (Security, error handling, scalability, observability, migration, rollback — depending on the domain)
+4. **Assess decision quality** — does each decision have rationale? Were alternatives explored? Are trade-offs acknowledged? Is confidence appropriate?
+5. **Assess depth** — are there shallow areas? Are edge cases identified? Were false paths documented?
+6. **Identify gaps** — implicit assumptions never validated, external dependencies not acknowledged, questions the participants should be asking but haven't
+7. **Write findings** to the output file path via the `.txt`-then-rename mechanism (see Output File Format)
 
 ## Hard Rules
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node build/knowledge.build.js",
     "knowledge:repl": "node scripts/knowledge-repl.js",
     "typecheck": "tsc -p tsconfig.json",
-    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs"
+    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs tests/scripts/test-engine-map.cjs"
   },
   "devDependencies": {
     "@msgpack/msgpack": "3.1.3",

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-discussion-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/discovery.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/discovery.cjs), Bash(node .claude/skills/workflow-discussion-process/scripts/discovery.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
 ---
 
 # Discussion Process
@@ -42,9 +42,9 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 Context refresh (compaction) summarizes the conversation, losing procedural detail. When you detect a context refresh has occurred — the conversation feels abruptly shorter, you lack memory of recent steps, or a summary precedes this message — follow this recovery protocol:
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
-2. **Read the discussion file** at `.workflows/{work_unit}/discussion/{topic}.md`. This is the only working document this skill creates. The Discussion Map section is your primary progress indicator — it shows which subtopics are decided, exploring, converging, or pending.
+2. **Read the discussion file** at `.workflows/{work_unit}/discussion/{topic}.md`. This is the only working document this skill creates. The Discussion Map is your primary progress indicator — which subtopics are decided, exploring, converging, pending, or deferred. It lives in the manifest; read it with `node .claude/skills/workflow-discussion-process/scripts/discovery.cjs map {work_unit} {topic}`.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
-4. **Announce your position** to the user before continuing: render the current Discussion Map, state what step you believe you're at, and what comes next. Wait for confirmation.
+4. **Announce your position** to the user before continuing: render the current Discussion Map (the adapter call above — emit its DISPLAY section verbatim as a code block), state what step you believe you're at, and what comes next. Wait for confirmation.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 
@@ -73,7 +73,7 @@ Check if the discussion file exists at `.workflows/{work_unit}/discussion/{topic
 
 #### If file exists
 
-Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `discussion`, file = `.workflows/{work_unit}/discussion/{topic}.md`, continue_step = `Step 2`, restart_targets = `the discussion file`, commit = `discussion({work_unit}): restart discussion`.
+Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `discussion`, file = `.workflows/{work_unit}/discussion/{topic}.md`, continue_step = `Step 2`, restart_targets = `the discussion file and the manifest's map state (node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discussion.{topic} subtopics)`, commit = `discussion({work_unit}): restart discussion`.
 
 ---
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -73,6 +73,14 @@ Check if the discussion file exists at `.workflows/{work_unit}/discussion/{topic
 
 #### If file exists
 
+Show the current map state so the continue-or-restart choice is informed:
+
+```bash
+node .claude/skills/workflow-discussion-process/scripts/discovery.cjs map {work_unit} {topic}
+```
+
+Emit the DISPLAY section verbatim as a code block — never the `===` marker lines.
+
 Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `discussion`, file = `.workflows/{work_unit}/discussion/{topic}.md`, continue_step = `Step 2`, restart_targets = `the discussion file and the manifest's map state (node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discussion.{topic} subtopics)`, commit = `discussion({work_unit}): restart discussion`.
 
 ---

--- a/skills/workflow-discussion-process/references/discussion-guidelines.md
+++ b/skills/workflow-discussion-process/references/discussion-guidelines.md
@@ -43,7 +43,7 @@ The discussion file is your memory. Context compaction is lossy — what's not o
 **Write to the file at natural moments:**
 
 - A subtopic decision is reached (even if provisional)
-- The Discussion Map states change
+- A subtopic's map state changes
 - A piece of the puzzle is solved
 - The discussion is about to branch into a new subtopic
 - A new subtopic is uncovered
@@ -53,6 +53,6 @@ These are natural pauses, not every exchange. Document the reasoning and context
 
 **After writing, git commit.** Commits let you track, backtrack, and recover after compaction. Don't batch — commit each time you write.
 
-**Create the file early.** After understanding the topic and initial seed subtopics, create the discussion file with context and the Discussion Map. Don't wait until you have decisions.
+**Create the file early.** After understanding the topic and initial seed subtopics, create the discussion file with context and seed the Discussion Map (manifest state, via the engine `map add` command). Don't wait until you have decisions.
 
 → Return to caller.

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -16,16 +16,26 @@ Two types of background agent operate during the discussion. Load their lifecycl
 
 ## B. Session Loop
 
-The discussion is an organic conversation. The Discussion Map is your tracking backbone — it tells you where you are, what's been decided, what's still open, and where to go next. Follow this loop:
+The discussion is an organic conversation. The Discussion Map is your tracking backbone — it tells you where you are, what's been decided, what's still open, and where to go next. It is typed state in the manifest (`phases.discussion.items.{topic}.subtopics`): you make every state call, the engine `map` commands record it, and the adapter renders it (see **E**). Follow this loop:
 
 1. **Check for findings** — Before each conversational turn, run the check-for-results logic from the background-agent files loaded above. Each file knows its own rules; follow the named section in each:
    - **Review agent**: follow **B. Check and Surface** in **[review-agent.md](review-agent.md)** — delegates to the shared surfacing protocol for review findings.
    - **Perspective agents**: follow **D. Check and Surface** in **[perspective-agents.md](perspective-agents.md)** — promotes completed perspective sets to synthesis, then delegates to the shared surfacing protocol for synthesis findings.
    
    Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip on the first iteration (no agents have been dispatched yet).
-2. **Discuss** — Engage with the user on the current subtopic or wherever the conversation leads. Challenge thinking, push back, explore edge cases. Participate as an expert architect. Follow interesting threads — tangents that surface new concerns are valuable. New subtopics may emerge; add them to the Discussion Map as `pending`.
-3. **Navigate** — When a subtopic feels explored or a decision lands, update the Discussion Map and guide the user to what's still open. Don't force transitions — suggest them. The user can follow your suggestion or go wherever they want.
-4. **Document** — At natural pauses, update the discussion file. Update the Discussion Map states. When a subtopic reaches `decided`, write up its section (Context → Options → Journey → Decision). Capture provisional thinking for subtopics still in progress if context compaction is a risk.
+2. **Discuss** — Engage with the user on the current subtopic or wherever the conversation leads. Challenge thinking, push back, explore edge cases. Participate as an expert architect. Follow interesting threads — tangents that surface new concerns are valuable. New subtopics may emerge; record each on the map as it's identified (kebab-case name; new subtopics start `pending`; `--parent` nests under an existing top-level subtopic):
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs map add {work_unit} {topic} {subtopic} [--parent {parent}]
+   ```
+3. **Navigate** — When a subtopic feels explored or a decision lands, record the transition and guide the user to what's still open:
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs map set {work_unit} {topic} {subtopic} {state}
+   ```
+
+   The command's JSON response carries `all_decided` and `unresolved_count` — no follow-up read needed. Don't force transitions — suggest them. The user can follow your suggestion or go wherever they want.
+4. **Document** — At natural pauses, update the discussion file — it holds the knowledge. When a subtopic reaches `decided`, write up its section (Context → Options → Journey → Decision); keep the Summary current. Capture provisional thinking for subtopics still in progress if context compaction is a risk. The live map state lives in the manifest only — never write a map section into the file.
 5. **Commit & dispatch check** — Git commit after each write. Don't batch. Then immediately evaluate agent dispatch — **CHECKPOINT**: Do not respond to the user until this check is complete. Evaluate the trigger conditions defined in the review agent and perspective agent instructions loaded above. If conditions are met, dispatch before continuing. If not, proceed.
 6. **Repeat** — Continue with the next subtopic or follow where the conversation leads.
 
@@ -33,7 +43,7 @@ The discussion is an organic conversation. The Discussion Map is your tracking b
 
 ## C. Subtopic Lifecycle
 
-Subtopics move through states as the conversation progresses:
+Subtopics move through states as the conversation progresses. The judgment call is yours; recording it is the `map set` command (session loop step 3):
 
 **pending** → Identified but not yet explored. Sits on the map waiting for attention. New subtopics from tangents, agent findings, or natural discovery start here.
 
@@ -43,7 +53,9 @@ Subtopics move through states as the conversation progresses:
 
 **decided** → Decision reached with rationale. The subtopic section gets written up with the full Context → Options → Journey → Decision structure. This is the terminal state.
 
-**State transitions are judgement calls.** Move a subtopic to `converging` when the viable options are narrowed and the discussion is heading toward resolution. Move to `decided` when there's a clear outcome with rationale — even if provisional. Don't wait for absolute certainty.
+**deferred** → Deliberately set aside. Applied at conclude-anyway time (see **H**) to subtopics still unresolved — each is also noted in Summary → Open Threads.
+
+**State transitions are judgement calls.** Move a subtopic to `converging` when the viable options are narrowed and the discussion is heading toward resolution. Move to `decided` when there's a clear outcome with rationale — even if provisional. Don't wait for absolute certainty. Any state can move to any other — judgment may revisit.
 
 Child subtopics can exist under parents. A parent might be `exploring` while one of its children is already `decided`. The parent reaches `decided` when all its meaningful children are resolved and the overall concern is addressed.
 
@@ -59,7 +71,7 @@ You own transitions between subtopics. The goal is natural flow, not rigid seque
 
 **When a tangent surfaces a new concern:**
 
-Add it to the Discussion Map as `pending`. If it's closely related to the current subtopic, it might become a child. If it's independent, it sits at the top level.
+Record it on the map as `pending` (`map add`, session loop step 2). If it's closely related to the current subtopic, it might become a child (`--parent`). If it's independent, it sits at the top level.
 
 > "Good catch — I've added {new subtopic} to the map. Let's finish {current} first and we can pick that up after."
 
@@ -77,63 +89,18 @@ If a subtopic was partially explored and the conversation moved on, remember it 
 
 ## E. Status Display
 
-At natural breaks — after a decision, when transitioning between subtopics, or when the user asks — render the current Discussion Map state. This gives the user visibility into where the discussion stands.
+At natural breaks — after a decision, when transitioning between subtopics, or when the user asks — render the current Discussion Map. This gives the user visibility into where the discussion stands.
 
-> *Output the next fenced block as a code block:*
-
-```
-  Discussion Map — {topic:(titlecase)} ({total} subtopics{state_breakdown})
-
-@foreach(parent in subtopics)
-  {parent_branch} {state_glyph} {parent.name:(titlecase)} [{parent.state}]
-@foreach(child in parent.children)
-  {parent_gutter}{child_branch} {state_glyph} {child.name:(titlecase)} [{child.state}]
-@endforeach
-@endforeach
+```bash
+node .claude/skills/workflow-discussion-process/scripts/discovery.cjs map {work_unit} {topic}
 ```
 
-**Render rules — follow exactly. Do not improvise spacing, glyphs, or branches.**
+The output is one snapshot in two demarcated sections:
 
-- **Two-space left indent** on every row (matches the discovery map). Header included.
-- **Header**: `Discussion Map — {topic:(titlecase)} ({total} subtopics{state_breakdown})`. Followed by **one blank line** before the first row.
-  - `{total}` — count of **all subtopics** (parents + children).
-  - `{state_breakdown}` — append ` — {decided} decided · {converging} converging · {exploring} exploring · {pending} pending`, **omitting zero-count categories**. When only one state bucket is non-zero (e.g. every subtopic still `pending`), the breakdown is redundant with the rows; omit it and render just `({total} subtopics)`.
-  - Examples: `Discussion Map — Portal Observability Layer (12 subtopics)` · `Discussion Map — Portal Observability Layer (12 subtopics — 3 decided · 2 converging · 1 exploring · 6 pending)`.
-- **Parent row**: `{parent_branch} {state_glyph} {name:(titlecase)} [{state}]`. **Single space** between each of the four segments. State label in lowercase, wrapped in square brackets.
-  - `{parent_branch}`: `┌─` for the first parent, `└─` for the last parent, `├─` for the rest. **With a single parent, use `└─`** (no upward stroke).
-- **Child row**: `{parent_gutter}{child_branch} {state_glyph} {name:(titlecase)} [{state}]`. Single space between segments after the gutter+branch.
-  - `{parent_gutter}` governs the continuation tree under the parent:
-    - **Parent is not the last parent**: `│  ` — `│` followed by **2 spaces** (3 chars total). The `│` runs continuously down through every child row of that parent so the trunk never breaks.
-    - **Parent is the last parent**: `   ` — **3 spaces** (no `│`), so the tree doesn't dangle below `└─`.
-  - `{child_branch}`: `├─` for a non-final child, `└─` for the final child. **With a single child, use `└─`**.
-  - Children never have grandchildren — the map is two levels deep maximum.
-- **State glyphs** — exactly one character before the name. **Do not substitute.**
-  - `pending` — `○`
-  - `exploring` — `◐`
-  - `converging` — `→`
-  - `decided` — `✓`
-- **Row order** within the map matches the order parents and children appear in the file's Discussion Map section. Do not re-sort.
+- **DATA** — reasoning surface: `counts`, `all_decided`, `unresolved`, `review_cycles`. Reason from it; never display or restate it.
+- **DISPLAY** — the rendered map. Emit verbatim as a code block. Never redraw, reflow, or trim it.
 
-**Single-row case (one parent, no children):**
-
-```
-  Discussion Map — {topic:(titlecase)} (1 subtopic)
-
-  └─ ○ Subsystem Prefix Taxonomy [pending]
-```
-
-**Full example (mixed states, nested children):**
-
-```
-  Discussion Map — Portal Observability Layer (12 subtopics — 3 decided · 2 converging · 1 exploring · 5 pending)
-
-  ┌─ ✓ Subsystem Prefix Taxonomy [decided]
-  ├─ → Decision-Point INFO Line Shape [converging]
-  │  ├─ ✓ Field Order [decided]
-  │  └─ ◐ Truncation Rules [exploring]
-  ├─ → Diagnostic Context Preservation At Boundaries [converging]
-  └─ ○ Rollout Sequencing And Scope Bundling [pending]
-```
+A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
 Don't render the map after every exchange — do it at meaningful transitions. If the user has just seen a similar state, skip it.
 
@@ -240,7 +207,7 @@ Note the concern in the Summary section for the user to consider separately, and
 
    **STOP.** Wait for user response.
 
-   A chosen candidate is the target; `new` means propose a kebab-case name and confirm it. If the resolved target is the current topic (`{topic}`), it's a detail of this discussion, not a reroute — add it to the Discussion Map as a `pending` subtopic and → Return to **B. Session Loop**.
+   A chosen candidate is the target; `new` means propose a kebab-case name and confirm it. If the resolved target is the current topic (`{topic}`), it's a detail of this discussion, not a reroute — record it as a `pending` subtopic (`map add`, session loop step 2) and → Return to **B. Session Loop**.
 
 2. Record the concern with the full context discussed about it as `concern` — the target topic picks it up cold.
 
@@ -267,15 +234,19 @@ Leave it as a subtopic on the map.
 
 Convergence is the natural end state — not a forced conclusion. The discussion converges when:
 
-- All subtopics on the Discussion Map are `decided` (or deliberately deferred)
+- All subtopics on the Discussion Map are `decided` (or `deferred`)
 - Neither you nor the user can identify new subtopics without breaking scope
 - At least one review cycle has completed (see safety net below)
 
-**Before rendering the convergence menu, verify:**
+**Before rendering the convergence menu**, run the map call:
 
-Count review files in `.workflows/.cache/{work_unit}/discussion/{topic}/`.
+```bash
+node .claude/skills/workflow-discussion-process/scripts/discovery.cjs map {work_unit} {topic}
+```
 
-#### If zero review files exist
+Its DATA section carries the convergence facts: `all_decided` and `review_cycles`.
+
+#### If `review_cycles` is 0
 
 > *Output the next fenced block as a code block:*
 
@@ -289,9 +260,9 @@ Dispatch a review agent as a foreground task (not background — results are nee
 
 → Return to **B. Session Loop**.
 
-#### If review files exist
+#### If `review_cycles` is at least 1
 
-**When convergence is reached:**
+**When convergence is reached** (`all_decided` is true):
 
 > *Output the next fenced block as a code block:*
 
@@ -328,9 +299,15 @@ Continue the discussion. The user may want to revisit a decision, explore an edg
 
 When the user indicates they want to conclude the discussion (e.g., "that covers it", "let's wrap up", "I think we're done") before natural convergence:
 
-**First, check the review safety net:** Count review files in `.workflows/.cache/{work_unit}/discussion/{topic}/`.
+**First**, run the map call:
 
-**If zero review files exist:**
+```bash
+node .claude/skills/workflow-discussion-process/scripts/discovery.cjs map {work_unit} {topic}
+```
+
+Its DATA section carries everything this flow needs: `all_decided`, `unresolved`, `review_cycles`.
+
+**If `review_cycles` is 0:**
 
 > *Output the next fenced block as a code block:*
 
@@ -342,13 +319,13 @@ When the user indicates they want to conclude the discussion (e.g., "that covers
 
 Dispatch a review agent as a foreground task (not background — results are needed before concluding). Follow **A. Dispatch** in review-agent.md but omit `run_in_background`. When results return, delegate to **B. Check and Surface** in review-agent.md — the shared surfacing protocol applies the never-dump rules and presents findings one at a time. Then continue with the conclusion flow below.
 
-**If review files exist:**
+**If `review_cycles` is at least 1:**
 
 Continue with the conclusion flow below.
 
-#### If there are subtopics still `pending` or `exploring`
+#### If `all_decided` is false
 
-Render the Discussion Map and note which subtopics are unresolved.
+Emit the map call's DISPLAY section verbatim as a code block, then ({N} = the length of `unresolved`):
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -356,9 +333,11 @@ Render the Discussion Map and note which subtopics are unresolved.
 · · · · · · · · · · · ·
 There are still {N} subtopics not yet decided:
 
-{list of pending/exploring subtopics}
+@foreach(name in unresolved)
+- {name:(titlecase)}
+@endforeach
 
-- **`y`/`yes`** — Conclude anyway (unresolved items noted in Summary)
+- **`y`/`yes`** — Conclude anyway (unresolved items deferred and noted in Summary)
 - **`n`/`no`** — Continue discussing
 · · · · · · · · · · · ·
 ```
@@ -367,7 +346,13 @@ There are still {N} subtopics not yet decided:
 
 **If `yes`:**
 
-Note unresolved subtopics in the Summary → Open Threads section of the discussion file. Commit.
+Set each `unresolved` subtopic to `deferred`:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs map set {work_unit} {topic} {subtopic} deferred
+```
+
+Note them in the Summary → Open Threads section of the discussion file. Commit.
 
 → Return to caller.
 
@@ -375,7 +360,7 @@ Note unresolved subtopics in the Summary → Open Threads section of the discuss
 
 → Return to **B. Session Loop**.
 
-#### If all subtopics are `decided`
+#### If `all_decided` is true
 
 Check for in-flight agents. If agents are still running:
 

--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -26,9 +26,15 @@ Discussion is higher-stakes than research for this check. The Context → Option
 
 Read the discussion file in full: `.workflows/{work_unit}/discussion/{topic}.md`
 
-Pull the current state fresh into context — don't rely on your memory of what you wrote earlier. Pay particular attention to:
+Pull the current Discussion Map state fresh as well:
 
-- The **Discussion Map** and every subtopic's state
+```bash
+node .claude/skills/workflow-discussion-process/scripts/discovery.cjs map {work_unit} {topic}
+```
+
+Don't rely on your memory of what you wrote earlier. Pay particular attention to:
+
+- The **Discussion Map** — every subtopic's state from the call's DATA section
 - Each subtopic section (Context → Options → Journey → Decision)
 - The **Summary** section (Key Insights, Open Threads, Current State)
 - The **Triage** section — it must read `(none)` by conclusion
@@ -45,13 +51,13 @@ Walk the conversation against the document and check three dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user pushback, competing options understated to make the chosen one look cleaner, or a subtopic marked `decided` on the Discussion Map when it was really `converging`. Check the Discussion Map itself for drift — child subtopics absorbed into a parent decision when they weren't fully resolved, Open Threads in the Summary that don't match what was actually left unresolved in the conversation.
 
-4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the working content — a `pending` subtopic on the Discussion Map plus a seeded `## {title}` section — and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
+4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the working content — a `pending` subtopic on the Discussion Map (engine `map add`) plus a seeded `## {title}` section — and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
 
 **Apply the reconciliation.** For each finding:
 
 - Gap → add the missing substance to the discussion file at the appropriate place (subtopic section, Journey, or Summary)
 - Hallucination → remove or correct to match what was discussed
-- Drift → rewrite to faithfully reflect the conversation; correct Discussion Map states where needed
+- Drift → rewrite to faithfully reflect the conversation; correct Discussion Map states where needed (`node .claude/skills/workflow-engine/scripts/engine.cjs map set {work_unit} {topic} {subtopic} {state}`)
 - Undrained Triage entry → fold into the Discussion Map and a subtopic section, then reset `## Triage` to `(none)`; restore the placeholder if it drifted
 
 Commit the changes with a descriptive message (e.g., `docs(discussion): capture undocumented trade-off thread`, `docs(discussion): correct drift on caching decision`, `docs(discussion): soften Map state to converging`).

--- a/skills/workflow-discussion-process/references/guidelines.md
+++ b/skills/workflow-discussion-process/references/guidelines.md
@@ -59,14 +59,13 @@ Best practices for documenting discussions. For DOCUMENTATION only - no plans or
 
 At natural pauses — not every exchange, but when something meaningful has been completed, explored, or uncovered — update the file on disk:
 
-- Update Discussion Map states as subtopics progress
+- Record Discussion Map state changes as subtopics progress (engine `map set`) and new subtopics as they emerge (engine `map add`)
 - Document subtopics when they reach `decided`
-- Add new subtopics to the map as they emerge
 - Document false paths when identified
 - Record decisions (even provisional ones) with rationale
 - Capture provisional thinking for in-progress subtopics before context refresh
 
-Then commit. The file is the source of truth, not the conversation.
+Then commit. The file and manifest are the source of truth, not the conversation.
 
 ## Common Pitfalls
 
@@ -83,7 +82,7 @@ Then commit. The file is the source of truth, not the conversation.
 ## Quality Check
 
 Before marking discussion complete:
-- ✅ All Discussion Map subtopics are `decided` or deliberately deferred
+- ✅ All Discussion Map subtopics are `decided` or `deferred`
 - ✅ Context clear
 - ✅ Options explored with trade-offs
 - ✅ False paths documented

--- a/skills/workflow-discussion-process/references/initialize-discussion.md
+++ b/skills/workflow-discussion-process/references/initialize-discussion.md
@@ -9,21 +9,25 @@
 → Load **[../../workflow-shared/references/read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 1. Ensure the discussion directory exists: `.workflows/{work_unit}/discussion/`
-2. Load **[template.md](template.md)** — use it to create the discussion file at `.workflows/{work_unit}/discussion/{topic}.md`. Include the terminal `## Triage` section seeded as `(none)`.
-3. Populate Context section and seed the Discussion Map:
-
-   **If the handoff includes a `Research files:` section:**
-
-   Read each listed research file using the Read tool. Use the full research content — guided by the `Topic context` field — to populate the Context section and derive initial subtopics for the Discussion Map. Seed subtopics should represent the key concerns, decisions, and questions that emerged from research. Set all initial subtopics to `pending`.
-
-   **Otherwise:**
-
-   Populate from the seed, handoff context, and user input. Derive initial subtopics from whatever context is available — the seed, the user's description, the topic itself, obvious architectural concerns. These are seeds, not a complete list — the map will grow during discussion.
-
-4. Register discussion in manifest:
+2. Register the discussion in the manifest (the map commands below require the item to exist):
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.discussion.{topic}
    ```
-5. Commit the initial file
+3. Load **[template.md](template.md)** — use it to create the discussion file at `.workflows/{work_unit}/discussion/{topic}.md`. Include the terminal `## Triage` section seeded as `(none)`.
+4. Populate the Context section and derive the initial subtopics:
+
+   **If the handoff includes a `Research files:` section:**
+
+   Read each listed research file using the Read tool. Use the full research content — guided by the `Topic context` field — to populate the Context section and derive initial subtopics. Seed subtopics should represent the key concerns, decisions, and questions that emerged from research.
+
+   **Otherwise:**
+
+   Populate from the seed, handoff context, and user input. Derive initial subtopics from whatever context is available — the seed, the user's description, the topic itself, obvious architectural concerns. These are seeds, not a complete list — the map grows during discussion.
+
+5. Seed the Discussion Map — record each initial subtopic (kebab-case name; new subtopics start `pending`):
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs map add {work_unit} {topic} {subtopic}
+   ```
+6. Commit the discussion file and manifest
 
 → Return to caller.

--- a/skills/workflow-discussion-process/references/perspective-agents.md
+++ b/skills/workflow-discussion-process/references/perspective-agents.md
@@ -171,6 +171,6 @@ This section handles two responsibilities: promoting completed perspective sets 
 
 → Load **[background-agent-surfacing.md](../../workflow-shared/references/background-agent-surfacing.md)** with agent_type = `synthesis`, cache_dir = `.workflows/.cache/{work_unit}/discussion/{topic}`, cache_glob = `synthesis-*.md`, findings_key = `tensions`.
 
-**Deriving subtopics during presentation**: When the user engages with a raised tension, reframe it as a practical subtopic tied to project constraints and add it to the Discussion Map as `pending`. Commit the update.
+**Deriving subtopics during presentation**: When the user engages with a raised tension, reframe it as a practical subtopic tied to project constraints and record it on the Discussion Map as `pending` (`node .claude/skills/workflow-engine/scripts/engine.cjs map add {work_unit} {topic} {subtopic}`). Commit the update.
 
 **Perspective files**: The shared protocol handles the synthesis file only. The individual perspective files remain available for reference if the user wants to drill into a specific angle — mention their existence during presentation if relevant, but do not read them out.

--- a/skills/workflow-discussion-process/references/review-agent.md
+++ b/skills/workflow-discussion-process/references/review-agent.md
@@ -93,6 +93,6 @@ Delegate all check-for-results and presentation behaviour to the shared surfacin
 
 → Load **[background-agent-surfacing.md](../../workflow-shared/references/background-agent-surfacing.md)** with agent_type = `review`, cache_dir = `.workflows/.cache/{work_unit}/discussion/{topic}`, cache_glob = `review-*.md`, findings_key = `findings`.
 
-**Deriving subtopics during presentation**: When the user engages with a raised finding, reframe it as a practical concern tied to project constraints and add it to the Discussion Map as a `pending` subtopic. Commit the update.
+**Deriving subtopics during presentation**: When the user engages with a raised finding, reframe it as a practical concern tied to project constraints and record it on the Discussion Map as a `pending` subtopic (`node .claude/skills/workflow-engine/scripts/engine.cjs map add {work_unit} {topic} {subtopic}`). Commit the update.
 
 **Findings the user deflects**: If the user doesn't want to engage with a finding you raised, note it in the Summary → Open Threads section of the discussion file.

--- a/skills/workflow-discussion-process/references/template.md
+++ b/skills/workflow-discussion-process/references/template.md
@@ -24,32 +24,9 @@ What this is about, why we're discussing it, the problem or opportunity, current
 - [Related spec or doc](link)
 - [Prior discussion](link)
 
-## Discussion Map
-
-A living index of subtopics tracked during the discussion. This is the structural backbone — it grows as the conversation branches, and converges as decisions land. You maintain this section throughout.
-
-### States
-
-- **pending** (`○`) — identified but not yet explored
-- **exploring** (`◐`) — actively being discussed
-- **converging** (`→`) — narrowing toward a decision
-- **decided** (`✓`) — decision reached with rationale documented
-
-### Map
-
-  Discussion Map — {Topic} ({total} subtopics{state_breakdown})
-
-  ┌─ ✓ {Subtopic A} [decided]
-  │  ├─ ✓ {Child subtopic} [decided]
-  │  └─ → {Child subtopic} [converging]
-  ├─ ◐ {Subtopic B} [exploring]
-  │  ├─ ◐ {Child subtopic} [exploring]
-  │  └─ ○ {Child subtopic} [pending]
-  └─ ○ {Subtopic C} [pending]
-
 ---
 
-*Subtopics are documented below as they reach `decided` or accumulate enough exploration to capture. Not every subtopic needs its own section — minor items resolved in passing can be folded into their parent.*
+*Subtopics are documented below as they reach `decided` or accumulate enough exploration to capture. Not every subtopic needs its own section — minor items resolved in passing can be folded into their parent. The Discussion Map (which subtopics exist and their states) lives in the manifest, not this file.*
 
 ---
 
@@ -112,14 +89,13 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 1. Ensure discussion directory exists: `.workflows/{work_unit}/discussion/`
 2. Create file: `.workflows/{work_unit}/discussion/{topic}.md`
 3. Start with context: why discussing?
-4. Seed the Discussion Map with initial subtopics (derived from research, handoff, or user input)
-5. Set status via manifest CLI (the skill handles this)
+4. Register in the manifest and seed the Discussion Map via the engine `map add` command (the skill handles this)
 
 **During discussion**:
 - Follow the conversation organically — don't force a rigid question order
-- Update the Discussion Map as subtopics are identified, explored, and decided
+- Track subtopics on the Discussion Map (manifest state, maintained via the engine `map` commands)
 - Document subtopics when they reach `decided` (or accumulate enough exploration to capture)
-- New subtopics emerge naturally — add them to the map as `pending`
+- New subtopics emerge naturally — record them on the map as `pending`
 - Minor items resolved in passing can be folded into their parent subtopic's documentation
 
 **Per-subtopic structure** (when documenting):
@@ -128,9 +104,9 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 - **Journey**: The exploration — what we thought, what changed, false paths, debates, insights
 - **Decision**: What we chose, why, the deciding factor
 
-**Discussion Map maintenance**:
-- Update states as the conversation progresses
-- New child subtopics can be added under parents
+**Discussion Map**:
+- Subtopic states (`pending`, `exploring`, `converging`, `decided`, `deferred`) live in the manifest — the file holds the knowledge, the map holds the live state
+- New child subtopics can be added under top-level parents (two levels max)
 - The map is the user's visibility into discussion shape and your tracking mechanism
 
 **Flexibility**: Not every subtopic needs all sections. Some have clear options with pros/cons. Some have heated debate worth capturing. Some are straightforward. Document what naturally came up — don't force structure onto a simple discussion.
@@ -146,7 +122,7 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 - `## Triage` is a fixed terminal landing zone for off-topic concerns rerouted from other topics; working discussion content stays above it; left as `(none)` until an entry lands
 
 **Complete when**:
-- All subtopics on the Discussion Map are `decided` (or deliberately deferred)
+- All subtopics on the Discussion Map are `decided` (or `deferred`)
 - Trade-offs understood
 - Path forward clear
 - No new subtopics emerging without breaking scope

--- a/skills/workflow-discussion-process/scripts/discovery.cjs
+++ b/skills/workflow-discussion-process/scripts/discovery.cjs
@@ -1,0 +1,51 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Adapter (read gateway) for workflow-discussion-process. Thin by design:
+// map state and rendering live in the engine; this script selects the
+// answers the session flow needs and sections the output.
+//
+//   discovery.cjs map {work_unit} {topic}
+//     → DATA (counts, all_decided, unresolved, review_cycles)
+//       + DISPLAY (the Discussion Map block)
+// ---------------------------------------------------------------------------
+
+const fs = require('fs');
+const path = require('path');
+const engine = require('../../workflow-engine/scripts/lib.cjs');
+
+// Completed review cycles = review-*.md files in the topic's discussion cache.
+function reviewCycles(cwd, workUnit, topic) {
+  const dir = path.join(cwd, '.workflows', '.cache', workUnit, 'discussion', topic);
+  try {
+    return fs.readdirSync(dir).filter((f) => /^review-.*\.md$/.test(f)).length;
+  } catch {
+    return 0;
+  }
+}
+
+function map(workUnit, topic) {
+  if (!workUnit || !topic) {
+    throw new Error('Usage: discovery.cjs map {work_unit} {topic}');
+  }
+  const cwd = process.cwd();
+  const manifest = engine.manifest.loadWorkUnitManifest(cwd, workUnit);
+  const state = engine.map.mapState(manifest, topic);
+
+  return [
+    engine.gateway.dataBlock({
+      topic,
+      counts: state.counts,
+      all_decided: state.all_decided,
+      unresolved: state.unresolved,
+      review_cycles: reviewCycles(cwd, workUnit, topic),
+    }),
+    engine.gateway.displayBlock(engine.project.discussionMap(topic, manifest)),
+  ].join('\n');
+}
+
+if (require.main === module) {
+  engine.gateway.runGateway({ map });
+}
+
+module.exports = { map };

--- a/skills/workflow-engine/SKILL.md
+++ b/skills/workflow-engine/SKILL.md
@@ -29,6 +29,15 @@ node .claude/skills/workflow-engine/scripts/engine.cjs <command> [args]
 
 Domain commands (state transitions, queries) land here as they are built.
 
+**`map`** — discussion-map transitions. Both commands load the work unit's manifest, apply the transition, save atomically, and print one decision-ready JSON line: `{"ok": true, "subtopic": "…", "status": "…", "all_decided": false, "unresolved_count": N}` — no follow-up read needed. Errors print `{"ok": false, "error": "…"}` to stderr and exit 1. No git commit — the calling session's commit cadence picks the manifest change up.
+
+```bash
+engine map add <work-unit> <topic> <subtopic> [--parent <subtopic>]   # new subtopic, starts pending
+engine map set <work-unit> <topic> <subtopic> <state>                 # pending|exploring|converging|decided|deferred
+```
+
+Subtopic names are kebab-case slugs; `--parent` nests under an existing top-level subtopic (two levels max).
+
 **Rendering is not a runtime CLI concern.** Static chrome (signposts, boxes, gate rules) lives as literal blocks in skill prose; parameterised chrome is rendered in-process by projections. No skill flow calls a render command at runtime — the `render` command group in `engine.cjs` is a development/debugging utility only (e.g. generating a correct literal while authoring prose).
 
 ## Library — `scripts/lib.cjs`
@@ -44,6 +53,10 @@ engine.render.wrapWithPrefix(text, { width, prefix }) // → string[] (prefixed 
 engine.render.wrap(text, budget)                  // → string[] (segments ≤ budget)
 engine.render.fillTo(head, fillChar, width)       // → string (padded)
 
+// kernel: manifest IO
+engine.manifest.loadWorkUnitManifest(cwd, wu)     // → parsed manifest (loud on missing/invalid)
+engine.manifest.saveWorkUnitManifest(cwd, wu, m)  // atomic write (temp file + rename)
+
 // domain: composition conventions
 engine.conventions.title({ glyph, label, tag })   // → "◐ Menu And Admin [researching]"
 engine.conventions.tag('decided')                 // → "[decided]"
@@ -52,11 +65,17 @@ engine.conventions.discoveryGlyph('researching')  // → "◐"
 engine.conventions.titlecase('auth-flow')         // → "Auth Flow"
 engine.conventions.TREE_WIDTH                     // 65 — tree content width incl. gutter
 
+// domain: discussion-map transitions + queries
+engine.map.addSubtopic(manifest, topic, name, { parent }) // mutates; new subtopic starts pending
+engine.map.setSubtopicState(manifest, topic, name, state) // mutates; enum is the only constraint
+engine.map.mapState(manifest, topic)              // → { counts, total, all_decided, unresolved }
+
 // domain: detail builders + projections
 engine.detail.epicDetail(cwd, manifest)           // → EpicDetail (the one structured object per epic)
 engine.project.epicDashboard(wu, detail, { newArrivals }) // → dashboard display block
 engine.project.epicKey(detail)                    // → Key block ('' for a brand-new epic)
 engine.project.epicMenu(wu, detail)               // → { keys, rendered } — keys carry action + route
+engine.project.discussionMap(topic, manifest)     // → Discussion Map display block
 
 // gateway: adapter harness
 engine.gateway.runGateway(handlers)               // argv verb dispatch → stdout
@@ -84,4 +103,4 @@ The .md's prescribed call names the verb (`discovery.cjs view {work_unit}`) — 
 
 ## Tests
 
-`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, and `tests/scripts/test-engine-epic-projections.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.
+`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, `tests/scripts/test-engine-epic-projections.cjs`, and `tests/scripts/test-engine-map.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.

--- a/skills/workflow-engine/scripts/domain/conventions.cjs
+++ b/skills/workflow-engine/scripts/domain/conventions.cjs
@@ -72,4 +72,22 @@ function discoveryGlyph(tier) {
   return DISCOVERY_GLYPH[/** @type {keyof typeof DISCOVERY_GLYPH} */ (tier)] || '';
 }
 
-module.exports = { TREE_WIDTH, capitalise, titlecase, tag, derivedFrom, title, discoveryGlyph, DISCOVERY_GLYPH };
+// Discussion-map glyph vocabulary — subtopic states. Distinct from the
+// discovery tiers: the symbol sets evolve independently.
+const DISCUSSION_GLYPH = {
+  pending: '○',
+  exploring: '◐',
+  converging: '→',
+  decided: '✓',
+  deferred: '⊙',
+};
+
+/** @param {string} state */
+function discussionGlyph(state) {
+  return DISCUSSION_GLYPH[/** @type {keyof typeof DISCUSSION_GLYPH} */ (state)] || '';
+}
+
+module.exports = {
+  TREE_WIDTH, capitalise, titlecase, tag, derivedFrom, title,
+  discoveryGlyph, DISCOVERY_GLYPH, discussionGlyph, DISCUSSION_GLYPH,
+};

--- a/skills/workflow-engine/scripts/domain/map.cjs
+++ b/skills/workflow-engine/scripts/domain/map.cjs
@@ -1,0 +1,147 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: the discussion map — typed subtopic state under a discussion
+// item (`phases.discussion.items.{topic}.subtopics`).
+//
+// Judgment decides, code records: the conversation makes every state call;
+// these transitions validate and write it. Two levels max — a subtopic's
+// `parent` names another subtopic that is itself top-level. Subtopic keys are
+// kebab-case slugs (display titlecases them); insertion order is render
+// order. All errors throw loud and specific.
+// ---------------------------------------------------------------------------
+
+const SUBTOPIC_STATES = ['pending', 'exploring', 'converging', 'decided', 'deferred'];
+
+const SLUG_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/**
+ * @typedef {object} Subtopic
+ * @property {string} status       `pending` | `exploring` | `converging` | `decided` | `deferred`
+ * @property {string|null} parent  another subtopic's key (itself top-level), or null
+ */
+
+/**
+ * @typedef {object} SubtopicCounts
+ * @property {number} pending
+ * @property {number} exploring
+ * @property {number} converging
+ * @property {number} decided
+ * @property {number} deferred
+ */
+
+/**
+ * @typedef {object} MapState
+ * @property {SubtopicCounts} counts
+ * @property {number} total
+ * @property {boolean} all_decided  every subtopic `decided` or `deferred`; false when zero subtopics
+ * @property {string[]} unresolved  names not `decided`/`deferred`, insertion order
+ */
+
+/**
+ * The discussion item for `topic`, or a loud error.
+ * @param {object} manifest @param {string} topic
+ * @returns {{status?: string, subtopics?: Record<string, Subtopic>}}
+ */
+function discussionItem(manifest, topic) {
+  const items = manifest && manifest.phases && manifest.phases.discussion && manifest.phases.discussion.items;
+  const item = items && typeof items === 'object' ? items[topic] : undefined;
+  if (!item || typeof item !== 'object') {
+    throw new Error(`no discussion item "${topic}" in the manifest (phases.discussion.items)`);
+  }
+  return item;
+}
+
+/**
+ * The subtopics record of a discussion item ({} when none yet).
+ * @param {object} manifest @param {string} topic
+ * @returns {Record<string, Subtopic>}
+ */
+function subtopicsOf(manifest, topic) {
+  const item = discussionItem(manifest, topic);
+  return item.subtopics && typeof item.subtopics === 'object' ? item.subtopics : {};
+}
+
+/**
+ * Add a subtopic to a discussion item's map. New subtopics start `pending`.
+ * @param {object} manifest
+ * @param {string} topic
+ * @param {string} name           kebab-case slug
+ * @param {{parent?: string|null}} [opts]  nest under this top-level subtopic
+ * @returns {Subtopic} the new subtopic
+ */
+function addSubtopic(manifest, topic, name, { parent = null } = {}) {
+  const item = discussionItem(manifest, topic);
+  if (!name || !SLUG_RE.test(name)) {
+    throw new Error(`subtopic name must be a kebab-case slug (got "${name}")`);
+  }
+  if (!item.subtopics || typeof item.subtopics !== 'object') item.subtopics = {};
+  const subtopics = item.subtopics;
+  if (subtopics[name]) {
+    throw new Error(`subtopic "${name}" already exists under "${topic}"`);
+  }
+  if (parent !== null) {
+    const parentSub = subtopics[parent];
+    if (!parentSub) {
+      throw new Error(`parent subtopic "${parent}" not found under "${topic}"`);
+    }
+    if (parentSub.parent !== null) {
+      throw new Error(`"${parent}" is itself a child of "${parentSub.parent}" — the map is two levels max`);
+    }
+  }
+  subtopics[name] = { status: 'pending', parent };
+  return subtopics[name];
+}
+
+/**
+ * Record a subtopic state. Any state → any state is legal (judgment may
+ * revisit); the enum is the only constraint.
+ * @param {object} manifest
+ * @param {string} topic
+ * @param {string} name
+ * @param {string} state  one of SUBTOPIC_STATES
+ * @returns {Subtopic} the updated subtopic
+ */
+function setSubtopicState(manifest, topic, name, state) {
+  if (!SUBTOPIC_STATES.includes(state)) {
+    throw new Error(`unknown subtopic state "${state}" (${SUBTOPIC_STATES.join('|')})`);
+  }
+  const subtopics = subtopicsOf(manifest, topic);
+  const sub = subtopics[name];
+  if (!sub) {
+    throw new Error(`subtopic "${name}" not found under "${topic}"`);
+  }
+  sub.status = state;
+  return sub;
+}
+
+/**
+ * Derived, decision-ready state of one discussion item's map.
+ * @param {object} manifest @param {string} topic
+ * @returns {MapState}
+ */
+function mapState(manifest, topic) {
+  const subtopics = subtopicsOf(manifest, topic);
+  /** @type {SubtopicCounts} */
+  const counts = { pending: 0, exploring: 0, converging: 0, decided: 0, deferred: 0 };
+  /** @type {string[]} */
+  const unresolved = [];
+  let total = 0;
+  for (const [name, sub] of Object.entries(subtopics)) {
+    const status = sub && sub.status;
+    if (!SUBTOPIC_STATES.includes(/** @type {string} */ (status))) {
+      throw new Error(`subtopic "${name}" under "${topic}" has unknown state "${status}"`);
+    }
+    counts[/** @type {keyof SubtopicCounts} */ (status)] += 1;
+    total += 1;
+    if (status !== 'decided' && status !== 'deferred') unresolved.push(name);
+  }
+  return {
+    counts,
+    total,
+    all_decided: total > 0 && unresolved.length === 0,
+    unresolved,
+  };
+}
+
+module.exports = { SUBTOPIC_STATES, addSubtopic, setSubtopicState, mapState, subtopicsOf };

--- a/skills/workflow-engine/scripts/domain/projections/discussion.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/discussion.cjs
@@ -59,7 +59,7 @@ function discussionMap(topic, manifest) {
       (parent.children = parent.children || []).push(node);
     }
   }
-  return header + '\n\n' + renderTree(top, { width: TREE_WIDTH });
+  return header + '\n' + renderTree(top, { width: TREE_WIDTH });
 }
 
 module.exports = { discussionMap };

--- a/skills/workflow-engine/scripts/domain/projections/discussion.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/discussion.cjs
@@ -1,0 +1,65 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: discussion projections — the Discussion Map view over one
+// discussion item's subtopics (see ../map.cjs).
+//
+// Deterministic: same manifest, same string. Rows hang off the header via the
+// kernel tree (├─/└─); insertion order is render order; children nest under
+// their parent, two levels max.
+// ---------------------------------------------------------------------------
+
+const { renderTree } = require('../../kernel/render.cjs');
+const { TREE_WIDTH, titlecase, title, discussionGlyph } = require('../conventions.cjs');
+const { mapState, subtopicsOf } = require('../map.cjs');
+
+/** @typedef {import('../../kernel/render.cjs').TreeNode} TreeNode */
+/** @typedef {import('../map.cjs').SubtopicCounts} SubtopicCounts */
+
+// Breakdown categories in display order. Omitted entirely when only one
+// category is non-zero (the rows already say it).
+const BREAKDOWN_ORDER = /** @type {(keyof SubtopicCounts)[]} */ (
+  ['decided', 'converging', 'exploring', 'pending', 'deferred']
+);
+
+/** @param {SubtopicCounts} counts */
+function breakdown(counts) {
+  const present = BREAKDOWN_ORDER.filter((s) => counts[s] > 0);
+  if (present.length <= 1) return '';
+  return ' — ' + present.map((s) => `${counts[s]} ${s}`).join(' · ');
+}
+
+/**
+ * The Discussion Map display block: header + two-level subtopic tree.
+ * @param {string} topic
+ * @param {object} manifest
+ * @returns {string}
+ */
+function discussionMap(topic, manifest) {
+  const state = mapState(manifest, topic);
+  const subtopics = subtopicsOf(manifest, topic);
+
+  const header = `  Discussion Map — ${titlecase(topic)} `
+    + `(${state.total} subtopic${state.total === 1 ? '' : 's'}${breakdown(state.counts)})`;
+  if (state.total === 0) return header + '\n';
+
+  /** @type {TreeNode[]} */
+  const top = [];
+  /** @type {Map<string, TreeNode>} */
+  const byName = new Map();
+  for (const [name, sub] of Object.entries(subtopics)) {
+    /** @type {TreeNode} */
+    const node = { title: title({ glyph: discussionGlyph(sub.status), label: titlecase(name), tag: sub.status }) };
+    byName.set(name, node);
+    if (sub.parent === null || sub.parent === undefined) {
+      top.push(node);
+    } else {
+      const parent = byName.get(sub.parent);
+      if (!parent) throw new Error(`subtopic "${name}" references missing parent "${sub.parent}"`);
+      (parent.children = parent.children || []).push(node);
+    }
+  }
+  return header + '\n\n' + renderTree(top, { width: TREE_WIDTH });
+}
+
+module.exports = { discussionMap };

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -16,6 +16,8 @@
 
 const fs = require('fs');
 const { signpost, box, wrapWithPrefix, renderTree, WIDTH } = require('./kernel/render.cjs');
+const { loadWorkUnitManifest, saveWorkUnitManifest } = require('./kernel/manifest.cjs');
+const { addSubtopic, setSubtopicState, mapState, SUBTOPIC_STATES } = require('./domain/map.cjs');
 
 /** @param {string} msg @returns {never} */
 function die(msg) {
@@ -44,10 +46,63 @@ function parseArgs(argv) {
 const USAGE = `Usage: engine <command> [args]
 
 Commands:
+  map add <work-unit> <topic> <subtopic> [--parent <subtopic>]
+  map set <work-unit> <topic> <subtopic> <state>
   render signpost <label> [--style step|substep] [--width N]
   render box <title> [--width N]
   render wrap <text> [--width N] [--prefix STR]
   render tree [--width N]            (reads a JSON TreeNode array on stdin)`;
+
+// ---------------------------------------------------------------------------
+// map — discussion-map transitions. Load (kernel) → apply (domain) → save →
+// one decision-ready JSON line, so the flow needs no follow-up read. No git
+// commit here: the session's commit cadence picks the manifest change up.
+// ---------------------------------------------------------------------------
+
+/** @param {string[]} argv */
+function runMap(argv) {
+  const [command, ...rest] = argv;
+  const { opts, positional } = parseArgs(rest);
+  const cwd = process.cwd();
+
+  try {
+    const [workUnit, topic, subtopic, state] = positional;
+    if (command === 'add') {
+      if (!workUnit || !topic || !subtopic) {
+        throw new Error('Usage: engine map add <work-unit> <topic> <subtopic> [--parent <subtopic>]');
+      }
+      const manifest = loadWorkUnitManifest(cwd, workUnit);
+      const sub = addSubtopic(manifest, topic, subtopic, { parent: opts.parent ?? null });
+      saveWorkUnitManifest(cwd, workUnit, manifest);
+      respondMap(manifest, topic, subtopic, sub.status);
+    } else if (command === 'set') {
+      if (!workUnit || !topic || !subtopic || !state) {
+        throw new Error(`Usage: engine map set <work-unit> <topic> <subtopic> <${SUBTOPIC_STATES.join('|')}>`);
+      }
+      const manifest = loadWorkUnitManifest(cwd, workUnit);
+      const sub = setSubtopicState(manifest, topic, subtopic, state);
+      saveWorkUnitManifest(cwd, workUnit, manifest);
+      respondMap(manifest, topic, subtopic, sub.status);
+    } else {
+      throw new Error('Usage: engine map <add|set> …');
+    }
+  } catch (err) {
+    process.stderr.write(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }) + '\n');
+    process.exit(1);
+  }
+}
+
+/** @param {object} manifest @param {string} topic @param {string} subtopic @param {string} status */
+function respondMap(manifest, topic, subtopic, status) {
+  const state = mapState(manifest, topic);
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    subtopic,
+    status,
+    all_decided: state.all_decided,
+    unresolved_count: state.unresolved.length,
+  }) + '\n');
+}
 
 /** @param {string[]} argv */
 function runRender(argv) {
@@ -85,6 +140,9 @@ function runRender(argv) {
 function runCli(argv) {
   const [command, ...rest] = argv;
   switch (command) {
+    case 'map':
+      runMap(rest);
+      break;
     case 'render':
       runRender(rest);
       break;

--- a/skills/workflow-engine/scripts/kernel/manifest.cjs
+++ b/skills/workflow-engine/scripts/kernel/manifest.cjs
@@ -1,0 +1,55 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Kernel: manifest IO — load and save one work unit's manifest.json.
+//
+// Mechanism only: file location, parse, atomic write. It knows nothing about
+// what the manifest contains. Saves go through a temp file in the same
+// directory followed by a rename, so a crash mid-write can never leave a
+// truncated manifest behind.
+// ---------------------------------------------------------------------------
+
+const fs = require('fs');
+const path = require('path');
+
+/** @param {string} cwd @param {string} workUnit */
+function manifestPath(cwd, workUnit) {
+  return path.join(cwd, '.workflows', workUnit, 'manifest.json');
+}
+
+/**
+ * Load and parse one work unit's manifest.
+ * @param {string} cwd      project root (the directory containing `.workflows/`)
+ * @param {string} workUnit
+ * @returns {object}
+ */
+function loadWorkUnitManifest(cwd, workUnit) {
+  const file = manifestPath(cwd, workUnit);
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    throw new Error(`manifest not found: ${file}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`invalid JSON in ${file}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/**
+ * Save one work unit's manifest atomically (temp file in the same directory,
+ * then rename over the target).
+ * @param {string} cwd
+ * @param {string} workUnit
+ * @param {object} manifest
+ */
+function saveWorkUnitManifest(cwd, workUnit, manifest) {
+  const file = manifestPath(cwd, workUnit);
+  const tmp = path.join(path.dirname(file), `.manifest.json.${process.pid}.tmp`);
+  fs.writeFileSync(tmp, JSON.stringify(manifest, null, 2) + '\n');
+  fs.renameSync(tmp, file);
+}
+
+module.exports = { loadWorkUnitManifest, saveWorkUnitManifest };

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -7,9 +7,11 @@
 //
 // Rings:
 //   engine.render       kernel — pure layout (no workflow vocabulary)
+//   engine.manifest     kernel — work-unit manifest IO (load / atomic save)
 //   engine.conventions  domain — workflow glyphs, tags, title composition
+//   engine.map          domain — discussion-map transitions + queries
 //   engine.detail       domain — detail builders (the one structured object per work unit)
-//   engine.project      domain — projections (dashboard / key / menu views over a detail)
+//   engine.project      domain — projections (dashboard / key / menu / map views)
 //   engine.gateway      adapter harness — verb dispatch + output sections
 //
 // Domain queries, projections, and transitions grow here as call sites
@@ -17,19 +19,30 @@
 // ---------------------------------------------------------------------------
 
 const render = require('./kernel/render.cjs');
+const manifest = require('./kernel/manifest.cjs');
 const conventions = require('./domain/conventions.cjs');
 const gateway = require('./gateway.cjs');
 const epic = require('./domain/epic.cjs');
+const map = require('./domain/map.cjs');
 const epicProjections = require('./domain/projections/epic.cjs');
+const discussionProjections = require('./domain/projections/discussion.cjs');
 
 module.exports = {
   render,
+  manifest,
   conventions,
   gateway,
+  map: {
+    addSubtopic: map.addSubtopic,
+    setSubtopicState: map.setSubtopicState,
+    mapState: map.mapState,
+    SUBTOPIC_STATES: map.SUBTOPIC_STATES,
+  },
   detail: { epicDetail: epic.epicDetail, EPIC_PHASES: epic.EPIC_PHASES },
   project: {
     epicDashboard: epicProjections.epicDashboard,
     epicKey: epicProjections.epicKey,
     epicMenu: epicProjections.epicMenu,
+    discussionMap: discussionProjections.discussionMap,
   },
 };

--- a/skills/workflow-migrate/scripts/migrations/047-discussion-map-to-manifest.sh
+++ b/skills/workflow-migrate/scripts/migrations/047-discussion-map-to-manifest.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+#
+# Migration 047: Discussion map to manifest
+#
+# The Discussion Map moved from a section inside the discussion file to typed
+# state in the manifest (phases.discussion.items.{topic}.subtopics). For each
+# work unit with an in-progress discussion item whose discussion file carries
+# a Discussion Map section, parse the subtopic tree rows
+# (`├─ ◐ Name [state]`, two-level nesting from the gutter indentation) and
+# write them as `subtopics` — kebab-cased keys, `{status, parent}` values.
+#
+# Idempotent: items that already have `subtopics` are skipped. Defensive:
+# the migration must never corrupt a manifest — rows that don't parse cleanly
+# are skipped (a child row with no preceding parent is dropped too), and an
+# item whose map yields no parseable rows is left untouched. Completed and
+# cancelled discussions are skipped entirely (their files stay as-is).
+#
+# Point-in-time snapshot: inline node reading/writing manifest.json directly.
+# Never uses the manifest CLI.
+#
+
+WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
+
+[ -d "$WORKFLOWS_DIR" ] || return 0
+
+result=$(node -e "
+const fs = require('fs');
+const path = require('path');
+
+const wfDir = '$WORKFLOWS_DIR';
+
+const STATES = ['pending', 'exploring', 'converging', 'decided'];
+
+function kebab(name) {
+  return String(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+\$/g, '');
+}
+
+// Extract the '## Discussion Map' section: everything from the heading to the
+// next level-2 heading (or EOF).
+function mapSection(content) {
+  const lines = content.split('\n');
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^##\s+Discussion Map\s*\$/.test(lines[i])) { start = i; break; }
+  }
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^##\s/.test(lines[i]) && !/^###/.test(lines[i])) { end = i; break; }
+  }
+  return lines.slice(start + 1, end);
+}
+
+// Parse tree rows into ordered {name, status, parent} entries. Returns null
+// when no rows parse (parse doubt — leave the item untouched).
+function parseRows(sectionLines) {
+  const candidates = [];
+  for (const line of sectionLines) {
+    if (/[┌├└]─/.test(line)) candidates.push(line);
+  }
+  if (candidates.length === 0) return null;
+
+  // Branch column of each candidate; the minimum is the top level.
+  const rows = [];
+  let minCol = Infinity;
+  for (const line of candidates) {
+    const col = line.search(/[┌├└]─/);
+    if (col >= 0 && col < minCol) minCol = col;
+  }
+
+  const rowRe = /^[\s│]*[┌├└]─\s+(?:[○◐→✓⊙⊘]\s+)?(.+?)\s*\[([a-z-]+)\]\s*\$/;
+  const out = [];
+  const seen = Object.create(null);
+  let lastParent = null;
+  for (const line of candidates) {
+    const m = line.match(rowRe);
+    if (!m) continue;                            // unparseable row — skip it
+    const status = m[2];
+    if (STATES.indexOf(status) === -1) continue; // unknown state — skip row
+    const name = kebab(m[1]);
+    if (!name || seen[name]) continue;           // empty or duplicate — skip row
+    const col = line.search(/[┌├└]─/);
+    const isChild = col > minCol || /│/.test(line.slice(0, col));
+    if (isChild) {
+      if (!lastParent) continue;                 // child before any parent — skip row
+      out.push({ name, status, parent: lastParent });
+    } else {
+      out.push({ name, status, parent: null });
+      lastParent = name;
+    }
+    seen[name] = true;
+  }
+  return out.length > 0 ? out : null;
+}
+
+let changedAny = false;
+
+let entries;
+try { entries = fs.readdirSync(wfDir, { withFileTypes: true }); } catch { entries = []; }
+
+for (const entry of entries) {
+  if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+
+  const wuDir = path.join(wfDir, entry.name);
+  const mPath = path.join(wuDir, 'manifest.json');
+  if (!fs.existsSync(mPath)) continue;
+
+  let m;
+  try { m = JSON.parse(fs.readFileSync(mPath, 'utf8')); } catch { continue; }
+
+  const items = m.phases && m.phases.discussion && m.phases.discussion.items;
+  if (!items || typeof items !== 'object') continue;
+
+  let updated = false;
+  for (const topic of Object.keys(items)) {
+    const item = items[topic] || {};
+    if (item.status !== 'in-progress') continue;          // completed/cancelled: skip
+    if (item.subtopics) continue;                         // already migrated
+
+    const filePath = path.join(wuDir, 'discussion', topic + '.md');
+    let content;
+    try { content = fs.readFileSync(filePath, 'utf8'); } catch { continue; }
+
+    const section = mapSection(content);
+    if (!section) continue;                               // no map section
+
+    const rows = parseRows(section);
+    if (!rows) continue;                                  // parse doubt — skip item
+
+    const subtopics = {};
+    for (const row of rows) {
+      subtopics[row.name] = { status: row.status, parent: row.parent };
+    }
+    item.subtopics = subtopics;
+    updated = true;
+  }
+
+  if (updated) {
+    fs.writeFileSync(mPath, JSON.stringify(m, null, 2) + '\n');
+    changedAny = true;
+  }
+}
+
+if (changedAny) console.log('changed');
+" 2>/dev/null) || true
+
+if [ "$result" = "changed" ]; then
+  report_update
+else
+  report_skip
+fi
+
+return 0

--- a/skills/workflow-shared/references/discovery-gap-analysis.md
+++ b/skills/workflow-shared/references/discovery-gap-analysis.md
@@ -27,7 +27,7 @@ Analyzing completed research and discussions for coverage gaps...
 Read `.workflows/{work_unit}/research/{name}.md` for each `completed_research` name and `.workflows/{work_unit}/discussion/{name}.md` for each `completed_discussion` name. Skip files missing on disk. Items with `in-progress`, `superseded`, or `cancelled` status are not in the input set.
 
 For each discussion, note:
-- The Discussion Map state (topics and their statuses: pending, exploring, converging, decided)
+- The subtopic map — final states live in the work unit manifest under `phases.discussion.items.{name}.subtopics` (`decided` / `deferred` for completed discussions; legacy files may instead carry a Discussion Map section inline)
 - Key decisions made and their dependencies on other topics
 - Deferred items, open threads, and unresolved questions
 - Integration points with other discussions

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -38,7 +38,11 @@ For each `### {title}` subsection under `## Triage`, carry its **full body** (ev
 
 **If `phase` is `discussion`:**
 
-- Add `{title}` to the Discussion Map as a `pending` subtopic (`○ {title} [pending]`).
+- Add `{title}` to the Discussion Map as a `pending` subtopic:
+
+  ```bash
+  node .claude/skills/workflow-engine/scripts/engine.cjs map add {work_unit} {topic} {title:(kebabcase)}
+  ```
 - Create a `## {title}` subtopic section with the entry body written in as its `### Context`, so the session explores it from there.
 
 **If `phase` is `research`:**

--- a/tests/scripts/test-engine-map.cjs
+++ b/tests/scripts/test-engine-map.cjs
@@ -142,7 +142,6 @@ describe('discussion-map projection: golden renders', () => {
     });
     assert.strictEqual(discussionMap('auth-flow', m), [
       '  Discussion Map — Auth Flow (6 subtopics — 2 decided · 1 converging · 1 exploring · 1 pending · 1 deferred)',
-      '',
       '  ├─ ✓ Subsystem Prefix Taxonomy [decided]',
       '  ├─ → Info Line Shape [converging]',
       '  │  ├─ ✓ Field Order [decided]',
@@ -160,7 +159,6 @@ describe('discussion-map projection: golden renders', () => {
     });
     assert.strictEqual(discussionMap('auth-flow', m), [
       '  Discussion Map — Auth Flow (2 subtopics)',
-      '',
       '  ├─ ○ One [pending]',
       '  └─ ○ Two [pending]',
       '',
@@ -171,7 +169,6 @@ describe('discussion-map projection: golden renders', () => {
     const m = manifestWith({ 'prefix-taxonomy': { status: 'pending', parent: null } });
     assert.strictEqual(discussionMap('auth-flow', m), [
       '  Discussion Map — Auth Flow (1 subtopic)',
-      '',
       '  └─ ○ Prefix Taxonomy [pending]',
       '',
     ].join('\n'));
@@ -299,7 +296,6 @@ describe('discussion adapter: map verb', () => {
       '',
       '=== DISPLAY (emit verbatim as a code block) ===',
       '  Discussion Map — Auth Flow (2 subtopics — 1 decided · 1 exploring)',
-      '',
       '  ├─ ◐ Token Refresh [exploring]',
       '  └─ ✓ Session Storage [decided]',
       '',

--- a/tests/scripts/test-engine-map.cjs
+++ b/tests/scripts/test-engine-map.cjs
@@ -1,0 +1,314 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+
+const { setupFixture, cleanupFixture, createManifest } = require('./discovery-test-utils.cjs');
+const { addSubtopic, setSubtopicState, mapState, SUBTOPIC_STATES } = require('../../skills/workflow-engine/scripts/domain/map.cjs');
+const { discussionMap } = require('../../skills/workflow-engine/scripts/domain/projections/discussion.cjs');
+const { loadWorkUnitManifest, saveWorkUnitManifest } = require('../../skills/workflow-engine/scripts/kernel/manifest.cjs');
+
+const ENGINE = path.join(__dirname, '../../skills/workflow-engine/scripts/engine.cjs');
+const ADAPTER = path.join(__dirname, '../../skills/workflow-discussion-process/scripts/discovery.cjs');
+
+/** A manifest with one in-progress discussion item, optionally pre-seeded subtopics. */
+function manifestWith(subtopics) {
+  const item = { status: 'in-progress' };
+  if (subtopics) item.subtopics = subtopics;
+  return { name: 'auth', work_type: 'epic', phases: { discussion: { items: { 'auth-flow': item } } } };
+}
+
+describe('map domain: addSubtopic', () => {
+  it('adds a pending top-level subtopic', () => {
+    const m = manifestWith();
+    const sub = addSubtopic(m, 'auth-flow', 'token-refresh');
+    assert.deepStrictEqual(sub, { status: 'pending', parent: null });
+    assert.deepStrictEqual(m.phases.discussion.items['auth-flow'].subtopics, {
+      'token-refresh': { status: 'pending', parent: null },
+    });
+  });
+
+  it('nests a child under a top-level parent', () => {
+    const m = manifestWith();
+    addSubtopic(m, 'auth-flow', 'token-refresh');
+    const sub = addSubtopic(m, 'auth-flow', 'refresh-rotation', { parent: 'token-refresh' });
+    assert.deepStrictEqual(sub, { status: 'pending', parent: 'token-refresh' });
+  });
+
+  it('throws when the discussion item does not exist', () => {
+    const m = manifestWith();
+    assert.throws(() => addSubtopic(m, 'nope', 'x'), /no discussion item "nope"/);
+  });
+
+  it('throws on a duplicate name', () => {
+    const m = manifestWith({ 'token-refresh': { status: 'pending', parent: null } });
+    assert.throws(() => addSubtopic(m, 'auth-flow', 'token-refresh'), /already exists/);
+  });
+
+  it('throws when the parent does not exist', () => {
+    const m = manifestWith();
+    assert.throws(() => addSubtopic(m, 'auth-flow', 'child', { parent: 'ghost' }), /parent subtopic "ghost" not found/);
+  });
+
+  it('throws when the parent is itself a child (two levels max)', () => {
+    const m = manifestWith();
+    addSubtopic(m, 'auth-flow', 'a');
+    addSubtopic(m, 'auth-flow', 'b', { parent: 'a' });
+    assert.throws(() => addSubtopic(m, 'auth-flow', 'c', { parent: 'b' }), /two levels max/);
+  });
+
+  it('throws on a non-kebab-case name', () => {
+    const m = manifestWith();
+    assert.throws(() => addSubtopic(m, 'auth-flow', 'Bad Name'), /kebab-case slug/);
+    assert.throws(() => addSubtopic(m, 'auth-flow', ''), /kebab-case slug/);
+  });
+});
+
+describe('map domain: setSubtopicState', () => {
+  it('records any state from the enum, in any order', () => {
+    const m = manifestWith({ a: { status: 'pending', parent: null } });
+    for (const state of ['decided', 'exploring', 'deferred', 'converging', 'pending']) {
+      assert.strictEqual(setSubtopicState(m, 'auth-flow', 'a', state).status, state);
+    }
+  });
+
+  it('throws on a state outside the enum', () => {
+    const m = manifestWith({ a: { status: 'pending', parent: null } });
+    assert.throws(() => setSubtopicState(m, 'auth-flow', 'a', 'done'), /unknown subtopic state "done"/);
+  });
+
+  it('throws when the subtopic does not exist', () => {
+    const m = manifestWith();
+    assert.throws(() => setSubtopicState(m, 'auth-flow', 'ghost', 'decided'), /subtopic "ghost" not found/);
+  });
+
+  it('exports the full enum', () => {
+    assert.deepStrictEqual(SUBTOPIC_STATES, ['pending', 'exploring', 'converging', 'decided', 'deferred']);
+  });
+});
+
+describe('map domain: mapState', () => {
+  it('derives counts, total, and unresolved in insertion order', () => {
+    const m = manifestWith({
+      a: { status: 'decided', parent: null },
+      b: { status: 'exploring', parent: null },
+      c: { status: 'pending', parent: 'b' },
+      d: { status: 'deferred', parent: null },
+      e: { status: 'converging', parent: null },
+    });
+    assert.deepStrictEqual(mapState(m, 'auth-flow'), {
+      counts: { pending: 1, exploring: 1, converging: 1, decided: 1, deferred: 1 },
+      total: 5,
+      all_decided: false,
+      unresolved: ['b', 'c', 'e'],
+    });
+  });
+
+  it('all_decided is false with zero subtopics', () => {
+    const state = mapState(manifestWith(), 'auth-flow');
+    assert.strictEqual(state.total, 0);
+    assert.strictEqual(state.all_decided, false);
+    assert.deepStrictEqual(state.unresolved, []);
+  });
+
+  it('all_decided is true when every subtopic is decided or deferred', () => {
+    const m = manifestWith({
+      a: { status: 'decided', parent: null },
+      b: { status: 'deferred', parent: null },
+    });
+    const state = mapState(m, 'auth-flow');
+    assert.strictEqual(state.all_decided, true);
+    assert.deepStrictEqual(state.unresolved, []);
+  });
+
+  it('throws on a corrupt subtopic state', () => {
+    const m = manifestWith({ a: { status: 'finished', parent: null } });
+    assert.throws(() => mapState(m, 'auth-flow'), /unknown state "finished"/);
+  });
+});
+
+describe('discussion-map projection: golden renders', () => {
+  it('mixed states with nesting and the deferred glyph', () => {
+    const m = manifestWith({
+      'subsystem-prefix-taxonomy': { status: 'decided', parent: null },
+      'info-line-shape': { status: 'converging', parent: null },
+      'field-order': { status: 'decided', parent: 'info-line-shape' },
+      'truncation-rules': { status: 'exploring', parent: 'info-line-shape' },
+      'context-preservation': { status: 'deferred', parent: null },
+      'rollout-sequencing': { status: 'pending', parent: null },
+    });
+    assert.strictEqual(discussionMap('auth-flow', m), [
+      '  Discussion Map — Auth Flow (6 subtopics — 2 decided · 1 converging · 1 exploring · 1 pending · 1 deferred)',
+      '',
+      '  ├─ ✓ Subsystem Prefix Taxonomy [decided]',
+      '  ├─ → Info Line Shape [converging]',
+      '  │  ├─ ✓ Field Order [decided]',
+      '  │  └─ ◐ Truncation Rules [exploring]',
+      '  ├─ ⊙ Context Preservation [deferred]',
+      '  └─ ○ Rollout Sequencing [pending]',
+      '',
+    ].join('\n'));
+  });
+
+  it('omits the breakdown when only one category is non-zero', () => {
+    const m = manifestWith({
+      'one': { status: 'pending', parent: null },
+      'two': { status: 'pending', parent: null },
+    });
+    assert.strictEqual(discussionMap('auth-flow', m), [
+      '  Discussion Map — Auth Flow (2 subtopics)',
+      '',
+      '  ├─ ○ One [pending]',
+      '  └─ ○ Two [pending]',
+      '',
+    ].join('\n'));
+  });
+
+  it('single subtopic — singular header, └─ row, no ┌─', () => {
+    const m = manifestWith({ 'prefix-taxonomy': { status: 'pending', parent: null } });
+    assert.strictEqual(discussionMap('auth-flow', m), [
+      '  Discussion Map — Auth Flow (1 subtopic)',
+      '',
+      '  └─ ○ Prefix Taxonomy [pending]',
+      '',
+    ].join('\n'));
+  });
+
+  it('two categories — breakdown present, zero categories omitted', () => {
+    const m = manifestWith({
+      a: { status: 'decided', parent: null },
+      b: { status: 'decided', parent: null },
+      c: { status: 'exploring', parent: null },
+    });
+    assert.strictEqual(
+      discussionMap('auth-flow', m).split('\n')[0],
+      '  Discussion Map — Auth Flow (3 subtopics — 2 decided · 1 exploring)'
+    );
+  });
+
+  it('zero subtopics — header only', () => {
+    assert.strictEqual(discussionMap('auth-flow', manifestWith()), '  Discussion Map — Auth Flow (0 subtopics)\n');
+  });
+});
+
+describe('kernel manifest IO', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('round-trips a manifest with a trailing newline', () => {
+    createManifest(dir, 'auth', manifestWith());
+    const m = loadWorkUnitManifest(dir, 'auth');
+    m.phases.discussion.items['auth-flow'].subtopics = { a: { status: 'pending', parent: null } };
+    saveWorkUnitManifest(dir, 'auth', m);
+    const raw = fs.readFileSync(path.join(dir, '.workflows', 'auth', 'manifest.json'), 'utf8');
+    assert.ok(raw.endsWith('}\n'));
+    assert.deepStrictEqual(JSON.parse(raw), m);
+  });
+
+  it('throws a clear error when the manifest is missing', () => {
+    assert.throws(() => loadWorkUnitManifest(dir, 'ghost'), /manifest not found/);
+  });
+
+  it('throws a clear error on invalid JSON', () => {
+    fs.mkdirSync(path.join(dir, '.workflows', 'broken'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.workflows', 'broken', 'manifest.json'), '{nope');
+    assert.throws(() => loadWorkUnitManifest(dir, 'broken'), /invalid JSON/);
+  });
+});
+
+describe('engine CLI: map round-trip', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  function engineMap(args) {
+    return JSON.parse(execFileSync('node', [ENGINE, 'map', ...args], { cwd: dir, encoding: 'utf8' }).trim());
+  }
+
+  it('add → set, decision-ready JSON each step, manifest persisted', () => {
+    createManifest(dir, 'auth', manifestWith());
+
+    assert.deepStrictEqual(engineMap(['add', 'auth', 'auth-flow', 'token-refresh']), {
+      ok: true, subtopic: 'token-refresh', status: 'pending', all_decided: false, unresolved_count: 1,
+    });
+    assert.deepStrictEqual(engineMap(['add', 'auth', 'auth-flow', 'refresh-rotation', '--parent', 'token-refresh']), {
+      ok: true, subtopic: 'refresh-rotation', status: 'pending', all_decided: false, unresolved_count: 2,
+    });
+    assert.deepStrictEqual(engineMap(['set', 'auth', 'auth-flow', 'refresh-rotation', 'decided']), {
+      ok: true, subtopic: 'refresh-rotation', status: 'decided', all_decided: false, unresolved_count: 1,
+    });
+    assert.deepStrictEqual(engineMap(['set', 'auth', 'auth-flow', 'token-refresh', 'deferred']), {
+      ok: true, subtopic: 'token-refresh', status: 'deferred', all_decided: true, unresolved_count: 0,
+    });
+
+    const saved = JSON.parse(fs.readFileSync(path.join(dir, '.workflows', 'auth', 'manifest.json'), 'utf8'));
+    assert.deepStrictEqual(saved.phases.discussion.items['auth-flow'].subtopics, {
+      'token-refresh': { status: 'deferred', parent: null },
+      'refresh-rotation': { status: 'decided', parent: 'token-refresh' },
+    });
+  });
+
+  it('errors print {ok:false} JSON to stderr and exit 1, manifest untouched', () => {
+    createManifest(dir, 'auth', manifestWith());
+    const before = fs.readFileSync(path.join(dir, '.workflows', 'auth', 'manifest.json'), 'utf8');
+
+    const res = spawnSync('node', [ENGINE, 'map', 'set', 'auth', 'auth-flow', 'ghost', 'decided'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1);
+    assert.strictEqual(res.stdout, '');
+    assert.deepStrictEqual(JSON.parse(res.stderr.trim()), { ok: false, error: 'subtopic "ghost" not found under "auth-flow"' });
+
+    const missing = spawnSync('node', [ENGINE, 'map', 'add', 'ghost-unit', 'auth-flow', 'x'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(missing.status, 1);
+    assert.match(JSON.parse(missing.stderr.trim()).error, /manifest not found/);
+
+    const usage = spawnSync('node', [ENGINE, 'map', 'add', 'auth'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(usage.status, 1);
+    assert.match(JSON.parse(usage.stderr.trim()).error, /Usage: engine map add/);
+
+    assert.strictEqual(fs.readFileSync(path.join(dir, '.workflows', 'auth', 'manifest.json'), 'utf8'), before);
+  });
+});
+
+describe('discussion adapter: map verb', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('emits DATA (counts, all_decided, unresolved, review_cycles) and the DISPLAY block', () => {
+    createManifest(dir, 'auth', manifestWith({
+      'token-refresh': { status: 'exploring', parent: null },
+      'session-storage': { status: 'decided', parent: null },
+    }));
+    const cacheDir = path.join(dir, '.workflows', '.cache', 'auth', 'discussion', 'auth-flow');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'review-001.md'), '');
+    fs.writeFileSync(path.join(cacheDir, 'synthesis-001.md'), ''); // not a review cycle
+
+    const out = execFileSync('node', [ADAPTER, 'map', 'auth', 'auth-flow'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(out, [
+      '=== DATA (reason from this — never display or parse the sections below) ===',
+      'topic: auth-flow',
+      'counts: {"pending":0,"exploring":1,"converging":0,"decided":1,"deferred":0}',
+      'all_decided: false',
+      'unresolved: ["token-refresh"]',
+      'review_cycles: 1',
+      '',
+      '=== DISPLAY (emit verbatim as a code block) ===',
+      '  Discussion Map — Auth Flow (2 subtopics — 1 decided · 1 exploring)',
+      '',
+      '  ├─ ◐ Token Refresh [exploring]',
+      '  └─ ✓ Session Storage [decided]',
+      '',
+    ].join('\n'));
+  });
+
+  it('review_cycles is 0 when the cache directory does not exist', () => {
+    createManifest(dir, 'auth', manifestWith());
+    const out = execFileSync('node', [ADAPTER, 'map', 'auth', 'auth-flow'], { cwd: dir, encoding: 'utf8' });
+    assert.match(out, /review_cycles: 0/);
+  });
+});

--- a/tests/scripts/test-migration-047.sh
+++ b/tests/scripts/test-migration-047.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+#
+# Tests for migration 047: discussion-map-to-manifest
+#
+# Run: bash tests/scripts/test-migration-047.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/047-discussion-map-to-manifest.sh"
+
+PASS=0
+FAIL=0
+
+report_update() { : ; }
+report_skip() { : ; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-047-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# Write a manifest with one discussion item of the given status.
+write_manifest() {
+  local wu="$1" status="$2"
+  mkdir -p "$TEST_DIR/.workflows/$wu/discussion"
+  cat > "$TEST_DIR/.workflows/$wu/manifest.json" <<EOF
+{
+  "name": "$wu",
+  "work_type": "epic",
+  "status": "in-progress",
+  "description": "Test epic",
+  "phases": {
+    "discussion": {
+      "items": {
+        "auth-flow": {
+          "status": "$status"
+        }
+      }
+    }
+  }
+}
+EOF
+}
+
+# Read a JSON path from a work unit's manifest (empty output when absent).
+read_manifest() {
+  local wu="$1" expr="$2"
+  node -e "
+    const m = JSON.parse(require('fs').readFileSync('$TEST_DIR/.workflows/$wu/manifest.json', 'utf8'));
+    const v = $expr;
+    console.log(v === undefined ? '' : (typeof v === 'object' ? JSON.stringify(v) : v));
+  "
+}
+
+# A discussion file with a Discussion Map section (mixed states, nested children).
+write_discussion_with_map() {
+  local wu="$1"
+  cat > "$TEST_DIR/.workflows/$wu/discussion/auth-flow.md" <<'EOF'
+# Discussion: Auth Flow
+
+## Context
+
+Why we are discussing.
+
+## Discussion Map
+
+A living index of subtopics.
+
+### States
+
+- **pending** (`○`) — identified but not yet explored
+
+### Map
+
+  Discussion Map — Auth Flow (4 subtopics — 1 decided · 1 converging · 1 exploring · 1 pending)
+
+  ┌─ ✓ Subsystem Prefix Taxonomy [decided]
+  ├─ → Token Refresh [converging]
+  │  ├─ ◐ Refresh Rotation [exploring]
+  │  └─ ○ Grace Window [pending]
+  └─ ○ Session Storage [pending]
+
+---
+
+## Subsystem Prefix Taxonomy
+
+### Decision
+We decided.
+
+## Summary
+
+### Open Threads
+- (none)
+
+## Triage
+
+(none)
+EOF
+}
+
+# --- Test 1: Happy path — map rows land as manifest subtopics ---
+test_happy_path() {
+  setup
+
+  write_manifest epic-a in-progress
+  write_discussion_with_map epic-a
+
+  source "$MIGRATION"
+
+  assert_eq "subtopics written" \
+    '{"subsystem-prefix-taxonomy":{"status":"decided","parent":null},"token-refresh":{"status":"converging","parent":null},"refresh-rotation":{"status":"exploring","parent":"token-refresh"},"grace-window":{"status":"pending","parent":"token-refresh"},"session-storage":{"status":"pending","parent":null}}' \
+    "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics")"
+
+  teardown
+}
+
+# --- Test 2: Nested children — parent linkage from gutter indentation ---
+test_nested_children() {
+  setup
+
+  write_manifest epic-a in-progress
+  write_discussion_with_map epic-a
+
+  source "$MIGRATION"
+
+  assert_eq "child parent set" "token-refresh" \
+    "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics['refresh-rotation'].parent")"
+  assert_eq "last parent's child (no gutter bar) nested" "token-refresh" \
+    "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics['grace-window'].parent")"
+  assert_eq "top-level row has null parent" "null" \
+    "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics['session-storage'].parent")"
+
+  teardown
+}
+
+# --- Test 3: No-op — discussion file without a map section ---
+test_no_map_section() {
+  setup
+
+  write_manifest epic-a in-progress
+  cat > "$TEST_DIR/.workflows/epic-a/discussion/auth-flow.md" <<'EOF'
+# Discussion: Auth Flow
+
+## Context
+
+No map here.
+
+## Summary
+EOF
+
+  source "$MIGRATION"
+
+  assert_eq "no subtopics written" "" \
+    "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics")"
+
+  teardown
+}
+
+# --- Test 4: No-op — completed discussion item is skipped entirely ---
+test_completed_item_skipped() {
+  setup
+
+  write_manifest epic-a completed
+  write_discussion_with_map epic-a
+
+  source "$MIGRATION"
+
+  assert_eq "completed item untouched" "" \
+    "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics")"
+
+  teardown
+}
+
+# --- Test 5: Idempotency — run twice, same result, existing subtopics never overwritten ---
+test_idempotency() {
+  setup
+
+  write_manifest epic-a in-progress
+  write_discussion_with_map epic-a
+
+  source "$MIGRATION"
+  local first
+  first="$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics")"
+
+  # Hand-advance a state between runs — a second run must not clobber it.
+  node -e "
+    const fs = require('fs');
+    const p = '$TEST_DIR/.workflows/epic-a/manifest.json';
+    const m = JSON.parse(fs.readFileSync(p, 'utf8'));
+    m.phases.discussion.items['auth-flow'].subtopics['session-storage'].status = 'decided';
+    fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
+  "
+
+  source "$MIGRATION"
+
+  assert_eq "first run parsed rows" "true" "$([ -n "$first" ] && echo true || echo false)"
+  assert_eq "second run preserved the advanced state" "decided" \
+    "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics['session-storage'].status")"
+
+  teardown
+}
+
+# --- Test 6: Content preservation — unrelated manifest fields untouched ---
+test_content_preservation() {
+  setup
+
+  write_manifest epic-a in-progress
+  node -e "
+    const fs = require('fs');
+    const p = '$TEST_DIR/.workflows/epic-a/manifest.json';
+    const m = JSON.parse(fs.readFileSync(p, 'utf8'));
+    m.seeds = [{ path: 'seeds/x.md', source: 'inbox:idea' }];
+    m.phases.research = { items: { 'auth-flow': { status: 'completed' } } };
+    fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
+  "
+  write_discussion_with_map epic-a
+  local file_before
+  file_before="$(cat "$TEST_DIR/.workflows/epic-a/discussion/auth-flow.md")"
+
+  source "$MIGRATION"
+
+  assert_eq "work_type preserved" "epic" "$(read_manifest epic-a "m.work_type")"
+  assert_eq "seeds preserved" '[{"path":"seeds/x.md","source":"inbox:idea"}]' "$(read_manifest epic-a "m.seeds")"
+  assert_eq "research phase preserved" '{"items":{"auth-flow":{"status":"completed"}}}' "$(read_manifest epic-a "m.phases.research")"
+  assert_eq "item status preserved" "in-progress" "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].status")"
+  assert_eq "discussion file untouched" "true" \
+    "$([ "$file_before" = "$(cat "$TEST_DIR/.workflows/epic-a/discussion/auth-flow.md")" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 7: Unparseable rows are skipped, clean rows still land ---
+test_unparseable_row_skip() {
+  setup
+
+  write_manifest epic-a in-progress
+  cat > "$TEST_DIR/.workflows/epic-a/discussion/auth-flow.md" <<'EOF'
+# Discussion: Auth Flow
+
+## Discussion Map
+
+  Discussion Map — Auth Flow (3 subtopics)
+
+  ┌─ ✓ Good Row [decided]
+  ├─ broken row without a state tag
+  ├─ ◐ Strange State [finished]
+  └─ ○ Another Good Row [pending]
+
+## Summary
+EOF
+
+  source "$MIGRATION"
+
+  assert_eq "only clean rows written" \
+    '{"good-row":{"status":"decided","parent":null},"another-good-row":{"status":"pending","parent":null}}' \
+    "$(read_manifest epic-a "m.phases.discussion.items['auth-flow'].subtopics")"
+
+  teardown
+}
+
+# --- Test 8: All rows unparseable — item left untouched (parse doubt) ---
+test_all_rows_unparseable() {
+  setup
+
+  write_manifest epic-a in-progress
+  cat > "$TEST_DIR/.workflows/epic-a/discussion/auth-flow.md" <<'EOF'
+# Discussion: Auth Flow
+
+## Discussion Map
+
+  ┌─ no tag here
+  └─ also no tag
+
+## Summary
+EOF
+
+  local before
+  before="$(cat "$TEST_DIR/.workflows/epic-a/manifest.json")"
+
+  source "$MIGRATION"
+
+  assert_eq "manifest untouched on parse doubt" "true" \
+    "$([ "$before" = "$(cat "$TEST_DIR/.workflows/epic-a/manifest.json")" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration 047 tests..."
+echo ""
+
+test_happy_path
+test_nested_children
+test_no_map_section
+test_completed_item_skipped
+test_idempotency
+test_content_preservation
+test_unparseable_row_skip
+test_all_rows_unparseable
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## What

PR 3 of the engine stack (on #384). The discussion map becomes **typed state in the manifest**, and the engine gains its first write commands.

- **Kernel manifest IO** — `kernel/manifest.cjs`: load + atomic save (temp-file rename).
- **`domain/map.cjs`** — `addSubtopic` / `setSubtopicState` (enum `pending|exploring|converging|decided|deferred`, two-level nesting, loud validation) + `mapState` (decision-ready: counts, `all_decided`, `unresolved`).
- **`engine map add/set`** — JSON responses carry the derived state (`all_decided`, `unresolved_count`) so the session never needs a follow-up read. No internal commits — the session's existing commit cadence picks the manifest change up.
- **Discussion-map projection + adapter** — `workflow-discussion-process` gets its gateway (`map {wu} {topic}`): DATA (counts, `all_decided`, `unresolved`, `review_cycles`) + DISPLAY (the tree, hang-off-header — the old `┌─` opener is normalised away).
- **`discussion-session.md` re-pointed** — judgment decides, `map set` records; the file holds knowledge only (template's map section dropped); convergence + the twice-stated manual cache count collapse into one adapter call; conclude-anyway sets unresolved subtopics `deferred` and notes them in Open Threads. Full survey of every "Discussion Map" reference across the skill, shared references, and agents — all re-pointed.
- **migration 046** — parses in-progress discussions' markdown maps into the manifest. Defensive (parse-doubt → skip, never corrupt), idempotent, 15-test harness file.

## Judgment calls to review

- **`⊙` for deferred** — collides visually with the discovery tier's `⊙ handled` (separate vocabularies, same symbol). Alternatives: `◌` / `▫`.
- `addSubtopic` enforces kebab-case slugs at write time.
- `review_cycles` counts `review-*.md` only (perspective/synthesis files would falsely satisfy the review safety net).
- Zero-subtopics projection renders header-only rather than throwing.
- Resume-detection's restart path now also clears `subtopics` (stale map state would corrupt a fresh start).

## Tests

82/82 engine (incl. 27 new map tests: domain, projection goldens, manifest IO, CLI round-trip); epic discovery suite 98/98 unchanged; migration 046 15/15 (044 still green); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. **#385** 👈 current
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->