### PR TITLE
feat(engine): transaction family — topic cancel/reactivate, inbox lifecycle, scoped commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node build/knowledge.build.js",
     "knowledge:repl": "node scripts/knowledge-repl.js",
     "typecheck": "tsc -p tsconfig.json",
-    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs tests/scripts/test-engine-map.cjs"
+    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs tests/scripts/test-engine-map.cjs tests/scripts/test-engine-transactions.cjs"
   },
   "devDependencies": {
     "@msgpack/msgpack": "3.1.3",

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-continue-epic
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-continue-epic/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs), Bash(node .claude/skills/workflow-discovery/scripts/discovery.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-continue-epic/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs), Bash(node .claude/skills/workflow-discovery/scripts/discovery.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
 ---
 
 Continue an in-progress epic. Shows full phase-by-phase state and routes to the appropriate phase skill.

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -278,36 +278,21 @@ cancelled. You can reactivate it later.
 
 **If user chose `yes`:**
 
-Run two manifest CLI calls to set cancelled status and preserve previous status:
+Run the cancel transaction — one command stashes the current status, marks the item cancelled, drops the topic's discovery-map order, removes its knowledge-base chunks, and commits:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{phase}.{topic} previous_status {current_status}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{phase}.{topic} status cancelled
+node .claude/skills/workflow-engine/scripts/engine.cjs topic cancel {work_unit} {phase} {topic}
 ```
 
-Drop the topic's discovery-map order so reactivation renumbers it cleanly:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{topic} order
-```
-
-Remove the cancelled topic's chunks from the knowledge base:
-
-```bash
-node .claude/skills/workflow-knowledge/scripts/knowledge.cjs remove --work-unit {work_unit} --phase {phase} --topic {topic}
-```
-
-If the remove command fails, display the error but do not block — the cancellation is already recorded:
+The JSON response reports `status`, `committed`, and `warnings`. If `warnings` is non-empty, display them — the cancellation is already recorded:
 
 > *Output the next fenced block as a code block:*
 
 ```
 ⚑ Knowledge removal warning
-  {error details}
+  {warning}
   The topic is cancelled. You can run knowledge remove manually later.
 ```
-
-Commit the change.
 
 > *Output the next fenced block as a code block:*
 
@@ -365,47 +350,26 @@ Recreate with actual items from discovery.
 
 #### If user chose a numbered topic
 
-Read the `previous_status` via manifest CLI:
+Run the reactivate transaction — one command restores the stashed status, removes `previous_status`, re-indexes the artifact into the knowledge base when the restored status is `completed` in an indexed phase (research / discussion / investigation / specification), and commits:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.{phase}.{topic} previous_status
+node .claude/skills/workflow-engine/scripts/engine.cjs topic reactivate {work_unit} {phase} {topic}
 ```
 
-Use the returned value as `{previous_status}` in the next two commands to restore the original status and remove the `previous_status` field:
-
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{phase}.{topic} status {previous_status}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.{phase}.{topic} previous_status
-```
-
-**If `previous_status` is `completed` and `phase` is one of the indexed phases (research / discussion / investigation / specification):**
-
-Re-index the reactivated topic's artifact into the knowledge base. Resolve the artifact path by phase:
-- research: `.workflows/{work_unit}/research/{topic}.md`
-- discussion: `.workflows/{work_unit}/discussion/{topic}.md`
-- investigation: `.workflows/{work_unit}/investigation/{topic}.md`
-- specification: `.workflows/{work_unit}/specification/{topic}/specification.md`
-
-```bash
-node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index {artifact_path}
-```
-
-If the index command fails, display the error but do not block — the reactivation is already recorded:
+The JSON response reports the restored `status`, `committed`, and `warnings`. If `warnings` is non-empty, display them — the reactivation is already recorded:
 
 > *Output the next fenced block as a code block:*
 
 ```
 ⚑ Knowledge indexing warning
-  {error details}
+  {warning}
   The artifact is saved. Indexing can be retried later.
 ```
-
-Commit the change.
 
 > *Output the next fenced block as a code block:*
 
 ```
-Reactivated "{topic:(titlecase)}" in {phase}. Status restored to {previous_status}.
+Reactivated "{topic:(titlecase)}" in {phase}. Status restored to {status}.
 ```
 
 → Return to **A. State Display and Menu**.

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -36,7 +36,13 @@ The discussion is an organic conversation. The Discussion Map is your tracking b
 
    The command's JSON response carries `all_decided` and `unresolved_count` — no follow-up read needed. Don't force transitions — suggest them. The user can follow your suggestion or go wherever they want.
 4. **Document** — At natural pauses, update the discussion file — it holds the knowledge. When a subtopic reaches `decided`, write up its section (Context → Options → Journey → Decision); keep the Summary current. Capture provisional thinking for subtopics still in progress if context compaction is a risk. The live map state lives in the manifest only — never write a map section into the file.
-5. **Commit & dispatch check** — Git commit after each write. Don't batch. Then immediately evaluate agent dispatch — **CHECKPOINT**: Do not respond to the user until this check is complete. Evaluate the trigger conditions defined in the review agent and perspective agent instructions loaded above. If conditions are met, dispatch before continuing. If not, proceed.
+5. **Commit & dispatch check** — Commit after each write. Don't batch:
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discussion({work_unit}/{topic}): {what changed}"
+   ```
+
+   Then immediately evaluate agent dispatch — **CHECKPOINT**: Do not respond to the user until this check is complete. Evaluate the trigger conditions defined in the review agent and perspective agent instructions loaded above. If conditions are met, dispatch before continuing. If not, proceed.
 6. **Repeat** — Continue with the next subtopic or follow where the conversation leads.
 
 ---
@@ -149,8 +155,7 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 4. Commit the conversion and the landing:
 
    ```bash
-   git add -- .workflows/{work_unit}/
-   git commit -m "discussion({work_unit}/{topic}): pivot to epic"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discussion({work_unit}/{topic}): pivot to epic"
    ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -216,8 +221,7 @@ Note the concern in the Summary section for the user to consider separately, and
 4. The current Discussion Map is unchanged — rerouting sends the concern away from this topic, it doesn't mark it. Commit:
 
    ```bash
-   git add -- .workflows/{work_unit}/
-   git commit -m "discussion({work_unit}/{topic}): reroute concern to {landed_topic}"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discussion({work_unit}/{topic}): reroute concern to {landed_topic}"
    ```
 
 → Return to **B. Session Loop**.

--- a/skills/workflow-engine/SKILL.md
+++ b/skills/workflow-engine/SKILL.md
@@ -38,6 +38,28 @@ engine map set <work-unit> <topic> <subtopic> <state>                 # pending|
 
 Subtopic names are kebab-case slugs; `--parent` nests under an existing top-level subtopic (two levels max).
 
+**`topic`** — epic topic cancel / reactivate, each one transaction: manifest write (stash/restore `previous_status`, cancel also drops the topic's discovery-map `order`), knowledge-base sync (remove on cancel; re-index on reactivate when the restored status is `completed` in research/discussion/investigation/specification), and a commit scoped to `.workflows/{wu}` (`workflow({wu}): cancel {topic} ({phase})` / `… reactivate …`). The knowledge base is a derived index — its failures land in `warnings`, never block. Response: `{"ok": true, "topic": "…", "phase": "…", "status": "…", "committed": "<short-sha>", "warnings": []}` (`committed: null` plus a note when nothing was staged).
+
+```bash
+engine topic cancel <work-unit> <phase> <topic>
+engine topic reactivate <work-unit> <phase> <topic>
+```
+
+**`inbox`** — archive / restore / delete one or more inbox items as a single transaction. Paths are validated strictly against the inbox layout (`.workflows/.inbox/{ideas|bugs|quickfixes}/…`, archived items under `.inbox/.archived/…`) before anything moves; one commit covers the whole set (`workflow(inbox): archive {slug}` for one item, `… archive {N} items` for several — same forms for restore/delete). Response: `{"ok": true, "archived": [paths…], "committed": "<short-sha>"}` (key matches the verb: `archived` / `restored` / `deleted`).
+
+```bash
+engine inbox archive <path> [<path> …]   # live → .archived/{folder}/
+engine inbox restore <path> [<path> …]   # .archived/{folder}/ → live
+engine inbox delete <path> [<path> …]    # git rm archived items
+```
+
+**`commit`** — the scoped commit helper: `git add -- .workflows/{wu}` (or `.workflows/.inbox` with `--inbox`) plus commit. A clean tree is fine: `{"ok": true, "committed": null, "note": "nothing to commit"}`, exit 0.
+
+```bash
+engine commit <work-unit> -m "<message>"
+engine commit --inbox -m "<message>"
+```
+
 **Rendering is not a runtime CLI concern.** Static chrome (signposts, boxes, gate rules) lives as literal blocks in skill prose; parameterised chrome is rendered in-process by projections. No skill flow calls a render command at runtime — the `render` command group in `engine.cjs` is a development/debugging utility only (e.g. generating a correct literal while authoring prose).
 
 ## Library — `scripts/lib.cjs`
@@ -103,4 +125,4 @@ The .md's prescribed call names the verb (`discovery.cjs view {work_unit}`) — 
 
 ## Tests
 
-`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, `tests/scripts/test-engine-epic-projections.cjs`, and `tests/scripts/test-engine-map.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.
+`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, `tests/scripts/test-engine-epic-projections.cjs`, `tests/scripts/test-engine-map.cjs`, and `tests/scripts/test-engine-transactions.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.

--- a/skills/workflow-engine/scripts/domain/inbox.cjs
+++ b/skills/workflow-engine/scripts/domain/inbox.cjs
@@ -1,0 +1,150 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: inbox transactions — archive, restore, delete as single
+// transactions over one or more inbox items. Every path is validated against
+// the exact inbox layout before anything moves; one scoped commit covers the
+// whole set, with the message form the inbox history already uses
+// (`archive {slug}` for one item, `archive {N} items` for several).
+//
+//   live:     .workflows/.inbox/{ideas|bugs|quickfixes}/{file}.md
+//   archived: .workflows/.inbox/.archived/{ideas|bugs|quickfixes}/{file}.md
+// ---------------------------------------------------------------------------
+
+const fs = require('fs');
+const path = require('path');
+const { commitScoped, removeFiles } = require('../kernel/git.cjs');
+
+const INBOX = '.workflows/.inbox';
+const FOLDERS = ['ideas', 'bugs', 'quickfixes'];
+
+/**
+ * @typedef {object} InboxItem
+ * @property {string} given   the path as passed (normalised)
+ * @property {string} folder  ideas | bugs | quickfixes
+ * @property {string} file    file name
+ * @property {string} slug    file name minus the date prefix and extension
+ */
+
+/**
+ * Validate one inbox path against the expected layout. Loud on anything
+ * outside it — wrong root, unknown folder, nesting, traversal.
+ * @param {string} given
+ * @param {{archived: boolean}} opts whether the path must be under `.archived/`
+ * @returns {InboxItem}
+ */
+function parseInboxPath(given, { archived }) {
+  const norm = path.normalize(given);
+  if (path.isAbsolute(norm) || norm.split(path.sep).includes('..')) {
+    throw new Error(`inbox paths must be project-relative without "..": "${given}"`);
+  }
+  const segs = norm.split(path.sep);
+  const expected = archived
+    ? `${INBOX}/.archived/{${FOLDERS.join('|')}}/{file}.md`
+    : `${INBOX}/{${FOLDERS.join('|')}}/{file}.md`;
+  const depth = archived ? 5 : 4;
+  const ok =
+    segs.length === depth &&
+    segs[0] === '.workflows' &&
+    segs[1] === '.inbox' &&
+    (!archived || segs[2] === '.archived') &&
+    FOLDERS.includes(segs[depth - 2]) &&
+    segs[depth - 1].endsWith('.md');
+  if (!ok) {
+    throw new Error(`not ${archived ? 'an archived' : 'a live'} inbox path (expected ${expected}): "${given}"`);
+  }
+  const file = segs[depth - 1];
+  return {
+    given: segs.join('/'),
+    folder: segs[depth - 2],
+    file,
+    slug: file.replace(/\.md$/, '').replace(/^\d{4}-\d{2}-\d{2}--/, ''),
+  };
+}
+
+/**
+ * Parse and existence-check every path before anything moves.
+ * @param {string} cwd @param {string[]} paths @param {{archived: boolean}} opts
+ * @returns {InboxItem[]}
+ */
+function parseAll(cwd, paths, opts) {
+  const items = paths.map((p) => parseInboxPath(p, opts));
+  for (const item of items) {
+    if (!fs.existsSync(path.join(cwd, item.given))) {
+      throw new Error(`inbox file not found: "${item.given}"`);
+    }
+  }
+  return items;
+}
+
+/** `archive {slug}` for one item, `archive {N} items` for several. @param {string} verb @param {InboxItem[]} items */
+function commitMessage(verb, items) {
+  const what = items.length === 1 ? items[0].slug : `${items.length} items`;
+  return `workflow(inbox): ${verb} ${what}`;
+}
+
+/**
+ * Move every item to its destination (collision-checked first), then commit
+ * the whole set scoped to the inbox.
+ * @param {string} cwd @param {InboxItem[]} items
+ * @param {(item: InboxItem) => string} destDir relative destination directory per item
+ * @param {string} verb commit-message verb
+ * @returns {{moved: string[], committed: string|null}}
+ */
+function moveAndCommit(cwd, items, destDir, verb) {
+  const moves = items.map((item) => ({ item, dest: `${destDir(item)}/${item.file}` }));
+  for (const { dest } of moves) {
+    if (fs.existsSync(path.join(cwd, dest))) {
+      throw new Error(`destination already exists: "${dest}"`);
+    }
+  }
+  const moved = [];
+  for (const { item, dest } of moves) {
+    fs.mkdirSync(path.dirname(path.join(cwd, dest)), { recursive: true });
+    fs.renameSync(path.join(cwd, item.given), path.join(cwd, dest));
+    moved.push(dest);
+  }
+  return { moved, committed: commitScoped(cwd, INBOX, commitMessage(verb, items)) };
+}
+
+/**
+ * Archive live inbox items into `.archived/{folder}/`. One commit for the set.
+ * @param {string} cwd project root
+ * @param {string[]} paths live inbox paths
+ * @returns {{archived: string[], committed: string|null}}
+ */
+function archiveItems(cwd, paths) {
+  const items = parseAll(cwd, paths, { archived: false });
+  const { moved, committed } = moveAndCommit(cwd, items, (i) => `${INBOX}/.archived/${i.folder}`, 'archive');
+  return { archived: moved, committed };
+}
+
+/**
+ * Restore archived items back to their live folders. One commit for the set.
+ * @param {string} cwd project root
+ * @param {string[]} paths archived inbox paths
+ * @returns {{restored: string[], committed: string|null}}
+ */
+function restoreItems(cwd, paths) {
+  const items = parseAll(cwd, paths, { archived: true });
+  const { moved, committed } = moveAndCommit(cwd, items, (i) => `${INBOX}/${i.folder}`, 'restore');
+  return { restored: moved, committed };
+}
+
+/**
+ * Permanently delete archived items (`git rm`). One commit for the set.
+ * Live-folder paths are rejected — delete only operates on `.archived/`.
+ * @param {string} cwd project root
+ * @param {string[]} paths archived inbox paths
+ * @returns {{deleted: string[], committed: string|null}}
+ */
+function deleteItems(cwd, paths) {
+  const items = parseAll(cwd, paths, { archived: true });
+  removeFiles(cwd, items.map((i) => i.given));
+  return {
+    deleted: items.map((i) => i.given),
+    committed: commitScoped(cwd, INBOX, commitMessage('delete', items)),
+  };
+}
+
+module.exports = { archiveItems, restoreItems, deleteItems };

--- a/skills/workflow-engine/scripts/domain/transitions.cjs
+++ b/skills/workflow-engine/scripts/domain/transitions.cjs
@@ -1,0 +1,154 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: epic topic transitions — cancel and reactivate as single
+// transactions. Each call is one atomic state change from the caller's
+// perspective: manifest write, knowledge-base sync, scoped git commit.
+//
+// The manifest write is the source of truth and lands first; the knowledge
+// base is a derived index, so its failures are recorded as warnings, never
+// blocks. Validation throws loud and specific before anything is touched.
+// ---------------------------------------------------------------------------
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { loadWorkUnitManifest, saveWorkUnitManifest } = require('../kernel/manifest.cjs');
+const { commitScoped } = require('../kernel/git.cjs');
+
+// Resolved against this file so it works wherever the skill tree is installed.
+const KNOWLEDGE_CLI = path.resolve(__dirname, '..', '..', '..', 'workflow-knowledge', 'scripts', 'knowledge.cjs');
+
+const PHASES = ['discovery', 'research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
+
+/** Phases whose completed artifact is knowledge-base indexed, with the artifact path per topic. */
+const INDEXED_ARTIFACTS = {
+  research: (wu, topic) => `.workflows/${wu}/research/${topic}.md`,
+  discussion: (wu, topic) => `.workflows/${wu}/discussion/${topic}.md`,
+  investigation: (wu, topic) => `.workflows/${wu}/investigation/${topic}.md`,
+  specification: (wu, topic) => `.workflows/${wu}/specification/${topic}/specification.md`,
+};
+
+/**
+ * @typedef {object} TopicTransitionResult
+ * @property {string} topic
+ * @property {string} phase
+ * @property {string} status     the topic's status after the transition
+ * @property {string|null} committed  short commit sha, or null when nothing was staged
+ * @property {string} [note]     set when committed is null
+ * @property {string[]} warnings non-blocking failures (knowledge-base sync)
+ */
+
+/**
+ * The phase item for `topic`, or a loud error.
+ * @param {object} manifest @param {string} phase @param {string} topic
+ * @returns {{status?: string, previous_status?: string}}
+ */
+function phaseItem(manifest, phase, topic) {
+  if (!PHASES.includes(phase)) {
+    throw new Error(`unknown phase "${phase}" (${PHASES.join('|')})`);
+  }
+  const phases = manifest && manifest.phases;
+  const ph = phases && typeof phases === 'object' ? phases[phase] : undefined;
+  const items = ph && typeof ph === 'object' ? ph.items : undefined;
+  if (!items || typeof items !== 'object') {
+    throw new Error(`no ${phase} items in the manifest (phases.${phase}.items)`);
+  }
+  const item = items[topic];
+  if (!item || typeof item !== 'object') {
+    throw new Error(`no ${phase} item "${topic}" in the manifest (phases.${phase}.items)`);
+  }
+  return item;
+}
+
+/**
+ * Spawn the knowledge CLI; on failure push a warning instead of throwing.
+ * @param {string} cwd @param {string[]} args @param {string} label @param {string[]} warnings
+ */
+function knowledge(cwd, args, label, warnings) {
+  const res = spawnSync('node', [KNOWLEDGE_CLI, ...args], { cwd, encoding: 'utf8' });
+  const failed = res.error || res.status !== 0;
+  if (failed) {
+    const detail = res.error
+      ? res.error.message
+      : (res.stderr || res.stdout || `exit ${res.status}`).trim();
+    warnings.push(`${label} failed: ${detail}`);
+  }
+}
+
+/**
+ * Cancel an epic topic: stash the current status into `previous_status`, set
+ * `status: cancelled`, drop the topic's discovery-map `order`, remove its
+ * knowledge-base chunks (warn-don't-block), commit scoped to the work unit.
+ * @param {string} cwd project root
+ * @param {string} workUnit
+ * @param {string} phase
+ * @param {string} topic
+ * @returns {TopicTransitionResult}
+ */
+function cancelTopic(cwd, workUnit, phase, topic) {
+  const manifest = loadWorkUnitManifest(cwd, workUnit);
+  const item = phaseItem(manifest, phase, topic);
+  if (item.status === 'cancelled') {
+    throw new Error(`${phase} item "${topic}" is already cancelled`);
+  }
+  item.previous_status = item.status;
+  item.status = 'cancelled';
+
+  const discovery = manifest.phases && manifest.phases.discovery;
+  const mapItem = discovery && discovery.items ? discovery.items[topic] : undefined;
+  if (mapItem && typeof mapItem === 'object' && 'order' in mapItem) delete mapItem.order;
+
+  saveWorkUnitManifest(cwd, workUnit, manifest);
+
+  /** @type {string[]} */
+  const warnings = [];
+  knowledge(cwd, ['remove', '--work-unit', workUnit, '--phase', phase, '--topic', topic], 'knowledge remove', warnings);
+
+  const committed = commitScoped(cwd, `.workflows/${workUnit}`, `workflow(${workUnit}): cancel ${topic} (${phase})`);
+  /** @type {TopicTransitionResult} */
+  const result = { topic, phase, status: 'cancelled', committed, warnings };
+  if (committed === null) result.note = 'nothing to commit';
+  return result;
+}
+
+/**
+ * Reactivate a cancelled epic topic: restore `previous_status` to `status`,
+ * delete the stash, re-index the artifact when the restored status is
+ * `completed` in an indexed phase (warn-don't-block), commit scoped to the
+ * work unit.
+ * @param {string} cwd project root
+ * @param {string} workUnit
+ * @param {string} phase
+ * @param {string} topic
+ * @returns {TopicTransitionResult}
+ */
+function reactivateTopic(cwd, workUnit, phase, topic) {
+  const manifest = loadWorkUnitManifest(cwd, workUnit);
+  const item = phaseItem(manifest, phase, topic);
+  if (item.status !== 'cancelled') {
+    throw new Error(`${phase} item "${topic}" is not cancelled (status: ${item.status ?? 'none'})`);
+  }
+  const restored = item.previous_status;
+  if (!restored) {
+    throw new Error(`${phase} item "${topic}" has no previous_status to restore`);
+  }
+  item.status = restored;
+  delete item.previous_status;
+
+  saveWorkUnitManifest(cwd, workUnit, manifest);
+
+  /** @type {string[]} */
+  const warnings = [];
+  const artifact = INDEXED_ARTIFACTS[/** @type {keyof typeof INDEXED_ARTIFACTS} */ (phase)];
+  if (restored === 'completed' && artifact) {
+    knowledge(cwd, ['index', artifact(workUnit, topic)], 'knowledge index', warnings);
+  }
+
+  const committed = commitScoped(cwd, `.workflows/${workUnit}`, `workflow(${workUnit}): reactivate ${topic} (${phase})`);
+  /** @type {TopicTransitionResult} */
+  const result = { topic, phase, status: restored, committed, warnings };
+  if (committed === null) result.note = 'nothing to commit';
+  return result;
+}
+
+module.exports = { cancelTopic, reactivateTopic };

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -15,13 +15,28 @@
 // ---------------------------------------------------------------------------
 
 const fs = require('fs');
+const path = require('path');
 const { signpost, box, wrapWithPrefix, renderTree, WIDTH } = require('./kernel/render.cjs');
 const { loadWorkUnitManifest, saveWorkUnitManifest } = require('./kernel/manifest.cjs');
+const { commitScoped } = require('./kernel/git.cjs');
 const { addSubtopic, setSubtopicState, mapState, SUBTOPIC_STATES } = require('./domain/map.cjs');
+const { cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
+const { archiveItems, restoreItems, deleteItems } = require('./domain/inbox.cjs');
 
 /** @param {string} msg @returns {never} */
 function die(msg) {
   process.stderr.write(msg + '\n');
+  process.exit(1);
+}
+
+/** One decision-ready JSON line on stdout. @param {object} obj */
+function respond(obj) {
+  process.stdout.write(JSON.stringify({ ok: true, ...obj }) + '\n');
+}
+
+/** `{ok:false}` JSON on stderr, exit 1. @param {unknown} err @returns {never} */
+function failJson(err) {
+  process.stderr.write(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }) + '\n');
   process.exit(1);
 }
 
@@ -48,6 +63,13 @@ const USAGE = `Usage: engine <command> [args]
 Commands:
   map add <work-unit> <topic> <subtopic> [--parent <subtopic>]
   map set <work-unit> <topic> <subtopic> <state>
+  topic cancel <work-unit> <phase> <topic>
+  topic reactivate <work-unit> <phase> <topic>
+  inbox archive <path> [<path> …]
+  inbox restore <path> [<path> …]
+  inbox delete <path> [<path> …]
+  commit <work-unit> -m <message>
+  commit --inbox -m <message>
   render signpost <label> [--style step|substep] [--width N]
   render box <title> [--width N]
   render wrap <text> [--width N] [--prefix STR]
@@ -87,21 +109,105 @@ function runMap(argv) {
       throw new Error('Usage: engine map <add|set> …');
     }
   } catch (err) {
-    process.stderr.write(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }) + '\n');
-    process.exit(1);
+    failJson(err);
   }
 }
 
 /** @param {object} manifest @param {string} topic @param {string} subtopic @param {string} status */
 function respondMap(manifest, topic, subtopic, status) {
   const state = mapState(manifest, topic);
-  process.stdout.write(JSON.stringify({
-    ok: true,
+  respond({
     subtopic,
     status,
     all_decided: state.all_decided,
     unresolved_count: state.unresolved.length,
-  }) + '\n');
+  });
+}
+
+// ---------------------------------------------------------------------------
+// topic — epic topic cancel / reactivate. One transaction per call: manifest
+// write, knowledge-base sync (warn-don't-block), scoped git commit. The JSON
+// response reports what happened — no follow-up read needed.
+// ---------------------------------------------------------------------------
+
+/** @param {string[]} argv */
+function runTopic(argv) {
+  const [command, workUnit, phase, topic] = argv;
+  try {
+    if (command !== 'cancel' && command !== 'reactivate') {
+      throw new Error('Usage: engine topic <cancel|reactivate> <work-unit> <phase> <topic>');
+    }
+    if (!workUnit || !phase || !topic) {
+      throw new Error(`Usage: engine topic ${command} <work-unit> <phase> <topic>`);
+    }
+    const fn = command === 'cancel' ? cancelTopic : reactivateTopic;
+    respond(fn(process.cwd(), workUnit, phase, topic));
+  } catch (err) {
+    failJson(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// inbox — archive / restore / delete one or more inbox items as a single
+// transaction: strict path validation, file moves (or git rm), one scoped
+// commit for the whole set.
+// ---------------------------------------------------------------------------
+
+/** @param {string[]} argv */
+function runInbox(argv) {
+  const [command, ...paths] = argv;
+  try {
+    if (!['archive', 'restore', 'delete'].includes(command) || paths.length === 0) {
+      throw new Error('Usage: engine inbox <archive|restore|delete> <path> [<path> …]');
+    }
+    const cwd = process.cwd();
+    if (command === 'archive') respond(archiveItems(cwd, paths));
+    else if (command === 'restore') respond(restoreItems(cwd, paths));
+    else respond(deleteItems(cwd, paths));
+  } catch (err) {
+    failJson(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// commit — the scoped commit helper: stage `.workflows/{wu}` (or the inbox
+// with --inbox) and commit. A clean tree is fine: {committed: null}.
+// ---------------------------------------------------------------------------
+
+/** @param {string[]} argv */
+function runCommit(argv) {
+  try {
+    /** @type {string|null} */ let workUnit = null;
+    /** @type {string|null} */ let message = null;
+    let inbox = false;
+    for (let i = 0; i < argv.length; i++) {
+      const a = argv[i];
+      if (a === '-m' || a === '--message') message = argv[++i];
+      else if (a === '--inbox') inbox = true;
+      else if (workUnit === null) workUnit = a;
+      else throw new Error(`unexpected argument "${a}"`);
+    }
+    if (!message || (inbox ? workUnit !== null : workUnit === null)) {
+      throw new Error('Usage: engine commit <work-unit> -m <message> | engine commit --inbox -m <message>');
+    }
+    const cwd = process.cwd();
+    let scope;
+    if (inbox) {
+      scope = '.workflows/.inbox';
+    } else {
+      const wu = /** @type {string} */ (workUnit);
+      if (wu.includes('/') || wu.includes('..')) throw new Error(`invalid work unit name "${wu}"`);
+      if (!fs.existsSync(path.join(cwd, '.workflows', wu))) {
+        throw new Error(`no work unit directory: .workflows/${wu}`);
+      }
+      scope = `.workflows/${wu}`;
+    }
+    const committed = commitScoped(cwd, scope, message);
+    if (committed === null) respond({ committed: null, note: 'nothing to commit' });
+    else respond({ committed });
+  } catch (err) {
+    failJson(err);
+  }
 }
 
 /** @param {string[]} argv */
@@ -142,6 +248,15 @@ function runCli(argv) {
   switch (command) {
     case 'map':
       runMap(rest);
+      break;
+    case 'topic':
+      runTopic(rest);
+      break;
+    case 'inbox':
+      runInbox(rest);
+      break;
+    case 'commit':
+      runCommit(rest);
       break;
     case 'render':
       runRender(rest);

--- a/skills/workflow-engine/scripts/kernel/git.cjs
+++ b/skills/workflow-engine/scripts/kernel/git.cjs
@@ -1,0 +1,67 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Kernel: scoped git operations — stage a pathspec, commit, report the sha.
+//
+// Mechanism only: it knows nothing about work units or the inbox. Every call
+// spawns `git` with an explicit cwd (the project root). Failures throw loud
+// with git's own stderr; a clean index is not a failure — `commitScoped`
+// reports it as `null` so callers can treat an empty pause as fine.
+// ---------------------------------------------------------------------------
+
+const { spawnSync } = require('child_process');
+
+/**
+ * Run git and return stdout. Throws with git's stderr on a non-zero exit.
+ * @param {string} cwd
+ * @param {string[]} args
+ * @returns {string}
+ */
+function git(cwd, args) {
+  const res = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (res.error) throw new Error(`git ${args[0]} failed: ${res.error.message}`);
+  if (res.status !== 0) {
+    const detail = (res.stderr || res.stdout || `exit ${res.status}`).trim();
+    throw new Error(`git ${args[0]} failed: ${detail}`);
+  }
+  return res.stdout;
+}
+
+/**
+ * Whether the index holds staged changes against HEAD.
+ * @param {string} cwd
+ * @returns {boolean}
+ */
+function hasStagedChanges(cwd) {
+  const res = spawnSync('git', ['diff', '--cached', '--quiet'], { cwd, encoding: 'utf8' });
+  if (res.error) throw new Error(`git diff failed: ${res.error.message}`);
+  if (res.status === 0) return false;
+  if (res.status === 1) return true;
+  throw new Error(`git diff failed: ${(res.stderr || `exit ${res.status}`).trim()}`);
+}
+
+/**
+ * Stage one pathspec and commit with the given message.
+ * @param {string} cwd      project root
+ * @param {string} pathspec e.g. `.workflows/{wu}` or `.workflows/.inbox`
+ * @param {string} message
+ * @returns {string|null} the short commit sha, or null when nothing was staged
+ */
+function commitScoped(cwd, pathspec, message) {
+  git(cwd, ['add', '--', pathspec]);
+  if (!hasStagedChanges(cwd)) return null;
+  git(cwd, ['commit', '-m', message]);
+  return git(cwd, ['rev-parse', '--short', 'HEAD']).trim();
+}
+
+/**
+ * `git rm` the given files (stages the deletions). One call — git validates
+ * every pathspec before removing anything.
+ * @param {string} cwd
+ * @param {string[]} paths
+ */
+function removeFiles(cwd, paths) {
+  git(cwd, ['rm', '-q', '--', ...paths]);
+}
+
+module.exports = { git, commitScoped, hasStagedChanges, removeFiles };

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/.inbox/), Bash(git add), Bash(git commit), Bash(git rm)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/.inbox/), Bash(git add), Bash(git commit), Bash(git rm)
 ---
 
 Unified workflow entry point. Discovers state, shows all active work, and routes to start or continue skills.

--- a/skills/workflow-start/references/inbox-archived.md
+++ b/skills/workflow-start/references/inbox-archived.md
@@ -95,13 +95,10 @@ Read the file and render its full content.
 
 #### If user chose `u`/`unarchive`
 
-Move the file back into its inbox folder and commit:
+Move the file back into its inbox folder and commit — one command:
 
 ```bash
-mkdir -p .workflows/.inbox/{type}/
-mv .workflows/.inbox/.archived/{type}/{date}--{slug}.md .workflows/.inbox/{type}/
-git add -- .workflows/.inbox/
-git commit -m "workflow(inbox): restore {slug}"
+node .claude/skills/workflow-engine/scripts/engine.cjs inbox restore .workflows/.inbox/.archived/{type}/{date}--{slug}.md
 ```
 
 > *Output the next fenced block as a code block:*
@@ -137,8 +134,7 @@ repo and cannot be undone.
 **If user chose `y`/`yes`:**
 
 ```bash
-git rm .workflows/.inbox/.archived/{type}/{date}--{slug}.md
-git commit -m "workflow(inbox): delete {slug}"
+node .claude/skills/workflow-engine/scripts/engine.cjs inbox delete .workflows/.inbox/.archived/{type}/{date}--{slug}.md
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-start/references/inbox-working-set.md
+++ b/skills/workflow-start/references/inbox-working-set.md
@@ -188,18 +188,10 @@ Remove the chosen items from the working set; they stay in the inbox. If the set
 
 ## D. Archive the Set
 
-Archive every item in the working set out of the inbox. For each item, move its file into the matching `.archived/{folder}` folder — `{folder}` is the item's inbox folder (`ideas` / `bugs` / `quickfixes`):
+Archive every item in the working set out of the inbox — one command moves each file into `.archived/` under its inbox folder and commits the whole set:
 
 ```bash
-mkdir -p .workflows/.inbox/.archived/{folder}/
-mv {path} .workflows/.inbox/.archived/{folder}/
-```
-
-Once every item has moved, commit the whole set in one commit — `archive {slug}` for a single item, `archive {N} items` for several:
-
-```bash
-git add -- .workflows/.inbox/
-git commit -m "workflow(inbox): archive {slug | N items}"
+node .claude/skills/workflow-engine/scripts/engine.cjs inbox archive {path} [{path} …]
 ```
 
 > *Output the next fenced block as a code block:*

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -1,0 +1,323 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+
+const ENGINE = path.join(__dirname, '../../skills/workflow-engine/scripts/engine.cjs');
+
+// Hermetic git: no user/system config leaks into fixtures or the engine's
+// spawned git subprocesses.
+process.env.GIT_CONFIG_GLOBAL = '/dev/null';
+process.env.GIT_CONFIG_SYSTEM = '/dev/null';
+
+/** @param {string} dir @param {string[]} args */
+function git(dir, args) {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+}
+
+/** A temp-dir fixture that is a real git repo with a `.workflows/` tree. */
+function setupGitFixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-tx-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  fs.mkdirSync(path.join(dir, '.workflows'), { recursive: true });
+  return dir;
+}
+
+function cleanupFixture(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function writeFile(dir, rel, content) {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+function commitAll(dir, message) {
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', message]);
+}
+
+function lastMessage(dir) {
+  return git(dir, ['log', '-1', '--pretty=%s']).trim();
+}
+
+function shortHead(dir) {
+  return git(dir, ['rev-parse', '--short', 'HEAD']).trim();
+}
+
+function readManifest(dir, wu) {
+  return JSON.parse(fs.readFileSync(path.join(dir, '.workflows', wu, 'manifest.json'), 'utf8'));
+}
+
+/** Run the engine expecting success; returns the parsed JSON response. */
+function engine(dir, args) {
+  return JSON.parse(execFileSync('node', [ENGINE, ...args], { cwd: dir, encoding: 'utf8' }).trim());
+}
+
+/** Run the engine expecting failure; returns the parsed stderr JSON. */
+function engineFails(dir, args) {
+  const res = spawnSync('node', [ENGINE, ...args], { cwd: dir, encoding: 'utf8' });
+  assert.strictEqual(res.status, 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+  assert.strictEqual(res.stdout, '');
+  const parsed = JSON.parse(res.stderr.trim());
+  assert.strictEqual(parsed.ok, false);
+  return parsed;
+}
+
+/** An epic manifest with one research item and a discovery-map entry carrying `order`. */
+function epicManifest() {
+  return {
+    name: 'payments',
+    work_type: 'epic',
+    status: 'in-progress',
+    phases: {
+      discovery: { items: { 'auth-flow': { routing: 'discussion', order: 2, source: 'discovery' } } },
+      research: { items: { 'auth-flow': { status: 'in-progress' } } },
+      discussion: { items: { 'session-model': { status: 'completed' } } },
+    },
+  };
+}
+
+function setupEpicFixture() {
+  const dir = setupGitFixture();
+  writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(epicManifest(), null, 2) + '\n');
+  commitAll(dir, 'init');
+  return dir;
+}
+
+describe('engine topic cancel', () => {
+  let dir;
+  beforeEach(() => { dir = setupEpicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('stashes status, cancels, drops the discovery order, commits — KB failure is a warning', () => {
+    const res = engine(dir, ['topic', 'cancel', 'payments', 'research', 'auth-flow']);
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.topic, 'auth-flow');
+    assert.strictEqual(res.phase, 'research');
+    assert.strictEqual(res.status, 'cancelled');
+    assert.strictEqual(res.committed, shortHead(dir));
+    // No KB configured in the fixture — warn-don't-block: the cancel still
+    // landed and the failure is reported, not thrown.
+    assert.strictEqual(res.warnings.length, 1);
+    assert.match(res.warnings[0], /knowledge remove failed/);
+
+    const m = readManifest(dir, 'payments');
+    assert.deepStrictEqual(m.phases.research.items['auth-flow'], {
+      status: 'cancelled',
+      previous_status: 'in-progress',
+    });
+    // `order` deleted; the rest of the map item preserved.
+    assert.deepStrictEqual(m.phases.discovery.items['auth-flow'], {
+      routing: 'discussion',
+      source: 'discovery',
+    });
+    assert.strictEqual(lastMessage(dir), 'workflow(payments): cancel auth-flow (research)');
+  });
+
+  it('rejects cancelling an already-cancelled topic', () => {
+    engine(dir, ['topic', 'cancel', 'payments', 'research', 'auth-flow']);
+    const err = engineFails(dir, ['topic', 'cancel', 'payments', 'research', 'auth-flow']);
+    assert.match(err.error, /already cancelled/);
+  });
+
+  it('rejects unknown work unit, phase, and topic — loud and specific', () => {
+    assert.match(engineFails(dir, ['topic', 'cancel', 'ghost', 'research', 'auth-flow']).error, /manifest not found/);
+    assert.match(engineFails(dir, ['topic', 'cancel', 'payments', 'nonsense', 'auth-flow']).error, /unknown phase "nonsense"/);
+    assert.match(engineFails(dir, ['topic', 'cancel', 'payments', 'planning', 'auth-flow']).error, /no planning items/);
+    assert.match(engineFails(dir, ['topic', 'cancel', 'payments', 'research', 'ghost']).error, /no research item "ghost"/);
+    assert.match(engineFails(dir, ['topic', 'cancel', 'payments']).error, /Usage: engine topic cancel/);
+  });
+});
+
+describe('engine topic reactivate', () => {
+  let dir;
+  beforeEach(() => { dir = setupEpicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('round-trips a cancel: status restored, previous_status removed, commit recorded', () => {
+    engine(dir, ['topic', 'cancel', 'payments', 'research', 'auth-flow']);
+    const res = engine(dir, ['topic', 'reactivate', 'payments', 'research', 'auth-flow']);
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.status, 'in-progress');
+    assert.strictEqual(res.committed, shortHead(dir));
+    // Restored to a non-completed status — no KB index attempted, no warnings.
+    assert.deepStrictEqual(res.warnings, []);
+
+    const m = readManifest(dir, 'payments');
+    assert.deepStrictEqual(m.phases.research.items['auth-flow'], { status: 'in-progress' });
+    assert.strictEqual(lastMessage(dir), 'workflow(payments): reactivate auth-flow (research)');
+  });
+
+  it('re-indexes a completed topic in an indexed phase — KB failure is a warning', () => {
+    engine(dir, ['topic', 'cancel', 'payments', 'discussion', 'session-model']);
+    const res = engine(dir, ['topic', 'reactivate', 'payments', 'discussion', 'session-model']);
+
+    assert.strictEqual(res.status, 'completed');
+    assert.strictEqual(res.warnings.length, 1);
+    assert.match(res.warnings[0], /knowledge index failed/);
+    assert.strictEqual(lastMessage(dir), 'workflow(payments): reactivate session-model (discussion)');
+  });
+
+  it('rejects reactivating a non-cancelled topic', () => {
+    const err = engineFails(dir, ['topic', 'reactivate', 'payments', 'research', 'auth-flow']);
+    assert.match(err.error, /not cancelled \(status: in-progress\)/);
+  });
+
+  it('rejects a cancelled topic with no previous_status', () => {
+    const m = epicManifest();
+    m.phases.research.items['auth-flow'] = { status: 'cancelled' };
+    writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(m, null, 2) + '\n');
+    const err = engineFails(dir, ['topic', 'reactivate', 'payments', 'research', 'auth-flow']);
+    assert.match(err.error, /no previous_status/);
+  });
+});
+
+describe('engine inbox archive / restore / delete', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setupGitFixture();
+    writeFile(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md', '# Smart Retry\n');
+    writeFile(dir, '.workflows/.inbox/bugs/2026-06-02--login-loop.md', '# Login Loop\n');
+    commitAll(dir, 'init');
+  });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('archives a single item — file moved to its source folder under .archived, slug commit message', () => {
+    const res = engine(dir, ['inbox', 'archive', '.workflows/.inbox/ideas/2026-06-01--smart-retry.md']);
+
+    assert.deepStrictEqual(res.archived, ['.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md']);
+    assert.strictEqual(res.committed, shortHead(dir));
+    assert.ok(!fs.existsSync(path.join(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md')));
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md')));
+    assert.strictEqual(lastMessage(dir), 'workflow(inbox): archive smart-retry');
+  });
+
+  it('archives a multi-item set in one commit with the N-items message form', () => {
+    const res = engine(dir, [
+      'inbox', 'archive',
+      '.workflows/.inbox/ideas/2026-06-01--smart-retry.md',
+      '.workflows/.inbox/bugs/2026-06-02--login-loop.md',
+    ]);
+
+    assert.deepStrictEqual(res.archived, [
+      '.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md',
+      '.workflows/.inbox/.archived/bugs/2026-06-02--login-loop.md',
+    ]);
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/.inbox/.archived/bugs/2026-06-02--login-loop.md')));
+    assert.strictEqual(lastMessage(dir), 'workflow(inbox): archive 2 items');
+    // One commit for the whole set.
+    assert.strictEqual(git(dir, ['rev-list', '--count', 'HEAD']).trim(), '2');
+  });
+
+  it('restores an archived item back to its live folder', () => {
+    engine(dir, ['inbox', 'archive', '.workflows/.inbox/ideas/2026-06-01--smart-retry.md']);
+    const res = engine(dir, ['inbox', 'restore', '.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md']);
+
+    assert.deepStrictEqual(res.restored, ['.workflows/.inbox/ideas/2026-06-01--smart-retry.md']);
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md')));
+    assert.ok(!fs.existsSync(path.join(dir, '.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md')));
+    assert.strictEqual(lastMessage(dir), 'workflow(inbox): restore smart-retry');
+  });
+
+  it('deletes an archived item via git rm', () => {
+    engine(dir, ['inbox', 'archive', '.workflows/.inbox/ideas/2026-06-01--smart-retry.md']);
+    const res = engine(dir, ['inbox', 'delete', '.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md']);
+
+    assert.deepStrictEqual(res.deleted, ['.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md']);
+    assert.ok(!fs.existsSync(path.join(dir, '.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md')));
+    assert.strictEqual(lastMessage(dir), 'workflow(inbox): delete smart-retry');
+    assert.strictEqual(git(dir, ['status', '--porcelain']).trim(), '');
+  });
+
+  it('rejects invalid paths strictly, before anything moves', () => {
+    // Outside the inbox entirely.
+    assert.match(
+      engineFails(dir, ['inbox', 'archive', '.workflows/payments/manifest.json']).error,
+      /not a live inbox path/);
+    // Unknown folder.
+    assert.match(
+      engineFails(dir, ['inbox', 'archive', '.workflows/.inbox/notes/2026-06-01--x.md']).error,
+      /not a live inbox path/);
+    // Traversal.
+    assert.match(
+      engineFails(dir, ['inbox', 'archive', '.workflows/.inbox/ideas/../../../etc/passwd.md']).error,
+      /not a live inbox path|without ".."/);
+    // Archived path passed to archive.
+    assert.match(
+      engineFails(dir, ['inbox', 'archive', '.workflows/.inbox/.archived/ideas/2026-06-01--x.md']).error,
+      /not a live inbox path/);
+    // Live path passed to delete.
+    assert.match(
+      engineFails(dir, ['inbox', 'delete', '.workflows/.inbox/ideas/2026-06-01--smart-retry.md']).error,
+      /not an archived inbox path/);
+    // Live path passed to restore.
+    assert.match(
+      engineFails(dir, ['inbox', 'restore', '.workflows/.inbox/ideas/2026-06-01--smart-retry.md']).error,
+      /not an archived inbox path/);
+    // Missing file.
+    assert.match(
+      engineFails(dir, ['inbox', 'archive', '.workflows/.inbox/ideas/2026-06-01--ghost.md']).error,
+      /not found/);
+    // One bad path poisons the whole set — the good file did not move.
+    engineFails(dir, [
+      'inbox', 'archive',
+      '.workflows/.inbox/ideas/2026-06-01--smart-retry.md',
+      '.workflows/.inbox/ideas/2026-06-01--ghost.md',
+    ]);
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md')));
+    assert.match(engineFails(dir, ['inbox', 'archive']).error, /Usage: engine inbox/);
+  });
+});
+
+describe('engine commit', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setupGitFixture();
+    writeFile(dir, '.workflows/payments/manifest.json', '{"name":"payments"}\n');
+    writeFile(dir, '.workflows/.inbox/ideas/2026-06-01--x.md', '# X\n');
+    commitAll(dir, 'init');
+  });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('stages the work-unit scope and commits with the given message', () => {
+    writeFile(dir, '.workflows/payments/discussion/auth.md', '# Auth\n');
+    writeFile(dir, 'unrelated.txt', 'outside the scope\n');
+
+    const res = engine(dir, ['commit', 'payments', '-m', 'discussion(payments/auth): document decision']);
+    assert.strictEqual(res.committed, shortHead(dir));
+    assert.strictEqual(lastMessage(dir), 'discussion(payments/auth): document decision');
+    // Scoped: the unrelated file stays uncommitted.
+    assert.match(git(dir, ['status', '--porcelain']), /\?\? unrelated\.txt/);
+  });
+
+  it('a clean tree is fine: committed null, nothing-to-commit note, exit 0', () => {
+    const res = engine(dir, ['commit', 'payments', '-m', 'noop']);
+    assert.deepStrictEqual(res, { ok: true, committed: null, note: 'nothing to commit' });
+  });
+
+  it('--inbox commits the inbox scope', () => {
+    writeFile(dir, '.workflows/.inbox/ideas/2026-06-02--y.md', '# Y\n');
+    const res = engine(dir, ['commit', '--inbox', '-m', 'workflow(inbox): capture y']);
+    assert.strictEqual(res.committed, shortHead(dir));
+    assert.strictEqual(lastMessage(dir), 'workflow(inbox): capture y');
+  });
+
+  it('rejects a missing message, missing scope, and bad work unit names', () => {
+    assert.match(engineFails(dir, ['commit', 'payments']).error, /Usage: engine commit/);
+    assert.match(engineFails(dir, ['commit', '-m', 'msg']).error, /Usage: engine commit/);
+    assert.match(engineFails(dir, ['commit', 'payments', '--inbox', '-m', 'msg']).error, /Usage: engine commit/);
+    assert.match(engineFails(dir, ['commit', '../escape', '-m', 'msg']).error, /invalid work unit name/);
+    assert.match(engineFails(dir, ['commit', 'ghost', '-m', 'msg']).error, /no work unit directory/);
+  });
+});


### PR DESCRIPTION
## What

PR 4 of the engine stack (on #385). The multi-step state changes Claude hand-executed across 3–5 tool calls each — with prose-specified error tolerance — become single engine commands with decision-ready JSON responses.

- **`engine topic cancel/reactivate`** — the five-step epic flows (stash status → set cancelled → drop map order → KB remove → scoped commit; and the reverse with re-indexing). KB steps are warn-don't-block, reported in the response's `warnings`; the .md renders the warning block only when present. The read-`previous_status`-and-pipe-it-back-by-hand plumbing is gone.
- **`engine inbox archive/restore/delete`** — the working-set and archived-view transactions (mkdir/mv/git rm + scoped commit), strict all-or-nothing path validation, existing commit-message conventions preserved.
- **`engine commit {wu} -m …`** (+ `--inbox`) — scoped stage+commit helper; clean tree returns ok/nothing-to-commit. Wired into discussion-session's commit sites.
- **`kernel/git.cjs`** — scoped stage+commit as mechanism (no workflow vocabulary); domain rings compose it.
- .md collapses: epic cancel 109→94 lines, reactivate 90→69, inbox archive 26→18; allowed-tools updated (nothing removed — `Bash(mv .workflows/.inbox/)` and `Bash(git rm)` in workflow-start are now call-site-free and can be dropped in a later cleanup).

## Judgment calls to review

- Session-loop step-5 commit message template written as `discussion({wu}/{topic}): {what changed}` (step 5 previously had no template; prefix derived from the existing F-block messages).
- `commitScoped` stages the pathspec then commits the index — pre-staged unrelated changes ride along, identical to the previous hand-run `git add -- … && git commit` behaviour.
- No `lib.cjs` exports for transitions/inbox — consumers are CLI-only skill prose (added when a real consumer lands).

## Tests

98/98 (`npm test`, +16 transaction tests on hermetic temp-dir git fixtures — KB warn-don't-block proven against an unconfigured fixture); epic discovery suite 98/98 unchanged; migration 045 15/15; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. **#386** 👈 current
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->