### PR TITLE
feat(engine): workflow-start read path — overview projection, unified menu with action keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node build/knowledge.build.js",
     "knowledge:repl": "node scripts/knowledge-repl.js",
     "typecheck": "tsc -p tsconfig.json",
-    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs tests/scripts/test-engine-map.cjs tests/scripts/test-engine-transactions.cjs"
+    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs tests/scripts/test-engine-start-projections.cjs tests/scripts/test-engine-map.cjs tests/scripts/test-engine-transactions.cjs"
   },
   "devDependencies": {
     "@msgpack/msgpack": "3.1.3",

--- a/skills/workflow-engine/SKILL.md
+++ b/skills/workflow-engine/SKILL.md
@@ -94,10 +94,13 @@ engine.map.mapState(manifest, topic)              // → { counts, total, all_de
 
 // domain: detail builders + projections
 engine.detail.epicDetail(cwd, manifest)           // → EpicDetail (the one structured object per epic)
+engine.detail.startDetail(cwd)                    // → StartDetail (all work units by type + inbox + closed counts)
 engine.project.epicDashboard(wu, detail, { newArrivals }) // → dashboard display block
 engine.project.epicKey(detail)                    // → Key block ('' for a brand-new epic)
 engine.project.epicMenu(wu, detail)               // → { keys, rendered } — keys carry action + route
 engine.project.discussionMap(topic, manifest)     // → Discussion Map display block
+engine.project.startOverview(detail)              // → Workflow Overview display block
+engine.project.startMenu(detail)                  // → { keys, rendered } — continue entries + start/lifecycle options
 
 // gateway: adapter harness
 engine.gateway.runGateway(handlers)               // argv verb dispatch → stdout
@@ -125,4 +128,4 @@ The .md's prescribed call names the verb (`discovery.cjs view {work_unit}`) — 
 
 ## Tests
 
-`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, `tests/scripts/test-engine-epic-projections.cjs`, `tests/scripts/test-engine-map.cjs`, and `tests/scripts/test-engine-transactions.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.
+`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, `tests/scripts/test-engine-epic-projections.cjs`, `tests/scripts/test-engine-start-projections.cjs`, `tests/scripts/test-engine-map.cjs`, and `tests/scripts/test-engine-transactions.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.

--- a/skills/workflow-engine/scripts/domain/projections/start.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/start.cjs
@@ -1,0 +1,191 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: workflow-start projections — the Workflow Overview display and
+// the unified continue/start menu over one StartDetail (see ../start.cjs).
+//
+// Deterministic: same detail, same string. The overview is a flat list (one
+// numbered item + one └─ sub-row each, numbering continuous across the type
+// sections) — composed line-by-line here, not a continuous-gutter tree. The
+// menu carries machine action keys so skills route on keys, never on labels.
+// ---------------------------------------------------------------------------
+
+const { box } = require('../../kernel/render.cjs');
+const { titlecase, capitalise } = require('../conventions.cjs');
+
+/** @typedef {import('../start.cjs').StartDetail} StartDetail */
+/** @typedef {import('../start.cjs').WorkUnitEntry} WorkUnitEntry */
+/** @typedef {import('../start.cjs').InboxDetail} InboxDetail */
+
+/**
+ * @typedef {object} StartMenuKey
+ * @property {string} key             what the user types (`1`, `2`, …, `s`, `m`, …)
+ * @property {string} [word]          long form of a command option (`start`, `inbox`, …)
+ * @property {string} action          machine action key — skills route on this, never the label
+ * @property {string} [work_type]     continue entries
+ * @property {string} [work_unit]     continue entries
+ * @property {string} [pre_seed]      start_new entries: `none` | a work type
+ * @property {string|null} route      skill invocation, or null for internal flows
+ * @property {string} label
+ */
+
+/**
+ * @typedef {object} TypeSection
+ * @property {string} label
+ * @property {'features'|'bugfixes'|'quick_fixes'|'cross_cutting'|'epics'} group
+ * @property {'feature'|'bugfix'|'quick-fix'|'cross-cutting'|'epic'} type
+ */
+
+// Display and numbering order of the type sections.
+/** @type {TypeSection[]} */
+const SECTIONS = [
+  { label: 'Features:', group: 'features', type: 'feature' },
+  { label: 'Bugfixes:', group: 'bugfixes', type: 'bugfix' },
+  { label: 'Quick Fixes:', group: 'quick_fixes', type: 'quick-fix' },
+  { label: 'Cross-Cutting:', group: 'cross_cutting', type: 'cross-cutting' },
+  { label: 'Epics:', group: 'epics', type: 'epic' },
+];
+
+const CONTINUE_SKILL = {
+  feature: 'workflow-continue-feature',
+  bugfix: 'workflow-continue-bugfix',
+  'quick-fix': 'workflow-continue-quickfix',
+  'cross-cutting': 'workflow-continue-cross-cutting',
+  epic: 'workflow-continue-epic',
+};
+
+// ---------------------------------------------------------------------------
+// Shared composition helpers
+// ---------------------------------------------------------------------------
+
+// Titlecase a phase label without disturbing its punctuation: every alphabetic
+// run is capitalised in place, so parentheses and hyphens survive.
+// `discussion (in-progress)` → `Discussion (In-Progress)`.
+/** @param {string} s */
+function titlecaseLabel(s) {
+  return String(s).replace(/[a-z]+/gi, (w) => capitalise(w));
+}
+
+/** One-line inbox count hint — non-zero categories, pluralised. @param {InboxDetail} inbox */
+function inboxHint(inbox) {
+  const parts = [];
+  if (inbox.idea_count > 0) parts.push(`${inbox.idea_count} idea${inbox.idea_count === 1 ? '' : 's'}`);
+  if (inbox.bug_count > 0) parts.push(`${inbox.bug_count} bug${inbox.bug_count === 1 ? '' : 's'}`);
+  if (inbox.quickfix_count > 0) parts.push(`${inbox.quickfix_count} quick-fix${inbox.quickfix_count === 1 ? '' : 'es'}`);
+  return parts.join(', ');
+}
+
+// The └─ sub-row: epics show their active phases (phase_label when nothing has
+// started yet); every other type shows the titlecased phase label.
+/** @param {WorkUnitEntry} unit @param {TypeSection['type']} type */
+function subRow(unit, type) {
+  if (type === 'epic') {
+    const phases = unit.active_phases || [];
+    if (phases.length > 0) return phases.map(titlecase).join(', ');
+  }
+  return titlecaseLabel(unit.phase_label);
+}
+
+// ---------------------------------------------------------------------------
+// Overview
+// ---------------------------------------------------------------------------
+
+/**
+ * Section A — the Workflow Overview display. One code-block string: box cap,
+ * non-empty type sections with continuous numbering, the inbox hint line, and
+ * the completed/cancelled count line.
+ * @param {StartDetail} detail
+ * @returns {string}
+ */
+function startOverview(detail) {
+  const lines = [];
+  let n = 0;
+  for (const s of SECTIONS) {
+    const units = detail[s.group].work_units;
+    if (units.length === 0) continue;
+    lines.push(s.label);
+    for (const u of units) {
+      n += 1;
+      lines.push(`  ${n}. ${titlecase(u.name)}`);
+      lines.push(`     └─ ${subRow(u, s.type)}`);
+      lines.push('');
+    }
+  }
+  if (detail.state.has_inbox) {
+    lines.push(`Inbox: ${inboxHint(detail.inbox)}`);
+    lines.push('');
+  }
+  if (detail.completed_count > 0 || detail.cancelled_count > 0) {
+    lines.push(`${detail.completed_count} completed, ${detail.cancelled_count} cancelled.`);
+    lines.push('');
+  }
+  return (box('Workflow Overview') + lines.join('\n')).replace(/\n+$/, '\n');
+}
+
+// ---------------------------------------------------------------------------
+// Menu
+// ---------------------------------------------------------------------------
+
+/** @param {WorkUnitEntry} unit @param {TypeSection['type']} type */
+function continueLabel(unit, type) {
+  const t = titlecase(unit.name);
+  if (type === 'epic') return `Continue "${t}" — epic`;
+  return `Continue "${t}" — ${type}, ${unit.phase_label}`;
+}
+
+/**
+ * Section B — the interactive menu. `keys` carries the machine action keys
+ * (skills route on these); `rendered` is the dotted-gate markdown block.
+ * Numbered continue entries first (overview order and numbering), then the
+ * start-new and lifecycle command options (`i` only with a live inbox, `v`
+ * only with completed/cancelled work units).
+ * @param {StartDetail} detail
+ * @returns {{keys: StartMenuKey[], rendered: string}}
+ */
+function startMenu(detail) {
+  /** @type {StartMenuKey[]} */
+  const numbered = [];
+  for (const s of SECTIONS) {
+    for (const u of detail[s.group].work_units) {
+      numbered.push({
+        key: String(numbered.length + 1),
+        action: 'continue_work_unit',
+        work_type: s.type,
+        work_unit: u.name,
+        route: `/${CONTINUE_SKILL[s.type]} ${u.name}`,
+        label: continueLabel(u, s.type),
+      });
+    }
+  }
+
+  /** @type {StartMenuKey[]} */
+  const options = [
+    { key: 's', word: 'start', action: 'start_new', pre_seed: 'none', route: null, label: 'Start something new (not sure what kind yet)' },
+    { key: 'f', word: 'feature', action: 'start_new', pre_seed: 'feature', route: null, label: 'Start new feature' },
+    { key: 'e', word: 'epic', action: 'start_new', pre_seed: 'epic', route: null, label: 'Start new epic' },
+    { key: 'b', word: 'bugfix', action: 'start_new', pre_seed: 'bugfix', route: null, label: 'Start new bugfix' },
+    { key: 'q', word: 'quick-fix', action: 'start_new', pre_seed: 'quick-fix', route: null, label: 'Start new quick-fix' },
+    { key: 'c', word: 'cross-cutting', action: 'start_new', pre_seed: 'cross-cutting', route: null, label: 'Start new cross-cutting concern' },
+  ];
+  if (detail.state.has_inbox) {
+    options.push({ key: 'i', word: 'inbox', action: 'view_inbox', route: null, label: 'View the inbox and start from an item' });
+  }
+  if (detail.completed_count > 0 || detail.cancelled_count > 0) {
+    options.push({ key: 'v', word: 'view', action: 'view_completed', route: null, label: 'View completed & cancelled work units' });
+  }
+  options.push({ key: 'm', word: 'manage', action: 'manage', route: null, label: "Manage a work unit's lifecycle" });
+
+  const lines = ['· · · · · · · · · · · ·', 'What would you like to do?', ''];
+  for (const e of numbered) {
+    lines.push(`- **\`${e.key}\`** — ${e.label}`);
+  }
+  if (numbered.length > 0) lines.push('');
+  for (const o of options) {
+    lines.push(`- **\`${o.key}\`/\`${o.word}\`** — ${o.label}`);
+  }
+  lines.push('', 'Select an option:', '· · · · · · · · · · · ·');
+
+  return { keys: [...numbered, ...options], rendered: lines.join('\n') };
+}
+
+module.exports = { startOverview, startMenu };

--- a/skills/workflow-engine/scripts/domain/start.cjs
+++ b/skills/workflow-engine/scripts/domain/start.cjs
@@ -1,0 +1,290 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: the workflow-start detail — the one structured object the
+// start overview, menu, and reasoning surfaces derive from.
+//
+// Collates every active work unit by type (with next-phase state), the inbox
+// (live and archived), and the completed/cancelled sets. Pure over the
+// project's `.workflows/` tree: same files, same answer. Shared manifest
+// semantics come from workflow-shared/discovery-utils — never duplicated here.
+// ---------------------------------------------------------------------------
+
+const fs = require('fs');
+const path = require('path');
+const {
+  loadActiveManifests,
+  loadAllManifests,
+  phaseStatus,
+  phaseItems,
+  computeNextPhase,
+} = require('../../../workflow-shared/scripts/discovery-utils.cjs');
+
+const EPIC_PHASES = ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
+
+const ALL_PHASES = ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
+
+/**
+ * @typedef {object} WorkUnitEntry
+ * @property {string} name
+ * @property {string} next_phase
+ * @property {string} phase_label
+ * @property {string[]} [active_phases]  epics only — phases that have items
+ */
+
+/**
+ * @typedef {object} TypeGroup
+ * @property {WorkUnitEntry[]} work_units
+ * @property {number} count
+ */
+
+/**
+ * @typedef {object} ClosedEntry
+ * @property {string} name
+ * @property {string} work_type
+ * @property {string} status
+ * @property {string|null} last_phase
+ */
+
+/**
+ * @typedef {object} InboxItem
+ * @property {string} slug
+ * @property {string} date
+ * @property {string} title
+ * @property {string} file
+ */
+
+/**
+ * @typedef {object} InboxScan
+ * @property {InboxItem[]} ideas
+ * @property {InboxItem[]} bugs
+ * @property {InboxItem[]} quickfixes
+ * @property {number} idea_count
+ * @property {number} bug_count
+ * @property {number} quickfix_count
+ * @property {number} total_count
+ */
+
+/** @typedef {InboxScan & {archived: InboxScan}} InboxDetail */
+
+/**
+ * @typedef {object} StartState
+ * @property {boolean} has_any_work
+ * @property {number} epic_count
+ * @property {number} feature_count
+ * @property {number} bugfix_count
+ * @property {number} quickfix_count
+ * @property {number} cross_cutting_count
+ * @property {boolean} has_inbox
+ * @property {number} inbox_count
+ * @property {boolean} has_archived
+ * @property {number} archived_count
+ */
+
+/**
+ * @typedef {object} StartDetail
+ * @property {TypeGroup} epics
+ * @property {TypeGroup} features
+ * @property {TypeGroup} bugfixes
+ * @property {TypeGroup} quick_fixes
+ * @property {TypeGroup} cross_cutting
+ * @property {ClosedEntry[]} completed
+ * @property {ClosedEntry[]} cancelled
+ * @property {number} completed_count
+ * @property {number} cancelled_count
+ * @property {InboxDetail} inbox
+ * @property {StartState} state
+ */
+
+/**
+ * Last phase with a completed item (epic) or completed aggregate status
+ * (single-topic types), in pipeline order. Null when nothing completed.
+ * @param {object} manifest
+ * @returns {string|null}
+ */
+function lastCompletedPhase(manifest) {
+  let last = null;
+  if (manifest.work_type === 'epic') {
+    for (const phase of ALL_PHASES) {
+      const items = phaseItems(manifest, phase);
+      if (items.length > 0 && items.some(i => i.status === 'completed')) {
+        last = phase;
+      }
+    }
+  } else {
+    for (const phase of ALL_PHASES) {
+      const s = phaseStatus(manifest, phase);
+      if (s === 'completed') last = phase;
+    }
+  }
+  return last;
+}
+
+/** First markdown H1, or null. @param {string} filePath @returns {string|null} */
+function readTitle(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const match = content.match(/^#\s+(.+)$/m);
+    return match ? match[1].trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse `YYYY-MM-DD--slug.md`, or null on a non-conforming name. @param {string} filename @returns {{date: string, slug: string}|null} */
+function parseInboxFile(filename) {
+  const match = filename.match(/^(\d{4}-\d{2}-\d{2})--(.+)\.md$/);
+  if (!match) return null;
+  return { date: match[1], slug: match[2] };
+}
+
+/**
+ * Scan one inbox layout root (`{ideas,bugs,quickfixes}/` beneath it).
+ * @param {string} baseDir
+ * @returns {InboxScan}
+ */
+function scanInboxDir(baseDir) {
+  /** @type {InboxItem[]} */
+  const ideas = [];
+  /** @type {InboxItem[]} */
+  const bugs = [];
+  /** @type {InboxItem[]} */
+  const quickfixes = [];
+
+  for (const type of ['ideas', 'bugs', 'quickfixes']) {
+    const dir = path.join(baseDir, type);
+    /** @type {string[]} */
+    let files;
+    try {
+      files = fs.readdirSync(dir).filter(f => f.endsWith('.md')).sort();
+    } catch {
+      files = [];
+    }
+    for (const f of files) {
+      const parsed = parseInboxFile(f);
+      if (!parsed) continue;
+      const title = readTitle(path.join(dir, f)) || parsed.slug;
+      const item = { slug: parsed.slug, date: parsed.date, title, file: f };
+      if (type === 'ideas') ideas.push(item);
+      else if (type === 'bugs') bugs.push(item);
+      else quickfixes.push(item);
+    }
+  }
+
+  return {
+    ideas,
+    bugs,
+    quickfixes,
+    idea_count: ideas.length,
+    bug_count: bugs.length,
+    quickfix_count: quickfixes.length,
+    total_count: ideas.length + bugs.length + quickfixes.length,
+  };
+}
+
+/**
+ * Live inbox plus the `.archived/` store nested beneath it.
+ * @param {string} cwd
+ * @returns {InboxDetail}
+ */
+function discoverInbox(cwd) {
+  const inboxDir = path.join(cwd, '.workflows', '.inbox');
+  const inbox = scanInboxDir(inboxDir);
+  return { ...inbox, archived: scanInboxDir(path.join(inboxDir, '.archived')) };
+}
+
+/**
+ * Build the full workflow-start detail for one project.
+ * @param {string} cwd  project root (the directory containing `.workflows/`)
+ * @returns {StartDetail}
+ */
+function startDetail(cwd) {
+  const manifests = loadActiveManifests(cwd);
+  /** @type {WorkUnitEntry[]} */
+  const epics = [];
+  /** @type {WorkUnitEntry[]} */
+  const features = [];
+  /** @type {WorkUnitEntry[]} */
+  const bugfixes = [];
+  /** @type {WorkUnitEntry[]} */
+  const quick_fixes = [];
+  /** @type {WorkUnitEntry[]} */
+  const cross_cutting = [];
+
+  for (const m of manifests) {
+    const state = computeNextPhase(m);
+    if (state.next_phase === 'done') continue;
+
+    /** @type {WorkUnitEntry} */
+    const unit = {
+      name: m.name,
+      next_phase: state.next_phase,
+      phase_label: state.phase_label,
+    };
+
+    if (m.work_type === 'epic') {
+      // For epics, include list of phases that have items
+      const activePhases = [];
+      for (const phase of EPIC_PHASES) {
+        const items = phaseItems(m, phase);
+        if (items.length > 0) {
+          activePhases.push(phase);
+        }
+      }
+      unit.active_phases = activePhases;
+      epics.push(unit);
+    } else if (m.work_type === 'bugfix') {
+      bugfixes.push(unit);
+    } else if (m.work_type === 'quick-fix') {
+      quick_fixes.push(unit);
+    } else if (m.work_type === 'cross-cutting') {
+      cross_cutting.push(unit);
+    } else {
+      features.push(unit);
+    }
+  }
+
+  // Load completed/cancelled work units across all types
+  const allManifests = loadAllManifests(cwd);
+  /** @type {ClosedEntry[]} */
+  const completed = [];
+  /** @type {ClosedEntry[]} */
+  const cancelled = [];
+
+  for (const m of allManifests) {
+    if (m.status === 'completed') {
+      completed.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
+    } else if (m.status === 'cancelled') {
+      cancelled.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
+    }
+  }
+
+  const inbox = discoverInbox(cwd);
+
+  return {
+    epics: { work_units: epics, count: epics.length },
+    features: { work_units: features, count: features.length },
+    bugfixes: { work_units: bugfixes, count: bugfixes.length },
+    quick_fixes: { work_units: quick_fixes, count: quick_fixes.length },
+    cross_cutting: { work_units: cross_cutting, count: cross_cutting.length },
+    completed,
+    cancelled,
+    completed_count: completed.length,
+    cancelled_count: cancelled.length,
+    inbox,
+    state: {
+      has_any_work: (epics.length + features.length + bugfixes.length + quick_fixes.length + cross_cutting.length) > 0,
+      epic_count: epics.length,
+      feature_count: features.length,
+      bugfix_count: bugfixes.length,
+      quickfix_count: quick_fixes.length,
+      cross_cutting_count: cross_cutting.length,
+      has_inbox: inbox.total_count > 0,
+      inbox_count: inbox.total_count,
+      has_archived: inbox.archived.total_count > 0,
+      archived_count: inbox.archived.total_count,
+    },
+  };
+}
+
+module.exports = { startDetail };

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -23,9 +23,11 @@ const manifest = require('./kernel/manifest.cjs');
 const conventions = require('./domain/conventions.cjs');
 const gateway = require('./gateway.cjs');
 const epic = require('./domain/epic.cjs');
+const start = require('./domain/start.cjs');
 const map = require('./domain/map.cjs');
 const epicProjections = require('./domain/projections/epic.cjs');
 const discussionProjections = require('./domain/projections/discussion.cjs');
+const startProjections = require('./domain/projections/start.cjs');
 
 module.exports = {
   render,
@@ -38,11 +40,13 @@ module.exports = {
     mapState: map.mapState,
     SUBTOPIC_STATES: map.SUBTOPIC_STATES,
   },
-  detail: { epicDetail: epic.epicDetail, EPIC_PHASES: epic.EPIC_PHASES },
+  detail: { epicDetail: epic.epicDetail, EPIC_PHASES: epic.EPIC_PHASES, startDetail: start.startDetail },
   project: {
     epicDashboard: epicProjections.epicDashboard,
     epicKey: epicProjections.epicKey,
     epicMenu: epicProjections.epicMenu,
     discussionMap: discussionProjections.discussionMap,
+    startOverview: startProjections.startOverview,
+    startMenu: startProjections.startMenu,
   },
 };

--- a/skills/workflow-start/references/active-work.md
+++ b/skills/workflow-start/references/active-work.md
@@ -8,155 +8,61 @@ Display all active work and present a unified menu for continuing or starting wo
 
 ## A. Display and Menu
 
-> *Output the next fenced block as a code block:*
+Render the workflow overview snapshot:
 
-```
-●───────────────────────────────────────────────●
-  Workflow Overview
-●───────────────────────────────────────────────●
-
-@if(feature_count > 0)
-Features:
-@foreach(unit in features.work_units)
-  {N}. {unit.name:(titlecase)}
-     └─ {unit.phase_label:(titlecase)}
-
-@endforeach
-@endif
-
-@if(bugfix_count > 0)
-Bugfixes:
-@foreach(unit in bugfixes.work_units)
-  {N}. {unit.name:(titlecase)}
-     └─ {unit.phase_label:(titlecase)}
-
-@endforeach
-@endif
-
-@if(quickfix_count > 0)
-Quick Fixes:
-@foreach(unit in quick_fixes.work_units)
-  {N}. {unit.name:(titlecase)}
-     └─ {unit.phase_label:(titlecase)}
-
-@endforeach
-@endif
-
-@if(cross_cutting_count > 0)
-Cross-Cutting:
-@foreach(unit in cross_cutting.work_units)
-  {N}. {unit.name:(titlecase)}
-     └─ {unit.phase_label:(titlecase)}
-
-@endforeach
-@endif
-
-@if(epic_count > 0)
-Epics:
-@foreach(unit in epics.work_units)
-  {N}. {unit.name:(titlecase)}
-     └─ {unit.active_phases:(titlecase, comma-separated)}
-
-@endforeach
-@endif
-
-@if(has_inbox)
-
-Inbox: {inbox_hint}
-@endif
-
-@if(completed_count > 0 || cancelled_count > 0)
-{completed_count} completed, {cancelled_count} cancelled.
-@endif
+```bash
+node .claude/skills/workflow-start/scripts/discovery.cjs view
 ```
 
-Build from discovery output. Only show sections that have work units. Numbering is continuous across sections. Feature/bugfix shows `phase_label` (titlecased). Epic shows comma-separated `active_phases` (titlecased). Blank line between each numbered item.
+The output is one snapshot in three demarcated sections:
 
-`{inbox_hint}` is a one-line count, not the items themselves — comma-separated non-zero categories from `inbox.idea_count` / `inbox.bug_count` / `inbox.quickfix_count`, pluralised (e.g. `10 ideas, 4 bugs, 3 quick-fixes`; `1 idea`). The `i`/`inbox` option opens the full list to pick from — keeping a project with many inbox items from flooding this menu.
+- **DATA** — reasoning surface: state flags, counts, and the `ACTIONS` table — one line per menu key, `key  action  work_unit  → route`, with `(pre_seed: …)` markers on start-new entries. Reason from it; never display or restate it.
+- **DISPLAY** — the workflow overview. Emit verbatim as a code block. Never redraw, reflow, or trim it.
+- **MENU** — the selection menu. Emit verbatim as markdown (not a code block).
 
-## Menu
-
-Build the menu with numbered continue items first, then command options for start-new and lifecycle actions, separated by blank lines.
+Emit the DISPLAY section, then the signpost blockquote below, then the MENU section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Numbered items continue existing work. Letter commands below
 > start something new or manage lifecycle.
-
-· · · · · · · · · · · ·
-What would you like to do?
-
-- **`1`** — Continue "{feature.name:(titlecase)}" — feature, {feature.phase_label}
-- **`2`** — Continue "{bugfix.name:(titlecase)}" — bugfix, {bugfix.phase_label}
-- **`3`** — Continue "{quickfix.name:(titlecase)}" — quick-fix, {quickfix.phase_label}
-- **`4`** — Continue "{cross_cutting.name:(titlecase)}" — cross-cutting, {cross_cutting.phase_label}
-- **`5`** — Continue "{epic.name:(titlecase)}" — epic
-
-- **`s`/`start`** — Start something new (not sure what kind yet)
-- **`f`/`feature`** — Start new feature
-- **`e`/`epic`** — Start new epic
-- **`b`/`bugfix`** — Start new bugfix
-- **`q`/`quick-fix`** — Start new quick-fix
-- **`c`/`cross-cutting`** — Start new cross-cutting concern
-@if(has_inbox)
-- **`i`/`inbox`** — View the inbox and start from an item
-@endif
-@if(completed_count > 0 || cancelled_count > 0)
-- **`v`/`view`** — View completed & cancelled work units
-@endif
-- **`m`/`manage`** — Manage a work unit's lifecycle
-
-Select an option:
-· · · · · · · · · · · ·
 ```
-
-**Continue items:** Same visual style as command options — `- **`N`** — description`. Feature/bugfix/cross-cutting shows type + phase label. Epic just shows "epic" (detail is in workflow-continue-epic). No auto-select — always show the full menu. No "(recommended)" labels.
-
-**Command options:** Start-new, inbox, view, and manage are always command options (not numbered). Always show all six start options (`s` plus the five typed picks).
-
-Recreate with actual work units from discovery.
 
 **STOP.** Wait for user response.
 
-#### If user chose a continue option
+→ Proceed to **B. Handle Selection**.
 
-Invoke the matching skill:
+---
 
-| Selection | Invoke |
-|-----------|--------|
-| Continue feature | `/workflow-continue-feature {work_unit}` |
-| Continue bugfix | `/workflow-continue-bugfix {work_unit}` |
-| Continue quick-fix | `/workflow-continue-quickfix {work_unit}` |
-| Continue cross-cutting | `/workflow-continue-cross-cutting {work_unit}` |
-| Continue epic | `/workflow-continue-epic {work_unit}` |
+## B. Handle Selection
+
+Match the user's input to its `ACTIONS` entry by `key` — a number, or a command option's letter / long form. Every decision below reads the entry's `action` value, never its label text.
+
+#### If `action` is `continue_work_unit`
+
+Invoke the entry's stored `route` (e.g. `/workflow-continue-feature {work_unit}`).
 
 This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
 
-#### If user chose a start-new option (`s`, `f`, `e`, `b`, `q`, or `c`)
+#### If `action` is `start_new`
 
-Set the work-type pre-seed from the pick — `s` → `none`, otherwise the matching type (feature / epic / bugfix / quick-fix / cross-cutting).
+→ Load **[route-to-discovery.md](route-to-discovery.md)** with work_type = `{pre_seed}`, inbox_seeds = `none`.
 
-→ Load **[route-to-discovery.md](route-to-discovery.md)** with work_type = `{work_type}`, inbox_seeds = `none`.
+#### If `action` is `view_inbox`
 
-#### If user chose `v`/`view`
-
-→ Load **[view-completed.md](view-completed.md)** and follow its instructions as written.
-
-Re-run discovery to refresh state after potential changes.
+Load **[start-from-inbox.md](start-from-inbox.md)** and follow its instructions as written.
 
 → Return to **A. Display and Menu**.
 
-#### If user chose `i`/`inbox`
+#### If `action` is `view_completed`
 
-→ Load **[start-from-inbox.md](start-from-inbox.md)** and follow its instructions as written.
+Load **[view-completed.md](view-completed.md)** and follow its instructions as written.
 
 → Return to **A. Display and Menu**.
 
-#### If user chose `m`/`manage`
+#### If `action` is `manage`
 
-→ Load **[manage-work-unit.md](manage-work-unit.md)** and follow its instructions as written.
-
-Re-run discovery to refresh state after potential changes.
+Load **[manage-work-unit.md](manage-work-unit.md)** and follow its instructions as written.
 
 → Return to **A. Display and Menu**.

--- a/skills/workflow-start/scripts/discovery.cjs
+++ b/skills/workflow-start/scripts/discovery.cjs
@@ -1,168 +1,18 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-const { loadActiveManifests, loadAllManifests, phaseStatus, phaseItems, computeNextPhase } = require('../../workflow-shared/scripts/discovery-utils.cjs');
+// ---------------------------------------------------------------------------
+// Adapter (read gateway) for workflow-start. Thin by design: collation lives
+// in the engine's domain ring; this script selects which engine answers the
+// skill's flow needs and sections the output.
+//
+//   discovery.cjs        → labelled dump, all work + inbox (head insert)
+//   discovery.cjs view   → DATA + DISPLAY + MENU snapshot (Step 3)
+// ---------------------------------------------------------------------------
 
-const EPIC_PHASES = ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
-
-const ALL_PHASES = ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
-
-function lastCompletedPhase(manifest) {
-  let last = null;
-  if (manifest.work_type === 'epic') {
-    for (const phase of ALL_PHASES) {
-      const items = phaseItems(manifest, phase);
-      if (items.length > 0 && items.some(i => i.status === 'completed')) {
-        last = phase;
-      }
-    }
-  } else {
-    for (const phase of ALL_PHASES) {
-      const s = phaseStatus(manifest, phase);
-      if (s === 'completed') last = phase;
-    }
-  }
-  return last;
-}
-
-function readTitle(filePath) {
-  try {
-    const content = fs.readFileSync(filePath, 'utf8');
-    const match = content.match(/^#\s+(.+)$/m);
-    return match ? match[1].trim() : null;
-  } catch {
-    return null;
-  }
-}
-
-function parseInboxFile(filename) {
-  const match = filename.match(/^(\d{4}-\d{2}-\d{2})--(.+)\.md$/);
-  if (!match) return null;
-  return { date: match[1], slug: match[2] };
-}
-
-function scanInboxDir(baseDir) {
-  const ideas = [];
-  const bugs = [];
-  const quickfixes = [];
-
-  for (const type of ['ideas', 'bugs', 'quickfixes']) {
-    const dir = path.join(baseDir, type);
-    let files;
-    try {
-      files = fs.readdirSync(dir).filter(f => f.endsWith('.md')).sort();
-    } catch {
-      files = [];
-    }
-    for (const f of files) {
-      const parsed = parseInboxFile(f);
-      if (!parsed) continue;
-      const title = readTitle(path.join(dir, f)) || parsed.slug;
-      const item = { slug: parsed.slug, date: parsed.date, title, file: f };
-      if (type === 'ideas') ideas.push(item);
-      else if (type === 'bugs') bugs.push(item);
-      else quickfixes.push(item);
-    }
-  }
-
-  return {
-    ideas,
-    bugs,
-    quickfixes,
-    idea_count: ideas.length,
-    bug_count: bugs.length,
-    quickfix_count: quickfixes.length,
-    total_count: ideas.length + bugs.length + quickfixes.length,
-  };
-}
-
-function discoverInbox(cwd) {
-  const inboxDir = path.join(cwd, '.workflows', '.inbox');
-  const inbox = scanInboxDir(inboxDir);
-  inbox.archived = scanInboxDir(path.join(inboxDir, '.archived'));
-  return inbox;
-}
+const engine = require('../../workflow-engine/scripts/lib.cjs');
 
 function discover(cwd) {
-  const manifests = loadActiveManifests(cwd);
-  const epics = [];
-  const features = [];
-  const bugfixes = [];
-  const quick_fixes = [];
-  const cross_cutting = [];
-
-  for (const m of manifests) {
-    const state = computeNextPhase(m);
-    if (state.next_phase === 'done') continue;
-
-    const unit = {
-      name: m.name,
-      next_phase: state.next_phase,
-      phase_label: state.phase_label,
-    };
-
-    if (m.work_type === 'epic') {
-      // For epics, include list of phases that have items or status
-      const activePhases = [];
-      for (const phase of EPIC_PHASES) {
-        const items = phaseItems(m, phase);
-        if (items.length > 0) {
-          activePhases.push(phase);
-        }
-      }
-      unit.active_phases = activePhases;
-      epics.push(unit);
-    } else if (m.work_type === 'bugfix') {
-      bugfixes.push(unit);
-    } else if (m.work_type === 'quick-fix') {
-      quick_fixes.push(unit);
-    } else if (m.work_type === 'cross-cutting') {
-      cross_cutting.push(unit);
-    } else {
-      features.push(unit);
-    }
-  }
-
-  // Load completed/cancelled work units across all types
-  const allManifests = loadAllManifests(cwd);
-  const completed = [];
-  const cancelled = [];
-
-  for (const m of allManifests) {
-    if (m.status === 'completed') {
-      completed.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
-    } else if (m.status === 'cancelled') {
-      cancelled.push({ name: m.name, work_type: m.work_type, status: m.status, last_phase: lastCompletedPhase(m) });
-    }
-  }
-
-  const inbox = discoverInbox(cwd);
-
-  return {
-    epics: { work_units: epics, count: epics.length },
-    features: { work_units: features, count: features.length },
-    bugfixes: { work_units: bugfixes, count: bugfixes.length },
-    quick_fixes: { work_units: quick_fixes, count: quick_fixes.length },
-    cross_cutting: { work_units: cross_cutting, count: cross_cutting.length },
-    completed,
-    cancelled,
-    completed_count: completed.length,
-    cancelled_count: cancelled.length,
-    inbox,
-    state: {
-      has_any_work: (epics.length + features.length + bugfixes.length + quick_fixes.length + cross_cutting.length) > 0,
-      epic_count: epics.length,
-      feature_count: features.length,
-      bugfix_count: bugfixes.length,
-      quickfix_count: quick_fixes.length,
-      cross_cutting_count: cross_cutting.length,
-      has_inbox: inbox.total_count > 0,
-      inbox_count: inbox.total_count,
-      has_archived: inbox.archived.total_count > 0,
-      archived_count: inbox.archived.total_count,
-    },
-  };
+  return engine.detail.startDetail(cwd);
 }
 
 function format(result) {
@@ -253,8 +103,38 @@ function format(result) {
   return lines.join('\n') + '\n';
 }
 
+// One snapshot for Step 3: reasoning DATA (state flags + the ACTIONS table),
+// the rendered overview (DISPLAY), and the menu (MENU).
+function view() {
+  const detail = discover(process.cwd());
+  const menu = engine.project.startMenu(detail);
+
+  const dataLines = [];
+  dataLines.push(`has_any_work: ${detail.state.has_any_work}`);
+  dataLines.push(`counts: ${detail.state.epic_count} epic, ${detail.state.feature_count} feature, ${detail.state.bugfix_count} bugfix, ${detail.state.quickfix_count} quick-fix, ${detail.state.cross_cutting_count} cross-cutting`);
+  dataLines.push(`inbox_count: ${detail.state.inbox_count}`);
+  dataLines.push(`completed_count: ${detail.completed_count}`);
+  dataLines.push(`cancelled_count: ${detail.cancelled_count}`);
+  dataLines.push('ACTIONS (key  action  work_unit  → route):');
+  for (const k of menu.keys) {
+    let line = `  ${k.key}  ${k.action}  ${k.work_unit || '—'}  → ${k.route || '(internal)'}`;
+    if (k.pre_seed) line += `  (pre_seed: ${k.pre_seed})`;
+    dataLines.push(line);
+  }
+
+  return [
+    engine.gateway.dataBlock(dataLines.join('\n')),
+    engine.gateway.displayBlock(engine.project.startOverview(detail)),
+    engine.gateway.menuBlock(menu.rendered),
+  ].join('\n');
+}
+
 if (require.main === module) {
-  process.stdout.write(format(discover(process.cwd())));
+  engine.gateway.runGateway({
+    index: () => format(discover(process.cwd())),
+    view,
+    fallback: () => format(discover(process.cwd())),
+  });
 }
 
 module.exports = { discover, format };

--- a/tests/scripts/test-engine-start-projections.cjs
+++ b/tests/scripts/test-engine-start-projections.cjs
@@ -1,0 +1,233 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const { setupFixture, cleanupFixture, createManifest, createFile } = require('./discovery-test-utils.cjs');
+const { startDetail } = require('../../skills/workflow-engine/scripts/domain/start.cjs');
+const { startOverview, startMenu } = require('../../skills/workflow-engine/scripts/domain/projections/start.cjs');
+
+// Golden tests: byte-exact expected strings for the workflow-start overview
+// and menu projections. Fixtures go through real manifests and inbox files in
+// temp dirs (the same shapes the discovery tests produce).
+
+const BOX = [
+  '●───────────────────────────────────────────────●',
+  '  Workflow Overview',
+  '●───────────────────────────────────────────────●',
+  '',
+];
+
+/** All five type sections populated, plus inbox and completed/cancelled. */
+function fullFixture(dir) {
+  createManifest(dir, 'dark-mode', {
+    phases: { discussion: { items: { 'dark-mode': { status: 'in-progress' } } } },
+  });
+  createManifest(dir, 'auth-flow', {
+    phases: { discussion: { items: { 'auth-flow': { status: 'completed' } } } },
+  });
+  createManifest(dir, 'login-crash', { work_type: 'bugfix' });
+  createManifest(dir, 'rename-api', {
+    work_type: 'quick-fix',
+    phases: { scoping: { items: { 'rename-api': { status: 'in-progress' } } } },
+  });
+  createManifest(dir, 'caching', {
+    work_type: 'cross-cutting',
+    phases: { discussion: { items: { caching: { status: 'in-progress' } } } },
+  });
+  createManifest(dir, 'quiz-competition-v1', {
+    work_type: 'epic',
+    phases: {
+      research: { items: { 'kitchen-hardware': { status: 'completed' } } },
+      discussion: { items: { 'menu-admin': { status: 'in-progress' } } },
+    },
+  });
+  createManifest(dir, 'done-feat', { status: 'completed', phases: { review: { items: { 'done-feat': { status: 'completed' } } } } });
+  createManifest(dir, 'dropped', { work_type: 'bugfix', status: 'cancelled' });
+  createFile(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md', '# Smart Retry\n');
+  createFile(dir, '.workflows/.inbox/ideas/2026-06-02--dark-launch.md', '# Dark Launch\n');
+  createFile(dir, '.workflows/.inbox/bugs/2026-06-03--login-timeout.md', '# Login Timeout\n');
+  return startDetail(dir);
+}
+
+describe('start projections: overview', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('renders all five type sections, the inbox hint, and the counts line byte-for-byte', () => {
+    assert.strictEqual(startOverview(fullFixture(dir)), [
+      ...BOX,
+      'Features:',
+      '  1. Auth Flow',
+      '     └─ Ready For Specification',
+      '',
+      '  2. Dark Mode',
+      '     └─ Discussion (In-Progress)',
+      '',
+      'Bugfixes:',
+      '  3. Login Crash',
+      '     └─ Ready For Investigation',
+      '',
+      'Quick Fixes:',
+      '  4. Rename Api',
+      '     └─ Scoping (In-Progress)',
+      '',
+      'Cross-Cutting:',
+      '  5. Caching',
+      '     └─ Discussion (In-Progress)',
+      '',
+      'Epics:',
+      '  6. Quiz Competition V1',
+      '     └─ Research, Discussion',
+      '',
+      'Inbox: 2 ideas, 1 bug',
+      '',
+      '1 completed, 1 cancelled.',
+      '',
+    ].join('\n'));
+  });
+
+  it('renders a single populated section with no inbox and no counts line', () => {
+    createManifest(dir, 'auth-flow', {});
+    assert.strictEqual(startOverview(startDetail(dir)), [
+      ...BOX,
+      'Features:',
+      '  1. Auth Flow',
+      '     └─ Ready For Discussion',
+      '',
+    ].join('\n'));
+  });
+
+  it('numbers continuously across sections, skipping empty ones', () => {
+    createManifest(dir, 'dark-mode', {});
+    createManifest(dir, 'auth-flow', {});
+    createManifest(dir, 'v1', { work_type: 'epic', phases: { research: { items: { exploration: { status: 'in-progress' } } } } });
+    assert.strictEqual(startOverview(startDetail(dir)), [
+      ...BOX,
+      'Features:',
+      '  1. Auth Flow',
+      '     └─ Ready For Discussion',
+      '',
+      '  2. Dark Mode',
+      '     └─ Ready For Discussion',
+      '',
+      'Epics:',
+      '  3. V1',
+      '     └─ Research',
+      '',
+    ].join('\n'));
+  });
+
+  it('pluralises the inbox hint per category and singularises one-item counts', () => {
+    createManifest(dir, 'auth-flow', {});
+    createFile(dir, '.workflows/.inbox/ideas/2026-06-01--one.md', '# One\n');
+    createFile(dir, '.workflows/.inbox/quickfixes/2026-06-02--qf-a.md', '# A\n');
+    createFile(dir, '.workflows/.inbox/quickfixes/2026-06-03--qf-b.md', '# B\n');
+    const out = startOverview(startDetail(dir));
+    assert.ok(out.includes('\nInbox: 1 idea, 2 quick-fixes\n'));
+  });
+
+  it('epic with no phase items falls back to its phase label', () => {
+    createManifest(dir, 'fresh-epic', { work_type: 'epic' });
+    assert.strictEqual(startOverview(startDetail(dir)), [
+      ...BOX,
+      'Epics:',
+      '  1. Fresh Epic',
+      '     └─ Ready For Discussion',
+      '',
+    ].join('\n'));
+  });
+});
+
+describe('start projections: menu', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('renders continue entries then command options with the conditional i/v present', () => {
+    const menu = startMenu(fullFixture(dir));
+    assert.strictEqual(menu.rendered, [
+      '· · · · · · · · · · · ·',
+      'What would you like to do?',
+      '',
+      '- **`1`** — Continue "Auth Flow" — feature, ready for specification',
+      '- **`2`** — Continue "Dark Mode" — feature, discussion (in-progress)',
+      '- **`3`** — Continue "Login Crash" — bugfix, ready for investigation',
+      '- **`4`** — Continue "Rename Api" — quick-fix, scoping (in-progress)',
+      '- **`5`** — Continue "Caching" — cross-cutting, discussion (in-progress)',
+      '- **`6`** — Continue "Quiz Competition V1" — epic',
+      '',
+      '- **`s`/`start`** — Start something new (not sure what kind yet)',
+      '- **`f`/`feature`** — Start new feature',
+      '- **`e`/`epic`** — Start new epic',
+      '- **`b`/`bugfix`** — Start new bugfix',
+      '- **`q`/`quick-fix`** — Start new quick-fix',
+      '- **`c`/`cross-cutting`** — Start new cross-cutting concern',
+      '- **`i`/`inbox`** — View the inbox and start from an item',
+      '- **`v`/`view`** — View completed & cancelled work units',
+      '- **`m`/`manage`** — Manage a work unit\'s lifecycle',
+      '',
+      'Select an option:',
+      '· · · · · · · · · · · ·',
+    ].join('\n'));
+  });
+
+  it('omits i and v when there is no inbox and nothing completed or cancelled', () => {
+    createManifest(dir, 'auth-flow', {});
+    const menu = startMenu(startDetail(dir));
+    assert.strictEqual(menu.rendered, [
+      '· · · · · · · · · · · ·',
+      'What would you like to do?',
+      '',
+      '- **`1`** — Continue "Auth Flow" — feature, ready for discussion',
+      '',
+      '- **`s`/`start`** — Start something new (not sure what kind yet)',
+      '- **`f`/`feature`** — Start new feature',
+      '- **`e`/`epic`** — Start new epic',
+      '- **`b`/`bugfix`** — Start new bugfix',
+      '- **`q`/`quick-fix`** — Start new quick-fix',
+      '- **`c`/`cross-cutting`** — Start new cross-cutting concern',
+      '- **`m`/`manage`** — Manage a work unit\'s lifecycle',
+      '',
+      'Select an option:',
+      '· · · · · · · · · · · ·',
+    ].join('\n'));
+  });
+
+  it('shows v with cancelled-only work units', () => {
+    createManifest(dir, 'auth-flow', {});
+    createManifest(dir, 'dropped', { status: 'cancelled' });
+    const { keys } = startMenu(startDetail(dir));
+    assert.ok(keys.some((k) => k.key === 'v' && k.action === 'view_completed'));
+    assert.ok(!keys.some((k) => k.key === 'i'));
+  });
+
+  it('keys carry actions, work types/units, routes, and pre_seeds', () => {
+    const { keys } = startMenu(fullFixture(dir));
+    assert.deepStrictEqual(
+      keys.map((k) => [k.key, k.action, k.work_unit || null, k.route, k.pre_seed || null]),
+      [
+        ['1', 'continue_work_unit', 'auth-flow', '/workflow-continue-feature auth-flow', null],
+        ['2', 'continue_work_unit', 'dark-mode', '/workflow-continue-feature dark-mode', null],
+        ['3', 'continue_work_unit', 'login-crash', '/workflow-continue-bugfix login-crash', null],
+        ['4', 'continue_work_unit', 'rename-api', '/workflow-continue-quickfix rename-api', null],
+        ['5', 'continue_work_unit', 'caching', '/workflow-continue-cross-cutting caching', null],
+        ['6', 'continue_work_unit', 'quiz-competition-v1', '/workflow-continue-epic quiz-competition-v1', null],
+        ['s', 'start_new', null, null, 'none'],
+        ['f', 'start_new', null, null, 'feature'],
+        ['e', 'start_new', null, null, 'epic'],
+        ['b', 'start_new', null, null, 'bugfix'],
+        ['q', 'start_new', null, null, 'quick-fix'],
+        ['c', 'start_new', null, null, 'cross-cutting'],
+        ['i', 'view_inbox', null, null, null],
+        ['v', 'view_completed', null, null, null],
+        ['m', 'manage', null, null, null],
+      ]
+    );
+    assert.deepStrictEqual(
+      keys.filter((k) => k.action === 'continue_work_unit').map((k) => k.work_type),
+      ['feature', 'feature', 'bugfix', 'quick-fix', 'cross-cutting', 'epic']
+    );
+  });
+});


### PR DESCRIPTION
## What

PR 5 of the engine stack (on #386). The front door joins the engine — same shape as the epic beachhead (#384).

- **`domain/start.cjs`** — `startDetail` ports the all-units collation; **`domain/projections/start.cjs`** — the Workflow Overview block (grouped flat list, continuous numbering, inbox hint, closed counts) + the unified menu with action keys (`continue_work_unit` entries carry `route: /workflow-continue-{type} {wu}`; `start_new` carries its `pre_seed`).
- **Adapter on the gateway** — `index` (head insert) byte-identical: the 56-test start discovery suite passes UNTOUCHED, and old-vs-new stdout diffed identical. `view` emits the DATA/DISPLAY/MENU snapshot.
- **`active-work.md`: 163 → 68 lines** — call → emit verbatim → STOP → route on keys, with the re-render loop on inbox/view/manage returns. The per-type continue routing table is gone.

## Judgment calls to review

- Overview blank-line canonicalisation (exactly one between blocks — old template was ambiguous).
- Epic with empty `active_phases` falls back to titlecased `phase_label` (template had no rule; empty `└─` row would be broken output).
- Display sub-rows titlecase with punctuation preserved; menu labels keep raw lowercase phase_label (as the old template distinguished).
- `pre_seed` surfaces as an ACTIONS-line marker, in the style of `(recommended)`/`(blocked: …)`.

## Tests

107/107 (`npm test`, +9 start projection goldens); start discovery 56/56 file-untouched; epic discovery 98/98; migration 045 15/15; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. **#387** 👈 current
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->