### PR TITLE
feat(engine): boot pipeline — Step 0 checks in one decision-ready call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ The phases group into three stages (the **three D's**), used as the top-level gr
 
 Skills organised in tiers:
 
-**Entry skill** (`workflow-start`): the sole user-invocable entry. Shows all work; routes new work into discovery and existing work into the per-type `workflow-continue-*` skills. Also hosts the inbox pickup — a **working set** (multi-select promotion, single-type-gated) with an `.archived` lifecycle (archive · restore · delete). Hosts the full Step 0 (casing · migrations · knowledge-check · knowledge-compact), run once. `/workflow-migrate` is model-invoked only (Step 0 of `workflow-start`).
+**Entry skill** (`workflow-start`): the sole user-invocable entry. Shows all work; routes new work into discovery and existing work into the per-type `workflow-continue-*` skills. Also hosts the inbox pickup — a **working set** (multi-select promotion, single-type-gated) with an `.archived` lifecycle (archive · restore · delete). Hosts the full Step 0 (casing, then `engine boot` — migrations + knowledge check + compact in one call), run once.
 
 **Discovery** (`workflow-discovery`): model-only (`user-invocable: false`). The universal first phase (see Workflow Phases #1) — new work is shaped and its type settled here before the pipeline branches into the type-specific phases. Two modes — new (decide the work type, persist at the commit, route out) and existing-epic (re-shape the map, delegated from `workflow-continue-epic`).
 
@@ -136,7 +136,7 @@ Contract and scaffolding templates live in `.claude/skills/create-output-format/
 
 ## Migrations
 
-`/workflow-migrate` keeps workflow files in sync with current system design (runs via Step 0 of every entry-point skill).
+Migrations keep workflow files in sync with current system design (run via `engine boot` in Step 0 of `workflow-start`).
 
 **How it works:**
 - `skills/workflow-migrate/scripts/migrate.sh` runs all migration scripts in `skills/workflow-migrate/scripts/migrations/` in numeric order

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -416,7 +416,7 @@ Never use `Stop here.`, `Command ends.`, `Wait for user to acknowledge before en
 
 Sequential: `## Step 0`, `## Step 1`, `## Step 2`, etc.
 
-- **Step 0** runs migrations via the `/workflow-migrate` skill (mandatory in all entry-point skills)
+- **Step 0** hosts initialisation; `workflow-start` runs migrations and the knowledge gate via `engine boot`
 - Steps are separated by `---` horizontal rules
 - Each step completes fully before the next begins
 - User-facing step markers (see Display & Output Conventions → Step Markers) use names only — no numbers. They are embedded at each step boundary, including steps with no explicit output (Claude's visible processing labels the activity for the user)
@@ -434,13 +434,14 @@ Decompose these steps into **sub-steps** using H3 decimal numbering:
 Load **[casing-conventions.md](...)** and follow its instructions as written.
 → Proceed to **Step 0.2**.
 
-### Step 0.2: Migrations
+### Step 0.2: Boot
 
-#### If the `/workflow-migrate` skill has already been invoked in this conversation
+#### If `migrations.changed` is `true`
+[diff review + summary + confirm gate]
 → Proceed to **Step 0.3**.
 
 #### Otherwise
-[run migrations + CRITICAL note]
+[up-to-date display]
 → Proceed to **Step 0.3**.
 
 ### Step 0.3: Intro and Knowledge Check

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "node build/knowledge.build.js",
     "knowledge:repl": "node scripts/knowledge-repl.js",
     "typecheck": "tsc -p tsconfig.json",
-    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs tests/scripts/test-engine-start-projections.cjs tests/scripts/test-engine-map.cjs tests/scripts/test-engine-transactions.cjs"
+    "test": "node --test tests/scripts/test-render.cjs tests/scripts/test-engine-gateway.cjs tests/scripts/test-engine-epic-projections.cjs tests/scripts/test-engine-start-projections.cjs tests/scripts/test-engine-map.cjs tests/scripts/test-engine-transactions.cjs tests/scripts/test-engine-boot.cjs"
   },
   "devDependencies": {
     "@msgpack/msgpack": "3.1.3",

--- a/skills/workflow-engine/SKILL.md
+++ b/skills/workflow-engine/SKILL.md
@@ -29,6 +29,12 @@ node .claude/skills/workflow-engine/scripts/engine.cjs <command> [args]
 
 Domain commands (state transitions, queries) land here as they are built.
 
+**`boot`** — the entry pipeline: runs `workflow-migrate/scripts/migrate.sh` (resolved relative to the engine, cwd = project root), then `knowledge check`, then `knowledge compact` when ready — one call in place of the sequential Step 0 commands. Response: `{"ok": true, "migrations": {"changed": false, "output": "<trimmed report>"}, "knowledge": "ready"|"not-ready", "compacted": false, "warnings": []}`. `migrations.changed` mirrors migrate.sh's own files-updated signal; `output` is the report with the prose stop-gate lines stripped (update counts kept). A failing migrate.sh is a hard error (`{ok:false}` on stderr, exit 1) — migrations must never half-run silently. A failing `check` reports `not-ready`; a failing `compact` lands in `warnings`, never blocks. The conversational pieces (migration summary, review gate, not-ready terminal stop) stay in the calling skill.
+
+```bash
+engine boot
+```
+
 **`map`** — discussion-map transitions. Both commands load the work unit's manifest, apply the transition, save atomically, and print one decision-ready JSON line: `{"ok": true, "subtopic": "…", "status": "…", "all_decided": false, "unresolved_count": N}` — no follow-up read needed. Errors print `{"ok": false, "error": "…"}` to stderr and exit 1. No git commit — the calling session's commit cadence picks the manifest change up.
 
 ```bash
@@ -53,11 +59,12 @@ engine inbox restore <path> [<path> …]   # .archived/{folder}/ → live
 engine inbox delete <path> [<path> …]    # git rm archived items
 ```
 
-**`commit`** — the scoped commit helper: `git add -- .workflows/{wu}` (or `.workflows/.inbox` with `--inbox`) plus commit. A clean tree is fine: `{"ok": true, "committed": null, "note": "nothing to commit"}`, exit 0.
+**`commit`** — the scoped commit helper: `git add -- .workflows/{wu}` (`.workflows/.inbox` with `--inbox`, or the whole `.workflows` tree with `--workflows` — migrations touch many work units plus `.workflows/.state`) plus commit. A clean tree is fine: `{"ok": true, "committed": null, "note": "nothing to commit"}`, exit 0.
 
 ```bash
 engine commit <work-unit> -m "<message>"
 engine commit --inbox -m "<message>"
+engine commit --workflows -m "<message>"
 ```
 
 **Rendering is not a runtime CLI concern.** Static chrome (signposts, boxes, gate rules) lives as literal blocks in skill prose; parameterised chrome is rendered in-process by projections. No skill flow calls a render command at runtime — the `render` command group in `engine.cjs` is a development/debugging utility only (e.g. generating a correct literal while authoring prose).
@@ -128,4 +135,4 @@ The .md's prescribed call names the verb (`discovery.cjs view {work_unit}`) — 
 
 ## Tests
 
-`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, `tests/scripts/test-engine-epic-projections.cjs`, `tests/scripts/test-engine-start-projections.cjs`, `tests/scripts/test-engine-map.cjs`, and `tests/scripts/test-engine-transactions.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.
+`tests/scripts/test-render.cjs`, `tests/scripts/test-engine-gateway.cjs`, `tests/scripts/test-engine-epic-projections.cjs`, `tests/scripts/test-engine-start-projections.cjs`, `tests/scripts/test-engine-map.cjs`, `tests/scripts/test-engine-transactions.cjs`, and `tests/scripts/test-engine-boot.cjs` (run via `npm test`). Type contracts are enforced by `npm run typecheck` (JSDoc + `tsc --noEmit`). Add a test alongside any change to engine scripts.

--- a/skills/workflow-engine/scripts/domain/boot.cjs
+++ b/skills/workflow-engine/scripts/domain/boot.cjs
@@ -1,0 +1,89 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: the boot pipeline — the sequential entry checks Step 0 needs,
+// collapsed into one call: run migrations, probe the knowledge base, compact
+// when ready.
+//
+// Migrations are the durability-critical leg: a failing migrate.sh is a hard
+// error — migrations must never half-run silently. The knowledge base is a
+// derived index: a failing `check` reports "not-ready" (the caller's gate),
+// a failing `compact` is a warning, never a block.
+// ---------------------------------------------------------------------------
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+// Resolved against this file so they work wherever the skill tree is installed.
+const SKILLS_ROOT = path.resolve(__dirname, '..', '..', '..');
+const MIGRATE_SH = path.join(SKILLS_ROOT, 'workflow-migrate', 'scripts', 'migrate.sh');
+const KNOWLEDGE_CLI = path.join(SKILLS_ROOT, 'workflow-knowledge', 'scripts', 'knowledge.cjs');
+
+// migrate.sh prints this marker if and only if files were updated — it is the
+// authoritative "changed" signal. (git status is no substitute: unrelated
+// session work may already be dirty under .workflows.) The marker's follow-on
+// instruction lines address a prose flow, not this caller, so the trimmed
+// report drops everything from the marker down.
+const STOP_GATE_MARKER = '---STOP_GATE: FILES_UPDATED---';
+
+/**
+ * @typedef {object} BootResult
+ * @property {{changed: boolean, output: string}} migrations
+ * @property {'ready'|'not-ready'} knowledge
+ * @property {boolean} compacted
+ * @property {string[]} warnings non-blocking failures (knowledge compaction)
+ */
+
+/**
+ * migrate.sh's report, trimmed for the JSON response: everything above the
+ * stop-gate marker (update counts included), whitespace collapsed at the ends.
+ * @param {string} stdout
+ * @returns {string}
+ */
+function trimReport(stdout) {
+  const lines = stdout.split('\n');
+  const idx = lines.findIndex((line) => line.trim() === STOP_GATE_MARKER);
+  return (idx === -1 ? lines : lines.slice(0, idx)).join('\n').trim();
+}
+
+/**
+ * Run the boot pipeline against the project at `cwd`.
+ * @param {string} cwd project root
+ * @returns {BootResult}
+ */
+function boot(cwd) {
+  const mig = spawnSync('bash', [MIGRATE_SH], { cwd, encoding: 'utf8' });
+  if (mig.error || mig.status !== 0) {
+    const detail = mig.error
+      ? mig.error.message
+      : `exit ${mig.status}: ${(mig.stderr || mig.stdout || '').trim()}`;
+    throw new Error(`migrate.sh failed — migrations must never half-run silently (${detail})`);
+  }
+  const stdout = mig.stdout || '';
+  const migrations = {
+    changed: stdout.includes(STOP_GATE_MARKER),
+    output: trimReport(stdout),
+  };
+
+  /** @type {string[]} */
+  const warnings = [];
+  const check = spawnSync('node', [KNOWLEDGE_CLI, 'check'], { cwd, encoding: 'utf8' });
+  const ready = !check.error && check.status === 0 && (check.stdout || '').trim() === 'ready';
+
+  let compacted = false;
+  if (ready) {
+    const compact = spawnSync('node', [KNOWLEDGE_CLI, 'compact'], { cwd, encoding: 'utf8' });
+    if (compact.error || compact.status !== 0) {
+      const detail = compact.error
+        ? compact.error.message
+        : (compact.stderr || compact.stdout || `exit ${compact.status}`).trim();
+      warnings.push(`knowledge compact failed: ${detail}`);
+    } else {
+      compacted = true;
+    }
+  }
+
+  return { migrations, knowledge: ready ? 'ready' : 'not-ready', compacted, warnings };
+}
+
+module.exports = { boot };

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -22,6 +22,7 @@ const { commitScoped } = require('./kernel/git.cjs');
 const { addSubtopic, setSubtopicState, mapState, SUBTOPIC_STATES } = require('./domain/map.cjs');
 const { cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
 const { archiveItems, restoreItems, deleteItems } = require('./domain/inbox.cjs');
+const { boot } = require('./domain/boot.cjs');
 
 /** @param {string} msg @returns {never} */
 function die(msg) {
@@ -61,6 +62,7 @@ function parseArgs(argv) {
 const USAGE = `Usage: engine <command> [args]
 
 Commands:
+  boot
   map add <work-unit> <topic> <subtopic> [--parent <subtopic>]
   map set <work-unit> <topic> <subtopic> <state>
   topic cancel <work-unit> <phase> <topic>
@@ -70,6 +72,7 @@ Commands:
   inbox delete <path> [<path> …]
   commit <work-unit> -m <message>
   commit --inbox -m <message>
+  commit --workflows -m <message>
   render signpost <label> [--style step|substep] [--width N]
   render box <title> [--width N]
   render wrap <text> [--width N] [--prefix STR]
@@ -170,8 +173,22 @@ function runInbox(argv) {
 }
 
 // ---------------------------------------------------------------------------
-// commit — the scoped commit helper: stage `.workflows/{wu}` (or the inbox
-// with --inbox) and commit. A clean tree is fine: {committed: null}.
+// boot — the entry pipeline: migrations (hard error on failure), knowledge
+// check (failure reports not-ready), compact when ready (warn-don't-block).
+// ---------------------------------------------------------------------------
+
+function runBoot() {
+  try {
+    respond(boot(process.cwd()));
+  } catch (err) {
+    failJson(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// commit — the scoped commit helper: stage `.workflows/{wu}` (the inbox with
+// --inbox, or the whole tree with --workflows) and commit. A clean tree is
+// fine: {committed: null}.
 // ---------------------------------------------------------------------------
 
 /** @param {string[]} argv */
@@ -180,19 +197,24 @@ function runCommit(argv) {
     /** @type {string|null} */ let workUnit = null;
     /** @type {string|null} */ let message = null;
     let inbox = false;
+    let workflows = false;
     for (let i = 0; i < argv.length; i++) {
       const a = argv[i];
       if (a === '-m' || a === '--message') message = argv[++i];
       else if (a === '--inbox') inbox = true;
+      else if (a === '--workflows') workflows = true;
       else if (workUnit === null) workUnit = a;
       else throw new Error(`unexpected argument "${a}"`);
     }
-    if (!message || (inbox ? workUnit !== null : workUnit === null)) {
-      throw new Error('Usage: engine commit <work-unit> -m <message> | engine commit --inbox -m <message>');
+    const scopeCount = [inbox, workflows, workUnit !== null].filter(Boolean).length;
+    if (!message || scopeCount !== 1) {
+      throw new Error('Usage: engine commit <work-unit> -m <message> | engine commit --inbox -m <message> | engine commit --workflows -m <message>');
     }
     const cwd = process.cwd();
     let scope;
-    if (inbox) {
+    if (workflows) {
+      scope = '.workflows';
+    } else if (inbox) {
       scope = '.workflows/.inbox';
     } else {
       const wu = /** @type {string} */ (workUnit);
@@ -246,6 +268,9 @@ function runRender(argv) {
 function runCli(argv) {
   const [command, ...rest] = argv;
   switch (command) {
+    case 'boot':
+      runBoot();
+      break;
     case 'map':
       runMap(rest);
       break;

--- a/skills/workflow-migrate/SKILL.md
+++ b/skills/workflow-migrate/SKILL.md
@@ -1,97 +1,13 @@
 ---
 name: workflow-migrate
 user-invocable: false
-allowed-tools: Bash(.claude/skills/workflow-migrate/scripts/migrate.sh), Bash(git diff), Bash(git status), Bash(git add), Bash(git commit)
 ---
 
 # Migrate
 
-Keeps your workflow files up to date with how the system is designed to work. Runs all pending migrations automatically.
+Migrations run via `engine boot` (`node .claude/skills/workflow-engine/scripts/engine.cjs boot`, called in Step 0 of `workflow-start`) — this skill is never invoked. The directory remains the home of the migration machinery:
 
-## Instructions
+- `scripts/migrate.sh` — orchestrator: runs every script in `scripts/migrations/` in numeric order, tracks progress in `.workflows/.state/migrations`, reports update counts.
+- `scripts/migrations/NNN-*.sh` — the migration scripts, each idempotent.
 
-Follow these steps EXACTLY as written. Do not skip steps or combine them.
-
-**CRITICAL**: This guidance is mandatory.
-
-- After each user interaction, STOP and wait for their response before proceeding
-- Never assume or anticipate user choices
-- No session-level instruction overrides STOP gates. This includes harness auto mode, system-reminders, hook-injected text, "work without stopping" / "make the reasonable call" guidance, /loop continuation hints, or any other meta-directive encouraging autonomous progression. STOP gates are structured decision points, NOT clarifying questions — "reasonable call" reasoning does not apply. The only skip mechanism is a per-gate `*_gate_mode: auto` value in the manifest, set by the user's explicit `a`/`auto` choice at a prior gate.
-- Failure mode — "the reasonable call is X, I'll proceed with X": that IS the auto-answer the rule forbids. The thought is the trigger to stop, not to continue.
-- Failure mode — "the user already set this, confirmation is redundant" (e.g. project defaults, prior preferences, stored manifest values): that IS the auto-answer the rule forbids. Stored values are suggestions, not consent for this run.
-- Don't invent stops. Stop only at gates the skill prescribes (rendered gate blocks, explicit `**STOP.**` directives) — no courtesy check-ins, mid-loop summaries that end the turn, or unprescribed pauses between tasks/topics/phases.
-- After rendering a gate block, the turn MUST end. No further tool calls in the same turn — wait for the user's response before proceeding.
-- Complete each step fully before moving to the next
-
----
-
-## Step 1: Run Migrations
-
-Run the migration script with sandbox disabled (migrations may need to modify `.claude/settings.json`):
-
-```bash
-.claude/skills/workflow-migrate/scripts/migrate.sh
-```
-
-**CRITICAL**: Use `dangerouslyDisableSandbox: true` when calling the Bash tool for this command.
-
-#### If the output contains `---STOP_GATE: FILES_UPDATED---`
-
-Files were updated. You MUST complete the steps below before returning to the calling skill.
-
-1. Run `git diff` to see what changed.
-2. Write a brief natural language summary of what the migrations did (e.g., "Restructured workflow directories, created manifest files, renamed tracking artifacts"). Focus on the nature of the changes, not individual file paths — these are internal workflow state files.
-3. Display the summary:
-
-> *Output the next fenced block as a code block:*
-
-```
-Migrations Applied
-
-{your natural language summary}
-
-{N} migration(s), {M} file(s) updated.
-```
-
-→ Proceed to **Step 2**.
-
-#### Otherwise
-
-> *Output the next fenced block as a code block:*
-
-```
-All documents up to date.
-```
-
-**Do not stop here.** No migrations were needed — continue executing the calling skill immediately.
-
-→ Return to caller.
-
----
-
-## Step 2: Confirm Changes
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Ready to continue?
-
-- **`c`/`continue`** — Proceed
-- **Ask** — Ask questions about the changes
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-#### If `continue`
-
-Check `git status`. If migration changes are uncommitted, stage and commit them with the message `chore: apply workflow migrations` before returning.
-
-→ Return to caller.
-
-#### If ask
-
-Answer the user's question.
-
-→ Return to **Step 2**.
+The conversational surface (change summary, review gate, commit) lives in `workflow-start` Step 0.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/.inbox/), Bash(git diff)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/.inbox/), Bash(git status), Bash(git diff)
 ---
 
 Unified workflow entry point. Discovers state, shows all active work, and routes to start or continue skills.
@@ -87,7 +87,7 @@ Migrations must never half-run silently. Surface the reported error to the user.
 
 Files were updated. You MUST complete the steps below before proceeding.
 
-1. Run `git diff -- .workflows` to see what changed.
+1. Run `git status --short -- .workflows` and `git diff -- .workflows` to see what changed. Status shows moved and newly-created files that diff cannot (untracked destinations render a move as bare deletions) — read both before summarising.
 2. Write a brief natural language summary of what the migrations did (e.g., "Restructured workflow directories, created manifest files, renamed tracking artifacts"). Focus on the nature of the changes, not individual file paths — these are internal workflow state files.
 3. Display the summary (`{N}`/`{M}` come from `migrations.output`):
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/.inbox/), Bash(git add), Bash(git commit), Bash(git rm)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/discovery.cjs), Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(mv .workflows/.inbox/), Bash(git diff)
 ---
 
 Unified workflow entry point. Discovers state, shows all active work, and routes to start or continue skills.
@@ -59,25 +59,128 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 → Proceed to **Step 0.2**.
 
-### Step 0.2: Migrations
+### Step 0.2: Boot
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Running migrations to keep workflow files in sync.
+> Running migrations and the knowledge base check.
 ```
 
-**Run migrations — this is mandatory. You must complete it before proceeding.**
+**Run the boot pipeline — this is mandatory. You must complete it before proceeding.**
 
-Invoke the `/workflow-migrate` skill and follow its instructions exactly — if it issues a STOP gate, you must stop.
+Run the boot command with sandbox disabled (migrations may need to modify `.claude/settings.json`) and capture its JSON response:
 
-**CRITICAL**: When the migrate skill returns (either after committing changes or reporting no changes needed), you MUST continue to **Step 0.3**. Do not stop after migration completes.
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs boot
+```
+
+**CRITICAL**: Use `dangerouslyDisableSandbox: true` when calling the Bash tool for this command.
+
+#### If the command fails (`ok: false` or non-zero exit)
+
+Migrations must never half-run silently. Surface the reported error to the user.
+
+**STOP.** Do not proceed — terminal condition.
+
+#### If `migrations.changed` is `true`
+
+Files were updated. You MUST complete the steps below before proceeding.
+
+1. Run `git diff -- .workflows` to see what changed.
+2. Write a brief natural language summary of what the migrations did (e.g., "Restructured workflow directories, created manifest files, renamed tracking artifacts"). Focus on the nature of the changes, not individual file paths — these are internal workflow state files.
+3. Display the summary (`{N}`/`{M}` come from `migrations.output`):
+
+> *Output the next fenced block as a code block:*
+
+```
+Migrations Applied
+
+{your natural language summary}
+
+{N} migration(s), {M} file(s) updated.
+```
+
+4. Confirm:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Ready to continue?
+
+- **`c`/`continue`** — Proceed
+- **Ask** — Ask questions about the changes
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `continue`:**
+
+Commit the migration changes:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "chore: apply workflow migrations"
+```
 
 → Proceed to **Step 0.3**.
 
-### Step 0.3: Knowledge Check
+**If ask:**
 
-Load **[knowledge-check.md](../workflow-knowledge/references/knowledge-check.md)** and follow its instructions as written.
+Answer the user's question, then re-render the confirmation prompt above.
+
+**STOP.** Wait for user response.
+
+#### Otherwise
+
+> *Output the next fenced block as a code block:*
+
+```
+All documents up to date.
+```
+
+**Do not stop here.** No migrations were needed.
+
+→ Proceed to **Step 0.3**.
+
+### Step 0.3: Knowledge Gate
+
+Branch on the boot response — run no further commands (`compact` already ran inside boot when the knowledge base was ready).
+
+#### If `knowledge` is `not-ready`
+
+> *Output the next fenced block as a code block:*
+
+```
+●───────────────────────────────────────────────●
+  Knowledge Base Not Ready
+●───────────────────────────────────────────────●
+
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> The knowledge base is required infrastructure for workflows.
+> It must be initialised before any workflow can proceed.
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+To set up the knowledge base, run:
+
+  node .claude/skills/workflow-knowledge/scripts/knowledge.cjs setup
+
+Setup configures system defaults, initialises the project store,
+and runs the initial indexing pass. If no API key is available,
+stub mode is offered as an alternative.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+#### If `knowledge` is `ready`
 
 → Proceed to **Step 1**.
 

--- a/tests/scripts/test-engine-boot.cjs
+++ b/tests/scripts/test-engine-boot.cjs
@@ -1,0 +1,288 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+
+const REAL_SCRIPTS = path.join(__dirname, '../../skills/workflow-engine/scripts');
+const REAL_ENGINE = path.join(REAL_SCRIPTS, 'engine.cjs');
+
+// Hermetic git: no user/system config leaks into fixtures or the engine's
+// spawned git subprocesses.
+process.env.GIT_CONFIG_GLOBAL = '/dev/null';
+process.env.GIT_CONFIG_SYSTEM = '/dev/null';
+
+/** @param {string} dir @param {string[]} args */
+function git(dir, args) {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+}
+
+function writeFile(dir, rel, content) {
+  const full = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+/** A project fixture: a real git repo with a `.workflows/` tree. */
+function setupProject(root) {
+  const project = path.join(root, 'project');
+  fs.mkdirSync(project, { recursive: true });
+  git(project, ['init', '-q', '-b', 'main']);
+  git(project, ['config', 'user.email', 'test@example.com']);
+  git(project, ['config', 'user.name', 'Test']);
+  git(project, ['config', 'commit.gpgsign', 'false']);
+  writeFile(project, '.workflows/payments/manifest.json', '{"name":"payments"}\n');
+  git(project, ['add', '-A']);
+  git(project, ['commit', '-q', '-m', 'init']);
+  return project;
+}
+
+// Stub migrate.sh: env-driven behaviour, mimicking the real report format
+// byte-for-byte (boot parses the report, so the stub must reproduce it).
+const STUB_MIGRATE = `#!/usr/bin/env bash
+case "$STUB_MIGRATE_MODE" in
+  update)
+    mkdir -p .workflows/.state .workflows/payments
+    echo "045" >> .workflows/.state/migrations
+    echo "migrated" > .workflows/payments/marker.md
+    echo ""
+    echo "1 migration(s) applied, 2 file(s) updated."
+    echo ""
+    echo "---STOP_GATE: FILES_UPDATED---"
+    echo "You MUST now follow the migration skill instructions to STOP and let the user review."
+    echo "Follow the explicit instructions in the migration skill before proceeding."
+    ;;
+  fail)
+    echo "partial output before the failure"
+    echo "boom: migration 099 exploded" >&2
+    exit 1
+    ;;
+  *)
+    echo "[SKIP] No changes needed"
+    ;;
+esac
+`;
+
+// Stub knowledge CLI: records each invocation to knowledge-calls.log in the
+// project cwd; check/compact behaviour is env-driven.
+const STUB_KNOWLEDGE = `#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const cmd = process.argv[2] || '';
+fs.appendFileSync('knowledge-calls.log', cmd + '\\n');
+if (cmd === 'check') {
+  if (process.env.STUB_CHECK_EXIT) process.exit(parseInt(process.env.STUB_CHECK_EXIT, 10));
+  process.stdout.write((process.env.STUB_CHECK || 'not-ready') + '\\n');
+  process.exit(0);
+}
+if (cmd === 'compact') {
+  if (process.env.STUB_COMPACT_EXIT) {
+    process.stderr.write('compact blew up\\n');
+    process.exit(parseInt(process.env.STUB_COMPACT_EXIT, 10));
+  }
+  process.exit(0);
+}
+process.exit(1);
+`;
+
+/**
+ * A hermetic skills layout: the real engine scripts copied into a temp skills
+ * root, with stub migrate.sh / knowledge.cjs siblings — exercising the
+ * engine's own __dirname-relative resolution exactly as installed.
+ */
+function setupSkillsFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-boot-'));
+  const skills = path.join(root, 'skills');
+  fs.cpSync(REAL_SCRIPTS, path.join(skills, 'workflow-engine/scripts'), { recursive: true });
+  writeFile(skills, 'workflow-migrate/scripts/migrate.sh', STUB_MIGRATE);
+  writeFile(skills, 'workflow-knowledge/scripts/knowledge.cjs', STUB_KNOWLEDGE);
+  return {
+    root,
+    project: setupProject(root),
+    engine: path.join(skills, 'workflow-engine/scripts/engine.cjs'),
+  };
+}
+
+/** Run an engine expecting success; returns the parsed JSON response. */
+function runEngine(engine, dir, args, env = {}) {
+  const out = execFileSync('node', [engine, ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  return JSON.parse(out.trim());
+}
+
+/** Run an engine expecting failure; returns the parsed stderr JSON. */
+function runEngineFails(engine, dir, args, env = {}) {
+  const res = spawnSync('node', [engine, ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+  assert.strictEqual(res.status, 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+  assert.strictEqual(res.stdout, '');
+  const parsed = JSON.parse(res.stderr.trim());
+  assert.strictEqual(parsed.ok, false);
+  return parsed;
+}
+
+function knowledgeCalls(project) {
+  const log = path.join(project, 'knowledge-calls.log');
+  return fs.existsSync(log) ? fs.readFileSync(log, 'utf8').trim().split('\n') : [];
+}
+
+describe('engine boot', () => {
+  let fix;
+  beforeEach(() => { fix = setupSkillsFixture(); });
+  afterEach(() => { fs.rmSync(fix.root, { recursive: true, force: true }); });
+
+  it('happy path: no pending migrations, knowledge ready — compact runs', () => {
+    const res = runEngine(fix.engine, fix.project, ['boot'], { STUB_CHECK: 'ready' });
+
+    assert.deepStrictEqual(res, {
+      ok: true,
+      migrations: { changed: false, output: '[SKIP] No changes needed' },
+      knowledge: 'ready',
+      compacted: true,
+      warnings: [],
+    });
+    assert.deepStrictEqual(knowledgeCalls(fix.project), ['check', 'compact']);
+  });
+
+  it('pending migration: changed true, report captured with the stop-gate lines stripped', () => {
+    const res = runEngine(fix.engine, fix.project, ['boot'], {
+      STUB_MIGRATE_MODE: 'update',
+      STUB_CHECK: 'ready',
+    });
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.migrations.changed, true);
+    assert.strictEqual(res.migrations.output, '1 migration(s) applied, 2 file(s) updated.');
+    // The migration landed in the project's .workflows tree.
+    assert.ok(fs.existsSync(path.join(fix.project, '.workflows/payments/marker.md')));
+    assert.match(git(fix.project, ['status', '--porcelain', '--', '.workflows']), /marker\.md/);
+  });
+
+  it('knowledge not-ready: reported, compact never invoked', () => {
+    const res = runEngine(fix.engine, fix.project, ['boot']);
+
+    assert.strictEqual(res.knowledge, 'not-ready');
+    assert.strictEqual(res.compacted, false);
+    assert.deepStrictEqual(res.warnings, []);
+    assert.deepStrictEqual(knowledgeCalls(fix.project), ['check']);
+  });
+
+  it('a crashing knowledge check reports not-ready — boot still succeeds', () => {
+    const res = runEngine(fix.engine, fix.project, ['boot'], { STUB_CHECK_EXIT: '2' });
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.knowledge, 'not-ready');
+    assert.strictEqual(res.compacted, false);
+  });
+
+  it('a failing compact is a warning, never a block', () => {
+    const res = runEngine(fix.engine, fix.project, ['boot'], {
+      STUB_CHECK: 'ready',
+      STUB_COMPACT_EXIT: '1',
+    });
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.knowledge, 'ready');
+    assert.strictEqual(res.compacted, false);
+    assert.strictEqual(res.warnings.length, 1);
+    assert.match(res.warnings[0], /knowledge compact failed: compact blew up/);
+  });
+
+  it('a failing migrate.sh is a hard error — ok false, stderr detail, exit 1', () => {
+    const err = runEngineFails(fix.engine, fix.project, ['boot'], { STUB_MIGRATE_MODE: 'fail' });
+
+    assert.match(err.error, /migrate\.sh failed/);
+    assert.match(err.error, /never half-run silently/);
+    assert.match(err.error, /boom: migration 099 exploded/);
+    // The knowledge legs never ran.
+    assert.deepStrictEqual(knowledgeCalls(fix.project), []);
+  });
+});
+
+describe('engine boot (real scripts)', () => {
+  let root;
+  let project;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-boot-real-'));
+    project = setupProject(root);
+  });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  it('runs the real migrate.sh and knowledge CLI against an isolated project', () => {
+    const first = runEngine(REAL_ENGINE, project, ['boot']);
+    assert.strictEqual(first.ok, true);
+    assert.strictEqual(typeof first.migrations.changed, 'boolean');
+    assert.strictEqual(typeof first.migrations.output, 'string');
+    // The trimmed report never leaks the prose stop-gate lines.
+    assert.ok(!first.migrations.output.includes('STOP_GATE'));
+    // No knowledge store in the fixture.
+    assert.strictEqual(first.knowledge, 'not-ready');
+    assert.strictEqual(first.compacted, false);
+    // The tracking file landed in the fixture, not the repo.
+    assert.ok(fs.existsSync(path.join(project, '.workflows/.state/migrations')));
+
+    // Second run: every migration is recorded — nothing to apply.
+    const second = runEngine(REAL_ENGINE, project, ['boot']);
+    assert.strictEqual(second.ok, true);
+    assert.strictEqual(second.migrations.changed, false);
+    assert.strictEqual(second.migrations.output, '[SKIP] No changes needed');
+  });
+});
+
+describe('engine commit --workflows', () => {
+  let root;
+  let project;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-boot-commit-'));
+    project = setupProject(root);
+  });
+  afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+
+  it('stages the whole .workflows tree — many work units plus .state — and commits', () => {
+    writeFile(project, '.workflows/payments/manifest.json', '{"name":"payments","v":2}\n');
+    writeFile(project, '.workflows/auth-flow/manifest.json', '{"name":"auth-flow"}\n');
+    writeFile(project, '.workflows/.state/migrations', '045\n');
+    writeFile(project, 'unrelated.txt', 'outside the scope\n');
+
+    const res = runEngine(REAL_ENGINE, project, ['commit', '--workflows', '-m', 'chore: apply workflow migrations']);
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.committed, git(project, ['rev-parse', '--short', 'HEAD']).trim());
+    assert.strictEqual(git(project, ['log', '-1', '--pretty=%s']).trim(), 'chore: apply workflow migrations');
+    // Everything under .workflows landed in the one commit…
+    const show = git(project, ['show', '--name-only', '--pretty=format:', 'HEAD']).trim().split('\n').sort();
+    assert.deepStrictEqual(show, [
+      '.workflows/.state/migrations',
+      '.workflows/auth-flow/manifest.json',
+      '.workflows/payments/manifest.json',
+    ]);
+    // …and the unrelated file stays uncommitted.
+    assert.match(git(project, ['status', '--porcelain']), /\?\? unrelated\.txt/);
+  });
+
+  it('a clean tree is fine: committed null, nothing-to-commit note, exit 0', () => {
+    const res = runEngine(REAL_ENGINE, project, ['commit', '--workflows', '-m', 'noop']);
+    assert.deepStrictEqual(res, { ok: true, committed: null, note: 'nothing to commit' });
+  });
+
+  it('rejects mixed scopes — exactly one of {wu, --inbox, --workflows}', () => {
+    assert.match(
+      runEngineFails(REAL_ENGINE, project, ['commit', '--workflows', 'payments', '-m', 'msg']).error,
+      /Usage: engine commit/);
+    assert.match(
+      runEngineFails(REAL_ENGINE, project, ['commit', '--workflows', '--inbox', '-m', 'msg']).error,
+      /Usage: engine commit/);
+    assert.match(
+      runEngineFails(REAL_ENGINE, project, ['commit', '--workflows']).error,
+      /Usage: engine commit/);
+  });
+});


### PR DESCRIPTION
## What

PR 7 of the engine stack (on #388). The boot check pipeline (moment-class 11 in the design log) becomes code.

- **`engine boot`** — runs migrate.sh + `knowledge check` + `knowledge compact` (when ready) in one call, returning `{migrations:{changed, output}, knowledge, compacted, warnings}`. migrate.sh failure is a hard error (migrations never half-run silently); compact failures warn-don't-block. `changed` is derived from migrate.sh's own stop-gate marker, deliberately not `git status` (pre-existing session dirt under `.workflows` would false-positive — reasoning documented in boot.cjs).
- **`engine commit --workflows`** — whole-`.workflows` scope for the migration commit.
- **workflow-start Step 0** — 0.2/0.3 rewritten around the one boot call; the migration summary + gate and the knowledge terminal stop move in verbatim. Tool calls per boot: happy path **3 → 1**, migrations-applied path **7 → 3**. ~197 lines of runtime-loaded instruction (migrate SKILL.md + knowledge-check.md) no longer load.
- **`/workflow-migrate` retired to an internal note** — survey confirmed workflow-start was its sole invoker; `scripts/migrate.sh` + `migrations/` stay (now invoked by boot). CLAUDE.md/CONVENTIONS.md dev docs re-pointed.
- allowed-tools audit: `git add`/`git commit`/`git rm` dropped from workflow-start (zero call sites — routed through the engine since #386); `git diff` added.

## Flags for review

- `knowledge-check.md` now has zero skill loaders (left intact per scope; candidate for retirement in a later cleanup).
- README's Utilities listing still mentions workflow-migrate (user-facing; left).
- Compact's chunks-removed display is no longer shown (boot reports `compacted: bool` only) — minor informational loss.

## Tests

117/117 (10 new boot tests — hermetic stub-script layout exercising real `__dirname` resolution, plus one real-migrations integration test asserting idempotent `changed: false` on second run); start 56/56 and epic 98/98 unchanged; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. **#389** 👈 current
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->