### PR TITLE
Deep Discovery PR2: The Deep-Discovery Conversation

### DIFF
--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -27,7 +27,7 @@ It runs in two modes:
 - **New mode** — from `workflow-start`. Decide the work type (epic / feature / bugfix / quick-fix / cross-cutting), shape the outline, persist at the work-type commit, route to the first phase.
 - **Existing-epic mode** — from `workflow-continue-epic`. The work type is already known; re-shape the epic's discovery map (refinement or resuming an interrupted sketch).
 
-**Stay in your lane**: Discovery handles SHAPE; downstream phases FILL the shape. Do not research (no feasibility/market/tech investigation), do not investigate (no symptom analysis or root-cause hunting), do not decide (no resolving design questions), do not scope (no spec or plan content). Name the work, figure out its shape, route it. If the conversation tunnels into substance, anchor and return — *"hold that thread, we'll cover it in research / discussion / investigation."*
+**Stay in your lane**: Discovery settles *what the work is* and shapes it — determine the type first (epic / feature / bugfix / quick-fix / cross-cutting), then route it into the pipeline. How much substance the conversation engages is set per work type by the guidance loaded on each path, not fixed here: while determining the type you shape rather than resolve; once an epic is settled, its path opens into deep exploration. Name the work, shape it, route it.
 
 ---
 

--- a/skills/workflow-discovery/references/detection-core.md
+++ b/skills/workflow-discovery/references/detection-core.md
@@ -102,7 +102,15 @@ When a tangential concern surfaces that doesn't fit the current shape, offer to 
 
 If the user accepts, invoke the matching capture skill (`/workflow-log-idea`, `/workflow-log-bug`, or `/workflow-log-quickfix` — default to idea if unsure). The capture skill writes the inbox file but does not commit it, so commit it now (`git add` the new `.workflows/.inbox/` file and commit) — it's a side-excursion from the main work, easy to leave uncommitted otherwise, and committing it means the capture survives even if this discovery session is abandoned. Note the surfacing so it's recoverable, then continue with the original work, now without scope creep. If the user says it's actually part of this work, fold it in. Soft, conversational — no structured gate.
 
-## H. Confirm with reasons — the commit protocol
+## H. Anchor and return — shape, don't dive
+
+While you're determining the type, you're shaping the work, not resolving it. Substance — mechanism, feasibility, design decisions, root cause — belongs to the phase the work routes into. If the conversation tunnels into it, anchor and return: note the thread for the right later phase, then keep shaping.
+
+> *"That's the kind of thing we'll get into once this is set up — hold that thread, we'll pick it up in research / discussion / investigation. For now, let's pin down what this is."*
+
+This is determination discipline; it doesn't carry past the commit (per the scope note above). It governs every type — and since the single-phase types route straight out once the type is settled, it is the whole of their discovery.
+
+## I. Confirm with reasons — the commit protocol
 
 This protocol governs the macro commit, rendered at **Step 4** — not here. Hold it in mind.
 

--- a/skills/workflow-discovery/references/discovery-guidelines.md
+++ b/skills/workflow-discovery/references/discovery-guidelines.md
@@ -6,145 +6,111 @@
 
 ## A. Curatorial Moves
 
-- **Open exploration is the loop.** The session is a conversation that pulls on the idea — sketches the shape, finds the edges, sees how the parts connect. Topics emerge at endpoint from the picture as a whole.
-- **Macro view always.** Don't tunnel into one item. If the user goes deep on mechanism, gently anchor and return to the map level.
-- **Tentative grouping** *during exploration*, not as topic decomposition. *"Sounds like the offline-mode bits all live together — agree?"* — confirming a surface boundary, not naming a topic.
-- **Coarseness check** *during exploration*. *"That's a lot of small operational things — most of those will fall out inside bigger discussions later."*
-- **Anchor and return.** When the conversation pulls into detail, gently re-anchor. *"We got pulled into payments mechanism — that's discussion territory once we're there. Want to come back to mapping the rest first?"*
-- **Endpoint observation.** Notice when the conversation circles back to surfaces already covered, when several turns produce only confirmation rather than new ground, when the picture feels mapped. Propose endpoint to the user — don't declare it. The user confirms or extends.
+- **Open exploration is the loop.** The session is a substantive, challenging conversation that pulls on the idea — sketches the shape, finds the edges, sees how the parts connect, and works through the decisions that shape forces. Topics are the **output**, harvested at the end from the picture as a whole — never named up front.
+- **Surface tensions, hold them open.** When two goals, constraints, or framings pull against each other, name the tension and sit with it. Don't resolve it prematurely or smooth it over — the friction is where the real shape is.
+- **Probe framing.** Question how the user has framed something; offer a counter-read. *"You're treating that as one thing — I think it's two, and they don't want the same data model. Push back on me?"*
+- **Macro view, deep on demand.** Default to the whole-picture level so no single item tunnels the session too early — but follow the user down into a thread when the decision there needs working through. The macro view is home base, not a cage.
+- **Anchor and return.** When a thread has given what it has, re-anchor to the picture. *"Payments feel settled enough for now — want to come back up and see how that choice touches the rest?"* Keeps the session moving across the whole rather than stuck on one item.
+- **Tentative grouping.** Mirror a surface boundary back so the user can confirm or correct it. *"Sounds like the offline-mode bits all live together — agree?"* — a surface boundary, not a topic.
+- **Coarseness check.** When a pile of small operational items lands, note that most will get absorbed into bigger topics later. *"That's a lot of small operational things — most will fall out inside bigger topics; leave them off for now?"*
 
-→ Load **[topic-granularity.md](../../workflow-shared/references/topic-granularity.md)** and follow its instructions as written. The rules apply at synthesis, not during exploration — but having them in context helps you avoid pre-emptively splitting things you don't yet need to.
+→ Load **[topic-granularity.md](../../workflow-shared/references/topic-granularity.md)** and follow its instructions as written. The rules apply at the harvest, not during exploration — but having them in context helps you avoid pre-emptively splitting things you don't yet need to.
 
-→ Load **[routing-inference.md](routing-inference.md)** and follow its instructions as written. Routing is proposed at synthesis based on cues from how each surface was framed.
+→ Load **[routing-inference.md](routing-inference.md)** and follow its instructions as written. Routing is proposed at the harvest based on cues from how each surface was framed.
 
-## B. Open Exploration — How
+## B. The Exploration Stance — How
 
-Discovery explores **breadth**, not depth. You're sketching the outline of a 3D shape; research and discussion fill the volume. The questioning style differs from research's interview probing — you're surfacing the shape, not interrogating reasoning behind it.
+Deep discovery is substantive: you explore the whole shape **and** work through the decisions that shape forces — breadth and depth together. The register is **collaborative challenge** — opinionated, willing to disagree, ready to counter-frame and propose alternatives. Two senior engineers throwing an idea around: not an interviewer running a checklist, not a lecturer delivering a monologue.
+
+**Sparring, not mirroring.** Don't just echo the shape back for confirmation — engage it. Agree, disagree, push on the weak point, offer a sharper framing. *"I'd push back on that — if the kitchen printer is the source of truth, the dashboard is just a cache, and that changes what happens when a venue drops offline. Buy that?"*
+
+**One thread, not a barrage.** One live thread at a time; let each answer shape the next move. No rapid-fire question lists (that's interrogation), no monologues (that's lecturing). A counter-frame is an opening for the user to push back, not a verdict.
 
 **Where to push:**
 
-- **User flows** — *"what would the user do here?"*, *"what's their next step?"*, *"who's the user at this point — diner or operator?"*
-- **Surfaces and modes** — *"is this same flow for the diner and the operator?"*, *"does it work the same online and offline?"*, *"does this exist on mobile only or also on the till?"*
-- **Connections** — *"how does this talk to X?"*, *"what kicks off Y?"*, *"where does this slot into the order flow?"*
-- **Edges** — *"what happens at the boundary between A and B?"*, *"what's the case where this doesn't apply?"*, *"is there a moment where this gets handed off?"*
-- **Hidden surfaces** — gently surface parts the user hasn't mentioned. *"I notice you didn't mention Z — is that a separate thing or part of W?"*
+- **User flows** — *"what would the user do here?"*, *"who is the user at this point — diner or operator?"*
+- **Surfaces and modes** — *"same flow for diner and operator?"*, *"does it work the same online and offline?"*
+- **Connections** — *"how does this talk to X?"*, *"what kicks off Y?"*
+- **Edges** — *"what happens at the boundary between A and B?"*, *"where does this get handed off?"*
+- **Hidden surfaces** — *"you didn't mention Z — separate thing, or part of W?"*
+- **The decisions the shape forces** — the tradeoffs between options, the tensions between goals. When the user states a position, test it: *"what breaks if we don't?"*
 
-**Where NOT to push:**
+**Substance is welcome — but stay conversational.** Decisions, half-decisions, working a design out in the conversation — all wanted. What you don't do is go off and *autonomously* research or spike: this is a conversation, not a research run. If a question genuinely needs investigation, spin up a background agent **only if the user asks**; otherwise reason from what you and the user already know.
 
-- **How something would be built** — architecture, data model, tech choices. That's specification later.
-- **Why one approach is better than another** — that's discussion.
-- **Whether something is feasible or competitive** — that's research.
-- **Reasons behind a position** — research-style "why do you think that?" probes go deeper than discovery needs. If the user says the printer should be wireless, you don't need to know why; you need to know whether wireless-vs-wired is a distinct surface to map.
+**Cadence:** One thread at a time. Wait for the answer. Let it shape where you push next. Many turns of this — the picture and its decisions develop together; topics fall out at the harvest, not before.
 
-**Cadence:** One question at a time. Wait for the answer. Let the answer shape where you push next. Don't run a checklist of question types — follow the conversation. Many turns of this **before** endpoint — the picture develops, then topics fall out at synthesis.
+**Documenting:** At natural pauses, write to the **Exploration** section of the session log — a running record of the conversation, nothing of substance lost (see [session-loop.md](session-loop.md) → *B. Session Loop*, step 5, for what to capture). The log survives context refresh; in-context memory does not.
 
-**Mirroring, not challenging:** Echo the emerging shape back so the user can correct it. *"So I'm picturing — the diner scans a QR, orders, the kitchen printer fires, the operator sees it in the dashboard. Am I drawing that right?"* Don't challenge assumptions during exploration — that posture belongs in research and discussion.
+## C. Reading Convergence
 
-**Documenting:** At natural pauses (a surface adequately explored, conversation about to branch, accumulating detail), write a strong-summary entry to the **Exploration** section of the session log. Prose, not transcript. Capture what was named and what crystallised. The log survives context refresh; in-context memory does not.
+A design conversation runs an arc: **diverge** (ideas widen) → **tension** (conflicts and tradeoffs surface) → **converge** (things settle, decisions decouple). Topics become separable only at convergence — and that is the only moment the harvest nudge belongs. Read the arc; don't drive it.
 
-## C. Endpoint Detection
+Convergence shows up as proxies, not a moment to declare:
 
-The user can signal endpoint explicitly (*"that covers it"*, *"let's wrap"*, *"done"*). You can also observe natural endpoint patterns and propose. Watch for:
+- The conversation circles back to ground already covered
+- Several turns produce confirmation rather than new ground
+- The decisions have settled enough that the parts feel separable
+- The user's energy on the current thread has flagged (shorter turns, more agreement)
 
-- The conversation circles back to surfaces already covered
-- Several turns produce only confirmation of existing surfaces — no new ground
-- The shape feels mapped — you could name the parts, find their edges, see the connections
-- The user's energy on the topic has flagged (paragraphs get shorter, agreement increases)
-
-When you observe these signals, **propose** endpoint to the user. Don't declare it. Use optional pushback if there's a genuinely unexplored angle worth surfacing first — but don't fabricate angles. If nothing comes to mind, just ask whether to proceed.
+When you read these, surface the ambient nudge — see [harvest-nudge.md](harvest-nudge.md). It is a light aside woven into the turn, never a gate and never a synthesis push. The user pulls the harvest when ready. In diverge or tension, there is no nudge: keep exploring.
 
 ## D. Hard Rules
 
-- **No inline topic decomposition.** Do not surface "hearing X, Y, Z as distinct shapes" moves during the loop. Topics are synthesised at endpoint.
-- **The user confirms endpoint.** You can propose, but the user decides. Don't move to synthesis without explicit confirmation.
-- **Initial spike, not exhaustive.** 2 topics is fine, 20 is fine. The map fills out as work progresses — analyses auto-add, splits and reroutes spawn. Don't push for completeness at synthesis.
-- **No active missing-piece probes during exploration.** Don't list things the user "hasn't mentioned" as if you're auditing coverage. If something comes to mind during exploration, raise it as a natural question. At endpoint, optional pushback can surface one or two angles — bounded, not exhaustive.
-- **No decisions, no investigations.** Defer mechanism questions to discussion; defer feasibility to research. Use what you and the user already know; don't go searching.
-- **No code, no architecture, no implementation talk.** Topics are named at the level a future research or discussion phase would pick up — *kitchen-printers*, *menu-management*, *analytics* — not API shapes or data models.
+- **No inline topic decomposition.** Don't surface "I'm hearing X, Y, Z as topics" during the loop. Topics are the harvest output, synthesised when the user pulls — not named mid-conversation.
+- **The user pulls the harvest.** Never push synthesis. Surface the ambient nudge at convergence (per **C**); the user decides when to harvest.
+- **Conversational, not autonomous.** Substance and soft decisions are welcome, but no automatic deep-dive — spin up a background agent or research thread only if the user asks.
+- **The initial map need not be exhaustive.** 2 topics is fine, 20 is fine. The map fills as work progresses — analyses auto-add, splits and reroutes spawn. Don't push for completeness at the harvest.
 
-## E. Worked Examples
+## E. Soft by Location
 
-Reference dialogues showing how each curatorial move plays out. Read these as context for your own moves — they are **not** output templates to render verbatim to the user.
+Discovery makes real decisions — and records them **plainly, as decisions**. They are soft not because of how they are worded but because of **where they live**: firmness is conferred by position on the gradient — discovery (soft) → discussion (hardened) → spec (golden) → plan. Later phases infer this from the artifact's origin; you don't mark it.
 
-**Open exploration**
+So **don't hedge.** Make the call, word it naturally, let position carry the softness. Don't weave "leaning…", "maybe…", "we could…" through the record — that buries the decision you actually reached. The per-topic discussion is where these harden via convergence, so nothing trustworthy is bypassed: discovery explores substance freely, and discussion still ratifies.
 
-```
-User: "I want to build a restaurant ordering platform. Menus, orders,
-       kitchen printers, some analytics."
+## F. Worked Examples
 
-Claude: "Who's the operator side — a single restaurant, or a chain
-        operator running multiple venues?"
+Reference dialogues showing the register. Read them as context for your own moves — they are **not** output templates to render verbatim.
 
-User: [answers]
-
-Claude: "Got it. When you say 'analytics', is that for the venue
-        owner watching their own place, or for the platform operator
-        looking across all venues?"
-
-User: [answers]
-
-Claude: "And the diner — do they interact with the system directly,
-        like scanning a QR at the table, or is it the waiter
-        punching the order in?"
-```
-
-Several turns of this before endpoint is proposed. One question per turn — wait for the answer, let it shape the next question. The questions don't push into *how* the printer works or *why* you'd pick one approach — they're feeling for where the surfaces are and where they connect.
-
-**Tentative grouping** (during exploration, surface-level)
+**Sparring** (challenge the framing, one thread at a time)
 
 ```
-User: "Then there's offline-mode, and also some way to handle
-       network-flakiness — like what happens mid-order if the
-       connection drops."
+User: "The dashboard is the operator's main view — orders, kitchen
+       status, analytics, all there."
 
-Claude: "Both about keeping the app usable when the network's bad —
-        I'd put them under the same surface. Are there any other
-        cases where you're picturing offline behaviour, or does
-        that pair cover it?"
+Claude: "I'd pull analytics out of that. Orders and kitchen status are
+        live operational state — the operator's acting on them in the
+        moment. Analytics is reflective, read after the fact. Lumping
+        them means one surface serving two very different tempos. Do
+        they really belong together, or is analytics its own thing?"
+
+User: "...yeah, analytics is more of an end-of-day thing."
+
+Claude: "Then I'd treat it as separate. Which means the live dashboard
+        only needs the operational slice — simpler real-time story.
+        Does the operator ever need analytics mid-service, or is
+        end-of-day the whole of it?"
 ```
 
-This isn't naming a topic. It's mirroring the shape back so the user can confirm or correct the surface boundary.
+One thread, pushed on — not a checklist. Claude disagreed with the framing, gave the reason, and let the answer reshape the next move.
 
-**Coarseness check**
-
-```
-User: "Oh, and we'll need to log errors. And rate-limit the
-       API. And add health checks. And…"
-
-Claude: "Stack of small operational items — most of those will
-        fall out naturally inside bigger discussions (deployment,
-        API-shape). Want me to leave them off and we add them
-        later if they don't get covered?"
-```
-
-**Anchor and return**
+**Recording a decision and a rejected path** (plain, not hedged)
 
 ```
-User: "For payments — Stripe charges 2.9% + 30c, but Adyen is
-       cheaper for European cards if you have over £X volume,
-       and there's also bank-direct..."
+## Exploration
 
-Claude: "We're a few clicks deep into payments-mechanism — that
-        sounds like discussion territory once we're there. Want
-        to come back to mapping the rest first, and we pick that
-        up properly there?"
+Worked through where order state lives. Decided the kitchen printer
+feed is the source of truth for order status — it's the physical
+reality the kitchen acts on; the dashboard is a projection of it.
+
+Considered making the dashboard the source of truth and treating the
+printer as an output. Rejected: a venue can keep cooking off printed
+tickets through a network drop, so the dashboard can't be authoritative
+without breaking offline operation.
+
+Open: how the dashboard re-syncs after a drop — parked for the
+kitchen-state discussion.
 ```
 
-**Endpoint observation and proposal**
-
-```
-[Twelve turns in. Last three turns have been the user confirming
-shapes already covered. No new surfaces named.]
-
-Claude: "Feels like we've sketched the shape — diner ordering, menu
-        management, kitchen output, operator analytics, and the
-        offline-mode surface. We didn't talk about how returns or
-        refunds work — worth a moment, or out of scope for now?"
-
-User: "Out of scope."
-
-Claude: "OK. Anything else you want to pull on before I synthesise
-        topics, or shall I go?"
-```
+The decision is stated as a decision, not "we're maybe leaning toward the printer." The rejected path is captured with *why* — that reasoning is what the downstream discussion inherits instead of re-deriving.
 
 → Return to caller.

--- a/skills/workflow-discovery/references/document-review.md
+++ b/skills/workflow-discovery/references/document-review.md
@@ -51,7 +51,7 @@ Read `.workflows/{work_unit}/discovery/sessions/session-{session_number:03d}.md`
 
 Walk the conversation against the log. Five checks:
 
-1. **Exploration narrative reflects the conversation.** The Exploration section should describe what was actually discussed — surfaces named, questions asked, what crystallised. If the conversation covered ground that isn't in the Exploration summary (and would be useful for the next session's resume or for synthesis), add a short entry. If the Exploration summary describes something that didn't actually come up, remove it. Strong summary, not verbatim — don't bloat with detail that wasn't substantive.
+1. **Exploration is a faithful running record.** The Exploration section should capture what was actually discussed — surfaces named, threads followed, the soft decisions reached, the false paths and why they were dropped, and the answers to any in-session research or investigation. If the conversation covered substance that isn't in the log (and the next session's resume or the downstream phase would want it), add it. If the log describes something that didn't come up, remove it. A running record, not verbatim — nothing of substance lost, but don't pad with detail that wasn't substantive.
 
 2. **Edits section matches applied operations.** Each entry under **Edits** should correspond to a manifest operation that actually committed. Each committed operation should have a matching entry. Map-operations writes these as it goes — gaps here are rare but worth catching, especially if a commit happened without a session-log update.
 

--- a/skills/workflow-discovery/references/harvest-nudge.md
+++ b/skills/workflow-discovery/references/harvest-nudge.md
@@ -1,0 +1,32 @@
+# Harvest Nudge
+
+*Reference for **[workflow-discovery](../SKILL.md)***
+
+---
+
+When the conversation reaches **convergence**, surface a light, ambient invitation to harvest topics — then keep exploring. This is the only place the harvest is ever offered; the user pulls it when ready, and you never push.
+
+## The arc
+
+A design conversation runs an arc:
+
+- **Diverge** — ideas widen, surfaces multiply, the space opens up.
+- **Tension** — conflicts and tradeoffs surface; goals pull against each other.
+- **Converge** — things settle; the decisions decouple enough that the parts can be siloed.
+
+Read which phase you're in. Convergence **is** the "decoupled enough to silo" signal — and the only moment the nudge belongs. In diverge or tension, there is **no nudge**: keep exploring. (For the proxies that signal convergence, see [discovery-guidelines.md](discovery-guidelines.md) → *Reading Convergence*.)
+
+## The nudge
+
+Ambient, rare, unobtrusive. Deliver it as part of a normal exploration turn's conversational prose — a light aside, not a separate block, not a framed menu, not a question that needs answering. It does **not** end the turn: say it, then carry on exploring in the same turn.
+
+Example phrasings (illustrative — match the conversation, don't render verbatim):
+
+- *"Say when you want to pull topics out of this and move forward — for now, let's keep going."*
+- *"There's enough here to start siloing into topics whenever you want; happy to keep pulling on it first."*
+
+**Rare.** Surface it once, when convergence first reads. Don't repeat it every turn, and never as a recurring *"I'm hearing N topics — what now?"* check-in — that breaks the conversation's flow.
+
+**Not a gate.** No `**STOP.**`, no menu, no required answer. The user can ignore it and keep talking — that's the point. When the user *does* pull (*"let's pull topics"*, *"done"*, *"ready"*), the session loop routes into synthesis.
+
+→ Return to caller.

--- a/skills/workflow-discovery/references/map-operations.md
+++ b/skills/workflow-discovery/references/map-operations.md
@@ -6,7 +6,7 @@
 
 Per-operation handling for **edits to existing map items**. Loaded by [session-loop.md](session-loop.md) when the user names one or more map operations in a conversational turn. Owns parsing, validation, manifest writes, session-log entries (under **Edits**), and commits for these moves.
 
-New topics are not added here — they are synthesised at endpoint from the exploration as a whole. See [topic-synthesis.md](topic-synthesis.md).
+New topics are not added here — they are synthesised at the harvest from the exploration as a whole. See [topic-synthesis.md](topic-synthesis.md).
 
 State for validation comes from `skills/workflow-discovery/scripts/discovery.cjs` — invoke it via Bash and read the structured output. Never invoke the underlying Node helpers inline.
 

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -182,10 +182,10 @@ Reached from **B** step 2 when the user pulls the harvest. Synthesis is user-pul
 
 → Load **[topic-synthesis.md](topic-synthesis.md)** and follow its instructions as written. It owns its own confirmation (`y` / `explore` / `adjust`) and returns a synthesis outcome:
 
-**If the outcome is `confirmed`:**
+#### If the outcome is `confirmed`
 
 → Return to caller.
 
-**If the outcome is `explore`:**
+#### If the outcome is `explore`
 
 → Return to **B. Session Loop**.

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -6,7 +6,7 @@
 
 Follow the curatorial moves and hard rules from **[discovery-guidelines.md](discovery-guidelines.md)** throughout. No background agents, no review cycles, no perspective dispatches.
 
-State-driven branches in **A. Open** pick the opening shape; **B. Session Loop** runs pure exploration; **C. Endpoint and Synthesis** detects the endpoint and produces the topic set. When the map already has items, edits to existing items happen in the loop alongside exploration.
+State-driven branches in **A. Open** pick the opening shape; **B. Session Loop** runs the exploration; **C. Harvest** synthesises topics when the user pulls. When the map already has items, edits to existing items happen in the loop alongside exploration.
 
 ## A. Open
 
@@ -14,16 +14,16 @@ Read `discovery_map` and `dismissed` from the most recent discovery output. `imp
 
 #### If `macro_continuation` is set (new epic, just confirmed)
 
-The macro shaping at Step 4 already explored the work enough to confirm it's an epic and surfaced the first topic seeds; the confirm-trigger backfilled that into `session-{session_number}.md`. Don't re-open with a cold prompt — the conversation is already live. Render a brief transition that moves from "what is this" to "what are its topics":
+The macro shaping at Step 4 already explored the work enough to confirm it's an epic and surfaced the first topic seeds; the confirm-trigger backfilled that into `session-{session_number}.md`. Don't re-open with a cold prompt — the conversation is already live. Render a brief transition that moves from "what is this" into exploring the whole:
 
 > *Output the next fenced block as a code block:*
 
 ```
-That's an epic — work unit created. Now let's map its topics. We can
-keep pulling on the shape, or synthesise the topics we've already
-sketched whenever you're ready.
+That's an epic — work unit created. We've started sketching the shape;
+now let's get into it properly. Topics come later — they fall out once
+we've thought the whole thing through.
 
-Anything more to sketch, or shall I synthesise?
+What do you want to dig into first?
 ```
 
 **STOP.** Wait for user response.
@@ -146,32 +146,26 @@ synthesise topics.
 
 ## B. Session Loop
 
-No fixed cadence — follow the conversation, not a checklist. **The loop is pure exploration.** Topics are synthesised at endpoint in **C**.
+No fixed cadence — follow the conversation, not a checklist. **The loop is the exploration.** Topics are synthesised at the harvest in **C**, when the user pulls.
 
 1. **Listen.** Take in what the user just said.
 2. **Recognise intent.** The user's message may contain:
-   - **Exploration content** — answers to your questions, new surfaces, descriptions of how parts work or connect. Continue the conversation: ask the next exploratory question, follow the thread the user opened. See [discovery-guidelines.md](discovery-guidelines.md) → *Open Exploration — How* for what to ask and where to push.
+   - **Exploration content** — answers to your questions, new surfaces, descriptions of how parts work or connect, positions taken on a decision. Continue the conversation: push on the thread the user opened, counter-frame, follow where it leads. See [discovery-guidelines.md](discovery-guidelines.md) → *The Exploration Stance — How* for the register and where to push.
    - **An edit operation on an existing map item** — *"remove X"*, *"rename X to Y"*, *"edit summary of X"*, etc. Only possible when the map is non-empty. Delegate to [map-operations.md](map-operations.md) — it handles the operation, writes to the **Edits** section, commits.
    - **A request to see the map** — *"show map"*, *"what's on the map"*. Re-render using the opener's render rules. No STOP gate; just render and continue.
    - **A request to see dismissed items** — *"show dismissed"*, *"what was removed"*. Load [show-dismissed.md](show-dismissed.md).
    - **A KB query for prior context** — when a conversational thread would benefit from prior work on this or sibling work units, invoke `knowledge query` with a query derived from the thread (see [contextual-query.md](../../workflow-knowledge/references/contextual-query.md) for the pattern).
-   - **An endpoint signal** — *"that covers it"*, *"good enough to start"*, *"let's wrap"*, *"done"*, *"ready to go"*. Route to **C. Endpoint and Synthesis**.
+   - **A harvest pull** — *"let's pull topics"*, *"that covers it"*, *"good enough to start"*, *"let's wrap"*, *"done"*, *"ready to go"*. Route to **C. Harvest**.
 
-3. **Continue the exploration.** Ask one question at a time. Follow the conversation. See *Mirroring, not challenging* in the guidelines.
+3. **Continue the exploration.** One thread at a time. Follow the conversation. See *The Exploration Stance — How* in the guidelines for the sparring register.
 
-4. **Watch for natural endpoint patterns** — Claude-side observations that the picture has been adequately mapped:
-   - The conversation circles back to surfaces already covered
-   - Several turns produce only confirmation of existing surfaces, no new ground
-   - The shape feels mapped to you and to the user
+4. **Read the arc for convergence.** Track whether the conversation is diverging, in tension, or converging (see [harvest-nudge.md](harvest-nudge.md) for the arc, and [discovery-guidelines.md](discovery-guidelines.md) → *Reading Convergence* for the proxies). When it converges:
 
-   When you observe these patterns, route to **C. Endpoint and Synthesis** — *propose* endpoint, don't *declare* it. The user confirms or extends.
+   → Load **[harvest-nudge.md](harvest-nudge.md)** and follow its instructions to surface the ambient nudge, then **stay in B** and keep exploring.
 
-5. **Document at natural pauses.** Write a strong-summary entry to the **Exploration** section of the session log at:
-   - A surface has been adequately explored — capture what was covered
-   - Conversation is about to branch to a new area — close out the current thread
-   - Context-compaction risk feels real (long conversation, lots of detail accumulating)
+   Convergence cues the nudge; it does **not** trigger synthesis. Only the user's pull (step 2) routes to **C**.
 
-   The Exploration entry is **prose, not transcript** — capture what was named, what crystallised, what was decided not to pursue. The log survives context refresh; in-context memory does not.
+5. **Keep the running record.** The **Exploration** section is a constant running record of the conversation — not verbatim, but **not summarised away; nothing of substance is lost.** Write to it at natural pauses (a thread worked through, the conversation about to branch, detail accumulating, context-compaction risk). Capture the journey: the ideas, the objections, the pivots, the route taken, the **false paths and failed designs** (with why they were dropped), the soft decisions reached, and the **answers to any research or investigation done in-session**. Append-forward — add depth by **layering down**, never by editing earlier entries back. Prose, not transcript; the log survives context refresh, in-context memory does not. Lossiness defeats the point: if the detail of the discovery is lost, the session was wasted.
 
    The lazy-creation rule applies: this may create the session log file if it doesn't exist yet — see [template.md](template.md) → *Lazy creation and finalisation*, which sets the active-session marker on first creation. After writing, commit:
 
@@ -180,53 +174,18 @@ No fixed cadence — follow the conversation, not a checklist. **The loop is pur
    git commit -m "discovery({work_unit}): exploration notes — session-{session_number:03d}"
    ```
 
-→ Proceed to **C. Endpoint and Synthesis** when either an endpoint signal is recognised in step 2 or a natural endpoint pattern is observed in step 4. Otherwise loop within **B**.
+→ Proceed to **C. Harvest** when the user pulls the harvest (a harvest pull recognised in step 2). Otherwise loop within **B** — convergence (step 4) cues the nudge but stays in the loop.
 
-## C. Endpoint and Synthesis
+## C. Harvest
 
-Reached from B when an endpoint signal arrives from the user or Claude observes natural endpoint patterns.
+Reached from **B** step 2 when the user pulls the harvest. Synthesis is user-pulled — there is no Claude-side gate here; the user has already asked.
 
-**Propose endpoint with optional pushback.** First, a one-line read of what got covered, plus zero, one, or two pushback angles if any genuinely unexplored ground comes to mind:
-
-> *Output the next fenced block as a code block:*
-
-```
-Feels like we've sketched the shape — {one-line read of what got covered}.
-
-{Optional pushback — one or two angles not yet pulled on. Examples:}
-- We didn't talk about how X handles Y — worth a moment?
-- Did you want to map Z, or is that scope for later?
-```
-
-Pushback is **optional and bounded**. If nothing genuinely unexplored comes to mind, skip the pushback lines entirely. Don't fabricate angles to look thorough.
-
-Then prompt the user:
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Ready to synthesise topics?
-
-- **`y`/`yes`** — Synthesise topics now
-- **Keep going** — Tell me what else to explore
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-#### If `yes`
-
-Load **[topic-synthesis.md](topic-synthesis.md)** and follow its instructions as written. It returns a synthesis outcome:
+→ Load **[topic-synthesis.md](topic-synthesis.md)** and follow its instructions as written. It owns its own confirmation (`y` / `explore` / `adjust`) and returns a synthesis outcome:
 
 **If the outcome is `confirmed`:**
 
 → Return to caller.
 
 **If the outcome is `explore`:**
-
-→ Return to **B. Session Loop**.
-
-#### If keep going
 
 → Return to **B. Session Loop**.

--- a/skills/workflow-discovery/references/shape-and-confirm.md
+++ b/skills/workflow-discovery/references/shape-and-confirm.md
@@ -10,7 +10,7 @@ Run the shaping conversation governed by the detection core (loaded at Step 2), 
 
 Gather all signal flavours simultaneously (work-type cues and topic seeds co-emerge); resolve in dependency order. Surface tentative reads mid-loop (soft, easy to redirect). Watch for pivots, and offer scope-down-to-inbox for tangential concerns. One question at a time — keep exploring until confident-enough-to-commit per the confidence clock.
 
-→ Proceed to **B. Commit** when convergence holds (detection core **H**); otherwise keep looping in **A**.
+→ Proceed to **B. Commit** when convergence holds (detection core **I**); otherwise keep looping in **A**.
 
 ## B. Commit
 

--- a/skills/workflow-discovery/references/template.md
+++ b/skills/workflow-discovery/references/template.md
@@ -10,10 +10,10 @@ One template, all sessions. Sections that don't apply this session write `(none)
 
 The session has two distinct flavours of content recorded in two distinct sections:
 
-- **Exploration** is **narrative** — strong-summary prose, written at natural pauses during the conversation. It's Claude's durable record of what got discussed for end-of-session topic synthesis (and for surviving context refresh).
+- **Exploration** is **narrative** — a prose record of the conversation. The writer sets its fidelity and write-timing: an epic writes a running record across the session; single-phase work backfills once at creation. It's the durable record of what got discussed — read downstream, and a hedge against context refresh.
 - **Edits** is **structured** — a deterministic record of map-operations applied to existing items during the session. Only meaningful for continuing sessions where the map is non-empty.
 
-**Topics Identified** is filled at endpoint synthesis, from analysing the exploration as a whole.
+**Topics Identified** is filled at the harvest, from analysing the exploration as a whole.
 
 ## Template
 
@@ -50,10 +50,12 @@ Example: `8 topics — 2 decided · 3 in flight · 1 ready · 2 fresh`
 
 ## Exploration
 
-{Strong-summary prose covering what was explored, what surfaces
-were named, what crystallised. Not verbatim. Grows over the
-session as natural pauses produce new entries. Used at endpoint
-synthesis to identify topics from the picture as a whole.}
+{Prose record of the conversation — what was explored and what
+came of it: the surfaces named, the threads followed, what was
+decided or set aside. Not verbatim. For an epic it's written
+across the session at natural pauses; for single-phase work it's
+backfilled once at creation. Used at the harvest to identify
+topics from the picture as a whole.}
 
 ## Edits
 
@@ -112,9 +114,7 @@ At finalisation, replace the `(none)` Conclusion with one of:
 
 ## Anti-patterns
 
-- **No transcript-style content in Exploration.** It's strong summary, not verbatim dialogue.
-- **No decisions, option weighing, or feasibility analysis.** Those belong in discussion and research. Capture what was framed, not what was uncovered.
-- **No investigation.** The log records the shape that was explored, not the answers to research questions.
-- **Don't write to Topics Identified during the loop.** It's filled by synthesis at endpoint.
+- **No transcript-style content in Exploration.** It's a prose record, not verbatim dialogue.
+- **Don't write to Topics Identified during the loop.** It's filled by synthesis at the harvest.
 
 → Return to caller.

--- a/skills/workflow-discovery/references/topic-synthesis.md
+++ b/skills/workflow-discovery/references/topic-synthesis.md
@@ -4,7 +4,7 @@
 
 ---
 
-The endpoint ceremony. Analyse the session's exploration as a whole, produce a topic set, and confirm it with the user. Loaded by [session-loop.md](session-loop.md) C when the user confirms ready to synthesise.
+The harvest ceremony. Analyse the session's exploration as a whole, produce a topic set, and confirm it with the user. Loaded by [session-loop.md](session-loop.md) C when the user pulls the harvest.
 
 ## A. Gather Source Material
 


### PR DESCRIPTION
**Stack position: 2 of 6 — do not merge.** Base/target is PR1 (`feat/deep-discovery-pr1-sessions-layout`); the stack lands root-first at the end.

The behavioural heart of Deep Discovery. Opens the epic discovery path into challenging, substantive, open-ended exploration; replaces the eager synthesis STOP gate with a rare, ambient, user-pulled harvest nudge; and makes the session log a non-lossy running record. Delivered by **progressive disclosure** — the epic stance lives only in files the epic path loads — **not** by an inline `if epic` carve-out. The fork is structural (by which file loads), never prose.

## What changed

**1. Epic deep-discovery stance (no backbone carve-out)**
- `SKILL.md` backbone: removed the premature `do not research / investigate / decide / scope` prohibition; "Stay in your lane" is now a type-agnostic role statement.
- `detection-core.md`: relocated the "shape, don't dive" anchor-and-return discipline to its real home — determination, where it governs every type.
- `discovery-guidelines.md` (epic-only by load position): rewritten in one positive voice — collaborative challenge / sparring (not mirroring, not interrogation, not lecturing); arc-state convergence reading; hard rules minus the substance bans; **soft-by-location stated once** (no woven hedging); sparring + plain-decision + rejected-path worked examples.

**2. Arc-aware harvest nudge (replaces the eager gate)**
- New `harvest-nudge.md`: the diverge → tension → converge arc and the ambient, non-blocking nudge surfaced only at convergence. Not a `**STOP.**`, no framed menu.
- `session-loop.md`: convergence cues the nudge and **stays in the loop**; the eager `Ready to synthesise topics?` STOP gate is **removed**; a user pull routes straight into `topic-synthesis.md` (which owns its own confirm).

**3. Non-lossy running-record log**
- `session-loop.md` §B step 5: the Exploration section is a constant running record — ideas, objections, pivots, false paths/failed designs, soft decisions, in-session research answers; append-forward, layering down.
- `template.md` kept structurally neutral; dropped the no-decisions / no-investigation anti-patterns (no fidelity fork). **Leak guard:** `confirm-trigger.md §E` untouched.

## Verification
- `grep "Ready to synthesise topics"` → empty; backbone has no residual substance prohibition; no dangling section refs.
- Full test suite: 75/75 relevant tests green. (3 `test-release-*` failures are pre-existing on the PR1 base — release-tooling/environment, unrelated to this change.)
- Behavioural fidelity (sparring stance, convergence-only nudge, plain decisions + rejected paths in the log, user-pull → synthesis) is verified live in the engine sandbox — pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #393
2. #391
3. **#394** 👈 current
4. #395
5. #396
6. #397
7. #398
<!-- stack:links:end -->