### PR TITLE
Deep Discovery PR5: Harvest → Briefs

### DIFF
--- a/skills/workflow-discovery/references/brief-synthesis.md
+++ b/skills/workflow-discovery/references/brief-synthesis.md
@@ -1,0 +1,83 @@
+# Brief Synthesis
+
+*Reference for **[workflow-discovery](../SKILL.md)***
+
+---
+
+Loaded by [topic-synthesis.md](topic-synthesis.md) E on the confirmed harvest, while the whole exploration is still in context. A **brief** is a per-topic *view* — one topic's slice of the discovery record (soft decisions, reasoning, rejected paths, open questions), projected out of the source-of-truth logs. It is regenerated freely at every harvest that touches its topic; it is never a record. Overwrite it without hesitation. Writes the briefs for the confirmed set, reconciles brief files against any topics the harvest restructured, and flags downstream work that a regenerated brief now post-dates.
+
+## A. Write the Briefs
+
+For each topic in the confirmed set — the working-list new topics **plus** any existing map topic this session's exploration materially deepened — extract that topic's slice from the whole exploration (all sessions in context) and (over)write `.workflows/{work_unit}/discovery/briefs/{topic}.md`.
+
+Note which briefs already existed on disk before this write (**regenerations**) versus which are **first writes** — **C** needs the distinction.
+
+The brief is a written artifact, not user output — write the file, do not render it. Word every decision plainly and naturally: softness is conferred by where the brief lives on the gradient, not by hedged wording. Empty sections get `(none)`.
+
+```markdown
+# Discovery Brief — {topic:(titlecase)}
+
+Drawn from discovery session(s) {coarse session range}.
+
+## Soft decisions
+
+{decisions reached, plainly, with the reasoning behind each}
+
+## Rejected paths
+
+{paths set aside, with why — so the next phase doesn't re-derive them}
+
+## Open questions
+
+{unresolved threads carried forward for the next phase}
+```
+
+→ Proceed to **B. Lifecycle**.
+
+## B. Lifecycle — Split / Merge / Drop
+
+When the harvest restructured topics that were already on the map, keep brief files and `brief_path` pointers in step with the confirmed set. Apply whichever operations occurred. The new topics' briefs are written in **A**; this section only removes what the restructuring orphaned.
+
+**Split** — parent `P` became children `C1`, `C2`:
+
+```bash
+rm -f .workflows/{work_unit}/discovery/briefs/{parent}.md
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{parent} brief_path
+```
+
+**Merge** — topics `A` and `B` became `M`. For each absorbed topic:
+
+```bash
+rm -f .workflows/{work_unit}/discovery/briefs/{absorbed}.md
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{absorbed} brief_path
+```
+
+**Drop** — topic `T` removed from the set:
+
+```bash
+rm -f .workflows/{work_unit}/discovery/briefs/{topic}.md
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{topic} brief_path
+```
+
+New topics with no prior brief need no cleanup. `delete` fails loudly when the field is absent — run it only for a topic that actually carried a `brief_path` (a committed map topic with a prior brief); skip it otherwise. The `rm -f` is safe to run unconditionally.
+
+→ Proceed to **C. Propagation**.
+
+## C. Propagation — Flag, Don't Overwrite
+
+For each brief **regenerated** in **A** (the topic already had a brief before this harvest), check whether downstream research or discussion work exists for that topic:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.research.{topic}
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discussion.{topic}
+```
+
+A topic routes to one of the two. If either returns a non-empty item, flag it to reconcile:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.{research|discussion}.{topic} reconcile_needed true
+```
+
+This is a signal, not a rewrite — it never touches the downstream artifact's content. Soft can prompt re-examination; it can never overwrite hard. The downstream phase surfaces the flag when it next runs. First-write briefs have no prior downstream work — skip them.
+
+→ Return to caller.

--- a/skills/workflow-discovery/references/brief-synthesis.md
+++ b/skills/workflow-discovery/references/brief-synthesis.md
@@ -4,7 +4,7 @@
 
 ---
 
-Loaded by [topic-synthesis.md](topic-synthesis.md) E on the confirmed harvest, while the whole exploration is still in context. A **brief** is a per-topic *view* — one topic's slice of the discovery record (soft decisions, reasoning, rejected paths, open questions), projected out of the source-of-truth logs. It is regenerated freely at every harvest that touches its topic; it is never a record. Overwrite it without hesitation. Writes the briefs for the confirmed set, reconciles brief files against any topics the harvest restructured, and flags downstream work that a regenerated brief now post-dates.
+Loaded by [topic-synthesis.md](topic-synthesis.md) E on the confirmed harvest, while the whole exploration is still in context. A **brief** is a per-topic *view* — one topic's slice of the discovery record (soft decisions, reasoning, rejected paths, open questions), projected out of the source-of-truth logs. It is regenerated at every harvest that touches its topic — overwrite freely; it is never a record. Writes the briefs for the confirmed set, reconciles brief files against any topics the harvest restructured, and flags downstream work that a regenerated brief now post-dates.
 
 ## A. Write the Briefs
 
@@ -34,25 +34,25 @@ Drawn from discovery session(s) {coarse session range}.
 
 → Proceed to **B. Lifecycle**.
 
-## B. Lifecycle — Split / Merge / Drop
+## B. Lifecycle
 
-When the harvest restructured topics that were already on the map, keep brief files and `brief_path` pointers in step with the confirmed set. Apply whichever operations occurred. The new topics' briefs are written in **A**; this section only removes what the restructuring orphaned.
+When the harvest restructured topics that were already on the map, keep brief files and `brief_path` pointers in step with the confirmed set. Apply whichever operations occurred — split, merge, and drop are independent, and more than one may apply in a single harvest. This section removes only what the restructuring orphaned.
 
-**Split** — parent `P` became children `C1`, `C2`:
+**Split** — a parent topic became two or more children. The children's briefs are written in **A**; remove the parent's:
 
 ```bash
 rm -f .workflows/{work_unit}/discovery/briefs/{parent}.md
 node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{parent} brief_path
 ```
 
-**Merge** — topics `A` and `B` became `M`. For each absorbed topic:
+**Merge** — two or more topics were absorbed into one merged topic. The merged topic's brief is written in **A**; for each absorbed topic, remove its brief:
 
 ```bash
 rm -f .workflows/{work_unit}/discovery/briefs/{absorbed}.md
 node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.discovery.{absorbed} brief_path
 ```
 
-**Drop** — topic `T` removed from the set:
+**Drop** — a topic was removed from the set:
 
 ```bash
 rm -f .workflows/{work_unit}/discovery/briefs/{topic}.md
@@ -63,9 +63,9 @@ New topics with no prior brief need no cleanup. `delete` fails loudly when the f
 
 → Proceed to **C. Propagation**.
 
-## C. Propagation — Flag, Don't Overwrite
+## C. Propagation
 
-For each brief **regenerated** in **A** (the topic already had a brief before this harvest), check whether downstream research or discussion work exists for that topic:
+Flag downstream work, never overwrite it. For each brief **regenerated** in **A** (the topic already had a brief before this harvest), check whether downstream research or discussion work exists for that topic:
 
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.research.{topic}

--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -25,6 +25,7 @@ For each topic on the working list, in synthesised order:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs pull {work_unit}.discovery dismissed "{topic}"
 node .claude/skills/workflow-manifest/scripts/manifest.cjs create-discovery-topic {work_unit}.{topic} --routing {research|discussion} --source discovery --summary "{one-line summary}" --description "{paragraphs}"
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} brief_path "discovery/briefs/{topic}.md"
 ```
 
 The `pull` is a no-op if the name isn't in the dismissed list.
@@ -38,6 +39,7 @@ Notes:
 - The topic name is the manifest dict key (the `{topic}` path segment). There is no separate `name` field to set.
 - `routing` is the value confirmed by the user at the synthesis gate.
 - `source: discovery` marks topics the user surfaced during discovery, distinguishing them from items added later with other provenance (e.g. `research-analysis`, `gap-analysis`).
+- `brief_path` is an opaque field set by a post-create `set` — never a `create-discovery-topic` builder flag. It records where the topic's brief lives; the brief file itself was written at harvest by [brief-synthesis.md](brief-synthesis.md).
 
 → Proceed to **B. Write Topics Identified**.
 
@@ -78,13 +80,13 @@ Replace the **Conclusion** `(none)` placeholder. Skip if no log file exists.
 - Edits only, no new topics: `{M} edit(s) applied. Map has {T} topics.`
 - Browse only (no log file): no Conclusion to replace.
 
-Check `git status`. If the working tree is dirty (manifest writes from **A**, the marker delete, the Topics Identified write, the Conclusion replacement, or any combination), commit. Stage the dirty paths and pick the appropriate message:
+Check `git status`. If the working tree is dirty (manifest writes from **A**, the marker delete, the Topics Identified write, the Conclusion replacement, the briefs written and reconciled at harvest by [brief-synthesis.md](brief-synthesis.md), or any combination), commit. Stage the manifest, the session log, and the briefs directory (so brief files land in the same commit), then pick the appropriate message:
 
 - New topics: `discovery({work_unit}): synthesise {N_new} new topic(s)`
 - Edits only: `discovery({work_unit}): finalise session log`
 
 ```bash
-git add .workflows/{work_unit}/manifest.json .workflows/{work_unit}/discovery/sessions/session-{session_number:03d}.md
+git add .workflows/{work_unit}/manifest.json .workflows/{work_unit}/discovery/
 git commit -m "{message}"
 ```
 

--- a/skills/workflow-discovery/references/document-review.md
+++ b/skills/workflow-discovery/references/document-review.md
@@ -61,6 +61,8 @@ Walk the conversation against the log. Five checks:
 
 5. **No prose where structure is expected.** Edits is structured (bulleted operation entries); Topics Identified is structured (per-topic subsections). If freeform prose has leaked into either, move it to Exploration.
 
+Briefs (`discovery/briefs/`) are views — regenerated at each harvest, never records — and are **out of scope** here. Reconcile only the log's narrative sections.
+
 Apply corrections directly to the file. Stage and commit the fixes:
 
 ```bash

--- a/skills/workflow-discovery/references/initialize-discovery.md
+++ b/skills/workflow-discovery/references/initialize-discovery.md
@@ -4,7 +4,7 @@
 
 ---
 
-1. Ensure the session-log directory exists: `mkdir -p .workflows/{work_unit}/discovery/sessions/` (safe to re-run).
+1. Ensure the session-log and briefs directories exist: `mkdir -p .workflows/{work_unit}/discovery/sessions/ .workflows/{work_unit}/discovery/briefs/` (safe to re-run).
 2. Read the work-unit `description`, `seeds` list, and `imports` list from the manifest — they are not carried in the discovery output, and the session loop's opener and seed/import-launchpad branch read them:
 
    ```bash

--- a/skills/workflow-discovery/references/topic-synthesis.md
+++ b/skills/workflow-discovery/references/topic-synthesis.md
@@ -81,6 +81,8 @@ Confirm to commit, or tell me what to adjust.
 
 The topic set is confirmed. Hold it in conversation memory as the **working list** for Step 12 confirm-and-persist. Do not write Topics Identified to the log yet — Step 12 writes the manifest items and the log section together. Synthesis outcome: `confirmed`.
 
+→ Load **[brief-synthesis.md](brief-synthesis.md)** and follow its instructions as written.
+
 → Return to caller.
 
 #### If `explore`


### PR DESCRIPTION
## Context

Discovery logs are the **record** — the whole many-topic journey (indexed by PR4, read across sessions by PR3). But a downstream research/discussion phase for one topic wants *its* slice, not the whole journey. PR5 makes the harvest extract that slice into a per-topic **brief** — a regenerable **view** of one topic, curated while the whole exploration is in context.

A brief is a **view**, never the source of truth (the log is): **regenerated** on each harvest that touches its topic, freely and losslessly relative to the log. The brief is the topic's read-in-full handoff, consumed in PR6.

Spec of record: `deep-discovery/pr-5-briefs.md` (+ `00-overview.md` → Records vs views, Briefs, Propagation).

## What changed

- **NEW `references/brief-synthesis.md`** — owns all brief logic. Loaded by `topic-synthesis.md` §E on the confirmed harvest.
  - **§A Write the Briefs** — for each confirmed topic (working-list new topics + any existing topic the session materially deepened), extract soft decisions / rejected paths / open questions from the whole exploration and (over)write `discovery/briefs/{topic}.md` (coarse session citation; a view, overwritten freely). The brief is a written artifact, not user output — no render instruction.
  - **§B Lifecycle** — split / merge / drop keep brief files + `brief_path` in step: delete orphaned brief files and clear their `brief_path` pointers.
  - **§C Propagation** — for each regenerated brief whose topic has existing downstream work, `set {wu}.{research|discussion}.{topic} reconcile_needed true`. Flag, never overwrite — the downstream phase surfaces it (PR6).
- **`topic-synthesis.md` §E** — the confirmed (`yes`) branch loads `brief-synthesis.md` before returning (adjust branch unchanged; reconciliation runs once on the final set).
- **`confirm-and-persist.md`** — §A sets the opaque `brief_path` after `create-discovery-topic` (builder untouched); §C stages `.workflows/{wu}/discovery/` so briefs land in the harvest commit.
- **`initialize-discovery.md`** — `mkdir -p` the `briefs/` dir at init.
- **`document-review.md`** — briefs are views, out of scope for log reconciliation.

Manifest fields (`brief_path`, `reconcile_needed`) are **opaque** — set via 3-segment dot-path, cleared via `delete`. No builder change, no schema, no migration (existing epics have no briefs; briefs regenerate at the next harvest).

## Verification

- **Full suite green** — 74 passed; the 3 `test-release-*` failures are pre-existing (no code changed).
- **Manifest CLI on a scratch fixture** — harvest writes `discovery/briefs/{topic}.md` per topic with `brief_path` set; regeneration sets `reconcile_needed: true` (boolean) on the downstream item without touching content; split / merge / drop each delete the orphaned brief file and clear `brief_path`.
- **Engine sandbox** (Mint copy) — remaining interactive validation: drive an epic to convergence → harvest → briefs written with the three sections + coarse session citation; second harvest regenerates + flags; exercise split/merge/drop; confirm document-review doesn't flag briefs.

## Stack

- **Base / target:** `feat/deep-discovery-pr4-kb-indexing` (PR4). Position 5 of 6.
- **Do not merge** — the stack lands root-first at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #393
2. #391
3. #394
4. #395
5. #396
6. **#397** 👈 current
7. #398
<!-- stack:links:end -->