### PR TITLE
Deep Discovery PR6: Downstream Consumption + Reconcile Surfacing

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -178,11 +178,9 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 
 **Otherwise:**
 
-The topic was shaped on the discovery map — its seed lives on the map item. Read the `description` and seed the discussion from it:
+The topic was shaped on the discovery map. Read its discovery brief as the starting context:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} description
-```
+Load **[read-brief-context.md](../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 Do not re-ask; live conversation context, when present, supplements the carrier.
 

--- a/skills/workflow-discussion-entry/references/validate-phase.md
+++ b/skills/workflow-discussion-entry/references/validate-phase.md
@@ -22,6 +22,8 @@ Resuming discussion: {topic:(titlecase)}
 
 Set source="continue".
 
+→ Load **[reconcile-advisory.md](../../workflow-shared/references/reconcile-advisory.md)** with downstream_phase = `discussion`.
+
 → Return to caller.
 
 #### If discussion exists and status is `completed`
@@ -39,5 +41,7 @@ Reopening discussion: {topic:(titlecase)}
 ```
 
 Set source="continue".
+
+→ Load **[reconcile-advisory.md](../../workflow-shared/references/reconcile-advisory.md)** with downstream_phase = `discussion`.
 
 → Return to caller.

--- a/skills/workflow-discussion-process/references/initialize-discussion.md
+++ b/skills/workflow-discussion-process/references/initialize-discussion.md
@@ -6,6 +6,8 @@
 
 → Load **[../../workflow-shared/references/seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
 
+→ Load **[../../workflow-shared/references/read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
+
 1. Ensure the discussion directory exists: `.workflows/{work_unit}/discussion/`
 2. Load **[template.md](template.md)** — use it to create the discussion file at `.workflows/{work_unit}/discussion/{topic}.md`. Include the terminal `## Triage` section seeded as `(none)`.
 3. Populate Context section and seed the Discussion Map:

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -196,11 +196,9 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 
 **Otherwise:**
 
-The topic was shaped on the discovery map — its seed lives on the map item. Read the `description` and seed the research session from it:
+The topic was shaped on the discovery map. Read its discovery brief as the starting context:
 
-```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} description
-```
+Load **[read-brief-context.md](../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 Do not re-ask; live conversation context, when present, supplements the carrier.
 

--- a/skills/workflow-research-entry/references/validate-phase.md
+++ b/skills/workflow-research-entry/references/validate-phase.md
@@ -26,6 +26,8 @@ Reopening research: {topic:(titlecase)}
 
 Set source="continue".
 
+→ Load **[reconcile-advisory.md](../../workflow-shared/references/reconcile-advisory.md)** with downstream_phase = `research`.
+
 → Return to caller.
 
 #### If status is `in-progress`
@@ -37,5 +39,7 @@ Resuming research: {topic:(titlecase)}
 ```
 
 Set source="continue".
+
+→ Load **[reconcile-advisory.md](../../workflow-shared/references/reconcile-advisory.md)** with downstream_phase = `research`.
 
 → Return to caller.

--- a/skills/workflow-research-process/references/initialize-research.md
+++ b/skills/workflow-research-process/references/initialize-research.md
@@ -6,6 +6,8 @@
 
 → Load **[../../workflow-shared/references/seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
 
+→ Load **[../../workflow-shared/references/read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
+
 1. Load **[template.md](template.md)** — use it to create the research file at the Output path from the handoff (e.g., `.workflows/{work_unit}/research/{resolved_filename}`). Include the terminal `## Triage` section seeded as `(none)`.
 2. Populate the Starting Point section with context from the handoff's `Context:` section and the seed. If restarting (no `Context:` in handoff), leave the Starting Point section empty — the session will gather context naturally.
 3. Register in manifest:

--- a/skills/workflow-shared/references/read-brief-context.md
+++ b/skills/workflow-shared/references/read-brief-context.md
@@ -1,0 +1,53 @@
+# Read the Topic's Discovery Brief
+
+*Shared reference for the research and discussion entry and processing skills.*
+
+---
+
+An epic topic's **discovery brief** is its read-in-full starting context for the next phase — one topic's slice of the discovery record, projected from the source-of-truth session logs. It plays the role a seed plays for a work unit, but is a distinct artifact — never call it a seed.
+
+Caller passes `work_type`, `work_unit`, `topic`.
+
+## A. Read the Brief
+
+#### If `work_type` is not `epic`
+
+Nothing to read here — briefs exist only for epics (the inverse of `seed-context.md`, which acts for non-epic work and no-ops for epics).
+
+→ Return to caller.
+
+#### Otherwise
+
+Read the topic's brief pointer:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} brief_path
+```
+
+**If `brief_path` is present and the brief file exists:**
+
+Read `.workflows/{work_unit}/discovery/briefs/{topic}.md` in full — the *discovery brief* — and use it as the starting context for this phase. Don't dump it back to the user verbatim. It is soft by location: treat it as provisional, to be ratified by this phase, not as settled fact.
+
+→ Proceed to **B. Track the Read**.
+
+**Otherwise:**
+
+No brief — an un-harvested, migration-seeded, or legacy topic. Fall back to the discovery item `description` and seed this phase from it (it may be empty, in which case the session gathers context naturally):
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.discovery.{topic} description
+```
+
+→ Proceed to **B. Track the Read**.
+
+## B. Track the Read
+
+Record that the brief (or its fallback) has been read:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.discovery.{topic} brief_incorporated true
+```
+
+No commit — this folds into the calling phase's next commit.
+
+→ Return to caller.

--- a/skills/workflow-shared/references/reconcile-advisory.md
+++ b/skills/workflow-shared/references/reconcile-advisory.md
@@ -1,0 +1,43 @@
+# Reconcile Advisory
+
+*Shared reference for the research and discussion entry skills.*
+
+---
+
+Caller passes `downstream_phase` = `research` | `discussion` — the phase whose downstream item may carry the flag.
+
+Read the reconcile flag on the downstream item:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.{downstream_phase}.{topic} reconcile_needed
+```
+
+`get` returns empty on an absent field.
+
+#### If output is empty (no reconcile pending)
+
+The common case. No output.
+
+→ Return to caller.
+
+#### If output is non-empty (reconcile flagged)
+
+The discovery brief was regenerated after this work started. Surface a non-blocking advisory (never a STOP gate), re-read the regenerated brief into context, and clear the flag.
+
+> *Output the next fenced block as a code block:*
+
+```
+  ⚑ Discovery context changed since this work started.
+    Reconciling against the regenerated discovery brief —
+    review and update as needed. Nothing has been overwritten.
+```
+
+→ Load **[read-brief-context.md](read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
+
+Clear the flag:
+
+```bash
+node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.{downstream_phase}.{topic} reconcile_needed
+```
+
+→ Return to caller.


### PR DESCRIPTION
**Stack position: 6 of 6 — final.** Base/target: `feat/deep-discovery-pr5-briefs` (PR #397). Do not merge standalone — after approval, land the whole stack root-first.

## What this closes

PR5 made the harvest produce per-topic **briefs** and set `reconcile_needed` when a regenerated brief post-dates downstream work. PR6 closes the loop:

- **Consume** — research and discussion read the topic's **discovery brief in full** as their read-in-full starting context (the brief plays a seed's *role* for an epic topic, but is a distinct concept — never called `seed`). Un-harvested/legacy topics with no `brief_path` fall back to the discovery item `description` (today's behaviour).
- **Surface** — when a research/discussion item carries `reconcile_needed: true`, a non-blocking `⚑` advisory appears on resume/reopen, the regenerated brief is re-read into context, and the flag clears. **Never auto-overwrites** the downstream artifact.

## Edits

- **NEW** `skills/workflow-shared/references/read-brief-context.md` — consume the brief (epic-gated; inverse of `seed-context.md`), with `description` fallback; tracks `brief_incorporated` on the discovery item.
- **NEW** `skills/workflow-shared/references/reconcile-advisory.md` — read `reconcile_needed`, render the `⚑` advisory, re-read the brief, clear the flag.
- Wire consumption: research/discussion entry `SKILL.md` epic `Otherwise` branches + both `initialize-*.md`.
- Wire surfacing: both `validate-phase.md` resume + reopen branches (`downstream_phase` = research/discussion).

## Scope

Epic-only. Non-epic and work-unit-level `seeds` paths byte-for-byte unchanged. Purely skill prose + opaque manifest fields — no builder, schema, migration, or `src/` change (no bundle rebuild).

## Verification

- Full suite: **74 passed, 3 failed** — the 3 `test-release-*` failures are pre-existing (release tooling, unrelated).
- Manifest fixture (scratch, not the real `.workflows/`): harvested topic → brief read in full + `brief_incorporated: true`; no `brief_path` → `description` fallback; `reconcile_needed` → advisory + re-read + `delete` clears it, brief file and downstream item content untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #393
2. #391
3. #394
4. #395
5. #396
6. #397
7. **#398** 👈 current
<!-- stack:links:end -->