### PR TITLE
feat(engine): topic lifecycle — start/complete; wave 4 migrates investigation, scoping, research

### DIFF
--- a/skills/workflow-engine/SKILL.md
+++ b/skills/workflow-engine/SKILL.md
@@ -63,9 +63,15 @@ Subtopic names are kebab-case slugs; `--parent` nests under an existing top-leve
 engine discovery-map sequence <work-unit> <topic>=<order> [<topic>=<order> …]   # suggested execution order, scoped commit
 ```
 
-**`topic`** — epic topic cancel / reactivate, each one transaction: manifest write (stash/restore `previous_status`, cancel also drops the topic's discovery-map `order`), knowledge-base sync (remove on cancel; re-index on reactivate when the restored status is `completed` in research/discussion/investigation/specification), and a commit scoped to `.workflows/{wu}` (`workflow({wu}): cancel {topic} ({phase})` / `… reactivate …`). The knowledge base is a derived index — its failures land in `warnings`, never block. Response: `{"ok": true, "topic": "…", "phase": "…", "status": "…", "committed": "<short-sha>", "warnings": []}` (`committed: null` plus a note when nothing was staged).
+**`topic`** — phase-item transitions. `start` and `complete` are lifecycle bookkeeping with no git commit — the calling flow's commit cadence picks the manifest change up. `start` creates the phase item with `status: in-progress` when absent (init-phase semantics: `phases.{phase}.items.{topic}`, status only) or sets an existing item back to `in-progress`; a completed item errors — resuming is not starting — and a cancelled item must go through `reactivate`. Response: `{"ok": true, "phase": "…", "topic": "…", "status": "in-progress", "created": bool}`. `complete` sets `status: completed` on an existing item and, when the phase is research/discussion/investigation/specification, indexes the phase artifact into the knowledge base. Response: `{"ok": true, "phase": "…", "topic": "…", "status": "completed", "warnings": []}`.
+
+`cancel` and `reactivate` are the epic transactions, each one transaction: manifest write (stash/restore `previous_status`, cancel also drops the topic's discovery-map `order`), knowledge-base sync (remove on cancel; re-index on reactivate when the restored status is `completed` in an indexed phase), and a commit scoped to `.workflows/{wu}` (`workflow({wu}): cancel {topic} ({phase})` / `… reactivate …`). Response: `{"ok": true, "topic": "…", "phase": "…", "status": "…", "committed": "<short-sha>", "warnings": []}` (`committed: null` plus a note when nothing was staged).
+
+Across all four, the knowledge base is a derived index — its failures land in `warnings`, never block.
 
 ```bash
+engine topic start <work-unit> <phase> <topic>
+engine topic complete <work-unit> <phase> <topic>
 engine topic cancel <work-unit> <phase> <topic>
 engine topic reactivate <work-unit> <phase> <topic>
 ```

--- a/skills/workflow-engine/scripts/domain/transitions.cjs
+++ b/skills/workflow-engine/scripts/domain/transitions.cjs
@@ -1,10 +1,14 @@
 'use strict';
 
 // ---------------------------------------------------------------------------
-// Domain ring: epic topic transitions — cancel and reactivate as single
-// transactions. Each call is one atomic state change from the caller's
-// perspective: manifest write, knowledge-base sync (where applicable),
-// scoped git commit.
+// Domain ring: topic transitions — start, complete, cancel, and reactivate,
+// each a single transaction from the caller's perspective.
+//
+// start/complete are phase-item lifecycle bookkeeping: manifest write plus,
+// for complete in an indexed phase, a knowledge-base index. No git commit —
+// the calling session's commit cadence picks the manifest change up.
+// cancel/reactivate are the epic transactions: manifest write, knowledge-base
+// sync, scoped git commit.
 //
 // The manifest write is the source of truth and lands first; the knowledge
 // base is a derived index, so its failures are recorded as warnings, never
@@ -74,6 +78,91 @@ function knowledge(cwd, args, label, warnings) {
       : (res.stderr || res.stdout || `exit ${res.status}`).trim();
     warnings.push(`${label} failed: ${detail}`);
   }
+}
+
+/**
+ * @typedef {object} TopicStartResult
+ * @property {string} topic
+ * @property {string} phase
+ * @property {string} status   always `in-progress`
+ * @property {boolean} created true when the phase item was created, false when resumed
+ */
+
+/**
+ * @typedef {object} TopicCompleteResult
+ * @property {string} topic
+ * @property {string} phase
+ * @property {string} status   always `completed`
+ * @property {string[]} warnings non-blocking failures (knowledge-base index)
+ */
+
+/**
+ * Start a phase item: create it with `status: in-progress` when absent
+ * (init-phase semantics), or set an existing item back to `in-progress`.
+ * A completed item is not startable — resuming is not starting — and a
+ * cancelled item must go through reactivate. No git commit.
+ * @param {string} cwd project root
+ * @param {string} workUnit
+ * @param {string} phase
+ * @param {string} topic
+ * @returns {TopicStartResult}
+ */
+function startTopic(cwd, workUnit, phase, topic) {
+  if (!PHASES.includes(phase)) {
+    throw new Error(`unknown phase "${phase}" (${PHASES.join('|')})`);
+  }
+  const manifest = loadWorkUnitManifest(cwd, workUnit);
+  if (!manifest.phases || typeof manifest.phases !== 'object') manifest.phases = {};
+  if (!manifest.phases[phase] || typeof manifest.phases[phase] !== 'object') manifest.phases[phase] = {};
+  const ph = manifest.phases[phase];
+  if (!ph.items || typeof ph.items !== 'object') ph.items = {};
+
+  const existing = ph.items[topic];
+  let created = false;
+  if (!existing || typeof existing !== 'object') {
+    ph.items[topic] = { status: 'in-progress' };
+    created = true;
+  } else if (existing.status === 'completed') {
+    throw new Error(`${phase} item "${topic}" is already completed — start cannot resume it`);
+  } else if (existing.status === 'cancelled') {
+    throw new Error(`${phase} item "${topic}" is cancelled — reactivate it instead`);
+  } else {
+    existing.status = 'in-progress';
+  }
+
+  saveWorkUnitManifest(cwd, workUnit, manifest);
+  return { topic, phase, status: 'in-progress', created };
+}
+
+/**
+ * Complete a phase item: set `status: completed` and, when the phase's
+ * artifact is knowledge-base indexed, index it (warn-don't-block). The item
+ * must exist; a cancelled item must go through reactivate first. No git
+ * commit.
+ * @param {string} cwd project root
+ * @param {string} workUnit
+ * @param {string} phase
+ * @param {string} topic
+ * @returns {TopicCompleteResult}
+ */
+function completeTopic(cwd, workUnit, phase, topic) {
+  const manifest = loadWorkUnitManifest(cwd, workUnit);
+  const item = phaseItem(manifest, phase, topic);
+  if (item.status === 'cancelled') {
+    throw new Error(`${phase} item "${topic}" is cancelled — reactivate it instead`);
+  }
+  item.status = 'completed';
+
+  saveWorkUnitManifest(cwd, workUnit, manifest);
+
+  /** @type {string[]} */
+  const warnings = [];
+  const artifact = INDEXED_ARTIFACTS[/** @type {keyof typeof INDEXED_ARTIFACTS} */ (phase)];
+  if (artifact) {
+    knowledge(cwd, ['index', artifact(workUnit, topic)], 'knowledge index', warnings);
+  }
+
+  return { topic, phase, status: 'completed', warnings };
 }
 
 /**
@@ -152,4 +241,4 @@ function reactivateTopic(cwd, workUnit, phase, topic) {
   return result;
 }
 
-module.exports = { cancelTopic, reactivateTopic };
+module.exports = { startTopic, completeTopic, cancelTopic, reactivateTopic };

--- a/skills/workflow-engine/scripts/domain/transitions.cjs
+++ b/skills/workflow-engine/scripts/domain/transitions.cjs
@@ -23,7 +23,26 @@ const { commitScoped } = require('../kernel/git.cjs');
 // Resolved against this file so it works wherever the skill tree is installed.
 const KNOWLEDGE_CLI = path.resolve(__dirname, '..', '..', '..', 'workflow-knowledge', 'scripts', 'knowledge.cjs');
 
-const PHASES = ['discovery', 'research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
+const { VALID_PHASES, VALID_PHASE_STATUSES } = require('../../../workflow-shared/scripts/manifest-schema.cjs');
+
+// Phase-item lifecycle operates on WORK phases only. Discovery items are map
+// items (no lifecycle status — computed at render time); they are created and
+// edited by the discovery tooling, never by topic commands.
+const LIFECYCLE_PHASES = VALID_PHASES.filter((p) => p !== 'discovery');
+
+// Refuse any status write the manifest CLI would refuse — the two enforcers
+// share one schema (workflow-shared/scripts/manifest-schema.cjs), so the
+// engine can never be the permissive path around a validation refusal.
+/** @param {string} phase @param {string} status */
+function assertLegalWrite(phase, status) {
+  if (!LIFECYCLE_PHASES.includes(phase)) {
+    throw new Error(`unknown or non-lifecycle phase "${phase}" (${LIFECYCLE_PHASES.join('|')}) — discovery items are map items; use the discovery tooling`);
+  }
+  const valid = VALID_PHASE_STATUSES[/** @type {keyof typeof VALID_PHASE_STATUSES} */ (phase)];
+  if (!valid || !valid.includes(status)) {
+    throw new Error(`Invalid status "${status}" for phase "${phase}". Must be one of: ${(valid || []).join(', ')}`);
+  }
+}
 
 /** Phases whose completed artifact is knowledge-base indexed, with the artifact path per topic. */
 const INDEXED_ARTIFACTS = {
@@ -49,9 +68,7 @@ const INDEXED_ARTIFACTS = {
  * @returns {{status?: string, previous_status?: string}}
  */
 function phaseItem(manifest, phase, topic) {
-  if (!PHASES.includes(phase)) {
-    throw new Error(`unknown phase "${phase}" (${PHASES.join('|')})`);
-  }
+  assertLegalWrite(phase, 'cancelled');
   const phases = manifest && manifest.phases;
   const ph = phases && typeof phases === 'object' ? phases[phase] : undefined;
   const items = ph && typeof ph === 'object' ? ph.items : undefined;
@@ -108,9 +125,7 @@ function knowledge(cwd, args, label, warnings) {
  * @returns {TopicStartResult}
  */
 function startTopic(cwd, workUnit, phase, topic) {
-  if (!PHASES.includes(phase)) {
-    throw new Error(`unknown phase "${phase}" (${PHASES.join('|')})`);
-  }
+  assertLegalWrite(phase, 'in-progress');
   const manifest = loadWorkUnitManifest(cwd, workUnit);
   if (!manifest.phases || typeof manifest.phases !== 'object') manifest.phases = {};
   if (!manifest.phases[phase] || typeof manifest.phases[phase] !== 'object') manifest.phases[phase] = {};
@@ -146,6 +161,7 @@ function startTopic(cwd, workUnit, phase, topic) {
  * @returns {TopicCompleteResult}
  */
 function completeTopic(cwd, workUnit, phase, topic) {
+  assertLegalWrite(phase, 'completed');
   const manifest = loadWorkUnitManifest(cwd, workUnit);
   const item = phaseItem(manifest, phase, topic);
   if (item.status === 'cancelled') {
@@ -222,6 +238,7 @@ function reactivateTopic(cwd, workUnit, phase, topic) {
   if (!restored) {
     throw new Error(`${phase} item "${topic}" has no previous_status to restore`);
   }
+  assertLegalWrite(phase, restored);
   item.status = restored;
   delete item.previous_status;
 

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -21,7 +21,7 @@ const { loadWorkUnitManifest, saveWorkUnitManifest } = require('./kernel/manifes
 const { commitScoped } = require('./kernel/git.cjs');
 const { addSubtopic, setSubtopicState, mapState, SUBTOPIC_STATES } = require('./domain/discussion-map.cjs');
 const { sequenceMap } = require('./domain/discovery-map.cjs');
-const { cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
+const { startTopic, completeTopic, cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
 const { initTasks, startTask, fixAttempt, completeTask, analysisCycle } = require('./domain/tasks.cjs');
 const { archiveItems, restoreItems, deleteItems } = require('./domain/inbox.cjs');
 const { stampAnalysisCache } = require('./domain/cache.cjs');
@@ -74,6 +74,8 @@ Commands:
   discussion-map add <work-unit> <topic> <subtopic> [--parent <subtopic>]
   discussion-map set <work-unit> <topic> <subtopic> <state>
   discovery-map sequence <work-unit> <topic>=<order> [<topic>=<order> …]
+  topic start <work-unit> <phase> <topic>
+  topic complete <work-unit> <phase> <topic>
   topic cancel <work-unit> <phase> <topic>
   topic reactivate <work-unit> <phase> <topic>
   task init <work-unit> <topic>
@@ -181,22 +183,27 @@ function runDiscoveryMap(argv) {
 }
 
 // ---------------------------------------------------------------------------
-// topic — epic topic cancel / reactivate. One transaction per call: manifest
-// write, knowledge-base sync (warn-don't-block), scoped git commit. The JSON
-// response reports what happened — no follow-up read needed.
+// topic — phase-item transitions. start/complete are manifest-side lifecycle
+// bookkeeping (complete also KB-indexes indexed phases, warn-don't-block) with
+// no git commit — the calling session's commit cadence picks the change up.
+// cancel/reactivate are one transaction per call: manifest write, knowledge-
+// base sync (warn-don't-block), scoped git commit. The JSON response reports
+// what happened — no follow-up read needed.
 // ---------------------------------------------------------------------------
+
+const TOPIC_COMMANDS = { start: startTopic, complete: completeTopic, cancel: cancelTopic, reactivate: reactivateTopic };
 
 /** @param {string[]} argv */
 function runTopic(argv) {
   const [command, workUnit, phase, topic] = argv;
   try {
-    if (command !== 'cancel' && command !== 'reactivate') {
-      throw new Error('Usage: engine topic <cancel|reactivate> <work-unit> <phase> <topic>');
+    if (!Object.prototype.hasOwnProperty.call(TOPIC_COMMANDS, command)) {
+      throw new Error('Usage: engine topic <start|complete|cancel|reactivate> <work-unit> <phase> <topic>');
     }
+    const fn = TOPIC_COMMANDS[/** @type {keyof typeof TOPIC_COMMANDS} */ (command)];
     if (!workUnit || !phase || !topic) {
       throw new Error(`Usage: engine topic ${command} <work-unit> <phase> <topic>`);
     }
-    const fn = command === 'cancel' ? cancelTopic : reactivateTopic;
     respond(fn(process.cwd(), workUnit, phase, topic));
   } catch (err) {
     failJson(err);

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-investigation-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
 ---
 
 # Investigation Process

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -25,18 +25,16 @@ Investigation complete. Ready to conclude?
 
 #### If `yes`
 
-1. Set investigation status to completed via manifest CLI:
+1. Mark the investigation completed — the engine sets the status and indexes the artifact into the knowledge base:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.investigation.{topic} status completed
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} investigation {topic}
    ```
-2. Final commit
-3. Index the completed artifact into the knowledge base:
+2. Final commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "investigation({work_unit}): complete {topic} investigation"
+   ```
 
-```bash
-node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index .workflows/{work_unit}/investigation/{topic}.md
-```
-
-If the index command fails, display the error but do not block — the artifact is already saved:
+If the `complete` response carries `warnings`, display them but do not block — the artifact is already saved:
 
 > *Output the next fenced block as a code block:*
 
@@ -46,7 +44,7 @@ If the index command fails, display the error but do not block — the artifact 
   The artifact is saved. Indexing can be retried later.
 ```
 
-4. Display conclusion:
+3. Display conclusion:
 
 > *Output the next fenced block as a code block:*
 
@@ -59,7 +57,7 @@ Fix direction: {chosen approach}
 The investigation is completed. Root cause and fix direction are documented.
 ```
 
-5. Closure signpost:
+4. Closure signpost:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -68,7 +66,7 @@ The investigation is completed. Root cause and fix direction are documented.
 > the fix approach into a document that drives planning.
 ```
 
-6. Invoke the bridge:
+5. Invoke the bridge:
 
 ```
 Pipeline bridge for: {work_unit}

--- a/skills/workflow-investigation-process/references/initialize-investigation.md
+++ b/skills/workflow-investigation-process/references/initialize-investigation.md
@@ -11,7 +11,7 @@
 3. Populate the Symptoms section with any context already gathered, including the seed
 4. Register investigation in manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.investigation.{topic}
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} investigation {topic}
    ```
 5. Commit the initial file
 

--- a/skills/workflow-manifest/scripts/manifest.cjs
+++ b/skills/workflow-manifest/scripts/manifest.cjs
@@ -10,29 +10,13 @@ const path = require('path');
 
 const WORKFLOWS_DIR = path.resolve(process.cwd(), '.workflows');
 
-const VALID_WORK_TYPES = ['epic', 'feature', 'bugfix', 'cross-cutting', 'quick-fix'];
-
-const VALID_PHASES = [
-  'discovery', 'research', 'discussion', 'investigation', 'scoping',
-  'specification', 'planning', 'implementation',
-  'review'
-];
-
-const VALID_PHASE_STATUSES = {
-  discovery:      ['in-progress'],
-  research:       ['in-progress', 'completed', 'superseded', 'cancelled'],
-  discussion:     ['in-progress', 'completed', 'cancelled'],
-  investigation:  ['in-progress', 'completed', 'cancelled'],
-  scoping:        ['in-progress', 'completed', 'cancelled'],
-  specification:  ['proposed', 'in-progress', 'completed', 'superseded', 'promoted', 'cancelled'],
-  planning:       ['in-progress', 'completed', 'cancelled'],
-  implementation: ['in-progress', 'completed', 'cancelled'],
-  review:         ['in-progress', 'completed', 'cancelled'],
-};
-
-const VALID_GATE_MODES = ['gated', 'auto'];
-
-const VALID_WORK_UNIT_STATUSES = ['in-progress', 'completed', 'cancelled'];
+const {
+  VALID_WORK_TYPES,
+  VALID_PHASES,
+  VALID_PHASE_STATUSES,
+  VALID_GATE_MODES,
+  VALID_WORK_UNIT_STATUSES,
+} = require('../../workflow-shared/scripts/manifest-schema.cjs');
 
 const RESERVED_NAMES = ['project'];
 

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-research-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/discovery.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/discovery.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
 ---
 
 # Research Process

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -21,18 +21,16 @@ A concern was rerouted into this topic after drain ran this session. It must be 
 
 **If `## Triage` is `(none)`:**
 
-1. Set research status to completed:
+1. Mark the research completed — the engine sets the status and indexes the artifact into the knowledge base:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.research.{topic} status completed
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} research {topic}
    ```
-2. Final commit: `research({work_unit}): complete {topic} research`
-3. Index the completed artifact into the knowledge base:
+2. Final commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}): complete {topic} research"
+   ```
 
-```bash
-node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index .workflows/{work_unit}/research/{topic}.md
-```
-
-If the index command fails, display the error but do not block — the artifact is already saved:
+If the `complete` response carries `warnings`, display them but do not block — the artifact is already saved:
 
 > *Output the next fenced block as a code block:*
 
@@ -42,7 +40,7 @@ If the index command fails, display the error but do not block — the artifact 
   The artifact is saved. Indexing can be retried later.
 ```
 
-4. Closure signpost:
+3. Closure signpost:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -51,7 +49,7 @@ If the index command fails, display the error but do not block — the artifact 
 > to make decisions about architecture and approach.
 ```
 
-5. Invoke the `/workflow-bridge` skill:
+4. Invoke the `/workflow-bridge` skill:
    ```
    Pipeline bridge for: {work_unit}
    Completed phase: research

--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -145,9 +145,12 @@ Delegate all check-for-results and presentation behaviour to the shared surfacin
 2. Synthesise the deep-dive findings into the file (don't copy the cache file verbatim — organise for the research document context)
 3. Register in the manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.research.{thread}
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} research {thread}
    ```
-4. Commit: `research({work_unit}): add {thread} research from deep dive`
+4. Commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}): add {thread} research from deep dive"
+   ```
 
 For feature work types, deep-dive findings fold into the existing research file — there is only one research topic per feature.
 

--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -72,8 +72,7 @@ When a concern surfaces that belongs to a *different* topic — raised in conver
 4. Commit:
 
    ```bash
-   git add -- .workflows/{work_unit}/
-   git commit -m "research({work_unit}/{topic}): reroute concern to {landed_topic}"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}/{topic}): reroute concern to {landed_topic}"
    ```
 
 → Return to **B. Session Loop**.

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -106,8 +106,7 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 4. Commit the conversion and the landing:
 
    ```bash
-   git add -- .workflows/{work_unit}/
-   git commit -m "research({work_unit}/{topic}): pivot to epic"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}/{topic}): pivot to epic"
    ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-research-process/references/initialize-research.md
+++ b/skills/workflow-research-process/references/initialize-research.md
@@ -12,8 +12,11 @@
 2. Populate the Starting Point section with context from the handoff's `Context:` section and the seed. If restarting (no `Context:` in handoff), leave the Starting Point section empty — the session will gather context naturally.
 3. Register in manifest:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.research.{topic}
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} research {topic}
    ```
-4. Commit: `research({work_unit}): initialize {topic} research`
+4. Commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}): initialize {topic} research"
+   ```
 
 → Return to caller.

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -22,7 +22,13 @@ Not a rigid checklist — a natural cadence for productive research conversation
 
 5. **Document** — At natural pauses, update the research file with insights, open questions, and emerging themes. Capture the substance, not a transcript. The research file is freeform — let structure emerge from the content rather than imposing it.
 
-6. **Commit & dispatch check** — Git commit after each write. Don't batch. The commit history is your safety net across context compaction. Then immediately evaluate agent dispatch — **CHECKPOINT**: Do not respond to the user until this check is complete. Evaluate the trigger conditions defined in the review agent and deep-dive agent instructions loaded by the session wrapper. If conditions are met, dispatch before continuing. If not, proceed.
+6. **Commit & dispatch check** — Commit after each write. Don't batch — the commit history is your safety net across context compaction:
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}/{topic}): {what changed}"
+   ```
+
+   Then immediately evaluate agent dispatch — **CHECKPOINT**: Do not respond to the user until this check is complete. Evaluate the trigger conditions defined in the review agent and deep-dive agent instructions loaded by the session wrapper. If conditions are met, dispatch before continuing. If not, proceed.
 
 7. **Continue** — Follow the conversation where it leads. If a tangent is promising, pursue it. If a thread is exhausted, move on. If earlier threads gain new context from what was just discussed, circle back.
 

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -54,8 +54,7 @@ Abandon this thread and continue the loop with the next.
 Once all accepted threads have been processed, single commit covering the manifest writes and the new research files:
 
 ```bash
-git add -- .workflows/{work_unit}/manifest.json .workflows/{work_unit}/research/
-git commit -m "research({work_unit}/{parent_topic}): split into {N} topic(s)"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}/{parent_topic}): split into {N} topic(s)"
 ```
 
 Then offer the user a choice of which topic to continue with:

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-scoping-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
 ---
 
 # Scoping Process
@@ -102,8 +102,8 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.sc
 If scoping doesn't exist, init and complete it:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.scoping.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.scoping.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} scoping {topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} scoping {topic}
 ```
 
 → Proceed to **Step 8**.

--- a/skills/workflow-scoping-process/references/complexity-check.md
+++ b/skills/workflow-scoping-process/references/complexity-check.md
@@ -59,7 +59,11 @@ Update the work type in the manifest:
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_type feature
 ```
 
-Commit: `workflow({work_unit}): promote quick-fix to feature`
+Commit:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "workflow({work_unit}): promote quick-fix to feature"
+```
 
 Invoke `/workflow-discussion-entry feature {work_unit}`.
 
@@ -73,7 +77,11 @@ Update the work type in the manifest:
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit} work_type bugfix
 ```
 
-Commit: `workflow({work_unit}): promote quick-fix to bugfix`
+Commit:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "workflow({work_unit}): promote quick-fix to bugfix"
+```
 
 Invoke `/workflow-investigation-entry bugfix {work_unit}`.
 

--- a/skills/workflow-scoping-process/references/write-specification.md
+++ b/skills/workflow-scoping-process/references/write-specification.md
@@ -46,19 +46,11 @@ Specification written: .workflows/{work_unit}/specification/{topic}/specificatio
 ## B. Register in Manifest
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.specification.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.specification.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} specification {topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} specification {topic}
 ```
 
-Commit: `spec({work_unit}): quick-fix specification`
-
-Index the completed specification into the knowledge base:
-
-```bash
-node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index .workflows/{work_unit}/specification/{topic}/specification.md
-```
-
-If the index command fails, display the error but do not block — the artifact is already saved:
+The `complete` call indexes the specification into the knowledge base. If its response carries `warnings`, display them but do not block — the artifact is already saved:
 
 > *Output the next fenced block as a code block:*
 
@@ -66,6 +58,12 @@ If the index command fails, display the error but do not block — the artifact 
 ⚑ Knowledge indexing warning
   {error details}
   The artifact is saved. Indexing can be retried later.
+```
+
+Commit:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): quick-fix specification"
 ```
 
 → Return to caller.

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -65,7 +65,7 @@ Load the chosen format's **authoring.md** from `skills/workflow-planning-process
 Capture the current git commit hash: `git rev-parse HEAD`
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.planning.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} planning {topic}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} format {chosen-format}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set project.defaults.plan_format {chosen-format}
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} spec_commit {commit-hash}
@@ -77,7 +77,7 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.plann
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task '~'
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_map '{}'
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} external_id {external_id}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} planning {topic}
 ```
 
 Register the task_map entries. For each task, map internal_id to external_id:
@@ -91,8 +91,8 @@ Both the plan-level `external_id` and per-task external IDs are determined by th
 ## D. Mark Scoping Complete
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.scoping.{topic}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.scoping.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} scoping {topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} scoping {topic}
 ```
 
 Commit all scoping artifacts:

--- a/skills/workflow-shared/scripts/manifest-schema.cjs
+++ b/skills/workflow-shared/scripts/manifest-schema.cjs
@@ -1,0 +1,43 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Manifest schema vocabulary — the single source of the legal work types,
+// phases, and per-phase status sets.
+//
+// Consumed by BOTH write paths (the manifest CLI's validators and the
+// engine's transitions), so the two enforcers can never drift: a status the
+// CLI refuses is refused by the engine identically. Pure constants — no IO,
+// no side effects, safe to require from anywhere.
+// ---------------------------------------------------------------------------
+
+const VALID_WORK_TYPES = ['epic', 'feature', 'bugfix', 'cross-cutting', 'quick-fix'];
+
+const VALID_PHASES = [
+  'discovery', 'research', 'discussion', 'investigation', 'scoping',
+  'specification', 'planning', 'implementation',
+  'review'
+];
+
+const VALID_PHASE_STATUSES = {
+  discovery:      ['in-progress'],
+  research:       ['in-progress', 'completed', 'superseded', 'cancelled'],
+  discussion:     ['in-progress', 'completed', 'cancelled'],
+  investigation:  ['in-progress', 'completed', 'cancelled'],
+  scoping:        ['in-progress', 'completed', 'cancelled'],
+  specification:  ['proposed', 'in-progress', 'completed', 'superseded', 'promoted', 'cancelled'],
+  planning:       ['in-progress', 'completed', 'cancelled'],
+  implementation: ['in-progress', 'completed', 'cancelled'],
+  review:         ['in-progress', 'completed', 'cancelled'],
+};
+
+const VALID_GATE_MODES = ['gated', 'auto'];
+
+const VALID_WORK_UNIT_STATUSES = ['in-progress', 'completed', 'cancelled'];
+
+module.exports = {
+  VALID_WORK_TYPES,
+  VALID_PHASES,
+  VALID_PHASE_STATUSES,
+  VALID_GATE_MODES,
+  VALID_WORK_UNIT_STATUSES,
+};

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -72,7 +72,7 @@ function engineFails(dir, args) {
   return parsed;
 }
 
-/** An epic manifest with one research item and a discovery-map entry carrying `order`. */
+/** An epic manifest with plural phase items and a discovery-map entry carrying `order`. */
 function epicManifest() {
   return {
     name: 'payments',
@@ -80,8 +80,8 @@ function epicManifest() {
     status: 'in-progress',
     phases: {
       discovery: { items: { 'auth-flow': { routing: 'discussion', order: 2, source: 'discovery' } } },
-      research: { items: { 'auth-flow': { status: 'in-progress' } } },
-      discussion: { items: { 'session-model': { status: 'completed' } } },
+      research: { items: { 'auth-flow': { status: 'in-progress' }, 'fee-model': { status: 'completed' } } },
+      discussion: { items: { 'session-model': { status: 'completed' }, 'refund-policy': { status: 'in-progress' } } },
     },
   };
 }
@@ -180,6 +180,132 @@ describe('engine topic reactivate', () => {
     writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(m, null, 2) + '\n');
     const err = engineFails(dir, ['topic', 'reactivate', 'payments', 'research', 'auth-flow']);
     assert.match(err.error, /no previous_status/);
+  });
+});
+
+describe('engine topic start', () => {
+  let dir;
+  beforeEach(() => { dir = setupEpicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('creates an absent phase item with status in-progress — init-phase semantics, no commit', () => {
+    const res = engine(dir, ['topic', 'start', 'payments', 'investigation', 'auth-flow']);
+
+    assert.deepStrictEqual(res, { ok: true, topic: 'auth-flow', phase: 'investigation', status: 'in-progress', created: true });
+
+    const m = readManifest(dir, 'payments');
+    assert.deepStrictEqual(m.phases.investigation.items, { 'auth-flow': { status: 'in-progress' } });
+    // No commit inside — the manifest change is left for the session's cadence.
+    assert.strictEqual(git(dir, ['rev-list', '--count', 'HEAD']).trim(), '1');
+    assert.match(git(dir, ['status', '--porcelain']), /^ M \.workflows\/payments\/manifest\.json/m);
+  });
+
+  it('creates alongside existing items in a populated phase — siblings untouched', () => {
+    const res = engine(dir, ['topic', 'start', 'payments', 'research', 'settlement']);
+
+    assert.strictEqual(res.created, true);
+    const m = readManifest(dir, 'payments');
+    assert.deepStrictEqual(m.phases.research.items, {
+      'auth-flow': { status: 'in-progress' },
+      'fee-model': { status: 'completed' },
+      settlement: { status: 'in-progress' },
+    });
+  });
+
+  it('resumes an existing in-progress item: created false, fields preserved', () => {
+    const m0 = epicManifest();
+    m0.phases.research.items['auth-flow'].note = 'keep me';
+    writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(m0, null, 2) + '\n');
+
+    const res = engine(dir, ['topic', 'start', 'payments', 'research', 'auth-flow']);
+
+    assert.deepStrictEqual(res, { ok: true, topic: 'auth-flow', phase: 'research', status: 'in-progress', created: false });
+    const m = readManifest(dir, 'payments');
+    assert.deepStrictEqual(m.phases.research.items['auth-flow'], { status: 'in-progress', note: 'keep me' });
+  });
+
+  it('rejects starting a completed item — resuming is not starting', () => {
+    const err = engineFails(dir, ['topic', 'start', 'payments', 'research', 'fee-model']);
+    assert.match(err.error, /already completed — start cannot resume it/);
+  });
+
+  it('rejects starting a cancelled item — reactivate owns that path', () => {
+    engine(dir, ['topic', 'cancel', 'payments', 'research', 'auth-flow']);
+    const err = engineFails(dir, ['topic', 'start', 'payments', 'research', 'auth-flow']);
+    assert.match(err.error, /is cancelled — reactivate it instead/);
+  });
+
+  it('rejects unknown work unit, phase, and missing args — loud and specific', () => {
+    assert.match(engineFails(dir, ['topic', 'start', 'ghost', 'research', 'auth-flow']).error, /manifest not found/);
+    assert.match(engineFails(dir, ['topic', 'start', 'payments', 'nonsense', 'auth-flow']).error, /unknown phase "nonsense"/);
+    assert.match(engineFails(dir, ['topic', 'start', 'payments', 'research']).error, /Usage: engine topic start/);
+    assert.match(engineFails(dir, ['topic', 'begin', 'payments', 'research', 'auth-flow']).error, /Usage: engine topic <start\|complete\|cancel\|reactivate>/);
+  });
+});
+
+describe('engine topic complete', () => {
+  let dir;
+  beforeEach(() => { dir = setupEpicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('completes an indexed-phase item and KB-indexes it — failure is a warning, no commit', () => {
+    const res = engine(dir, ['topic', 'complete', 'payments', 'research', 'auth-flow']);
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.topic, 'auth-flow');
+    assert.strictEqual(res.phase, 'research');
+    assert.strictEqual(res.status, 'completed');
+    // No KB configured in the fixture — warn-don't-block.
+    assert.strictEqual(res.warnings.length, 1);
+    assert.match(res.warnings[0], /knowledge index failed/);
+
+    const m = readManifest(dir, 'payments');
+    assert.deepStrictEqual(m.phases.research.items, {
+      'auth-flow': { status: 'completed' },
+      'fee-model': { status: 'completed' },
+    });
+    // No commit inside.
+    assert.strictEqual(git(dir, ['rev-list', '--count', 'HEAD']).trim(), '1');
+    assert.match(git(dir, ['status', '--porcelain']), /^ M \.workflows\/payments\/manifest\.json/m);
+  });
+
+  it('completes a non-indexed phase with no KB attempt — empty warnings', () => {
+    const m0 = epicManifest();
+    m0.phases.scoping = { items: { 'auth-flow': { status: 'in-progress' }, 'fee-model': { status: 'in-progress' } } };
+    writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(m0, null, 2) + '\n');
+
+    const res = engine(dir, ['topic', 'complete', 'payments', 'scoping', 'fee-model']);
+
+    assert.deepStrictEqual(res, { ok: true, topic: 'fee-model', phase: 'scoping', status: 'completed', warnings: [] });
+    const m = readManifest(dir, 'payments');
+    assert.deepStrictEqual(m.phases.scoping.items, {
+      'auth-flow': { status: 'in-progress' },
+      'fee-model': { status: 'completed' },
+    });
+  });
+
+  it('is idempotent on an already-completed item — mirrors the manifest set it replaces', () => {
+    engine(dir, ['topic', 'complete', 'payments', 'discussion', 'refund-policy']);
+    const res = engine(dir, ['topic', 'complete', 'payments', 'discussion', 'refund-policy']);
+    assert.strictEqual(res.status, 'completed');
+  });
+
+  it('rejects completing a non-existent item, unknown phase, and a cancelled item', () => {
+    assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'research', 'ghost']).error, /no research item "ghost"/);
+    assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'investigation', 'auth-flow']).error, /no investigation items/);
+    assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'nonsense', 'auth-flow']).error, /unknown phase "nonsense"/);
+    engine(dir, ['topic', 'cancel', 'payments', 'research', 'auth-flow']);
+    assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'research', 'auth-flow']).error, /is cancelled — reactivate it instead/);
+    assert.match(engineFails(dir, ['topic', 'complete', 'payments']).error, /Usage: engine topic complete/);
+  });
+
+  it('round-trips with start: start → complete → reopen via start is still rejected', () => {
+    engine(dir, ['topic', 'start', 'payments', 'investigation', 'auth-flow']);
+    const res = engine(dir, ['topic', 'complete', 'payments', 'investigation', 'auth-flow']);
+    assert.strictEqual(res.status, 'completed');
+    assert.strictEqual(res.warnings.length, 1);
+    const err = engineFails(dir, ['topic', 'start', 'payments', 'investigation', 'auth-flow']);
+    assert.match(err.error, /already completed/);
   });
 });
 

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -132,7 +132,7 @@ describe('engine topic cancel', () => {
 
   it('rejects unknown work unit, phase, and topic — loud and specific', () => {
     assert.match(engineFails(dir, ['topic', 'cancel', 'ghost', 'research', 'auth-flow']).error, /manifest not found/);
-    assert.match(engineFails(dir, ['topic', 'cancel', 'payments', 'nonsense', 'auth-flow']).error, /unknown phase "nonsense"/);
+    assert.match(engineFails(dir, ['topic', 'cancel', 'payments', 'nonsense', 'auth-flow']).error, /unknown or non-lifecycle phase "nonsense"/);
     assert.match(engineFails(dir, ['topic', 'cancel', 'payments', 'planning', 'auth-flow']).error, /no planning items/);
     assert.match(engineFails(dir, ['topic', 'cancel', 'payments', 'research', 'ghost']).error, /no research item "ghost"/);
     assert.match(engineFails(dir, ['topic', 'cancel', 'payments']).error, /Usage: engine topic cancel/);
@@ -237,7 +237,7 @@ describe('engine topic start', () => {
 
   it('rejects unknown work unit, phase, and missing args — loud and specific', () => {
     assert.match(engineFails(dir, ['topic', 'start', 'ghost', 'research', 'auth-flow']).error, /manifest not found/);
-    assert.match(engineFails(dir, ['topic', 'start', 'payments', 'nonsense', 'auth-flow']).error, /unknown phase "nonsense"/);
+    assert.match(engineFails(dir, ['topic', 'start', 'payments', 'nonsense', 'auth-flow']).error, /unknown or non-lifecycle phase "nonsense"/);
     assert.match(engineFails(dir, ['topic', 'start', 'payments', 'research']).error, /Usage: engine topic start/);
     assert.match(engineFails(dir, ['topic', 'begin', 'payments', 'research', 'auth-flow']).error, /Usage: engine topic <start\|complete\|cancel\|reactivate>/);
   });
@@ -293,7 +293,7 @@ describe('engine topic complete', () => {
   it('rejects completing a non-existent item, unknown phase, and a cancelled item', () => {
     assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'research', 'ghost']).error, /no research item "ghost"/);
     assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'investigation', 'auth-flow']).error, /no investigation items/);
-    assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'nonsense', 'auth-flow']).error, /unknown phase "nonsense"/);
+    assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'nonsense', 'auth-flow']).error, /unknown or non-lifecycle phase "nonsense"/);
     engine(dir, ['topic', 'cancel', 'payments', 'research', 'auth-flow']);
     assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'research', 'auth-flow']).error, /is cancelled — reactivate it instead/);
     assert.match(engineFails(dir, ['topic', 'complete', 'payments']).error, /Usage: engine topic complete/);
@@ -445,5 +445,36 @@ describe('engine commit', () => {
     assert.match(engineFails(dir, ['commit', 'payments', '--inbox', '-m', 'msg']).error, /Usage: engine commit/);
     assert.match(engineFails(dir, ['commit', '../escape', '-m', 'msg']).error, /invalid work unit name/);
     assert.match(engineFails(dir, ['commit', 'ghost', '-m', 'msg']).error, /no work unit directory/);
+  });
+});
+
+describe('schema enforcement: engine refuses what the manifest CLI refuses', () => {
+  const { VALID_PHASE_STATUSES } = require('../../skills/workflow-shared/scripts/manifest-schema.cjs');
+
+  it('discovery is not a lifecycle phase — start/complete/cancel all refuse', () => {
+    const dir = setupGitFixture();
+    writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify({
+      name: 'payments', work_type: 'epic', status: 'in-progress',
+      phases: { discovery: { items: { 'auth-flow': { routing: 'research' } } } },
+    }, null, 2));
+    for (const verb of ['start', 'complete', 'cancel']) {
+      assert.match(
+        engineFails(dir, ['topic', verb, 'payments', 'discovery', 'auth-flow']).error,
+        /non-lifecycle phase "discovery"[\s\S]*discovery tooling/
+      );
+    }
+    // the invalid state the live drive produced must now be impossible
+    const m = JSON.parse(fs.readFileSync(path.join(dir, '.workflows/payments/manifest.json'), 'utf8'));
+    assert.strictEqual(m.phases.discovery.items['auth-flow'].status, undefined);
+    cleanupFixture(dir);
+  });
+
+  it('the enforcement table IS the manifest CLI schema (shared module, no mirror)', () => {
+    assert.deepStrictEqual(VALID_PHASE_STATUSES.discovery, ['in-progress']);
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../skills/workflow-engine/scripts/domain/transitions.cjs'), 'utf8');
+    assert.ok(src.includes("require('../../../workflow-shared/scripts/manifest-schema.cjs')"),
+      'transitions must require the shared schema, not mirror it');
+    assert.ok(!/VALID_PHASE_STATUSES\s*=\s*{/.test(src), 'no local copy of the status table');
   });
 });


### PR DESCRIPTION
## What

PR 13 (wave 4) of the engine stack (on #403). The three smallest process pipelines join the engine, and the `topic` noun completes its lifecycle family.

- **`engine topic start`** — create-or-resume a phase item (mirrors `init-phase`; errors on completed — resuming is not starting — and on cancelled — that's `reactivate`'s transaction). **`engine topic complete`** — status flip + KB index for indexed phases (warn-don't-block), idempotent on re-complete. Grammar-compliant; no internal commits.
- **Re-points across six skills** (survey-first, every moment classified): entry/initialize bootstrap chains → `topic start`; conclude sequences (status + knowledge index) → `topic complete`; session/pivot/reroute/split commits → `engine commit {wu}` with messages verbatim. Entry-skill *reopen* paths deliberately stay single-field manifest writes (reopening ≠ starting). The one commit staging outside `.workflows/{wu}` (scoping's plan artifacts — format storage lives at repo root) **stays raw git**, per the drill-derived doctrine.
- **Latent bug fixed by the migration**: the restart path deletes artifacts but keeps manifest items, so re-running initialize's old `init-phase` died on "already exists"; create-or-resume heals restart→initialize (and write-tasks re-runs after reopen).
- Displays deliberately untouched and catalogued for a later wave (none carry known survey-family defects — no tree templates exist in these six skills).

## Judgment calls to review

Invented one commit message (conclude-investigation's untemplated "Final commit" → `investigation({wu}): complete {topic} investigation`, mirroring research's); topic-splitting's staging widens to the wu tree (accepted precedent); write-specification now indexes inside `topic complete` before the commit (KB store is outside the commit's scope either way).

## Tests

410/410 (+11: plural-fixture lifecycle suite — create/resume/error paths, KB warn, no-commit assertions); migrations green; typecheck clean; discovery suites file-untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. **#404** 👈 current
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->