### PR TITLE
Planning pipeline onto the workflow engine

### DIFF
--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-planning-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
 ---
 
 # Planning Process
@@ -55,6 +55,16 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
    - `node .claude/skills/workflow-manifest/scripts/manifest.cjs get {work_unit}.planning.{topic} finding_gate_mode`
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
+
+---
+
+## Hard Rules
+
+1. **Commit frequently** — commit at natural breaks and before any context refresh. Context refresh = lost work. Work-unit commits go through the scoped helper:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "{message}"
+   ```
+2. **Raw git when the plan format's storage is staged** — task authoring, graph writes, and applied review fixes write through the format adapter, whose task storage may live outside `.workflows/{work_unit}`. Commit those with raw git, staging explicitly (`git add -- .workflows/{work_unit} {format task storage paths}`) — never the scoped helper.
 
 ---
 
@@ -145,7 +155,11 @@ Found existing plan for **{topic:(titlecase)}** (previously reached phase {N}, t
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.planning items.{topic}
    ```
-6. Commit: `planning({work_unit}): restart planning`
+6. Commit with raw git — the format's cleanup may remove task storage outside the work unit, so the scoped helper cannot cover it. Stage the work unit and every path the cleanup touched, then commit:
+   ```bash
+   git add -- .workflows/{work_unit} {paths the format cleanup touched}
+   git commit -m "planning({work_unit}): restart planning"
+   ```
 
 → Proceed to **Step 1**.
 

--- a/skills/workflow-planning-process/references/analyze-task-graph.md
+++ b/skills/workflow-planning-process/references/analyze-task-graph.md
@@ -75,7 +75,12 @@ The agent will clear all existing graph data and re-analyze from scratch.
 
 **If `approved`:**
 
-Commit: `planning({work_unit}): analyze task dependencies and priorities`
+Commit with raw git — the graph data lands in the format's task storage, which may live outside the work unit, so the scoped helper cannot cover it:
+
+```bash
+git add -- .workflows/{work_unit} {format task storage paths}
+git commit -m "planning({work_unit}): analyze task dependencies and priorities"
+```
 
 → Return to caller.
 
@@ -142,6 +147,11 @@ The agent will clear all existing graph data and re-analyze from scratch.
 
 **If `approved`:**
 
-Commit: `planning({work_unit}): analyze task dependencies and priorities`
+Commit with raw git — the graph data lands in the format's task storage, which may live outside the work unit, so the scoped helper cannot cover it:
+
+```bash
+git add -- .workflows/{work_unit} {format task storage paths}
+git commit -m "planning({work_unit}): analyze task dependencies and priorities"
+```
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -198,7 +198,11 @@ For each approved task in the task detail file, in order:
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task {next_task_id}
    ```
-7. Commit: `planning({work_unit}): author task {internal_id} ({task name})`
+7. Commit with raw git — the format's task storage may live outside the work unit, so the scoped helper cannot cover it. Stage the format's storage and the work unit, then commit:
+   ```bash
+   git add -- .workflows/{work_unit} {format task storage paths}
+   git commit -m "planning({work_unit}): author task {internal_id} ({task name})"
+   ```
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -25,11 +25,14 @@ Ready to conclude?
 
 #### If `yes`
 
-1. **Update plan status** via manifest CLI:
+1. **Mark the plan completed** — the engine sets the status:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} status completed
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} planning {topic}
    ```
-2. **Final commit** — Commit the completed plan: `planning({work_unit}): complete plan`
+2. **Final commit** — Commit the completed plan:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): complete plan"
+   ```
 3. **Present completion summary**:
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -54,7 +54,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.plann
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task '~'
 ```
 
-Commit: `planning({work_unit}): draft phase structure`
+Commit:
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): draft phase structure"
+```
 
 → Proceed to **B. Review and Approve**.
 
@@ -93,7 +96,10 @@ Update the planning file with the revised output.
 **If the phase structure is new or was amended:**
 
 1. Update each phase in the planning file: set `status: approved` and `approved_at: YYYY-MM-DD` (use today's actual date)
-2. Commit: `planning({work_unit}): approve phase structure`
+2. Commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): approve phase structure"
+   ```
 
 If the phase structure was already approved and unchanged, no updates are needed.
 

--- a/skills/workflow-planning-process/references/define-tasks.md
+++ b/skills/workflow-planning-process/references/define-tasks.md
@@ -45,7 +45,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.plann
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task '~'
 ```
 
-Commit: `planning({work_unit}): draft Phase {N} task list`
+Commit:
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): draft Phase {N} task list"
+```
 
 Present the task list to the user using the overview returned by the agent:
 
@@ -131,7 +134,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.plann
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task {first_task_id}
    ```
-3. Commit: `planning({work_unit}): approve Phase {N} task list`
+3. Commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): approve Phase {N} task list"
+   ```
 
 If the task list was already approved and unchanged, no updates are needed.
 

--- a/skills/workflow-planning-process/references/initialize-plan.md
+++ b/skills/workflow-planning-process/references/initialize-plan.md
@@ -53,9 +53,12 @@ Project default format is **{format}**. Use the same format?
 
 1. Capture the current git commit hash: `git rev-parse HEAD`
 2. Create the planning file at `.workflows/{work_unit}/planning/{topic}/planning.md` with the title `# Plan: {Topic Name}`.
-3. Register planning and set metadata in the manifest:
+3. Start the planning item — the engine creates it with `status: in-progress`:
    ```bash
-   node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.planning.{topic}
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} planning {topic}
+   ```
+4. Set metadata in the manifest:
+   ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} format {chosen-format}
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set project.defaults.plan_format {chosen-format}
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} spec_commit {commit-hash}
@@ -68,6 +71,10 @@ Project default format is **{format}**. Use the same format?
    node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task_map '{}'
    ```
 
-4. Commit: `planning({work_unit}): initialize plan`
+5. Commit with raw git — the project default lands in `.workflows/manifest.json`, outside the work unit, so the scoped helper cannot cover it. Stage both directly:
+   ```bash
+   git add -- .workflows/manifest.json .workflows/{work_unit}
+   git commit -m "planning({work_unit}): initialize plan"
+   ```
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -137,10 +137,13 @@ Phase {N}: {Phase Name} — all tasks already authored.
 Advance the manifest planning position to the next phase:
 ```bash
 node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} phase {N+1}
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task ~
+node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.planning.{topic} task '~'
 ```
 
-Commit: `planning({work_unit}): complete Phase {N} tasks`
+Commit:
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): complete Phase {N} tasks"
+```
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -203,7 +203,10 @@ Run another review round?
 
 > **CHECKPOINT**: Do not confirm completion if any tracking files still show `status: in-progress`. They indicate incomplete review work.
 
-2. **Commit** all review tracking files: `planning({work_unit}): complete plan review (cycle {N})`
+2. **Commit** all review tracking files:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): complete plan review (cycle {N})"
+   ```
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-planning-process/references/process-review-findings.md
+++ b/skills/workflow-planning-process/references/process-review-findings.md
@@ -8,6 +8,8 @@ Process findings from a review agent interactively with the user. The agent writ
 
 **Review type**: `{review_type:[traceability|integrity]}` — set by the calling context (B or C in plan-review.md).
 
+**Commits in this file**: applying a finding writes through the format adapter, and the format's task storage may live outside the work unit. Commit with raw git — `git add -- .workflows/{work_unit} {format task storage paths}`, then `git commit` — never the scoped helper.
+
 #### If `STATUS` is `clean`
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-planning-process/references/resolve-dependencies.md
+++ b/skills/workflow-planning-process/references/resolve-dependencies.md
@@ -216,7 +216,10 @@ Approve the dependency resolution?
 
 #### If `yes`
 
-Commit: `planning({work_unit}): resolve external dependencies`
+Commit:
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): resolve external dependencies"
+```
 
 → Return to caller.
 

--- a/skills/workflow-planning-process/references/review-integrity.md
+++ b/skills/workflow-planning-process/references/review-integrity.md
@@ -124,4 +124,8 @@ topic: {Topic Name}
 ...
 ```
 
-Commit the tracking file after creation: `planning({work_unit}): integrity review cycle {N}`
+Commit the tracking file after creation:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): integrity review cycle {N}"
+```

--- a/skills/workflow-planning-process/references/review-traceability.md
+++ b/skills/workflow-planning-process/references/review-traceability.md
@@ -102,4 +102,8 @@ topic: {Topic Name}
 ...
 ```
 
-Commit the tracking file after creation: `planning({work_unit}): traceability review cycle {N}`
+Commit the tracking file after creation:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): traceability review cycle {N}"
+```


### PR DESCRIPTION
Wave 5, second half (PR 15 of the engine migration). Stacked on #405.

## What moved

**Lifecycle → engine commands.** `init-phase` at plan initialization → `engine topic start {wu} planning {topic}` (no `created` branch needed — Step 0's restart flow deletes the item first, and a crash-rerun now heals instead of erroring on init-phase); `set status completed` at conclusion → `engine topic complete`. Planning is deliberately not KB-indexed, and the old prose had no index call — the engine's behaviour matches by construction.

**Commits split into two lanes, now explicit.** All work-unit-scoped prescribed commits (draft/approve phases, draft/approve task lists, phase completion, dependency resolution, review tracking files, plan conclusion) → `engine commit {wu} -m` with messages verbatim. Sites that stage outside the work unit stay **raw git with explicit `git add --`**: plan initialization (the project default lands in `.workflows/manifest.json`), restart cleanup, task authoring, graph analysis, and applied review findings (format task storage may live outside the tree). A new Hard Rules section in the process SKILL.md states both lanes once.

**Format-blind law holds absolutely**: zero engine code changed, zero format names added anywhere, all format adapters untouched.

**Stays in its lane:** every single-field manifest op (format, gate modes, positions, task_map, review cycles, external_dependencies), project-default reads, the entry skill entirely (no engine call sites; reopen stays on the manifest CLI since `topic start` refuses completed items by design).

## Also

- Defect fix: `plan-construction.md` used unquoted `task ~` (zsh expands bare `~` to `$HOME`) while every sibling quotes it.
- Flagged for follow-up, untouched (out of scope): `agents/workflow-planning-review-*.md` self-commit with a `planning({topic})` message while the criteria files say `planning({work_unit})`; recommend aligning these agents to the spec review agents' no-git-writes contract in a later PR.
- Recommended against building a `plan init` engine transaction: it would push a format name through the engine CLI boundary and write the project manifest cross-scope.

## Tests

482 pass, migrations green (46 files), typecheck clean, all `test-discovery-for-*` suites untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. **#406** 👈 current
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->