### PR TITLE
Review pipeline onto the workflow engine

### DIFF
--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-review-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(mkdir -p .workflows/.inbox)
+allowed-tools: Bash(node .claude/skills/workflow-manifest/scripts/manifest.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.inbox)
 ---
 
 # Review Process
@@ -192,8 +192,10 @@ node .claude/skills/workflow-manifest/scripts/manifest.cjs exists {work_unit}.re
 
 #### If `false`
 
+Start the review item — the engine creates it with `status: in-progress`:
+
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs init-phase {work_unit}.review.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} review {topic}
 ```
 
 → Proceed to **Step 2**.

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -164,7 +164,10 @@ Set `unreviewed_tasks` = `[{list of unreviewed internal IDs}]`.
    ```bash
    node .claude/skills/workflow-manifest/scripts/manifest.cjs delete {work_unit}.review.{topic} reviewed_tasks
    ```
-3. Commit: `review({work_unit}): restart review`
+3. Commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): restart review"
+   ```
 
 → Proceed to **Step 1**.
 

--- a/skills/workflow-review-process/references/invoke-review-synthesizer.md
+++ b/skills/workflow-review-process/references/invoke-review-synthesizer.md
@@ -46,8 +46,8 @@ If the agent fails (error, timeout), record the failure and report "synthesis fa
 
 Commit the report and staging file (if created):
 
-```
-review({scope}): synthesis cycle {N} — findings
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — findings"
 ```
 
 ---

--- a/skills/workflow-review-process/references/present-review.md
+++ b/skills/workflow-review-process/references/present-review.md
@@ -213,7 +213,11 @@ Surfaced to inbox:
 @endforeach
 ```
 
-Commit: `review({work_unit}): surface recommendations to inbox`
+Commit — the surfaced files live in `.workflows/.inbox/`, outside the work unit, so use the inbox scope:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --inbox -m "review({work_unit}): surface recommendations to inbox"
+```
 
 → Return to **B. Q&A Loop**.
 
@@ -234,7 +238,12 @@ Apply every item in the `### Do now` subsection of `report.md`:
 2. Run the project's linters; when any change touched a code or test file, also run the test suite (see the project skills loaded in Step 3 and the topic's configured linters).
 3. If a change fails verification, revert that single change and re-tag its item `[quickfix]` in `report.md` — leave the rest applied.
 
-Commit the applied changes: `review({work_unit}): apply do-now fixes`
+Commit the applied changes with raw git — the fixes touch project files outside the work unit, so the scoped helper cannot cover them. Stage the touched files and the work unit (for any report re-tags), then commit:
+
+```bash
+git add -- .workflows/{work_unit} {files the fixes touched}
+git commit -m "review({work_unit}): apply do-now fixes"
+```
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-review-process/references/produce-review.md
+++ b/skills/workflow-review-process/references/produce-review.md
@@ -38,7 +38,11 @@ Order subsections `### Do now`, `### Quick-fixes`, `### Ideas`, `### Bugs`. Only
 
 ### Commit and Continue
 
-Commit: `review({work_unit}): complete review`
+Commit:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review"
+```
 
 Your review feedback can be:
 - Addressed by implementation (same or new session)

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -300,8 +300,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit
 
 Commit the staging file updates:
 
-```
-review({work_unit}): synthesis cycle {N} — tasks skipped
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — tasks skipped"
 ```
 
 **Pipeline continuation** — Invoke the bridge:
@@ -325,10 +325,11 @@ Filter staging file to tasks with `status: approved`.
 
 > **CHECKPOINT**: Do not proceed until the task writer has returned.
 
-Commit all changes (staging file, plan tasks, task_map updates):
+Commit all changes (staging file, plan tasks, task_map updates) with raw git — the format's task storage may live outside the work unit, so the scoped helper cannot cover it. Stage the format's storage and the work unit, then commit:
 
-```
-review({work_unit}): add review remediation ({K} tasks)
+```bash
+git add -- .workflows/{work_unit} {format task storage paths}
+git commit -m "review({work_unit}): add review remediation ({K} tasks)"
 ```
 
 → Proceed to **G. Re-open Implementation**.
@@ -344,8 +345,8 @@ For each plan that received new tasks:
    - `node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.implementation.{topic} updated {today's date}`
 2. Commit tracking changes:
 
-```
-review({work_unit}): re-open implementation tracking
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): re-open implementation tracking"
 ```
 
 Then enter plan mode and write the following plan:

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -358,7 +358,7 @@ Review findings have been synthesized into {N} implementation tasks.
 
 ## Summary
 
-{Summary, e.g., "tick-core: 3 tasks in Phase 9"}
+{Summary, e.g., "auth-flow: 3 tasks in Phase 9"}
 
 ## Instructions
 

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -32,10 +32,10 @@ Check the verdict(s) from the review(s) being analyzed.
 No actionable findings. All reviews passed with no required changes.
 ```
 
-Set the review phase status to completed:
+Mark the review completed — the engine sets the status:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.review.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} review {topic}
 ```
 
 **Pipeline continuation** — Invoke the bridge:
@@ -79,10 +79,10 @@ Proceed with synthesis?
 
 **If `no`:**
 
-Set review status to completed:
+Mark the review completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.review.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} review {topic}
 ```
 
 **Pipeline continuation** — Invoke the bridge:
@@ -126,10 +126,10 @@ Synthesize non-blocking findings?
 
 **If `no`:**
 
-Set review status to completed:
+Mark the review completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.review.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} review {topic}
 ```
 
 **Pipeline continuation** — Invoke the bridge:
@@ -153,10 +153,10 @@ Invoke the workflow-bridge skill to enter plan mode with completion confirmation
 
 #### If `STATUS` is `clean`
 
-No actionable tasks from synthesis. Set review status to completed:
+No actionable tasks from synthesis. Mark the review completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.review.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} review {topic}
 ```
 
 > *Output the next fenced block as a code block:*
@@ -292,10 +292,10 @@ Revise the task content in the staging file based on the user's feedback.
 
 #### If all tasks were skipped
 
-Set review status to completed:
+Mark the review completed:
 
 ```bash
-node .claude/skills/workflow-manifest/scripts/manifest.cjs set {work_unit}.review.{topic} status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} review {topic}
 ```
 
 Commit the staging file updates:


### PR DESCRIPTION
Wave 6 (PR 16 of the engine migration). Stacked on #406.

## What moved

**Lifecycle → engine commands.** `init-phase` at review start → `engine topic start {wu} review {topic}` (the `exists` guard kept — the process skill is model-invocable and `topic start` refuses completed items); all five phase-completion sites in the actions loop → `engine topic complete` (each checked individually — all are genuine completion writes). Review is not KB-indexed and the old prose had no index call — engine behaviour matches by construction.

**Commits onto their designed lanes.** Work-unit-scoped prescribed commits (restart, complete review, synthesis findings, tasks-skipped, re-open tracking) → `engine commit {wu} -m` verbatim. The surface-to-inbox commit stages only `.workflows/.inbox/` files → **`engine commit --inbox`** (its designed lane). Two sites stay raw git with explicit `git add --`: do-now fixes (touch arbitrary project files) and review-remediation task writing (stages format task storage). No Hard Rules boilerplate added — review has no freeform commit sites; every site carries its exact command inline.

**Stays in its lane:** the cross-phase reopen (`implementation.{topic}` → in-progress when sending work back — reopening is the manifest CLI's lane by design), the entry's review reopen, `reviewed_tasks` array ops, all format-adapter reads, the read-only `git log --grep` scope query.

## Defects fixed

- `invoke-review-synthesizer.md` committed with an undefined `{scope}` placeholder → `{work_unit}` (matches every sibling message).
- A format name leaked as an example work-unit name in the re-open handoff template → neutral example.

## Flagged, preserved (pre-existing)

Four of the five completion sites set review `completed` with no commit before the terminal bridge stop (only the tasks-skipped site commits) — the manifest change rides uncommitted into the bridge. Same class as the KB-store commit-point looseness; logged for a later decision, not silently changed.

## Tests

482 pass, migrations green, typecheck clean, discovery suites untouched, zero engine-code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. **#407** 👈 current
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->