### PR TITLE
campaign fixes: engine integrity — lock-break race, root validation, tmp hygiene

### DIFF
--- a/skills/workflow-engine/scripts/domain/cache.cjs
+++ b/skills/workflow-engine/scripts/domain/cache.cjs
@@ -13,7 +13,7 @@
 // ---------------------------------------------------------------------------
 
 const path = require('path');
-const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock } = require('../kernel/manifest.cjs');
+const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock, ensureContainer } = require('../kernel/manifest.cjs');
 const { collectAnalysisInputs, filesChecksum } = require('./discovery-utils.cjs');
 const { knowledge } = require('./kb.cjs');
 
@@ -40,10 +40,7 @@ const CACHE_FILES = {
  * @returns {Record<string, unknown>}
  */
 function phaseObject(manifest, phase) {
-  if (!manifest.phases || typeof manifest.phases !== 'object') manifest.phases = {};
-  const existing = manifest.phases[phase];
-  if (!existing || typeof existing !== 'object') manifest.phases[phase] = {};
-  return manifest.phases[phase];
+  return ensureContainer(ensureContainer(manifest, 'phases', 'phases'), phase, `phases.${phase}`);
 }
 
 /**

--- a/skills/workflow-engine/scripts/domain/discovery-map.cjs
+++ b/skills/workflow-engine/scripts/domain/discovery-map.cjs
@@ -20,7 +20,7 @@
 // manifest lock (the same lock every manifest writer honours).
 // ---------------------------------------------------------------------------
 
-const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock } = require('../kernel/manifest.cjs');
+const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock, ensureContainer } = require('../kernel/manifest.cjs');
 const { commitScopedWithKb } = require('./commit.cjs');
 const { computeTopicLifecycle } = require('./discovery-utils.cjs');
 const { VALID_ROUTINGS } = require('../kernel/manifest-schema.cjs');
@@ -181,10 +181,9 @@ function addItem(cwd, workUnit, name, { routing, source = 'discovery', summary, 
 
   return withWorkUnitLock(cwd, workUnit, () => {
     const manifest = loadWorkUnitManifest(cwd, workUnit);
-    if (!manifest.phases || typeof manifest.phases !== 'object') manifest.phases = {};
-    if (!manifest.phases.discovery || typeof manifest.phases.discovery !== 'object') manifest.phases.discovery = {};
-    const discovery = manifest.phases.discovery;
-    if (!discovery.items || typeof discovery.items !== 'object') discovery.items = {};
+    const phases = ensureContainer(manifest, 'phases', 'phases');
+    const discovery = ensureContainer(phases, 'discovery', 'phases.discovery');
+    ensureContainer(discovery, 'items', 'phases.discovery.items');
 
     if (discovery.items[name]) {
       throw new Error(`"${name}" is already on the map — edit it, or pick a different name`);

--- a/skills/workflow-engine/scripts/domain/fields.cjs
+++ b/skills/workflow-engine/scripts/domain/fields.cjs
@@ -241,17 +241,32 @@ function getByPath(obj, segments) {
   return current;
 }
 
+// A named field assigned into an array is silently dropped by
+// JSON.stringify — the write would falsely succeed. Numeric indexes are fine.
+/** @param {any} container @param {string} seg @param {string} pathSoFar */
+function refuseNamedArrayWrite(container, seg, pathSoFar) {
+  if (Array.isArray(container) && !/^(0|[1-9][0-9]*)$/.test(seg)) {
+    fail(`Path "${pathSoFar}" is an array — cannot set field "${seg}" in it`);
+  }
+}
+
 /** @param {any} obj @param {string[]} segments @param {*} value */
 function setByPath(obj, segments, value) {
   let current = obj;
   for (let i = 0; i < segments.length - 1; i++) {
     const seg = segments[i];
-    if (current[seg] == null || typeof current[seg] !== 'object') {
+    refuseNamedArrayWrite(current, seg, segments.slice(0, i).join('.') || '(root)');
+    if (current[seg] == null) {
       current[seg] = {};
+    } else if (typeof current[seg] !== 'object') {
+      // Descending through a scalar would silently destroy it — refuse.
+      fail(`Path "${segments.slice(0, i + 1).join('.')}" is not an object — refusing to overwrite it with a container`);
     }
     current = current[seg];
   }
-  current[segments[segments.length - 1]] = value;
+  const last = segments[segments.length - 1];
+  refuseNamedArrayWrite(current, last, segments.slice(0, -1).join('.') || '(root)');
+  current[last] = value;
 }
 
 /** @param {any} obj @param {string[]} segments */

--- a/skills/workflow-engine/scripts/domain/tasks.cjs
+++ b/skills/workflow-engine/scripts/domain/tasks.cjs
@@ -12,7 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock } = require('../kernel/manifest.cjs');
+const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock, ensureContainer } = require('../kernel/manifest.cjs');
 
 const FIX_THRESHOLD = 3;
 const SESSION_CYCLE_LIMIT = 3;
@@ -118,11 +118,9 @@ function counterOf(item, field) {
 function initTasks(cwd, workUnit, topic) {
   return withWorkUnitLock(cwd, workUnit, () => {
     const manifest = loadWorkUnitManifest(cwd, workUnit);
-    if (!manifest.phases || typeof manifest.phases !== 'object') manifest.phases = {};
-    const phases = manifest.phases;
-    if (!phases.implementation || typeof phases.implementation !== 'object') phases.implementation = {};
-    if (!phases.implementation.items || typeof phases.implementation.items !== 'object') phases.implementation.items = {};
-    const items = phases.implementation.items;
+    const phases = ensureContainer(manifest, 'phases', 'phases');
+    const implementation = ensureContainer(phases, 'implementation', 'phases.implementation');
+    const items = ensureContainer(implementation, 'items', 'phases.implementation.items');
 
     /** @type {'created'|'resumed'} */
     let mode;

--- a/skills/workflow-engine/scripts/domain/transitions.cjs
+++ b/skills/workflow-engine/scripts/domain/transitions.cjs
@@ -20,7 +20,7 @@
 // release — the lock protects the manifest read-modify-write, nothing else.
 // ---------------------------------------------------------------------------
 
-const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock } = require('../kernel/manifest.cjs');
+const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock, ensureContainer } = require('../kernel/manifest.cjs');
 const { commitScopedWithKb } = require('./commit.cjs');
 const { knowledge, INDEXED_ARTIFACTS } = require('./kb.cjs');
 
@@ -106,15 +106,14 @@ function startTopic(cwd, workUnit, phase, topic) {
   assertLegalWrite(phase, 'in-progress');
   return withWorkUnitLock(cwd, workUnit, () => {
     const manifest = loadWorkUnitManifest(cwd, workUnit);
-    if (!manifest.phases || typeof manifest.phases !== 'object') manifest.phases = {};
-    if (!manifest.phases[phase] || typeof manifest.phases[phase] !== 'object') manifest.phases[phase] = {};
-    const ph = manifest.phases[phase];
-    if (!ph.items || typeof ph.items !== 'object') ph.items = {};
+    const phases = ensureContainer(manifest, 'phases', 'phases');
+    const ph = ensureContainer(phases, phase, `phases.${phase}`);
+    const items = ensureContainer(ph, 'items', `phases.${phase}.items`);
 
-    const existing = ph.items[topic];
+    const existing = items[topic];
     let created = false;
     if (!existing || typeof existing !== 'object') {
-      ph.items[topic] = { status: 'in-progress' };
+      items[topic] = { status: 'in-progress' };
       created = true;
     } else if (existing.status === 'completed') {
       throw new Error(`${phase} item "${topic}" is already completed — start cannot resume it`);

--- a/skills/workflow-engine/scripts/domain/workunit-absorb.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-absorb.cjs
@@ -26,6 +26,7 @@ const {
   readProjectManifest,
   writeProjectManifestAtomic,
   withProjectLock,
+  ensureContainer,
 } = require('../kernel/manifest.cjs');
 const { commitScopedWithKb } = require('./commit.cjs');
 const { knowledge, INDEXED_ARTIFACTS } = require('./kb.cjs');
@@ -234,15 +235,14 @@ function absorbWorkUnit(cwd, feature, { into, topic }) {
     // Epic manifest: phase items mirror the feature's statuses; tracked
     // entries carry their original timestamps (and seed provenance) with new
     // paths.
-    if (!epicManifest.phases || typeof epicManifest.phases !== 'object') epicManifest.phases = {};
-    if (!epicManifest.phases.discussion || typeof epicManifest.phases.discussion !== 'object') epicManifest.phases.discussion = {};
-    if (!epicManifest.phases.discussion.items || typeof epicManifest.phases.discussion.items !== 'object') epicManifest.phases.discussion.items = {};
-    epicManifest.phases.discussion.items[topic] = { status: discussionItem.status };
+    const epicPhases = ensureContainer(epicManifest, 'phases', 'phases');
+    const discussion = ensureContainer(epicPhases, 'discussion', 'phases.discussion');
+    ensureContainer(discussion, 'items', 'phases.discussion.items')[topic] = { status: discussionItem.status };
     if (researchPlan.length > 0) {
-      if (!epicManifest.phases.research || typeof epicManifest.phases.research !== 'object') epicManifest.phases.research = {};
-      if (!epicManifest.phases.research.items || typeof epicManifest.phases.research.items !== 'object') epicManifest.phases.research.items = {};
+      const research = ensureContainer(epicPhases, 'research', 'phases.research');
+      const researchItems = ensureContainer(research, 'items', 'phases.research.items');
       for (const move of researchPlan) {
-        epicManifest.phases.research.items[move.target] = { status: move.status };
+        researchItems[move.target] = { status: move.status };
       }
     }
     for (const move of importPlan) {

--- a/skills/workflow-engine/scripts/domain/workunit-create.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-create.cjs
@@ -26,6 +26,7 @@ const {
   readProjectManifest,
   writeProjectManifestAtomic,
   withProjectLock,
+  ensureContainer,
 } = require('../kernel/manifest.cjs');
 const { commitScopedWithKb } = require('./commit.cjs');
 const { knowledge } = require('./kb.cjs');
@@ -256,9 +257,8 @@ function createWorkUnit(cwd, workUnit, workType, { description, sessionLogFile, 
 
       // Epic is the sole work type with a resumable discovery session loop.
       if (workType === 'epic') {
-        if (!manifest.phases || typeof manifest.phases !== 'object') manifest.phases = {};
-        if (!manifest.phases.discovery || typeof manifest.phases.discovery !== 'object') manifest.phases.discovery = {};
-        manifest.phases.discovery.active_session = '001';
+        const phases = ensureContainer(manifest, 'phases', 'phases');
+        ensureContainer(phases, 'discovery', 'phases.discovery').active_session = '001';
       }
     }
 
@@ -270,8 +270,7 @@ function createWorkUnit(cwd, workUnit, workType, { description, sessionLogFile, 
   if (created) {
     withProjectLock(cwd, () => {
       const projectManifest = readProjectManifest(cwd);
-      if (!projectManifest.work_units || typeof projectManifest.work_units !== 'object') projectManifest.work_units = {};
-      projectManifest.work_units[workUnit] = { work_type: workType };
+      ensureContainer(projectManifest, 'work_units', 'work_units')[workUnit] = { work_type: workType };
       writeProjectManifestAtomic(cwd, projectManifest);
     });
   }

--- a/skills/workflow-engine/scripts/domain/workunit-lifecycle.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-lifecycle.cjs
@@ -26,6 +26,7 @@ const {
   readProjectManifest,
   writeProjectManifestAtomic,
   withProjectLock,
+  ensureContainer,
 } = require('../kernel/manifest.cjs');
 const { commitScopedWithKb } = require('./commit.cjs');
 const { knowledge, INDEXED_ARTIFACTS } = require('./kb.cjs');
@@ -289,11 +290,8 @@ function pivotWorkUnit(cwd, workUnit) {
   // registered rather than skipped.
   withProjectLock(cwd, () => {
     const projectManifest = readProjectManifest(cwd);
-    if (!projectManifest.work_units || typeof projectManifest.work_units !== 'object') projectManifest.work_units = {};
-    if (!projectManifest.work_units[workUnit] || typeof projectManifest.work_units[workUnit] !== 'object') {
-      projectManifest.work_units[workUnit] = {};
-    }
-    projectManifest.work_units[workUnit].work_type = 'epic';
+    const workUnits = ensureContainer(projectManifest, 'work_units', 'work_units');
+    ensureContainer(workUnits, workUnit, `work_units.${workUnit}`).work_type = 'epic';
     writeProjectManifestAtomic(cwd, projectManifest);
   });
 

--- a/skills/workflow-engine/scripts/domain/workunit-promote.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-promote.cjs
@@ -26,6 +26,7 @@ const {
   readProjectManifest,
   writeProjectManifestAtomic,
   withProjectLock,
+  ensureContainer,
 } = require('../kernel/manifest.cjs');
 const { commitScopedWithKb } = require('./commit.cjs');
 const { knowledge, INDEXED_ARTIFACTS } = require('./kb.cjs');
@@ -181,8 +182,7 @@ function promoteWorkUnit(cwd, workUnit, topic, { to, description }) {
   // Registration — a fresh read under the project lock.
   withProjectLock(cwd, () => {
     const projectManifest = readProjectManifest(cwd);
-    if (!projectManifest.work_units || typeof projectManifest.work_units !== 'object') projectManifest.work_units = {};
-    projectManifest.work_units[to] = { work_type: 'cross-cutting' };
+    ensureContainer(projectManifest, 'work_units', 'work_units')[to] = { work_type: 'cross-cutting' };
     writeProjectManifestAtomic(cwd, projectManifest);
   });
 

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -153,7 +153,6 @@ Commands:
 // ---------------------------------------------------------------------------
 
 /** @param {string[]} argv */
-/** @param {string[]} argv */
 function runManifest(argv) {
   const [command, ...rest] = argv;
   if (command !== undefined && isRead(command)) {

--- a/skills/workflow-engine/scripts/kernel/manifest-io.cjs
+++ b/skills/workflow-engine/scripts/kernel/manifest-io.cjs
@@ -30,6 +30,10 @@ const LOCK_STALE_MS = 30000;
 const LOCK_RETRY_MS = 50;
 const LOCK_TIMEOUT_MS = 10000;
 
+// A temp file older than this is an orphan from a crashed writer — a live
+// writer's temp file exists only for the instant between write and rename.
+const TMP_STALE_MS = 60000;
+
 /** @param {string} workflowsDir @param {string} workUnit */
 function workUnitManifestPath(workflowsDir, workUnit) {
   return path.join(workflowsDir, workUnit, 'manifest.json');
@@ -51,6 +55,87 @@ function projectLockPath(workflowsDir) {
 }
 
 /**
+ * The root every manifest writer requires: a plain object. JSON.stringify
+ * silently drops named properties assigned to an array, and a null/scalar
+ * root cannot hold fields at all — a write against such a root would falsely
+ * succeed, so it must refuse before any mutation runs.
+ * @param {any} root @param {string} file
+ */
+function assertObjectRoot(root, file) {
+  if (root === null || typeof root !== 'object' || Array.isArray(root)) {
+    throw new Error(`manifest root is not an object in ${file} — fix it by hand; fields written to it would be silently discarded`);
+  }
+}
+
+/**
+ * Pre-write guard, run under the lock before the writer's `fn`: a manifest
+ * already on disk must have an object root before anything may mutate it.
+ * Missing and unparseable files pass through — the writer's own read owns
+ * those semantics (create writes fresh; corrupt JSON throws its established
+ * loud error).
+ * @param {string} file
+ */
+function assertWritableManifest(file) {
+  let raw;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return;
+  }
+  let root;
+  try {
+    root = JSON.parse(raw);
+  } catch {
+    return;
+  }
+  assertObjectRoot(root, file);
+}
+
+/**
+ * Descend into `parent[key]` as a structural container, creating a plain
+ * object when the slot is empty. A slot holding anything else (string,
+ * number, array, …) is refused loudly — replacing it would destroy data, and
+ * fields assigned into an array are silently dropped by JSON.stringify.
+ * @param {Record<string, any>} parent @param {string} key
+ * @param {string} label the container's dot-path, for the diagnostic
+ * @returns {Record<string, any>}
+ */
+function ensureContainer(parent, key, label) {
+  const existing = parent[key];
+  if (existing == null) {
+    parent[key] = {};
+  } else if (typeof existing !== 'object' || Array.isArray(existing)) {
+    throw new Error(`manifest field "${label}" is not an object (found ${Array.isArray(existing) ? 'array' : typeof existing}) — fix the manifest by hand`);
+  }
+  return parent[key];
+}
+
+/**
+ * Remove orphaned temp files a crashed writer left beside `file` — the next
+ * scoped `git add` would commit them. Only files past TMP_STALE_MS go; a
+ * younger one belongs to a live concurrent writer. Best-effort: a file
+ * vanishing mid-sweep means another process finished the same job.
+ * @param {string} file
+ */
+function sweepOrphanedTmpFiles(file) {
+  const dir = path.dirname(file);
+  const prefix = `.${path.basename(file)}.`;
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.startsWith(prefix) || !name.endsWith('.tmp')) continue;
+    const orphan = path.join(dir, name);
+    try {
+      if (Date.now() - fs.statSync(orphan).mtimeMs > TMP_STALE_MS) fs.unlinkSync(orphan);
+    } catch { /* vanished mid-sweep */ }
+  }
+}
+
+/**
  * Atomic JSON write: serialise, write a hidden pid-suffixed temp file in the
  * same directory, rename over the target — a crash mid-write can never leave
  * a truncated manifest behind. One serialisation for every writer:
@@ -58,6 +143,8 @@ function projectLockPath(workflowsDir) {
  * @param {string} file @param {object} data
  */
 function writeJsonAtomic(file, data) {
+  assertObjectRoot(data, file);
+  sweepOrphanedTmpFiles(file);
   const tmp = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.tmp`);
   fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf8');
   fs.renameSync(tmp, file);
@@ -134,12 +221,53 @@ function writeProjectManifestAtomic(workflowsDir, data) {
 }
 
 /**
+ * Break a stale lock, at most one contender at a time. The `.breaking` guard
+ * (O_EXCL, pid recorded) admits a single breaker, which re-checks the lock's
+ * mtime INSIDE the guarded section before unlinking. A naive stat-then-unlink
+ * lets a contender act on a pre-break observation: after the true break and a
+ * re-acquire it would remove the new holder's fresh lock — two writers at
+ * once. Inside the guard a stale mtime is decisive: the holder is dead
+ * (nothing can release-race the unlink) and creations need the absence the
+ * unlink is about to produce. Losers return false and fall back to the
+ * acquire loop's wait/retry cadence. A dead breaker's guard heals by the
+ * same staleness rule.
+ * @param {string} lockFile
+ * @returns {boolean} true when this process performed the break
+ */
+function breakStaleLockFile(lockFile) {
+  const guard = `${lockFile}.breaking`;
+  let fd;
+  try {
+    fd = fs.openSync(guard, 'wx');
+  } catch {
+    try {
+      if (Date.now() - fs.statSync(guard).mtimeMs > LOCK_STALE_MS) fs.unlinkSync(guard);
+    } catch { /* guard already gone */ }
+    return false;
+  }
+  try {
+    fs.writeSync(fd, String(process.pid));
+    if (Date.now() - fs.statSync(lockFile).mtimeMs > LOCK_STALE_MS) {
+      fs.unlinkSync(lockFile);
+      return true;
+    }
+    return false;
+  } catch {
+    return false; // lock vanished — already broken, not yet re-acquired
+  } finally {
+    fs.closeSync(fd);
+    try { fs.unlinkSync(guard); } catch { /* healed from under us */ }
+  }
+}
+
+/**
  * Acquire `lockFile` (O_EXCL create, pid recorded), breaking a stale holder
  * and spinning on a live one up to the timeout.
  * @param {string} lockFile @param {string} timeoutMessage
+ * @param {number} [timeoutMs]
  */
-function acquireLockFile(lockFile, timeoutMessage) {
-  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+function acquireLockFile(lockFile, timeoutMessage, timeoutMs = LOCK_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs;
 
   while (true) {
     try {
@@ -155,7 +283,7 @@ function acquireLockFile(lockFile, timeoutMessage) {
     try {
       const stat = fs.statSync(lockFile);
       if (Date.now() - stat.mtimeMs > LOCK_STALE_MS) {
-        fs.unlinkSync(lockFile);
+        breakStaleLockFile(lockFile);
         continue;
       }
     } catch {
@@ -164,7 +292,10 @@ function acquireLockFile(lockFile, timeoutMessage) {
     }
 
     if (Date.now() >= deadline) {
-      throw new Error(timeoutMessage);
+      throw new Error(
+        `${timeoutMessage} (lock file: ${lockFile}). A stale lock from a crashed process clears automatically after ` +
+        `${LOCK_STALE_MS / 1000} seconds — retry; if it persists, delete the lock file.`
+      );
     }
 
     // Busy wait (short)
@@ -194,6 +325,7 @@ function withWorkUnitLock(workflowsDir, workUnit, fn) {
   const lockFile = workUnitLockPath(workflowsDir, workUnit);
   acquireLockFile(lockFile, `Timed out waiting for lock on "${workUnit}"`);
   try {
+    assertWritableManifest(workUnitManifestPath(workflowsDir, workUnit));
     return fn();
   } finally {
     releaseLockFile(lockFile);
@@ -212,6 +344,7 @@ function withProjectLock(workflowsDir, fn) {
   const lockFile = projectLockPath(workflowsDir);
   acquireLockFile(lockFile, 'Timed out waiting for project manifest lock');
   try {
+    assertWritableManifest(projectManifestPath(workflowsDir));
     return fn();
   } finally {
     releaseLockFile(lockFile);
@@ -222,10 +355,14 @@ module.exports = {
   LOCK_STALE_MS,
   LOCK_RETRY_MS,
   LOCK_TIMEOUT_MS,
+  TMP_STALE_MS,
   workUnitManifestPath,
   workUnitLockPath,
   projectManifestPath,
   projectLockPath,
+  breakStaleLockFile,
+  acquireLockFile,
+  ensureContainer,
   readWorkUnitManifest,
   writeWorkUnitManifestAtomic,
   readProjectManifest,

--- a/skills/workflow-engine/scripts/kernel/manifest.cjs
+++ b/skills/workflow-engine/scripts/kernel/manifest.cjs
@@ -82,6 +82,10 @@ function withProjectLock(cwd, fn) {
   return io.withProjectLock(workflowsDir(cwd), fn);
 }
 
+// Structural-container descent (create when empty, refuse scalars/arrays) —
+// the io module's single implementation, re-exported for the domain ring.
+const { ensureContainer } = io;
+
 module.exports = {
   loadWorkUnitManifest,
   saveWorkUnitManifest,
@@ -89,4 +93,5 @@ module.exports = {
   readProjectManifest,
   writeProjectManifestAtomic,
   withProjectLock,
+  ensureContainer,
 };

--- a/skills/workflow-migrate/scripts/migrations/049-nested-workflows-gitignore.sh
+++ b/skills/workflow-migrate/scripts/migrations/049-nested-workflows-gitignore.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Migration 049: Nested .workflows/.gitignore
+#
+# Migrations 010/011 wrote the cache ignore rule into the repo-root
+# .gitignore, which no engine commit scope can ever stage (every scope lives
+# under .workflows/) — it stayed untracked forever. The ignore rules belong
+# inside the tree the engine commits: .workflows/.gitignore, which also
+# covers orphaned atomic-write temp files (.manifest.json.<pid>.tmp) a
+# crashed writer can leave behind.
+#
+# Steps:
+#   1. Ensure .workflows/.gitignore carries the .cache/ and temp-file rules
+#   2. Remove the exact .workflows/.cache/ line from the repo-root .gitignore
+#   3. Delete the root .gitignore only when that rule was its only content
+#
+# Idempotent: rules already present are skipped; a root .gitignore without
+# the rule is untouched.
+#
+# This script is sourced by migrate.sh and has access to:
+#   - report_update
+#   - report_skip
+
+PROJECT_ROOT="${PROJECT_DIR:-.}"
+WORKFLOWS_DIR="$PROJECT_ROOT/.workflows"
+NESTED_GITIGNORE="$WORKFLOWS_DIR/.gitignore"
+ROOT_GITIGNORE="$PROJECT_ROOT/.gitignore"
+ROOT_ENTRY=".workflows/.cache/"
+
+# --- Step 1: Ensure the nested .workflows/.gitignore carries both rules ---
+
+mkdir -p "$WORKFLOWS_DIR"
+
+nested_changed=false
+for rule in ".cache/" ".manifest.json.*.tmp"; do
+    if [ -f "$NESTED_GITIGNORE" ] && grep -qxF "$rule" "$NESTED_GITIGNORE"; then
+        continue
+    fi
+    # Ensure file ends with newline before appending
+    if [ -f "$NESTED_GITIGNORE" ] && [ -n "$(tail -c 1 "$NESTED_GITIGNORE")" ]; then
+        echo >> "$NESTED_GITIGNORE"
+    fi
+    echo "$rule" >> "$NESTED_GITIGNORE"
+    nested_changed=true
+done
+
+if [ "$nested_changed" = true ]; then
+    report_update
+else
+    report_skip
+fi
+
+# --- Steps 2+3: Retire the repo-root rule; drop the file only when the rule
+# --- was all it held ---
+
+if [ -f "$ROOT_GITIGNORE" ] && grep -qxF "$ROOT_ENTRY" "$ROOT_GITIGNORE"; then
+    grep -vxF "$ROOT_ENTRY" "$ROOT_GITIGNORE" > "${ROOT_GITIGNORE}.tmp" || true
+    if [ -s "${ROOT_GITIGNORE}.tmp" ]; then
+        mv "${ROOT_GITIGNORE}.tmp" "$ROOT_GITIGNORE"
+    else
+        rm "${ROOT_GITIGNORE}.tmp" "$ROOT_GITIGNORE"
+    fi
+    report_update
+else
+    report_skip
+fi
+
+return 0

--- a/tests/scripts/test-engine-manifest-io.cjs
+++ b/tests/scripts/test-engine-manifest-io.cjs
@@ -85,10 +85,11 @@ describe('manifest-io — shared lock constants and IO contract', () => {
   beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-io-')); });
   afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
 
-  it('carries the shared lock discipline: 30s stale, 50ms retry, 10s timeout', () => {
+  it('carries the shared lock discipline: 30s stale, 50ms retry, 10s timeout, 60s tmp orphan', () => {
     assert.strictEqual(io.LOCK_STALE_MS, 30000);
     assert.strictEqual(io.LOCK_RETRY_MS, 50);
     assert.strictEqual(io.LOCK_TIMEOUT_MS, 10000);
+    assert.strictEqual(io.TMP_STALE_MS, 60000);
   });
 
   it('work-unit read is loud on missing and on corrupt JSON', () => {
@@ -148,6 +149,210 @@ describe('manifest-io — shared lock constants and IO contract', () => {
       assert.ok(fs.existsSync(lock));
     });
     assert.ok(!fs.existsSync(lock));
+  });
+
+  it('lock timeout carries the remedy: lock path, 30s stale self-clear, manual delete', () => {
+    fs.mkdirSync(path.join(dir, 'unit'));
+    const lock = path.join(dir, 'unit', '.lock');
+    fs.writeFileSync(lock, String(process.pid)); // fresh — never breakable
+    assert.throws(
+      () => io.acquireLockFile(lock, 'Timed out waiting for lock on "unit"', 250),
+      (/** @type {Error} */ err) => {
+        assert.match(err.message, /Timed out waiting for lock on "unit"/);
+        assert.ok(err.message.includes(lock), 'message names the lock file');
+        assert.match(err.message, /clears automatically after 30 seconds/);
+        assert.match(err.message, /delete the lock file/);
+        return true;
+      }
+    );
+    assert.strictEqual(fs.readFileSync(lock, 'utf8'), String(process.pid), 'fresh lock never touched');
+  });
+
+  it('write sweeps orphaned temp files past TMP_STALE_MS and spares fresh ones', () => {
+    fs.mkdirSync(path.join(dir, 'unit'));
+    const orphan = path.join(dir, 'unit', '.manifest.json.11111.tmp');
+    const fresh = path.join(dir, 'unit', '.manifest.json.22222.tmp');
+    fs.writeFileSync(orphan, '{}');
+    fs.writeFileSync(fresh, '{}');
+    const past = (Date.now() - io.TMP_STALE_MS - 5000) / 1000;
+    fs.utimesSync(orphan, past, past);
+
+    io.writeWorkUnitManifestAtomic(dir, 'unit', { name: 'unit' });
+    assert.ok(!fs.existsSync(orphan), 'crashed writer\'s orphan swept');
+    assert.ok(fs.existsSync(fresh), 'fresh temp file spared — a live concurrent writer owns it');
+    assert.deepStrictEqual(JSON.parse(fs.readFileSync(path.join(dir, 'unit/manifest.json'), 'utf8')), { name: 'unit' });
+  });
+});
+
+describe('stale-lock break is atomic — one winner, mutual exclusion holds', () => {
+  const IO_PATH = path.join(__dirname, '../../skills/workflow-engine/scripts/kernel/manifest-io.cjs');
+  let dir;
+  beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lock-break-')); });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  /** Spawn a node child running `script` with argv, resolving with its exit code. */
+  function child(script, args) {
+    const proc = spawn('node', ['-e', script, ...args]);
+    let stderr = '';
+    proc.stderr.on('data', (chunk) => { stderr += chunk; });
+    return new Promise((resolve) => proc.on('exit', (code) => resolve({ code, stderr })));
+  }
+
+  it('N contenders racing the break primitive: exactly one wins, no residue', async () => {
+    const lock = path.join(dir, '.lock');
+    const log = path.join(dir, 'break.log');
+    fs.writeFileSync(lock, '99999');
+    makeStale(lock);
+
+    const script = [
+      "const fs = require('fs');",
+      'const [ioPath, lock, fenceStr, log] = process.argv.slice(1);',
+      'const io = require(ioPath);',
+      'const fence = Number(fenceStr);',
+      'while (Date.now() < fence) {}',
+      'const won = io.breakStaleLockFile(lock);',
+      "fs.appendFileSync(log, process.pid + ' ' + won + '\\n');",
+    ].join('\n');
+
+    // Fence far enough out that every child has booted before contending.
+    const fence = Date.now() + 700;
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => child(script, [IO_PATH, lock, String(fence), log])));
+    for (const r of results) assert.strictEqual(r.code, 0, r.stderr);
+
+    const lines = fs.readFileSync(log, 'utf8').trim().split('\n');
+    assert.strictEqual(lines.length, 6, 'every contender reported');
+    const winners = lines.filter((line) => line.endsWith(' true'));
+    assert.strictEqual(winners.length, 1, `exactly one contender may break the stale lock:\n${lines.join('\n')}`);
+    assert.ok(!fs.existsSync(lock), 'stale lock gone');
+    assert.deepStrictEqual(fs.readdirSync(dir).filter((n) => n.includes('.breaking.')), [],
+      'the winner removed its renamed file');
+  });
+
+  it('N contenders racing a stale lock through withProjectLock: all acquire, never concurrently', async () => {
+    const lock = path.join(dir, '.project-lock');
+    const log = path.join(dir, 'hold.log');
+    fs.writeFileSync(lock, '99999');
+    makeStale(lock);
+
+    const script = [
+      "const fs = require('fs');",
+      'const [ioPath, wfDir, fenceStr, log] = process.argv.slice(1);',
+      'const io = require(ioPath);',
+      'const fence = Number(fenceStr);',
+      'while (Date.now() < fence) {}',
+      'io.withProjectLock(wfDir, () => {',
+      '  const t0 = Date.now();',
+      '  const end = t0 + 40;',
+      '  while (Date.now() < end) {}',
+      "  fs.appendFileSync(log, process.pid + ' ' + t0 + ' ' + Date.now() + '\\n');",
+      '});',
+    ].join('\n');
+
+    const fence = Date.now() + 700;
+    const results = await Promise.all(
+      Array.from({ length: 5 }, () => child(script, [IO_PATH, dir, String(fence), log])));
+    for (const r of results) assert.strictEqual(r.code, 0, r.stderr);
+
+    const holds = fs.readFileSync(log, 'utf8').trim().split('\n')
+      .map((line) => line.split(' ').map(Number))
+      .sort((a, b) => a[1] - b[1]);
+    assert.strictEqual(holds.length, 5, 'every contender eventually acquired');
+    for (let i = 1; i < holds.length; i++) {
+      assert.ok(holds[i][1] >= holds[i - 1][2],
+        `holds overlap — two contenders held the lock at once:\n${holds.map((h) => h.join(' ')).join('\n')}`);
+    }
+    assert.ok(!fs.existsSync(lock), 'lock released after the last holder');
+  });
+});
+
+describe('structurally corrupt manifests refuse writes', () => {
+  let dir;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-root-'));
+    fs.mkdirSync(path.join(dir, '.workflows/unit'), { recursive: true });
+  });
+  afterEach(() => { fs.rmSync(dir, { recursive: true, force: true }); });
+
+  /** Run the engine expecting `{ok:false}` exit 1; returns the parsed stderr JSON. */
+  function engineFail(args) {
+    const res = spawnSync('node', [ENGINE, ...args], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1, `expected exit 1, got ${res.status}\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
+    return JSON.parse(res.stderr.trim());
+  }
+
+  /** Write raw manifest bytes; returns a function asserting they are untouched. */
+  function plant(rel, raw) {
+    const file = path.join(dir, rel);
+    fs.writeFileSync(file, raw);
+    return () => assert.strictEqual(fs.readFileSync(file, 'utf8'), raw, 'manifest bytes must be untouched');
+  }
+
+  it('array root: set refuses with the domain diagnostic, file byte-identical', () => {
+    const untouched = plant('.workflows/unit/manifest.json', '[]\n');
+    const res = engineFail(['manifest', 'set', 'unit', 'status', 'completed']);
+    assert.strictEqual(res.ok, false);
+    assert.match(res.error, /manifest root is not an object/);
+    untouched();
+  });
+
+  it('null root: the domain diagnostic, never a raw TypeError', () => {
+    const untouched = plant('.workflows/unit/manifest.json', 'null\n');
+    const res = engineFail(['manifest', 'set', 'unit', 'status', 'completed']);
+    assert.match(res.error, /manifest root is not an object/);
+    assert.ok(!/TypeError/.test(res.error), 'no raw JS TypeError may surface');
+    untouched();
+  });
+
+  it('number root: the domain diagnostic, never a raw TypeError', () => {
+    const untouched = plant('.workflows/unit/manifest.json', '42\n');
+    const res = engineFail(['manifest', 'set', 'unit', 'status', 'completed']);
+    assert.match(res.error, /manifest root is not an object/);
+    assert.ok(!/TypeError/.test(res.error));
+    untouched();
+  });
+
+  it('string `phases` + topic start: refusal, manifest pristine — no silent coercion', () => {
+    const untouched = plant('.workflows/unit/manifest.json', JSON.stringify({
+      name: 'unit', work_type: 'epic', status: 'in-progress', phases: 'oops',
+    }, null, 2) + '\n');
+    const res = engineFail(['topic', 'start', 'unit', 'research', 'auth']);
+    assert.match(res.error, /"phases" is not an object \(found string\)/);
+    untouched();
+  });
+
+  it('array `phases` + topic start: refusal — fields set into an array are stringify-dropped', () => {
+    const untouched = plant('.workflows/unit/manifest.json', JSON.stringify({
+      name: 'unit', work_type: 'epic', status: 'in-progress', phases: [],
+    }, null, 2) + '\n');
+    const res = engineFail(['topic', 'start', 'unit', 'research', 'auth']);
+    assert.match(res.error, /"phases" is not an object \(found array\)/);
+    untouched();
+  });
+
+  it('scalar mid-path container: set refuses instead of coercing to {}', () => {
+    const untouched = plant('.workflows/unit/manifest.json', JSON.stringify({
+      name: 'unit', work_type: 'epic', status: 'in-progress', phases: { research: 'active' },
+    }, null, 2) + '\n');
+    const res = engineFail(['manifest', 'set', 'unit.research.auth', 'status', 'in-progress']);
+    assert.match(res.error, /"phases\.research" is not an object — refusing to overwrite/);
+    untouched();
+  });
+
+  it('named field into an array: set refuses — stringify would silently drop it', () => {
+    const untouched = plant('.workflows/unit/manifest.json', JSON.stringify({
+      name: 'unit', work_type: 'feature', status: 'in-progress', imports: [], phases: {},
+    }, null, 2) + '\n');
+    const res = engineFail(['manifest', 'set', 'unit', 'imports.name', 'x']);
+    assert.match(res.error, /"imports" is an array — cannot set field "name"/);
+    untouched();
+  });
+
+  it('array-root project manifest: set refuses with the domain diagnostic, file byte-identical', () => {
+    const untouched = plant('.workflows/manifest.json', '[]\n');
+    const res = engineFail(['manifest', 'set', 'project.defaults.plan_format', 'tick']);
+    assert.match(res.error, /manifest root is not an object/);
+    untouched();
   });
 });
 

--- a/tests/scripts/test-migration-049.sh
+++ b/tests/scripts/test-migration-049.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# Tests for migration 049: nested-workflows-gitignore
+#
+# Run: bash tests/scripts/test-migration-049.sh
+#
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATION="$REPO_DIR/skills/workflow-migrate/scripts/migrations/049-nested-workflows-gitignore.sh"
+
+report_update() { :; }
+report_skip() { :; }
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migration-049-test.XXXXXX)
+  export PROJECT_DIR="$TEST_DIR"
+  mkdir -p "$TEST_DIR/.workflows"
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+  unset PROJECT_DIR
+}
+
+# --- Test 1: Happy path — nested rules created, root rule removed, other root lines kept ---
+test_happy_path() {
+  setup
+  printf 'node_modules/\n.workflows/.cache/\n.env\n' > "$TEST_DIR/.gitignore"
+  source "$MIGRATION"
+  local nested; nested=$(cat "$TEST_DIR/.workflows/.gitignore")
+  assert_eq "nested gitignore created" "true" "$([ -f "$TEST_DIR/.workflows/.gitignore" ] && echo true || echo false)"
+  assert_eq "nested carries cache rule" "true" "$(echo "$nested" | grep -qxF '.cache/' && echo true || echo false)"
+  assert_eq "nested carries tmp rule" "true" "$(echo "$nested" | grep -qxF '.manifest.json.*.tmp' && echo true || echo false)"
+  local root; root=$(cat "$TEST_DIR/.gitignore")
+  assert_eq "root rule removed" "false" "$(echo "$root" | grep -qxF '.workflows/.cache/' && echo true || echo false)"
+  assert_eq "other root lines preserved" "$(printf 'node_modules/\n.env')" "$root"
+  teardown
+}
+
+# --- Test 2: Root .gitignore holding only the rule is deleted ---
+test_root_deleted_when_only_rule() {
+  setup
+  printf '.workflows/.cache/\n' > "$TEST_DIR/.gitignore"
+  source "$MIGRATION"
+  assert_eq "root gitignore deleted" "false" "$([ -f "$TEST_DIR/.gitignore" ] && echo true || echo false)"
+  assert_eq "nested gitignore created" "true" "$([ -f "$TEST_DIR/.workflows/.gitignore" ] && echo true || echo false)"
+  teardown
+}
+
+# --- Test 3: Skip — no root .gitignore; nested still created, no root file conjured ---
+test_no_root_gitignore() {
+  setup
+  source "$MIGRATION"
+  assert_eq "no root gitignore conjured" "false" "$([ -f "$TEST_DIR/.gitignore" ] && echo true || echo false)"
+  local nested; nested=$(cat "$TEST_DIR/.workflows/.gitignore")
+  assert_eq "nested carries cache rule" "true" "$(echo "$nested" | grep -qxF '.cache/' && echo true || echo false)"
+  assert_eq "nested carries tmp rule" "true" "$(echo "$nested" | grep -qxF '.manifest.json.*.tmp' && echo true || echo false)"
+  teardown
+}
+
+# --- Test 4: Existing nested .gitignore — rules appended, user content preserved, no newline mangling ---
+test_existing_nested_preserved() {
+  setup
+  printf 'my-scratch/\n' > "$TEST_DIR/.workflows/.gitignore"
+  source "$MIGRATION"
+  local nested; nested=$(cat "$TEST_DIR/.workflows/.gitignore")
+  assert_eq "user rule preserved" "true" "$(echo "$nested" | grep -qxF 'my-scratch/' && echo true || echo false)"
+  assert_eq "cache rule appended" "true" "$(echo "$nested" | grep -qxF '.cache/' && echo true || echo false)"
+  assert_eq "tmp rule appended" "true" "$(echo "$nested" | grep -qxF '.manifest.json.*.tmp' && echo true || echo false)"
+  assert_eq "exact content" "$(printf 'my-scratch/\n.cache/\n.manifest.json.*.tmp')" "$nested"
+  teardown
+}
+
+# --- Test 5: Idempotency — second run changes nothing, no duplicate rules ---
+test_idempotent() {
+  setup
+  printf 'node_modules/\n.workflows/.cache/\n' > "$TEST_DIR/.gitignore"
+  source "$MIGRATION"
+  local nested_first; nested_first=$(cat "$TEST_DIR/.workflows/.gitignore")
+  local root_first; root_first=$(cat "$TEST_DIR/.gitignore")
+  source "$MIGRATION"
+  assert_eq "nested identical after second run" "$nested_first" "$(cat "$TEST_DIR/.workflows/.gitignore")"
+  assert_eq "root identical after second run" "$root_first" "$(cat "$TEST_DIR/.gitignore")"
+  assert_eq "cache rule appears once" "1" "$(grep -cxF '.cache/' "$TEST_DIR/.workflows/.gitignore")"
+  assert_eq "tmp rule appears once" "1" "$(grep -cxF '.manifest.json.*.tmp' "$TEST_DIR/.workflows/.gitignore")"
+  teardown
+}
+
+# --- Test 6: Missing .workflows/ — directory and nested gitignore created ---
+test_creates_workflows_dir() {
+  setup
+  rmdir "$TEST_DIR/.workflows"
+  source "$MIGRATION"
+  assert_eq "workflows dir created" "true" "$([ -d "$TEST_DIR/.workflows" ] && echo true || echo false)"
+  assert_eq "nested gitignore created" "true" "$([ -f "$TEST_DIR/.workflows/.gitignore" ] && echo true || echo false)"
+  teardown
+}
+
+# --- Test 7: Root file without newline terminator — removal still exact-line ---
+test_root_no_trailing_newline() {
+  setup
+  printf 'node_modules/\n.workflows/.cache/' > "$TEST_DIR/.gitignore"
+  source "$MIGRATION"
+  local root; root=$(cat "$TEST_DIR/.gitignore")
+  assert_eq "root rule removed" "false" "$(echo "$root" | grep -qxF '.workflows/.cache/' && echo true || echo false)"
+  assert_eq "other root line preserved" "node_modules/" "$root"
+  teardown
+}
+
+test_happy_path
+test_root_deleted_when_only_rule
+test_no_root_gitignore
+test_existing_nested_preserved
+test_idempotent
+test_creates_workflows_dir
+test_root_no_trailing_newline
+
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Stacked on #420. First of four PRs fixing the five-fleet deep-review campaign's findings (adversarial probes fleet).

- **Stale-lock break race (TOCTOU)**: two contenders could both break a >30s-stale lock and hold simultaneously. Fixed with an O_EXCL `.breaking` guard admitting exactly one breaker, which re-checks staleness inside the guarded section before unlinking. (The initially-prescribed rename-based break was itself racy — a loser with a pre-break stat could rename the re-acquired holder's fresh lock away; traced and rejected during build.) The probe fleet's own attack script now yields fully serialized holds, zero overlap.
- **Manifest root/container validation**: an array-root manifest passed JSON checks and returned `ok:true` while the write was silently discarded. Now: array/null/scalar roots refuse with a domain diagnostic (exit 1, disk byte-identical) on both work-unit and project manifests; corrupt containers (string `phases` etc.) refuse instead of silently coercing to `{}`.
- **Lock-timeout remedy hint**: the timeout error now names the lock path and the 30s self-heal rule.
- **Tmp hygiene**: crashed atomic writes left `.manifest.json.<pid>.tmp` files that the next scoped commit swept into git — writes now sweep orphans older than 60s. Migration 049 moves the `.cache/` ignore into `.workflows/.gitignore` (inside every commit scope, unlike the repo-root file 010/011 wrote, which no engine commit could ever stage) and adds the tmp pattern; 010/011 untouched per the never-edit-shipped-migrations rule.

12 new node tests (race primitives, corrupt-manifest refusal battery, tmp sweep) + 7-test migration suite. Gates: 1217 node tests, CLI contracts, 49 migration suites, typecheck — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. **#421** 👈 current
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->