### PR TITLE
review tweaks: versioned banner byline, boot announcement, knowledge-gate wording

### DIFF
--- a/.mint.toml
+++ b/.mint.toml
@@ -26,6 +26,12 @@ diff_exclude = [
     "tests/"
 ]
 
+[release]
+# The workflow-start banner byline carries the shipped version; mint mirrors the
+# new version onto that line at release time.
+version_file = "skills/workflow-start/SKILL.md"
+version_pattern = "Agentic Engineering Workflows (v{version})"
+
 [release.hooks]
 # Rebuild and commit the knowledge CLI bundle before the tag so every release ships
 # a fresh skills/workflow-knowledge/scripts/knowledge.cjs (AGNTC installs from tags

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -43,7 +43,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 |__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
 
 ●─────────────────────────────────────────────────────────────────●
-  Agentic engineering workflows — from idea to implementation.
+  Agentic Engineering Workflows (v0.5.13)
 ●─────────────────────────────────────────────────────────────────●
 ```
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -61,10 +61,10 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 ### Step 0.2: Boot
 
-> *Output the next fenced block as markdown (not a code block):*
+> *Output the next fenced block as a code block:*
 
 ```
-> Running migrations and the knowledge base check.
+Running migrations and the knowledge base check.
 ```
 
 **Run the boot pipeline — this is mandatory. You must complete it before proceeding.**

--- a/skills/workflow-start/references/knowledge-gate.md
+++ b/skills/workflow-start/references/knowledge-gate.md
@@ -24,12 +24,14 @@ Read the boot response's `system_config` object: `status` (`valid`, `absent`, or
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> The knowledge base powers cross-work-unit recall and must be
-> initialised before any workflow runs. Your machine already has
-> a system configuration this project can reuse.
+> The knowledge base powers recall across work units and within
+> them — later phases draw on earlier work. It is required
+> infrastructure: no workflow runs until it is initialised. Your
+> machine already has a system configuration this project can
+> reuse.
 
 · · · · · · · · · · · ·
-Set up the knowledge base for this project?
+Set up the knowledge base for this project:
 
 - **`y`/`yes`** — Use the existing configuration (@if(system_config.provider) {system_config.provider} · {system_config.model} @else keyword-only @endif)
 - **`d`/`different`** — Choose a different mode for this project


### PR DESCRIPTION
Stacked on the rings-and-tests PR. First round of stack-review tweaks:

- **Versioned byline**: the start banner byline now reads `Agentic Engineering Workflows (v0.5.13)` (current release), replacing the idea-to-implementation line. Mint mirrors the new version onto it at every release via `[release] version_file`/`version_pattern` in `.mint.toml` — semantics proven with a real release in a scratch repo (the `{version}` placeholder replaces just the version on the matched line; bookkeeping commit carries it).
- **Boot announcement**: Step 0.2's one-liner is now a code block per the announcement convention, not a `>` blockquote.
- **Knowledge gate wording**: the intro blockquote now accurately describes recall (across work units *and* within one — later phases draw on earlier work), and the B menu leads with a directive (`Set up the knowledge base for this project:`) instead of a question — setup is mandatory, only the mode is a choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. **#425** 👈 current
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->