### PR TITLE
review tweaks: clamp user-authored labels in the title composer

### DIFF
--- a/skills/workflow-engine/scripts/domain/conventions.cjs
+++ b/skills/workflow-engine/scripts/domain/conventions.cjs
@@ -53,11 +53,16 @@ function derivedFrom(text) {
 
 // Compose a tree node's title from its parts: `glyph label [tag]`. Any part may
 // be omitted. Single space between segments; the tag is bracketed.
+// Labels are user-authored names with no length limit; clamp them here so a
+// pathological name cannot overflow the tree row — the glyph and tag always
+// survive the clamp.
+const LABEL_MAX = 40;
+
 /** @param {{glyph?: string, label?: string, tag?: string}} [parts] */
 function title({ glyph, label, tag: term } = {}) {
   const parts = [];
   if (glyph) parts.push(glyph);
-  if (label) parts.push(label);
+  if (label) parts.push(label.length > LABEL_MAX ? label.slice(0, LABEL_MAX - 1) + '…' : label);
   let line = parts.join(' ');
   if (term) line += (line ? ' ' : '') + tag(term);
   return line;

--- a/tests/scripts/test-render.cjs
+++ b/tests/scripts/test-render.cjs
@@ -278,6 +278,17 @@ describe('conventions (domain composition layer)', () => {
     assert.strictEqual(title({ label: 'Bare' }), 'Bare');
   });
 
+  it('clamps over-long labels with an ellipsis — glyph and tag survive', () => {
+    const long = 'x'.repeat(100);
+    const out = title({ glyph: '◐', label: long, tag: 'researching' });
+    assert.strictEqual(out, `◐ ${'x'.repeat(39)}… [researching]`);
+  });
+
+  it('leaves a 40-char label unclamped', () => {
+    const exact = 'y'.repeat(40);
+    assert.strictEqual(title({ label: exact }), exact);
+  });
+
   it('discoveryGlyph maps tiers to the canonical symbol set', () => {
     assert.strictEqual(discoveryGlyph('decided'), '✓');
     assert.strictEqual(discoveryGlyph('fresh'), '○');


### PR DESCRIPTION
Stacked on the review-tweaks PR. Ruled: display clamping, no name-length limit.

A pathological topic name overflowed tree rows unbounded (a 100-char name made a 138-col line). The clamp lives in the domain title composer (`conventions.cjs title()`, label capped at 40 chars with an ellipsis) — the glyph and `[tag]` always survive, names stay unrestricted as identifiers, and the kernel's pure-layout contract (titles never truncated by `renderTree`) is untouched. First attempt clamped in the kernel and broke legitimate fixtures — real dashboard title lines exceed the body-wrap width by design; the composer is the layer that knows which part is the name.

Two new composer tests. Gates green (1222 node tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. **#426** 👈 current
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->