### PR TITLE
review tweaks: boot announcement restored as a multi-line signpost

### DIFF
--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -61,10 +61,11 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 
 ### Step 0.2: Boot
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Running migrations and the knowledge base check.
+> Checking the workflow system before anything runs — applying any
+> pending migrations, then confirming the knowledge base is ready.
 ```
 
 **Run the boot pipeline — this is mandatory. You must complete it before proceeding.**


### PR DESCRIPTION
Reverses the Step 0.2 code-block conversion from #425 per the maintainer's updated ruling: the `>` blockquote was correct (tier-2 signpost; the occasional literal-`>` rendering is a TUI markdown-detection flake we can't control). Expanded to two wrapped lines — more for the renderer to key on, and it properly satisfies the marker-needs-signpost convention (resolves the conventions sweep's M3 for this site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. **#435** 👈 current
56. #452
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->