### PR TITLE
cert: cross-cutting joins the specification entry

### DIFF
--- a/skills/workflow-specification-entry/references/confirm-unify.md
+++ b/skills/workflow-specification-entry/references/confirm-unify.md
@@ -26,7 +26,7 @@ Existing specifications to incorporate:
   • .workflows/{work_unit}/specification/{topic}/specification.md → will be superseded
   • .workflows/{work_unit}/specification/{topic}/specification.md → will be superseded
 
-Output: .workflows/unified/specification/unified/specification.md
+Output: .workflows/{work_unit}/specification/unified/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -55,7 +55,7 @@ Sources:
   • {discussion-name}
   ...
 
-Output: .workflows/unified/specification/unified/specification.md
+Output: .workflows/{work_unit}/specification/unified/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-specification-entry/references/invoke-skill.md
+++ b/skills/workflow-specification-entry/references/invoke-skill.md
@@ -62,3 +62,22 @@ Invoke the workflow-specification-process skill.
 ```
 
 Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+
+#### If `work_type` is `cross-cutting`
+
+Check for completed research: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{topic} status`. Include the `Research:` line only when the status is `completed`; omit it otherwise.
+
+```
+Specification session for: {work_unit}
+
+Source material:
+- Discussion: .workflows/{work_unit}/discussion/{topic}.md
+- Research: .workflows/{work_unit}/research/{topic}.md
+
+Work unit: {work_unit}
+Action: {verb} specification
+
+Invoke the workflow-specification-process skill.
+```
+
+Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -114,3 +114,39 @@ Run /workflow-start to continue an in-progress discussion.
 **If at least one completed discussion exists:**
 
 → Return to caller.
+
+#### If `work_type` is `cross-cutting`
+
+Check if discussion exists and is completed. Read status via `engine manifest`: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} status`.
+
+**If discussion doesn't exist:**
+
+> *Output the next fenced block as a code block:*
+
+```
+Source Material Missing
+
+No discussion found for "{work_unit:(titlecase)}".
+
+A completed discussion is required before specification can begin.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If discussion exists but status is "in-progress":**
+
+> *Output the next fenced block as a code block:*
+
+```
+Discussion In Progress
+
+The discussion for "{work_unit:(titlecase)}" is not yet completed.
+
+The discussion must be completed before specification can begin.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If discussion exists and status is "completed":**
+
+→ Return to caller.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -198,6 +198,26 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 
 → Load **[promote-to-cross-cutting.md](promote-to-cross-cutting.md)** and follow its instructions as written.
 
+#### If work_type is `cross-cutting`
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Specification complete. The specification is the final artifact
+> for a cross-cutting concern — the pipeline completes here.
+```
+
+Invoke the bridge:
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: specification
+
+Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
 #### Otherwise
 
 > *Output the next fenced block as markdown (not a code block):*


### PR DESCRIPTION
Certification fix 1 of 6. The spec entry's validate-source and invoke-skill had branches for feature/bugfix/epic only — a cross-cutting run fell through with no legal instruction (pre-existing; three fleet agents confirmed independently). Adds both branches (research correctly optional), makes spec-completion's terminal line type-aware (no false planning promise for cc), and fixes confirm-unify's two wrong displayed output paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. **#436** 👈 current
45. #437
46. #438
47. #439
48. #440
49. #441
<!-- stack:links:end -->