### PR TITLE
cert: cross-cutting joins the specification entry

### DIFF
--- a/skills/workflow-specification-entry/references/confirm-unify.md
+++ b/skills/workflow-specification-entry/references/confirm-unify.md
@@ -26,7 +26,7 @@ Existing specifications to incorporate:
   • .workflows/{work_unit}/specification/{topic}/specification.md → will be superseded
   • .workflows/{work_unit}/specification/{topic}/specification.md → will be superseded
 
-Output: .workflows/unified/specification/unified/specification.md
+Output: .workflows/{work_unit}/specification/unified/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -55,7 +55,7 @@ Sources:
   • {discussion-name}
   ...
 
-Output: .workflows/unified/specification/unified/specification.md
+Output: .workflows/{work_unit}/specification/unified/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-specification-entry/references/invoke-skill.md
+++ b/skills/workflow-specification-entry/references/invoke-skill.md
@@ -62,3 +62,22 @@ Invoke the workflow-specification-process skill.
 ```
 
 Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+
+#### If `work_type` is `cross-cutting`
+
+Check for completed research: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{topic} status`. Include the `Research:` line only when the status is `completed`; omit it otherwise.
+
+```
+Specification session for: {work_unit}
+
+Source material:
+- Discussion: .workflows/{work_unit}/discussion/{topic}.md
+- Research: .workflows/{work_unit}/research/{topic}.md
+
+Work unit: {work_unit}
+Action: {verb} specification
+
+Invoke the workflow-specification-process skill.
+```
+
+Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -114,3 +114,39 @@ Run /workflow-start to continue an in-progress discussion.
 **If at least one completed discussion exists:**
 
 → Return to caller.
+
+#### If `work_type` is `cross-cutting`
+
+Check if discussion exists and is completed. Read status via `engine manifest`: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} status`.
+
+**If discussion doesn't exist:**
+
+> *Output the next fenced block as a code block:*
+
+```
+Source Material Missing
+
+No discussion found for "{work_unit:(titlecase)}".
+
+A completed discussion is required before specification can begin.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If discussion exists but status is "in-progress":**
+
+> *Output the next fenced block as a code block:*
+
+```
+Discussion In Progress
+
+The discussion for "{work_unit:(titlecase)}" is not yet completed.
+
+The discussion must be completed before specification can begin.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If discussion exists and status is "completed":**
+
+→ Return to caller.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -198,6 +198,26 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 
 → Load **[promote-to-cross-cutting.md](promote-to-cross-cutting.md)** and follow its instructions as written.
 
+#### If work_type is `cross-cutting`
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Specification complete. The specification is the final artifact
+> for a cross-cutting concern — the pipeline completes here.
+```
+
+Invoke the bridge:
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: specification
+
+Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
 #### Otherwise
 
 > *Output the next fenced block as markdown (not a code block):*


### PR DESCRIPTION
Certification fix 1 of 6. The spec entry's validate-source and invoke-skill had branches for feature/bugfix/epic only — a cross-cutting run fell through with no legal instruction (pre-existing; three fleet agents confirmed independently). Adds both branches (research correctly optional), makes spec-completion's terminal line type-aware (no false planning promise for cc), and fixes confirm-unify's two wrong displayed output paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #383
8. #384
9. #385
10. #386
11. #387
12. #388
13. #389
14. #399
15. #400
16. #401
17. #402
18. #403
19. #404
20. #405
21. #406
22. #407
23. #408
24. #409
25. #411
26. #412
27. #413
28. #414
29. #415
30. #416
31. #417
32. #418
33. #419
34. #420
35. #421
36. #422
37. #423
38. #424
39. #425
40. #426
41. #427
42. #428
43. #429
44. #430
45. #431
46. #432
47. #433
48. #434
49. #435
50. **#442** 👈 current
51. #443
52. #444
53. #445
54. #446
55. #447
56. #448
57. #449
58. #450
59. #451
<!-- stack:links:end -->