### PR TITLE
cert: bridge routing repairs — the stored route is authoritative

### DIFF
--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -116,21 +116,22 @@ Epic Completed
 
 ## F. Enter Plan Mode
 
-Map the selection to a skill invocation using this routing table:
+Section E returned the selected entry's `action`, `topic`, and `route` (stored by epic-display-and-menu.md **C. Route Selection**). The stored `route` is the authoritative skill invocation — the plan file carries it verbatim. Never reconstruct an invocation from the phase name; not every selection maps to a `workflow-{phase}-entry` skill. The routes resolve as follows:
 
-| Selection | Skill | Work Type | Work Unit | Topic |
-|-----------|-------|-----------|-----------|-------|
-| Continue discussion | `/workflow-discussion-entry` | epic | {work_unit} | {topic} |
-| Continue specification | `/workflow-specification-entry` | epic | {work_unit} | {topic} |
-| Continue plan | `/workflow-planning-entry` | epic | {work_unit} | {topic} |
-| Continue implementation | `/workflow-implementation-entry` | epic | {work_unit} | {topic} |
-| Continue research | `/workflow-research-entry` | epic | {work_unit} | {topic} |
-| Start specification | `/workflow-specification-entry` | epic | {work_unit} | — |
-| Start planning for {topic} | `/workflow-planning-entry` | epic | {work_unit} | {topic} |
-| Start implementation of {topic} | `/workflow-implementation-entry` | epic | {work_unit} | {topic} |
-| Start review for {topic} | `/workflow-review-entry` | epic | {work_unit} | {topic} |
-| Start new research | `/workflow-research-entry` | epic | {work_unit} | — |
-| Start new discussion | `/workflow-discussion-entry` | epic | {work_unit} | — |
+| Selection | Route |
+|-----------|-------|
+| Continue discussion | `/workflow-discussion-entry epic {work_unit} {topic}` |
+| Continue specification | `/workflow-specification-entry epic {work_unit} {topic}` |
+| Continue plan | `/workflow-planning-entry epic {work_unit} {topic}` |
+| Continue implementation | `/workflow-implementation-entry epic {work_unit} {topic}` |
+| Continue research | `/workflow-research-entry epic {work_unit} {topic}` |
+| Continue discovery | `/workflow-discovery epic {work_unit}` |
+| Start specification | `/workflow-specification-entry epic {work_unit}` |
+| Start planning for {topic} | `/workflow-planning-entry epic {work_unit} {topic}` |
+| Start implementation of {topic} | `/workflow-implementation-entry epic {work_unit} {topic}` |
+| Start review for {topic} | `/workflow-review-entry epic {work_unit} {topic}` |
+| Start new research | `/workflow-research-entry epic {work_unit}` |
+| Start new discussion | `/workflow-discussion-entry epic {work_unit}` |
 
 Skills receive positional arguments: `$0` = work_type, `$1` = work_unit, `$2` = topic (optional).
 
@@ -145,7 +146,7 @@ Continue {selected_phase} for "{topic}" in "{work_unit}".
 
 ## Next Step
 
-Invoke `/workflow-{selected_phase}-entry epic {work_unit} {topic}`
+Invoke `{route}`
 
 Arguments: work_type = epic, work_unit = {work_unit}, topic = {topic}
 The skill will skip discovery and proceed directly to validation.
@@ -164,14 +165,14 @@ Call the `EnterPlanMode` tool to enter plan mode. Then write the following conte
 ```
 # Continue Epic: {selected_phase:(titlecase)}
 
-Start {selected_phase} phase for "{work_unit}".
+@if(action == continue_discovery) Continue discovery for "{work_unit}" — re-shape the topic map. @else Start {selected_phase} phase for "{work_unit}". @endif
 
 ## Next Step
 
-Invoke `/workflow-{selected_phase}-entry epic {work_unit}`
+Invoke `{route}`
 
 Arguments: work_type = epic, work_unit = {work_unit}
-The skill will run discovery with epic context.
+@if(action == continue_discovery) The discovery skill detects the existing work unit and re-shapes the map. @else The skill will run discovery with epic context. @endif
 
 ## How to proceed
 

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -93,7 +93,7 @@ Quick-Fix Completed
 
 ## C. Check for Earlier Phases
 
-Check if there are completed phases earlier in the pipeline that the user could revisit. Read the discovery output's `completed_phases` — any phase listed before `next_phase` in the pipeline order.
+Check if there are completed phases earlier in the pipeline that the user could revisit. Read the discovery output's `completed_phases` and keep only quick-fix pipeline phases — scoping, implementation, review — listed before `next_phase` in the pipeline order. The dump also lists specification and planning (written by scoping); they are not quick-fix phases, have no quick-fix entry route, and are never revisit targets.
 
 #### If no earlier completed phases exist
 
@@ -142,7 +142,7 @@ Select an option:
 · · · · · · · · · · · ·
 ```
 
-List only completed phases that come before `next_phase`.
+List only completed quick-fix pipeline phases (scoping, implementation, review) that come before `next_phase` — never specification or planning.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-bridge/scripts/gateway.cjs
+++ b/skills/workflow-bridge/scripts/gateway.cjs
@@ -17,8 +17,6 @@ function phaseFileExists(cwd, workUnit, phase, manifest) {
     case 'specification':  return listDirs(dir).some(d => fileExists(path.join(dir, d, 'specification.md')));
     case 'planning':       return phaseStatus(manifest, phase) !== null;
     case 'implementation': return phaseStatus(manifest, phase) !== null;
-    case 'review':         return listDirs(dir).some(d =>
-      listDirs(path.join(dir, d)).some(r => r.startsWith('r') && fileExists(path.join(dir, d, r, 'review.md'))));
     default: return false;
   }
 }

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -373,7 +373,11 @@ For each plan that received new tasks:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): re-open implementation tracking"
 ```
 
-Then enter plan mode and write the following plan:
+Then enter plan mode and write the following plan. Resolve `{work_type}` from the manifest when not already in context:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
+```
 
 ```
 # Review Actions Complete: {work_unit}
@@ -384,10 +388,12 @@ Review findings have been synthesized into {N} implementation tasks.
 
 {Summary, e.g., "auth-flow: 3 tasks in Phase 9"}
 
-## Instructions
+## Next Step
 
-1. Invoke `workflow-implementation-entry`
-2. The skill will detect the new tasks and start executing them
+Invoke `/workflow-implementation-entry {work_type} {work_unit} {topic}`
+
+Arguments: work_type = {work_type}, work_unit = {work_unit}, topic = {topic}
+The skill will detect the new tasks and start executing them.
 
 ## Context
 

--- a/tests/scripts/test-gateway-for-bridge.cjs
+++ b/tests/scripts/test-gateway-for-bridge.cjs
@@ -89,13 +89,11 @@ describe('workflow-bridge discovery', () => {
     });
     createFile(dir, '.workflows/full/discussion/full.md', '');
     createFile(dir, '.workflows/full/specification/full/specification.md', '');
-    createFile(dir, '.workflows/full/review/full/r1/review.md', '');
     const r = discover(dir, 'full');
     assert.strictEqual(r.phases.discussion.exists, true);
     assert.strictEqual(r.phases.specification.exists, true);
     assert.strictEqual(r.phases.planning.exists, true);
     assert.strictEqual(r.phases.implementation.exists, true);
-    assert.strictEqual(r.phases.review.exists, true);
   });
 
   it('detects planning existence from manifest not files', () => {


### PR DESCRIPTION
Certification fix 2 of 6. epic-continuation §F could write a nonexistent /workflow-discovery-entry into the continuation plan for the reachable continue_discovery action — §F now carries the menu's stored route verbatim (never reconstructs from phase names). Quickfix revisit list constrained to actual pipeline phases; the review rework handoff gains explicit arguments plus a work_type resolution step; the bridge gateway's dead obsolete-path probe deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #383
8. #384
9. #385
10. #386
11. #387
12. #388
13. #389
14. #399
15. #400
16. #401
17. #402
18. #403
19. #404
20. #405
21. #406
22. #407
23. #408
24. #409
25. #411
26. #412
27. #413
28. #414
29. #415
30. #416
31. #417
32. #418
33. #419
34. #420
35. #421
36. #422
37. #423
38. #424
39. #425
40. #426
41. #427
42. #428
43. #429
44. #430
45. #431
46. #432
47. #433
48. #434
49. #435
50. #442
51. **#443** 👈 current
52. #444
53. #445
54. #446
55. #447
56. #448
57. #449
58. #450
59. #451
<!-- stack:links:end -->