### PR TITLE
cert: engine truth — finalising units surfaced, honest tags, epic adapter hardened

### DIFF
--- a/skills/workflow-continue-bugfix/references/bugfix-display-and-menu.md
+++ b/skills/workflow-continue-bugfix/references/bugfix-display-and-menu.md
@@ -20,9 +20,9 @@ node .claude/skills/workflow-continue-bugfix/scripts/gateway.cjs view {work_unit
 
 The output is one snapshot in three demarcated sections:
 
-- **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
+- **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `finalising`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
 - **DISPLAY** — the status block. Emit verbatim as a code block. Never redraw, reflow, or trim it.
-- **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit.
+- **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit or finalise.
 
 Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
@@ -51,6 +51,24 @@ Match the user's input to its `ACTIONS` entry by `key` — a command option's le
 Store the entry's `action` and `route`.
 
 → Return to caller.
+
+#### If `action` is `finalise`
+
+Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline"
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Bugfix Completed
+
+"{work_unit:(titlecase)}" has completed all pipeline phases.
+```
+
+**STOP.** Do not proceed — terminal condition.
 
 #### If `action` is `revisit`
 

--- a/skills/workflow-continue-cross-cutting/references/cross-cutting-display-and-menu.md
+++ b/skills/workflow-continue-cross-cutting/references/cross-cutting-display-and-menu.md
@@ -20,9 +20,9 @@ node .claude/skills/workflow-continue-cross-cutting/scripts/gateway.cjs view {wo
 
 The output is one snapshot in three demarcated sections:
 
-- **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
+- **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `finalising`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
 - **DISPLAY** — the status block. Emit verbatim as a code block. Never redraw, reflow, or trim it.
-- **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit.
+- **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit or finalise.
 
 Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
@@ -51,6 +51,24 @@ Match the user's input to its `ACTIONS` entry by `key` — a command option's le
 Store the entry's `action` and `route`.
 
 → Return to caller.
+
+#### If `action` is `finalise`
+
+Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline"
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Cross-Cutting Completed
+
+"{work_unit:(titlecase)}" has completed all pipeline phases.
+```
+
+**STOP.** Do not proceed — terminal condition.
 
 #### If `action` is `revisit`
 

--- a/skills/workflow-continue-epic/scripts/gateway.cjs
+++ b/skills/workflow-continue-epic/scripts/gateway.cjs
@@ -12,6 +12,10 @@
 //   gateway.cjs completed-menu {work_unit}   → Resume Completed sub-view (D)
 //   gateway.cjs cancel-menu {work_unit}      → Cancel Topic sub-view (E)
 //   gateway.cjs reactivate-menu {work_unit}  → Reactivate Topic sub-view (F)
+//
+// Those calls are the whole legal surface: a verb without its work unit, an
+// unknown verb, or excess arguments is a usage error (stderr, exit 1) — never
+// a silent first-epic render.
 // ---------------------------------------------------------------------------
 
 const engine = require('../../workflow-engine/scripts/lib.cjs');
@@ -234,16 +238,36 @@ function subView(workUnit, projection) {
   ].join('\n');
 }
 
+const USAGE = 'Usage: gateway.cjs | gateway.cjs {work_unit} | gateway.cjs view {work_unit} [new_arrivals_json] | gateway.cjs (completed-menu|cancel-menu|reactivate-menu) {work_unit}';
+
+/** Reject the call: usage to stderr, exit 1. @param {string} message @returns {string} */
+function usageError(message) {
+  process.stderr.write(`gateway: ${message}\n${USAGE}\n`);
+  process.exit(1);
+  return ''; // unreachable; keeps the handler's return type uniform
+}
+
+/** @param {string} verb @param {(name: string, detail: object) => {keys: object[], display: string, rendered: string}} projection */
+function subViewHandler(verb, projection) {
+  return (/** @type {string} */ workUnit, /** @type {string[]} */ ...rest) => (!workUnit || rest.length > 0
+    ? usageError(`${verb} takes exactly one work unit`)
+    : subView(workUnit, projection));
+}
+
 if (require.main === module) {
   engine.gateway.runGateway({
-    index: () => format(discover(process.cwd())),
-    view,
-    'completed-menu': (workUnit) => subView(workUnit, (name, d) => engine.project.epicCompletedMenu(name, d)),
-    'cancel-menu': (workUnit) => subView(workUnit, (name, d) => engine.project.epicCancelMenu(d)),
-    'reactivate-menu': (workUnit) => subView(workUnit, (name, d) => engine.project.epicReactivateMenu(d)),
-    fallback: (workUnit) => (workUnit
-      ? formatScoped(workUnit, discover(process.cwd(), workUnit))
+    index: (...rest) => (rest.length > 0
+      ? usageError('index takes no arguments')
       : format(discover(process.cwd()))),
+    view: (workUnit, newArrivalsJson, ...rest) => (!workUnit || rest.length > 0
+      ? usageError('view takes a work unit and an optional new-arrivals JSON')
+      : view(workUnit, newArrivalsJson)),
+    'completed-menu': subViewHandler('completed-menu', (name, d) => engine.project.epicCompletedMenu(name, d)),
+    'cancel-menu': subViewHandler('cancel-menu', (name, d) => engine.project.epicCancelMenu(d)),
+    'reactivate-menu': subViewHandler('reactivate-menu', (name, d) => engine.project.epicReactivateMenu(d)),
+    fallback: (workUnit, ...rest) => (rest.length > 0
+      ? usageError(`unknown verb "${workUnit}"`)
+      : formatScoped(workUnit, discover(process.cwd(), workUnit))),
   });
 }
 

--- a/skills/workflow-continue-feature/references/feature-display-and-menu.md
+++ b/skills/workflow-continue-feature/references/feature-display-and-menu.md
@@ -20,9 +20,9 @@ node .claude/skills/workflow-continue-feature/scripts/gateway.cjs view {work_uni
 
 The output is one snapshot in three demarcated sections:
 
-- **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
+- **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `finalising`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
 - **DISPLAY** — the status block. Emit verbatim as a code block. Never redraw, reflow, or trim it.
-- **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit.
+- **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit or finalise.
 
 Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
@@ -51,6 +51,24 @@ Match the user's input to its `ACTIONS` entry by `key` — a command option's le
 Store the entry's `action` and `route`.
 
 → Return to caller.
+
+#### If `action` is `finalise`
+
+Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline"
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Feature Completed
+
+"{work_unit:(titlecase)}" has completed all pipeline phases.
+```
+
+**STOP.** Do not proceed — terminal condition.
 
 #### If `action` is `revisit`
 

--- a/skills/workflow-continue-quickfix/references/quickfix-display-and-menu.md
+++ b/skills/workflow-continue-quickfix/references/quickfix-display-and-menu.md
@@ -20,9 +20,9 @@ node .claude/skills/workflow-continue-quickfix/scripts/gateway.cjs view {work_un
 
 The output is one snapshot in three demarcated sections:
 
-- **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
+- **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `finalising`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
 - **DISPLAY** — the status block. Emit verbatim as a code block. Never redraw, reflow, or trim it.
-- **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit.
+- **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit or finalise.
 
 Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
@@ -51,6 +51,24 @@ Match the user's input to its `ACTIONS` entry by `key` — a command option's le
 Store the entry's `action` and `route`.
 
 → Return to caller.
+
+#### If `action` is `finalise`
+
+Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline"
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Quick-Fix Completed
+
+"{work_unit:(titlecase)}" has completed all pipeline phases.
+```
+
+**STOP.** Do not proceed — terminal condition.
 
 #### If `action` is `revisit`
 

--- a/skills/workflow-discovery/scripts/gateway.cjs
+++ b/skills/workflow-discovery/scripts/gateway.cjs
@@ -30,7 +30,7 @@ function buildDiscoveryMap(manifest) {
   const discoveryItems = phaseItems(manifest, 'discovery');
   if (discoveryItems.length === 0) return { map: [], summary: { total: 0, decided: 0, in_flight: 0, ready: 0, fresh: 0, handled: 0, cancelled: 0 }, needs_sequencing: false };
   const map = discoveryItems.map(item => {
-    const { lifecycle, tier, current_phase } = computeTopicLifecycle(manifest, item.name);
+    const { lifecycle, tier, current_phase, research_state } = computeTopicLifecycle(manifest, item.name);
     return {
       name: item.name,
       summary: item.summary || null,
@@ -42,6 +42,7 @@ function buildDiscoveryMap(manifest) {
       lifecycle,
       tier,
       current_phase,
+      research_state,
     };
   });
   map.sort(compareMapRows);

--- a/skills/workflow-engine/scripts/domain/conventions.cjs
+++ b/skills/workflow-engine/scripts/domain/conventions.cjs
@@ -86,15 +86,21 @@ function discoveryGlyph(tier) {
 
 // Discovery-map row `[tag]` vocabulary — the lifecycle label each map row
 // carries. One phrasing, every map render (epic dashboard, discovery session
-// map view).
-/** @param {string} lifecycle @param {string|null} [routing] */
-function discoveryLifecycleLabel(lifecycle, routing) {
+// map view). `researchState` is the topic's actual research-item status (null
+// when none exists — see computeTopicLifecycle's research_state): a handled
+// topic claims a research fan-out only when research exists, and superseded
+// research is named as such, never as complete.
+/** @param {string} lifecycle @param {string|null} [routing] @param {string|null} [researchState] */
+function discoveryLifecycleLabel(lifecycle, routing, researchState) {
   switch (lifecycle) {
-    case 'ready_for_discussion': return 'research complete · ready for discussion';
+    case 'ready_for_discussion':
+      return researchState === 'superseded'
+        ? 'research superseded · ready for discussion'
+        : 'research complete · ready for discussion';
     case 'researching': return 'researching';
     case 'discussing': return 'discussing';
     case 'decided': return 'decided';
-    case 'handled': return 'handled · research fanned out';
+    case 'handled': return researchState ? 'handled · research fanned out' : 'handled';
     case 'cancelled': return 'cancelled';
     default: return routing ? `fresh · routed to ${routing}` : 'fresh';
   }

--- a/skills/workflow-engine/scripts/domain/derivations.cjs
+++ b/skills/workflow-engine/scripts/domain/derivations.cjs
@@ -231,46 +231,50 @@ function computeNeedsSequencing(mapItems) {
   return mapItems.some(it => it.tier !== '⊘' && it.tier !== '⊙' && it.order == null);
 }
 
+// `research_state` rides along on every result — the research item's raw
+// status (null when no research item exists), so labels can be derived from
+// the actual per-phase state (a handled topic without research, superseded
+// research) rather than assumed from the lifecycle alone.
 function computeTopicLifecycle(manifest, topicName) {
   const discovery = phaseItems(manifest, 'discovery').find(i => i.name === topicName);
+  const research = phaseItems(manifest, 'research').find(i => i.name === topicName);
+  const discussion = phaseItems(manifest, 'discussion').find(i => i.name === topicName);
+
+  const rs = research ? research.status ?? null : null;
+  const ds = discussion ? discussion.status : null;
+
   // Stored marker wins over name-matching: a research topic that fanned out
   // into differently-named discussions is terminal, with no next action. Read
   // only the item's own field — never inspect siblings or provenance.
   if (discovery && discovery.handled === true) {
-    return { lifecycle: 'handled', tier: '⊙', current_phase: null };
+    return { lifecycle: 'handled', tier: '⊙', current_phase: null, research_state: rs };
   }
-
-  const research = phaseItems(manifest, 'research').find(i => i.name === topicName);
-  const discussion = phaseItems(manifest, 'discussion').find(i => i.name === topicName);
-
-  const rs = research ? research.status : null;
-  const ds = discussion ? discussion.status : null;
 
   if (ds === 'completed') {
-    return { lifecycle: 'decided', tier: '✓', current_phase: 'discussion' };
+    return { lifecycle: 'decided', tier: '✓', current_phase: 'discussion', research_state: rs };
   }
   if (ds === 'in-progress') {
-    return { lifecycle: 'discussing', tier: '◐', current_phase: 'discussion' };
+    return { lifecycle: 'discussing', tier: '◐', current_phase: 'discussion', research_state: rs };
   }
   if (rs === 'completed') {
-    return { lifecycle: 'ready_for_discussion', tier: '→', current_phase: 'research' };
+    return { lifecycle: 'ready_for_discussion', tier: '→', current_phase: 'research', research_state: rs };
   }
   if (rs === 'in-progress') {
-    return { lifecycle: 'researching', tier: '◐', current_phase: 'research' };
+    return { lifecycle: 'researching', tier: '◐', current_phase: 'research', research_state: rs };
   }
   // All attempted phase items are cancelled (both research and discussion items exist
   // and are cancelled). Single-cancelled (only research, or only discussion) falls
   // through to fresh — the alternate path remains open.
   if (rs === 'cancelled' && ds === 'cancelled') {
-    return { lifecycle: 'cancelled', tier: '⊘', current_phase: null };
+    return { lifecycle: 'cancelled', tier: '⊘', current_phase: null, research_state: rs };
   }
   // Superseded research with no discussion: the topic's research lineage is
   // closed but a discussion path remains open. Render as ready-for-discussion
   // — the next available action is to discuss.
   if (rs === 'superseded' && !ds) {
-    return { lifecycle: 'ready_for_discussion', tier: '→', current_phase: 'research' };
+    return { lifecycle: 'ready_for_discussion', tier: '→', current_phase: 'research', research_state: rs };
   }
-  return { lifecycle: 'fresh', tier: '○', current_phase: null };
+  return { lifecycle: 'fresh', tier: '○', current_phase: null, research_state: rs };
 }
 
 function computeNextAction(routing, lifecycle) {

--- a/skills/workflow-engine/scripts/domain/epic-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/epic-detail.cjs
@@ -82,6 +82,7 @@ const EPIC_PHASES = ['discovery', 'research', 'discussion', 'specification', 'pl
  * @property {string} lifecycle  `fresh` | `researching` | `ready_for_discussion` | `discussing` | `decided` | `handled` | `cancelled`
  * @property {string} tier       `→` | `◐` | `✓` | `○` | `⊙` | `⊘`
  * @property {string|null} current_phase
+ * @property {string|null} research_state  the research item's raw status, null when none exists
  * @property {string|null} next_action
  */
 
@@ -328,7 +329,7 @@ function epicDetail(cwd, manifest) {
   let mapSummary = null;
   if (discoveryItems.length > 0) {
     discoveryMap = discoveryItems.map(item => {
-      const { lifecycle, tier, current_phase } = computeTopicLifecycle(manifest, item.name);
+      const { lifecycle, tier, current_phase, research_state } = computeTopicLifecycle(manifest, item.name);
       const next_action = computeNextAction(item.routing, lifecycle);
       const source_provenance = computeSourceProvenance(item.source);
       const summaryText = typeof item.summary === 'string' && item.summary.trim() ? item.summary : null;
@@ -345,6 +346,7 @@ function epicDetail(cwd, manifest) {
         lifecycle,
         tier,
         current_phase,
+        research_state,
         next_action,
       };
     });

--- a/skills/workflow-engine/scripts/domain/epic-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/epic-detail.cjs
@@ -48,6 +48,7 @@ const EPIC_PHASES = ['discovery', 'research', 'discussion', 'specification', 'pl
  * @property {boolean} [deps_satisfied]        planning items
  * @property {DepBlocking[]} [deps_blocking]   planning items with unmet deps
  * @property {string|number} [current_phase]   implementation items
+ * @property {string} [current_task]           implementation items — the task in flight
  * @property {string[]} [completed_phases]     implementation items
  * @property {string[]} [completed_tasks]      implementation items
  */
@@ -234,6 +235,7 @@ function epicDetail(cwd, manifest) {
       // Enrich implementation items with progress data
       if (phase === 'implementation') {
         if (item.current_phase != null && item.current_phase !== '~') entry.current_phase = item.current_phase;
+        if (typeof item.current_task === 'string' && item.current_task) entry.current_task = item.current_task;
         if (Array.isArray(item.completed_phases) && item.completed_phases.length > 0) entry.completed_phases = item.completed_phases;
         if (Array.isArray(item.completed_tasks) && item.completed_tasks.length > 0) entry.completed_tasks = item.completed_tasks;
       }

--- a/skills/workflow-engine/scripts/domain/projections/discovery-map.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/discovery-map.cjs
@@ -21,6 +21,7 @@ const { TREE_WIDTH, titlecase, title, discoveryGlyph, discoveryLifecycleLabel } 
  * @property {string} name
  * @property {string} lifecycle   fresh|researching|ready_for_discussion|discussing|decided|handled|cancelled
  * @property {string|null} [routing]
+ * @property {string|null} [research_state]  the research item's raw status, null when none exists
  * @property {string|null} [summary]
  */
 
@@ -66,7 +67,7 @@ function mapNodes(rows) {
     title: title({
       glyph: discoveryGlyph(row.lifecycle),
       label: titlecase(row.name),
-      tag: discoveryLifecycleLabel(row.lifecycle, row.routing ?? null),
+      tag: discoveryLifecycleLabel(row.lifecycle, row.routing ?? null, row.research_state ?? null),
     }),
   }));
 }

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -385,8 +385,11 @@ function discoveryEntryLabel(action, name) {
 function continueLabel(phase, item) {
   const t = titlecase(item.name);
   if (phase === 'implementation' && item.current_phase != null) {
+    if (item.current_task) {
+      return `Continue "${t}" — implementation (Phase ${item.current_phase}, Task ${item.current_task})`;
+    }
     const tasks = Array.isArray(item.completed_tasks) ? item.completed_tasks.length : 0;
-    return `Continue "${t}" — implementation (Phase ${item.current_phase}, Task ${tasks})`;
+    return `Continue "${t}" — implementation (Phase ${item.current_phase}, ${tasks} task(s) completed)`;
   }
   return `Continue "${t}" — ${phase} [in-progress]`;
 }

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -87,7 +87,7 @@ const START_GATE = {
 
 /** @param {MapRow} row */
 function lifecycleLabel(row) {
-  return discoveryLifecycleLabel(row.lifecycle, row.routing);
+  return discoveryLifecycleLabel(row.lifecycle, row.routing, row.research_state ?? null);
 }
 
 /** Count summary for a phase sub-header — statuses present, zero counts omitted. @param {PhaseEntry[]} items */

--- a/skills/workflow-engine/scripts/domain/projections/specification.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/specification.cjs
@@ -12,7 +12,7 @@
 // ---------------------------------------------------------------------------
 
 const { box, renderTree, wrap } = require('../../kernel/render.cjs');
-const { TREE_WIDTH, titlecase, SPEC_LEGEND } = require('../conventions.cjs');
+const { TREE_WIDTH, titlecase, title, SPEC_LEGEND } = require('../conventions.cjs');
 
 /** @typedef {import('../specification.cjs').SpecificationDetail} SpecificationDetail */
 /** @typedef {import('../specification.cjs').SpecRow} SpecRow */
@@ -375,7 +375,10 @@ function specificationCompletedMenu(detail) {
   }
   lines.push('', 'Select an option:', '· · · · · · · · · · · ·');
 
-  return { keys, display: 'Completed Specifications\n', rendered: lines.join('\n') };
+  const display = 'Completed Specifications\n'
+    + renderTree(detail.concluded.map((row) => ({ title: title({ label: titlecase(row.name), tag: 'completed' }) })), { width: TREE_WIDTH });
+
+  return { keys, display, rendered: lines.join('\n') };
 }
 
 module.exports = { specificationDisplay, specificationMenu, specificationCompletedMenu };

--- a/skills/workflow-engine/scripts/domain/projections/specification.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/specification.cjs
@@ -56,6 +56,11 @@ function bullets(names) {
   return names.map((n) => `  • ${n}`).join('\n');
 }
 
+/** `N noun` with plural agreement (`1 spec` / `2 specs`). @param {number} n @param {string} noun */
+function counted(n, noun) {
+  return `${n} ${noun}${n === 1 ? '' : 's'}`;
+}
+
 /** ⚑ block for in-progress discussions, or '' when none. @param {string[]} names */
 function notReadyBlock(names) {
   if (names.length === 0) return '';
@@ -193,7 +198,7 @@ function groupingsDisplay(detail) {
 /** @param {SpecificationDetail} detail */
 function analyzeDisplay(detail) {
   return compose([
-    `${detail.counts.completed_count} completed discussions found. No specifications exist yet.`,
+    `${counted(detail.counts.completed_count, 'completed discussion')} found. No specifications exist yet.`,
     'Completed discussions:\n' + bullets(detail.completed_discussions),
     notReadyBlock(detail.in_progress_discussions),
   ]);
@@ -202,7 +207,8 @@ function analyzeDisplay(detail) {
 /** @param {SpecificationDetail} detail */
 function specsMenuDisplay(detail) {
   const cs = detail.counts;
-  const blocks = [`${cs.completed_count} completed discussions found. ${cs.spec_count} specifications exist.`];
+  const blocks = [`${counted(cs.completed_count, 'completed discussion')} found. `
+    + `${counted(cs.spec_count, 'specification')} exist${cs.spec_count === 1 ? 's' : ''}.`];
   if (detail.actionable.length > 0) {
     blocks.push('Existing specifications:');
     detail.actionable.forEach((row, i) => blocks.push(itemBlock(i + 1, row)));
@@ -347,8 +353,9 @@ function specificationMenu(detail) {
 }
 
 /**
- * The concluded-specs sub-view (`c`/`completed`): flat Refine entries — no
- * tree, the specs have no pending work.
+ * The concluded-specs sub-view (`c`/`completed`): the heading with one row per
+ * concluded spec, and flat Refine entries — no source detail, the specs have
+ * no pending work.
  * @param {SpecificationDetail} detail
  * @returns {{keys: SpecMenuKey[], display: string, rendered: string}}
  */

--- a/skills/workflow-engine/scripts/domain/projections/start.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/start.cjs
@@ -76,13 +76,15 @@ function inboxHint(inbox) {
 }
 
 // The └─ sub-row: epics show their active phases (phase_label when nothing has
-// started yet); every other type shows the titlecased phase label.
+// started yet); every other type shows the titlecased phase label — prefixed
+// `Finalising —` when the pipeline finished but `workunit complete` never ran.
 /** @param {WorkUnitEntry} unit @param {TypeSection['type']} type */
 function subRow(unit, type) {
   if (type === 'epic') {
     const phases = unit.active_phases || [];
     if (phases.length > 0) return phases.map(titlecase).join(', ');
   }
+  if (unit.finalising) return titlecaseLabel(`finalising — ${unit.phase_label}`);
   return titlecaseLabel(unit.phase_label);
 }
 
@@ -126,10 +128,13 @@ function startOverview(detail) {
 // Menu
 // ---------------------------------------------------------------------------
 
+// A finalising unit's entry reads `Finalise …` — the continue skill it routes
+// to presents the completion gate.
 /** @param {WorkUnitEntry} unit @param {TypeSection['type']} type */
 function continueLabel(unit, type) {
   const t = titlecase(unit.name);
   if (type === 'epic') return `Continue "${t}" — epic`;
+  if (unit.finalising) return `Finalise "${t}" — ${type}, ${unit.phase_label}`;
   return `Continue "${t}" — ${type}, ${unit.phase_label}`;
 }
 

--- a/skills/workflow-engine/scripts/domain/projections/workunit.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/workunit.cjs
@@ -91,15 +91,18 @@ function workUnitStatus(type, unit) {
   if (callouts.length > 0) out += callouts.join('\n') + '\n\n';
   out += `  PIPELINE (${cfg.workType})\n`;
   out += renderTree(pipelineNodes(cfg, unit), { width: TREE_WIDTH });
+  if (unit.finalising) out += '\n  ⚑ All phases complete — ready to finalise.\n';
   return out.replace(/\n+$/, '\n');
 }
 
 /**
  * Section B — the proceed/revisit menu. `keys` carries the machine action keys
- * (skills route on these): the `continue` entry always, plus `revisit` and one
- * `revisit_phase` entry per earlier completed phase when any exist. `rendered`
- * is the dotted-gate markdown block — empty when there is nothing to revisit
- * (the calling skill routes straight through, no stop).
+ * (skills route on these): the `continue` entry always (a `finalise` entry on
+ * a finalising unit — the skill runs `workunit complete`, no route), plus
+ * `revisit` and one `revisit_phase` entry per earlier completed phase when any
+ * exist. `rendered` is the dotted-gate markdown block — empty when there is
+ * nothing to revisit and nothing to finalise (the calling skill routes
+ * straight through, no stop).
  * @param {string} type  a WORK_UNIT_TYPES key
  * @param {WorkUnitEntry} unit
  * @returns {{keys: WorkUnitMenuKey[], rendered: string}}
@@ -109,11 +112,16 @@ function workUnitMenu(type, unit) {
   const revisitable = earlierCompleted(cfg, unit);
 
   /** @type {WorkUnitMenuKey[]} */
-  const keys = [{
-    key: 'y', word: 'yes', action: 'continue', topic: unit.name,
-    route: entryRoute(cfg, unit.next_phase, unit.name),
-    label: `Proceed to ${unit.next_phase}`,
-  }];
+  const keys = [unit.finalising
+    ? {
+      key: 'y', word: 'yes', action: 'finalise', topic: unit.name, route: null,
+      label: 'Mark the work unit completed',
+    }
+    : {
+      key: 'y', word: 'yes', action: 'continue', topic: unit.name,
+      route: entryRoute(cfg, unit.next_phase, unit.name),
+      label: `Proceed to ${unit.next_phase}`,
+    }];
 
   if (revisitable.length > 0) {
     keys.push({ key: 'r', word: 'revisit', action: 'revisit', topic: unit.name, route: null, label: 'Revisit an earlier phase' });
@@ -127,13 +135,14 @@ function workUnitMenu(type, unit) {
   }
 
   let rendered = '';
-  if (revisitable.length > 0) {
+  if (unit.finalising || revisitable.length > 0) {
+    const options = [`- **\`y\`/\`yes\`** — ${keys[0].label}`];
+    if (revisitable.length > 0) options.push('- **`r`/`revisit`** — Revisit an earlier phase');
     rendered = [
       '· · · · · · · · · · · ·',
-      `Continuing "${titlecase(unit.name)}" — ${unit.phase_label}.`,
+      `${unit.finalising ? 'Finalising' : 'Continuing'} "${titlecase(unit.name)}" — ${unit.phase_label}.`,
       '',
-      `- **\`y\`/\`yes\`** — Proceed to ${unit.next_phase}`,
-      '- **`r`/`revisit`** — Revisit an earlier phase',
+      ...options,
       '· · · · · · · · · · · ·',
     ].join('\n');
   }
@@ -156,6 +165,7 @@ function workUnitData(type, unit, menu) {
   lines.push(`work_type: ${cfg.workType}`);
   lines.push(`next_phase: ${unit.next_phase}`);
   lines.push(`phase_label: ${unit.phase_label}`);
+  lines.push(`finalising: ${unit.finalising === true}`);
   lines.push(`completed_phases: ${unit.completed_phases.join(', ') || '(none)'}`);
   lines.push(`revisit_available: ${menu.keys.some((k) => k.action === 'revisit')}`);
   if (cfg.surfacesSeeds) {

--- a/skills/workflow-engine/scripts/domain/start.cjs
+++ b/skills/workflow-engine/scripts/domain/start.cjs
@@ -29,6 +29,8 @@ const ALL_PHASES = ['research', 'discussion', 'investigation', 'scoping', 'speci
  * @property {string} name
  * @property {string} next_phase
  * @property {string} phase_label
+ * @property {boolean} finalising        pipeline finished (`next_phase: done`) but the unit is
+ *                                       still in-progress — `workunit complete` never ran
  * @property {string[]} [active_phases]  epics only — phases that have items
  */
 
@@ -213,13 +215,16 @@ function startDetail(cwd) {
 
   for (const m of manifests) {
     const state = computeNextPhase(m);
-    if (state.next_phase === 'done') continue;
 
+    // A finished pipeline on a still-in-progress unit is surfaced, never
+    // hidden: the unit sat between the last topic completion and `workunit
+    // complete` when the flow stopped, and finalising is its only way out.
     /** @type {WorkUnitEntry} */
     const unit = {
       name: m.name,
       next_phase: state.next_phase,
       phase_label: state.phase_label,
+      finalising: state.next_phase === 'done',
     };
 
     if (m.work_type === 'epic') {

--- a/skills/workflow-engine/scripts/domain/workunit-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-detail.cjs
@@ -74,6 +74,8 @@ const WORK_UNIT_TYPES = {
  * @property {string} name
  * @property {string} next_phase
  * @property {string} phase_label
+ * @property {boolean} finalising      pipeline finished (`next_phase: done`) but the unit is
+ *                                     still in-progress — `workunit complete` never ran
  * @property {string[]} completed_phases
  * @property {number} [imports_count]  types with surfacesSeeds only
  * @property {number} [seeds_count]    types with surfacesSeeds only
@@ -145,12 +147,15 @@ function workUnitDetail(cwd, type) {
   for (const m of loadActiveManifests(cwd)) {
     if (m.work_type !== cfg.workType) continue;
     const state = computeNextPhase(m);
-    if (state.next_phase === 'done') continue;
+    // A finished pipeline on a still-in-progress unit is surfaced, never
+    // hidden: the unit sat between the last topic completion and `workunit
+    // complete` when the flow stopped, and finalising is its only way out.
     /** @type {WorkUnitEntry} */
     const unit = {
       name: m.name,
       next_phase: state.next_phase,
       phase_label: state.phase_label,
+      finalising: state.next_phase === 'done',
       completed_phases: completedPhases(cfg, m),
     };
     if (cfg.surfacesSeeds) {
@@ -200,7 +205,7 @@ function workUnitIndex(type, detail) {
   const lines = [];
   lines.push(`=== ${cfg.header} (${detail.count}) ===`);
   for (const u of unitsOf(cfg, detail)) {
-    lines.push(`  ${u.name}: ${u.phase_label}`);
+    lines.push(`  ${u.name}: ${u.finalising ? `finalising — ${u.phase_label}` : u.phase_label}`);
   }
   lines.push(`=== COMPLETED (${detail.completed_count}) ===`);
   for (const u of detail.completed) {

--- a/skills/workflow-engine/scripts/domain/workunit-lifecycle.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-lifecycle.cjs
@@ -31,6 +31,7 @@ const {
 const { commitScopedWithKb } = require('./commit.cjs');
 const { knowledge, INDEXED_ARTIFACTS } = require('./kb.cjs');
 const { addItem } = require('./discovery-map.cjs');
+const { computeNextPhase } = require('./derivations.cjs');
 
 const { VALID_WORK_UNIT_STATUSES } = require('../kernel/manifest-schema.cjs');
 
@@ -63,8 +64,11 @@ function todayStamp() {
  * Complete a work unit: `status: completed`, `completed_at` stamped today
  * (engine-stamped, UTC), commit scoped to the work unit with the caller's
  * message. No knowledge-base action — completed units retain their chunks.
- * Refuses an already-completed unit; a cancelled unit must go through
- * reactivate first.
+ * Refuses an already-completed unit. A cancelled unit must go through
+ * reactivate first — unless its pipeline is finished (derived next phase
+ * `done`): reactivate refuses that state, so complete is its only terminal
+ * transition, and cancellation removed the unit's chunks, so this path
+ * re-indexes them (warn-don't-block).
  * @param {string} cwd project root
  * @param {string} workUnit
  * @param {{message: string}} opts  commit message — varies by caller (manual
@@ -73,25 +77,32 @@ function todayStamp() {
  */
 function completeWorkUnit(cwd, workUnit, { message }) {
   assertLegalStatus('completed');
-  const completedAt = withWorkUnitLock(cwd, workUnit, () => {
-    const manifest = loadWorkUnitManifest(cwd, workUnit);
-    if (manifest.status === 'completed') {
+  const { completedAt, previous, manifest } = withWorkUnitLock(cwd, workUnit, () => {
+    const loaded = loadWorkUnitManifest(cwd, workUnit);
+    if (loaded.status === 'completed') {
       throw new Error(`work unit "${workUnit}" is already completed`);
     }
-    if (manifest.status === 'cancelled') {
+    if (loaded.status === 'cancelled' && computeNextPhase(loaded).next_phase !== 'done') {
       throw new Error(`work unit "${workUnit}" is cancelled — reactivate it first`);
     }
-    manifest.status = 'completed';
+    const from = loaded.status;
+    loaded.status = 'completed';
     const stamped = todayStamp();
-    manifest.completed_at = stamped;
+    loaded.completed_at = stamped;
 
-    saveWorkUnitManifest(cwd, workUnit, manifest);
-    return stamped;
+    saveWorkUnitManifest(cwd, workUnit, loaded);
+    return { completedAt: stamped, previous: from, manifest: loaded };
   });
+
+  /** @type {string[]} */
+  const warnings = [];
+  if (previous === 'cancelled') {
+    reindexWorkUnit(cwd, workUnit, manifest, warnings);
+  }
 
   const committed = commitScopedWithKb(cwd, `.workflows/${workUnit}`, message);
   /** @type {WorkUnitLifecycleResult} */
-  const result = { work_unit: workUnit, status: 'completed', completed_at: completedAt, committed, warnings: [] };
+  const result = { work_unit: workUnit, status: 'completed', completed_at: completedAt, committed, warnings };
   if (committed === null) result.note = 'nothing to commit';
   return result;
 }
@@ -191,10 +202,13 @@ function reindexWorkUnit(cwd, workUnit, manifest, warnings) {
 
 /**
  * Reactivate a completed or cancelled work unit: `status: in-progress`, a
- * stale `completed_at` cleared, commit scoped to the work unit. Cancellation
- * removed the unit's knowledge-base chunks, so reactivating from `cancelled`
- * re-indexes them (warn-don't-block); completed units retained their chunks —
- * no knowledge-base action.
+ * stale `completed_at` cleared, commit scoped to the work unit. Refuses a
+ * unit whose pipeline is finished (derived next phase `done`) — reactivating
+ * it would strand the unit with no next phase; `workunit complete` is the
+ * terminal transition for that state. Cancellation removed the unit's
+ * knowledge-base chunks, so reactivating from `cancelled` re-indexes them
+ * (warn-don't-block); completed units retained their chunks — no
+ * knowledge-base action.
  * @param {string} cwd project root
  * @param {string} workUnit
  * @returns {WorkUnitLifecycleResult}
@@ -208,6 +222,9 @@ function reactivateWorkUnit(cwd, workUnit) {
     }
     if (loaded.status !== 'completed' && loaded.status !== 'cancelled') {
       throw new Error(`work unit "${workUnit}" is not completed or cancelled (status: ${loaded.status ?? 'none'})`);
+    }
+    if (computeNextPhase(loaded).next_phase === 'done') {
+      throw new Error(`work unit "${workUnit}" has a finished pipeline — reactivating would strand it with no next phase; use \`workunit complete\` instead`);
     }
     const from = loaded.status;
     loaded.status = 'in-progress';

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -122,6 +122,7 @@ Commands:
   discovery-session close <work-unit> -m <message>
   topic start <work-unit> <phase> <topic>
   topic complete <work-unit> <phase> <topic>
+  topic reopen <work-unit> <phase> <topic>
   topic supersede <work-unit> <phase> <topic> --by <topic>
   topic cancel <work-unit> <phase> <topic>
   topic reactivate <work-unit> <phase> <topic>

--- a/tests/scripts/test-engine-discovery-projections.cjs
+++ b/tests/scripts/test-engine-discovery-projections.cjs
@@ -76,7 +76,7 @@ describe('discoveryMapView', () => {
       '  ├─ ✓ Ordering Flow [decided]',
       '  ├─ ○ Loyalty [fresh]',
       '  ├─ ○ Operator Analytics [fresh · routed to research]',
-      '  ├─ ⊙ Umbrella [handled · research fanned out]',
+      '  ├─ ⊙ Umbrella [handled]',
       '  └─ ⊘ Legacy Import [cancelled]',
       '',
     ].join('\n'));
@@ -115,6 +115,38 @@ describe('discoveryMapView', () => {
       '',
       '  Discovery Map (0 topics)',
       '  (empty)',
+      '',
+    ].join('\n'));
+  });
+
+  it('tags derive from the actual research state — fan-out claimed only when research exists, superseded named', () => {
+    createManifest(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discovery: {
+          items: {
+            'umbrella': { routing: 'research', source: 'discovery', handled: true },
+            'no-research': { routing: 'discussion', source: 'discovery', handled: true },
+            'split-parent': { routing: 'research', source: 'discovery' },
+          },
+        },
+        research: {
+          items: {
+            'umbrella': { status: 'completed' },
+            'split-parent': { status: 'superseded' },
+          },
+        },
+      },
+    });
+    assert.strictEqual(discoveryMapView('v1', mapOf(dir, 'v1')), [
+      '●───────────────────────────────────────────────●',
+      '  Discovery — V1',
+      '●───────────────────────────────────────────────●',
+      '',
+      '  Discovery Map (3 topics — 1 ready · 2 handled)',
+      '  ├─ → Split Parent [research superseded · ready for discussion]',
+      '  ├─ ⊙ No Research [handled]',
+      '  └─ ⊙ Umbrella [handled · research fanned out]',
       '',
     ].join('\n'));
   });

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -412,6 +412,35 @@ describe('epic projections: menu', () => {
     assert.ok(!rendered.includes('Dropped'), 'cancelled row has no menu entry');
   });
 
+  it('implementation continue label names the task in flight, not the completed count', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discussion: { items: { roles: { status: 'completed' } } },
+        specification: { items: { roles: { status: 'completed', sources: { roles: { status: 'incorporated' } } } } },
+        planning: { items: { roles: { status: 'completed' } } },
+        implementation: { items: { roles: { status: 'in-progress', current_phase: 2, current_task: 'r-2-2', completed_tasks: ['r-1-1', 'r-1-2', 'r-2-1'] } } },
+      },
+    });
+    const { rendered } = epicMenu('v1', d);
+    assert.ok(rendered.includes('— Continue "Roles" — implementation (Phase 2, Task r-2-2)'), rendered);
+    assert.ok(!rendered.includes('Task 3'), 'completed count must not masquerade as a task position');
+  });
+
+  it('implementation continue label falls back to the completed count when no task is in flight', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discussion: { items: { roles: { status: 'completed' } } },
+        specification: { items: { roles: { status: 'completed', sources: { roles: { status: 'incorporated' } } } } },
+        planning: { items: { roles: { status: 'completed' } } },
+        implementation: { items: { roles: { status: 'in-progress', current_phase: 2, current_task: null, completed_tasks: ['r-1-1', 'r-1-2', 'r-2-1'] } } },
+      },
+    });
+    const { rendered } = epicMenu('v1', d);
+    assert.ok(rendered.includes('— Continue "Roles" — implementation (Phase 2, 3 task(s) completed)'), rendered);
+  });
+
   it('brand-new epic menu offers only the always-present command options', () => {
     const d = detailFor(dir, 'fresh', { work_type: 'epic' });
     const { keys, rendered } = epicMenu('fresh', d);

--- a/tests/scripts/test-engine-specification-projections.cjs
+++ b/tests/scripts/test-engine-specification-projections.cjs
@@ -341,6 +341,24 @@ describe('specification projections: display goldens', () => {
     ].join('\n'));
   });
 
+  it('specs-menu: a single spec renders with singular agreement — "1 specification exists"', () => {
+    createManifest(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discussion: { items: { a: { status: 'completed' }, b: { status: 'completed' } } },
+        specification: {
+          items: {
+            's1': { status: 'completed', sources: { a: { status: 'incorporated' }, b: { status: 'incorporated' } } },
+          },
+        },
+      },
+    });
+    createFile(dir, '.workflows/v1/specification/s1/specification.md', '# S1');
+    const out = specificationDisplay(detailOf(dir, 'v1'));
+    assert.ok(out.includes('\n2 completed discussions found. 1 specification exists.\n'), out);
+    assert.ok(!out.includes('1 specifications'), out);
+  });
+
   it('single no-spec: ready row, no spec line, ready-only key', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',

--- a/tests/scripts/test-engine-specification-projections.cjs
+++ b/tests/scripts/test-engine-specification-projections.cjs
@@ -664,7 +664,12 @@ describe('specification projections: menu goldens', () => {
     createFile(dir, '.workflows/v1/specification/auth-flow/specification.md', '# A');
     createFile(dir, '.workflows/v1/specification/data-model/specification.md', '# D');
     const sub = specificationCompletedMenu(detailOf(dir, 'v1'));
-    assert.strictEqual(sub.display, 'Completed Specifications\n');
+    assert.strictEqual(sub.display, [
+      'Completed Specifications',
+      '  ├─ Auth Flow [completed]',
+      '  └─ Data Model [completed]',
+      '',
+    ].join('\n'));
     assert.strictEqual(sub.rendered, [
       '· · · · · · · · · · · ·',
       'Which completed specification would you like to refine?',

--- a/tests/scripts/test-engine-start-projections.cjs
+++ b/tests/scripts/test-engine-start-projections.cjs
@@ -138,6 +138,23 @@ describe('start projections: overview', () => {
       '',
     ].join('\n'));
   });
+
+  it('finalising unit renders the Finalising sub-row', () => {
+    createManifest(dir, 'caching', {
+      work_type: 'cross-cutting',
+      phases: {
+        discussion: { items: { caching: { status: 'completed' } } },
+        specification: { items: { caching: { status: 'completed' } } },
+      },
+    });
+    assert.strictEqual(startOverview(startDetail(dir)), [
+      ...BOX,
+      'Cross-Cutting:',
+      '  1. Caching',
+      '     └─ Finalising — Pipeline Complete',
+      '',
+    ].join('\n'));
+  });
 });
 
 describe('start projections: menu', () => {
@@ -193,6 +210,21 @@ describe('start projections: menu', () => {
       'Select an option:',
       '· · · · · · · · · · · ·',
     ].join('\n'));
+  });
+
+  it('finalising unit gets a Finalise entry that still routes to its continue skill', () => {
+    createManifest(dir, 'caching', {
+      work_type: 'cross-cutting',
+      phases: {
+        discussion: { items: { caching: { status: 'completed' } } },
+        specification: { items: { caching: { status: 'completed' } } },
+      },
+    });
+    const menu = startMenu(startDetail(dir));
+    assert.ok(menu.rendered.includes('- **`1`** — Finalise "Caching" — cross-cutting, pipeline complete'));
+    const entry = menu.keys.find((k) => k.key === '1');
+    assert.strictEqual(entry.action, 'continue_work_unit');
+    assert.strictEqual(entry.route, '/workflow-continue-cross-cutting caching');
   });
 
   it('shows v with cancelled-only work units', () => {

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -550,6 +550,7 @@ describe('engine workunit complete', () => {
     assert.match(engineFails(dir, ['workunit', 'complete', 'ghost', '-m', 'msg']).error, /manifest not found/);
     assert.match(engineFails(dir, ['workunit', 'finish', 'auth-flow']).error, /Usage: engine workunit <create\|complete\|cancel\|reactivate\|pivot\|absorb\|promote>/);
   });
+
 });
 
 describe('engine workunit cancel', () => {
@@ -889,5 +890,22 @@ describe('schema enforcement: transitions refuse what the field surface refuses'
     assert.ok(src.includes("require('../kernel/manifest-schema.cjs')"),
       'transitions must require the shared schema, not mirror it');
     assert.ok(!/VALID_PHASE_STATUSES\s*=\s*{/.test(src), 'no local copy of the status table');
+  });
+});
+
+describe('engine usage banner', () => {
+  it('lists every topic transition, reopen included', () => {
+    const res = spawnSync('node', [ENGINE, 'bogus-command'], { encoding: 'utf8' });
+    assert.strictEqual(res.status, 1);
+    for (const line of [
+      'topic start <work-unit> <phase> <topic>',
+      'topic complete <work-unit> <phase> <topic>',
+      'topic reopen <work-unit> <phase> <topic>',
+      'topic supersede <work-unit> <phase> <topic> --by <topic>',
+      'topic cancel <work-unit> <phase> <topic>',
+      'topic reactivate <work-unit> <phase> <topic>',
+    ]) {
+      assert.ok(res.stderr.includes(`  ${line}\n`), `usage banner missing "${line}"`);
+    }
   });
 });

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -505,6 +505,24 @@ function setupFeatureFixture() {
   return dir;
 }
 
+/** A cross-cutting unit whose pipeline is finished (derived next phase `done`). */
+function setupFinishedCrossCuttingFixture() {
+  const dir = setupGitFixture();
+  writeFile(dir, '.workflows/caching/manifest.json', JSON.stringify({
+    name: 'caching',
+    work_type: 'cross-cutting',
+    status: 'in-progress',
+    phases: {
+      discussion: { items: { caching: { status: 'completed' } } },
+      specification: { items: { caching: { status: 'completed' } } },
+    },
+  }, null, 2) + '\n');
+  // Deterministic KB failure: a plain file where the store directory belongs.
+  writeFile(dir, '.workflows/.knowledge', 'not a directory\n');
+  commitAll(dir, 'init');
+  return dir;
+}
+
 describe('engine workunit complete', () => {
   let dir;
   beforeEach(() => { dir = setupFeatureFixture(); });
@@ -551,6 +569,29 @@ describe('engine workunit complete', () => {
     assert.match(engineFails(dir, ['workunit', 'finish', 'auth-flow']).error, /Usage: engine workunit <create\|complete\|cancel\|reactivate\|pivot\|absorb\|promote>/);
   });
 
+  it('completes a cancelled unit with a finished pipeline directly, restoring its chunks', () => {
+    // Reactivate refuses a finished pipeline, so complete is the only
+    // terminal transition left for this state — and cancellation removed the
+    // unit's chunks, so the transition re-indexes them (warn-don't-block).
+    const ccDir = setupFinishedCrossCuttingFixture();
+    engine(ccDir, ['workunit', 'cancel', 'caching']);
+    const res = engine(ccDir, ['workunit', 'complete', 'caching', '-m', 'workflow(caching): complete cross-cutting pipeline']);
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.status, 'completed');
+    assert.strictEqual(res.committed, shortHead(ccDir));
+    // No KB configured in the fixture — one warning per completed indexed
+    // artifact (discussion/caching, specification/caching).
+    assert.strictEqual(res.warnings.length, 2, res.warnings.join('\n'));
+    assert.match(res.warnings[0], /knowledge index \(discussion\/caching\)/);
+    assert.match(res.warnings[1], /knowledge index \(specification\/caching\)/);
+
+    const m = readManifest(ccDir, 'caching');
+    assert.strictEqual(m.status, 'completed');
+    assert.strictEqual(m.completed_at, new Date().toISOString().slice(0, 10));
+    assert.strictEqual(lastMessage(ccDir), 'workflow(caching): complete cross-cutting pipeline');
+    cleanupFixture(ccDir);
+  });
 });
 
 describe('engine workunit cancel', () => {
@@ -663,6 +704,24 @@ describe('engine workunit reactivate', () => {
     assert.match(res.warnings[1], /knowledge index \(discovery\/sessions\/session-001\.md\)/);
     assert.match(res.warnings[2], /knowledge index \(discovery\/sessions\/session-002\.md\)/);
     cleanupFixture(epicDir);
+  });
+
+  it('refuses a completed unit whose pipeline is finished — nothing remains to continue', () => {
+    const ccDir = setupFinishedCrossCuttingFixture();
+    engine(ccDir, ['workunit', 'complete', 'caching', '-m', 'workflow(caching): complete cross-cutting pipeline']);
+    const err = engineFails(ccDir, ['workunit', 'reactivate', 'caching']);
+    assert.match(err.error, /has a finished pipeline — reactivating would strand it with no next phase; use `workunit complete` instead/);
+    assert.strictEqual(readManifest(ccDir, 'caching').status, 'completed');
+    cleanupFixture(ccDir);
+  });
+
+  it('refuses a cancelled unit whose pipeline is finished, pointing at workunit complete', () => {
+    const ccDir = setupFinishedCrossCuttingFixture();
+    engine(ccDir, ['workunit', 'cancel', 'caching']);
+    const err = engineFails(ccDir, ['workunit', 'reactivate', 'caching']);
+    assert.match(err.error, /use `workunit complete` instead/);
+    assert.strictEqual(readManifest(ccDir, 'caching').status, 'cancelled');
+    cleanupFixture(ccDir);
   });
 
   it('rejects an in-progress unit and a status outside the shared vocabulary', () => {

--- a/tests/scripts/test-engine-workunit-projections.cjs
+++ b/tests/scripts/test-engine-workunit-projections.cjs
@@ -114,6 +114,25 @@ describe('workunit projections: status display', () => {
       '',
     ].join('\n'));
   });
+
+  it('cross-cutting: finalising unit renders all-completed rows and the finalise callout', () => {
+    createManifest(dir, 'caching', {
+      work_type: 'cross-cutting',
+      phases: {
+        discussion: { items: { caching: { status: 'completed' } } },
+        specification: { items: { caching: { status: 'completed' } } },
+      },
+    });
+    assert.strictEqual(workUnitStatus('cross-cutting', unitOf(dir, 'cross-cutting', 'caching')), [
+      ...boxOf('Caching'),
+      '  PIPELINE (cross-cutting)',
+      '  ├─ ✓ Discussion [completed]',
+      '  └─ ✓ Specification [completed]',
+      '',
+      '  ⚑ All phases complete — ready to finalise.',
+      '',
+    ].join('\n'));
+  });
 });
 
 describe('workunit projections: menu', () => {
@@ -221,6 +240,39 @@ describe('workunit projections: menu', () => {
     );
   });
 
+  it('feature: finalising unit gates on finalise, with every completed phase revisitable', () => {
+    createManifest(dir, 'auth-flow', {
+      phases: {
+        discussion: { items: { 'auth-flow': { status: 'completed' } } },
+        specification: { items: { 'auth-flow': { status: 'completed' } } },
+        planning: { items: { 'auth-flow': { status: 'completed' } } },
+        implementation: { items: { 'auth-flow': { status: 'completed' } } },
+        review: { items: { 'auth-flow': { status: 'completed' } } },
+      },
+    });
+    const menu = workUnitMenu('feature', unitOf(dir, 'feature', 'auth-flow'));
+    assert.strictEqual(menu.rendered, [
+      '· · · · · · · · · · · ·',
+      'Finalising "Auth Flow" — pipeline complete.',
+      '',
+      '- **`y`/`yes`** — Mark the work unit completed',
+      '- **`r`/`revisit`** — Revisit an earlier phase',
+      '· · · · · · · · · · · ·',
+    ].join('\n'));
+    assert.deepStrictEqual(
+      menu.keys.map((k) => [k.key, k.action, k.phase || null, k.route]),
+      [
+        ['y', 'finalise', null, null],
+        ['r', 'revisit', null, null],
+        ['1', 'revisit_phase', 'discussion', '/workflow-discussion-entry feature auth-flow'],
+        ['2', 'revisit_phase', 'specification', '/workflow-specification-entry feature auth-flow'],
+        ['3', 'revisit_phase', 'planning', '/workflow-planning-entry feature auth-flow'],
+        ['4', 'revisit_phase', 'implementation', '/workflow-implementation-entry feature auth-flow'],
+        ['5', 'revisit_phase', 'review', '/workflow-review-entry feature auth-flow'],
+      ]
+    );
+  });
+
   it('cross-cutting: numbers one revisit_phase entry per completed phase in pipeline order', () => {
     createManifest(dir, 'caching', {
       work_type: 'cross-cutting',
@@ -270,6 +322,7 @@ describe('workunit projections: data body', () => {
       'work_type: feature',
       'next_phase: specification',
       'phase_label: specification (in-progress)',
+      'finalising: false',
       'completed_phases: discussion',
       'revisit_available: true',
       'seeds_count: 1',
@@ -290,10 +343,39 @@ describe('workunit projections: data body', () => {
       'work_type: bugfix',
       'next_phase: investigation',
       'phase_label: ready for investigation',
+      'finalising: false',
       'completed_phases: (none)',
       'revisit_available: false',
       'ACTIONS (key  action  topic  → route):',
       '  y  continue  login-crash  → /workflow-investigation-entry bugfix login-crash',
+    ].join('\n'));
+  });
+
+  it('quick-fix: finalising unit flags true and the finalise entry is internal', () => {
+    createManifest(dir, 'hotfix-logs', {
+      work_type: 'quick-fix',
+      phases: {
+        scoping: { items: { 'hotfix-logs': { status: 'completed' } } },
+        implementation: { items: { 'hotfix-logs': { status: 'completed' } } },
+        review: { items: { 'hotfix-logs': { status: 'completed' } } },
+      },
+    });
+    const unit = unitOf(dir, 'quick-fix', 'hotfix-logs');
+    const menu = workUnitMenu('quick-fix', unit);
+    assert.strictEqual(workUnitData('quick-fix', unit, menu), [
+      'work_unit: hotfix-logs',
+      'work_type: quick-fix',
+      'next_phase: done',
+      'phase_label: pipeline complete',
+      'finalising: true',
+      'completed_phases: scoping, implementation, review',
+      'revisit_available: true',
+      'ACTIONS (key  action  topic  → route):',
+      '  y  finalise  hotfix-logs  → (internal)',
+      '  r  revisit  hotfix-logs  → (internal)',
+      '  1  revisit_phase  hotfix-logs  → /workflow-scoping-entry quick-fix hotfix-logs',
+      '  2  revisit_phase  hotfix-logs  → /workflow-implementation-entry quick-fix hotfix-logs',
+      '  3  revisit_phase  hotfix-logs  → /workflow-review-entry quick-fix hotfix-logs',
     ].join('\n'));
   });
 });

--- a/tests/scripts/test-gateway-for-start.cjs
+++ b/tests/scripts/test-gateway-for-start.cjs
@@ -52,7 +52,7 @@ describe('workflow-start discovery', () => {
     assert.strictEqual(r.bugfixes.work_units[0].phase_label, 'investigation (in-progress)');
   });
 
-  it('filters out done work units', () => {
+  it('surfaces a finished pipeline still in-progress as finalising work', () => {
     createManifest(dir, 'done-feature', {
       work_type: 'feature',
       phases: {
@@ -64,8 +64,10 @@ describe('workflow-start discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.state.has_any_work, false);
-    assert.strictEqual(r.features.count, 0);
+    assert.strictEqual(r.state.has_any_work, true);
+    assert.strictEqual(r.features.count, 1);
+    assert.strictEqual(r.features.work_units[0].next_phase, 'done');
+    assert.strictEqual(r.features.work_units[0].finalising, true);
   });
 
   it('epic stays active when one topic completes review with others mid-pipeline', () => {
@@ -148,7 +150,7 @@ describe('workflow-start discovery', () => {
     assert.strictEqual(r.bugfixes.work_units[0].phase_label, 'ready for specification');
   });
 
-  it('mixed active and done in same type only shows active', () => {
+  it('mixed active and finalising in same type lists both', () => {
     createManifest(dir, 'active-feat', {
       work_type: 'feature',
       phases: { discussion: { items: { 'active-feat': { status: 'in-progress' } } } },
@@ -164,11 +166,14 @@ describe('workflow-start discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.features.count, 1);
-    assert.strictEqual(r.features.work_units[0].name, 'active-feat');
+    assert.strictEqual(r.features.count, 2);
+    assert.deepStrictEqual(r.features.work_units.map((u) => [u.name, u.finalising]), [
+      ['active-feat', false],
+      ['done-feat', true],
+    ]);
   });
 
-  it('has_any_work is false when only completed and done exist', () => {
+  it('has_any_work counts a finalising unit — only closed units leave it false', () => {
     createManifest(dir, 'archived', { work_type: 'feature', status: 'completed' });
     createManifest(dir, 'done', {
       work_type: 'bugfix',
@@ -181,7 +186,8 @@ describe('workflow-start discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.state.has_any_work, false);
+    assert.strictEqual(r.state.has_any_work, true);
+    assert.strictEqual(r.bugfixes.work_units[0].finalising, true);
   });
 
   it('groups quick-fix work units separately', () => {
@@ -203,7 +209,7 @@ describe('workflow-start discovery', () => {
     assert.strictEqual(r.quick_fixes.work_units[0].phase_label, 'scoping (in-progress)');
   });
 
-  it('quick-fix done is excluded from active', () => {
+  it('quick-fix done is surfaced as finalising', () => {
     createManifest(dir, 'done-qf', {
       work_type: 'quick-fix',
       phases: {
@@ -213,7 +219,8 @@ describe('workflow-start discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.quick_fixes.count, 0);
+    assert.strictEqual(r.quick_fixes.count, 1);
+    assert.strictEqual(r.quick_fixes.work_units[0].finalising, true);
   });
 
   it('discovers inbox quickfixes', () => {
@@ -252,7 +259,7 @@ describe('workflow-start discovery', () => {
     assert.strictEqual(r.cross_cutting.work_units[0].phase_label, 'discussion (in-progress)');
   });
 
-  it('cross-cutting done is excluded from active', () => {
+  it('cross-cutting done is surfaced as finalising', () => {
     createManifest(dir, 'done-cc', {
       work_type: 'cross-cutting',
       phases: {
@@ -261,7 +268,8 @@ describe('workflow-start discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.cross_cutting.count, 0);
+    assert.strictEqual(r.cross_cutting.count, 1);
+    assert.strictEqual(r.cross_cutting.work_units[0].finalising, true);
   });
 
   it('cross-cutting completed shows in completed array', () => {

--- a/tests/scripts/test-gateway-for-workflow-continue-bugfix.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-bugfix.cjs
@@ -34,7 +34,7 @@ describe('workflow-continue-bugfix discovery', () => {
     assert.strictEqual(r.count, 1);
   });
 
-  it('excludes done bugfixes', () => {
+  it('surfaces a finished pipeline still in-progress as finalising', () => {
     createManifest(dir, 'done', {
       work_type: 'bugfix',
       phases: {
@@ -46,7 +46,10 @@ describe('workflow-continue-bugfix discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.count, 0);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.bugfixes[0].next_phase, 'done');
+    assert.strictEqual(r.bugfixes[0].finalising, true);
+    assert.ok(format(r).includes('  done: finalising — pipeline complete\n'));
   });
 
   it('includes completed_phases', () => {

--- a/tests/scripts/test-gateway-for-workflow-continue-cross-cutting.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-cross-cutting.cjs
@@ -37,7 +37,7 @@ describe('workflow-continue-cross-cutting discovery', () => {
     assert.strictEqual(r.cross_cutting[0].name, 'caching');
   });
 
-  it('excludes done cross-cutting concerns', () => {
+  it('surfaces a finished pipeline still in-progress as finalising', () => {
     createManifest(dir, 'done-cc', {
       work_type: 'cross-cutting',
       phases: {
@@ -46,7 +46,10 @@ describe('workflow-continue-cross-cutting discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.count, 0);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.cross_cutting[0].next_phase, 'done');
+    assert.strictEqual(r.cross_cutting[0].finalising, true);
+    assert.ok(format(r).includes('  done-cc: finalising — pipeline complete\n'));
   });
 
   it('includes phase_label and completed_phases', () => {

--- a/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
@@ -1681,3 +1681,110 @@ describe('workflow-continue-epic detail counts (imports/seeds)', () => {
     assert.strictEqual(d.seeds_count, 0);
   });
 });
+
+describe('workflow-continue-epic CLI dispatch', () => {
+  const path = require('path');
+  const { spawnSync } = require('child_process');
+  const GATEWAY = path.join(__dirname, '../../skills/workflow-continue-epic/scripts/gateway.cjs');
+  const USAGE = 'Usage: gateway.cjs | gateway.cjs {work_unit} | gateway.cjs view {work_unit} [new_arrivals_json] | gateway.cjs (completed-menu|cancel-menu|reactivate-menu) {work_unit}\n';
+
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  function epicFixture() {
+    createManifest(dir, 'v1', {
+      work_type: 'epic',
+      phases: { discussion: { items: { auth: { status: 'in-progress' } } } },
+    });
+  }
+
+  /** @param {string[]} args */
+  function run(args) {
+    return spawnSync('node', [GATEWAY, ...args], { cwd: dir, encoding: 'utf8' });
+  }
+
+  it('bare call still renders the index byte-identically', () => {
+    epicFixture();
+    const res = run([]);
+    assert.strictEqual(res.status, 0);
+    assert.strictEqual(res.stderr, '');
+    assert.strictEqual(res.stdout, format(discover(dir)));
+  });
+
+  it('bare positional still renders the scoped dump byte-identically', () => {
+    epicFixture();
+    const res = run(['v1']);
+    assert.strictEqual(res.status, 0);
+    assert.strictEqual(res.stderr, '');
+    assert.strictEqual(res.stdout, formatScoped('v1', discover(dir, 'v1')));
+  });
+
+  it('bare positional for an unknown epic keeps the in-band error dump', () => {
+    const res = run(['ghost']);
+    assert.strictEqual(res.status, 0);
+    assert.strictEqual(res.stdout, '=== EPIC: ghost ===\nerror: no active epic with this name\n');
+  });
+
+  it('view {work_unit} still answers the sectioned snapshot, with and without new arrivals', () => {
+    epicFixture();
+    for (const args of [['view', 'v1'], ['view', 'v1', '{"research_analysis":[],"gap_analysis":[]}']]) {
+      const res = run(args);
+      assert.strictEqual(res.status, 0, res.stderr);
+      assert.ok(res.stdout.includes('=== DATA'));
+      assert.ok(res.stdout.includes('=== DISPLAY'));
+      assert.ok(res.stdout.includes('=== MENU'));
+    }
+  });
+
+  it('view without a work unit errors instead of rendering the first epic', () => {
+    epicFixture();
+    const res = run(['view']);
+    assert.strictEqual(res.status, 1);
+    assert.strictEqual(res.stdout, '');
+    assert.strictEqual(res.stderr, 'gateway: view takes a work unit and an optional new-arrivals JSON\n' + USAGE);
+  });
+
+  it('view with excess positionals errors with usage', () => {
+    epicFixture();
+    const res = run(['view', 'v1', '{}', 'extra']);
+    assert.strictEqual(res.status, 1);
+    assert.strictEqual(res.stdout, '');
+    assert.strictEqual(res.stderr, 'gateway: view takes a work unit and an optional new-arrivals JSON\n' + USAGE);
+  });
+
+  it('each sub-view verb errors without its work unit instead of rendering the first epic', () => {
+    epicFixture();
+    for (const verb of ['completed-menu', 'cancel-menu', 'reactivate-menu']) {
+      const res = run([verb]);
+      assert.strictEqual(res.status, 1, verb);
+      assert.strictEqual(res.stdout, '', verb);
+      assert.strictEqual(res.stderr, `gateway: ${verb} takes exactly one work unit\n` + USAGE, verb);
+    }
+  });
+
+  it('each sub-view verb errors on excess positionals', () => {
+    epicFixture();
+    for (const verb of ['completed-menu', 'cancel-menu', 'reactivate-menu']) {
+      const res = run([verb, 'v1', 'extra']);
+      assert.strictEqual(res.status, 1, verb);
+      assert.strictEqual(res.stdout, '', verb);
+      assert.strictEqual(res.stderr, `gateway: ${verb} takes exactly one work unit\n` + USAGE, verb);
+    }
+  });
+
+  it('an unknown verb with arguments errors instead of falling to the scoped dump', () => {
+    epicFixture();
+    const res = run(['veiw', 'v1']);
+    assert.strictEqual(res.status, 1);
+    assert.strictEqual(res.stdout, '');
+    assert.strictEqual(res.stderr, 'gateway: unknown verb "veiw"\n' + USAGE);
+  });
+
+  it('index with excess positionals errors with usage', () => {
+    const res = run(['index', 'extra']);
+    assert.strictEqual(res.status, 1);
+    assert.strictEqual(res.stdout, '');
+    assert.strictEqual(res.stderr, 'gateway: index takes no arguments\n' + USAGE);
+  });
+});

--- a/tests/scripts/test-gateway-for-workflow-continue-feature.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-feature.cjs
@@ -36,7 +36,7 @@ describe('workflow-continue-feature discovery', () => {
     assert.strictEqual(r.features[0].name, 'auth');
   });
 
-  it('excludes done features', () => {
+  it('surfaces a finished pipeline still in-progress as finalising', () => {
     createManifest(dir, 'done', {
       work_type: 'feature',
       phases: {
@@ -48,7 +48,10 @@ describe('workflow-continue-feature discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.count, 0);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.features[0].next_phase, 'done');
+    assert.strictEqual(r.features[0].finalising, true);
+    assert.ok(format(r).includes('  done: finalising — pipeline complete\n'));
   });
 
   it('includes phase_label and completed_phases', () => {

--- a/tests/scripts/test-gateway-for-workflow-continue-quickfix.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-quickfix.cjs
@@ -34,7 +34,7 @@ describe('workflow-continue-quickfix discovery', () => {
     assert.strictEqual(r.count, 1);
   });
 
-  it('excludes done quick-fixes', () => {
+  it('surfaces a finished pipeline still in-progress as finalising', () => {
     createManifest(dir, 'done', {
       work_type: 'quick-fix',
       phases: {
@@ -44,7 +44,10 @@ describe('workflow-continue-quickfix discovery', () => {
       },
     });
     const r = discover(dir);
-    assert.strictEqual(r.count, 0);
+    assert.strictEqual(r.count, 1);
+    assert.strictEqual(r.quick_fixes[0].next_phase, 'done');
+    assert.strictEqual(r.quick_fixes[0].finalising, true);
+    assert.ok(format(r).includes('  done: finalising — pipeline complete\n'));
   });
 
   it('includes completed_phases', () => {

--- a/tests/scripts/test-reads-derivations.cjs
+++ b/tests/scripts/test-reads-derivations.cjs
@@ -980,49 +980,49 @@ describe('reads + derivations', () => {
       createManifest(dir, 'alpha', { phases: {} });
       const m = loadManifest(dir, 'alpha');
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'fresh', tier: '○', current_phase: null });
+      assert.deepStrictEqual(r, { lifecycle: 'fresh', tier: '○', current_phase: null, research_state: null });
     });
 
     it('returns researching when research item is in-progress', () => {
       const m = loadWithPhases('auth', { research: 'in-progress' });
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'researching', tier: '◐', current_phase: 'research' });
+      assert.deepStrictEqual(r, { lifecycle: 'researching', tier: '◐', current_phase: 'research', research_state: 'in-progress' });
     });
 
     it('returns ready_for_discussion when research is completed and no discussion item yet', () => {
       const m = loadWithPhases('auth', { research: 'completed' });
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'ready_for_discussion', tier: '→', current_phase: 'research' });
+      assert.deepStrictEqual(r, { lifecycle: 'ready_for_discussion', tier: '→', current_phase: 'research', research_state: 'completed' });
     });
 
     it('returns discussing when discussion item is in-progress', () => {
       const m = loadWithPhases('auth', { discussion: 'in-progress' });
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'discussing', tier: '◐', current_phase: 'discussion' });
+      assert.deepStrictEqual(r, { lifecycle: 'discussing', tier: '◐', current_phase: 'discussion', research_state: null });
     });
 
     it('returns decided when discussion item is completed', () => {
       const m = loadWithPhases('auth', { discussion: 'completed' });
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'decided', tier: '✓', current_phase: 'discussion' });
+      assert.deepStrictEqual(r, { lifecycle: 'decided', tier: '✓', current_phase: 'discussion', research_state: null });
     });
 
     it('returns cancelled only when BOTH research and discussion items are cancelled', () => {
       const m = loadWithPhases('auth', { research: 'cancelled', discussion: 'cancelled' });
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'cancelled', tier: '⊘', current_phase: null });
+      assert.deepStrictEqual(r, { lifecycle: 'cancelled', tier: '⊘', current_phase: null, research_state: 'cancelled' });
     });
 
     it('falls through to fresh when only research is cancelled (discussion path still open)', () => {
       const m = loadWithPhases('auth', { research: 'cancelled' });
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'fresh', tier: '○', current_phase: null });
+      assert.deepStrictEqual(r, { lifecycle: 'fresh', tier: '○', current_phase: null, research_state: 'cancelled' });
     });
 
     it('falls through to fresh when only discussion is cancelled (research path still open)', () => {
       const m = loadWithPhases('auth', { discussion: 'cancelled' });
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'fresh', tier: '○', current_phase: null });
+      assert.deepStrictEqual(r, { lifecycle: 'fresh', tier: '○', current_phase: null, research_state: null });
     });
 
     it('renders ready_for_discussion when research is superseded and no discussion exists', () => {
@@ -1032,7 +1032,7 @@ describe('reads + derivations', () => {
       // remains open and the lifecycle should reflect that.
       const m = loadWithPhases('auth', { research: 'superseded' });
       const r = computeTopicLifecycle(m, 'auth');
-      assert.deepStrictEqual(r, { lifecycle: 'ready_for_discussion', tier: '→', current_phase: 'research' });
+      assert.deepStrictEqual(r, { lifecycle: 'ready_for_discussion', tier: '→', current_phase: 'research', research_state: 'superseded' });
     });
 
     it('discussion status wins over research status — decided overrides ready_for_discussion', () => {
@@ -1061,7 +1061,7 @@ describe('reads + derivations', () => {
     it('handled marker beats ready_for_discussion (research completed, no discussion)', () => {
       const m = loadWithHandled('umbrella', true, { research: 'completed' });
       const r = computeTopicLifecycle(m, 'umbrella');
-      assert.deepStrictEqual(r, { lifecycle: 'handled', tier: '⊙', current_phase: null });
+      assert.deepStrictEqual(r, { lifecycle: 'handled', tier: '⊙', current_phase: null, research_state: 'completed' });
     });
 
     it('handled marker beats decided (same-named discussion completed)', () => {
@@ -1099,6 +1099,18 @@ describe('reads + derivations', () => {
       const m = loadManifest(dir, 'alpha');
       assert.strictEqual(computeTopicLifecycle(m, 'umbrella').lifecycle, 'handled');
       assert.strictEqual(computeTopicLifecycle(m, 'sibling').lifecycle, 'ready_for_discussion');
+    });
+
+    it('handled without a research item reports research_state null', () => {
+      const m = loadWithHandled('umbrella', true, {});
+      const r = computeTopicLifecycle(m, 'umbrella');
+      assert.deepStrictEqual(r, { lifecycle: 'handled', tier: '⊙', current_phase: null, research_state: null });
+    });
+
+    it('handled with superseded research reports the superseded state', () => {
+      const m = loadWithHandled('umbrella', true, { research: 'superseded' });
+      const r = computeTopicLifecycle(m, 'umbrella');
+      assert.deepStrictEqual(r, { lifecycle: 'handled', tier: '⊙', current_phase: null, research_state: 'superseded' });
     });
   });
 


### PR DESCRIPTION
Certification fix 4 of 6 — the ruled engine changes.

- **Orphan window surfaced**: units with a finished pipeline but no `workunit complete` (the crash window between the last topic complete and pipeline completion) are no longer filtered from every surface — they list as *finalising* with a `finalise` action that runs the type's documented completion. `workunit reactivate` refuses terminal units with a finished pipeline (reactivating stranded them invisibly). Companion fix: `workunit complete` now accepts a *cancelled* unit whose pipeline is finished (the refusal message pointed there — previously a deadlock), re-indexing what cancellation removed. Epics can't enter the window (`computeNextPhase` never derives `done` for them).
- **Provenance-tag honesty**: lifecycle tags derive from actual per-phase state — superseded research renders `research superseded`, never `research complete`; `[handled]` claims a research fan-out only when research exists.
- **continue-epic adapter hardened** to match its four siblings (it silently rendered the first epic on bare `view`); legal forms byte-identical, everything else a usage error.
- Implementation menu label uses `current_task` (was printing completed-count as position); singular/plural on spec-entry counts; completed-specs display gains its body; `topic reopen` joins the usage banner.

+35 node tests (1291): finalising goldens across three types, tag-honesty goldens, 9-case epic CLI dispatch suite, terminal-reactivate refusals, complete-from-cancelled transaction. Byte-pins re-pinned deliberately, never loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #383
8. #384
9. #385
10. #386
11. #387
12. #388
13. #389
14. #399
15. #400
16. #401
17. #402
18. #403
19. #404
20. #405
21. #406
22. #407
23. #408
24. #409
25. #411
26. #412
27. #413
28. #414
29. #415
30. #416
31. #417
32. #418
33. #419
34. #420
35. #421
36. #422
37. #423
38. #424
39. #425
40. #426
41. #427
42. #428
43. #429
44. #430
45. #431
46. #432
47. #433
48. #434
49. #435
50. #442
51. #443
52. #444
53. **#445** 👈 current
54. #446
55. #447
56. #448
57. #449
58. #450
59. #451
<!-- stack:links:end -->