### PR TITLE
cert: prose sweep — ten small holes closed

### DIFF
--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -70,7 +70,7 @@ Then frame the opener:
 You can open a fresh thread — a new area of the work you want
 to sketch out — and we'll explore it the same way we did first
 time, then synthesise topics at the end. Or you can name changes
-to existing items: add, remove, rename, re-route, edit summary,
+to existing items: remove, rename, re-route, edit summary,
 edit description, mark handled. Both in one go is fine.
 
 Say "show map" anytime to pull the map back up.

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -150,6 +150,14 @@ Then the discovery session log. Single-phase work has exactly one, at a fixed pa
 
 Seed the discussion from the `description` and that **Exploration**. Do not re-ask; live conversation context, when present, supplements the carrier.
 
+Then, when `source` is `topic-provided`, read the research item statuses:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get '{work_unit}.research.*' status
+```
+
+When any item is `completed`, list the research files via `ls .workflows/{work_unit}/research/*.md` and set `source = "topic-provided-with-research"` so the handoff carries them.
+
 → Proceed to **Step 4**.
 
 **Otherwise:**

--- a/skills/workflow-discussion-entry/references/validate-phase.md
+++ b/skills/workflow-discussion-entry/references/validate-phase.md
@@ -12,6 +12,12 @@ Use `engine manifest` to check discussion phase state:
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic}
 ```
 
+#### If output is empty (discussion doesn't exist — fresh start)
+
+Nothing to validate — `source` keeps the value set in Step 1.
+
+→ Return to caller.
+
 #### If discussion exists and status is `in-progress`
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -28,7 +28,10 @@ Complete the phase item:
 node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} implementation {topic}
 ```
 
-Commit: `impl({work_unit}): complete implementation`
+Commit:
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): complete implementation"
+```
 
 **Pipeline continuation**:
 

--- a/skills/workflow-planning-entry/references/validate-phase.md
+++ b/skills/workflow-planning-entry/references/validate-phase.md
@@ -19,13 +19,21 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 Any additional context since the specification was completed?
 
 - **`c`/`continue`** — Continue with the specification as-is
-- Or provide additional context (priorities, constraints, new considerations)
+- **Add context** — Tell me the priorities, constraints, or new considerations
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-Set source="fresh".
+**If `continue`:**
+
+Set source="fresh" with no additional context.
+
+→ Return to caller.
+
+**If add context:**
+
+Store the user's response as the additional context for the handoff. Set source="fresh".
 
 → Return to caller.
 

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -276,7 +276,7 @@ Approve this task?
 - **`y`/`yes`** — Approve this task
 - **`a`/`auto`** — Approve this and all remaining tasks automatically
 - **`s`/`skip`** — Skip this task
-- **Comment** — Revise based on feedback
+- **Comment** — Tell me what to change
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-scoping-process/references/complexity-check.md
+++ b/skills/workflow-scoping-process/references/complexity-check.md
@@ -53,16 +53,17 @@ How would you like to proceed?
 
 #### If `feature`
 
-Update the work type in the manifest:
+Update the work type in the work-unit manifest and the project registry:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit} work_type feature
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.work_units.{work_unit}.work_type feature
 ```
 
-Commit:
+Commit both manifests:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "workflow({work_unit}): promote quick-fix to feature"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "workflow({work_unit}): promote quick-fix to feature"
 ```
 
 Invoke `/workflow-discussion-entry feature {work_unit}`.
@@ -71,16 +72,17 @@ Invoke `/workflow-discussion-entry feature {work_unit}`.
 
 #### If `bugfix`
 
-Update the work type in the manifest:
+Update the work type in the work-unit manifest and the project registry:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit} work_type bugfix
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.work_units.{work_unit}.work_type bugfix
 ```
 
-Commit:
+Commit both manifests:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "workflow({work_unit}): promote quick-fix to bugfix"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "workflow({work_unit}): promote quick-fix to bugfix"
 ```
 
 Invoke `/workflow-investigation-entry bugfix {work_unit}`.

--- a/skills/workflow-shared/references/analysis-approval-gate.md
+++ b/skills/workflow-shared/references/analysis-approval-gate.md
@@ -208,7 +208,7 @@ handled — fanned out, keep on the map but stop prompting to discuss it?
 **If `yes`:**
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.discovery.{parent} handled true
+node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map handle {work_unit} {parent}
 ```
 
 Set `fanout_offer: marked` on every block sharing this `parent`.

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -6,6 +6,8 @@
 
 No active work found. Offer to start something new, with option to view completed/cancelled work if any exist.
 
+## A. Display and Menu
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -48,11 +50,17 @@ Select an option:
 
 **STOP.** Wait for user response.
 
+→ Proceed to **B. Handle Selection**.
+
+---
+
+## B. Handle Selection
+
 #### If user chose `i`/`inbox`
 
-→ Load **[start-from-inbox.md](start-from-inbox.md)** and follow its instructions as written.
+Load **[start-from-inbox.md](start-from-inbox.md)** and follow its instructions as written.
 
-→ Return to caller.
+→ Return to **A. Display and Menu**.
 
 #### If user chose a start-new option (`s`, `f`, `e`, `b`, `q`, or `c`)
 
@@ -62,7 +70,7 @@ Set the work-type pre-seed from the pick — `s` → `none`, otherwise the match
 
 #### If user chose `v`/`view`
 
-→ Load **[view-completed.md](view-completed.md)** and follow its instructions as written.
+Load **[view-completed.md](view-completed.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 

--- a/skills/workflow-start/references/knowledge-gate.md
+++ b/skills/workflow-start/references/knowledge-gate.md
@@ -253,9 +253,19 @@ Ready to retry?
 
 #### If `done`
 
-Re-run the setup command that routed here and handle its result exactly as that branch prescribes (including routing back here if the key is still unresolvable).
+Re-run the setup command whose key failure routed here and handle its result exactly as its branch prescribes — including routing back to this section if the key is still unresolvable. Skip the originating branch's menus and questions; its values are already collected.
 
-→ Return to **B. Use Existing Configuration** when routed from **B**; otherwise → Return to **C. Choose a Mode**.
+**If routed from B's `yes` branch:**
+
+→ Return to **B. Use Existing Configuration** for the `yes` branch's setup command.
+
+**If routed from C's `openai` branch:**
+
+→ Return to **C. Choose a Mode** for the `openai` branch's setup command.
+
+**If routed from C's `compatible` branch:**
+
+→ Return to **C. Choose a Mode** for the `compatible` branch's setup command.
 
 #### If `keyword`
 


### PR DESCRIPTION
Certification fix 5 of 6. Discussion-entry's missing not-exists branch; session-loop's phantom 'add' promise dropped; conclude-implementation's commit gains its mechanism; the last raw handled-marker write re-pointed onto discovery-map handle; knowledge-gate D restructured to per-branch routing; the Comment prompt description directs the user, not Claude; planning-entry's third-kind menu option formalised; empty-state's inbox branch re-renders instead of dangling; quick-fix promotion also updates the project registry (with commit scope corrected to --workflows — {wu} scope wouldn't stage it); and the ruled carrier-bypass restoration: discussion-entry's carrier path now checks research status so completed research gets the read-in-full handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #383
8. #384
9. #385
10. #386
11. #387
12. #388
13. #389
14. #399
15. #400
16. #401
17. #402
18. #403
19. #404
20. #405
21. #406
22. #407
23. #408
24. #409
25. #411
26. #412
27. #413
28. #414
29. #415
30. #416
31. #417
32. #418
33. #419
34. #420
35. #421
36. #422
37. #423
38. #424
39. #425
40. #426
41. #427
42. #428
43. #429
44. #430
45. #431
46. #432
47. #433
48. #434
49. #435
50. #442
51. #443
52. #444
53. #445
54. **#446** 👈 current
55. #447
56. #448
57. #449
58. #450
59. #451
<!-- stack:links:end -->