### PR TITLE
r3: planning/spec logic — gates that gate, resumable truth

### DIFF
--- a/agents/workflow-review-task-verifier.md
+++ b/agents/workflow-review-task-verifier.md
@@ -20,6 +20,7 @@ You receive:
 6. **Work unit**: The work unit name (for path construction)
 7. **Topic**: The plan topic name (used for output directory)
 8. **Task suffix**: The `{phase_id}-{task_id}` portion of the internal ID (for output file naming, e.g., `1-1`)
+9. **Work type**: `quick-fix` tasks are deliberately authored without acceptance criteria — verify them by the quick-fix branches in Steps 3 and 4, never report the missing criteria as a finding
 
 ## Your Task
 
@@ -61,6 +62,11 @@ Search the codebase:
 - Does it align with the spec's expected behavior?
 - Any drift from what was planned?
 
+**For quick-fix work**: Instead of acceptance criteria, verify completeness against the task's Verification section:
+- Are all target files updated?
+- Do any occurrences of the old pattern remain in scope?
+- Were exclusions respected?
+
 ### Step 4: Verify Tests
 
 You assess tests by **reading** them — running tests is not your job; your only shell use is the output-file rename. Do not attempt to execute the suite.
@@ -71,6 +77,11 @@ Evaluate test coverage critically:
 - **Not under-tested**: Are edge cases from the spec covered?
 - **Not over-tested**: Are tests focused and necessary, or bloated with redundant checks?
 - Would the test fail if the feature broke?
+
+**For quick-fix work**: Instead of new test coverage, verify the existing suite still holds:
+- Do all previously passing tests still pass (judge by reading — did the change break any assertion)?
+- If tests were updated (e.g., to reference a new API), are the updates correct?
+- Do not flag the absence of new tests — mechanical changes are verified by test baselines, not new coverage.
 
 ### Step 5: Check Code Quality
 

--- a/skills/workflow-implementation-entry/references/check-dependencies.md
+++ b/skills/workflow-implementation-entry/references/check-dependencies.md
@@ -16,20 +16,22 @@ Evaluate each dependency and collect any that are blocking into a list:
 
 - **`state: satisfied_externally`** — skip, not blocking
 - **`state: unresolved`** — add to the blocking list
-- **`state: resolved`** — check the dependency topic's implementation status and completed tasks:
+- **`state: resolved`** — check the dependency topic's implementation status:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{dep_topic} status
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{dep_topic} completed_tasks
 ```
 
-**If status is `completed`, or `internal_id` is in the completed tasks list:**
+**If status is `completed`:**
 
 Skip, not blocking. A completed implementation satisfies the dependency even if the referenced task was skipped.
 
-**If status is not `completed` and `internal_id` is not in the list, or the implementation entry does not exist:**
+**If status is not `completed` or the implementation entry does not exist:**
 
-Add to the blocking list.
+Read the referenced task's status from the dependency's plan. Read the dep plan's `format` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{dep_topic} format`), load the format's **reading.md** (`../workflow-planning-process/references/output-formats/{format}/reading.md`), and look up the task by `internal_id` — resolving to its external ID via `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{dep_topic} task_map.{internal_id}` when the format needs one.
+
+- Task status is the format's completed status → skip, not blocking.
+- Any other status (open, in-progress, skipped/cancelled), or no plan or task found → add to the blocking list. A skipped or cancelled task does not satisfy a dependency while its implementation is still in progress.
 
 ---
 

--- a/skills/workflow-implementation-process/references/invoke-analysis.md
+++ b/skills/workflow-implementation-process/references/invoke-analysis.md
@@ -13,10 +13,10 @@ This step dispatches the three analysis agents in parallel to evaluate the compl
 Build the list of implementation files using git history:
 
 ```bash
-git log --oneline --name-only --pretty=format: --grep="impl({work_unit}):" | sort -u | grep -v '^$'
+git log --oneline --name-only --pretty=format: --grep="impl({work_unit}): T{topic}-" | sort -u | grep -v '^$'
 ```
 
-This captures all files touched by implementation commits for the topic.
+This captures all files touched by this topic's task commits (internal IDs embed the topic, so the `T{topic}-` prefix keeps sibling topics of a multi-topic epic out of scope).
 
 ---
 

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -31,7 +31,50 @@ Follow the format's **reading.md** instructions to determine the next available 
 
 #### If no available tasks remain
 
+"No available tasks" is not the same as "all tasks complete". Using the format's **reading.md**, list all tasks and check for tasks still open or in-progress — these are blocked: excluded from "next available" because a dependency was skipped, cancelled, or otherwise never reached the format's completed status.
+
+**If no open or in-progress tasks remain:**
+
 → Proceed to **I. All Tasks Complete**.
+
+**If open or in-progress tasks remain (blocked):**
+
+> *Output the next fenced block as a code block:*
+
+```
+No ready tasks remain, but {N} task(s) are still open — blocked:
+
+  {internal_id}: {Task Name}
+  └─ Blocked by {blocker_id} [{blocker status}]
+
+  ...
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+How would you like to proceed?
+
+- **`p`/`proceed`** — Continue with the first blocked task anyway (its blocker will not be completed)
+- **`s`/`skip`** — Skip the blocked tasks and conclude the loop
+- **`t`/`stop`** — Stop implementation entirely
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `proceed`:**
+
+Treat the first blocked task as the available task — continue with the *If a task is available* flow below.
+
+**If `skip`:**
+
+Take the first blocked task and → Proceed to **H. Update Progress and Commit** (mark task as skipped). Stage A re-detects any remaining blocked tasks on the loop back.
+
+**If `stop`:**
+
+→ Return to **[the skill](../SKILL.md)** for **Step 8**.
 
 #### If a task is available
 

--- a/skills/workflow-planning-entry/references/invoke-skill.md
+++ b/skills/workflow-planning-entry/references/invoke-skill.md
@@ -33,6 +33,7 @@ Work unit: {work_unit}
 
 Specification: .workflows/{work_unit}/specification/{topic}/specification.md
 Existing plan: .workflows/{work_unit}/planning/{topic}/planning.md
+Cross-cutting references: {list of applicable cross-cutting specs with brief summaries, or "none"}
 
 Invoke the workflow-planning-process skill.
 ```

--- a/skills/workflow-planning-entry/references/validate-spec.md
+++ b/skills/workflow-planning-entry/references/validate-spec.md
@@ -54,6 +54,35 @@ completes.
 
 **STOP.** Do not proceed — terminal condition.
 
+#### If specification exists and status is `superseded`
+
+> *Output the next fenced block as a code block:*
+
+```
+Specification Superseded
+
+The specification for "{topic:(titlecase)}" was consolidated into
+"{superseded_by:(titlecase)}".
+
+Plan the superseding specification instead.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+#### If specification exists and status is `promoted`
+
+> *Output the next fenced block as a code block:*
+
+```
+Specification Promoted
+
+"{topic:(titlecase)}" was promoted to the cross-cutting work unit
+"{promoted_to}". Cross-cutting specifications inform other plans —
+they are not planned directly.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
 #### If specification exists and status is `completed`
 
 → Return to caller.

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -140,6 +140,8 @@ Found existing plan for **{topic:(titlecase)}** (previously reached phase {N}, t
 
 #### If `continue`
 
+If spec-change-detection reported changes, carry them into the walkthrough: reconcile the changed spec content into the affected phases and tasks before concluding. The `spec_commit` baseline is re-stamped only at conclusion.
+
 → Proceed to **Step 2**.
 
 #### If `restart`

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -42,15 +42,49 @@ The agent writes all tasks to the task detail file and returns.
 
 ## C. Validate Task Detail File
 
-Read the task detail file and count tasks. Verify task count matches the task table in the planning file for this phase.
-
-#### If `mismatch`
-
-→ Return to **B. Invoke the Agent**.
+Read the task detail file and count tasks. Verify task count matches the task table in the planning file for this phase. Track the number of agent invocations for this phase in-conversation.
 
 #### If `valid`
 
 → Proceed to **D. Check Gate Mode**.
+
+#### If `mismatch` and fewer than 2 agent invocations have been made
+
+→ Return to **B. Invoke the Agent**.
+
+#### If `mismatch` after 2 agent invocations
+
+> *Output the next fenced block as a code block:*
+
+```
+Task count mismatch persists after 2 authoring attempts.
+
+Planning file task table: {N} tasks — {internal IDs from the table}
+Task detail file:         {M} tasks — {internal IDs found in the file}
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+How would you like to proceed?
+
+- **`r`/`retry`** — Re-invoke the author agent once more
+- **Adjust** — Tell me what to correct (the task table or the detail file), and I'll apply it and re-validate
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `retry`:**
+
+→ Return to **B. Invoke the Agent**.
+
+**If adjust:**
+
+Apply the user's correction.
+
+→ Return to **C. Validate Task Detail File**.
 
 ---
 
@@ -62,6 +96,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 ```
 
 #### If `author_gate_mode` is `auto`
+
+Set every `pending` task in the task detail file to `approved`.
 
 > *Output the next fenced block as a code block:*
 
@@ -127,7 +163,7 @@ Mark the task `approved` in the task detail file. Set all remaining `pending` ta
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} author_gate_mode auto
 ```
 
-→ Proceed to **G. Write to Plan**.
+→ Proceed to **F. Revision Check** (earlier `rejected` tasks still need revision before writing).
 
 **If the user provides feedback:**
 
@@ -145,6 +181,8 @@ Mark the task `rejected` in the task detail file and add the feedback as a block
 → Return to **E. Approval Loop**.
 
 **If the user navigates:**
+
+Authoring for this phase is **incomplete** — report that to the caller.
 
 → Return to caller.
 
@@ -176,7 +214,7 @@ Check for rejected tasks in the task detail file.
 
 ## G. Write to Plan
 
-> **CHECKPOINT**: If `author_gate_mode: gated`, verify all tasks in the task detail file are marked `approved` before writing.
+> **CHECKPOINT**: Verify all tasks in the task detail file are marked `approved` before writing — both gate modes approve every task before reaching this section.
 
 For each approved task in the task detail file, in order:
 
@@ -211,5 +249,7 @@ Task {M} of {total}: {Task Name} — authored.
 ```
 
 Repeat for each task.
+
+Authoring for this phase is **complete** — report that to the caller.
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -25,15 +25,19 @@ Ready to conclude?
 
 #### If `yes`
 
-1. **Mark the plan completed** — the engine sets the status:
+1. **Re-baseline `spec_commit`** — the plan now reflects the specification as of this point; stamp the baseline spec-change detection will diff against on any later resume:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} spec_commit $(git rev-parse HEAD)
+   ```
+2. **Mark the plan completed** — the engine sets the status:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} planning {topic}
    ```
-2. **Final commit** — Commit the completed plan:
+3. **Final commit** — Commit the completed plan:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): complete plan"
    ```
-3. **Present completion summary**:
+4. **Present completion summary**:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -45,7 +49,7 @@ The plan contains **{N} phases** with **{M} tasks** total, reviewed for traceabi
 Status has been marked as `completed`. The plan is ready for implementation.
 ```
 
-4. **Pipeline continuation**:
+5. **Pipeline continuation**:
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -128,7 +128,15 @@ Phase {N}: {Phase Name} — all tasks already authored.
 
 → Load **[author-tasks.md](author-tasks.md)** and follow its instructions as written.
 
+**If authoring reported complete** (every task written to the plan):
+
 → Proceed to **D. Advance Phase**.
+
+**If authoring reported incomplete** (the user navigated away):
+
+Do not advance the manifest position — the phase is unauthored and remains the leading edge.
+
+→ Return to **B. Process Current Phase** for the phase the user navigated to.
 
 ---
 

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -215,6 +215,8 @@ Run another review round?
 
 > **CHECKPOINT**: Do not confirm completion if any tracking files still show `status: in-progress`. They indicate incomplete review work.
 
+If any tracking file still shows `status: in-progress`, its findings were not fully processed — work them now per **[process-review-findings.md](process-review-findings.md)** for that tracking file, then re-verify.
+
 2. **Commit** all review tracking files:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): complete plan review (cycle {N})"

--- a/skills/workflow-planning-process/references/process-review-findings.md
+++ b/skills/workflow-planning-process/references/process-review-findings.md
@@ -6,7 +6,7 @@
 
 Process findings from a review agent interactively with the user. The agent writes findings — with full fix content — to a tracking file. Read the tracking file and present each finding for approval.
 
-**Review type**: `{review_type:[traceability|integrity]}` — set by the calling context (B or C in plan-review.md).
+**Review type**: `{review_type:[traceability|integrity]}` — set by the calling context (C or D in plan-review.md).
 
 **Commits in this file**: applying a finding writes through the format adapter, and the format's task storage may live outside the work unit. Commit with raw git — `git add -- .workflows/{work_unit} {format task storage paths}`, then `git commit` — never the scoped helper.
 
@@ -132,8 +132,13 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 #### If `finding_gate_mode: auto`
 
 1. Apply the fix to the plan (use **Proposed** content exactly as in tracking file)
-2. Update the tracking file: set resolution to "Fixed"
-3. Commit the tracking file and plan changes
+2. Keep `task_map` current — for `add-task`/`add-phase`, record each new internal ID → external ID mapping; for `remove-task`/`remove-phase`, delete each removed ID's entry:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{internal_id} {external_id}
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.planning.{topic} task_map.{internal_id}
+   ```
+3. Update the tracking file: set resolution to "Fixed"
+4. Commit the tracking file and plan changes
 
 > *Output the next fenced block as a code block:*
 
@@ -178,9 +183,10 @@ Incorporate feedback and update the tracking file with the revised content. Re-p
 #### If `approved`
 
 1. Apply the fix to the plan — use the **Proposed** content exactly as shown, using the output format adapter to determine how it's written. Do not modify content between approval and writing.
-2. Update the tracking file: set resolution to "Fixed", add any discussion notes.
-3. Commit the tracking file and any plan changes — ensures progress survives context refresh.
-4. > *Output the next fenced block as a code block:*
+2. Keep `task_map` current — for `add-task`/`add-phase`, record each new internal ID → external ID mapping; for `remove-task`/`remove-phase`, delete each removed ID's entry (same commands as the auto flow above).
+3. Update the tracking file: set resolution to "Fixed", add any discussion notes.
+4. Commit the tracking file and any plan changes — ensures progress survives context refresh.
+5. > *Output the next fenced block as a code block:*
 
    ```
    Finding {N} of {total}: {Brief Title} — fixed.
@@ -190,7 +196,7 @@ Incorporate feedback and update the tracking file with the revised content. Re-p
 
 #### If `auto`
 
-1. Apply the fix (same as "If approved" above)
+1. Apply the fix and the `task_map` upkeep (same as "If approved" steps 1–2 above)
 2. Update the tracking file: set resolution to "Fixed"
 3. Update `finding_gate_mode` in the manifest:
    ```bash

--- a/skills/workflow-planning-process/references/session-setup.md
+++ b/skills/workflow-planning-process/references/session-setup.md
@@ -15,9 +15,7 @@
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} author_gate_mode gated
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} finding_gate_mode gated
    ```
-4. Update `spec_commit` to current HEAD:
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} spec_commit $(git rev-parse HEAD)
-   ```
+
+Never touch `spec_commit` here — it is the baseline spec-change detection diffs against, stamped at plan initialization and re-stamped only when the plan concludes.
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/spec-change-detection.md
+++ b/skills/workflow-planning-process/references/spec-change-detection.md
@@ -6,7 +6,7 @@
 
 When resuming planning, check whether the specification or cross-cutting specifications have changed since planning started.
 
-The manifest stores `spec_commit` — the git commit hash captured when planning began. This allows diffing any input file against that point in time.
+The manifest stores `spec_commit` — the git commit hash of the spec baseline the plan last reconciled against, stamped at plan initialization and re-stamped when the plan concludes. This allows diffing any input file against that point in time.
 
 ## Detection
 
@@ -33,5 +33,7 @@ Summarise the extent of changes:
 - **What files changed** (specification, cross-cutting specs, or both)
 - **Whether any cross-cutting specs are new** (didn't exist at the stored commit)
 - **Nature of changes** — formatting/cosmetic, minor additions/removals, or substantial restructuring
+
+These changes are unreconciled: fold them into the affected phases and tasks during the session. The baseline is re-stamped only when the plan concludes, so unreconciled changes keep being reported here.
 
 → Return to caller.

--- a/skills/workflow-review-entry/references/invoke-skill.md
+++ b/skills/workflow-review-entry/references/invoke-skill.md
@@ -16,9 +16,12 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 ```
 Review session
 Work unit: {work_unit}
+Topic: {topic}
+Scope: single
 
 Plans to review:
   - work_unit: {work_unit}
+    topic: {topic}
     format: {format}
     specification: .workflows/{work_unit}/specification/{topic}/specification.md (exists: {true|false})
 

--- a/skills/workflow-review-process/references/invoke-review-synthesizer.md
+++ b/skills/workflow-review-process/references/invoke-review-synthesizer.md
@@ -10,10 +10,10 @@ This step dispatches a `workflow-review-findings-synthesizer` agent to read revi
 
 ## Determine Cycle Number
 
-Count existing `review-tasks-c*.md` files in `.workflows/{work_unit}/implementation/{topic}/` and add 1.
+Count existing `review-report-c*.md` files in `.workflows/{work_unit}/implementation/{topic}/` and add 1. The report is written every cycle — staging files are only written when tasks are proposed, so counting them would reuse a cycle number after a `clean` cycle.
 
 ```bash
-ls .workflows/{work_unit}/implementation/{topic}/review-tasks-c*.md 2>/dev/null | wc -l
+ls .workflows/{work_unit}/implementation/{topic}/review-report-c*.md 2>/dev/null | wc -l
 ```
 
 ---

--- a/skills/workflow-review-process/references/invoke-task-verifiers.md
+++ b/skills/workflow-review-process/references/invoke-task-verifiers.md
@@ -13,10 +13,10 @@ This step dispatches `workflow-review-task-verifier` agents in batches to verify
 Build the list of implementation files using git history. For each plan in scope:
 
 ```bash
-git log --oneline --name-only --pretty=format: --grep="impl({work_unit}):" | sort -u | grep -v '^$'
+git log --oneline --name-only --pretty=format: --grep="impl({work_unit}): T{topic}-" | sort -u | grep -v '^$'
 ```
 
-This captures all files touched by implementation commits for the topic.
+This captures all files touched by that plan topic's task commits (internal IDs embed the topic, so the `T{topic}-` prefix keeps sibling topics of a multi-topic epic out of scope).
 
 → Proceed to **B. Extract All Tasks**.
 
@@ -24,10 +24,16 @@ This captures all files touched by implementation commits for the topic.
 
 ## B. Extract All Tasks
 
+Read the work type:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
+```
+
 Using the format reading adapter loaded in Step 2, extract every task across all phases from each plan in scope:
 - Note each task's description
-- Note each task's acceptance criteria
-- Note expected micro acceptance (test name)
+- Note each task's acceptance criteria — quick-fix tasks carry a **Verification** section instead of acceptance criteria; note that
+- Note expected micro acceptance (test name) — absent for quick-fix tasks
 - Note each task's **internal ID** (format: `{topic}-{phase_id}-{task_id}`) — derive the **task suffix** by stripping the topic prefix (e.g., `auth-flow-1-1` → `1-1`)
 
 → Proceed to **C. Filter Tasks**.
@@ -85,6 +91,7 @@ Each verifier receives:
 6. **Work unit** — the work unit name (for path construction)
 7. **Topic** — the plan topic name (used for output directory)
 8. **Task suffix** — the `{phase_id}-{task_id}` portion of the internal ID (for output file naming, e.g., `1-1`)
+9. **Work type** — from the manifest (`quick-fix` switches the verifier to completeness-based criteria)
 
 If any verifier fails (error, timeout), record the failure and continue — aggregate what's available.
 

--- a/skills/workflow-review-process/references/review-checklist.md
+++ b/skills/workflow-review-process/references/review-checklist.md
@@ -46,6 +46,22 @@ Review as a senior architect would:
 - **Security**: No obvious vulnerabilities (injection, exposure, etc.)
 - **Performance**: No obvious inefficiencies (N+1 queries, unnecessary loops, etc.)
 
+## Quick-Fix Variant
+
+Quick-fix tasks are deliberately authored without acceptance criteria or micro acceptance — never flag their absence. Substitute:
+
+**Implementation** — verify completeness against the task's Verification section:
+- Are all target files updated?
+- Do any occurrences of the old pattern remain in scope?
+- Were exclusions respected?
+
+**Test adequacy** — verify the existing suite still holds instead of new coverage:
+- Do all previously passing tests still pass?
+- If tests were updated (e.g., to reference a new API), are the updates correct?
+- Do not expect new tests — mechanical changes are verified by test baselines.
+
+Code quality criteria apply unchanged.
+
 ## Plan Completion Check
 
 After task-level verification, check overall plan completion:

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -80,13 +80,14 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} planning {topic}
 ```
 
-Register the task_map entries. For each task, map internal_id to external_id:
+Register the task_map entries. Map the phase's internal ID (`{topic}-1`) to its external ID, then each task's internal_id to external_id:
 
 ```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{topic}-1 {phase_external_id}
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{internal_id} {external_id}
 ```
 
-Both the plan-level `external_id` and per-task external IDs are determined by the format's authoring instructions (see the Plan Structure and Task Storage sections).
+The plan-level `external_id`, the phase external ID, and per-task external IDs are all determined by the format's authoring instructions (see the Plan Structure, Phase Structure, and Task Storage sections).
 
 ## D. Mark Scoping Complete
 

--- a/skills/workflow-specification-entry/references/validate-phase.md
+++ b/skills/workflow-specification-entry/references/validate-phase.md
@@ -51,3 +51,29 @@ Reopening specification: {work_unit:(titlecase)}
 Set verb = "Continuing".
 
 → Return to caller.
+
+#### If the status is `superseded`
+
+> *Output the next fenced block as a code block:*
+
+```
+Specification Superseded
+
+The specification for "{topic:(titlecase)}" was consolidated into
+"{superseded_by:(titlecase)}". Work on that specification instead.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+#### If the status is `promoted`
+
+> *Output the next fenced block as a code block:*
+
+```
+Specification Promoted
+
+"{topic:(titlecase)}" was promoted to the cross-cutting work unit
+"{promoted_to}". Continue it from that work unit.
+```
+
+**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-entry/scripts/gateway.cjs
+++ b/skills/workflow-specification-entry/scripts/gateway.cjs
@@ -105,7 +105,7 @@ function discover(cwd, workUnit) {
 
       if (item.sources && typeof item.sources === 'object') {
         spec.sources = Object.entries(item.sources).map(([srcName, srcData]) => {
-          const srcStatus = (typeof srcData === 'object') ? (srcData.status || 'incorporated') : 'incorporated';
+          const srcStatus = (typeof srcData === 'object') ? (srcData.status || 'pending') : 'pending';
           const match = discItemsList.find(i => i.name === srcName);
           const discStatus = match ? (match.status || 'unknown') : 'unknown';
           return { name: srcName, status: srcStatus, discussion_status: discStatus };

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -6,7 +6,7 @@
 
 Process findings from a review phase interactively with the user. The analysis phase writes findings to a tracking file. Read the tracking file and present each finding for approval.
 
-**Review type**: `{review_type:[Input Review|Gap Analysis]}` — set by the calling context (B or C in spec-review.md).
+**Review type**: `{review_type:[Input Review|Gap Analysis]}` — set by the calling context (C or D in spec-review.md).
 
 Check if the tracking file exists at the expected path.
 

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -82,6 +82,16 @@ If any tracking file still shows `status: in-progress`, mark it complete now.
 
 > **CHECKPOINT**: Do not proceed to sign-off if any tracking files still show `status: in-progress`. They indicate incomplete review work.
 
+Also confirm every source is incorporated:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic} sources
+```
+
+If any show `status: pending`, work them now per **[spec-construction.md](spec-construction.md)** → Exhaustive Extraction — extract the source's relevant content into the specification through the construction cycle, then mark it `incorporated`.
+
+> **CHECKPOINT**: Do not proceed to sign-off while any source is `pending`. Its material has not been extracted into the specification.
+
 Also confirm every consult reference is addressed:
 
 ```bash

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -30,7 +30,7 @@ Commit the updated manifest.
 
 #### If `review_cycle` is already set
 
-Increment `review_cycle` by 1 via `engine manifest` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} review_cycle {N}`).
+Increment `review_cycle` by 1 via `engine manifest` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} review_cycle {N+1}`).
 
 Record the current cycle number — used for tracking file naming (`c{N}`).
 
@@ -96,9 +96,11 @@ Dispatch the `workflow-specification-review-input` agent via the Task tool:
   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic} sources
   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
   ```
-  Sources returns an object keyed by source name (e.g., `{"auth-design": {"status": "incorporated"}}`). For each source name, construct the source file path based on work type:
-  - Bugfix: `.workflows/{work_unit}/investigation/{source-name}.md`
-  - Otherwise: `.workflows/{work_unit}/discussion/{source-name}.md`
+  Sources returns an object keyed by source name (e.g., `{"auth-design": {"status": "incorporated"}}`). Resolve each source name to its artifact — sources can be incorporated specifications or research files, not only discussions:
+  - If a specification item named `{source-name}` exists in the manifest (an incorporated source spec): `.workflows/{work_unit}/specification/{source-name}/specification.md`
+  - Else if `.workflows/{work_unit}/research/{source-name}.md` exists: that research file
+  - Else, when work type is `bugfix`: `.workflows/{work_unit}/investigation/{source-name}.md`
+  - Else: `.workflows/{work_unit}/discussion/{source-name}.md`
 
   Pass all resolved paths to the agent.
 - **Topic name**: the current topic
@@ -226,6 +228,8 @@ Run another review cycle?
 1. **Verify tracking files are marked complete** — All input review and gap analysis tracking files across all cycles must have `status: complete`.
 
 > **CHECKPOINT**: Do not confirm completion if any tracking files still show `status: in-progress`. They indicate incomplete review work.
+
+If any tracking file still shows `status: in-progress`, its findings were not fully processed — work them now per **[process-review-findings.md](process-review-findings.md)** for that tracking file, then re-verify.
 
 2. **Commit** all review tracking files:
 

--- a/tests/scripts/test-gateway-for-specification.cjs
+++ b/tests/scripts/test-gateway-for-specification.cjs
@@ -294,6 +294,29 @@ describe('workflow-specification-entry discovery', () => {
     assert.strictEqual(commit.status, 'addressed');
   });
 
+  it('defaults source status to pending when object-shaped without status', () => {
+    createManifest(dir, 'auth', {
+      work_type: 'feature',
+      phases: {
+        discussion: { items: { auth: { status: 'completed' } } },
+        specification: {
+          items: {
+            auth: {
+              status: 'completed',
+              sources: { auth: {}, design: 'not-an-object' },
+            },
+          },
+        },
+      },
+    });
+    createFile(dir, '.workflows/auth/specification/auth/specification.md', '# Spec');
+    const r = discover(dir);
+    const spec = r.specifications[0];
+    assert.strictEqual(spec.sources.find(s => s.name === 'auth').status, 'pending');
+    assert.strictEqual(spec.sources.find(s => s.name === 'design').status, 'pending');
+    assert.strictEqual(spec.has_pending_sources, true);
+  });
+
   it('defaults consult reference status to pending when object-shaped without status', () => {
     createManifest(dir, 'mint', {
       work_type: 'epic',


### PR DESCRIPTION
Round-3 hunt fixes, wave 2 of 4 (13 items, zero skips).

The spec sources `incorporated` gate is now operationalised before completion (it was listed after `topic complete` had already run); `spec_commit` re-baselines only at conclusion with reconciliation on resume; auto-mode task authoring approves-then-authors (it previously wrote zero tasks); the count-mismatch retry — the tree's only autonomous agent re-invoke loop — is capped at two with a diagnostic STOP; review fixes maintain task_map; dependency satisfaction reads the dep task's real status via its format adapter (skipped ≠ done); the task loop distinguishes blocked-open from all-complete; the review verifier gains the quick-fix carve-outs the implementation reviewer already had; analysis/verification scope is topic-scoped. Plus the eight-LOW cluster (terminal-status branches, remediation routes, handoff completeness, a conservative gateway default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #442
2. #443
3. #444
4. #445
5. #446
6. #447
7. #383
8. #384
9. #385
10. #386
11. #387
12. #388
13. #389
14. #399
15. #400
16. #401
17. #402
18. #403
19. #404
20. #405
21. #406
22. #407
23. #408
24. #409
25. #411
26. #412
27. #413
28. #414
29. #415
30. #416
31. #417
32. #418
33. #419
34. #420
35. #421
36. #422
37. #423
38. #424
39. #425
40. #426
41. #427
42. #428
43. #429
44. #430
45. #431
46. #432
47. #433
48. #434
49. #435
50. #452
51. #453
52. #454
53. #455
54. #456
55. #457
56. #448
57. **#449** 👈 current
58. #450
59. #451
60. #458
61. #459
62. #460
63. #461
64. #462
65. #463
66. #464
67. #465
68. #466
69. #467
70. #468
71. #469
72. #470
73. #471
74. #472
75. #473
76. #474
77. #475
78. #476
79. #477
80. #478
<!-- stack:links:end -->