### PR TITLE
r3: agent briefs and format adapters — executable contracts

### DIFF
--- a/.claude/skills/create-output-format/SKILL.md
+++ b/.claude/skills/create-output-format/SKILL.md
@@ -72,20 +72,30 @@ For each file:
 
 ## Step 5: Register the Format
 
-Add an entry to `skills/workflow-planning-process/references/output-formats.md` following the existing pattern:
+`skills/workflow-planning-process/references/output-formats.md` renders a numbered selection menu. Register the new format with three edits, using the next available number `{N}`:
 
-```markdown
-### {Format Name}
-format: `{format-key}`
+1. **Listing** — append an entry to the "Available output formats" code block:
 
-adapter: [{format-key}/](output-formats/{format-key}/)
+   ```
+   {N}. {Format Name}
+      {One-line description.}
+      {Requirements — external tools/accounts, or "No external tools required."}
+      Best for: {ideal use cases}
+   ```
 
-{One-line description of the format.}
+2. **Menu** — append an option to the selection menu block:
 
-- **Pros**: ...
-- **Cons**: ...
-- **Best for**: ...
-```
+   ```
+   - **`{N}`** — {Format Name}
+   ```
+
+3. **Branch** — append a routing branch after the existing `#### If` branches:
+
+   ```markdown
+   #### If `{N}`
+
+   Set `chosen-format` = `{format-key}`.
+   ```
 
 ## Step 6: Validate
 
@@ -97,6 +107,6 @@ Verify:
 - [ ] Authoring.md documents task properties: status, phase grouping, labels (NOT priority or dependencies)
 - [ ] Authoring.md includes a complete task creation example
 - [ ] Reading.md explains next-task ordering using status, priority, dependencies, and phase
-- [ ] Updating.md covers all status transitions and how to modify task properties
+- [ ] Updating.md covers all status transitions, how to modify task properties, and phase completion
 - [ ] Graph.md covers priority levels and adding/removing dependencies
 - [ ] Format is registered in output-formats.md

--- a/.claude/skills/create-output-format/references/contract.md
+++ b/.claude/skills/create-output-format/references/contract.md
@@ -58,8 +58,9 @@ Instructions for modifying tasks.
 
 Must include:
 
-- **Status Transitions** — how to change task status. Document all supported statuses (e.g., complete, skipped, cancelled) and how to set each one.
+- **Status Transitions** — how to change task status. Document all supported statuses (e.g., complete, skipped, cancelled, in progress) and how to set each one.
 - **Updating Task Content** — how to modify a task's title, description, or other properties after creation.
+- **Phase Completion** — what to do when all tasks in a phase are complete or skipped. Formats with no phase entity (or with automatic cascading) declare an explicit no-op — consumers follow this section at every phase boundary.
 
 ### graph.md
 

--- a/.claude/skills/create-output-format/references/scaffolding/about.md
+++ b/.claude/skills/create-output-format/references/scaffolding/about.md
@@ -2,6 +2,8 @@
 
 <!-- Replace {Format Name} with the display name of this format -->
 
+*Output format adapter for **[workflow-planning-process](../../../SKILL.md)***
+
 ---
 
 <!-- One-line description of when to use this format -->

--- a/.claude/skills/create-output-format/references/scaffolding/updating.md
+++ b/.claude/skills/create-output-format/references/scaffolding/updating.md
@@ -11,6 +11,7 @@
 | Complete | {How to mark a task as done} |
 | Skipped | {How to mark a task as skipped} |
 | Cancelled | {How to mark a task as cancelled, or "Not supported — use skipped."} |
+| In Progress | {How to mark a task as in progress} |
 
 ## Updating Task Content
 
@@ -22,3 +23,9 @@ To update a task's properties:
 - **Description**: {how to change it}
 - **Priority**: {how to change it, or "Not supported."}
 - **Labels/tags**: {how to change them}
+
+## Phase Completion
+
+<!-- What to do when all tasks in a phase are complete/skipped. If the format has no phase entity or cascades automatically, say so explicitly — consumers follow this section at every phase boundary -->
+
+{How to mark the phase entity complete, or an explicit no-op with the reason}

--- a/agents/workflow-discussion-synthesis.md
+++ b/agents/workflow-discussion-synthesis.md
@@ -90,7 +90,7 @@ announced: false
 
 ### T1: Framing alignment _(only if restatements diverged significantly)_
 
-{What divergence the framing check found. Which perspective is answering a different question, and what the actual decision might be. Omit this entire section if restatements aligned and renumber.}
+{What divergence the framing check found. Which perspective is answering a different question, and what the actual decision might be. Omit this entire section if restatements aligned — the first tradeoff then starts at T1.}
 
 ### T1: {label} _(or T2 if Framing alignment is present)_
 

--- a/agents/workflow-implementation-analysis-task-writer.md
+++ b/agents/workflow-implementation-analysis-task-writer.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-implementation-analysis-task-writer
 description: Creates plan tasks from approved analysis findings. Reads the staging file, extracts approved tasks, and creates them in the plan using the format's authoring adapter. Invoked by workflow-implementation-process skill after user approves analysis tasks.
-tools: Read, Write, Edit, Glob, Grep, Bash
+tools: Read, Write, Edit, Glob, Grep, Bash, mcp__linear__list_issues, mcp__linear__get_issue, mcp__linear__create_issue, mcp__linear__create_issue_label
 model: opus
 ---
 
@@ -39,9 +39,9 @@ When creating any new `.md` file with the Write tool, write it to the same path 
 
 Append the new phase and task table to the planning file (path provided in inputs):
 
-- Phase heading: `### Phase {N}: {phase_label}`
+- Phase heading: `### Phase {N}: {phase_label}`, followed by `status: approved` and `approved_at: YYYY-MM-DD` (today's date) — the staging-file gate already approved these tasks
 - Phase goal: `Address findings from {phase_label}.`
-- Task table with Internal ID, Name, and Edge Cases columns
+- Task table under a `#### Tasks` heading with `status: approved`, columns Internal ID, Name, and Edge Cases
 - Internal IDs must match the IDs used in the created task files
 
 ## Update task_map

--- a/agents/workflow-implementation-task-executor.md
+++ b/agents/workflow-implementation-task-executor.md
@@ -74,12 +74,12 @@ Return a structured completion report:
 ```
 STATUS: complete | blocked | failed
 TASK: {task name}
-SUMMARY: {what was done}
-FILES_CHANGED: {list of files created/modified}
-TESTS_WRITTEN: {list of test files/methods}
-TEST_RESULTS: {all passing | failures — details}
-ISSUES: {any concerns, blockers, or deviations discovered}
+SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
+TEST_RESULTS: {all passing | failures — details only if failures}
+ISSUES: {blockers or deviations — omit if none}
 ```
 
 - If STATUS is `blocked` or `failed`, ISSUES **must** explain why and what decision is needed.
 - If STATUS is `complete`, all acceptance criteria must be met and all tests passing.
+
+Keep the report minimal. "All passing" is sufficient for TEST_RESULTS when nothing failed. ISSUES can be omitted entirely on a clean run.

--- a/agents/workflow-planning-dependency-grapher.md
+++ b/agents/workflow-planning-dependency-grapher.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-planning-dependency-grapher
 description: Analyzes authored tasks to establish internal dependencies and priorities. Invoked by workflow-planning-process skill after plan construction.
-tools: Read, Glob, Grep, Edit
+tools: Read, Glob, Grep, Edit, Bash, mcp__linear__list_issues, mcp__linear__get_issue, mcp__linear__update_issue, mcp__linear__create_issue_relation
 model: opus
 ---
 
@@ -16,6 +16,8 @@ You receive file paths via the orchestrator's prompt:
 1. **Planning file path** — The planning file with phases and task tables
 2. **reading.md** — The output format's reading reference (how to list and read tasks)
 3. **graph.md** — The output format's graph reference (priority + dependency CRUD instructions)
+4. **Plan external ID** — the plan-level identifier in the output format (the manifest's `external_id`)
+5. **Task map** — internal ID → external ID mapping for phases and tasks (the manifest's `task_map`)
 
 On **re-invocation after feedback**, you also receive:
 - **Previous output** — Your prior dependency/priority analysis
@@ -26,13 +28,13 @@ On **re-invocation after feedback**, you also receive:
 1. Read `reading.md` — understand how to list and read tasks for this format
 2. Read `graph.md` — understand how to record priorities and dependencies for this format
 3. Read the planning file — understand phase structure and task tables
-4. List all authored task files using the method described in reading.md
+4. List all authored tasks using the method described in reading.md, addressing the plan by its external ID and resolving internal IDs through the task map
 5. **Clear existing graph data** — using graph.md's removal instructions, remove all existing dependencies and priorities from every task. This ensures a clean slate on every invocation (first run, re-invocation after feedback, or `continue` of a previous session).
 6. Read every authored task file — absorb each task's Problem, Solution, Do steps, and Acceptance Criteria
 7. Analyze dependencies — follow the methodology in "Detecting Dependencies" below
 8. Assign priorities — follow the methodology in "Assigning Priorities" below
 9. Detect cycles — verify the dependency graph is acyclic (see "Cycle Detection" below)
-10. If no cycles: **apply all changes** — follow graph.md instructions to record dependencies and priorities on each task
+10. If no cycles: **apply all changes** — follow graph.md instructions to record dependencies and priorities on each task, resolving each internal ID to its external ID via the task map
 11. If cycles detected: **do not apply any changes** — report the cycle chain and stop
 
 If this is a **re-invocation after feedback**: read your previous output and the user's feedback, then revise accordingly. Step 5 (clearing) ensures previous analysis doesn't bias the new run.

--- a/agents/workflow-planning-review-integrity.md
+++ b/agents/workflow-planning-review-integrity.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-planning-review-integrity
 description: Reviews plan structural quality, implementation readiness, and standards adherence. Invoked by workflow-planning-process skill during plan review.
-tools: Read, Glob, Grep, Write, Bash
+tools: Read, Glob, Grep, Write, Bash, mcp__linear__list_issues, mcp__linear__get_issue
 model: opus
 ---
 

--- a/agents/workflow-planning-review-traceability.md
+++ b/agents/workflow-planning-review-traceability.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-planning-review-traceability
 description: Analyzes plan traceability against specification in both directions. Invoked by workflow-planning-process skill during plan review.
-tools: Read, Glob, Grep, Write, Bash
+tools: Read, Glob, Grep, Write, Bash, mcp__linear__list_issues, mcp__linear__get_issue
 model: opus
 ---
 

--- a/agents/workflow-review-task-verifier.md
+++ b/agents/workflow-review-task-verifier.md
@@ -16,7 +16,7 @@ You receive:
 2. **Specification path**: For loading context about this task's feature/requirement
 3. **Plan path**: The full plan for additional context
 4. **Project skill paths**: Relevant `.claude/skills/` paths for framework conventions
-5. **Review checklist path**: Path to the review checklist (`skills/workflow-review-process/references/review-checklist.md`) — read this for detailed verification criteria
+5. **Review checklist path**: Path to the review checklist (`.claude/skills/workflow-review-process/references/review-checklist.md`) — read this for detailed verification criteria
 6. **Work unit**: The work unit name (for path construction)
 7. **Topic**: The plan topic name (used for output directory)
 8. **Task suffix**: The `{phase_id}-{task_id}` portion of the internal ID (for output file naming, e.g., `1-1`)

--- a/agents/workflow-specification-review-gap-analysis.md
+++ b/agents/workflow-specification-review-gap-analysis.md
@@ -13,10 +13,11 @@ You are reviewing a specification as a standalone document — looking *inward* 
 
 You receive via the orchestrator's prompt:
 
-1. **Specification path** — the specification file to review
-2. **Topic name** — the specification topic
-3. **Cycle number** — which review cycle this is (used in output file naming)
-4. **Review tracking format path** — the tracking file format reference
+1. **Work unit** — the work unit name (for output path construction)
+2. **Specification path** — the specification file to review
+3. **Topic name** — the specification topic
+4. **Cycle number** — which review cycle this is (used in output file naming)
+5. **Review tracking format path** — the tracking file format reference
 
 No source material — this phase looks inward only.
 
@@ -115,6 +116,7 @@ topic: {Topic Name}
 
 **Source**: Specification analysis
 **Category**: Enhancement to existing topic | New topic | Gap/Ambiguity
+**Priority**: Critical | Important | Minor
 **Affects**: {which section(s) of the specification}
 
 **Details**:

--- a/agents/workflow-specification-review-input.md
+++ b/agents/workflow-specification-review-input.md
@@ -7,17 +7,18 @@ model: opus
 
 # Specification Review: Input Review
 
-You are comparing a specification against its source material to catch anything that was missed during synthesis. Discussions, research notes, and reference documents contain details that may not have made it into the specification — your job is to find them.
+You are comparing a specification against its source material to catch anything that was missed during synthesis. The source documents contain details that may not have made it into the specification — your job is to find them.
 
 ## Your Input
 
 You receive via the orchestrator's prompt:
 
-1. **Specification path** — the specification file to review
-2. **Source material paths** — all source documents (discussions, research, references)
-3. **Topic name** — the specification topic
-4. **Cycle number** — which review cycle this is (used in output file naming)
-5. **Review tracking format path** — the tracking file format reference
+1. **Work unit** — the work unit name (for output path construction)
+2. **Specification path** — the specification file to review
+3. **Source material paths** — the spec's source documents, resolved to file paths by the orchestrator
+4. **Topic name** — the specification topic
+5. **Cycle number** — which review cycle this is (used in output file naming)
+6. **Review tracking format path** — the tracking file format reference
 
 ## Your Focus
 

--- a/skills/workflow-discussion-process/references/perspective-agents.md
+++ b/skills/workflow-discussion-process/references/perspective-agents.md
@@ -84,7 +84,7 @@ Each perspective agent receives:
 1. **Lens** — the assigned lens from the polarity pair (e.g., `Formal Systems`, `Tail-Risk`)
 2. **Decision topic** — the decision being explored
 3. **Discussion file path** — `.workflows/{work_unit}/discussion/{topic}.md`
-4. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/perspective-{NNN}-{lens}.md`
+4. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/perspective-{NNN}-{lens:(kebabcase)}.md`
 5. **Frontmatter** — the frontmatter block to write:
    ```yaml
    ---

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -146,12 +146,13 @@ If spec-change-detection reported changes, carry them into the walkthrough: reco
 
 #### If `restart`
 
-1. Read the `format` from the manifest:
+1. Read the `format` and the plan's `external_id` from the manifest:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
    ```
 2. Load the format's **[authoring.md](references/output-formats/{format}/authoring.md)**
-3. Follow the authoring file's cleanup instructions to remove authored tasks for this topic
+3. Follow the authoring file's cleanup instructions to remove authored tasks for this topic — the cleanup targets the entity identified by `external_id`
 4. Delete all planning files: `rm -rf .workflows/{work_unit}/planning/{topic}/`
 5. Delete the planning manifest entry:
    ```bash

--- a/skills/workflow-planning-process/references/analyze-task-graph.md
+++ b/skills/workflow-planning-process/references/analyze-task-graph.md
@@ -17,18 +17,22 @@ All tasks are authored. Now I'll analyze internal dependencies and
 priorities across the full plan.
 ```
 
-Read the `format` from the manifest:
+Read the `format`, the plan's `external_id`, and the `task_map` from the manifest:
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map
 ```
 
 Load the format's **[reading.md](output-formats/{format}/reading.md)** and **[graph.md](output-formats/{format}/graph.md)**.
 
-Invoke `workflow-planning-dependency-grapher` with these file paths:
+Invoke `workflow-planning-dependency-grapher` with these inputs:
 
 1. **Planning file path**: `.workflows/{work_unit}/planning/{topic}/planning.md`
 2. **reading.md**: the format's reading reference loaded above
 3. **graph.md**: the format's graph reference loaded above
+4. **Plan external ID**: the `external_id` value read above
+5. **Task map**: the `task_map` value read above
 
 The agent clears any existing dependencies/priorities, analyzes all tasks, and — if no cycles — applies the new graph data directly. It returns a structured summary of what was done.
 

--- a/skills/workflow-planning-process/references/output-formats/linear/about.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/about.md
@@ -20,7 +20,11 @@ Requires the Linear MCP server to be configured.
 
 Check if Linear MCP is available by looking for Linear tools. If not configured, inform the user that Linear MCP is required for this format.
 
-Ask the user: **Which team should own this project?**
+Ask the user: **Which team should own this project?** Resolve the team's ID via the Linear MCP (`list_teams`), then persist it as a project default so every later phase can reach it:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.defaults.linear_team_id {team_id}
+```
 
 ## Structure Mapping
 

--- a/skills/workflow-planning-process/references/output-formats/linear/authoring.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/authoring.md
@@ -2,6 +2,16 @@
 
 Uses the official Linear MCP server (`https://mcp.linear.app/mcp`). Tool names below reflect this server — verify available tools if using a different implementation.
 
+## Identifiers
+
+`{team_id}` is the project default `linear_team_id` (persisted during setup — see about.md); `{project_id}` is the plan's `external_id`; phase and task issue UUIDs are recorded in `task_map`:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defaults.linear_team_id
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map
+```
+
 ## Plan Structure
 
 Create a Linear project — this is the plan-level entity:

--- a/skills/workflow-planning-process/references/output-formats/linear/graph.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/graph.md
@@ -63,3 +63,5 @@ get_issue(issueId: "{issue_id}")
 ```
 
 Look for the relation in the issue's relations list, then remove it using the relation ID.
+
+> **Note**: The official Linear MCP server may not expose a relation-deletion tool. If none is available, ask the user to remove the relation in the Linear UI (issue → Relations), then confirm before proceeding.

--- a/skills/workflow-planning-process/references/output-formats/linear/reading.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/reading.md
@@ -1,5 +1,14 @@
 # Linear: Reading
 
+## Identifiers
+
+`{project_id}` is the plan's `external_id` in the manifest; phase and task issue UUIDs are recorded in `task_map` (internal ID → issue UUID):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map
+```
+
 ## Listing Tasks
 
 To retrieve all tasks for a plan:
@@ -28,8 +37,8 @@ To find the next task to implement:
 
 1. Query Linear MCP for project issues: `list_issues(projectId: "{project_id}")`
 2. Identify phase parent issues (those without a `parentId`) — order by phase number from their title
-3. Filter to sub-issues (tasks) whose state is not "completed" or "cancelled"
-4. Exclude tasks where any blocking issue has a state other than "completed"
+3. Filter to sub-issues (tasks) whose state is not "Done" or "Cancelled"
+4. Exclude tasks where any blocking issue has a state other than "Done"
 5. Process phases in order — complete all tasks in Phase 1 before Phase 2
 6. Within a phase, order by priority (Urgent > High > Medium > Low)
 7. The first match is the next task

--- a/skills/workflow-planning-process/references/output-formats/linear/updating.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/updating.md
@@ -15,10 +15,14 @@ Update the issue state in Linear via MCP:
 update_issue(issueId: "{id}", stateId: "{state_id}")
 ```
 
-To find available workflow states for a team:
+To find available workflow states for a team — `{team_id}` is the project default persisted during setup:
 
 ```
 list_issue_statuses(teamId: "{team_id}")
+```
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defaults.linear_team_id
 ```
 
 ## Updating Task Content
@@ -29,3 +33,11 @@ Update issue properties via MCP:
 - **Description**: `update_issue(issueId: "{id}", description: "{new description}")`
 - **Priority**: `update_issue(issueId: "{id}", priority: {level})`
 - **Labels**: `update_issue(issueId: "{id}", labelIds: ["{label_id}", ...])`
+
+## Phase Completion
+
+Phases are parent issues. When every sub-issue of a phase parent is in a "Done" or "Cancelled" state, set the phase parent issue's state to the team's "Done" workflow state:
+
+```
+update_issue(issueId: "{phase_issue_id}", stateId: "{done_state_id}")
+```

--- a/skills/workflow-planning-process/references/output-formats/local-markdown/graph.md
+++ b/skills/workflow-planning-process/references/output-formats/local-markdown/graph.md
@@ -28,15 +28,15 @@ Add the blocking task's ID to the `depends_on` field in the dependent task's fro
 
 ```yaml
 depends_on:
-  - {work_unit}-1-2
+  - {topic}-1-2
 ```
 
 A task can depend on multiple tasks:
 
 ```yaml
 depends_on:
-  - {work_unit}-1-2
-  - {work_unit}-1-3
+  - {topic}-1-2
+  - {topic}-1-3
 ```
 
 ### Removing a Dependency

--- a/skills/workflow-planning-process/references/output-formats/local-markdown/reading.md
+++ b/skills/workflow-planning-process/references/output-formats/local-markdown/reading.md
@@ -24,6 +24,6 @@ To find the next task to implement:
 2. Filter to tasks where `status` is `pending` or `in-progress` (or missing — treat as `pending`)
 3. If any tasks have `depends_on`, check each referenced task's `status` — exclude the task unless all dependencies have `status: completed`
 4. Order by phase number (from internal ID: `{topic}-{phase_id}-{task_id}`) — complete all earlier phases first
-5. Within a phase, order by `priority` if present (lower number = higher priority), then by task number
+5. Within a phase, order by `priority` (lower number = higher priority) — but treat `priority: 0` or a missing field as unset, sorting after all prioritised tasks — then by task number
 6. The first match is the next task
 7. If no incomplete tasks remain, all tasks are complete.

--- a/skills/workflow-planning-process/references/output-formats/local-markdown/updating.md
+++ b/skills/workflow-planning-process/references/output-formats/local-markdown/updating.md
@@ -20,3 +20,7 @@ Edit the task file directly:
 - **Priority**: Set or change the `priority:` field in frontmatter
 - **Tags**: Set or change the `tags:` field in frontmatter
 - **Dependencies**: See [graph.md](graph.md)
+
+## Phase Completion
+
+No action — phases have no entity in this format. Phase progress is derived from the task files' `status` fields; the internal ID encodes the phase.

--- a/skills/workflow-planning-process/references/output-formats/tick/authoring.md
+++ b/skills/workflow-planning-process/references/output-formats/tick/authoring.md
@@ -136,7 +136,7 @@ tick create "[NEEDS INFO] Rate limiting strategy" \
 
 ## Cleanup (Restart)
 
-Remove the topic task and all its descendants:
+Remove the topic task and all its descendants. `<topic-tick-id>` is the plan's `external_id` in the manifest:
 
 ```bash
 tick remove <topic-tick-id> --force

--- a/skills/workflow-planning-process/references/output-formats/tick/reading.md
+++ b/skills/workflow-planning-process/references/output-formats/tick/reading.md
@@ -1,5 +1,16 @@
 # Tick: Reading
 
+## Identifiers
+
+`<topic-tick-id>` is the plan's `external_id` in the manifest; phase and task tick IDs are recorded in `task_map` (internal ID → tick ID):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map
+```
+
+`tick list` output does not include refs — correlate internal IDs through `task_map`, or use `tick show <tick-id>` to see a single task's refs.
+
 ## Listing Tasks
 
 To retrieve all tasks for a topic:

--- a/skills/workflow-review-process/references/invoke-review-task-writer.md
+++ b/skills/workflow-review-process/references/invoke-review-task-writer.md
@@ -20,12 +20,13 @@ Read the `format` field from the manifest (`node .claude/skills/workflow-engine/
 
 Pass via the orchestrator's prompt:
 
-1. **Topic name** — the implementation topic (scopes tasks to correct plan)
-2. **Staging file path** — `.workflows/{work_unit}/implementation/{topic}/review-tasks-c{cycle-number}.md`
-3. **Planning file path** — `.workflows/{work_unit}/planning/{topic}/planning.md`
-4. **Plan format reading adapter path** — `../../workflow-planning-process/references/output-formats/{format}/reading.md`
-5. **Plan format authoring adapter path** — `../../workflow-planning-process/references/output-formats/{format}/authoring.md`
-6. **Phase label** — `Review Remediation (Cycle {N})`
+1. **Work unit** — the work unit name (for path construction)
+2. **Topic name** — the implementation topic (scopes tasks to correct plan)
+3. **Staging file path** — `.workflows/{work_unit}/implementation/{topic}/review-tasks-c{cycle-number}.md`
+4. **Planning file path** — `.workflows/{work_unit}/planning/{topic}/planning.md`
+5. **Plan format reading adapter path** — `../../workflow-planning-process/references/output-formats/{format}/reading.md`
+6. **Plan format authoring adapter path** — `../../workflow-planning-process/references/output-formats/{format}/authoring.md`
+7. **Phase label** — `Review Remediation (Cycle {N})`
 
 ---
 

--- a/skills/workflow-review-process/references/invoke-task-verifiers.md
+++ b/skills/workflow-review-process/references/invoke-task-verifiers.md
@@ -87,7 +87,7 @@ Each verifier receives:
 2. **Specification path** — from the manifest (if available)
 3. **Plan path** — the full plan for phase context
 4. **Project skill paths** — from Step 3 discovery
-5. **Review checklist path** — `skills/workflow-review-process/references/review-checklist.md`
+5. **Review checklist path** — `.claude/skills/workflow-review-process/references/review-checklist.md`
 6. **Work unit** — the work unit name (for path construction)
 7. **Topic** — the plan topic name (used for output directory)
 8. **Task suffix** — the `{phase_id}-{task_id}` portion of the internal ID (for output file naming, e.g., `1-1`)

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -129,10 +129,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit
 
 #### If `continue`
 
-Load the artifacts as session context: read the spec (`.workflows/{work_unit}/specification/{topic}/specification.md`) and the plan (`.workflows/{work_unit}/planning/{topic}/planning.md`) in full, then read the `format` from the manifest and locate and read the task files via the format's **[reading.md](../workflow-planning-process/references/output-formats/{format}/reading.md)**:
+Load the artifacts as session context: read the spec (`.workflows/{work_unit}/specification/{topic}/specification.md`) and the plan (`.workflows/{work_unit}/planning/{topic}/planning.md`) in full, then read the `format` and the plan's `external_id` from the manifest and locate and read the task files via the format's **[reading.md](../workflow-planning-process/references/output-formats/{format}/reading.md)**:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
 ```
 
 > *Output the next fenced block as a code block:*
@@ -165,12 +166,13 @@ Apply the requested edits — the spec and `planning.md` directly, task file con
 
 #### If `restart`
 
-1. Read the `format` from the manifest:
+1. Read the `format` and the plan's `external_id` from the manifest:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
    ```
 2. Load the format's **[authoring.md](../workflow-planning-process/references/output-formats/{format}/authoring.md)**
-3. Follow the authoring file's cleanup instructions to remove authored tasks for this topic
+3. Follow the authoring file's cleanup instructions to remove authored tasks for this topic — the cleanup targets the entity identified by `external_id`
 4. Delete the spec and plan files: `rm -rf .workflows/{work_unit}/specification/{topic}/ .workflows/{work_unit}/planning/{topic}/`
 5. Remove the spec's knowledge-base entry:
    ```bash

--- a/skills/workflow-scoping-process/references/select-format.md
+++ b/skills/workflow-scoping-process/references/select-format.md
@@ -47,4 +47,6 @@ Project default format is **{format}**. Use the same format?
 
 → Load **[../../workflow-planning-process/references/output-formats.md](../../workflow-planning-process/references/output-formats.md)** and follow its instructions as written.
 
+Load the chosen format's **[about.md](../../workflow-planning-process/references/output-formats/{chosen-format}/about.md)** and follow its Setup section — complete any prerequisites (installation, initialisation, MCP configuration) before tasks are written.
+
 → Return to caller.

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -35,7 +35,7 @@ If a second task is needed (e.g., separate pass for config files, test file upda
 
 ## B. Write Task Files
 
-Load the chosen format's **authoring.md** from `skills/workflow-planning-process/references/output-formats/{format}/authoring.md` and follow its task storage instructions.
+Load the chosen format's **[authoring.md](../../workflow-planning-process/references/output-formats/{format}/authoring.md)** and follow its task storage instructions.
 
 **Task content** — each task file includes:
 

--- a/skills/workflow-specification-process/references/review-tracking-format.md
+++ b/skills/workflow-specification-process/references/review-tracking-format.md
@@ -33,6 +33,7 @@ topic: [Topic Name]
 
 **Source**: [Where this came from — file/section reference, or "Specification analysis" for Gap Analysis]
 **Category**: Enhancement to existing topic | New topic | Gap/Ambiguity
+**Priority**: [Gap Analysis only — Critical | Important | Minor. Omit for Input Review.]
 **Affects**: [Which section(s) of the specification]
 
 **Details**:

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -90,6 +90,7 @@ You MUST NOT choose on the user's behalf.
 Dispatch the `workflow-specification-review-input` agent via the Task tool:
 
 - **Agent file**: `../../../agents/workflow-specification-review-input.md`
+- **Work unit**: the current work unit
 - **Specification path**: the specification file path
 - **Source material paths**: resolve source names to file paths. Read source names and work type from the manifest:
   ```bash
@@ -128,6 +129,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "sp
 Dispatch the `workflow-specification-review-gap-analysis` agent via the Task tool:
 
 - **Agent file**: `../../../agents/workflow-specification-review-gap-analysis.md`
+- **Work unit**: the current work unit
 - **Specification path**: the specification file path
 - **Topic name**: the current topic
 - **Cycle number**: the current cycle number


### PR DESCRIPTION
Round-3 hunt fixes, wave 3 of 4 (12 items + one same-class discretionary fix).

The two-witness HIGHs: the dependency-grapher gains Bash + the linear MCP read/write set (enumerated from the adapters; it could previously execute only one of three formats) and the task-writer/planning-reviewers gain linear's MCP tools; both dispatch sites now pass external_id/task_map. Contract seams closed: Work-unit input restored to the review-side task-writer dispatch, the verifier checklist path gets its runtime prefix, the gap-analysis Priority field exists where the display expected it, spec-review agents receive the work unit their output paths embed. Format adapters: external-id provenance documented with manifest reads, phase-completion sections in all three adapters, scoping loads about.md setup, the create-output-format registration step rewritten against the real menu structure, linear team_id persisted under project.defaults, and the LOW set (priority-0 guard, state names, examples, scaffolding gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #442
2. #443
3. #444
4. #445
5. #446
6. #447
7. #383
8. #384
9. #385
10. #386
11. #387
12. #388
13. #389
14. #399
15. #400
16. #401
17. #402
18. #403
19. #404
20. #405
21. #406
22. #407
23. #408
24. #409
25. #411
26. #412
27. #413
28. #414
29. #415
30. #416
31. #417
32. #418
33. #419
34. #420
35. #421
36. #422
37. #423
38. #424
39. #425
40. #426
41. #427
42. #428
43. #429
44. #430
45. #431
46. #432
47. #433
48. #434
49. #435
50. #452
51. #453
52. #454
53. #455
54. #456
55. #457
56. #448
57. #449
58. **#450** 👈 current
59. #451
60. #458
61. #459
62. #460
63. #461
64. #462
65. #463
66. #464
67. #465
68. #466
69. #467
70. #468
71. #469
72. #470
73. #471
74. #472
75. #473
76. #474
77. #475
78. #476
79. #477
80. #478
<!-- stack:links:end -->