### PR TITLE
r3: discovery and sessions — honest classification, visible agents

### DIFF
--- a/agents/workflow-discussion-perspective.md
+++ b/agents/workflow-discussion-perspective.md
@@ -18,8 +18,7 @@ You receive via the orchestrator's prompt:
 1. **Lens** — the analytical lens you are operating through (e.g., `Formal Systems`, `Ship Now`, `Tail-Risk`)
 2. **Decision topic** — the specific decision being explored
 3. **Discussion file path** — the discussion document for context on what's been discussed
-4. **Output file path** — where to write your analysis
-5. **Frontmatter** — the frontmatter block to use in the output file
+4. **Output file path** — where to write your analysis. A skeleton file with `status: in-flight` frontmatter is already on disk there; your rewrite replaces it
 
 ## Your Process
 
@@ -53,10 +52,10 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to the output file path provided — in two steps: write the content to the same path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Bash is for this rename only. Use this structure:
+Write to the output file path provided — in two steps: write the content to the same path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context, and the rename lands atomically over the dispatch-time skeleton. Bash is for this rename only. Reproduce the skeleton's frontmatter with `status` flipped to `pending` (results ready for the orchestrator). Use this structure:
 
 ```markdown
-{frontmatter provided by orchestrator}
+{skeleton frontmatter, with status: pending}
 
 # Perspective: {Lens}
 

--- a/agents/workflow-discussion-review.md
+++ b/agents/workflow-discussion-review.md
@@ -14,8 +14,7 @@ You are an independent reviewer assessing the quality and completeness of a tech
 You receive via the orchestrator's prompt:
 
 1. **Discussion file path** — the discussion document to review
-2. **Output file path** — where to write your analysis
-3. **Frontmatter** — the frontmatter block to use in the output file (includes type, status, set number, date)
+2. **Output file path** — where to write your analysis. A skeleton file with `status: in-flight` frontmatter is already on disk there; your rewrite replaces it
 
 ## Your Process
 
@@ -43,7 +42,7 @@ You receive via the orchestrator's prompt:
 
 Write to the output file path provided — in two steps: write the content to the same path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Bash is for this rename only.
 
-The orchestrator passes skeleton frontmatter (`type`, `status`, `created`, `set`, `surfaced: []`, `announced: false`). You must add a `findings:` list containing one entry per gap or question with its stable ID, kind, and a short label. The body mirrors the same IDs as section headings so the orchestrator can look up full content for any ID.
+The orchestrator wrote skeleton frontmatter at the output path when it dispatched you (`type`, `status: in-flight`, `created`, `set`, empty `findings:`, `surfaced: []`, `announced: false`). Your rewrite replaces the whole file — the `.txt`-then-rename lands atomically over the skeleton. Keep the skeleton's fields, set `status: pending` (results ready for the orchestrator), and populate `findings:` with one entry per gap or question — stable ID, kind, and a short label. The body mirrors the same IDs as section headings so the orchestrator can look up full content for any ID.
 
 ```markdown
 ---

--- a/agents/workflow-discussion-synthesis.md
+++ b/agents/workflow-discussion-synthesis.md
@@ -15,8 +15,7 @@ You receive via the orchestrator's prompt:
 
 1. **Perspective file paths** — paths to all perspective files to synthesize
 2. **Decision topic** — the decision being explored
-3. **Output file path** — where to write your synthesis
-4. **Frontmatter** — the frontmatter block to use in the output file
+3. **Output file path** — where to write your synthesis. A skeleton file with `status: in-flight` frontmatter is already on disk there; your rewrite replaces it
 
 ## Your Process
 
@@ -48,7 +47,7 @@ You receive via the orchestrator's prompt:
 
 Write to the output file path provided — in two steps: write the content to the same path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Bash is for this rename only.
 
-The orchestrator passes skeleton frontmatter (`type`, `status`, `created`, `set`, `decision`, `surfaced: []`, `announced: false`). You must add a `tensions:` list containing one entry per key tension with its stable ID and a short label. The body mirrors the same IDs as section headings under "Key Tensions" so the orchestrator can look up full content for any ID.
+The orchestrator wrote skeleton frontmatter at the output path when it dispatched you (`type`, `status: in-flight`, `created`, `set`, `decision`, empty `tensions:`, `surfaced: []`, `announced: false`). Your rewrite replaces the whole file — the `.txt`-then-rename lands atomically over the skeleton. Keep the skeleton's fields, set `status: pending` (results ready for the orchestrator), and populate `tensions:` with one entry per key tension — stable ID and a short label. The body mirrors the same IDs as section headings under "Key Tensions" so the orchestrator can look up full content for any ID.
 
 ```markdown
 ---

--- a/agents/workflow-investigation-synthesis.md
+++ b/agents/workflow-investigation-synthesis.md
@@ -14,8 +14,7 @@ You are an independent analyst validating a root cause hypothesis for a bug inve
 You receive via the orchestrator's prompt:
 
 1. **Investigation file path** — the investigation document containing symptoms, code analysis, and root cause hypothesis
-2. **Output file path** — where to write your analysis
-3. **Frontmatter** — the frontmatter block to use in the output file (includes type, status, date)
+2. **Output file path** — where to write your analysis. A skeleton file with `status: in-flight` frontmatter is already on disk there; your rewrite replaces it
 
 ## Your Process
 
@@ -42,10 +41,10 @@ You receive via the orchestrator's prompt:
 
 ## Output File Format
 
-Write to the output file path provided — in two steps: write the content to the same path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Use this structure:
+Write to the output file path provided — in two steps: write the content to the same path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context, and the rename lands atomically over the dispatch-time skeleton. Reproduce the skeleton's frontmatter with `status` flipped to `pending` (results ready for the orchestrator). Use this structure:
 
 ```markdown
-{frontmatter provided by orchestrator}
+{skeleton frontmatter, with status: pending}
 
 # Investigation Synthesis: {topic}
 

--- a/agents/workflow-research-deep-dive.md
+++ b/agents/workflow-research-deep-dive.md
@@ -15,8 +15,7 @@ You receive via the orchestrator's prompt:
 
 1. **Research brief** — what to investigate and why (enough context to work independently)
 2. **Research file path** — the current research document for background context
-3. **Output file path** — where to write your findings
-4. **Frontmatter** — the frontmatter block to use in the output file
+3. **Output file path** — where to write your findings. A skeleton file with `status: in-flight` frontmatter is already on disk there; your rewrite replaces it
 
 ## Your Process
 
@@ -52,7 +51,7 @@ Choose based on the brief:
 
 Write to the output file path provided — in two steps: write the content to the same path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context.
 
-The orchestrator passes skeleton frontmatter (`type`, `status`, `created`, `set`, `thread`, `surfaced: []`, `announced: false`). You must add a `findings:` list containing one entry per discrete key finding with its stable ID and a short label. The body's "Key Findings" section uses the same IDs as sub-section headings so the orchestrator can look up full content for any ID.
+The orchestrator wrote skeleton frontmatter at the output path when it dispatched you (`type`, `status: in-flight`, `created`, `set`, `thread`, empty `findings:`, `surfaced: []`, `announced: false`). Your rewrite replaces the whole file — the `.txt`-then-rename lands atomically over the skeleton. Keep the skeleton's fields, set `status: pending` (results ready for the orchestrator), and populate `findings:` with one entry per discrete key finding — stable ID and a short label. The body's "Key Findings" section uses the same IDs as sub-section headings so the orchestrator can look up full content for any ID.
 
 ```markdown
 ---

--- a/agents/workflow-research-review.md
+++ b/agents/workflow-research-review.md
@@ -14,8 +14,7 @@ You are an independent reviewer assessing the breadth, depth, and rigour of a re
 You receive via the orchestrator's prompt:
 
 1. **Research file path(s)** — the research document(s) to review
-2. **Output file path** — where to write your analysis
-3. **Frontmatter** — the frontmatter block to use in the output file (includes type, status, set number, date)
+2. **Output file path** — where to write your analysis. A skeleton file with `status: in-flight` frontmatter is already on disk there; your rewrite replaces it
 
 ## Your Process
 
@@ -43,7 +42,7 @@ You receive via the orchestrator's prompt:
 
 Write to the output file path provided — in two steps: write the content to the same path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Bash is for this rename only.
 
-The orchestrator passes skeleton frontmatter (`type`, `status`, `created`, `set`, `surfaced: []`, `announced: false`). You must add a `findings:` list containing one entry per unexplored area, shallow-coverage item, or unvalidated assumption with its stable ID, kind, and a short label. The body mirrors the same IDs as section headings so the orchestrator can look up full content for any ID.
+The orchestrator wrote skeleton frontmatter at the output path when it dispatched you (`type`, `status: in-flight`, `created`, `set`, empty `findings:`, `surfaced: []`, `announced: false`). Your rewrite replaces the whole file — the `.txt`-then-rename lands atomically over the skeleton. Keep the skeleton's fields, set `status: pending` (results ready for the orchestrator), and populate `findings:` with one entry per unexplored area, shallow-coverage item, or unvalidated assumption — stable ID, kind, and a short label. The body mirrors the same IDs as section headings so the orchestrator can look up full content for any ID.
 
 ```markdown
 ---

--- a/skills/workflow-continue-epic/references/summary-backfill.md
+++ b/skills/workflow-continue-epic/references/summary-backfill.md
@@ -117,6 +117,32 @@ Update the in-memory summary for that item with the user's response. Re-render t
 
 ## D. Write and Commit
 
+**If any item's needed field is still null** (source file missing, nothing provided via the edit loop), give it an exit — otherwise it re-triggers this flow on every epic entry forever:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+{K} topic(s) have no source file to draft from:
+
+@foreach(item in items_to_recover where derived field is null)
+- {item.name:(titlecase)}
+@endforeach
+
+- **`p`/`provide`** — Tell me the summary for each and I'll write it
+- **`d`/`dismiss`** — Write a minimal name-derived summary noting the missing source, so this stops re-prompting
+- **`l`/`leave`** — Leave them unset; this flow re-offers next time
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `provide`:** set each item's derived field from the user's text and include it in the writes below.
+
+**If `dismiss`:** for each such item, set the null field(s) to a minimal value derived from the topic name and routing, ending `(source artifact missing)`, and include them in the writes below.
+
+**If `leave`:** the items stay out of the writes below and re-qualify on the next epic entry.
+
 For each item, write only the newly-drafted fields:
 
 - If `item.needs_summary` is true and `item.derived_summary` is non-null:
@@ -130,8 +156,6 @@ For each item, write only the newly-drafted fields:
   ```bash
   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.discovery.{item.name} description "{description}"
   ```
-
-Skip items where the relevant derived field is null (source file was missing) — they remain unset and will trigger this flow again on the next workflow-continue-epic invocation, giving the user another chance.
 
 Single commit covering all writes:
 

--- a/skills/workflow-continue-epic/references/summary-backfill.md
+++ b/skills/workflow-continue-epic/references/summary-backfill.md
@@ -51,10 +51,8 @@ Proposed summaries for {N} topic(s):
 
 @foreach(item in items_to_recover)
   {N}. {item.name:(titlecase)}  ({item.routing})
-@if(item.needs_summary and item.derived_summary)
-       {item.derived_summary}
-@elseif(item.needs_summary)
-       (source file missing — please provide)
+@if(item.needs_summary)
+       @if(item.derived_summary) {item.derived_summary} @else (source file missing — please provide) @endif
 @else
        {item.summary}  (already populated)
 @endif

--- a/skills/workflow-discovery/references/brief-synthesis.md
+++ b/skills/workflow-discovery/references/brief-synthesis.md
@@ -36,7 +36,7 @@ Drawn from discovery session(s) {coarse session range}.
 
 ## B. Lifecycle
 
-When the harvest restructured topics that were already on the map, keep brief files and `brief_path` pointers in step with the confirmed set. Apply whichever operations occurred — split, merge, and drop are independent, and more than one may apply in a single harvest. This section removes only what the restructuring orphaned.
+This section applies only to restructures **within the session's working list** — the set the harvest shaped and the user confirmed. Committed map items outside the working list are never restructured by a harvest (map edits go through map-operations, which owns its own log entries); their briefs are untouched here. When the confirmed working list restructured a topic that already carried a brief, keep brief files and `brief_path` pointers in step with the confirmed set. Apply whichever operations occurred — split, merge, and drop are independent, and more than one may apply in a single harvest. This section removes only what the restructuring orphaned.
 
 **Split** — a parent topic became two or more children. The children's briefs are written in **A**; remove the parent's:
 

--- a/skills/workflow-discovery/references/resume-detection.md
+++ b/skills/workflow-discovery/references/resume-detection.md
@@ -29,7 +29,7 @@ The output is the in-progress session number string (e.g. `002`) — the prior s
 Found an in-progress discovery session for **{work_unit:(titlecase)}** at `session-{active_session}.md`.
 
 - **`c`/`continue`** — Pick up where you left off
-- **`r`/`restart`** — Delete the draft and start a new session
+- **`r`/`restart`** — Discard the interrupted log and start a new session (map edits already applied stay applied — only their session record is lost)
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-discovery/references/template.md
+++ b/skills/workflow-discovery/references/template.md
@@ -66,6 +66,8 @@ existing map. Format:}
 - Edited summary: {name} — {short note}
 - Edited description: {name} — {short note}
 - Changed routing: {name} → {new routing} — {short reason}
+- Marked handled: {name} — {short reason}
+- Unhandled: {name} — {short reason}
 
 ## Topics Identified
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-discussion-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-discussion-process/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(rm -rf .workflows/.cache/), Bash(git status), Bash(git log)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-discussion-process/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(rm .workflows/.cache/), Bash(rm -rf .workflows/.cache/), Bash(git status), Bash(git log)
 ---
 
 # Discussion Process

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-discussion-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-discussion-process/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(git status), Bash(git log)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-discussion-process/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(rm -rf .workflows/.cache/), Bash(git status), Bash(git log)
 ---
 
 # Discussion Process
@@ -82,7 +82,7 @@ node .claude/skills/workflow-discussion-process/scripts/gateway.cjs map {work_un
 
 Emit the DISPLAY section verbatim as a code block — never the `===` marker lines.
 
-Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `discussion`, file = `.workflows/{work_unit}/discussion/{topic}.md`, continue_step = `Step 2`, restart_targets = `the discussion file and the manifest's map state (node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.discussion.{topic} subtopics)`, commit = `discussion({work_unit}): restart discussion`.
+Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `discussion`, file = `.workflows/{work_unit}/discussion/{topic}.md`, continue_step = `Step 2`, restart_targets = `the discussion file, the manifest's map state (node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.discussion.{topic} subtopics), and the phase cache directory (rm -rf .workflows/.cache/{work_unit}/discussion/{topic}/) — stale agent results would poison the restarted session's review gates`, commit = `discussion({work_unit}): restart discussion`.
 
 ---
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -43,8 +43,9 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Read the discussion file** at `.workflows/{work_unit}/discussion/{topic}.md`. This is the only working document this skill creates. The Discussion Map is your primary progress indicator — which subtopics are decided, exploring, converging, pending, or deferred. It lives in the manifest; read it with `node .claude/skills/workflow-discussion-process/scripts/gateway.cjs map {work_unit} {topic}`.
-3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
-4. **Announce your position** to the user before continuing: render the current Discussion Map (the adapter call above — emit its DISPLAY section verbatim as a code block), state what step you believe you're at, and what comes next. Wait for confirmation.
+3. **Check agent cache.** Scan `.workflows/.cache/{work_unit}/discussion/{topic}/` for any files whose `status` is anything other than `incorporated` — `in-flight` agents still running, `pending` results unread, `acknowledged` results partially surfaced.
+4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
+5. **Announce your position** to the user before continuing: render the current Discussion Map (the adapter call above — emit its DISPLAY section verbatim as a code block), state what step you believe you're at, and what comes next. Wait for confirmation.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -289,7 +289,7 @@ Discussion complete. Ready to conclude?
 
 **If `yes`:**
 
-→ Return to caller.
+→ Proceed to **I. In-Flight Agent Check**.
 
 **If keep going:**
 
@@ -358,7 +358,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map set {work_
 
 Note them in the Summary → Open Threads section of the discussion file. Commit.
 
-→ Return to caller.
+→ Proceed to **I. In-Flight Agent Check**.
 
 **If `no`:**
 
@@ -366,7 +366,19 @@ Note them in the Summary → Open Threads section of the discussion file. Commit
 
 #### If `all_decided` is true
 
-Check for in-flight agents. If agents are still running:
+→ Proceed to **I. In-Flight Agent Check**.
+
+---
+
+## I. In-Flight Agent Check
+
+The last gate before conclusion, whichever path led here. Scan `.workflows/.cache/{work_unit}/discussion/{topic}/` for files with `status: in-flight` in their frontmatter — dispatch-time skeletons whose agents haven't returned yet.
+
+#### If no agents are in flight
+
+→ Return to caller.
+
+#### If agents are still running
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -383,14 +395,10 @@ There are still {N} background agents working.
 
 **If `wait`:**
 
-Check for agent completion. When all agents have returned, delegate surfacing to the shared protocol loaded by review-agent.md and perspective-agents.md. The protocol applies the never-dump rules: two-phase surfacing, one finding at a time. Treat the current moment as a natural break — we are at phase conclusion, so the break check will pass.
+Watch for each in-flight file to flip to `status: pending`. When none remain in-flight, delegate surfacing to the shared protocol loaded by review-agent.md and perspective-agents.md. The protocol applies the never-dump rules: two-phase surfacing, one finding at a time. Treat the current moment as a natural break — we are at phase conclusion, so the break check will pass.
 
 → Return to **B. Session Loop**.
 
 **If `proceed`:**
-
-→ Return to caller.
-
-**If no agents are in flight:**
 
 → Return to caller.

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -12,6 +12,16 @@ The **never-dump rules apply in full**. Findings are raised one at a time via th
 
 ## A. Check Review State
 
+**Synthesis findings drain first.** Scan `.workflows/.cache/{work_unit}/discussion/{topic}/` for `synthesis-*.md` files with `status: pending` or `status: acknowledged` — perspective-council tensions that never finished surfacing during the session would otherwise be dropped at conclusion.
+
+**If any such file exists:**
+
+Surface one tension via **D. Check and Surface** in [perspective-agents.md](perspective-agents.md), then bounce back to the session so the user can engage.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 5**.
+
+**Otherwise:**
+
 Find the most recent review file in `.workflows/.cache/{work_unit}/discussion/{topic}/` by set number.
 
 #### If no review files exist

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -16,7 +16,7 @@ The **never-dump rules apply in full**. Findings are raised one at a time via th
 
 **If any such file exists:**
 
-Surface one tension via **D. Check and Surface** in [perspective-agents.md](perspective-agents.md), then bounce back to the session so the user can engage.
+Surface one tension via **D. Check and Surface** in **[perspective-agents.md](perspective-agents.md)**, then bounce back to the session so the user can engage.
 
 → Return to **[the skill](../SKILL.md)** for **Step 5**.
 

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -67,6 +67,20 @@ ls .workflows/.cache/{work_unit}/discussion/{topic}/ 2>/dev/null
 
 Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`).
 
+Write the skeleton cache file at `.workflows/.cache/{work_unit}/discussion/{topic}/review-{NNN}.md` — frontmatter only, no body. `status: in-flight` is the dispatch record; the agent's rewrite flips it to `pending`:
+
+```yaml
+---
+type: review
+status: in-flight
+created: {date}
+set: {NNN}
+findings: []
+surfaced: []
+announced: false
+---
+```
+
 **Agent path**: `../../../agents/workflow-discussion-review.md`
 
 Dispatch **one agent** as a foreground task (omit `run_in_background` — results are needed before continuing).
@@ -74,19 +88,7 @@ Dispatch **one agent** as a foreground task (omit `run_in_background` — result
 The review agent receives:
 
 1. **Discussion file path** — `.workflows/{work_unit}/discussion/{topic}.md`
-2. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/review-{NNN}.md`
-3. **Frontmatter** — the frontmatter block to write:
-   ```yaml
-   ---
-   type: review
-   status: pending
-   created: {date}
-   set: {NNN}
-   findings: []   # sub-agent populates with F1/F2/... IDs
-   surfaced: []
-   announced: false
-   ---
-   ```
+2. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/review-{NNN}.md` (the skeleton above is already on disk there)
 
 When the agent returns:
 

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -30,9 +30,21 @@ Find the most recent review file in `.workflows/.cache/{work_unit}/discussion/{t
 
 #### If the most recent review has `status: incorporated`
 
-The prior review was fully drained. Dispatch a fresh one to catch anything that emerged since.
+The prior review was fully drained. A fresh one is warranted only when the discussion moved since — otherwise each conclusion attempt mints a new gap set and the topic can never close. Check what landed after that review's dispatch (its frontmatter `created` date, and — same session — your memory of when it drained):
+
+```bash
+git log --oneline -- .workflows/{work_unit}/discussion/{topic}.md
+```
+
+**If a meaningful discussion commit landed after the prior review was dispatched** (a decision documented, a subtopic explored — not typo fixes):
 
 → Proceed to **B. Dispatch Final Review**.
+
+**Otherwise:**
+
+Nothing new for a fresh review to see — the final-review gate is satisfied.
+
+→ Return to caller.
 
 #### If the most recent review has `status: pending`
 

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -46,17 +46,33 @@ Nothing new for a fresh review to see — the final-review gate is satisfied.
 
 → Return to caller.
 
+#### If the most recent review has `status: in-flight`
+
+A dispatch-time skeleton whose agent hasn't returned.
+
+**If it was dispatched this session** (the agent may still be running):
+
+Watch for the file to flip to `status: pending`.
+
+→ Proceed to **C. Surface via Final Review Menu**.
+
+**Otherwise** (an interrupted earlier session — no agent can still be running):
+
+Delete the skeleton file.
+
+→ Proceed to **B. Dispatch Final Review**.
+
 #### If the most recent review has `status: pending`
 
-A review is in flight or just returned unread.
+A review returned but hasn't been read.
 
-→ Proceed to **C. Surface via Shared Protocol**.
+→ Proceed to **C. Surface via Final Review Menu**.
 
 #### If the most recent review has `status: acknowledged`
 
 Findings from the current review are still being drained.
 
-→ Proceed to **C. Surface via Shared Protocol**.
+→ Proceed to **C. Surface via Final Review Menu**.
 
 ---
 
@@ -114,7 +130,7 @@ The review agent receives:
 
 When the agent returns:
 
-→ Proceed to **C. Surface via Shared Protocol**.
+→ Proceed to **C. Surface via Final Review Menu**.
 
 ---
 

--- a/skills/workflow-discussion-process/references/perspective-agents.md
+++ b/skills/workflow-discussion-process/references/perspective-agents.md
@@ -75,6 +75,19 @@ ls .workflows/.cache/{work_unit}/discussion/{topic}/ 2>/dev/null
 
 Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`). All agents in this set share the same `{NNN}`.
 
+For each perspective, write a skeleton cache file at `.workflows/.cache/{work_unit}/discussion/{topic}/perspective-{NNN}-{lens:(kebabcase)}.md` — frontmatter only, no body. `status: in-flight` is the dispatch record: it makes each running agent (and the set's expected size) visible until the agent's rewrite flips it to `pending`:
+
+```yaml
+---
+type: perspective
+status: in-flight
+created: {date}
+set: {NNN}
+lens: {lens}
+decision: {decision topic}
+---
+```
+
 **Agent path**: `../../../agents/workflow-discussion-perspective.md`
 
 Dispatch **all perspective agents in parallel** via the Task tool with `run_in_background: true`.
@@ -84,19 +97,7 @@ Each perspective agent receives:
 1. **Lens** — the assigned lens from the polarity pair (e.g., `Formal Systems`, `Tail-Risk`)
 2. **Decision topic** — the decision being explored
 3. **Discussion file path** — `.workflows/{work_unit}/discussion/{topic}.md`
-4. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/perspective-{NNN}-{lens:(kebabcase)}.md`
-5. **Frontmatter** — the frontmatter block to write:
-   ```yaml
-   ---
-   type: perspective
-   status: pending
-   created: {date}
-   set: {NNN}
-   lens: {lens}
-   decision: {decision topic}
-   ---
-   ```
-
+4. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/perspective-{NNN}-{lens:(kebabcase)}.md` (its skeleton is already on disk there; the agent's rewrite flips `status` to `pending`)
 Each perspective agent restates the decision through its lens before arguing (Problem Restate Gate) and returns:
 
 ```
@@ -121,6 +122,21 @@ The discussion continues — do not wait for agents to return.
 
 This section is reached when all perspective agents in a set have completed. The synthesis agent reconciles their findings into a tradeoff landscape.
 
+Write the skeleton cache file at `.workflows/.cache/{work_unit}/discussion/{topic}/synthesis-{NNN}.md` — frontmatter only, no body. `status: in-flight` is the dispatch record: it makes the running agent visible to the in-flight scans (and stops **D** re-dispatching synthesis for this set) until the agent's rewrite flips it to `pending`:
+
+```yaml
+---
+type: synthesis
+status: in-flight
+created: {date}
+set: {NNN}
+decision: {decision topic}
+tensions: []
+surfaced: []
+announced: false
+---
+```
+
 **Agent path**: `../../../agents/workflow-discussion-synthesis.md`
 
 Dispatch **one agent** via the Task tool with `run_in_background: true`.
@@ -129,22 +145,9 @@ The synthesis agent receives:
 
 1. **Perspective file paths** — paths to all perspective files in this set
 2. **Decision topic** — the decision being explored
-3. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/synthesis-{NNN}.md`
-4. **Frontmatter** — the frontmatter block to write:
-   ```yaml
-   ---
-   type: synthesis
-   status: pending
-   created: {date}
-   set: {NNN}
-   decision: {decision topic}
-   tensions: []   # sub-agent populates with T1/T2/... IDs
-   surfaced: []
-   announced: false
-   ---
-   ```
+3. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/synthesis-{NNN}.md` (the skeleton above is already on disk there)
 
-The sub-agent writes tension entries with stable IDs (`T1`, `T2`, …) into the `tensions:` list. See `agents/workflow-discussion-synthesis.md` for the schema.
+The sub-agent rewrites the file at completion — populating `tensions:` with stable IDs (`T1`, `T2`, …) and flipping `status` to `pending`. See `agents/workflow-discussion-synthesis.md` for the schema.
 
 The synthesis agent also compares the Restatement sections from each perspective. If lenses diverge meaningfully on what the decision IS — different scope, different question, or one lens answering an unasked question — synthesis records a **Framing alignment** tension as `T1` so it surfaces first. This is the Problem Restate Gate's payoff: wrong-question failures get caught before the user acts on a tradeoff landscape.
 
@@ -165,7 +168,7 @@ The discussion continues — do not wait for the agent to return.
 
 This section handles two responsibilities: promoting completed perspective sets to synthesis, and surfacing synthesis findings via the never-dump protocol.
 
-**Perspective completion check** — scan the cache directory for perspective files. For each set `{NNN}`, if all perspective files in the set have returned AND no synthesis file exists for that set, proceed to **C. Dispatch Synthesis Agent** for that set.
+**Perspective completion check** — scan the cache directory for perspective files. For each set `{NNN}`, if every perspective file in the set has `status: pending` (a file still `in-flight` is an agent still running) AND no synthesis file exists for that set, proceed to **C. Dispatch Synthesis Agent** for that set.
 
 **Synthesis surfacing** — synthesis files carry findings (`tensions:`) that must NOT be dumped. Delegate presentation to the shared surfacing protocol.
 

--- a/skills/workflow-discussion-process/references/perspective-agents.md
+++ b/skills/workflow-discussion-process/references/perspective-agents.md
@@ -98,6 +98,7 @@ Each perspective agent receives:
 2. **Decision topic** — the decision being explored
 3. **Discussion file path** — `.workflows/{work_unit}/discussion/{topic}.md`
 4. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/perspective-{NNN}-{lens:(kebabcase)}.md` (its skeleton is already on disk there; the agent's rewrite flips `status` to `pending`)
+
 Each perspective agent restates the decision through its lens before arguing (Problem Restate Gate) and returns:
 
 ```

--- a/skills/workflow-discussion-process/references/review-agent.md
+++ b/skills/workflow-discussion-process/references/review-agent.md
@@ -45,6 +45,20 @@ ls .workflows/.cache/{work_unit}/discussion/{topic}/ 2>/dev/null
 
 Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`).
 
+Write the skeleton cache file at `.workflows/.cache/{work_unit}/discussion/{topic}/review-{NNN}.md` — frontmatter only, no body. `status: in-flight` is the dispatch record: it makes the running agent visible to the in-flight scans until the agent's rewrite flips it to `pending`:
+
+```yaml
+---
+type: review
+status: in-flight
+created: {date}
+set: {NNN}
+findings: []
+surfaced: []
+announced: false
+---
+```
+
 **Agent path**: `../../../agents/workflow-discussion-review.md`
 
 Dispatch **one agent** via the Task tool with `run_in_background: true`.
@@ -52,21 +66,9 @@ Dispatch **one agent** via the Task tool with `run_in_background: true`.
 The review agent receives:
 
 1. **Discussion file path** — `.workflows/{work_unit}/discussion/{topic}.md`
-2. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/review-{NNN}.md`
-3. **Frontmatter** — the frontmatter block to write:
-   ```yaml
-   ---
-   type: review
-   status: pending
-   created: {date}
-   set: {NNN}
-   findings: []   # sub-agent populates with F1/F2/... IDs
-   surfaced: []
-   announced: false
-   ---
-   ```
+2. **Output file path** — `.workflows/.cache/{work_unit}/discussion/{topic}/review-{NNN}.md` (the skeleton above is already on disk there)
 
-The sub-agent writes finding entries with stable IDs (`F1`, `F2`, …) into the `findings:` list. See `agents/workflow-discussion-review.md` for the schema.
+The sub-agent rewrites the file at completion — populating `findings:` with stable IDs (`F1`, `F2`, …) and flipping `status` to `pending`. See `agents/workflow-discussion-review.md` for the schema.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-discussion-process/references/review-agent.md
+++ b/skills/workflow-discussion-process/references/review-agent.md
@@ -13,7 +13,7 @@ These instructions are loaded into context at the start of the discussion sessio
 - □ Not the first commit? (the discussion needs enough content to review)
 - □ At least 2-3 conversational exchanges since the last review dispatch?
 
-**Why block on undrained reviews**: two reasons, both important. First, dispatching a fresh review while the prior review's findings are still being discussed produces stale analysis — the document will look different once those findings land, and the new review would be critiquing a version the user is already fixing. Second, the block is self-healing: the next meaningful commit after the current review drains to `incorporated` will naturally re-fire the trigger check and dispatch a fresh review, so no trigger is lost. If the session ends before drainage completes, the final review in Step 4 picks up the outstanding findings via the shared surfacing protocol.
+**Why block on undrained reviews**: two reasons, both important. First, dispatching a fresh review while the prior review's findings are still being discussed produces stale analysis — the document will look different once those findings land, and the new review would be critiquing a version the user is already fixing. Second, the block is self-healing: the next meaningful commit after the current review drains to `incorporated` will naturally re-fire the trigger check and dispatch a fresh review, so no trigger is lost. If the session ends before drainage completes, the final review in Step 6 picks up the outstanding findings via the shared surfacing protocol.
 
 **If all checked:**
 

--- a/skills/workflow-investigation-process/references/synthesis-agent.md
+++ b/skills/workflow-investigation-process/references/synthesis-agent.md
@@ -149,4 +149,29 @@ Synthesis: {CONFIDENCE} confidence. {GAPS_COUNT} gap(s) identified.
 Full analysis: .workflows/.cache/{work_unit}/investigation/{topic}/synthesis-{NNN}.md
 ```
 
+The gaps live only in cache — each must land in the investigation file or be explicitly dismissed before the phase concludes over them:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+How should these gaps be handled?
+
+- **`a`/`address`** — Work through them and fold the answers into the investigation
+- **`d`/`dismiss`** — Note them as considered-and-dismissed and proceed
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `address`:**
+
+Work through each gap with the user — re-trace code where needed — and update the investigation file's affected sections (Analysis, Root Cause, Blast Radius) with what the answers change or confirm. Commit the updated file.
+
+→ Return to caller.
+
+**If `dismiss`:**
+
+Record the gaps under a short "Synthesis gaps (dismissed)" note in the investigation file's Analysis section so the record shows they were considered. Commit.
+
 → Return to caller.

--- a/skills/workflow-investigation-process/references/synthesis-agent.md
+++ b/skills/workflow-investigation-process/references/synthesis-agent.md
@@ -78,6 +78,16 @@ ls .workflows/.cache/{work_unit}/investigation/{topic}/ 2>/dev/null
 
 Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`).
 
+Write the skeleton cache file at `.workflows/.cache/{work_unit}/investigation/{topic}/synthesis-{NNN}.md` — frontmatter only, no body. `status: in-flight` is the dispatch record; the agent's rewrite flips it to `pending`:
+
+```yaml
+---
+type: synthesis
+status: in-flight
+created: {date}
+---
+```
+
 **Agent path**: `../../../agents/workflow-investigation-synthesis.md`
 
 > *Output the next fenced block as a code block:*
@@ -91,15 +101,7 @@ Dispatch **one agent** via the Task tool (**synchronous** — do not use `run_in
 The synthesis agent receives:
 
 1. **Investigation file path** — `.workflows/{work_unit}/investigation/{topic}.md`
-2. **Output file path** — `.workflows/.cache/{work_unit}/investigation/{topic}/synthesis-{NNN}.md`
-3. **Frontmatter** — the frontmatter block to write:
-   ```yaml
-   ---
-   type: synthesis
-   status: pending
-   created: {date}
-   ---
-   ```
+2. **Output file path** — `.workflows/.cache/{work_unit}/investigation/{topic}/synthesis-{NNN}.md` (the skeleton above is already on disk there)
 
 The synthesis agent returns:
 

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-research-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(rm -rf .workflows/.cache/), Bash(git status), Bash(git log)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(rm .workflows/.cache/), Bash(rm -rf .workflows/.cache/), Bash(git status), Bash(git log)
 ---
 
 # Research Process

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -44,7 +44,7 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 
 1. **Re-read this skill file completely.** Do not rely on your summary of it. The full process, steps, and rules must be reloaded.
 2. **Read all research files** in `.workflows/{work_unit}/research/`. These are the working documents this skill creates. Their content is your source of truth for progress.
-3. **Check agent cache.** Scan `.workflows/.cache/{work_unit}/research/` for any files with `status: pending` or `status: read` in their frontmatter. These are background agent results that may need surfacing or have been partially processed.
+3. **Check agent cache.** Scan `.workflows/.cache/{work_unit}/research/` for any files whose `status` is anything other than `incorporated` — `in-flight` agents still running, `pending` results unread, `acknowledged` results partially surfaced.
 4. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 5. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
 

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-research-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(git status), Bash(git log)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(rm -rf .workflows/.cache/), Bash(git status), Bash(git log)
 ---
 
 # Research Process
@@ -75,7 +75,7 @@ Check if the research file exists at `.workflows/{work_unit}/research/{topic}.md
 
 #### If file exists
 
-Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `research`, file = `.workflows/{work_unit}/research/{topic}.md`, continue_step = `Step 2`, restart_targets = `the research file`, commit = `research({work_unit}): restart research`.
+Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `research`, file = `.workflows/{work_unit}/research/{topic}.md`, continue_step = `Step 2`, restart_targets = `the research file and the phase cache directory (rm -rf .workflows/.cache/{work_unit}/research/{topic}/) — stale agent results would poison the restarted session's review gates`, commit = `research({work_unit}): restart research`.
 
 ---
 

--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -86,6 +86,21 @@ Compose a research brief for the agent. The brief must be self-contained — the
 - Specific questions to answer if applicable
 - Boundaries — what's in scope and what isn't
 
+Write the skeleton cache file at `.workflows/.cache/{work_unit}/research/{topic}/deep-dive-{NNN}-{thread}.md` — frontmatter only, no body. `status: in-flight` is the dispatch record: it makes the running agent visible to the in-flight scans and the concurrency count until the agent's rewrite flips it to `pending`:
+
+```yaml
+---
+type: deep-dive
+status: in-flight
+created: {date}
+set: {NNN}
+thread: {thread name}
+findings: []
+surfaced: []
+announced: false
+---
+```
+
 **Agent path**: `../../../agents/workflow-research-deep-dive.md`
 
 Dispatch **one agent** via the Task tool with `run_in_background: true`.
@@ -94,22 +109,9 @@ The deep-dive agent receives:
 
 1. **Research brief** — the self-contained investigation brief
 2. **Research file path** — `.workflows/{work_unit}/research/{topic}.md` (for background context)
-3. **Output file path** — `.workflows/.cache/{work_unit}/research/{topic}/deep-dive-{NNN}-{thread}.md`
-4. **Frontmatter** — the frontmatter block to write:
-   ```yaml
-   ---
-   type: deep-dive
-   status: pending
-   created: {date}
-   set: {NNN}
-   thread: {thread name}
-   findings: []   # sub-agent populates with F1/F2/... IDs
-   surfaced: []
-   announced: false
-   ---
-   ```
+3. **Output file path** — `.workflows/.cache/{work_unit}/research/{topic}/deep-dive-{NNN}-{thread}.md` (the skeleton above is already on disk there)
 
-The sub-agent writes finding entries with stable IDs (`F1`, `F2`, …) into the `findings:` list. See `agents/workflow-research-deep-dive.md` for the schema.
+The sub-agent rewrites the file at completion — populating `findings:` with stable IDs (`F1`, `F2`, …) and flipping `status` to `pending`. See `agents/workflow-research-deep-dive.md` for the schema.
 
 > *Output the next fenced block as a code block:*
 
@@ -129,7 +131,7 @@ SUMMARY: {1-2 sentences}
 
 The research session continues — do not wait for the agent to return.
 
-**Concurrency**: Before dispatching, count files matching `deep-dive-*.md` with `status: pending` in their frontmatter in the cache directory. Limit to 3-4 in flight at once. If the limit is reached, note the thread for later dispatch.
+**Concurrency**: Before dispatching, count files matching `deep-dive-*.md` with `status: in-flight` in their frontmatter in the cache directory — the skeletons of agents still running. Limit to 3-4 in flight at once. If the limit is reached, note the thread for later dispatch.
 
 ---
 

--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -141,17 +141,15 @@ Delegate all check-for-results and presentation behaviour to the shared surfacin
 
 → Load **[background-agent-surfacing.md](../../workflow-shared/references/background-agent-surfacing.md)** with agent_type = `deep-dive`, cache_dir = `.workflows/.cache/{work_unit}/research/{topic}`, cache_glob = `deep-dive-*.md`, findings_key = `findings`.
 
-**Promoting to a research file** (epic work type only): If during presentation the user engages with findings substantial enough to warrant their own research file — and agrees or requests it — promote them:
+**Promoting to a research file** (epic work type only): If during presentation the user engages with findings substantial enough to warrant their own research file — and agrees or requests it — promote them through the shared topic-creation core, so the new topic lands on the discovery map with validated naming and provenance:
 
-1. Create a new research file at `.workflows/{work_unit}/research/{thread}.md`
-2. Synthesise the deep-dive findings into the file (don't copy the cache file verbatim — organise for the research document context)
-3. Register in the manifest:
+1. Derive a one-line `summary` and a paragraph or two of `description` from the deep-dive findings.
+
+2. → Load **[create-discovery-topic.md](../../workflow-shared/references/create-discovery-topic.md)** with work_unit = `{work_unit}`, proposed_name = `{thread}`, phase = `research`, routing = `research`, source = `research-split:{topic}`, summary = `{summary}`, description = `{description}`.
+
+3. **If `result` is `cancelled`:** the promotion was dropped — the findings stay in the cache file. Otherwise create the research file at `.workflows/{work_unit}/research/{created_topic}.md` and synthesise the deep-dive findings into it (don't copy the cache file verbatim — organise for the research document context), then commit:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} research {thread}
-   ```
-4. Commit:
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}): add {thread} research from deep dive"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}): add {created_topic} research from deep dive"
    ```
 
 For feature work types, deep-dive findings fold into the existing research file — there is only one research topic per feature.

--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -97,7 +97,7 @@ The current file is drifting — multiple exchanges have been adding material th
 
 → Return to **B. Session Loop**.
 
-#### If the current topic is converging (tradeoffs clear, approaching decision territory)
+#### If the current topic is converging (tradeoffs clear, approaching decision territory) or the user indicates they're done
 
 → Proceed to **E. In-Flight Agent Handling**.
 

--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -105,7 +105,7 @@ The current file is drifting — multiple exchanges have been adding material th
 
 ## E. In-Flight Agent Handling
 
-Before concluding, check for in-flight agents. Scan the cache directory for review or deep-dive files with `status: pending` in their frontmatter.
+Before concluding, check for in-flight agents. Scan `.workflows/.cache/{work_unit}/research/{topic}/` for review or deep-dive files with `status: in-flight` in their frontmatter — dispatch-time skeletons whose agents haven't returned yet.
 
 #### If no agents are in flight
 
@@ -130,7 +130,7 @@ There are still {N} background agents working.
 
 **If `wait`:**
 
-Check for agent completion. When all agents have returned, delegate surfacing to the shared protocol loaded by review-agent.md and deep-dive-agent.md. The protocol applies the never-dump rules: two-phase surfacing, one finding at a time. Treat the current moment as a natural break — we are at phase conclusion, so the break check will pass.
+Watch for each in-flight file to flip to `status: pending`. When none remain in-flight, delegate surfacing to the shared protocol loaded by review-agent.md and deep-dive-agent.md. The protocol applies the never-dump rules: two-phase surfacing, one finding at a time. Treat the current moment as a natural break — we are at phase conclusion, so the break check will pass.
 
 → Return to **B. Session Loop**.
 

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -32,7 +32,7 @@ When the topic feels well-explored or the user indicates they're done:
 
 ## D. In-Flight Agent Handling
 
-Before concluding, check for in-flight agents. Scan the cache directory for review or deep-dive files with `status: pending` in their frontmatter.
+Before concluding, check for in-flight agents. Scan `.workflows/.cache/{work_unit}/research/{topic}/` for review or deep-dive files with `status: in-flight` in their frontmatter — dispatch-time skeletons whose agents haven't returned yet.
 
 #### If no agents are in flight
 
@@ -57,7 +57,7 @@ There are still {N} background agents working.
 
 **If `wait`:**
 
-Check for agent completion. When all agents have returned, delegate surfacing to the shared protocol loaded by review-agent.md and deep-dive-agent.md. The protocol applies the never-dump rules: two-phase surfacing, one finding at a time. Treat the current moment as a natural break — we are at phase conclusion, so the break check will pass.
+Watch for each in-flight file to flip to `status: pending`. When none remain in-flight, delegate surfacing to the shared protocol loaded by review-agent.md and deep-dive-agent.md. The protocol applies the never-dump rules: two-phase surfacing, one finding at a time. Treat the current moment as a natural break — we are at phase conclusion, so the break check will pass.
 
 → Return to **B. Session Loop**.
 

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -67,6 +67,20 @@ ls .workflows/.cache/{work_unit}/research/{topic}/ 2>/dev/null
 
 Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`).
 
+Write the skeleton cache file at `.workflows/.cache/{work_unit}/research/{topic}/review-{NNN}.md` — frontmatter only, no body. `status: in-flight` is the dispatch record; the agent's rewrite flips it to `pending`:
+
+```yaml
+---
+type: review
+status: in-flight
+created: {date}
+set: {NNN}
+findings: []
+surfaced: []
+announced: false
+---
+```
+
 **Agent path**: `../../../agents/workflow-research-review.md`
 
 Dispatch **one agent** as a foreground task (omit `run_in_background` — results are needed before continuing).
@@ -74,19 +88,7 @@ Dispatch **one agent** as a foreground task (omit `run_in_background` — result
 The review agent receives:
 
 1. **Research file path(s)** — `.workflows/{work_unit}/research/{topic}.md` (for epic, include all research files in `.workflows/{work_unit}/research/` relevant to the current topic)
-2. **Output file path** — `.workflows/.cache/{work_unit}/research/{topic}/review-{NNN}.md`
-3. **Frontmatter** — the frontmatter block to write:
-   ```yaml
-   ---
-   type: review
-   status: pending
-   created: {date}
-   set: {NNN}
-   findings: []   # sub-agent populates with F1/F2/... IDs
-   surfaced: []
-   announced: false
-   ---
-   ```
+2. **Output file path** — `.workflows/.cache/{work_unit}/research/{topic}/review-{NNN}.md` (the skeleton above is already on disk there)
 
 When the agent returns:
 

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -20,9 +20,21 @@ Find the most recent review file in `.workflows/.cache/{work_unit}/research/{top
 
 #### If the most recent review has `status: incorporated`
 
-The prior review was fully drained. Dispatch a fresh one to catch anything that emerged since.
+The prior review was fully drained. A fresh one is warranted only when the research moved since — otherwise each conclusion attempt mints a new gap set and the topic can never close. Check what landed after that review's dispatch (its frontmatter `created` date, and — same session — your memory of when it drained):
+
+```bash
+git log --oneline -- .workflows/{work_unit}/research/{topic}.md
+```
+
+**If a meaningful research commit landed after the prior review was dispatched** (new findings, folded threads — not typo fixes):
 
 → Proceed to **B. Dispatch Final Review**.
+
+**Otherwise:**
+
+Nothing new for a fresh review to see — the final-review gate is satisfied.
+
+→ Return to caller.
 
 #### If the most recent review has `status: pending`
 

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -36,17 +36,33 @@ Nothing new for a fresh review to see — the final-review gate is satisfied.
 
 → Return to caller.
 
+#### If the most recent review has `status: in-flight`
+
+A dispatch-time skeleton whose agent hasn't returned.
+
+**If it was dispatched this session** (the agent may still be running):
+
+Watch for the file to flip to `status: pending`.
+
+→ Proceed to **C. Surface via Final Review Menu**.
+
+**Otherwise** (an interrupted earlier session — no agent can still be running):
+
+Delete the skeleton file.
+
+→ Proceed to **B. Dispatch Final Review**.
+
 #### If the most recent review has `status: pending`
 
-A review is in flight or just returned unread.
+A review returned but hasn't been read.
 
-→ Proceed to **C. Surface via Shared Protocol**.
+→ Proceed to **C. Surface via Final Review Menu**.
 
 #### If the most recent review has `status: acknowledged`
 
 Findings from the current review are still being drained.
 
-→ Proceed to **C. Surface via Shared Protocol**.
+→ Proceed to **C. Surface via Final Review Menu**.
 
 ---
 
@@ -104,7 +120,7 @@ The review agent receives:
 
 When the agent returns:
 
-→ Proceed to **C. Surface via Shared Protocol**.
+→ Proceed to **C. Surface via Final Review Menu**.
 
 ---
 

--- a/skills/workflow-research-process/references/review-agent.md
+++ b/skills/workflow-research-process/references/review-agent.md
@@ -45,6 +45,20 @@ ls .workflows/.cache/{work_unit}/research/{topic}/ 2>/dev/null
 
 Use the next available `{NNN}` (zero-padded, e.g., `001`, `002`).
 
+Write the skeleton cache file at `.workflows/.cache/{work_unit}/research/{topic}/review-{NNN}.md` — frontmatter only, no body. `status: in-flight` is the dispatch record: it makes the running agent visible to the in-flight scans and the concurrency count until the agent's rewrite flips it to `pending`:
+
+```yaml
+---
+type: review
+status: in-flight
+created: {date}
+set: {NNN}
+findings: []
+surfaced: []
+announced: false
+---
+```
+
 **Agent path**: `../../../agents/workflow-research-review.md`
 
 Dispatch **one agent** via the Task tool with `run_in_background: true`.
@@ -52,21 +66,9 @@ Dispatch **one agent** via the Task tool with `run_in_background: true`.
 The review agent receives:
 
 1. **Research file path(s)** — `.workflows/{work_unit}/research/{topic}.md` (for epic, include all research files in `.workflows/{work_unit}/research/` relevant to the current topic)
-2. **Output file path** — `.workflows/.cache/{work_unit}/research/{topic}/review-{NNN}.md`
-3. **Frontmatter** — the frontmatter block to write:
-   ```yaml
-   ---
-   type: review
-   status: pending
-   created: {date}
-   set: {NNN}
-   findings: []   # sub-agent populates with F1/F2/... IDs
-   surfaced: []
-   announced: false
-   ---
-   ```
+2. **Output file path** — `.workflows/.cache/{work_unit}/research/{topic}/review-{NNN}.md` (the skeleton above is already on disk there)
 
-The sub-agent writes finding entries with stable IDs (`F1`, `F2`, …) into the `findings:` list. See `agents/workflow-research-review.md` for the schema.
+The sub-agent rewrites the file at completion — populating `findings:` with stable IDs (`F1`, `F2`, …) and flipping `status` to `pending`. See `agents/workflow-research-review.md` for the schema.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -125,7 +125,21 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit
 
 **If plan status is not `completed`** (empty or `in-progress`):
 
-→ Proceed to **Step 6** (spec exists but plan is incomplete — resume from format selection).
+The spec exists but the plan is incomplete — an interrupted prior run. Rebuild the context the interrupted run had:
+
+1. Read `.workflows/{work_unit}/specification/{topic}/specification.md` in full — it is the gathered context Step 7 authors tasks from.
+2. Read the specification item's status:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic} status
+   ```
+   If the output is empty (the run crashed between writing the spec file and registering it), register and index it now:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} specification {topic}
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} specification {topic}
+   ```
+   If the `complete` response carries `warnings`, display them but do not block — the artifact is already saved.
+
+→ Proceed to **Step 6** (resume from format selection).
 
 #### If `continue`
 

--- a/skills/workflow-scoping-process/references/select-format.md
+++ b/skills/workflow-scoping-process/references/select-format.md
@@ -47,6 +47,6 @@ Project default format is **{format}**. Use the same format?
 
 → Load **[../../workflow-planning-process/references/output-formats.md](../../workflow-planning-process/references/output-formats.md)** and follow its instructions as written.
 
-Load the chosen format's **[about.md](../../workflow-planning-process/references/output-formats/{chosen-format}/about.md)** and follow its Setup section — complete any prerequisites (installation, initialisation, MCP configuration) before tasks are written.
+→ Load the chosen format's **[about.md](../../workflow-planning-process/references/output-formats/{chosen-format}/about.md)** and follow its Setup section — complete any prerequisites (installation, initialisation, MCP configuration) before tasks are written.
 
 → Return to caller.

--- a/skills/workflow-shared/references/analysis-approval-gate.md
+++ b/skills/workflow-shared/references/analysis-approval-gate.md
@@ -151,13 +151,31 @@ node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map add {work_u
 
 `source` is the block's stored value verbatim — `research-analysis:{parent}` for research-analysis (provenance renders as `from {parent}`), `gap-analysis` for gap-analysis.
 
+#### If the response is `ok: false`
+
+Deferred-reuse boots only — the map can change between staging and this write. Route on the refusal:
+
+**If refused as an active duplicate** (the topic landed on the map via another path since staging):
+
+Merge provenance instead, following the already-on-map branch of the analysis's **D. Filter and Stage** — read the item's `source` and, unless it already includes this analysis, extend it comma-joined. Set this block's `status: resolved`; nothing is added to `tracker`.
+
+→ Return to **B. Gate Each Candidate**.
+
+**If refused as dismissed** (the user dismissed this name since staging):
+
+Honour the dismissal. Set this block's `status: skipped` — the name is already on the dismissed list, no push needed.
+
+→ Return to **B. Gate Each Candidate**.
+
+#### Otherwise
+
 Append `{name}` to the caller's `tracker`.
 
-#### If `analysis` is `research-analysis`
+**If `analysis` is `research-analysis`:**
 
 → Proceed to **D. Fan-Out Parent-Handled Offer**.
 
-#### Otherwise
+**Otherwise:**
 
 → Return to **B. Gate Each Candidate**.
 

--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -41,6 +41,8 @@ Once you raise a finding, control belongs to the conversation. The user engages 
 
 Cache files move through these states:
 
+**`in-flight`** → Skeleton written by the orchestrator at dispatch. The sub-agent is still running — there is nothing to surface, and the scans below ignore it. The agent's completed rewrite flips it to `pending`.
+
 **`pending`** → Sub-agent wrote the file. You haven't read it yet.
 
 **`acknowledged`** → You have read the file. Two frontmatter flags track sub-state:
@@ -77,7 +79,7 @@ The file was first-read on an earlier iteration. C. Decide Action will read its 
 
 1. Read the cache file completely.
 2. Count findings in the frontmatter `{findings_key}` list.
-3. Transition the frontmatter: `status: pending` → `status: acknowledged`. The `surfaced: []` and `announced: false` fields were set by the orchestrator at dispatch time and are already present.
+3. Transition the frontmatter: `status: pending` → `status: acknowledged`. The `surfaced: []` and `announced: false` fields were written with the dispatch-time skeleton and are already present.
 
 #### If the finding count is 0 (zero-gap case)
 

--- a/skills/workflow-shared/references/convergence-analysis.md
+++ b/skills/workflow-shared/references/convergence-analysis.md
@@ -17,7 +17,7 @@ The caller provides these via context before loading:
 
 ## Threshold Check
 
-Cross-cycle analysis requires at least 2 data points. Determine the number of available cycles by checking which tracking files exist for this loop type.
+Cross-cycle analysis requires at least 2 data points. Determine the number of available cycles from how the loop type stores them: the `fix` loop appends every cycle as an `## Attempt {N}` section inside its single tracking file — count those sections; the other three loop types write one numbered `-c{N}` file per cycle — count the files.
 
 #### If fewer than 2 cycles of data exist
 
@@ -87,7 +87,7 @@ For each cycle, extract:
 - Each finding's title
 - Affects field (which specification section)
 - Category
-- Resolution (Approved/Skipped)
+- Resolution (Approved/Adjusted/Skipped)
 
 → Proceed to **B. Classify Findings**.
 
@@ -121,7 +121,7 @@ Compute:
 > *Output the next fenced block as a code block:*
 
 ```
-{loop_type_label:(titlecase)} — {latest_cycle} cycle diagnostic
+{loop_type_label:(titlecase)} — cycle {latest_cycle} diagnostic
 
   Trend: {trend:[converging|stable|diverging]}
   Latest cycle: {finding_count} findings ({new_count} new, {recurring_count} recurring)

--- a/skills/workflow-shared/references/create-discovery-topic.md
+++ b/skills/workflow-shared/references/create-discovery-topic.md
@@ -73,9 +73,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map add {work_u
 Assemble the call as follows:
 
 - Positional `{routing}`, `--source "{source}"`, and `--force-dismissed` — always included.
-- `--summary "{summary}"` — included only when `summary` is present and non-empty.
-- `--description "{description}"` — included only when `description` is present and non-empty.
-- When `summary` is absent, pass `--backfill` in place of both fields — the next epic entry's summary-backfill drafts them.
+- When `summary` is present and non-empty: include `--summary "{summary}"`, plus `--description "{description}"` when `description` is present and non-empty.
+- When `summary` is absent: pass `--backfill` in place of both fields — the engine refuses `--backfill` combined with either — and the next epic entry's summary-backfill drafts them.
 
 Single-quote any value containing characters zsh would interpret — backticks, `$`, `[]`, `{}`, `~` — so the shell passes it through literally.
 

--- a/skills/workflow-shared/references/discovery-gap-analysis.md
+++ b/skills/workflow-shared/references/discovery-gap-analysis.md
@@ -188,7 +188,7 @@ Overwrite with the topic list:
 - **Gap type**: {cross-artifact|emergent|integration|uncovered}
 ```
 
-List every topic from **C**, even those that filtered out in **D** — the cache file is the analysis output, not the diff. If re-entered on a reuse boot where **C** did not run this session (a deferred staging file was picked up), source the topic list from the staging file's candidate blocks instead.
+List every topic from **C**, even those that filtered out in **D** — the cache file is the analysis output, not the diff. If re-entered on a reuse boot where **C** did not run this session (a deferred staging file was picked up), source the topic list from the staging file's candidate blocks instead — that file holds only the genuinely-new candidates, so the rebuilt cache is narrower than a fresh pass; the filtered topics' outcomes are already recorded on the map and the dismissed list, and the next content change re-runs the full analysis.
 
 Stamp the manifest's gap_analysis_cache — one command checksums the completed research plus completed discussion files, writes `checksum`, `generated`, and `input_files`, and indexes the cache file into the knowledge base so its content surfaces in future contextual queries:
 

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -4,7 +4,7 @@
 
 ---
 
-Folds the current topic's `## Triage` entries — concerns rerouted here from other topics — into its working content, then resets the section to `(none)`. Runs once per session, before the loop. A fresh `(none)` artefact is a no-op; a resume or reopen folds whatever landed since the topic last ran.
+Folds the current topic's `## Triage` entries — concerns rerouted here from other topics — into its working content, then resets the section to `(none)`. Runs at every entry to the session step — the first pass of a session, and again when the conclusion gate bounces back because an entry landed mid-session. A `(none)` artefact is a no-op; a resume or reopen folds whatever landed since the topic last ran.
 
 The fold preserves the **full** rerouted context — each entry becomes real working material the session explores, not a bare map row. The conclusion gate backstops this: a topic cannot conclude while its `## Triage` ≠ `(none)`.
 
@@ -43,6 +43,8 @@ For each `### {title}` subsection under `## Triage`, carry its **full body** (ev
   ```bash
   node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map add {work_unit} {topic} {title:(kebabcase)}
   ```
+
+  If the add refuses because the subtopic already exists, the concern names ground this discussion already covers — skip the map write and fold the entry body into that existing subtopic's section instead of creating a new one.
 - Create a `## {title}` subtopic section with the entry body written in as its `### Context`, so the session explores it from there.
 
 **If `phase` is `research`:**

--- a/skills/workflow-shared/references/ensure-discovery-item.md
+++ b/skills/workflow-shared/references/ensure-discovery-item.md
@@ -58,9 +58,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map add {work_u
 Assemble the call as follows:
 
 - Positional `{routing}`, `--source direct-start`, and `--force-dismissed` — always included.
-- `--summary "{summary}"` — included only when `summary` was supplied and is non-empty.
-- `--description "{description}"` — included only when `description` was supplied and is non-empty (multi-paragraph values are fine).
-- When `summary` was not supplied, pass `--backfill` in place of both fields — the item lands without them and a later discovery session backfills.
+- When `summary` was supplied and is non-empty: include `--summary "{summary}"`, plus `--description "{description}"` when `description` was supplied and is non-empty (multi-paragraph values are fine).
+- When `summary` was not supplied: pass `--backfill` in place of both fields — the engine refuses `--backfill` combined with either — and the item lands without them for a later discovery session to backfill.
 
 Single-quote any value containing characters zsh would interpret — backticks, `$`, `[]`, `{}`, `~`.
 

--- a/skills/workflow-shared/references/final-review-menu.md
+++ b/skills/workflow-shared/references/final-review-menu.md
@@ -4,7 +4,7 @@
 
 ---
 
-This reference is loaded at phase conclusion when a final-review agent has produced a cache file. It renders a three-option menu (review / skip / back) and delegates the raise-one-finding loop to the shared surfacing protocol.
+This reference is loaded at phase conclusion when a final-review agent has produced a cache file. It renders a two-option menu (review / skip) and delegates the raise-one-finding loop to the shared surfacing protocol.
 
 **Parameters** (provided by caller via Load directive):
 
@@ -56,15 +56,9 @@ Transition `status: acknowledged` → `status: incorporated`.
 
 → Return to caller.
 
-#### If `surfaced:` is non-empty
+#### If the unsurfaced set is non-empty
 
-The user opted in via the `review` option on a prior iteration. Continue raising findings via the shared protocol — its state machine sees `surfaced:` non-empty and routes directly to its raise-one-finding step.
-
-→ Load **[background-agent-surfacing.md](background-agent-surfacing.md)** with agent_type = `review`, cache_dir = `{cache_dir}`, cache_glob = `{cache_glob}`, findings_key = `{findings_key}`.
-
-→ Return to caller.
-
-#### If `surfaced:` is empty
+Conclusion is a decision point every time — whether the drain started mid-session or at a prior conclusion attempt, the user chooses between continuing the walk-through and concluding with the rest on record.
 
 → Proceed to **C. Render Menu**.
 
@@ -74,7 +68,7 @@ The user opted in via the `review` option on a prior iteration. Continue raising
 
 ```
 · · · · · · · · · · · ·
-Final review returned — flagged {N} area(s).
+Final review: {N} area(s) still unreviewed.
 
 - **`r`/`review`** — Walk through them one at a time
 - **`s`/`skip`** — Acknowledge and conclude the topic

--- a/skills/workflow-shared/references/final-review-menu.md
+++ b/skills/workflow-shared/references/final-review-menu.md
@@ -24,7 +24,7 @@ Find the most recent file in `{cache_dir}` matching `{cache_glob}` by set number
 
 #### If status is `pending`
 
-Read the file completely. Count findings in the frontmatter `{findings_key}` list. Transition the frontmatter: `status: pending` → `status: acknowledged`. The `surfaced: []` and `announced: false` fields were set by the orchestrator at dispatch time.
+Read the file completely. Count findings in the frontmatter `{findings_key}` list. Transition the frontmatter: `status: pending` → `status: acknowledged`. The `surfaced: []` and `announced: false` fields were written with the dispatch-time skeleton.
 
 **If the finding count is 0:**
 

--- a/skills/workflow-shared/references/read-brief-context.md
+++ b/skills/workflow-shared/references/read-brief-context.md
@@ -26,7 +26,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 **If `brief_path` is present and the brief file exists:**
 
-Read `.workflows/{work_unit}/discovery/briefs/{topic}.md` in full — the *discovery brief* — and use it as the starting context for this phase. Don't dump it back to the user verbatim. It is soft by location: treat it as provisional, to be ratified by this phase, not as settled fact.
+Read the file at `brief_path` in full — the *discovery brief* — and use it as the starting context for this phase. Don't dump it back to the user verbatim. It is soft by location: treat it as provisional, to be ratified by this phase, not as settled fact.
 
 → Proceed to **B. Track the Read**.
 

--- a/skills/workflow-shared/references/reconcile-advisory.md
+++ b/skills/workflow-shared/references/reconcile-advisory.md
@@ -4,7 +4,7 @@
 
 ---
 
-Caller passes `downstream_phase` = `research` | `discussion` — the phase whose downstream item may carry the flag.
+Caller passes `work_type`, `work_unit`, `topic`, and `downstream_phase` = `research` | `discussion` — the phase whose downstream item may carry the flag.
 
 Read the reconcile flag on the downstream item:
 

--- a/skills/workflow-shared/references/research-analysis.md
+++ b/skills/workflow-shared/references/research-analysis.md
@@ -172,7 +172,7 @@ Overwrite with the topic list:
 - **Sources**: {filename1}.md, {filename2}.md
 ```
 
-List every topic from **B**, even those that filtered out in **D** — the cache file is the analysis output, not the diff. If re-entered on a reuse boot where **B** did not run this session (a deferred staging file was picked up), source the topic list from the staging file's candidate blocks instead.
+List every topic from **B**, even those that filtered out in **D** — the cache file is the analysis output, not the diff. If re-entered on a reuse boot where **B** did not run this session (a deferred staging file was picked up), source the topic list from the staging file's candidate blocks instead — that file holds only the genuinely-new candidates, so the rebuilt cache is narrower than a fresh pass; the filtered topics' outcomes are already recorded on the map and the dismissed list, and the next content change re-runs the full analysis.
 
 Stamp the manifest's analysis_cache — one command checksums the completed research files, writes `checksum`, `generated`, and `files`, and indexes the cache file into the knowledge base so its content surfaces in future contextual queries:
 

--- a/skills/workflow-shared/references/resume-detection.md
+++ b/skills/workflow-shared/references/resume-detection.md
@@ -6,6 +6,15 @@
 
 Read `{file}`.
 
+**If the file has a `## Triage` section that is not `(none)`:** it holds concerns rerouted here from other topics — their origin sessions recorded them as landed, and restart destroys them. Render this warning before the menu ({N} = the count of `### {title}` entries):
+
+> *Output the next fenced block as a code block:*
+
+```
+  ⚑ {N} rerouted concern(s) from other topics sit undrained in this
+    file's Triage section. Restarting deletes them permanently.
+```
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```

--- a/skills/workflow-shared/references/topic-discovery-dispatch.md
+++ b/skills/workflow-shared/references/topic-discovery-dispatch.md
@@ -20,10 +20,10 @@ The caller is also responsible for surfacing `new_arrivals` afterwards (e.g. as 
 Initialise an in-conversation tracker:
 
 ```
-new_arrivals = {}
+new_arrivals = { research_analysis: [], gap_analysis: [] }
 ```
 
-This tracker is populated by `topic-discovery.md` when analyses fire below. The caller reads it after this reference returns.
+This tracker is populated by `topic-discovery.md` when analyses fire below. The caller reads it after this reference returns — the keys exist even when no analysis fires.
 
 → Proceed to **B. Cache Status Check**.
 

--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -51,7 +51,7 @@ This tracker captures topic names **approved and written** during this run, per 
 
 ## B. Run Research Analysis if Stale
 
-Research-analysis runs first because gap-analysis reads its cache file as a secondary input.
+Research-analysis runs first so that a theme both analyses surface is already on the map when gap-analysis stages — its already-on-map branch then merges provenance instead of staging a duplicate (see **D. Dedupe Sources**).
 
 #### If `analysis_caches.research_analysis.status` is `stale`
 

--- a/skills/workflow-shared/references/topic-name-validation.md
+++ b/skills/workflow-shared/references/topic-name-validation.md
@@ -4,7 +4,7 @@
 
 ---
 
-Validates a proposed topic name. First step normalises to kebab-case silently (callers always have Claude pick the name, so a slip should self-correct rather than escalate). Then checks against active discovery-map items (collision rejects) and the dismissed list (informational — caller pulls before writing). Returns a `result` the caller branches on. The reference is read-only — it never mutates the manifest.
+Validates a proposed topic name. First step normalises to kebab-case silently (callers always have Claude pick the name, so a slip should self-correct rather than escalate). Then checks against active discovery-map items (collision rejects) and the dismissed list (informational — the write clears the entry). Returns a `result` the caller branches on. The reference is read-only — it never mutates the manifest.
 
 ## Parameters
 
@@ -16,7 +16,7 @@ The caller provides these via context before loading:
 After return, the caller reads `result` from conversation memory. Possible values:
 
 - `collision-active` — name matches an active discovery-map item. Rejection rendered.
-- `matches-dismissed` — name matches an entry on the dismissed list. **Informational** — caller pulls before writing.
+- `matches-dismissed` — name matches an entry on the dismissed list. **Informational** — the creating flow's write clears the entry.
 - `ok` — no conflict. Caller proceeds.
 
 ## A. Normalise to Kebab-Case
@@ -33,7 +33,7 @@ Test `proposed_name` against this pattern: `^[a-z0-9]+(-[a-z0-9]+)*$`.
 
 #### Otherwise
 
-Re-derive a kebab-case form for `proposed_name` per casing-conventions.md (lowercase, split on spaces/underscores/punctuation, join with single hyphens, strip leading/trailing hyphens). Use the corrected value as `proposed_name` for all subsequent steps. Do not render a rejection or surface the correction to the user — the caller and the user only see the normalised name from this point onward.
+Re-derive a kebab-case form for `proposed_name` — lowercase, split on spaces/underscores/punctuation, join with single hyphens, strip leading/trailing hyphens. Use the corrected value as `proposed_name` for all subsequent steps. Do not render a rejection or surface the correction to the user — the caller and the user only see the normalised name from this point onward.
 
 → Proceed to **B. Read Map and Dismissed List**.
 
@@ -77,7 +77,7 @@ or use edit-summary / change-routing on the existing item.
 
 Check whether `proposed_name` matches any entry in `dismissed` (case-sensitive).
 
-A dismissed-list match is **not** a rejection. User-explicit spawns (split, reroute, discovery session add, direct-entry) bypass the dismissed list — the list only blocks automatic re-adds by analyses. The caller pulls the name from `dismissed` before writing the new item.
+A dismissed-list match is **not** a rejection. User-explicit spawns (split, reroute, discovery session add, direct-entry) bypass the dismissed list — the list only blocks automatic re-adds by analyses. The creating flow's `discovery-map add --force-dismissed` clears the entry at write time.
 
 #### If a match exists
 

--- a/skills/workflow-shared/references/triage-landing.md
+++ b/skills/workflow-shared/references/triage-landing.md
@@ -6,7 +6,7 @@
 
 Lands a rerouted concern in a target topic's `## Triage` section so the target drains it when its phase next runs. Epic-only — single-topic work types (feature, bugfix, quick-fix) have no second topic to route to; their callers ignore the concern, surface it to the inbox, or pivot to an epic, and never load this reference.
 
-The caller has already resolved and confirmed the target, and confirmed it is a **different** topic from the current one (a concern that belongs to the current topic is normal subtopic or thread work, not a reroute). This reference writes the manifest and artefact but does **not** commit — the caller's commit covers both.
+The caller has already resolved and confirmed the target, and confirmed it is a **different** topic from the current one (a concern that belongs to the current topic is normal subtopic or thread work, not a reroute). This reference writes the manifest and artefact but does **not** commit — the caller's commit covers both. (The one exception: `topic reactivate` in **E** is an engine transaction that commits itself.)
 
 ## Parameters
 
@@ -21,7 +21,7 @@ The caller provides these via context before loading:
 
 After return, the caller reads these from conversation memory:
 
-- `result` — `landed` (entry written; manifest/artefact ready for the caller's commit) or `cancelled` (a new target's name was dropped; nothing written).
+- `result` — `landed` (entry written; manifest/artefact ready for the caller's commit) or `cancelled` (the reroute was dropped or blocked; nothing written).
 - `landed_topic` — the final target name (a new target may have been renamed during validation).
 
 ## Triage Entry Shape
@@ -39,7 +39,7 @@ Carry **everything** worked out about the concern — as many paragraphs as it t
 
 ## A. Classify the Target
 
-Resolution is computed against the **live** map at landing time, never cached — a target created earlier in the same session must resolve correctly:
+Resolution is computed against the **live** state at landing time, never cached — a target created earlier in the same session must resolve correctly:
 
 ```bash
 node .claude/skills/workflow-discovery/scripts/gateway.cjs {work_unit}
@@ -53,17 +53,46 @@ The target is not on the map yet.
 
 → Proceed to **B. New Target**.
 
-#### If the row has no `phase=` field
+#### If the row's lifecycle is `handled` or `cancelled`
 
-A discovery item exists but no research or discussion artefact does yet.
+The topic is closed — no future session will drain its Triage, and concluded artefacts may exist beneath it.
 
-→ Proceed to **C. Fresh Target**.
+→ Proceed to **E. Closed Target**.
 
 #### Otherwise
 
-The artefact named by the row's `phase=` field already exists.
+The dump's `phase=` field only reflects live phase work — completed, cancelled, and superseded items exist without it. Classify by the phase items themselves. Read both statuses (`get` prints nothing for an absent item):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{target} status
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{target} status
+```
+
+Evaluate in order — first match wins:
+
+**If the discussion status is `in-progress` or `completed`:**
+
+Set `landing_phase = discussion` and `landing_status` to that status.
 
 → Proceed to **D. Existing Target**.
+
+**If the research status is `in-progress` or `completed`:**
+
+Set `landing_phase = research` and `landing_status` to that status.
+
+→ Proceed to **D. Existing Target**.
+
+**If the research status is `superseded`:**
+
+The research lineage is closed — an entry written there would never drain.
+
+→ Proceed to **F. Superseded Research**.
+
+**If neither item is live:**
+
+No live artefact. Set `landing_phase` to the row's `routing=` value — unless that phase's item exists as `cancelled` (`topic start` refuses it), in which case set `landing_phase` to the other phase.
+
+→ Proceed to **C. Fresh Target**.
 
 ## B. New Target
 
@@ -89,13 +118,21 @@ Set `result = landed`.
 
 ## C. Fresh Target
 
-The discovery item exists; read its `routing=` value from the map row. Create that phase's item:
+The discovery item exists with no live phase item. Create the `{landing_phase}` item:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} {routing} {target}
+node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} {landing_phase} {target}
 ```
 
-Create the artefact stub at `.workflows/{work_unit}/{routing}/{target}.md` from the `{routing}` template — [discussion template](../../workflow-discussion-process/references/template.md) or [research template](../../workflow-research-process/references/template.md). Write the concern into its `## Triage` section using the entry shape above, replacing the `(none)` placeholder.
+**If the response is `ok: false`:**
+
+Surface the engine's error verbatim — it names the recovery path (e.g. a cancelled item routes through `topic reactivate`). Nothing has been written; set `result = cancelled`.
+
+→ Return to caller.
+
+**Otherwise:**
+
+Create the artefact stub at `.workflows/{work_unit}/{landing_phase}/{target}.md` from the `{landing_phase}` template — [discussion template](../../workflow-discussion-process/references/template.md) or [research template](../../workflow-research-process/references/template.md). Write the concern into its `## Triage` section using the entry shape above, replacing the `(none)` placeholder.
 
 Set `landed_topic = {target}` and `result = landed`.
 
@@ -103,28 +140,124 @@ Set `landed_topic = {target}` and `result = landed`.
 
 ## D. Existing Target
 
-Read the row's `phase=` value as `{current_phase}`. The live artefact is `.workflows/{work_unit}/{current_phase}/{target}.md`.
+The live artefact is `.workflows/{work_unit}/{landing_phase}/{target}.md`.
 
-Append the concern as a `### {short title}` subsection under that file's `## Triage` heading, using the entry shape above. If the section holds the `(none)` placeholder, replace it; otherwise add the entry below the existing ones. If the file has no `## Triage` heading at all — an artefact created outside the template — add the heading at end of file with the entry beneath it.
+#### If `landing_status` is `completed`
 
-Reopen the target if it has concluded, so it recomputes as actionable:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.{current_phase}.{target} status
-```
-
-**If the status is `completed`:**
+Reopen the target first — never land an entry in an artefact left concluded:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} {current_phase} {target}
+node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} {landing_phase} {target}
 ```
 
-Set `landed_topic = {target}` and `result = landed`.
+**If the response is `ok: false`:**
+
+Surface the engine's error verbatim. Nothing has been written; set `result = cancelled`.
 
 → Return to caller.
 
 **Otherwise:**
 
-The item is already in progress — no reopen needed. Set `landed_topic = {target}` and `result = landed`.
+→ Proceed to **G. Append the Entry**.
+
+#### If `landing_status` is `in-progress`
+
+The item is already live — no reopen needed.
+
+→ Proceed to **G. Append the Entry**.
+
+## E. Closed Target
+
+Never stub over a concluded artefact, and never land an entry no session will drain. Surface the state and let the user decide:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+"{target}" is @if(lifecycle == 'handled') marked handled — fanned out into other topics @else cancelled @endif, so it won't pick up rerouted concerns.
+
+- **`o`/`open`** — @if(lifecycle == 'handled') Clear the handled marker @else Reactivate it @endif and land the concern there
+- **`e`/`elsewhere`** — Pick a different target
+- **`d`/`drop`** — Drop the reroute; the concern stays with the current topic
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `open`:**
+
+Reopen the topic — for `handled`:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map unhandle {work_unit} {target}
+```
+
+For `cancelled` (an engine transaction — it commits itself):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs topic reactivate {work_unit} {routing} {target}
+```
+
+If the response is `ok: false`, surface the engine's error verbatim and re-render this menu — the concern is still unlanded. Otherwise re-classify against the fresh state:
+
+→ Return to **A. Classify the Target**.
+
+**If `elsewhere`:**
+
+Ask the user which topic the concern should land in, set `target` to their answer, and re-classify:
+
+→ Return to **A. Classify the Target**.
+
+**If `drop`:**
+
+Nothing written. Set `result = cancelled`.
+
+→ Return to caller.
+
+## F. Superseded Research
+
+Read where the research lineage went:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{target} superseded_by
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+"{target}"'s research was superseded by "{superseded_by}" — an entry there would never drain.
+
+- **`s`/`superseding`** — Land the concern in "{superseded_by}" instead
+- **`d`/`discussion`** — Start "{target}"'s discussion and land it there
+- **`e`/`elsewhere`** — Pick a different target
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `superseding`:**
+
+Set `target = {superseded_by}` and re-classify:
+
+→ Return to **A. Classify the Target**.
+
+**If `discussion`:**
+
+Set `landing_phase = discussion`.
+
+→ Proceed to **C. Fresh Target**.
+
+**If `elsewhere`:**
+
+Ask the user which topic the concern should land in, set `target` to their answer, and re-classify:
+
+→ Return to **A. Classify the Target**.
+
+## G. Append the Entry
+
+Append the concern as a `### {short title}` subsection under `.workflows/{work_unit}/{landing_phase}/{target}.md`'s `## Triage` heading, using the entry shape above. If the section holds the `(none)` placeholder, replace it; otherwise add the entry below the existing ones. If the file has no `## Triage` heading at all — an artefact created outside the template — add the heading at end of file with the entry beneath it.
+
+Set `landed_topic = {target}` and `result = landed`.
 
 → Return to caller.

--- a/skills/workflow-shared/references/triage-landing.md
+++ b/skills/workflow-shared/references/triage-landing.md
@@ -55,7 +55,7 @@ The target is not on the map yet.
 
 #### If the row's lifecycle is `handled` or `cancelled`
 
-The topic is closed — no future session will drain its Triage, and concluded artefacts may exist beneath it.
+The topic is closed — no future session will drain its Triage, and concluded artefacts may exist beneath it. Record the row's lifecycle as `lifecycle` and its `routing=` value as `routing`.
 
 → Proceed to **E. Closed Target**.
 


### PR DESCRIPTION
Round-3 hunt fixes, wave 4 of 4 (19 items, zero skips) + the strict conventions compliance pass over all four waves.

triage-landing rewritten: targets classify by manifest state, never the dump's phase field — handled/cancelled targets get an explicit closed-target menu (no more template-stubbing over completed research), superseded research gets its own routing, and every engine call has a refusal branch. The in-flight detection redesign: orchestrators write skeleton cache files (`status: in-flight`) at all 8 dispatch sites so running agents are actually visible to scans, caps count the right population, and the briefs fill-and-flip to pending. Restarts clear the phase cache and warn about undrained triage; final reviews stop re-dispatching without new commits and keep the skip affordance mid-drain; deep-dive promotion goes through the map; investigation gaps must be addressed or dismissed before conclusion. Conventions gate: PASS after 4 fixes (`@elseif`, spacing, link bolding, routing arrow), 86 files checked, mechanical checks scripted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #442
2. #443
3. #444
4. #445
5. #446
6. #447
7. #383
8. #384
9. #385
10. #386
11. #387
12. #388
13. #389
14. #399
15. #400
16. #401
17. #402
18. #403
19. #404
20. #405
21. #406
22. #407
23. #408
24. #409
25. #411
26. #412
27. #413
28. #414
29. #415
30. #416
31. #417
32. #418
33. #419
34. #420
35. #421
36. #422
37. #423
38. #424
39. #425
40. #426
41. #427
42. #428
43. #429
44. #430
45. #431
46. #432
47. #433
48. #434
49. #435
50. #452
51. #453
52. #454
53. #455
54. #456
55. #457
56. #448
57. #449
58. #450
59. **#451** 👈 current
60. #458
61. #459
62. #460
63. #461
64. #462
65. #463
66. #464
67. #465
68. #466
69. #467
70. #468
71. #469
72. #470
73. #471
74. #472
75. #473
76. #474
77. #475
78. #476
79. #477
80. #478
<!-- stack:links:end -->