### PR TITLE
cert: cross-cutting joins the specification entry

### DIFF
--- a/skills/workflow-specification-entry/references/confirm-unify.md
+++ b/skills/workflow-specification-entry/references/confirm-unify.md
@@ -26,7 +26,7 @@ Existing specifications to incorporate:
   • .workflows/{work_unit}/specification/{topic}/specification.md → will be superseded
   • .workflows/{work_unit}/specification/{topic}/specification.md → will be superseded
 
-Output: .workflows/unified/specification/unified/specification.md
+Output: .workflows/{work_unit}/specification/unified/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -55,7 +55,7 @@ Sources:
   • {discussion-name}
   ...
 
-Output: .workflows/unified/specification/unified/specification.md
+Output: .workflows/{work_unit}/specification/unified/specification.md
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-specification-entry/references/invoke-skill.md
+++ b/skills/workflow-specification-entry/references/invoke-skill.md
@@ -62,3 +62,22 @@ Invoke the workflow-specification-process skill.
 ```
 
 Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
+
+#### If `work_type` is `cross-cutting`
+
+Check for completed research: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{topic} status`. Include the `Research:` line only when the status is `completed`; omit it otherwise.
+
+```
+Specification session for: {work_unit}
+
+Source material:
+- Discussion: .workflows/{work_unit}/discussion/{topic}.md
+- Research: .workflows/{work_unit}/research/{topic}.md
+
+Work unit: {work_unit}
+Action: {verb} specification
+
+Invoke the workflow-specification-process skill.
+```
+
+Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -114,3 +114,39 @@ Run /workflow-start to continue an in-progress discussion.
 **If at least one completed discussion exists:**
 
 → Return to caller.
+
+#### If `work_type` is `cross-cutting`
+
+Check if discussion exists and is completed. Read status via `engine manifest`: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} status`.
+
+**If discussion doesn't exist:**
+
+> *Output the next fenced block as a code block:*
+
+```
+Source Material Missing
+
+No discussion found for "{work_unit:(titlecase)}".
+
+A completed discussion is required before specification can begin.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If discussion exists but status is "in-progress":**
+
+> *Output the next fenced block as a code block:*
+
+```
+Discussion In Progress
+
+The discussion for "{work_unit:(titlecase)}" is not yet completed.
+
+The discussion must be completed before specification can begin.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If discussion exists and status is "completed":**
+
+→ Return to caller.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -198,6 +198,26 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 
 → Load **[promote-to-cross-cutting.md](promote-to-cross-cutting.md)** and follow its instructions as written.
 
+#### If work_type is `cross-cutting`
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Specification complete. The specification is the final artifact
+> for a cross-cutting concern — the pipeline completes here.
+```
+
+Invoke the bridge:
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: specification
+
+Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
 #### Otherwise
 
 > *Output the next fenced block as markdown (not a code block):*


### PR DESCRIPTION
Certification fix 1 of 6. The spec entry's validate-source and invoke-skill had branches for feature/bugfix/epic only — a cross-cutting run fell through with no legal instruction (pre-existing; three fleet agents confirmed independently). Adds both branches (research correctly optional), makes spec-completion's terminal line type-aware (no false planning promise for cc), and fixes confirm-unify's two wrong displayed output paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. **#452** 👈 current
57. #453
58. #454
59. #455
60. #456
61. #457
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->