### PR TITLE
cert: allowed-tools sweep — declarations match the runtime closures

### DIFF
--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-bridge
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-bridge/scripts/gateway.cjs), Bash(node .claude/skills/workflow-continue-epic/scripts/gateway.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-bridge/scripts/gateway.cjs), Bash(node .claude/skills/workflow-continue-epic/scripts/gateway.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/)
 ---
 
 Enter plan mode with deterministic continuation instructions.

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-continue-epic
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-continue-epic/scripts/gateway.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-continue-epic/scripts/gateway.cjs), Bash(node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/)
 ---
 
 Continue an in-progress epic. Shows full phase-by-phase state and routes to the appropriate phase skill.

--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-discovery
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(git status), Bash(mkdir -p .workflows/)
+allowed-tools: Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(git status), Bash(git log), Bash(mkdir -p .workflows/), Bash(rm .workflows/), Bash(rm -f .workflows/)
 ---
 
 # Discovery

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-discussion-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-discussion-process/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-discussion-process/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(git status), Bash(git log)
 ---
 
 # Discussion Process

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-implementation-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(git status), Bash(git log)
 ---
 
 # Implementation Process

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-investigation-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(git status), Bash(git log)
 ---
 
 # Investigation Process

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-planning-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(ls .workflows/), Bash(rm -rf .workflows/), Bash(git status), Bash(git log), Bash(git diff), Bash(git add), Bash(git commit)
 ---
 
 # Planning Process

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-research-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(git status), Bash(git log)
 ---
 
 # Research Process

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-review-entry
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(ls .workflows/)
+allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
 ---
 
 Act as **precise intake coordinator**. Follow each step literally without interpretation. Do not engage with the subject matter — your role is preparation, not processing.

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-review-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.inbox/*)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(ls .workflows/), Bash(git status), Bash(git log), Bash(git add), Bash(git commit)
 ---
 
 # Review Process

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-scoping-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(ls .workflows/), Bash(git status), Bash(git log), Bash(git add), Bash(git commit)
 ---
 
 # Scoping Process

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-specification-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(ls .workflows/), Bash(git status), Bash(git log)
 ---
 
 # Specification Process

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-start
 disable-model-invocation: true
-allowed-tools: Bash(node .claude/skills/workflow-start/scripts/gateway.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(git status), Bash(git diff)
+allowed-tools: Bash(node .claude/skills/workflow-start/scripts/gateway.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(git status), Bash(git diff)
 ---
 
 Unified workflow entry point. Discovers state, shows all active work, and routes to start or continue skills.


### PR DESCRIPTION
Certification fix 6 of 6, frontmatter-only. Every main-thread command each skill's runtime closure prescribes now has a matching declaration (mkdir/ls/rm scoped to .workflows paths, read-only git ops, and — per ruling — git add/commit in the skills with deliberate raw sites). Dead declarations removed with closure evidence, including bridge/continue-epic's knowledge declarations: the manual-remove fallback they once served became display-only text when KB removal moved into the topic cancel/reactivate transactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #436
2. #437
3. #438
4. #439
5. #440
6. #441
7. #442
8. #443
9. #444
10. #445
11. #446
12. #447
13. #383
14. #384
15. #385
16. #386
17. #387
18. #388
19. #389
20. #399
21. #400
22. #401
23. #402
24. #403
25. #404
26. #405
27. #406
28. #407
29. #408
30. #409
31. #411
32. #412
33. #413
34. #414
35. #415
36. #416
37. #417
38. #418
39. #419
40. #420
41. #421
42. #422
43. #423
44. #424
45. #425
46. #426
47. #427
48. #428
49. #429
50. #430
51. #431
52. #432
53. #433
54. #434
55. #435
56. #452
57. #453
58. #454
59. #455
60. #456
61. **#457** 👈 current
62. #448
63. #449
64. #450
65. #451
66. #458
67. #459
68. #460
69. #461
70. #462
71. #463
72. #464
73. #465
74. #466
75. #467
76. #468
77. #469
78. #470
79. #471
80. #472
81. #473
82. #474
83. #475
84. #476
85. #477
86. #478
<!-- stack:links:end -->