### PR TITLE
r4: dynamic menus codified — state-derived options render engine-side

### DIFF
--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -45,7 +45,7 @@ Run the discovery script with the work unit:
 node .claude/skills/workflow-bridge/scripts/gateway.cjs {work_unit}
 ```
 
-The output contains `next_phase` and `completed_phases` (in pipeline order).
+The output contains `next_phase`, `completed_phases` (in pipeline order), and `revisitable_phases` — the completed phases before `next_phase`, filtered to the work type's pipeline. When candidates exist, a labelled `MENU: revisit phases` section follows the dump — emitted only at the continuation's revisit gate, never here.
 
 → Proceed to **Step 2**.
 

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -95,13 +95,13 @@ Bugfix Completed
 
 ## C. Check for Earlier Phases
 
-Check if there are completed phases earlier in the pipeline that the user could revisit. Read the discovery output's `completed_phases` — any phase listed before `next_phase` in the pipeline order.
+Read the discovery output's `revisitable_phases` — the completed phases the user could revisit.
 
-#### If no earlier completed phases exist
+#### If `revisitable_phases` is `(none)`
 
 → Proceed to **F. Enter Plan Mode**.
 
-#### If earlier completed phases exist
+#### Otherwise
 
 → Proceed to **D. Offer Revisit**.
 
@@ -130,21 +130,7 @@ Check if there are completed phases earlier in the pipeline that the user could 
 
 ## E. Select Phase
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which phase would you like to revisit?
-
-- **`1`** — {phase:(titlecase)} — completed
-- **`2`** — ...
-- **`b`/`back`** — Return to the previous menu
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-List only completed phases that come before `next_phase`.
+Emit the discovery output's `MENU: revisit phases` section verbatim as markdown (not a code block). Its numbering follows `revisitable_phases` order.
 
 **STOP.** Wait for user response.
 
@@ -154,7 +140,7 @@ List only completed phases that come before `next_phase`.
 
 #### If user chose a phase
 
-Set `target_phase` = selected phase.
+Set `target_phase` = the number's phase in `revisitable_phases`.
 
 → Proceed to **F. Enter Plan Mode**.
 

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -47,13 +47,13 @@ Set `target_phase` = `next_phase`.
 
 ## B. Check for Earlier Phases
 
-Check if there are completed phases earlier in the pipeline that the user could revisit. Read the discovery output's `completed_phases` — any phase listed before `next_phase` in the pipeline order.
+Read the discovery output's `revisitable_phases` — the completed phases the user could revisit.
 
-#### If no earlier completed phases exist
+#### If `revisitable_phases` is `(none)`
 
 → Proceed to **E. Enter Plan Mode**.
 
-#### If earlier completed phases exist
+#### Otherwise
 
 → Proceed to **C. Offer Revisit**.
 
@@ -82,21 +82,7 @@ Check if there are completed phases earlier in the pipeline that the user could 
 
 ## D. Select Phase
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which phase would you like to revisit?
-
-- **`1`** — {phase:(titlecase)} — completed
-- **`2`** — ...
-- **`b`/`back`** — Return to the previous menu
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-List only completed phases that come before `next_phase`.
+Emit the discovery output's `MENU: revisit phases` section verbatim as markdown (not a code block). Its numbering follows `revisitable_phases` order.
 
 **STOP.** Wait for user response.
 
@@ -106,7 +92,7 @@ List only completed phases that come before `next_phase`.
 
 #### If user chose a phase
 
-Set `target_phase` = selected phase.
+Set `target_phase` = the number's phase in `revisitable_phases`.
 
 → Proceed to **E. Enter Plan Mode**.
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -96,13 +96,13 @@ Feature Completed
 
 ## C. Check for Earlier Phases
 
-Check if there are completed phases earlier in the pipeline that the user could revisit. Read the discovery output's `completed_phases` — any phase listed before `next_phase` in the pipeline order.
+Read the discovery output's `revisitable_phases` — the completed phases the user could revisit.
 
-#### If no earlier completed phases exist
+#### If `revisitable_phases` is `(none)`
 
 → Proceed to **F. Enter Plan Mode**.
 
-#### If earlier completed phases exist
+#### Otherwise
 
 → Proceed to **D. Offer Revisit**.
 
@@ -131,21 +131,7 @@ Check if there are completed phases earlier in the pipeline that the user could 
 
 ## E. Select Phase
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which phase would you like to revisit?
-
-- **`1`** — {phase:(titlecase)} — completed
-- **`2`** — ...
-- **`b`/`back`** — Return to the previous menu
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-List only completed phases that come before `next_phase`.
+Emit the discovery output's `MENU: revisit phases` section verbatim as markdown (not a code block). Its numbering follows `revisitable_phases` order.
 
 **STOP.** Wait for user response.
 
@@ -155,7 +141,7 @@ List only completed phases that come before `next_phase`.
 
 #### If user chose a phase
 
-Set `target_phase` = selected phase.
+Set `target_phase` = the number's phase in `revisitable_phases`.
 
 → Proceed to **F. Enter Plan Mode**.
 

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -93,13 +93,13 @@ Quick-Fix Completed
 
 ## C. Check for Earlier Phases
 
-Check if there are completed phases earlier in the pipeline that the user could revisit. Read the discovery output's `completed_phases` and keep only quick-fix pipeline phases — scoping, implementation, review — listed before `next_phase` in the pipeline order. The dump also lists specification and planning (written by scoping); they are not quick-fix phases, have no quick-fix entry route, and are never revisit targets.
+Read the discovery output's `revisitable_phases` — the completed phases the user could revisit, already filtered to quick-fix pipeline phases (specification and planning, written by scoping, are never revisit targets).
 
-#### If no earlier completed phases exist
+#### If `revisitable_phases` is `(none)`
 
 → Proceed to **F. Enter Plan Mode**.
 
-#### If earlier completed phases exist
+#### Otherwise
 
 → Proceed to **D. Offer Revisit**.
 
@@ -128,21 +128,7 @@ Check if there are completed phases earlier in the pipeline that the user could 
 
 ## E. Select Phase
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which phase would you like to revisit?
-
-- **`1`** — {phase:(titlecase)} — completed
-- **`2`** — ...
-- **`b`/`back`** — Return to the previous menu
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-List only completed quick-fix pipeline phases (scoping, implementation, review) that come before `next_phase` — never specification or planning.
+Emit the discovery output's `MENU: revisit phases` section verbatim as markdown (not a code block). Its numbering follows `revisitable_phases` order.
 
 **STOP.** Wait for user response.
 
@@ -152,7 +138,7 @@ List only completed quick-fix pipeline phases (scoping, implementation, review) 
 
 #### If user chose a phase
 
-Set `target_phase` = selected phase.
+Set `target_phase` = the number's phase in `revisitable_phases`.
 
 → Proceed to **F. Enter Plan Mode**.
 

--- a/skills/workflow-bridge/scripts/gateway.cjs
+++ b/skills/workflow-bridge/scripts/gateway.cjs
@@ -45,9 +45,11 @@ function discover(cwd, workUnit) {
   };
 }
 
-// The thin scoped dump: the two fields the continuation references branch
-// on — the derived next phase, and the completed set (in pipeline order) that
-// feeds the revisit menu.
+// The thin scoped dump: the fields the continuation references branch on —
+// the derived next phase, the completed set (in pipeline order), and the
+// revisit candidates (completed phases before next_phase, filtered to the
+// type's pipeline). When candidates exist, the labelled revisit-phase menu
+// follows the dump — emitted only at the gate its marker names.
 function format(result) {
   if (result.error) return `Error: ${result.error}\n`;
 
@@ -59,7 +61,17 @@ function format(result) {
   lines.push(`=== ${result.work_unit} (${result.work_type}) ===`);
   lines.push(`next_phase: ${result.next_phase}`);
   lines.push(`completed_phases: ${completed.join(', ') || '(none)'}`);
-  return lines.join('\n') + '\n';
+
+  let section = '';
+  if (engine.detail.WORK_UNIT_TYPES[result.work_type]) {
+    const revisitable = result.next_phase === 'done'
+      ? []
+      : engine.project.revisitablePhases(result.work_type, { next_phase: result.next_phase, completed_phases: completed });
+    lines.push(`revisitable_phases: ${revisitable.join(', ') || '(none)'}`);
+    section = engine.project.revisitPhasesSection(revisitable);
+  }
+
+  return lines.join('\n') + '\n' + (section ? section : '');
 }
 
 if (require.main === module) {

--- a/skills/workflow-continue-bugfix/SKILL.md
+++ b/skills/workflow-continue-bugfix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-continue-bugfix
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-continue-bugfix/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick)
+allowed-tools: Bash(node .claude/skills/workflow-continue-bugfix/scripts/gateway.cjs), Bash(node .claude/skills/workflow-start/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick)
 ---
 
 Continue an in-progress bugfix. Determines current phase and routes to the appropriate phase skill.

--- a/skills/workflow-continue-bugfix/references/bugfix-display-and-menu.md
+++ b/skills/workflow-continue-bugfix/references/bugfix-display-and-menu.md
@@ -23,6 +23,7 @@ The output is one snapshot in three demarcated sections:
 - **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `finalising`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
 - **DISPLAY** — the status block. Emit verbatim as a code block. Never redraw, reflow, or trim it.
 - **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit or finalise.
+- **MENU: revisit phases** — labelled deferred section, present when earlier phases can be revisited. Emitted only at **C. Select Phase**, never here.
 
 Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
@@ -78,21 +79,7 @@ Bugfix Completed
 
 ## C. Select Phase
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which phase would you like to revisit?
-
-- **`1`** — {phase:(titlecase)} — completed
-- **`2`** — ...
-- **`b`/`back`** — Return to the previous menu
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-List one option per `revisit_phase` entry in `ACTIONS`, numbered by its key.
+Emit the snapshot's `MENU: revisit phases` section verbatim as markdown (not a code block). Its numbering matches the `revisit_phase` keys in `ACTIONS`.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-bugfix/scripts/gateway.cjs
+++ b/skills/workflow-continue-bugfix/scripts/gateway.cjs
@@ -8,7 +8,9 @@
 //
 //   gateway.cjs               → labelled dump, all active bugfixes (head insert)
 //   gateway.cjs view {work_unit}
-//                               → DATA + DISPLAY + MENU snapshot (Step 5)
+//                               → DATA + DISPLAY + MENU snapshot (Step 5),
+//                                 plus the deferred revisit-phase menu when
+//                                 earlier phases can be revisited
 //
 // Those two calls are the whole legal surface: an unknown verb, a bare
 // positional, or excess arguments is a usage error (stderr, exit 1) — never
@@ -40,7 +42,8 @@ function view(workUnit) {
     engine.gateway.dataBlock(engine.project.workUnitData(TYPE, unit, menu)),
     engine.gateway.displayBlock(engine.project.workUnitStatus(TYPE, unit)),
     engine.gateway.menuBlock(menu.rendered),
-  ].join('\n');
+    engine.project.revisitPhasesSection(engine.project.revisitablePhases(TYPE, unit)),
+  ].filter(Boolean).join('\n');
 }
 
 const USAGE = 'Usage: gateway.cjs | gateway.cjs view {work_unit}';

--- a/skills/workflow-continue-cross-cutting/SKILL.md
+++ b/skills/workflow-continue-cross-cutting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-continue-cross-cutting
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-continue-cross-cutting/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick)
+allowed-tools: Bash(node .claude/skills/workflow-continue-cross-cutting/scripts/gateway.cjs), Bash(node .claude/skills/workflow-start/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick)
 ---
 
 Continue an in-progress cross-cutting concern. Determines current phase and routes to the appropriate phase skill.

--- a/skills/workflow-continue-cross-cutting/references/cross-cutting-display-and-menu.md
+++ b/skills/workflow-continue-cross-cutting/references/cross-cutting-display-and-menu.md
@@ -23,6 +23,7 @@ The output is one snapshot in three demarcated sections:
 - **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `finalising`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
 - **DISPLAY** — the status block. Emit verbatim as a code block. Never redraw, reflow, or trim it.
 - **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit or finalise.
+- **MENU: revisit phases** — labelled deferred section, present when earlier phases can be revisited. Emitted only at **C. Select Phase**, never here.
 
 Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
@@ -78,21 +79,7 @@ Cross-Cutting Completed
 
 ## C. Select Phase
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which phase would you like to revisit?
-
-- **`1`** — {phase:(titlecase)} — completed
-- **`2`** — ...
-- **`b`/`back`** — Return to the previous menu
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-List one option per `revisit_phase` entry in `ACTIONS`, numbered by its key.
+Emit the snapshot's `MENU: revisit phases` section verbatim as markdown (not a code block). Its numbering matches the `revisit_phase` keys in `ACTIONS`.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-cross-cutting/scripts/gateway.cjs
+++ b/skills/workflow-continue-cross-cutting/scripts/gateway.cjs
@@ -8,7 +8,9 @@
 //
 //   gateway.cjs               → labelled dump, all active concerns (head insert)
 //   gateway.cjs view {work_unit}
-//                               → DATA + DISPLAY + MENU snapshot (Step 5)
+//                               → DATA + DISPLAY + MENU snapshot (Step 5),
+//                                 plus the deferred revisit-phase menu when
+//                                 earlier phases can be revisited
 //
 // Those two calls are the whole legal surface: an unknown verb, a bare
 // positional, or excess arguments is a usage error (stderr, exit 1) — never
@@ -40,7 +42,8 @@ function view(workUnit) {
     engine.gateway.dataBlock(engine.project.workUnitData(TYPE, unit, menu)),
     engine.gateway.displayBlock(engine.project.workUnitStatus(TYPE, unit)),
     engine.gateway.menuBlock(menu.rendered),
-  ].join('\n');
+    engine.project.revisitPhasesSection(engine.project.revisitablePhases(TYPE, unit)),
+  ].filter(Boolean).join('\n');
 }
 
 const USAGE = 'Usage: gateway.cjs | gateway.cjs view {work_unit}';

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-continue-epic
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-continue-epic/scripts/gateway.cjs), Bash(node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick), Bash(mkdir -p .workflows/)
+allowed-tools: Bash(node .claude/skills/workflow-continue-epic/scripts/gateway.cjs), Bash(node .claude/skills/workflow-start/scripts/gateway.cjs), Bash(node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs), Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick), Bash(mkdir -p .workflows/)
 ---
 
 Continue an in-progress epic. Shows full phase-by-phase state and routes to the appropriate phase skill.

--- a/skills/workflow-continue-feature/SKILL.md
+++ b/skills/workflow-continue-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-continue-feature
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-continue-feature/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick)
+allowed-tools: Bash(node .claude/skills/workflow-continue-feature/scripts/gateway.cjs), Bash(node .claude/skills/workflow-start/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick)
 ---
 
 Continue an in-progress feature. Determines current phase and routes to the appropriate phase skill.

--- a/skills/workflow-continue-feature/references/feature-display-and-menu.md
+++ b/skills/workflow-continue-feature/references/feature-display-and-menu.md
@@ -23,6 +23,7 @@ The output is one snapshot in three demarcated sections:
 - **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `finalising`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
 - **DISPLAY** — the status block. Emit verbatim as a code block. Never redraw, reflow, or trim it.
 - **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit or finalise.
+- **MENU: revisit phases** — labelled deferred section, present when earlier phases can be revisited. Emitted only at **C. Select Phase**, never here.
 
 Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
@@ -78,21 +79,7 @@ Feature Completed
 
 ## C. Select Phase
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which phase would you like to revisit?
-
-- **`1`** — {phase:(titlecase)} — completed
-- **`2`** — ...
-- **`b`/`back`** — Return to the previous menu
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-List one option per `revisit_phase` entry in `ACTIONS`, numbered by its key.
+Emit the snapshot's `MENU: revisit phases` section verbatim as markdown (not a code block). Its numbering matches the `revisit_phase` keys in `ACTIONS`.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-feature/scripts/gateway.cjs
+++ b/skills/workflow-continue-feature/scripts/gateway.cjs
@@ -8,7 +8,9 @@
 //
 //   gateway.cjs               → labelled dump, all active features (head insert)
 //   gateway.cjs view {work_unit}
-//                               → DATA + DISPLAY + MENU snapshot (Step 5)
+//                               → DATA + DISPLAY + MENU snapshot (Step 5),
+//                                 plus the deferred revisit-phase menu when
+//                                 earlier phases can be revisited
 //
 // Those two calls are the whole legal surface: an unknown verb, a bare
 // positional, or excess arguments is a usage error (stderr, exit 1) — never
@@ -40,7 +42,8 @@ function view(workUnit) {
     engine.gateway.dataBlock(engine.project.workUnitData(TYPE, unit, menu)),
     engine.gateway.displayBlock(engine.project.workUnitStatus(TYPE, unit)),
     engine.gateway.menuBlock(menu.rendered),
-  ].join('\n');
+    engine.project.revisitPhasesSection(engine.project.revisitablePhases(TYPE, unit)),
+  ].filter(Boolean).join('\n');
 }
 
 const USAGE = 'Usage: gateway.cjs | gateway.cjs view {work_unit}';

--- a/skills/workflow-continue-quickfix/SKILL.md
+++ b/skills/workflow-continue-quickfix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-continue-quickfix
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-continue-quickfix/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick)
+allowed-tools: Bash(node .claude/skills/workflow-continue-quickfix/scripts/gateway.cjs), Bash(node .claude/skills/workflow-start/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(tick)
 ---
 
 Continue an in-progress quick-fix. Determines current phase and routes to the appropriate phase skill.

--- a/skills/workflow-continue-quickfix/references/quickfix-display-and-menu.md
+++ b/skills/workflow-continue-quickfix/references/quickfix-display-and-menu.md
@@ -23,6 +23,7 @@ The output is one snapshot in three demarcated sections:
 - **DATA** — reasoning surface: state flags (`next_phase`, `phase_label`, `finalising`, `completed_phases`, `revisit_available`) and the `ACTIONS` table — one line per key, `key  action  topic  → route`. Reason from it; never display or restate it.
 - **DISPLAY** — the status block. Emit verbatim as a code block. Never redraw, reflow, or trim it.
 - **MENU** — the proceed/revisit menu. Emit verbatim as markdown (not a code block). Empty when there is nothing to revisit or finalise.
+- **MENU: revisit phases** — labelled deferred section, present when earlier phases can be revisited. Emitted only at **C. Select Phase**, never here.
 
 Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
@@ -78,21 +79,7 @@ Quick-Fix Completed
 
 ## C. Select Phase
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which phase would you like to revisit?
-
-- **`1`** — {phase:(titlecase)} — completed
-- **`2`** — ...
-- **`b`/`back`** — Return to the previous menu
-
-Select an option:
-· · · · · · · · · · · ·
-```
-
-List one option per `revisit_phase` entry in `ACTIONS`, numbered by its key.
+Emit the snapshot's `MENU: revisit phases` section verbatim as markdown (not a code block). Its numbering matches the `revisit_phase` keys in `ACTIONS`.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-quickfix/scripts/gateway.cjs
+++ b/skills/workflow-continue-quickfix/scripts/gateway.cjs
@@ -8,7 +8,9 @@
 //
 //   gateway.cjs               → labelled dump, all active quick-fixes (head insert)
 //   gateway.cjs view {work_unit}
-//                               → DATA + DISPLAY + MENU snapshot (Step 5)
+//                               → DATA + DISPLAY + MENU snapshot (Step 5),
+//                                 plus the deferred revisit-phase menu when
+//                                 earlier phases can be revisited
 //
 // Those two calls are the whole legal surface: an unknown verb, a bare
 // positional, or excess arguments is a usage error (stderr, exit 1) — never
@@ -40,7 +42,8 @@ function view(workUnit) {
     engine.gateway.dataBlock(engine.project.workUnitData(TYPE, unit, menu)),
     engine.gateway.displayBlock(engine.project.workUnitStatus(TYPE, unit)),
     engine.gateway.menuBlock(menu.rendered),
-  ].join('\n');
+    engine.project.revisitPhasesSection(engine.project.revisitablePhases(TYPE, unit)),
+  ].filter(Boolean).join('\n');
 }
 
 const USAGE = 'Usage: gateway.cjs | gateway.cjs view {work_unit}';

--- a/skills/workflow-engine/references/library-and-gateway.md
+++ b/skills/workflow-engine/references/library-and-gateway.md
@@ -64,6 +64,9 @@ engine.discussionMap.mapState(manifest, topic)    // → { counts, total, all_de
 // domain: detail builders + projections
 engine.detail.epicDetail(cwd, manifest)           // → EpicDetail (the one structured object per epic)
 engine.detail.startDetail(cwd)                    // → StartDetail (all work units by type + inbox + closed counts)
+engine.detail.combinedInbox(scan, { archived })   // → PickupItem[] (one inbox scan combined, date-ordered, numbered)
+engine.detail.workingSetDetail(cwd, paths)        // → WorkingSetDetail (held selection: uniformity, pre-seed type, addable items)
+engine.detail.manageDetail(cwd, wu)               // → ManageDetail (lifecycle-action availability), or null
 engine.detail.workUnitDetail(cwd, type)           // → WorkUnitDetail (single-topic types: feature | bugfix | quick-fix | cross-cutting)
 engine.detail.workUnitIndex(type, detail)         // → labelled dump for the head-of-skill insert (thin DATA index)
 engine.detail.specificationDetail(wu, result, { consultHints }) // → SpecificationDetail (entry scenario + grouping rows over one discover() result)
@@ -75,9 +78,19 @@ engine.project.discoverySynthesisView(wu, map, proposed) // → harvest proposal
 engine.project.discussionMap(topic, manifest)     // → Discussion Map display block
 engine.project.startOverview(detail)              // → Workflow Overview display block
 engine.project.startMenu(detail)                  // → { keys, rendered } — continue entries + start/lifecycle options
+engine.project.emptyOverview(detail)              // → empty-state overview block
+engine.project.emptyMenu(detail)                  // → { keys, rendered } — empty-state start menu
+engine.project.inboxPickupView(items, hasArchived)// → { data, display, menu } — inbox pickup snapshot bodies
+engine.project.archivedView(items)                // → { data, display, menu } — archived store snapshot bodies
+engine.project.workingSetView(ws)                 // → { data, menu, sections } — set menu + deferred add/drop gates
+engine.project.manageListView(detail)             // → { data, display, menu, rows } — manage selection snapshot
+engine.project.manageUnitView(md)                 // → { data, menu, sections } — action menu + deferred absorb/plan gates
+engine.project.completedView(detail, filter)      // → { data, display, menu, rows } — completed & cancelled snapshot
 engine.project.workUnitStatus(type, unit)         // → status display block (box + pipeline tree)
 engine.project.workUnitMenu(type, unit)           // → { keys, rendered } — proceed/revisit gate; '' rendered when nothing to revisit
 engine.project.workUnitData(type, unit, menu)     // → DATA body (flow flags + ACTIONS key table)
+engine.project.revisitablePhases(type, unit)      // → string[] — completed phases before next_phase, pipeline-filtered
+engine.project.revisitPhasesSection(phases)       // → labelled `MENU: revisit phases` section ('' when none)
 engine.project.specificationDisplay(detail)       // → scenario overview block ('' when the scenario renders nothing)
 engine.project.specificationMenu(detail)          // → { keys, rendered } — grouping/spec menu; both empty for menu-less scenarios
 engine.project.specificationCompletedMenu(detail) // → { keys, display, rendered } — concluded-specs Refine sub-view

--- a/skills/workflow-engine/scripts/domain/inbox-set.cjs
+++ b/skills/workflow-engine/scripts/domain/inbox-set.cjs
@@ -1,0 +1,115 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: inbox pickup collation — the combined, date-ordered item list
+// the pickup and archived sub-views number, and the working-set detail (the
+// selection the pickup carries toward discovery). Pure over the project's
+// `.workflows/.inbox/` tree plus the caller-held set paths: same files, same
+// paths, same answer. Path validation comes from domain/inbox — the same
+// layout rules the inbox transactions enforce.
+// ---------------------------------------------------------------------------
+
+const { discoverInbox } = require('./start.cjs');
+const { parseInboxPath } = require('./inbox.cjs');
+
+// Folder → display type (the index dump's vocabulary) and → the work-type
+// pre-seed a uniform set carries into discovery.
+const FOLDER_TYPE = { ideas: 'idea', bugs: 'bug', quickfixes: 'quick-fix' };
+const FOLDER_PRE_SEED = { ideas: 'none', bugs: 'bugfix', quickfixes: 'quick-fix' };
+
+/**
+ * @typedef {object} PickupItem
+ * @property {number} n       1-based position in its list
+ * @property {string} type    idea | bug | quick-fix
+ * @property {string} folder  ideas | bugs | quickfixes
+ * @property {string} date
+ * @property {string} slug
+ * @property {string} title
+ * @property {string} path    project-relative inbox path
+ */
+
+/**
+ * @typedef {object} WorkingSetDetail
+ * @property {PickupItem[]} items    the set, in the caller's order
+ * @property {number} count
+ * @property {boolean} uniform       every item shares one folder
+ * @property {string} set_type      uniform → the folder's pre-seed (`bugfix` | `quick-fix` | `none`); otherwise `mixed`
+ * @property {PickupItem[]} addable  live inbox items not in the set, pickup order
+ */
+
+/**
+ * One folder's scan rows as pickup items (unnumbered; combine() numbers).
+ * @param {import('./start.cjs').InboxScan} scan
+ * @param {'ideas'|'bugs'|'quickfixes'} folder
+ * @param {boolean} archived
+ * @returns {PickupItem[]}
+ */
+function folderItems(scan, folder, archived) {
+  const rows = folder === 'ideas' ? scan.ideas : folder === 'bugs' ? scan.bugs : scan.quickfixes;
+  const base = archived ? '.workflows/.inbox/.archived' : '.workflows/.inbox';
+  return rows.map((r) => ({
+    n: 0,
+    type: FOLDER_TYPE[folder],
+    folder,
+    date: r.date,
+    slug: r.slug,
+    title: r.title,
+    path: `${base}/${folder}/${r.file}`,
+  }));
+}
+
+/**
+ * The combined pickup list over one inbox scan: all three folders, sorted by
+ * date (oldest first) then slug, numbered 1..N.
+ * @param {import('./start.cjs').InboxScan} scan
+ * @param {{archived?: boolean}} [opts]
+ * @returns {PickupItem[]}
+ */
+function combinedInbox(scan, opts = {}) {
+  const archived = opts.archived === true;
+  const items = [
+    ...folderItems(scan, 'ideas', archived),
+    ...folderItems(scan, 'bugs', archived),
+    ...folderItems(scan, 'quickfixes', archived),
+  ];
+  items.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0));
+  items.forEach((item, i) => { item.n = i + 1; });
+  return items;
+}
+
+/**
+ * Build the working-set detail for a held selection of live inbox paths.
+ * Loud on anything outside the live inbox — the set can only hold items that
+ * are still there to act on.
+ * @param {string} cwd
+ * @param {string[]} paths  project-relative live inbox paths, caller's order
+ * @returns {WorkingSetDetail}
+ */
+function workingSetDetail(cwd, paths) {
+  if (paths.length === 0) throw new Error('working set is empty — pass at least one inbox path');
+  const live = combinedInbox(discoverInbox(cwd));
+  const byPath = new Map(live.map((item) => [item.path, item]));
+
+  /** @type {PickupItem[]} */
+  const items = paths.map((given, i) => {
+    const parsed = parseInboxPath(given, { archived: false });
+    const found = byPath.get(parsed.given);
+    if (!found) throw new Error(`not in the live inbox: "${given}"`);
+    return { ...found, n: i + 1 };
+  });
+
+  const folders = new Set(items.map((item) => item.folder));
+  const uniform = folders.size === 1;
+  const inSet = new Set(items.map((item) => item.path));
+  const addable = live.filter((item) => !inSet.has(item.path)).map((item, i) => ({ ...item, n: i + 1 }));
+
+  return {
+    items,
+    count: items.length,
+    uniform,
+    set_type: uniform ? FOLDER_PRE_SEED[items[0].folder] : 'mixed',
+    addable,
+  };
+}
+
+module.exports = { combinedInbox, workingSetDetail };

--- a/skills/workflow-engine/scripts/domain/projections/start.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/start.cjs
@@ -2,12 +2,17 @@
 
 // ---------------------------------------------------------------------------
 // Domain ring: workflow-start projections — the Workflow Overview display and
-// the unified continue/start menu over one StartDetail (see ../start.cjs).
+// the unified continue/start menu over one StartDetail (see ../start.cjs),
+// plus the skill's state-derived sub-views: the empty state, the inbox pickup
+// and archived lists, the working set, the manage flow, and the completed &
+// cancelled view. Sub-view projections return `{data, display, menu}` bodies
+// (the adapter wraps them in section markers); flows with later gates also
+// return labelled deferred `sections`, emitted only where their marker says.
 //
 // Deterministic: same detail, same string. The overview is a flat list (one
 // numbered item + one └─ sub-row each, numbering continuous across the type
-// sections) — composed line-by-line here, not a continuous-gutter tree. The
-// menu carries machine action keys so skills route on keys, never on labels.
+// sections) — composed line-by-line here, not a continuous-gutter tree. Menus
+// carry machine action keys so skills route on keys, never on labels.
 // ---------------------------------------------------------------------------
 
 const { box } = require('../../kernel/render.cjs');
@@ -16,6 +21,21 @@ const { titlecase, capitalise } = require('../conventions.cjs');
 /** @typedef {import('../start.cjs').StartDetail} StartDetail */
 /** @typedef {import('../start.cjs').WorkUnitEntry} WorkUnitEntry */
 /** @typedef {import('../start.cjs').InboxDetail} InboxDetail */
+/** @typedef {import('../inbox-set.cjs').PickupItem} PickupItem */
+/** @typedef {import('../inbox-set.cjs').WorkingSetDetail} WorkingSetDetail */
+/** @typedef {import('../workunit-manage.cjs').ManageDetail} ManageDetail */
+
+const DOTS = '· · · · · · · · · · · ·';
+
+/** Dot-framed menu block. @param {string[]} lines @returns {string} */
+function dotMenu(lines) {
+  return [DOTS, ...lines, DOTS].join('\n');
+}
+
+/** One labelled `=== NAME (instruction) ===` deferred section. @param {string} name @param {string} instruction @param {string} body */
+function labelled(name, instruction, body) {
+  return `=== ${name} (${instruction}) ===\n${body.replace(/\n+$/, '')}\n`;
+}
 
 /**
  * @typedef {object} StartMenuKey
@@ -193,4 +213,424 @@ function startMenu(detail) {
   return { keys: [...numbered, ...options], rendered: lines.join('\n') };
 }
 
-module.exports = { startOverview, startMenu };
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+/**
+ * The empty-state Workflow Overview: no active work, closed counts when any.
+ * @param {StartDetail} detail
+ * @returns {string}
+ */
+function emptyOverview(detail) {
+  let out = box('Workflow Overview') + 'No active work found.\n';
+  if (detail.completed_count > 0 || detail.cancelled_count > 0) {
+    out += `\n${detail.completed_count} completed, ${detail.cancelled_count} cancelled.\n`;
+  }
+  return out;
+}
+
+/**
+ * The empty-state start menu — the six start-new options with pipeline-shape
+ * labels, `i` only with a live inbox, `v` only with closed work units. Same
+ * key shape as startMenu, so the ACTIONS table and routing are uniform.
+ * @param {StartDetail} detail
+ * @returns {{keys: StartMenuKey[], rendered: string}}
+ */
+function emptyMenu(detail) {
+  /** @type {StartMenuKey[]} */
+  const options = [
+    { key: 's', word: 'start', action: 'start_new', pre_seed: 'none', route: null, label: "Not sure what kind yet — describe it and we'll shape it" },
+    { key: 'f', word: 'feature', action: 'start_new', pre_seed: 'feature', route: null, label: 'Single topic: (research →) discussion → spec → plan → implement → review' },
+    { key: 'e', word: 'epic', action: 'start_new', pre_seed: 'epic', route: null, label: 'Multiple topics, multi-session, same pipeline per topic' },
+    { key: 'b', word: 'bugfix', action: 'start_new', pre_seed: 'bugfix', route: null, label: 'Investigation → spec → plan → implement → review' },
+    { key: 'q', word: 'quick-fix', action: 'start_new', pre_seed: 'quick-fix', route: null, label: 'Scoping → implement → review (no formal planning)' },
+    { key: 'c', word: 'cross-cutting', action: 'start_new', pre_seed: 'cross-cutting', route: null, label: '(Research →) discussion → spec (patterns or policies that inform other work)' },
+  ];
+  if (detail.state.has_inbox) {
+    const n = detail.state.inbox_count;
+    options.push({ key: 'i', word: 'inbox', action: 'view_inbox', route: null, label: `View the inbox and start from an item (${n} item${n === 1 ? '' : 's'})` });
+  }
+  if (detail.completed_count > 0 || detail.cancelled_count > 0) {
+    options.push({ key: 'v', word: 'view', action: 'view_completed', route: null, label: 'View completed & cancelled work units' });
+  }
+
+  const lines = ['What would you like to start?', ''];
+  for (const o of options) {
+    lines.push(`- **\`${o.key}\`/\`${o.word}\`** — ${o.label}`);
+  }
+  lines.push('', 'Select an option:');
+
+  return { keys: options, rendered: dotMenu(lines) };
+}
+
+// ---------------------------------------------------------------------------
+// Inbox pickup + archived store
+// ---------------------------------------------------------------------------
+
+/** The `n  type  date  slug  → path` table under a header line. @param {string} header @param {PickupItem[]} items */
+function itemTable(header, items) {
+  const lines = [`${header} (n  type  date  slug  → path):`];
+  for (const item of items) {
+    lines.push(`  ${item.n}  ${item.type}  ${item.date}  ${item.slug}  → ${item.path}`);
+  }
+  return lines;
+}
+
+/** Numbered pickup rows, dated. @param {PickupItem[]} items */
+function pickupRows(items) {
+  return items.map((item) => `  ${item.n}. ${item.title} (${item.type}, ${item.date})`);
+}
+
+/**
+ * The inbox pickup snapshot: numbered live items, the select/archived/back
+ * menu. Selection numbers resolve through the DATA `ITEMS` table.
+ * @param {PickupItem[]} items      combined live inbox, pickup order
+ * @param {boolean} hasArchived
+ * @returns {{data: string, display: string, menu: string}}
+ */
+function inboxPickupView(items, hasArchived) {
+  const data = [
+    `inbox_count: ${items.length}`,
+    `has_archived: ${hasArchived}`,
+    ...itemTable('ITEMS', items),
+  ].join('\n');
+
+  const display = box('Inbox')
+    + (items.length > 0 ? pickupRows(items).join('\n') + '\n' : 'No inbox items.\n');
+
+  const options = [];
+  if (items.length === 1) {
+    options.push('- **`1`** — Select the item to work on');
+  } else if (items.length > 1) {
+    options.push(`- **\`1\`–\`${items.length}\`** — Select item(s) to work on (comma-separated for several)`);
+  }
+  if (hasArchived) options.push('- **`a`/`archived`** — View archived items (restore or delete)');
+  options.push('- **`b`/`back`** — Return');
+
+  return { data, display, menu: dotMenu(['What would you like to do?', '', ...options]) };
+}
+
+/**
+ * The archived-store snapshot: numbered archived items and the select prompt
+ * (empty menu when nothing is archived).
+ * @param {PickupItem[]} items  combined archived items, pickup order
+ * @returns {{data: string, display: string, menu: string}}
+ */
+function archivedView(items) {
+  const data = [
+    `archived_count: ${items.length}`,
+    ...itemTable('ITEMS', items),
+  ].join('\n');
+
+  const display = box('Archived')
+    + (items.length > 0 ? pickupRows(items).join('\n') + '\n' : 'No archived items.\n');
+
+  const menu = items.length > 0
+    ? dotMenu(['Select an item (enter number, or **`b`/`back`** to return):'])
+    : '';
+
+  return { data, display, menu };
+}
+
+// ---------------------------------------------------------------------------
+// Working set
+// ---------------------------------------------------------------------------
+
+/**
+ * The working-set snapshot: the set menu (`w`/`work` renders only for a
+ * type-uniform set) plus the deferred add/drop gates. The set's item render
+ * (titles, summaries) stays with the session — summaries are synthesised
+ * content the engine never writes.
+ * @param {WorkingSetDetail} ws
+ * @returns {{data: string, menu: string, sections: string}}
+ */
+function workingSetView(ws) {
+  const data = [
+    `set_count: ${ws.count}`,
+    `set_uniform: ${ws.uniform}`,
+    `set_type: ${ws.set_type}`,
+    `addable_count: ${ws.addable.length}`,
+    ...itemTable('SET', ws.items),
+    ...itemTable('ADDABLE', ws.addable),
+  ].join('\n');
+
+  const options = [];
+  if (ws.uniform) options.push('- **`w`/`work`** — Proceed to discovery with this set');
+  options.push(
+    '- **`a`/`add`** — Add another inbox item to the set',
+    '- **`d`/`drop`** — Drop item(s) from the set (keeps them in the inbox)',
+    '- **`r`/`archive`** — Archive the whole set out of the inbox',
+    '- **`v`/`view`** — View full content of the set',
+    '- **`b`/`back`** — Return to the inbox list',
+    '- **Ask** — Ask about the set',
+  );
+  const menu = dotMenu([
+    'What would you like to do? Type a shortcut, or just tell me in',
+    'your own words — e.g. "add 2 and 4", "drop the bug", "archive these".',
+    '',
+    ...options,
+  ]);
+
+  const sections = [];
+  if (ws.addable.length > 0) {
+    sections.push(labelled(
+      'DISPLAY: add candidates',
+      'emit verbatim as a code block only at the add-items gate — never at the call',
+      ws.addable.map((item) => `  ${item.n}. ${item.title} (${item.type}, ${item.date})`).join('\n'),
+    ));
+    sections.push(labelled(
+      'MENU: add gate',
+      'emit verbatim as markdown only at the add-items gate',
+      dotMenu(['Add which? (enter number(s), comma-separated, or **`b`/`back`**)']),
+    ));
+  }
+  sections.push(labelled(
+    'DISPLAY: drop candidates',
+    'emit verbatim as a code block only at the drop-items gate — never at the call',
+    ws.items.map((item) => `  ${item.n}. ${item.title} (${item.type})`).join('\n'),
+  ));
+  sections.push(labelled(
+    'MENU: drop gate',
+    'emit verbatim as markdown only at the drop-items gate',
+    dotMenu(['Drop which? (enter number(s), comma-separated, or **`b`/`back`**)']),
+  ));
+
+  return { data, menu, sections: sections.join('\n') };
+}
+
+// ---------------------------------------------------------------------------
+// Manage
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} ManageRow
+ * @property {number} n
+ * @property {string} work_type
+ * @property {string} work_unit
+ */
+
+/**
+ * The manage selection snapshot: every active work unit by type, numbering
+ * continuous across sections — the same order and numbers as the overview.
+ * @param {StartDetail} detail
+ * @returns {{data: string, display: string, menu: string, rows: ManageRow[]}}
+ */
+function manageListView(detail) {
+  /** @type {ManageRow[]} */
+  const rows = [];
+  const displayLines = [];
+  for (const s of SECTIONS) {
+    const units = detail[s.group].work_units;
+    if (units.length === 0) continue;
+    displayLines.push(s.label);
+    for (const u of units) {
+      rows.push({ n: rows.length + 1, work_type: s.type, work_unit: u.name });
+      displayLines.push(`  ${rows.length}. ${titlecase(u.name)}`);
+    }
+    displayLines.push('');
+  }
+
+  const data = [
+    `unit_count: ${rows.length}`,
+    'UNITS (n  work_type  work_unit):',
+    ...rows.map((r) => `  ${r.n}  ${r.work_type}  ${r.work_unit}`),
+  ].join('\n');
+
+  const display = box('Manage')
+    + (rows.length > 0 ? displayLines.join('\n') : 'No active work units.\n');
+
+  const menu = rows.length > 0
+    ? dotMenu(['Select a work unit (enter number, or **`b`/`back`** to return):'])
+    : '';
+
+  return { data, display, menu, rows };
+}
+
+/**
+ * One work unit's manage snapshot: the action menu offering exactly the
+ * actions its state allows, plus the deferred absorb-target and view-plan
+ * topic gates when those actions are live.
+ * @param {ManageDetail} md
+ * @returns {{data: string, menu: string, sections: string}}
+ */
+function manageUnitView(md) {
+  /** @type {[string, string][]} */
+  const actions = [];
+  const options = [];
+  if (md.implementation_completed) {
+    actions.push(['d', 'mark_completed']);
+    options.push('- **`d`/`done`** — Mark as completed');
+  }
+  if (md.work_type === 'feature') {
+    actions.push(['p', 'pivot']);
+    options.push('- **`p`/`pivot`** — Convert to epic (enables multiple topics)');
+  }
+  if (md.absorb_available) {
+    actions.push(['a', 'absorb']);
+    options.push('- **`a`/`absorb`** — Merge into an existing epic');
+  }
+  if (md.has_plan) {
+    actions.push(['v', 'view_plan']);
+    options.push('- **`v`/`view-plan`** — View the implementation plan');
+  }
+  actions.push(['c', 'cancel'], ['b', 'back']);
+  options.push(
+    '- **`c`/`cancel`** — Mark as cancelled',
+    '- **`b`/`back`** — Return',
+    '- **Ask** — Ask a question about this work unit',
+  );
+
+  const data = [
+    `work_unit: ${md.work_unit}`,
+    `work_type: ${md.work_type}`,
+    `status: ${md.status}`,
+    `implementation_completed: ${md.implementation_completed}`,
+    `has_plan: ${md.has_plan}`,
+    `has_spec: ${md.has_spec}`,
+    `has_discussion: ${md.has_discussion}`,
+    `absorb_available: ${md.absorb_available}`,
+    `available_epics: ${md.available_epics.join(', ') || '(none)'}`,
+    `planning_topics: ${md.planning_topics.map((t) => `${t.name} [${t.status}]`).join(', ') || '(none)'}`,
+    'ACTIONS (key  action):',
+    ...actions.map(([k, a]) => `  ${k}  ${a}`),
+  ].join('\n');
+
+  const menu = dotMenu([
+    `**${titlecase(md.work_unit)}** (${md.work_type})`,
+    '',
+    ...options,
+  ]);
+
+  const sections = [];
+  if (md.absorb_available) {
+    sections.push(labelled(
+      'MENU: absorb target',
+      'emit verbatim as markdown only at the absorb target gate — never at the call',
+      dotMenu([
+        'Select a target epic:',
+        '',
+        ...md.available_epics.map((name, i) => `- **\`${i + 1}\`** — ${titlecase(name)}`),
+        '',
+        '- **`b`/`back`** — Return',
+      ]),
+    ));
+  }
+  if (md.work_type === 'epic' && md.has_plan && md.planning_topics.length > 1) {
+    sections.push(labelled(
+      'MENU: plan topics',
+      'emit verbatim as markdown only at the view-plan topic gate — never at the call',
+      dotMenu([
+        'Which plan would you like to view?',
+        '',
+        ...md.planning_topics.map((t, i) => `- **\`${i + 1}\`** — ${titlecase(t.name)} — ${t.status}`),
+      ]),
+    ));
+  }
+
+  return { data, menu, sections: sections.join('\n') };
+}
+
+// ---------------------------------------------------------------------------
+// Completed & cancelled
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} ClosedRow
+ * @property {number} n
+ * @property {string} status
+ * @property {string} work_type
+ * @property {string} work_unit
+ * @property {string} last_phase
+ */
+
+// The `Showing:` label per work-type filter — the overview's section labels.
+/** @type {Record<string, string>} */
+const FILTER_LABELS = {
+  feature: 'Features',
+  bugfix: 'Bugfixes',
+  'quick-fix': 'Quick Fixes',
+  'cross-cutting': 'Cross-Cutting',
+  epic: 'Epics',
+};
+
+/**
+ * The completed & cancelled snapshot, optionally filtered to one work type
+ * (the per-type navigation skills pass their own). Numbering is continuous
+ * across the two lists; numbers resolve through the DATA `UNITS` table.
+ * @param {StartDetail} detail
+ * @param {string} [filter]  a work type, or undefined for all
+ * @returns {{data: string, display: string, menu: string, rows: ClosedRow[]}}
+ */
+function completedView(detail, filter) {
+  if (filter !== undefined && !FILTER_LABELS[filter]) {
+    throw new Error(`unknown work-type filter "${filter}" (${Object.keys(FILTER_LABELS).join(' | ')})`);
+  }
+  const match = (/** @type {import('../start.cjs').ClosedEntry} */ e) => filter === undefined || e.work_type === filter;
+  /** @type {ClosedRow[]} */
+  const rows = [];
+  for (const e of [...detail.completed.filter(match), ...detail.cancelled.filter(match)]) {
+    rows.push({ n: rows.length + 1, status: e.status, work_type: e.work_type, work_unit: e.name, last_phase: e.last_phase || 'none' });
+  }
+  const completedRows = rows.filter((r) => r.status === 'completed');
+  const cancelledRows = rows.filter((r) => r.status === 'cancelled');
+
+  const data = [
+    `filter: ${filter || '(none)'}`,
+    `completed_count: ${completedRows.length}`,
+    `cancelled_count: ${cancelledRows.length}`,
+    'UNITS (n  status  work_type  work_unit  last_phase):',
+    ...rows.map((r) => `  ${r.n}  ${r.status}  ${r.work_type}  ${r.work_unit}  ${r.last_phase}`),
+  ].join('\n');
+
+  let display = box('Completed & Cancelled');
+  if (rows.length === 0) {
+    display += 'No completed or cancelled work units found.\n';
+  } else {
+    const lines = [];
+    if (filter !== undefined) {
+      lines.push(`Showing: ${FILTER_LABELS[filter]}`);
+      lines.push('');
+    }
+    if (completedRows.length > 0) {
+      lines.push('Completed:');
+      for (const r of completedRows) {
+        lines.push(`  ${r.n}. ${titlecase(r.work_unit)}`);
+        lines.push(`     └─ Completed after: ${r.last_phase}`);
+        lines.push('');
+      }
+    }
+    if (cancelledRows.length > 0) {
+      lines.push('Cancelled:');
+      for (const r of cancelledRows) {
+        lines.push(`  ${r.n}. ${titlecase(r.work_unit)}`);
+        lines.push(`     └─ Cancelled during: ${r.last_phase}`);
+        lines.push('');
+      }
+    }
+    display += lines.join('\n').replace(/\n+$/, '\n');
+  }
+
+  const menu = rows.length > 0
+    ? dotMenu([
+      'Select a work unit for details, or **`b`/`back`** to return.',
+      '',
+      'Select an option (enter number):',
+    ])
+    : '';
+
+  return { data, display, menu, rows };
+}
+
+module.exports = {
+  startOverview,
+  startMenu,
+  emptyOverview,
+  emptyMenu,
+  inboxPickupView,
+  archivedView,
+  workingSetView,
+  manageListView,
+  manageUnitView,
+  completedView,
+};

--- a/skills/workflow-engine/scripts/domain/projections/workunit.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/workunit.cjs
@@ -181,4 +181,40 @@ function workUnitData(type, unit, menu) {
   return lines.join('\n');
 }
 
-module.exports = { workUnitStatus, workUnitMenu, workUnitData };
+/**
+ * The revisit candidates for one unit — completed phases before `next_phase`
+ * in the type's pipeline (every completed phase when `next_phase` sits outside
+ * it, the finalising case). The same set workUnitMenu numbers its
+ * `revisit_phase` keys from.
+ * @param {string} type  a WORK_UNIT_TYPES key
+ * @param {{next_phase: string, completed_phases: string[]}} unit
+ * @returns {string[]}
+ */
+function revisitablePhases(type, unit) {
+  return earlierCompleted(typeConfig(type), /** @type {WorkUnitEntry} */ (unit));
+}
+
+/**
+ * The labelled deferred revisit-phase menu — one numbered option per phase,
+ * numbering matching the `revisit_phase` keys. Empty string when there is
+ * nothing to revisit.
+ * @param {string[]} phases  revisitablePhases order
+ * @returns {string}
+ */
+function revisitPhasesSection(phases) {
+  if (phases.length === 0) return '';
+  const body = [
+    '· · · · · · · · · · · ·',
+    'Which phase would you like to revisit?',
+    '',
+    ...phases.map((phase, i) => `- **\`${i + 1}\`** — ${titlecase(phase)} — completed`),
+    '- **`b`/`back`** — Return to the previous menu',
+    '',
+    'Select an option:',
+    '· · · · · · · · · · · ·',
+  ].join('\n');
+  const marker = '=== MENU: revisit phases (emit verbatim as markdown only at the revisit phase gate — never at the call) ===';
+  return `${marker}\n${body}\n`;
+}
+
+module.exports = { workUnitStatus, workUnitMenu, workUnitData, revisitablePhases, revisitPhasesSection };

--- a/skills/workflow-engine/scripts/domain/start.cjs
+++ b/skills/workflow-engine/scripts/domain/start.cjs
@@ -320,4 +320,4 @@ function startDetail(cwd) {
   };
 }
 
-module.exports = { startDetail };
+module.exports = { startDetail, discoverInbox };

--- a/skills/workflow-engine/scripts/domain/workunit-manage.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-manage.cjs
@@ -1,0 +1,71 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: the manage detail — one work unit's lifecycle-action
+// availability, computed for the manage action menu. Which actions the menu
+// offers is manifest state (work type, phase presence, implementation
+// completion, in-progress epics for absorption), so it is derived here, in one
+// place, never re-derived by the session. Pure over the project's
+// `.workflows/` tree: same files, same answer.
+// ---------------------------------------------------------------------------
+
+const { loadManifest, loadActiveManifests } = require('./reads.cjs');
+const { phaseItems } = require('./derivations.cjs');
+
+/**
+ * @typedef {object} PlanningTopic
+ * @property {string} name
+ * @property {string} status
+ */
+
+/**
+ * @typedef {object} ManageDetail
+ * @property {string} work_unit
+ * @property {string} work_type
+ * @property {string} status
+ * @property {boolean} implementation_completed  any implementation item completed → `done` offered
+ * @property {boolean} has_plan                  planning phase present → `view-plan` offered
+ * @property {boolean} has_spec                  specification phase present (absorb guard)
+ * @property {boolean} has_discussion            discussion phase present (absorb guard)
+ * @property {string[]} available_epics          in-progress epic names — absorb targets
+ * @property {boolean} absorb_available          feature, no spec, has discussion, ≥1 epic target
+ * @property {PlanningTopic[]} planning_topics   the view-plan topic choices (epics)
+ */
+
+/** @param {object} manifest @param {string} phase */
+function phasePresent(manifest, phase) {
+  return Object.prototype.hasOwnProperty.call(manifest.phases || {}, phase);
+}
+
+/**
+ * Build the manage detail for one work unit.
+ * @param {string} cwd
+ * @param {string} workUnit
+ * @returns {ManageDetail|null} null when the manifest is missing or unreadable
+ */
+function manageDetail(cwd, workUnit) {
+  const manifest = loadManifest(cwd, workUnit);
+  if (!manifest) return null;
+
+  const workType = manifest.work_type || 'feature';
+  const hasSpec = phasePresent(manifest, 'specification');
+  const hasDiscussion = phasePresent(manifest, 'discussion');
+  const availableEpics = loadActiveManifests(cwd)
+    .filter((m) => m.work_type === 'epic' && m.name !== workUnit)
+    .map((m) => m.name);
+
+  return {
+    work_unit: workUnit,
+    work_type: workType,
+    status: manifest.status,
+    implementation_completed: phaseItems(manifest, 'implementation').some((i) => i.status === 'completed'),
+    has_plan: phasePresent(manifest, 'planning'),
+    has_spec: hasSpec,
+    has_discussion: hasDiscussion,
+    available_epics: availableEpics,
+    absorb_available: workType === 'feature' && !hasSpec && hasDiscussion && availableEpics.length > 0,
+    planning_topics: phaseItems(manifest, 'planning').map((i) => ({ name: i.name, status: i.status || 'in-progress' })),
+  };
+}
+
+module.exports = { manageDetail };

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -28,7 +28,9 @@ const derivations = require('./domain/derivations.cjs');
 const gateway = require('./gateway.cjs');
 const epic = require('./domain/epic-detail.cjs');
 const start = require('./domain/start.cjs');
+const inboxSet = require('./domain/inbox-set.cjs');
 const workunit = require('./domain/workunit-detail.cjs');
+const workunitManage = require('./domain/workunit-manage.cjs');
 const specification = require('./domain/specification.cjs');
 const discussionMap = require('./domain/discussion-map.cjs');
 const epicProjections = require('./domain/projections/epic.cjs');
@@ -74,6 +76,9 @@ module.exports = {
     epicDetail: epic.epicDetail,
     EPIC_PHASES: epic.EPIC_PHASES,
     startDetail: start.startDetail,
+    combinedInbox: inboxSet.combinedInbox,
+    workingSetDetail: inboxSet.workingSetDetail,
+    manageDetail: workunitManage.manageDetail,
     workUnitDetail: workunit.workUnitDetail,
     workUnitIndex: workunit.workUnitIndex,
     WORK_UNIT_TYPES: workunit.WORK_UNIT_TYPES,
@@ -91,9 +96,19 @@ module.exports = {
     discussionMap: discussionProjections.discussionMap,
     startOverview: startProjections.startOverview,
     startMenu: startProjections.startMenu,
+    emptyOverview: startProjections.emptyOverview,
+    emptyMenu: startProjections.emptyMenu,
+    inboxPickupView: startProjections.inboxPickupView,
+    archivedView: startProjections.archivedView,
+    workingSetView: startProjections.workingSetView,
+    manageListView: startProjections.manageListView,
+    manageUnitView: startProjections.manageUnitView,
+    completedView: startProjections.completedView,
     workUnitStatus: workunitProjections.workUnitStatus,
     workUnitMenu: workunitProjections.workUnitMenu,
     workUnitData: workunitProjections.workUnitData,
+    revisitablePhases: workunitProjections.revisitablePhases,
+    revisitPhasesSection: workunitProjections.revisitPhasesSection,
     specificationDisplay: specificationProjections.specificationDisplay,
     specificationMenu: specificationProjections.specificationMenu,
     specificationCompletedMenu: specificationProjections.specificationCompletedMenu,

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -14,17 +14,9 @@ Merge a feature's discussion into an existing epic as a new topic, then remove t
 > This will move the feature's discussion, research, seed, and imports
 > into the selected epic as a new topic and delete the feature work unit.
 > Git history serves as provenance.
-
-· · · · · · · · · · · ·
-Select a target epic:
-
-@foreach(epic in available_epics)
-- **`{N}`** — {epic.name:(titlecase)}
-@endforeach
-
-- **`b`/`back`** — Return
-· · · · · · · · · · · ·
 ```
+
+Emit the `MENU: absorb target` section from the caller's `manage {selected.name}` snapshot verbatim as markdown (not a code block). Its numbering follows the snapshot's `available_epics` order.
 
 **STOP.** Wait for user response.
 
@@ -34,7 +26,7 @@ Select a target epic:
 
 #### If user chose a number
 
-Store the selected epic as `target_epic`.
+Resolve the number against `available_epics` and store the selected epic as `target_epic`.
 
 → Proceed to **B. Name Topic**.
 

--- a/skills/workflow-start/references/empty-state.md
+++ b/skills/workflow-start/references/empty-state.md
@@ -8,44 +8,25 @@ No active work found. Offer to start something new, with option to view complete
 
 ## A. Display and Menu
 
-> *Output the next fenced block as a code block:*
+Render the workflow overview snapshot — with no active work it carries the empty-state display and start menu:
 
+```bash
+node .claude/skills/workflow-start/scripts/gateway.cjs view
 ```
-●───────────────────────────────────────────────●
-  Workflow Overview
-●───────────────────────────────────────────────●
 
-No active work found.
+The output is one snapshot in three demarcated sections:
 
-@if(completed_count > 0 || cancelled_count > 0)
-{completed_count} completed, {cancelled_count} cancelled.
-@endif
-```
+- **DATA** — reasoning surface: state flags, counts, and the `ACTIONS` table — one line per menu key, `key  action  work_unit  → route`, with `(pre_seed: …)` markers on start-new entries. Reason from it; never display or restate it.
+- **DISPLAY** — the empty-state overview. Emit verbatim as a code block. Never redraw, reflow, or trim it.
+- **MENU** — the start menu. Emit verbatim as markdown (not a code block).
+
+Emit the DISPLAY section, then the signpost blockquote below, then the MENU section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Pick a type if you know it, or start unsure and we'll figure out
 > the shape together. Each type follows its own pipeline.
-
-· · · · · · · · · · · ·
-What would you like to start?
-
-- **`s`/`start`** — Not sure what kind yet — describe it and we'll shape it
-- **`f`/`feature`** — Single topic: (research →) discussion → spec → plan → implement → review
-- **`e`/`epic`** — Multiple topics, multi-session, same pipeline per topic
-- **`b`/`bugfix`** — Investigation → spec → plan → implement → review
-- **`q`/`quick-fix`** — Scoping → implement → review (no formal planning)
-- **`c`/`cross-cutting`** — (Research →) discussion → spec (patterns or policies that inform other work)
-@if(has_inbox)
-- **`i`/`inbox`** — View the inbox and start from an item ({inbox_count} items)
-@endif
-@if(completed_count > 0 || cancelled_count > 0)
-- **`v`/`view`** — View completed & cancelled work units
-@endif
-
-Select an option:
-· · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
@@ -56,19 +37,19 @@ Select an option:
 
 ## B. Handle Selection
 
-#### If user chose `i`/`inbox`
+Match the user's input to its `ACTIONS` entry by `key` — a command option's letter or long form. Every decision below reads the entry's `action` value, never its label text.
+
+#### If `action` is `view_inbox`
 
 Load **[start-from-inbox.md](start-from-inbox.md)** and follow its instructions as written.
 
 → Return to **A. Display and Menu**.
 
-#### If user chose a start-new option (`s`, `f`, `e`, `b`, `q`, or `c`)
+#### If `action` is `start_new`
 
-Set the work-type pre-seed from the pick — `s` → `none`, otherwise the matching type (feature / epic / bugfix / quick-fix / cross-cutting).
+→ Load **[route-to-discovery.md](route-to-discovery.md)** with work_type = `{pre_seed}`, inbox_seeds = `none`.
 
-→ Load **[route-to-discovery.md](route-to-discovery.md)** with work_type = `{work_type}`, inbox_seeds = `none`.
-
-#### If user chose `v`/`view`
+#### If `action` is `view_completed`
 
 Load **[view-completed.md](view-completed.md)** and follow its instructions as written.
 

--- a/skills/workflow-start/references/inbox-archived.md
+++ b/skills/workflow-start/references/inbox-archived.md
@@ -8,47 +8,27 @@ View and manage items archived out of the inbox. Pick one item, then restore it,
 
 ## A. Select
 
-Run discovery for the current archived state — re-run on every entry so prior actions are reflected:
+Render the archived snapshot — re-run on every entry so prior actions are reflected:
 
 ```bash
-node .claude/skills/workflow-start/scripts/gateway.cjs
+node .claude/skills/workflow-start/scripts/gateway.cjs archived
 ```
 
-Read the `=== ARCHIVED ===` section.
+The output is one snapshot in three demarcated sections:
 
-#### If no archived items remain
+- **DATA** — reasoning surface: `archived_count` and the `ITEMS` table — one line per item, `n  type  date  slug  → path`. Reason from it; never display or restate it.
+- **DISPLAY** — the numbered archived list. Emit verbatim as a code block. Never redraw, reflow, or trim it.
+- **MENU** — the selection prompt. Emit verbatim as markdown (not a code block). Empty when nothing is archived.
 
-> *Output the next fenced block as a code block:*
+Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
-```
-  No archived items.
-```
+#### If `archived_count` is 0
 
 → Return to caller.
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
-
-```
-●───────────────────────────────────────────────●
-  Archived
-●───────────────────────────────────────────────●
-
-@foreach(item in archived_items sorted by date)
-  {N}. {item.title} ({item.type}, {item.date})
-@endforeach
-```
-
-Build a numbered list combining all archived ideas, bugs, and quick-fixes, sorted by date. Hold the number → item mapping (type, slug, date).
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Select an item (enter number, or **`b`/`back`** to return):
-· · · · · · · · · · · ·
-```
+Emit the MENU section.
 
 **STOP.** Wait for user response.
 
@@ -58,7 +38,7 @@ Select an item (enter number, or **`b`/`back`** to return):
 
 **If user chose a number:**
 
-Store the selected item and resolve its path `.workflows/.inbox/.archived/{type}/{date}--{slug}.md`.
+Store the selected item's `ITEMS` row — its type, slug, date, and path.
 
 → Proceed to **B. Action Menu**.
 
@@ -98,7 +78,7 @@ Read the file and render its full content.
 Move the file back into its inbox folder and commit — one command:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs inbox restore .workflows/.inbox/.archived/{type}/{date}--{slug}.md
+node .claude/skills/workflow-engine/scripts/engine.cjs inbox restore {item.path}
 ```
 
 > *Output the next fenced block as a code block:*
@@ -134,7 +114,7 @@ repo and cannot be undone.
 **If user chose `y`/`yes`:**
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs inbox delete .workflows/.inbox/.archived/{type}/{date}--{slug}.md
+node .claude/skills/workflow-engine/scripts/engine.cjs inbox delete {item.path}
 ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-start/references/inbox-working-set.md
+++ b/skills/workflow-start/references/inbox-working-set.md
@@ -8,13 +8,25 @@ Build and act on a set of inbox items. The caller holds the **working set** — 
 
 ## A. Render the Working Set
 
-For each item in the set, read its file and synthesise a short summary of what it describes (do not quote it verbatim). Hold each item's title (the file's `#` heading, falling back to its slug). The set is **type-uniform** when every item shares one folder, **mixed** otherwise — this gates the `w`/`work` option below.
+Fetch the working-set snapshot — pass every held item's inbox path, in set order:
+
+```bash
+node .claude/skills/workflow-start/scripts/gateway.cjs working-set {path} [{path} …]
+```
+
+The response carries demarcated sections:
+
+- **DATA** — reasoning surface: `set_uniform` / `set_type`, `addable_count`, and the `SET` and `ADDABLE` tables — one line per item, `n  type  date  slug  → path`. Reason from it; never display or restate it.
+- **MENU** — the set menu. Emit verbatim as markdown (not a code block) at this section's gate below. The `w`/`work` option renders only for a type-uniform set.
+- **Labelled sections** (`DISPLAY: add candidates`, `MENU: add gate`, `DISPLAY: drop candidates`, `MENU: drop gate`) — deferred: each is emitted only at the gate its marker names (**B** / **C**), never here.
+
+For each item in the set, read its file and synthesise a short summary of what it describes (do not quote it verbatim). Hold each item's title (the file's `#` heading, falling back to its slug).
 
 > *Output the next fenced block as a code block:*
 
 ```
   Working Set ({count} item{s}) — actions apply to all of them
-@if(set is mixed)
+@if(set_uniform is false)
 
   ⚑ Work is unavailable while the set mixes types — drop to a single
     type to enable it.
@@ -35,28 +47,11 @@ For each item in the set, read its file and synthesise a short summary of what i
 - **Summary sub-lines**: hard-wrap at 65 characters, capped at **3 lines** — if it would run longer, truncate the third line with `…` (`v`/`view` shows the full text). Each line is indented **two columns past the title text** so the description reads as subordinate, not aligned directly under the title.
   - **`{gutter}`** (the template's 2-space lead precedes it): non-last item → `│` then 6 spaces; last item → 7 spaces (no `│`); single item → 4 spaces. The `│` sits under the branch character and runs continuously through every sub-line of non-last items so the tree never breaks.
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-What would you like to do? Type a shortcut, or just tell me in
-your own words — e.g. "add 2 and 4", "drop the bug", "archive these".
-
-@if(set is type-uniform)
-- **`w`/`work`** — Proceed to discovery with this set
-@endif
-- **`a`/`add`** — Add another inbox item to the set
-- **`d`/`drop`** — Drop item(s) from the set (keeps them in the inbox)
-- **`r`/`archive`** — Archive the whole set out of the inbox
-- **`v`/`view`** — View full content of the set
-- **`b`/`back`** — Return to the inbox list
-- **Ask** — Ask about the set
-· · · · · · · · · · · ·
-```
+Emit the MENU section.
 
 **STOP.** Wait for user response.
 
-The user types a shorthand (`w`/`a`/`d`/`r`/`v`/`b`) **or** describes the action in their own words. Map the response to one branch below; a message that only asks about the set, naming no action, is `Ask`. When the phrasing also names items (*"add 2 and 4"*, *"drop the bug"*), carry that selection into the action so **B**/**C** apply it without re-prompting.
+The user types a shorthand (`w`/`a`/`d`/`r`/`v`/`b`) **or** describes the action in their own words. Map the response to one branch below; a message that only asks about the set, naming no action, is `Ask`. When the phrasing also names items (*"add 2 and 4"*, *"drop the bug"*), carry that selection into the action so **B**/**C** apply it without re-prompting. `w`/`work` can only be chosen when the menu offered it (`set_uniform` is `true`).
 
 #### If user chose `w`/`work`
 
@@ -90,15 +85,9 @@ Answer from the set items' content. Keep it short. Do not act on the set — the
 
 ## B. Add Items
 
-Run discovery for the current inbox state:
+The `ADDABLE` table in the working-set DATA lists the inbox items not already in the set.
 
-```bash
-node .claude/skills/workflow-start/scripts/gateway.cjs
-```
-
-Build a numbered list of inbox items **not already in the working set**, sorted by date.
-
-#### If no items remain to add
+#### If `addable_count` is 0
 
 > *Output the next fenced block as a code block:*
 
@@ -110,27 +99,13 @@ Build a numbered list of inbox items **not already in the working set**, sorted 
 
 #### If the triggering message already named the item(s) to add
 
-Match each named item against the list — by title, or by the number if the user referenced one. If any reference is ambiguous or unmatched, → Proceed to **Otherwise**. Otherwise append the matched items to the working set.
+Match each named item against the `ADDABLE` table — by title, or by the number if the user referenced one. If any reference is ambiguous or unmatched, → Proceed to **Otherwise**. Otherwise append the matched items' paths to the working set.
 
 → Return to **A. Render the Working Set**.
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
-
-```
-@foreach(item in available_items sorted by date)
-  {N}. {item.title} ({item.type}, {item.date})
-@endforeach
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Add which? (enter number(s), comma-separated, or **`b`/`back`**)
-· · · · · · · · · · · ·
-```
+Emit the `DISPLAY: add candidates` section verbatim as a code block, then the `MENU: add gate` section verbatim as markdown (not a code block).
 
 **STOP.** Wait for user response.
 
@@ -140,7 +115,7 @@ Add which? (enter number(s), comma-separated, or **`b`/`back`**)
 
 **If user chose one or more numbers:**
 
-Resolve each chosen item's inbox path and append it to the working set.
+Resolve each chosen number to its `ADDABLE` row and append the row's path to the working set.
 
 → Return to **A. Render the Working Set**.
 
@@ -160,21 +135,7 @@ Resolve each named item against the working set by title or description. If any 
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
-
-```
-@foreach(item in working_set)
-  {N}. {item.title} ({item.type})
-@endforeach
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Drop which? (enter number(s), comma-separated, or **`b`/`back`**)
-· · · · · · · · · · · ·
-```
+Emit the `DISPLAY: drop candidates` section verbatim as a code block, then the `MENU: drop gate` section verbatim as markdown (not a code block).
 
 **STOP.** Wait for user response.
 
@@ -184,7 +145,7 @@ Drop which? (enter number(s), comma-separated, or **`b`/`back`**)
 
 **If user chose one or more numbers:**
 
-Remove the chosen items from the working set; they stay in the inbox. If the set is now empty, → Return to caller; otherwise → Return to **A. Render the Working Set**.
+Resolve each chosen number to its `SET` row and remove that item from the working set; it stays in the inbox. If the set is now empty, → Return to caller; otherwise → Return to **A. Render the Working Set**.
 
 ## D. Archive the Set
 
@@ -223,14 +184,8 @@ Read each item in the set and render its full content.
 
 ## F. Work the Set
 
-Reached only for a type-uniform set — `w`/`work` is offered solely when every item shares one folder (**A**). Map the work-type pre-seed from that shared folder:
+Reached only for a type-uniform set — `w`/`work` is offered solely when `set_uniform` is `true`. The DATA `set_type` is the work-type pre-seed (all bugs → `bugfix`, all quick-fixes → `quick-fix`, all ideas → `none`).
 
-| Set composition | work_type |
-|---|---|
-| All bugs | `bugfix` |
-| All quick-fixes | `quick-fix` |
-| All ideas | `none` |
+Build `inbox_seeds` — the set items' inbox paths, comma-joined.
 
-Build `inbox_seeds` — the chosen items' inbox paths, comma-joined.
-
-→ Load **[route-to-discovery.md](route-to-discovery.md)** with work_type = `{work_type}`, inbox_seeds = `{inbox_seeds}`.
+→ Load **[route-to-discovery.md](route-to-discovery.md)** with work_type = `{set_type}`, inbox_seeds = `{inbox_seeds}`.

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -8,58 +8,19 @@ Manage an in-progress work unit's lifecycle.
 
 ## A. Select
 
-> *Output the next fenced block as a code block:*
+Render the manage selection snapshot:
 
-```
-●───────────────────────────────────────────────●
-  Manage
-●───────────────────────────────────────────────●
-
-@if(feature_count > 0)
-Features:
-@foreach(unit in the FEATURES section)
-  {N}. {unit.name:(titlecase)}
-@endforeach
-@endif
-
-@if(bugfix_count > 0)
-Bugfixes:
-@foreach(unit in the BUGFIXES section)
-  {N}. {unit.name:(titlecase)}
-@endforeach
-@endif
-
-@if(quickfix_count > 0)
-Quick Fixes:
-@foreach(unit in the QUICK-FIXES section)
-  {N}. {unit.name:(titlecase)}
-@endforeach
-@endif
-
-@if(cross_cutting_count > 0)
-Cross-Cutting:
-@foreach(unit in the CROSS-CUTTING section)
-  {N}. {unit.name:(titlecase)}
-@endforeach
-@endif
-
-@if(epic_count > 0)
-Epics:
-@foreach(unit in the EPICS section)
-  {N}. {unit.name:(titlecase)}
-@endforeach
-@endif
+```bash
+node .claude/skills/workflow-start/scripts/gateway.cjs manage
 ```
 
-Build from discovery output. Only show sections that have work units. Numbering is continuous across sections — same numbers as the overview.
+The output is one snapshot in three demarcated sections:
 
-> *Output the next fenced block as markdown (not a code block):*
+- **DATA** — reasoning surface: the `UNITS` table — one line per work unit, `n  work_type  work_unit`, numbering matching the overview. Reason from it; never display or restate it.
+- **DISPLAY** — the numbered work-unit list by type. Emit verbatim as a code block. Never redraw, reflow, or trim it.
+- **MENU** — the selection prompt. Emit verbatim as markdown (not a code block).
 
-```
-· · · · · · · · · · · ·
-Select a work unit (enter number, or **`b`/`back`** to return):
-· · · · · · · · · · · ·
-```
+Emit the DISPLAY section, then the MENU section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
 **STOP.** Wait for user response.
 
@@ -69,73 +30,23 @@ Select a work unit (enter number, or **`b`/`back`** to return):
 
 #### If user chose a number
 
-Store the selected work unit.
+Store the selected work unit's `UNITS` row — its name and work type.
 
-→ Proceed to **B. Pre-Checks**.
+→ Proceed to **B. Action Menu**.
 
-## B. Pre-Checks
+## B. Action Menu
 
-Default `implementation_completed` = false, `has_plan` = false.
-
-Check whether the planning phase exists and store the result as `has_plan`:
+Render the selected work unit's manage snapshot:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {selected.name}.planning
+node .claude/skills/workflow-start/scripts/gateway.cjs manage {selected.name}
 ```
 
-#### If `selected.work_type` is `feature`
+The response carries demarcated sections:
 
-Default `has_spec` = false, `has_discussion` = false, `has_in_progress_epics` = false.
-
-Check whether the specification phase exists and store the result as `has_spec`:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {selected.name}.specification
-```
-
-Check whether the discussion phase exists and store the result as `has_discussion`:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {selected.name}.discussion
-```
-
-List in-progress epics:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest list --status in-progress --work-type epic
-```
-
-If the result is a non-empty JSON array, set `has_in_progress_epics` = true and store the array as `available_epics`.
-
-→ Proceed to **C. Implementation Check**.
-
-#### Otherwise
-
-→ Proceed to **C. Implementation Check**.
-
-## C. Implementation Check
-
-Read all topic statuses in the implementation phase:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get '{selected.name}.implementation.*' status
-```
-
-#### If output is empty (no implementation phase)
-
-→ Proceed to **D. Action Menu**.
-
-#### If any result has `"value": "completed"`
-
-Set `implementation_completed` = true.
-
-→ Proceed to **D. Action Menu**.
-
-#### Otherwise
-
-→ Proceed to **D. Action Menu**.
-
-## D. Action Menu
+- **DATA** — reasoning surface: lifecycle flags (`implementation_completed`, `has_plan`, `absorb_available`, …), `available_epics`, `planning_topics`, and the `ACTIONS` key table. Reason from it; never display or restate it.
+- **MENU** — the action menu, offering exactly the actions this work unit's state allows. Emit verbatim as markdown (not a code block) at this section's gate below.
+- **Labelled sections** (`MENU: absorb target`, `MENU: plan topics`) — deferred: each is emitted only at the gate its marker names (inside **[absorb-into-epic.md](absorb-into-epic.md)** / **[view-plan.md](view-plan.md)**), never here.
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -144,29 +55,13 @@ Set `implementation_completed` = true.
 > cancel abandons it, pivot converts a feature to an epic when the
 > scope grows beyond a single topic, absorb merges a feature's
 > discussion into an existing epic.
-
-· · · · · · · · · · · ·
-**{selected.name:(titlecase)}** ({selected.work_type})
-
-@if(implementation_completed)
-- **`d`/`done`** — Mark as completed
-@endif
-@if(selected.work_type == 'feature')
-- **`p`/`pivot`** — Convert to epic (enables multiple topics)
-@endif
-@if(selected.work_type == 'feature' and !has_spec and has_discussion and has_in_progress_epics)
-- **`a`/`absorb`** — Merge into an existing epic
-@endif
-@if(has_plan)
-- **`v`/`view-plan`** — View the implementation plan
-@endif
-- **`c`/`cancel`** — Mark as cancelled
-- **`b`/`back`** — Return
-- **Ask** — Ask a question about this work unit
-· · · · · · · · · · · ·
 ```
 
+Emit the MENU section.
+
 **STOP.** Wait for user response.
+
+A branch below can only be chosen when the menu offered its option.
 
 #### If user chose `d`/`done`
 
@@ -221,7 +116,7 @@ Invoke the `/workflow-continue-epic` skill.
 
 → Load **[view-plan.md](view-plan.md)** and follow its instructions as written.
 
-→ Return to **D. Action Menu**.
+→ Return to **B. Action Menu**.
 
 #### If user chose `c`/`cancel`
 
@@ -257,4 +152,4 @@ The JSON response reports `status`, `committed`, and `warnings`. If `warnings` i
 
 Answer the question.
 
-→ Return to **D. Action Menu**.
+→ Return to **B. Action Menu**.

--- a/skills/workflow-start/references/start-from-inbox.md
+++ b/skills/workflow-start/references/start-from-inbox.md
@@ -8,45 +8,31 @@ Select inbox items to work on, or manage what's been archived. Selecting one or 
 
 ## A. Display and Menu
 
-Run discovery for the current inbox state — re-run on every entry so archive and unarchive changes are reflected:
+Render the inbox pickup snapshot — re-run on every entry so archive and unarchive changes are reflected:
 
 ```bash
-node .claude/skills/workflow-start/scripts/gateway.cjs
+node .claude/skills/workflow-start/scripts/gateway.cjs inbox
 ```
 
-Read the `=== INBOX ===` and `=== STATE ===` sections.
+The output is one snapshot in three demarcated sections:
 
-> *Output the next fenced block as a code block:*
+- **DATA** — reasoning surface: `inbox_count`, `has_archived`, and the `ITEMS` table — one line per item, `n  type  date  slug  → path`. Reason from it; never display or restate it.
+- **DISPLAY** — the numbered inbox list. Emit verbatim as a code block. Never redraw, reflow, or trim it.
+- **MENU** — the pickup menu. Emit verbatim as markdown (not a code block). The `a`/`archived` option renders only when the archived store has items.
 
-```
-●───────────────────────────────────────────────●
-  Inbox
-●───────────────────────────────────────────────●
+Emit the DISPLAY section, then the MENU section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 
-@foreach(item in inbox_items sorted by date)
-  {N}. {item.title} ({item.type}, {item.date})
-@endforeach
-```
+#### If `inbox_count` is 0
 
-Build a numbered list combining all ideas, bugs, and quick-fixes, sorted by date (oldest first). Hold the number → item mapping (each item's type, slug, and date) for the selection.
+→ Return to caller.
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-What would you like to do?
-
-- **`1`–`{N}`** — Select item(s) to work on (comma-separated for several)
-@if(has_archived)
-- **`a`/`archived`** — View archived items (restore or delete)
-@endif
-- **`b`/`back`** — Return
-· · · · · · · · · · · ·
-```
-
-`{N}` is the inbox item count (`state.inbox_count`). Show the `a`/`archived` option only when `state.has_archived` is true.
+#### Otherwise
 
 **STOP.** Wait for user response.
+
+→ Proceed to **B. Handle Selection**.
+
+## B. Handle Selection
 
 #### If user chose `b`/`back`
 
@@ -60,7 +46,7 @@ What would you like to do?
 
 #### If user chose one or more numbers
 
-Build the **working set** from the chosen numbers. For each, resolve the inbox path `.workflows/.inbox/{folder}/{date}--{slug}.md` — `{folder}` is `ideas` / `bugs` / `quickfixes` by type — and hold its type and path.
+Build the **working set** from the chosen numbers — resolve each number to its `ITEMS` row and hold the row's type and path.
 
 → Load **[inbox-working-set.md](inbox-working-set.md)** and follow its instructions as written.
 

--- a/skills/workflow-start/references/view-completed.md
+++ b/skills/workflow-start/references/view-completed.md
@@ -4,65 +4,35 @@
 
 ---
 
-Display completed and cancelled work units from discovery output.
+Display completed and cancelled work units.
 
 ## A. Display List
 
-#### If no completed or cancelled work units exist
+Render the completed & cancelled snapshot — append the work-type filter when the caller set one:
 
-> *Output the next fenced block as a code block:*
+```bash
+node .claude/skills/workflow-start/scripts/gateway.cjs completed [{work_type_filter}]
+```
 
-```
-No completed or cancelled work units found.
-```
+The output is one snapshot in three demarcated sections:
+
+- **DATA** — reasoning surface: the filter, counts, and the `UNITS` table — one line per work unit, `n  status  work_type  work_unit  last_phase`, numbering continuous across the completed and cancelled lists. Reason from it; never display or restate it.
+- **DISPLAY** — the completed & cancelled list. Emit verbatim as a code block. Never redraw, reflow, or trim it.
+- **MENU** — the selection prompt. Emit verbatim as markdown (not a code block). Empty when nothing matches.
+
+Emit the DISPLAY section. A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
+
+#### If `completed_count` and `cancelled_count` are both 0
 
 → Return to caller.
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
-
-```
-●───────────────────────────────────────────────●
-  Completed & Cancelled
-●───────────────────────────────────────────────●
-
-@if(work_type_filter) Showing: {work_type_filter:(titlecase)}s @endif
-
-@if(completed.length > 0)
-Completed:
-@foreach(item in completed)
-  {N}. {item.name:(titlecase)}
-     └─ Completed after: {item.last_phase}
-
-@endforeach
-@endif
-
-@if(cancelled.length > 0)
-Cancelled:
-@foreach(item in cancelled)
-  {N}. {item.name:(titlecase)}
-     └─ Cancelled during: {item.last_phase}
-
-@endforeach
-@endif
-```
-
-Build from the completed and cancelled sections in the discovery output. Numbering is continuous across both sections. Blank line between each numbered item.
-
 → Proceed to **B. Select**.
 
 ## B. Select
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Select a work unit for details, or **`b`/`back`** to return.
-
-Select an option (enter number):
-· · · · · · · · · · · ·
-```
+Emit the MENU section.
 
 **STOP.** Wait for user response.
 
@@ -72,7 +42,7 @@ Select an option (enter number):
 
 #### If user chose a number
 
-Store the selected item.
+Store the selected work unit's `UNITS` row — its name and status.
 
 → Proceed to **C. Action Menu**.
 

--- a/skills/workflow-start/references/view-plan.md
+++ b/skills/workflow-start/references/view-plan.md
@@ -8,7 +8,7 @@ Display a readable summary of a plan's phases, tasks, and status.
 
 ## A. Determine Topic
 
-#### If work_type is `feature` or `bugfix`
+#### If work_type is not `epic`
 
 Set `topic` = `selected.name`.
 
@@ -16,11 +16,7 @@ Set `topic` = `selected.name`.
 
 #### If work_type is `epic`
 
-Query manifest for all planning topics:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get '{selected.name}.planning.*' status
-```
+Read `planning_topics` from the caller's `manage {selected.name}` snapshot DATA.
 
 **If only one topic exists:**
 
@@ -36,21 +32,11 @@ Set `topic` to that topic.
 
 **If multiple topics exist:**
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which plan would you like to view?
-
-@foreach(topic in planning_topics)
-{N}. **{topic.name:(titlecase)}** ({topic.status})
-@endforeach
-· · · · · · · · · · · ·
-```
+Emit the `MENU: plan topics` section from the same snapshot verbatim as markdown (not a code block). Its numbering follows `planning_topics` order.
 
 **STOP.** Wait for user response.
 
-Set `topic` to the selected topic.
+Resolve the number against `planning_topics` and set `topic` to the selected topic.
 
 → Proceed to **B. Read Plan**.
 

--- a/skills/workflow-start/scripts/gateway.cjs
+++ b/skills/workflow-start/scripts/gateway.cjs
@@ -5,8 +5,15 @@
 // in the engine's domain ring; this script selects which engine answers the
 // skill's flow needs and sections the output.
 //
-//   gateway.cjs        → labelled dump, all work + inbox (head insert)
-//   gateway.cjs view   → DATA + DISPLAY + MENU snapshot (Step 3)
+//   gateway.cjs                       → labelled dump, all work + inbox (head insert)
+//   gateway.cjs view                  → DATA + DISPLAY + MENU snapshot (Step 3 /
+//                                       empty state — the snapshot follows has_any_work)
+//   gateway.cjs inbox                 → inbox pickup snapshot
+//   gateway.cjs archived              → archived store snapshot
+//   gateway.cjs working-set {path} …  → working-set snapshot + deferred add/drop gates
+//   gateway.cjs manage                → manage selection snapshot
+//   gateway.cjs manage {work_unit}    → action-menu snapshot + deferred absorb/plan gates
+//   gateway.cjs completed [{type}]    → completed & cancelled snapshot
 // ---------------------------------------------------------------------------
 
 const engine = require('../../workflow-engine/scripts/lib.cjs');
@@ -84,11 +91,14 @@ function format(result) {
   return lines.join('\n') + '\n';
 }
 
-// One snapshot for Step 3: reasoning DATA (state flags + the ACTIONS table),
-// the rendered overview (DISPLAY), and the menu (MENU).
+// One snapshot for Step 3 and the empty state: reasoning DATA (state flags +
+// the ACTIONS table), the rendered overview (DISPLAY), and the menu (MENU).
+// Which variant renders follows has_any_work — the empty state swaps in the
+// start-something menu, same ACTIONS shape.
 function view() {
   const detail = discover(process.cwd());
-  const menu = engine.project.startMenu(detail);
+  const empty = !detail.state.has_any_work;
+  const menu = empty ? engine.project.emptyMenu(detail) : engine.project.startMenu(detail);
 
   const dataLines = [];
   dataLines.push(`has_any_work: ${detail.state.has_any_work}`);
@@ -105,8 +115,87 @@ function view() {
 
   return [
     engine.gateway.dataBlock(dataLines.join('\n')),
-    engine.gateway.displayBlock(engine.project.startOverview(detail)),
+    engine.gateway.displayBlock(empty ? engine.project.emptyOverview(detail) : engine.project.startOverview(detail)),
     engine.gateway.menuBlock(menu.rendered),
+  ].join('\n');
+}
+
+// The inbox pickup snapshot: the combined live list, numbered, plus the
+// select/archived/back menu.
+function inboxView() {
+  const detail = discover(process.cwd());
+  const v = engine.project.inboxPickupView(engine.detail.combinedInbox(detail.inbox), detail.state.has_archived);
+  return [
+    engine.gateway.dataBlock(v.data),
+    engine.gateway.displayBlock(v.display),
+    engine.gateway.menuBlock(v.menu),
+  ].join('\n');
+}
+
+// The archived store snapshot: the combined archived list, numbered, plus the
+// select prompt.
+function archivedView() {
+  const detail = discover(process.cwd());
+  const v = engine.project.archivedView(engine.detail.combinedInbox(detail.inbox.archived, { archived: true }));
+  return [
+    engine.gateway.dataBlock(v.data),
+    engine.gateway.displayBlock(v.display),
+    engine.gateway.menuBlock(v.menu),
+  ].join('\n');
+}
+
+// The working-set snapshot over the caller-held selection: DATA (set + addable
+// tables), the set menu, and the deferred add/drop gate sections.
+function workingSetView(...paths) {
+  let ws;
+  try {
+    ws = engine.detail.workingSetDetail(process.cwd(), paths);
+  } catch (err) {
+    return engine.gateway.dataBlock({ error: err.message });
+  }
+  const v = engine.project.workingSetView(ws);
+  return [
+    engine.gateway.dataBlock(v.data),
+    engine.gateway.menuBlock(v.menu),
+    v.sections,
+  ].filter(Boolean).join('\n');
+}
+
+// manage → the selection snapshot; manage {work_unit} → the unit's action-menu
+// snapshot with its deferred absorb-target / plan-topic gates.
+function manageView(workUnit) {
+  if (workUnit === undefined) {
+    const v = engine.project.manageListView(discover(process.cwd()));
+    return [
+      engine.gateway.dataBlock(v.data),
+      engine.gateway.displayBlock(v.display),
+      engine.gateway.menuBlock(v.menu),
+    ].join('\n');
+  }
+  const md = engine.detail.manageDetail(process.cwd(), workUnit);
+  if (!md) {
+    return engine.gateway.dataBlock({ work_unit: workUnit, error: 'no work unit with this name' });
+  }
+  const v = engine.project.manageUnitView(md);
+  return [
+    engine.gateway.dataBlock(v.data),
+    engine.gateway.menuBlock(v.menu),
+    v.sections,
+  ].filter(Boolean).join('\n');
+}
+
+// The completed & cancelled snapshot, optionally filtered to one work type.
+function completedView(filter) {
+  let v;
+  try {
+    v = engine.project.completedView(discover(process.cwd()), filter);
+  } catch (err) {
+    return engine.gateway.dataBlock({ error: err.message });
+  }
+  return [
+    engine.gateway.dataBlock(v.data),
+    engine.gateway.displayBlock(v.display),
+    engine.gateway.menuBlock(v.menu),
   ].join('\n');
 }
 
@@ -114,6 +203,11 @@ if (require.main === module) {
   engine.gateway.runGateway({
     index: () => format(discover(process.cwd())),
     view,
+    inbox: inboxView,
+    archived: archivedView,
+    'working-set': workingSetView,
+    manage: manageView,
+    completed: completedView,
     fallback: () => format(discover(process.cwd())),
   });
 }

--- a/tests/scripts/test-engine-start-projections.cjs
+++ b/tests/scripts/test-engine-start-projections.cjs
@@ -5,7 +5,20 @@ const assert = require('node:assert');
 
 const { setupFixture, cleanupFixture, createManifest, createFile } = require('./discovery-test-utils.cjs');
 const { startDetail } = require('../../skills/workflow-engine/scripts/domain/start.cjs');
-const { startOverview, startMenu } = require('../../skills/workflow-engine/scripts/domain/projections/start.cjs');
+const {
+  startOverview,
+  startMenu,
+  emptyOverview,
+  emptyMenu,
+  inboxPickupView,
+  archivedView,
+  workingSetView,
+  manageListView,
+  manageUnitView,
+  completedView,
+} = require('../../skills/workflow-engine/scripts/domain/projections/start.cjs');
+const { combinedInbox, workingSetDetail } = require('../../skills/workflow-engine/scripts/domain/inbox-set.cjs');
+const { manageDetail } = require('../../skills/workflow-engine/scripts/domain/workunit-manage.cjs');
 
 // Golden tests: byte-exact expected strings for the workflow-start overview
 // and menu projections. Fixtures go through real manifests and inbox files in
@@ -261,5 +274,562 @@ describe('start projections: menu', () => {
       keys.filter((k) => k.action === 'continue_work_unit').map((k) => k.work_type),
       ['feature', 'feature', 'bugfix', 'quick-fix', 'cross-cutting', 'epic']
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sub-view projections
+// ---------------------------------------------------------------------------
+
+const DOTS = '· · · · · · · · · · · ·';
+
+describe('start projections: empty state', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('renders the bare empty overview and start menu with no inbox and no closed units', () => {
+    const detail = startDetail(dir);
+    assert.strictEqual(emptyOverview(detail), [
+      ...BOX,
+      'No active work found.',
+      '',
+    ].join('\n'));
+    const menu = emptyMenu(detail);
+    assert.strictEqual(menu.rendered, [
+      DOTS,
+      'What would you like to start?',
+      '',
+      "- **`s`/`start`** — Not sure what kind yet — describe it and we'll shape it",
+      '- **`f`/`feature`** — Single topic: (research →) discussion → spec → plan → implement → review',
+      '- **`e`/`epic`** — Multiple topics, multi-session, same pipeline per topic',
+      '- **`b`/`bugfix`** — Investigation → spec → plan → implement → review',
+      '- **`q`/`quick-fix`** — Scoping → implement → review (no formal planning)',
+      '- **`c`/`cross-cutting`** — (Research →) discussion → spec (patterns or policies that inform other work)',
+      '',
+      'Select an option:',
+      DOTS,
+    ].join('\n'));
+    assert.deepStrictEqual(
+      menu.keys.map((k) => [k.key, k.action, k.pre_seed || null]),
+      [
+        ['s', 'start_new', 'none'],
+        ['f', 'start_new', 'feature'],
+        ['e', 'start_new', 'epic'],
+        ['b', 'start_new', 'bugfix'],
+        ['q', 'start_new', 'quick-fix'],
+        ['c', 'start_new', 'cross-cutting'],
+      ]
+    );
+  });
+
+  it('adds the counts line, singular inbox option, and view option when state has them', () => {
+    createManifest(dir, 'done-feat', { status: 'completed', phases: { review: { items: { 'done-feat': { status: 'completed' } } } } });
+    createManifest(dir, 'dropped', { work_type: 'bugfix', status: 'cancelled' });
+    createFile(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md', '# Smart Retry\n');
+    const detail = startDetail(dir);
+    assert.strictEqual(emptyOverview(detail), [
+      ...BOX,
+      'No active work found.',
+      '',
+      '1 completed, 1 cancelled.',
+      '',
+    ].join('\n'));
+    const menu = emptyMenu(detail);
+    assert.ok(menu.rendered.includes('- **`i`/`inbox`** — View the inbox and start from an item (1 item)'));
+    assert.ok(menu.rendered.includes('- **`v`/`view`** — View completed & cancelled work units'));
+    assert.deepStrictEqual(
+      menu.keys.map((k) => k.action).slice(6),
+      ['view_inbox', 'view_completed']
+    );
+  });
+
+  it('pluralises the inbox option label', () => {
+    createFile(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md', '# Smart Retry\n');
+    createFile(dir, '.workflows/.inbox/bugs/2026-06-03--login-timeout.md', '# Login Timeout\n');
+    assert.ok(emptyMenu(startDetail(dir)).rendered.includes('start from an item (2 items)'));
+  });
+});
+
+describe('start projections: inbox pickup', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  function pickup(d) {
+    const detail = startDetail(d);
+    return inboxPickupView(combinedInbox(detail.inbox), detail.state.has_archived);
+  }
+
+  it('renders the combined, date-ordered list with the multi-select menu and archived option', () => {
+    createFile(dir, '.workflows/.inbox/ideas/2026-06-02--dark-launch.md', '# Dark Launch\n');
+    createFile(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md', '# Smart Retry\n');
+    createFile(dir, '.workflows/.inbox/bugs/2026-06-03--login-timeout.md', '# Login Timeout\n');
+    createFile(dir, '.workflows/.inbox/.archived/ideas/2026-05-01--old-idea.md', '# Old Idea\n');
+    const v = pickup(dir);
+    assert.strictEqual(v.data, [
+      'inbox_count: 3',
+      'has_archived: true',
+      'ITEMS (n  type  date  slug  → path):',
+      '  1  idea  2026-06-01  smart-retry  → .workflows/.inbox/ideas/2026-06-01--smart-retry.md',
+      '  2  idea  2026-06-02  dark-launch  → .workflows/.inbox/ideas/2026-06-02--dark-launch.md',
+      '  3  bug  2026-06-03  login-timeout  → .workflows/.inbox/bugs/2026-06-03--login-timeout.md',
+    ].join('\n'));
+    assert.strictEqual(v.display, [
+      '●───────────────────────────────────────────────●',
+      '  Inbox',
+      '●───────────────────────────────────────────────●',
+      '',
+      '  1. Smart Retry (idea, 2026-06-01)',
+      '  2. Dark Launch (idea, 2026-06-02)',
+      '  3. Login Timeout (bug, 2026-06-03)',
+      '',
+    ].join('\n'));
+    assert.strictEqual(v.menu, [
+      DOTS,
+      'What would you like to do?',
+      '',
+      '- **`1`–`3`** — Select item(s) to work on (comma-separated for several)',
+      '- **`a`/`archived`** — View archived items (restore or delete)',
+      '- **`b`/`back`** — Return',
+      DOTS,
+    ].join('\n'));
+  });
+
+  it('renders the singular select option for one item without an archived store', () => {
+    createFile(dir, '.workflows/.inbox/bugs/2026-06-03--login-timeout.md', '# Login Timeout\n');
+    const v = pickup(dir);
+    assert.strictEqual(v.menu, [
+      DOTS,
+      'What would you like to do?',
+      '',
+      '- **`1`** — Select the item to work on',
+      '- **`b`/`back`** — Return',
+      DOTS,
+    ].join('\n'));
+  });
+
+  it('renders the empty inbox with no select option', () => {
+    const v = pickup(dir);
+    assert.strictEqual(v.data, [
+      'inbox_count: 0',
+      'has_archived: false',
+      'ITEMS (n  type  date  slug  → path):',
+    ].join('\n'));
+    assert.strictEqual(v.display, [
+      '●───────────────────────────────────────────────●',
+      '  Inbox',
+      '●───────────────────────────────────────────────●',
+      '',
+      'No inbox items.',
+      '',
+    ].join('\n'));
+    assert.strictEqual(v.menu, [
+      DOTS,
+      'What would you like to do?',
+      '',
+      '- **`b`/`back`** — Return',
+      DOTS,
+    ].join('\n'));
+  });
+});
+
+describe('start projections: archived store', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('renders the archived list and select prompt', () => {
+    createFile(dir, '.workflows/.inbox/.archived/ideas/2026-05-01--old-idea.md', '# Old Idea\n');
+    createFile(dir, '.workflows/.inbox/.archived/quickfixes/2026-05-02--tidy-logs.md', '# Tidy Logs\n');
+    const detail = startDetail(dir);
+    const v = archivedView(combinedInbox(detail.inbox.archived, { archived: true }));
+    assert.strictEqual(v.data, [
+      'archived_count: 2',
+      'ITEMS (n  type  date  slug  → path):',
+      '  1  idea  2026-05-01  old-idea  → .workflows/.inbox/.archived/ideas/2026-05-01--old-idea.md',
+      '  2  quick-fix  2026-05-02  tidy-logs  → .workflows/.inbox/.archived/quickfixes/2026-05-02--tidy-logs.md',
+    ].join('\n'));
+    assert.strictEqual(v.display, [
+      '●───────────────────────────────────────────────●',
+      '  Archived',
+      '●───────────────────────────────────────────────●',
+      '',
+      '  1. Old Idea (idea, 2026-05-01)',
+      '  2. Tidy Logs (quick-fix, 2026-05-02)',
+      '',
+    ].join('\n'));
+    assert.strictEqual(v.menu, [
+      DOTS,
+      'Select an item (enter number, or **`b`/`back`** to return):',
+      DOTS,
+    ].join('\n'));
+  });
+
+  it('renders the empty archived store with an empty menu', () => {
+    const detail = startDetail(dir);
+    const v = archivedView(combinedInbox(detail.inbox.archived, { archived: true }));
+    assert.ok(v.display.endsWith('No archived items.\n'));
+    assert.strictEqual(v.menu, '');
+  });
+});
+
+describe('start projections: working set', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  function seedInbox(d) {
+    createFile(d, '.workflows/.inbox/bugs/2026-06-01--login-timeout.md', '# Login Timeout\n');
+    createFile(d, '.workflows/.inbox/bugs/2026-06-02--crash-on-save.md', '# Crash On Save\n');
+    createFile(d, '.workflows/.inbox/ideas/2026-06-03--smart-retry.md', '# Smart Retry\n');
+  }
+
+  it('uniform bug set: offers work, maps the bugfix pre-seed, and defers add/drop gates', () => {
+    seedInbox(dir);
+    const ws = workingSetDetail(dir, [
+      '.workflows/.inbox/bugs/2026-06-01--login-timeout.md',
+      '.workflows/.inbox/bugs/2026-06-02--crash-on-save.md',
+    ]);
+    const v = workingSetView(ws);
+    assert.strictEqual(v.data, [
+      'set_count: 2',
+      'set_uniform: true',
+      'set_type: bugfix',
+      'addable_count: 1',
+      'SET (n  type  date  slug  → path):',
+      '  1  bug  2026-06-01  login-timeout  → .workflows/.inbox/bugs/2026-06-01--login-timeout.md',
+      '  2  bug  2026-06-02  crash-on-save  → .workflows/.inbox/bugs/2026-06-02--crash-on-save.md',
+      'ADDABLE (n  type  date  slug  → path):',
+      '  1  idea  2026-06-03  smart-retry  → .workflows/.inbox/ideas/2026-06-03--smart-retry.md',
+    ].join('\n'));
+    assert.strictEqual(v.menu, [
+      DOTS,
+      'What would you like to do? Type a shortcut, or just tell me in',
+      'your own words — e.g. "add 2 and 4", "drop the bug", "archive these".',
+      '',
+      '- **`w`/`work`** — Proceed to discovery with this set',
+      '- **`a`/`add`** — Add another inbox item to the set',
+      '- **`d`/`drop`** — Drop item(s) from the set (keeps them in the inbox)',
+      '- **`r`/`archive`** — Archive the whole set out of the inbox',
+      '- **`v`/`view`** — View full content of the set',
+      '- **`b`/`back`** — Return to the inbox list',
+      '- **Ask** — Ask about the set',
+      DOTS,
+    ].join('\n'));
+    assert.strictEqual(v.sections, [
+      '=== DISPLAY: add candidates (emit verbatim as a code block only at the add-items gate — never at the call) ===',
+      '  1. Smart Retry (idea, 2026-06-03)',
+      '',
+      '=== MENU: add gate (emit verbatim as markdown only at the add-items gate) ===',
+      DOTS,
+      'Add which? (enter number(s), comma-separated, or **`b`/`back`**)',
+      DOTS,
+      '',
+      '=== DISPLAY: drop candidates (emit verbatim as a code block only at the drop-items gate — never at the call) ===',
+      '  1. Login Timeout (bug)',
+      '  2. Crash On Save (bug)',
+      '',
+      '=== MENU: drop gate (emit verbatim as markdown only at the drop-items gate) ===',
+      DOTS,
+      'Drop which? (enter number(s), comma-separated, or **`b`/`back`**)',
+      DOTS,
+      '',
+    ].join('\n'));
+  });
+
+  it('mixed set: no work option, set_type mixed', () => {
+    seedInbox(dir);
+    const ws = workingSetDetail(dir, [
+      '.workflows/.inbox/bugs/2026-06-01--login-timeout.md',
+      '.workflows/.inbox/ideas/2026-06-03--smart-retry.md',
+    ]);
+    assert.strictEqual(ws.uniform, false);
+    assert.strictEqual(ws.set_type, 'mixed');
+    const v = workingSetView(ws);
+    assert.ok(!v.menu.includes('`w`/`work`'));
+    assert.ok(v.data.includes('set_uniform: false'));
+  });
+
+  it('idea set maps the none pre-seed; a fully-selected inbox defers no add gate', () => {
+    createFile(dir, '.workflows/.inbox/ideas/2026-06-03--smart-retry.md', '# Smart Retry\n');
+    const ws = workingSetDetail(dir, ['.workflows/.inbox/ideas/2026-06-03--smart-retry.md']);
+    assert.strictEqual(ws.set_type, 'none');
+    const v = workingSetView(ws);
+    assert.ok(v.data.includes('addable_count: 0'));
+    assert.ok(!v.sections.includes('add candidates'));
+    assert.ok(!v.sections.includes('add gate'));
+    assert.ok(v.sections.includes('DISPLAY: drop candidates'));
+  });
+
+  it('quick-fix set maps the quick-fix pre-seed', () => {
+    createFile(dir, '.workflows/.inbox/quickfixes/2026-06-04--tidy-logs.md', '# Tidy Logs\n');
+    const ws = workingSetDetail(dir, ['.workflows/.inbox/quickfixes/2026-06-04--tidy-logs.md']);
+    assert.strictEqual(ws.set_type, 'quick-fix');
+  });
+
+  it('is loud on paths outside the live inbox', () => {
+    assert.throws(() => workingSetDetail(dir, ['.workflows/.inbox/bugs/2026-06-01--gone.md']), /not in the live inbox/);
+    assert.throws(() => workingSetDetail(dir, []), /working set is empty/);
+  });
+});
+
+describe('start projections: manage list', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('numbers continuously across type sections, matching the overview', () => {
+    const v = manageListView(fullFixture(dir));
+    assert.strictEqual(v.data, [
+      'unit_count: 6',
+      'UNITS (n  work_type  work_unit):',
+      '  1  feature  auth-flow',
+      '  2  feature  dark-mode',
+      '  3  bugfix  login-crash',
+      '  4  quick-fix  rename-api',
+      '  5  cross-cutting  caching',
+      '  6  epic  quiz-competition-v1',
+    ].join('\n'));
+    assert.strictEqual(v.display, [
+      '●───────────────────────────────────────────────●',
+      '  Manage',
+      '●───────────────────────────────────────────────●',
+      '',
+      'Features:',
+      '  1. Auth Flow',
+      '  2. Dark Mode',
+      '',
+      'Bugfixes:',
+      '  3. Login Crash',
+      '',
+      'Quick Fixes:',
+      '  4. Rename Api',
+      '',
+      'Cross-Cutting:',
+      '  5. Caching',
+      '',
+      'Epics:',
+      '  6. Quiz Competition V1',
+      '',
+    ].join('\n'));
+    assert.strictEqual(v.menu, [
+      DOTS,
+      'Select a work unit (enter number, or **`b`/`back`** to return):',
+      DOTS,
+    ].join('\n'));
+  });
+
+  it('renders the empty case with an empty menu', () => {
+    const v = manageListView(startDetail(dir));
+    assert.ok(v.display.endsWith('No active work units.\n'));
+    assert.strictEqual(v.menu, '');
+    assert.deepStrictEqual(v.rows, []);
+  });
+});
+
+describe('start projections: manage unit', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('bare feature: pivot only, no absorb without a discussion or epic target', () => {
+    createManifest(dir, 'auth-flow', {});
+    const md = manageDetail(dir, 'auth-flow');
+    const v = manageUnitView(md);
+    assert.strictEqual(v.data, [
+      'work_unit: auth-flow',
+      'work_type: feature',
+      'status: in-progress',
+      'implementation_completed: false',
+      'has_plan: false',
+      'has_spec: false',
+      'has_discussion: false',
+      'absorb_available: false',
+      'available_epics: (none)',
+      'planning_topics: (none)',
+      'ACTIONS (key  action):',
+      '  p  pivot',
+      '  c  cancel',
+      '  b  back',
+    ].join('\n'));
+    assert.strictEqual(v.menu, [
+      DOTS,
+      '**Auth Flow** (feature)',
+      '',
+      '- **`p`/`pivot`** — Convert to epic (enables multiple topics)',
+      '- **`c`/`cancel`** — Mark as cancelled',
+      '- **`b`/`back`** — Return',
+      '- **Ask** — Ask a question about this work unit',
+      DOTS,
+    ].join('\n'));
+    assert.strictEqual(v.sections, '');
+  });
+
+  it('absorbable feature: absorb option plus the deferred target menu', () => {
+    createManifest(dir, 'auth-flow', {
+      phases: { discussion: { items: { 'auth-flow': { status: 'completed' } } } },
+    });
+    createManifest(dir, 'v1', { work_type: 'epic' });
+    createManifest(dir, 'v2', { work_type: 'epic' });
+    const v = manageUnitView(manageDetail(dir, 'auth-flow'));
+    assert.ok(v.menu.includes('- **`a`/`absorb`** — Merge into an existing epic'));
+    assert.strictEqual(v.sections, [
+      '=== MENU: absorb target (emit verbatim as markdown only at the absorb target gate — never at the call) ===',
+      DOTS,
+      'Select a target epic:',
+      '',
+      '- **`1`** — V1',
+      '- **`2`** — V2',
+      '',
+      '- **`b`/`back`** — Return',
+      DOTS,
+      '',
+    ].join('\n'));
+  });
+
+  it('spec-or-beyond feature loses absorb even with a target epic', () => {
+    createManifest(dir, 'auth-flow', {
+      phases: {
+        discussion: { items: { 'auth-flow': { status: 'completed' } } },
+        specification: { items: { 'auth-flow': { status: 'in-progress' } } },
+      },
+    });
+    createManifest(dir, 'v1', { work_type: 'epic' });
+    const v = manageUnitView(manageDetail(dir, 'auth-flow'));
+    assert.ok(!v.menu.includes('absorb'));
+    assert.strictEqual(v.sections, '');
+  });
+
+  it('completed implementation offers done; a plan offers view-plan', () => {
+    createManifest(dir, 'hotfix', {
+      work_type: 'quick-fix',
+      phases: {
+        scoping: { items: { hotfix: { status: 'completed' } } },
+        planning: { items: { hotfix: { status: 'completed' } } },
+        implementation: { items: { hotfix: { status: 'completed' } } },
+      },
+    });
+    const v = manageUnitView(manageDetail(dir, 'hotfix'));
+    assert.strictEqual(v.menu, [
+      DOTS,
+      '**Hotfix** (quick-fix)',
+      '',
+      '- **`d`/`done`** — Mark as completed',
+      '- **`v`/`view-plan`** — View the implementation plan',
+      '- **`c`/`cancel`** — Mark as cancelled',
+      '- **`b`/`back`** — Return',
+      '- **Ask** — Ask a question about this work unit',
+      DOTS,
+    ].join('\n'));
+    assert.ok(!v.menu.includes('pivot'));
+    assert.strictEqual(v.sections, '');
+  });
+
+  it('multi-plan epic defers the plan-topics menu; a single plan does not', () => {
+    createManifest(dir, 'v1', {
+      work_type: 'epic',
+      phases: { planning: { items: { 'topic-a': { status: 'completed' }, 'topic-b': { status: 'in-progress' } } } },
+    });
+    createManifest(dir, 'v2', {
+      work_type: 'epic',
+      phases: { planning: { items: { solo: { status: 'in-progress' } } } },
+    });
+    const multi = manageUnitView(manageDetail(dir, 'v1'));
+    assert.strictEqual(multi.sections, [
+      '=== MENU: plan topics (emit verbatim as markdown only at the view-plan topic gate — never at the call) ===',
+      DOTS,
+      'Which plan would you like to view?',
+      '',
+      '- **`1`** — Topic A — completed',
+      '- **`2`** — Topic B — in-progress',
+      DOTS,
+      '',
+    ].join('\n'));
+    assert.ok(multi.data.includes('planning_topics: topic-a [completed], topic-b [in-progress]'));
+    const single = manageUnitView(manageDetail(dir, 'v2'));
+    assert.ok(!single.sections.includes('plan topics'));
+  });
+
+  it('manageDetail is null for a missing work unit', () => {
+    assert.strictEqual(manageDetail(dir, 'ghost'), null);
+  });
+});
+
+describe('start projections: completed & cancelled', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  function closedFixture(d) {
+    createManifest(d, 'done-feat', { status: 'completed', phases: { review: { items: { 'done-feat': { status: 'completed' } } } } });
+    createManifest(d, 'done-cc', { work_type: 'cross-cutting', status: 'completed', phases: { specification: { items: { 'done-cc': { status: 'completed' } } } } });
+    createManifest(d, 'dropped', { work_type: 'bugfix', status: 'cancelled' });
+    return startDetail(d);
+  }
+
+  it('renders both lists with continuous numbering and no filter line', () => {
+    const v = completedView(closedFixture(dir));
+    assert.strictEqual(v.data, [
+      'filter: (none)',
+      'completed_count: 2',
+      'cancelled_count: 1',
+      'UNITS (n  status  work_type  work_unit  last_phase):',
+      '  1  completed  cross-cutting  done-cc  specification',
+      '  2  completed  feature  done-feat  review',
+      '  3  cancelled  bugfix  dropped  none',
+    ].join('\n'));
+    assert.strictEqual(v.display, [
+      '●───────────────────────────────────────────────●',
+      '  Completed & Cancelled',
+      '●───────────────────────────────────────────────●',
+      '',
+      'Completed:',
+      '  1. Done Cc',
+      '     └─ Completed after: specification',
+      '',
+      '  2. Done Feat',
+      '     └─ Completed after: review',
+      '',
+      'Cancelled:',
+      '  3. Dropped',
+      '     └─ Cancelled during: none',
+      '',
+    ].join('\n'));
+    assert.strictEqual(v.menu, [
+      DOTS,
+      'Select a work unit for details, or **`b`/`back`** to return.',
+      '',
+      'Select an option (enter number):',
+      DOTS,
+    ].join('\n'));
+  });
+
+  it('filters to one work type with the Showing line', () => {
+    const v = completedView(closedFixture(dir), 'feature');
+    assert.strictEqual(v.display, [
+      '●───────────────────────────────────────────────●',
+      '  Completed & Cancelled',
+      '●───────────────────────────────────────────────●',
+      '',
+      'Showing: Features',
+      '',
+      'Completed:',
+      '  1. Done Feat',
+      '     └─ Completed after: review',
+      '',
+    ].join('\n'));
+    assert.ok(v.data.includes('filter: feature'));
+  });
+
+  it('a filter with no matches renders the empty display and no menu', () => {
+    const v = completedView(closedFixture(dir), 'quick-fix');
+    assert.ok(v.display.endsWith('No completed or cancelled work units found.\n'));
+    assert.strictEqual(v.menu, '');
+    assert.deepStrictEqual(v.rows, []);
+  });
+
+  it('is loud on an unknown filter', () => {
+    assert.throws(() => completedView(closedFixture(dir), 'gizmo'), /unknown work-type filter/);
   });
 });

--- a/tests/scripts/test-engine-workunit-projections.cjs
+++ b/tests/scripts/test-engine-workunit-projections.cjs
@@ -5,7 +5,7 @@ const assert = require('node:assert');
 
 const { setupFixture, cleanupFixture, createManifest } = require('./discovery-test-utils.cjs');
 const { workUnitDetail, typeConfig } = require('../../skills/workflow-engine/scripts/domain/workunit-detail.cjs');
-const { workUnitStatus, workUnitMenu, workUnitData } = require('../../skills/workflow-engine/scripts/domain/projections/workunit.cjs');
+const { workUnitStatus, workUnitMenu, workUnitData, revisitablePhases, revisitPhasesSection } = require('../../skills/workflow-engine/scripts/domain/projections/workunit.cjs');
 
 // Golden tests: byte-exact expected strings for the work-unit status display
 // and proceed/revisit menu, across all four single-topic types. Fixtures go
@@ -454,5 +454,59 @@ describe('workunit projections: data body', () => {
 describe('workunit domain: type registry', () => {
   it('throws loudly on an unknown work type', () => {
     assert.throws(() => typeConfig('epic'), /unknown work type "epic"/);
+  });
+});
+
+describe('workunit projections: revisit phases section', () => {
+  let dir;
+  beforeEach(() => { dir = setupFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('mirrors the revisit_phase keys for a mid-pipeline feature', () => {
+    createManifest(dir, 'auth-flow', {
+      phases: {
+        discussion: { items: { 'auth-flow': { status: 'completed' } } },
+        specification: { items: { 'auth-flow': { status: 'completed' } } },
+        planning: { items: { 'auth-flow': { status: 'in-progress' } } },
+      },
+    });
+    const unit = unitOf(dir, 'feature', 'auth-flow');
+    assert.deepStrictEqual(revisitablePhases('feature', unit), ['discussion', 'specification']);
+  });
+
+  it('pins the labelled section byte-for-byte', () => {
+    assert.strictEqual(revisitPhasesSection(['discussion', 'specification']), [
+      '=== MENU: revisit phases (emit verbatim as markdown only at the revisit phase gate — never at the call) ===',
+      '· · · · · · · · · · · ·',
+      'Which phase would you like to revisit?',
+      '',
+      '- **`1`** — Discussion — completed',
+      '- **`2`** — Specification — completed',
+      '- **`b`/`back`** — Return to the previous menu',
+      '',
+      'Select an option:',
+      '· · · · · · · · · · · ·',
+      '',
+    ].join('\n'));
+  });
+
+  it('renders nothing when there is nothing to revisit', () => {
+    assert.strictEqual(revisitPhasesSection([]), '');
+    createManifest(dir, 'fresh', {});
+    assert.deepStrictEqual(revisitablePhases('feature', unitOf(dir, 'feature', 'fresh')), []);
+  });
+
+  it('filters quick-fix candidates to the quick-fix pipeline', () => {
+    createManifest(dir, 'hotfix', {
+      work_type: 'quick-fix',
+      phases: {
+        scoping: { items: { hotfix: { status: 'completed' } } },
+        specification: { items: { hotfix: { status: 'completed' } } },
+        planning: { items: { hotfix: { status: 'completed' } } },
+        implementation: { items: { hotfix: { status: 'completed' } } },
+      },
+    });
+    const unit = unitOf(dir, 'quick-fix', 'hotfix');
+    assert.deepStrictEqual(revisitablePhases('quick-fix', unit), ['scoping', 'implementation']);
   });
 });

--- a/tests/scripts/test-gateway-for-bridge.cjs
+++ b/tests/scripts/test-gateway-for-bridge.cjs
@@ -211,13 +211,14 @@ describe('workflow-bridge format', () => {
     assert.ok(out.startsWith('Error: '));
   });
 
-  it('fresh feature pins the full dump byte-exactly', () => {
+  it('fresh feature pins the full dump byte-exactly — no revisit section', () => {
     createManifest(dir, 'auth', { work_type: 'feature' });
     const out = format(discover(dir, 'auth'));
     assert.strictEqual(out, [
       '=== auth (feature) ===',
       'next_phase: discussion',
       'completed_phases: (none)',
+      'revisitable_phases: (none)',
       '',
     ].join('\n'));
   });
@@ -237,11 +238,23 @@ describe('workflow-bridge format', () => {
       '=== auth (feature) ===',
       'next_phase: planning',
       'completed_phases: research, discussion, specification',
+      'revisitable_phases: research, discussion, specification',
+      '=== MENU: revisit phases (emit verbatim as markdown only at the revisit phase gate — never at the call) ===',
+      '· · · · · · · · · · · ·',
+      'Which phase would you like to revisit?',
+      '',
+      '- **`1`** — Research — completed',
+      '- **`2`** — Discussion — completed',
+      '- **`3`** — Specification — completed',
+      '- **`b`/`back`** — Return to the previous menu',
+      '',
+      'Select an option:',
+      '· · · · · · · · · · · ·',
       '',
     ].join('\n'));
   });
 
-  it('completed pipeline reports next_phase done', () => {
+  it('completed pipeline reports next_phase done — nothing revisitable, no section', () => {
     createManifest(dir, 'rename-api', {
       work_type: 'quick-fix',
       phases: {
@@ -255,8 +268,49 @@ describe('workflow-bridge format', () => {
       '=== rename-api (quick-fix) ===',
       'next_phase: done',
       'completed_phases: scoping, implementation, review',
+      'revisitable_phases: (none)',
       '',
     ].join('\n'));
+  });
+
+  it('quick-fix filters specification and planning out of the revisit candidates', () => {
+    createManifest(dir, 'rename-api', {
+      work_type: 'quick-fix',
+      phases: {
+        scoping: { items: { 'rename-api': { status: 'completed' } } },
+        specification: { items: { 'rename-api': { status: 'completed' } } },
+        planning: { items: { 'rename-api': { status: 'completed' } } },
+        implementation: { items: { 'rename-api': { status: 'completed' } } },
+      },
+    });
+    const out = format(discover(dir, 'rename-api'));
+    assert.strictEqual(out, [
+      '=== rename-api (quick-fix) ===',
+      'next_phase: review',
+      'completed_phases: scoping, specification, planning, implementation',
+      'revisitable_phases: scoping, implementation',
+      '=== MENU: revisit phases (emit verbatim as markdown only at the revisit phase gate — never at the call) ===',
+      '· · · · · · · · · · · ·',
+      'Which phase would you like to revisit?',
+      '',
+      '- **`1`** — Scoping — completed',
+      '- **`2`** — Implementation — completed',
+      '- **`b`/`back`** — Return to the previous menu',
+      '',
+      'Select an option:',
+      '· · · · · · · · · · · ·',
+      '',
+    ].join('\n'));
+  });
+
+  it('epic dump carries no revisitable line and no section', () => {
+    createManifest(dir, 'v1', {
+      work_type: 'epic',
+      phases: { discussion: { items: { 'auth-design': { status: 'completed' } } } },
+    });
+    const out = format(discover(dir, 'v1'));
+    assert.ok(!out.includes('revisitable_phases'));
+    assert.ok(!out.includes('MENU: revisit phases'));
   });
 
   it('carries no per-phase status or file-existence lines — completed_phases is the surface', () => {


### PR DESCRIPTION
Ruled: fixed-vocabulary menus stay prose; menus whose option sets derive from state come from the engine, so the agent never hand-renders state into options. Eleven sites codified: the inbox pickup/working-set/archived views (option lists from inbox contents + type-uniformity gating), manage-work-unit (availability computed — pivot feature-only, absorb's three-way guard, done, view-plan), view-completed, absorb's target-epic list, the empty state, view-plan's topic selection, and the revisit-phase menus across all four bridge continuations and four continue skills (pipeline-filtered engine-side — permanently killing the unfiltered-phase-list bug class). ~60 fixed-vocabulary menus ruled out with reasons; `select-*` unit lists flagged as the one follow-up candidate. New `domain/inbox-set.cjs` + `workunit-manage.cjs`, labelled deferred-emission sections per the #458 grammar, eleven prose files emit verbatim. 31 new byte-pinned renders; 1355 node tests at the restacked head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. **#460** 👈 current
57. #461
58. #462
59. #463
60. #464
61. #465
62. #466
63. #467
64. #468
65. #469
66. #470
67. #471
68. #472
69. #473
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->