### PR TITLE
conventions: final pre-merge pass — skills prose

### DIFF
--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -61,7 +61,6 @@ Implementation completed for "{work_unit:(titlecase)}".
 
 - **`y`/`yes`** — Proceed to review
 - **`d`/`done`** — Complete without review
-
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -66,7 +66,6 @@ All topics have completed review for "{work_unit:(titlecase)}".
 
 - **`y`/`yes`** — Mark this epic as completed
 - **`n`/`no`** — Return to the epic menu
-
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -62,7 +62,6 @@ Implementation completed for "{work_unit:(titlecase)}".
 
 - **`y`/`yes`** — Proceed to review
 - **`d`/`done`** — Complete without review
-
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -59,7 +59,6 @@ Implementation completed for "{work_unit:(titlecase)}".
 
 - **`y`/`yes`** — Proceed to review
 - **`d`/`done`** — Complete without review
-
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-continue-bugfix/SKILL.md
+++ b/skills/workflow-continue-bugfix/SKILL.md
@@ -42,6 +42,12 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Loading shared display conventions for this session.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → Proceed to **Step 1**.

--- a/skills/workflow-continue-bugfix/references/select-bugfix.md
+++ b/skills/workflow-continue-bugfix/references/select-bugfix.md
@@ -58,7 +58,7 @@ Store the selected bugfix's name as `work_unit`.
 
 Set work_type filter = `bugfix`.
 
-→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
+→ Load **[view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 
@@ -66,7 +66,7 @@ Re-run discovery to refresh state after potential changes.
 
 #### If user chose `m`/`manage`
 
-→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
+→ Load **[manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 

--- a/skills/workflow-continue-cross-cutting/SKILL.md
+++ b/skills/workflow-continue-cross-cutting/SKILL.md
@@ -42,6 +42,12 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Loading shared display conventions for this session.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → Proceed to **Step 1**.

--- a/skills/workflow-continue-cross-cutting/references/select-cross-cutting.md
+++ b/skills/workflow-continue-cross-cutting/references/select-cross-cutting.md
@@ -58,7 +58,7 @@ Store the selected cross-cutting concern's name as `work_unit`.
 
 Set work_type filter = `cross-cutting`.
 
-→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
+→ Load **[view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 
@@ -66,7 +66,7 @@ Re-run discovery to refresh state after potential changes.
 
 #### If user chose `m`/`manage`
 
-→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
+→ Load **[manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -42,6 +42,12 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Loading shared display conventions for this session.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → Proceed to **Step 1**.

--- a/skills/workflow-continue-epic/references/backfill-checks.md
+++ b/skills/workflow-continue-epic/references/backfill-checks.md
@@ -68,4 +68,4 @@ Mutations from A and B are already committed. Returning to the caller would cont
 > takes over immediately.
 ```
 
-**STOP.** Terminal — do not return to the caller's Step 6.
+**STOP.** Do not proceed — terminal condition. Do not return to the caller's Step 6.

--- a/skills/workflow-continue-epic/references/select-epic.md
+++ b/skills/workflow-continue-epic/references/select-epic.md
@@ -58,7 +58,7 @@ Store the selected epic's name as `work_unit`.
 
 Set work_type filter = `epic`.
 
-→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
+→ Load **[view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 
@@ -66,7 +66,7 @@ Re-run discovery to refresh state after potential changes.
 
 #### If user chose `m`/`manage`
 
-→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
+→ Load **[manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 

--- a/skills/workflow-continue-feature/SKILL.md
+++ b/skills/workflow-continue-feature/SKILL.md
@@ -42,6 +42,12 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Loading shared display conventions for this session.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → Proceed to **Step 1**.

--- a/skills/workflow-continue-feature/references/select-feature.md
+++ b/skills/workflow-continue-feature/references/select-feature.md
@@ -58,7 +58,7 @@ Store the selected feature's name as `work_unit`.
 
 Set work_type filter = `feature`.
 
-→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
+→ Load **[view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 
@@ -66,7 +66,7 @@ Re-run discovery to refresh state after potential changes.
 
 #### If user chose `m`/`manage`
 
-→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
+→ Load **[manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 

--- a/skills/workflow-continue-quickfix/SKILL.md
+++ b/skills/workflow-continue-quickfix/SKILL.md
@@ -42,6 +42,12 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Loading shared display conventions for this session.
+```
+
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → Proceed to **Step 1**.

--- a/skills/workflow-continue-quickfix/references/select-quickfix.md
+++ b/skills/workflow-continue-quickfix/references/select-quickfix.md
@@ -58,7 +58,7 @@ Store the selected quick-fix's name as `work_unit`.
 
 Set work_type filter = `quick-fix`.
 
-→ Load **[../../workflow-start/references/view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
+→ Load **[view-completed.md](../../workflow-start/references/view-completed.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 
@@ -66,7 +66,7 @@ Re-run discovery to refresh state after potential changes.
 
 #### If user chose `m`/`manage`
 
-→ Load **[../../workflow-start/references/manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
+→ Load **[manage-work-unit.md](../../workflow-start/references/manage-work-unit.md)** and follow its instructions as written.
 
 Re-run discovery to refresh state after potential changes.
 

--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -69,6 +69,13 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 ── Dispatch ─────────────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Determining the invocation mode — brand-new work, or re-shaping
+> an existing epic's map.
+```
+
 Read the positional arguments:
 
 - `$0` — **work_type pre-seed**: one of `epic` / `feature` / `bugfix` / `quick-fix` / `cross-cutting`, or `none` (the `s`/start path, no hint). A hint, not a given — still confirmed in new mode.

--- a/skills/workflow-discussion-process/references/initialize-discussion.md
+++ b/skills/workflow-discussion-process/references/initialize-discussion.md
@@ -4,9 +4,9 @@
 
 ---
 
-→ Load **[../../workflow-shared/references/seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
+→ Load **[seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
 
-→ Load **[../../workflow-shared/references/read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
+→ Load **[read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 1. Ensure the discussion directory exists: `.workflows/{work_unit}/discussion/`
 2. Register the discussion in the manifest (the map commands below require the item to exist):

--- a/skills/workflow-discussion-process/references/meeting-assistant.md
+++ b/skills/workflow-discussion-process/references/meeting-assistant.md
@@ -10,19 +10,19 @@ Capture technical discussions for planning teams to build from.
 
 Wear **two hats simultaneously**:
 
-1. **Expert Architect** - Participate deeply, challenge approaches, identify edge cases, provide insights
-2. **Documentation Assistant** - Capture discussion, decisions, debates, rationale, edge cases, false paths
+1. **Expert Architect** — Participate deeply, challenge approaches, identify edge cases, provide insights
+2. **Documentation Assistant** — Capture discussion, decisions, debates, rationale, edge cases, false paths
 
-You're an AI - do both. Engage fully while documenting. Don't dumb down.
+You're an AI — do both. Engage fully while documenting. Don't dumb down.
 
 ## Workflow
 
 **Your role: discuss and document only**
 
-1. **Discuss** - Participate
-2. **Document** - Capture
-3. **Plan** - ❌ Not covered here
-4. **Implement** - ❌ Not covered here
+1. **Discuss** — Participate
+2. **Document** — Capture
+3. **Plan** — ❌ Not covered here
+4. **Implement** — ❌ Not covered here
 
 Stop after documentation. No plans, implementation steps, or code.
 
@@ -38,7 +38,7 @@ Stop after documentation. No plans, implementation steps, or code.
 
 ## Capture Debates
 
-When discussions are challenging/prolonged - document thoroughly. Back-and-forth shows:
+When discussions are challenging/prolonged — document thoroughly. Back-and-forth shows:
 - How we challenged approaches
 - Why solutions won over alternatives
 - Small details that mattered

--- a/skills/workflow-implementation-process/references/tdd-workflow.md
+++ b/skills/workflow-implementation-process/references/tdd-workflow.md
@@ -17,7 +17,7 @@ This is pragmatic TDD, not purist. The mandatory discipline is **test-first sequ
 - You MUST see it fail for the right reason
 - You MUST NOT change tests to make broken code pass
 
-But write **complete, functional implementations** - don't artificially minimize with hardcoded returns or fake values that you'll "fix later". "Minimal" means no gold-plating beyond what the test requires, not "return 42 and triangulate".
+But write **complete, functional implementations** — don't artificially minimize with hardcoded returns or fake values that you'll "fix later". "Minimal" means no gold-plating beyond what the test requires, not "return 42 and triangulate".
 
 ## TDD Violation Recovery
 
@@ -55,7 +55,7 @@ Write complete, functional code that passes:
 - No "while I'm here" improvements
 - No edge cases not yet tested
 
-If you think "I should also handle X" - STOP. Write a test for X first.
+If you think "I should also handle X" — STOP. Write a test for X first.
 
 **One test at a time**: Write test → Run (fails) → Implement → Run (passes) → Commit → Next
 

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -20,7 +20,7 @@ The output becomes source material for a specification focused on the fix approa
 
 - **Topic** (required) - Bug identifier or short description
 - **Bug context** (optional) - Initial symptoms, error messages, reproduction steps
-- **Work type** - Always "bugfix" for investigation
+- **Work type** — Always "bugfix" for investigation
 
 ---
 

--- a/skills/workflow-investigation-process/references/initialize-investigation.md
+++ b/skills/workflow-investigation-process/references/initialize-investigation.md
@@ -4,7 +4,7 @@
 
 ---
 
-→ Load **[../../workflow-shared/references/seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
+→ Load **[seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
 
 1. Create the investigation directory: `.workflows/{work_unit}/investigation/`
 2. Load **[template.md](template.md)** — use it to create `.workflows/{work_unit}/investigation/{topic}.md`

--- a/skills/workflow-investigation-process/references/symptom-gathering.md
+++ b/skills/workflow-investigation-process/references/symptom-gathering.md
@@ -153,12 +153,12 @@ Questions to ask when gathering bug symptoms.
 
 Start broad, then narrow:
 
-1. **Problem description** - What's wrong?
-2. **Impact assessment** - How bad is it?
-3. **Reproduction** - Can we trigger it?
-4. **Environment** - Where does it happen?
-5. **History** - When did it start?
-6. **References** - What do we have to work with?
-7. **Hypotheses** - What do you suspect?
+1. **Problem description** — What's wrong?
+2. **Impact assessment** — How bad is it?
+3. **Reproduction** — Can we trigger it?
+4. **Environment** — Where does it happen?
+5. **History** — When did it start?
+6. **References** — What do we have to work with?
+7. **Hypotheses** — What do you suspect?
 
 Don't ask all questions upfront. Start with the most important, gather initial context, then drill down based on responses.

--- a/skills/workflow-legacy-research-split/SKILL.md
+++ b/skills/workflow-legacy-research-split/SKILL.md
@@ -56,6 +56,13 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── List Qualifying Sources ──────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Scanning the epic's research files for migration-seeded broad
+> sources that qualify for decomposition.
+```
+
 Initialise `applied_count = 0`, `abandoned_count = 0`, `errored_count = 0`.
 
 ```bash

--- a/skills/workflow-legacy-research-split/references/dialog.md
+++ b/skills/workflow-legacy-research-split/references/dialog.md
@@ -86,8 +86,8 @@ Candidate themes for {current_source}.md:
 ```
 · · · · · · · · · · · ·
 - **`y`/`yes`** — Proceed to draft cache files
-- **Redirect** — Adjust the theme list (rename, merge two, split one, add, remove)
 - **`a`/`abandon`** — Skip this source file
+- **Redirect** — Adjust the theme list (rename, merge two, split one, add, remove)
 · · · · · · · · · · · ·
 ```
 
@@ -201,8 +201,8 @@ Source file will be renamed to {current_source}-superseded-{datetime}.md.
 ```
 · · · · · · · · · · · ·
 - **`y`/`yes`** — Apply this plan
-- **Edit** — Modify cache files or plan.json (rename, merge, split, add, remove). To rewrite a draft, edit the cache file directly between renders.
 - **`a`/`abandon`** — Skip this source file
+- **Edit** — Modify cache files or plan.json (rename, merge, split, add, remove). To rewrite a draft, edit the cache file directly between renders.
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-planning-process/references/phase-design/bugfix.md
+++ b/skills/workflow-planning-process/references/phase-design/bugfix.md
@@ -1,6 +1,6 @@
 # Bugfix Phase Design
 
-*Context guidance for **[phase-design.md](../phase-design.md)** — bug fixes*
+*Reference for **[phase-design.md](../phase-design.md)** — bug fixes*
 
 ---
 

--- a/skills/workflow-planning-process/references/phase-design/epic.md
+++ b/skills/workflow-planning-process/references/phase-design/epic.md
@@ -1,6 +1,6 @@
 # Epic Phase Design
 
-*Context guidance for **[phase-design.md](../phase-design.md)** — new system builds*
+*Reference for **[phase-design.md](../phase-design.md)** — new system builds*
 
 ---
 

--- a/skills/workflow-planning-process/references/phase-design/feature.md
+++ b/skills/workflow-planning-process/references/phase-design/feature.md
@@ -1,6 +1,6 @@
 # Feature Phase Design
 
-*Context guidance for **[phase-design.md](../phase-design.md)** — feature additions to existing systems*
+*Reference for **[phase-design.md](../phase-design.md)** — feature additions to existing systems*
 
 ---
 

--- a/skills/workflow-planning-process/references/planning-principles.md
+++ b/skills/workflow-planning-process/references/planning-principles.md
@@ -38,7 +38,7 @@ At every stop point — phases, task lists, individual tasks, dependencies — t
 
 When uncertain whether the user approved, ask: "Ready to proceed, or do you want to change something?"
 
-#### Self-Check Before Logging
+### Self-Check Before Logging
 
 Before logging any task to the plan, ask yourself:
 

--- a/skills/workflow-planning-process/references/task-design/bugfix.md
+++ b/skills/workflow-planning-process/references/task-design/bugfix.md
@@ -1,6 +1,6 @@
 # Bugfix Task Design
 
-*Context guidance for **[task-design.md](../task-design.md)** — bug fixes*
+*Reference for **[task-design.md](../task-design.md)** — bug fixes*
 
 ---
 

--- a/skills/workflow-planning-process/references/task-design/epic.md
+++ b/skills/workflow-planning-process/references/task-design/epic.md
@@ -1,6 +1,6 @@
 # Epic Task Design
 
-*Context guidance for **[task-design.md](../task-design.md)** — new system builds*
+*Reference for **[task-design.md](../task-design.md)** — new system builds*
 
 ---
 

--- a/skills/workflow-planning-process/references/task-design/feature.md
+++ b/skills/workflow-planning-process/references/task-design/feature.md
@@ -1,6 +1,6 @@
 # Feature Task Design
 
-*Context guidance for **[task-design.md](../task-design.md)** — feature additions to existing systems*
+*Reference for **[task-design.md](../task-design.md)** — feature additions to existing systems*
 
 ---
 

--- a/skills/workflow-research-process/references/initialize-research.md
+++ b/skills/workflow-research-process/references/initialize-research.md
@@ -4,9 +4,9 @@
 
 ---
 
-→ Load **[../../workflow-shared/references/seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
+→ Load **[seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
 
-→ Load **[../../workflow-shared/references/read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
+→ Load **[read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 1. Load **[template.md](template.md)** — use it to create the research file at the Output path from the handoff (e.g., `.workflows/{work_unit}/research/{resolved_filename}`). Include the terminal `## Triage` section seeded as `(none)`.
 2. Populate the Starting Point section with context from the handoff's `Context:` section and the seed. If restarting (no `Context:` in handoff), leave the Starting Point section empty — the session will gather context naturally.

--- a/skills/workflow-scoping-process/references/gather-context.md
+++ b/skills/workflow-scoping-process/references/gather-context.md
@@ -8,7 +8,7 @@ Gather targeted context about the mechanical change. Read the work's seed and th
 
 ## A. Read Existing Context
 
-→ Load **[../../workflow-shared/references/seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
+→ Load **[seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} description

--- a/skills/workflow-scoping-process/references/select-format.md
+++ b/skills/workflow-scoping-process/references/select-format.md
@@ -45,7 +45,7 @@ Project default format is **{format}**. Use the same format?
 
 ## B. Select Format
 
-→ Load **[../../workflow-planning-process/references/output-formats.md](../../workflow-planning-process/references/output-formats.md)** and follow its instructions as written.
+→ Load **[output-formats.md](../../workflow-planning-process/references/output-formats.md)** and follow its instructions as written.
 
 → Load the chosen format's **[about.md](../../workflow-planning-process/references/output-formats/{chosen-format}/about.md)** and follow its Setup section — complete any prerequisites (installation, initialisation, MCP configuration) before tasks are written.
 

--- a/skills/workflow-specification-entry/references/confirm-continue.md
+++ b/skills/workflow-specification-entry/references/confirm-continue.md
@@ -107,7 +107,7 @@ Proceed?
 
 ## B. Handle Response
 
-#### If user confirms (y)
+#### If `yes`
 
 **If spec is completed with pending sources:**
 
@@ -117,7 +117,7 @@ Proceed?
 
 → Load **[continue.md](handoffs/continue.md)** and follow its instructions as written.
 
-#### If user declines (n)
+#### If `no`
 
 **If single discussion (no menu to return to):**
 

--- a/skills/workflow-specification-entry/references/confirm-create.md
+++ b/skills/workflow-specification-entry/references/confirm-create.md
@@ -82,7 +82,7 @@ Proceed?
 
 ## B. Handle Response
 
-#### If user confirms (y)
+#### If `yes`
 
 **If any source discussions have individual specs:**
 
@@ -92,7 +92,7 @@ Proceed?
 
 → Load **[create.md](handoffs/create.md)** and follow its instructions as written.
 
-#### If user declines (n)
+#### If `no`
 
 **If single discussion (no menu to return to):**
 

--- a/skills/workflow-specification-entry/references/confirm-refine.md
+++ b/skills/workflow-specification-entry/references/confirm-refine.md
@@ -36,11 +36,11 @@ Proceed?
 
 **STOP.** Wait for user response.
 
-#### If user confirms (y)
+#### If `yes`
 
 → Load **[continue.md](handoffs/continue.md)** and follow its instructions as written.
 
-#### If user declines (n)
+#### If `no`
 
 **If single discussion (no menu to return to):**
 

--- a/skills/workflow-specification-entry/references/confirm-unify.md
+++ b/skills/workflow-specification-entry/references/confirm-unify.md
@@ -76,7 +76,7 @@ Proceed?
 
 ## B. Handle Response
 
-#### If user confirms (y)
+#### If `yes`
 
 **If existing specifications will be superseded:**
 
@@ -86,6 +86,6 @@ Proceed?
 
 → Load **[unify.md](handoffs/unify.md)** and follow its instructions as written.
 
-#### If user declines (n)
+#### If `no`
 
 → Return to caller.

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -57,7 +57,7 @@ Proceed with analysis?
 
 ## B. Handle Response
 
-#### If user confirms (y)
+#### If `yes`
 
 If `cache_status` is `stale`, delete the cache first:
 ```bash
@@ -66,7 +66,7 @@ rm .workflows/{work_unit}/.state/discussion-consolidation-analysis.md
 
 → Load **[analysis-flow.md](analysis-flow.md)** and follow its instructions as written.
 
-#### If user declines (n)
+#### If `no`
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -53,6 +53,13 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 ── Initialisation ───────────────────────────────
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Setting up the session — shared conventions first, then the
+> system boot checks.
+```
+
 ### Step 0.1: Casing Conventions
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.


### PR DESCRIPTION
Final merge-day conventions audit, territory 1: all 284 skill prose files, mechanical checker self-tested against 21 planted violations, ~70 full judgment reads covering the entire fix-round churn set. 40 files corrected: em-dash rule in menu descriptions, canonical reference headers, an H4 misuse, a home-grown STOP variant, menu option ordering, dot-frame spacing, eight marker-without-signpost sites (workflow-start's own included), command-value branch labels across the spec-entry confirms, and Load-directive link text. Checker re-run clean at zero across the tree. Deliberate non-fixes documented in the audit (runtime-parameterised adapter links, the banner width exemption, sanctioned loop idioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. **#462** 👈 current
59. #463
60. #464
61. #465
62. #466
63. #467
64. #468
65. #469
66. #470
67. #471
68. #472
69. #473
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->