### PR TITLE
conventions: final pre-merge pass — agents, rendered output, and the rulebook

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -54,7 +54,7 @@ Skills that render state via an engine/adapter call (e.g. `gateway.cjs view {wor
 
 A section is everything beneath its marker up to the next marker; the marker lines themselves are never emitted. Section content is emitted byte-for-byte — never redrawn, reflowed, trimmed, or re-derived. Routing uses the `ACTIONS` entry's `action`/`route` values, never label text.
 
-Engine transaction verbs (e.g. `engine task …`) may append labelled DISPLAY/MENU sections after their one-line JSON response — the state-derived gates of the calling flow. The label names the gate (`=== MENU: fix gate … ===`) and the marker's instruction names the emission moment: the section is emitted only where the flow's prose prescribes it, which may be a later gate than the call — never at the call itself. The same verbatim rules apply.
+Engine calls may append labelled DISPLAY/MENU sections — transaction verbs (e.g. `engine task …`) after their one-line JSON response, snapshot verbs after their unlabelled sections — the state-derived gates of the calling flow. The label names the gate (`=== MENU: fix gate … ===`) and the marker's instruction names the emission moment: the section is emitted only where the flow's prose prescribes it, which may be a later gate than the call — never at the call itself. The same verbatim rules apply.
 
 ### Phase Titles
 
@@ -228,7 +228,7 @@ Unnumbered trees follow the same structure:
 
 Item-level statuses use square brackets `[term]`. Phase header count summaries use parentheses `(N completed, M pending)`. Never dash-separated.
 
-Core vocabulary: `in-progress`, `completed`, `ready`, `extracted`, `pending`, `reopened`, `promoted`. Discussion Map uses `pending`, `exploring`, `converging`, `decided`. Phase-specific terms are fine but format is always `[term]` for items.
+Core vocabulary: `in-progress`, `completed`, `ready`, `extracted`, `pending`, `reopened`, `promoted`. Discussion Map uses `pending`, `exploring`, `converging`, `decided`, `deferred`. Phase-specific terms are fine but format is always `[term]` for items.
 
 ### Callout Flag
 
@@ -259,7 +259,7 @@ Reads as: "advanced-features is blocked by task core-2-3 in the core-features pl
 
 ### Key / Legend
 
-Separate code block. Categorized. Em dash (`—`) separators. **No `---` separator before the Key block.** Only show statuses that appear in the current display. **Blank line between categories.**
+Separate code block (engine snapshots compose the Key into the same DISPLAY block, beneath the display it explains). Categorized. Em dash (`—`) separators. **No `---` separator before the Key block.** Only show statuses that appear in the current display. **Blank line between categories.**
 
 ```
 Key:
@@ -276,7 +276,7 @@ Key:
 
 ### Menus / Interactive Prompts
 
-Rendered as markdown (not code blocks). Framed with `· · · · · · · · · · · ·` dot separators at top and bottom — no blank lines between the dots and the content they frame. A question or contextual label appears first inside the dots, followed by a blank line, then the options. Verb-based labels for selection menus. No single-character icons.
+Rendered as markdown (not code blocks). Framed with `· · · · · · · · · · · ·` dot separators at top and bottom — no blank lines between the dots and the content they frame. A question or contextual label opens the menu, followed by a blank line, then the options — compact yes/no prompts may omit the blank line. Selection menus may carry the prompt as a trailing `Select an option:` line after the options instead of (or in addition to) an opening label, as in the examples below. Verb-based labels for selection menus. No single-character icons.
 
 **Option types** — menus contain two kinds of option:
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -301,7 +301,7 @@ Sister patterns: `**Name them** — Tell me which to re-add`; `**Adjust** — Te
 Investigation complete. Ready to conclude?
 
 - **`y`/`yes`** — Conclude investigation
-- **Keep going** — Continue discussing to explore further
+- **Keep going** — Tell me what else to explore
 · · · · · · · · · · · ·
 ```
 

--- a/agents/workflow-investigation-synthesis.md
+++ b/agents/workflow-investigation-synthesis.md
@@ -88,7 +88,7 @@ Write to the output file path provided — in two steps: write the content to th
 If fully validated with no gaps:
 
 ```markdown
-{frontmatter provided by orchestrator}
+{skeleton frontmatter, with status: pending}
 
 # Investigation Synthesis: {topic}
 

--- a/agents/workflow-review-task-verifier.md
+++ b/agents/workflow-review-task-verifier.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-review-task-verifier
-description: Verifies a single plan task was implemented correctly. Checks implementation, tests, and code quality against the task's acceptance criteria and spec context. Writes structured findings to file, returns brief status to orchestrator.
+description: Verifies a single plan task was implemented correctly. Checks implementation, tests, and code quality against the task's acceptance criteria and spec context. Writes structured findings to file, returns brief status to orchestrator. Invoked by workflow-review-process skill for each task in scope.
 tools: Read, Write, Glob, Grep, Bash
 model: opus
 ---

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -281,7 +281,7 @@ All subtopics on the Discussion Map are decided.
 Discussion complete. Ready to conclude?
 
 - **`y`/`yes`** — Conclude discussion
-- **Keep going** — Continue discussing to explore further
+- **Keep going** — Tell me what else to explore
 · · · · · · · · · · · ·
 ```
 

--- a/skills/workflow-engine/scripts/domain/projections/specification.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/specification.cjs
@@ -360,6 +360,9 @@ function specificationMenu(detail) {
  * @returns {{keys: SpecMenuKey[], display: string, rendered: string}}
  */
 function specificationCompletedMenu(detail) {
+  if (detail.concluded.length === 0) {
+    throw new Error('specificationCompletedMenu: no concluded specifications — nothing to render');
+  }
   /** @type {SpecMenuKey[]} */
   const keys = detail.concluded.map((row, i) => ({
     key: String(i + 1), action: 'refine_spec', topic: row.name, verb: 'Refining',

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -13,7 +13,7 @@ The user has already reviewed findings and agreed on fix direction. This step co
 Investigation complete. Ready to conclude?
 
 - **`y`/`yes`** — Conclude investigation
-- **Keep going** — Continue discussing to explore further
+- **Keep going** — Tell me what else to explore
 · · · · · · · · · · · ·
 ```
 

--- a/tests/scripts/test-engine-specification-projections.cjs
+++ b/tests/scripts/test-engine-specification-projections.cjs
@@ -690,6 +690,25 @@ describe('specification projections: menu goldens', () => {
       ]
     );
   });
+
+  it('completed sub-view: refuses cleanly when nothing is concluded', () => {
+    createManifest(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discussion: { items: { a: { status: 'completed' } } },
+        specification: {
+          items: {
+            'auth-flow': { status: 'in-progress', sources: { a: { status: 'pending' } } },
+          },
+        },
+      },
+    });
+    createFile(dir, '.workflows/v1/specification/auth-flow/specification.md', '# A');
+    assert.throws(
+      () => specificationCompletedMenu(detailOf(dir, 'v1')),
+      /no concluded specifications/
+    );
+  });
 });
 
 describe('specification adapter: gateway verbs', () => {


### PR DESCRIPTION
Territory 2: the 23 agent briefs (structural consistency, dispatch-contract mirroring re-verified), the engine's rendered output driven live across every projection surface and measured against the display rules (all PASS; every border and marker verified at exactly 49 code points, dot frames byte-exact, zero broken gutters), and CONVENTIONS.md itself. Fixes: a real crash in the spec completed-menu empty case (raw stack trace → clean refusal, with test), two brief nits, and five rulebook corrections including the menu section contradicting its own examples, the missing `deferred` state, and the mixed-prompt sample violating its own prompt-option rule (sample and its two prose mirrors aligned). Flagged-not-changed: the epic Key's documented pre-engine shape, the Rules/Hard Rules heading variance in five briefs.

1356 node tests, CLI, migrations, typecheck green at the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. #462
59. **#463** 👈 current
60. #464
61. #465
62. #466
63. #467
64. #468
65. #469
66. #470
67. #471
68. #472
69. #473
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->