### PR TITLE
fix(migrations): bash-3.2 orchestrator + crash-hardening across the frozen fleet

### DIFF
--- a/skills/workflow-migrate/scripts/migrate.sh
+++ b/skills/workflow-migrate/scripts/migrate.sh
@@ -103,6 +103,12 @@ report_skip() {
 export -f report_update report_skip
 export TRACKING_FILE FILES_UPDATED FILES_SKIPPED
 
+# Pin the project directory migrations operate on. Migrations 019+ use
+# ${PROJECT_DIR:-.} while 001-018/027 use bare relative paths — both resolve to
+# the current directory. A user-exported PROJECT_DIR would otherwise redirect
+# half the fleet elsewhere, so force it to "." for the duration of the run.
+export PROJECT_DIR="."
+
 #
 # Main: Run all migrations in order
 #
@@ -113,8 +119,13 @@ if [ ! -d "$MIGRATIONS_DIR" ]; then
     exit 0
 fi
 
-# Find all migration scripts, sorted by name (numeric order)
-mapfile -t MIGRATION_SCRIPTS < <(find "$MIGRATIONS_DIR" -name "*.sh" -type f | sort)
+# Find all migration scripts, sorted by name (numeric order).
+# bash 3.2 (stock macOS) has no `mapfile`, so read the sorted find output line
+# by line via process substitution — which keeps the array in this shell.
+MIGRATION_SCRIPTS=()
+while IFS= read -r script; do
+    MIGRATION_SCRIPTS+=("$script")
+done < <(find "$MIGRATIONS_DIR" -name "*.sh" -type f | sort)
 
 if [ ${#MIGRATION_SCRIPTS[@]} -eq 0 ]; then
     echo "No migration scripts found."

--- a/skills/workflow-migrate/scripts/migrations/001-discussion-frontmatter.sh
+++ b/skills/workflow-migrate/scripts/migrations/001-discussion-frontmatter.sh
@@ -64,8 +64,11 @@ for file in "$DISCUSSION_DIR"/*.md; do
     date_value=$(grep -m1 '^\*\*Date\*\*:\|^\*\*Started:\*\*' "$file" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || echo "")
 
     # Extract status from **Status**: Value or **Status:** Value (colon inside or outside bold)
-    # First extract the line, then remove all variations of the prefix
-    status_raw=$(grep -m1 '^\*\*Status' "$file" | sed 's/^\*\*Status\*\*:[[:space:]]*//' | sed 's/^\*\*Status:\*\*[[:space:]]*//' | tr '[:upper:]' '[:lower:]')
+    # First extract the line, then remove all variations of the prefix.
+    # Guard the pipeline: a file that matched line 51 on **Date**/**Started**
+    # alone has no Status line, and under `set -eo pipefail` the failed grep
+    # would otherwise abort the whole migration chain.
+    status_raw=$(grep -m1 '^\*\*Status' "$file" | sed 's/^\*\*Status\*\*:[[:space:]]*//' | sed 's/^\*\*Status:\*\*[[:space:]]*//' | tr '[:upper:]' '[:lower:]' || true)
     # Remove any emoji characters (like ✅) and trim whitespace
     status_raw=$(echo "$status_raw" | sed 's/✅//g' | xargs)
 
@@ -98,29 +101,43 @@ status: $status_new
 date: $date_value
 ---"
 
-    # Extract H1 heading (preserve original)
-    h1_heading=$(grep -m1 "^# " "$file")
+    # Extract H1 heading (preserve original). Guarded so a heading-less file
+    # can't abort the run under `set -eo pipefail`.
+    h1_heading=$(grep -m1 "^# " "$file" || true)
 
-    # Find line number of first ## heading (start of real content)
-    first_section_line=$(grep -n "^## " "$file" | head -1 | cut -d: -f1)
+    # Find line number of first ## heading (start of real content). Guarded: a
+    # file with no ## section must not fail the pipeline under pipefail.
+    first_section_line=$(grep -n "^## " "$file" | head -1 | cut -d: -f1 || true)
 
     # Get content from first ## onwards (preserves all content including **Status:** in decisions)
     if [ -n "$first_section_line" ]; then
-        content=$(tail -n +$first_section_line "$file")
+        content=$(tail -n +"$first_section_line" "$file")
     else
-        # No ## found - take everything after metadata block
-        # Find first blank line after H1, then take from there
-        content=""
+        # No ## found — preserve the body verbatim instead of dropping it.
+        # Skip the leading H1, the legacy **…** metadata lines, and blank lines,
+        # then emit everything from the first real body line onward.
+        content=$(awk '
+            seen { print; next }
+            /^# / { next }
+            /^\*\*/ { next }
+            /^[[:space:]]*$/ { next }
+            { seen = 1; print }
+        ' "$file")
     fi
 
-    # Write new content: frontmatter + H1 + blank line + content
+    # Write new content: frontmatter + H1 + blank line + content.
+    # Write to a temp file in the same directory then rename, so a mid-write
+    # kill can't leave a truncated file that the frontmatter skip-check would
+    # then treat as already migrated.
+    tmp_file="$file.tmp.$$"
     {
         echo "$frontmatter"
         echo ""
         echo "$h1_heading"
         echo ""
         echo "$content"
-    } > "$file"
+    } > "$tmp_file"
+    mv "$tmp_file" "$file"
 
     report_update
 done

--- a/skills/workflow-migrate/scripts/migrations/002-specification-frontmatter.sh
+++ b/skills/workflow-migrate/scripts/migrations/002-specification-frontmatter.sh
@@ -76,11 +76,15 @@ for file in "$SPEC_DIR"/*.md; do
 
     # Extract status from **Status**: Value or **Status:** Value
     # Handle variations: "Building specification", "Building", "Complete", "Completed", etc.
+    # Guard the pipeline: a file that matched line 65 on **Type**/**Last Updated**
+    # alone has no Status line, and under `set -eo pipefail` the failed grep
+    # would otherwise abort the whole migration chain (sibling extractions below
+    # already carry the same || guard).
     status_raw=$(grep -m1 '^\*\*Status\*\*:\|^\*\*Status:\*\*' "$file" | \
         sed 's/^\*\*Status\*\*:[[:space:]]*//' | \
         sed 's/^\*\*Status:\*\*[[:space:]]*//' | \
         tr '[:upper:]' '[:lower:]' | \
-        xargs)
+        xargs || echo "")
 
     # Map legacy status to normalized values (consistent across all document types)
     case "$status_raw" in
@@ -170,29 +174,43 @@ date: $date_value
 ---"
     fi
 
-    # Extract H1 heading (preserve original)
-    h1_heading=$(grep -m1 "^# " "$file")
+    # Extract H1 heading (preserve original). Guarded so a heading-less file
+    # can't abort the run under `set -eo pipefail`.
+    h1_heading=$(grep -m1 "^# " "$file" || true)
 
-    # Find line number of first ## heading (start of real content after metadata)
-    first_section_line=$(grep -n "^## " "$file" | head -1 | cut -d: -f1)
+    # Find line number of first ## heading (start of real content after metadata).
+    # Guarded: a file with no ## section must not fail the pipeline under pipefail.
+    first_section_line=$(grep -n "^## " "$file" | head -1 | cut -d: -f1 || true)
 
     # Get content from first ## onwards (preserves all content)
     if [ -n "$first_section_line" ]; then
-        content=$(tail -n +$first_section_line "$file")
+        content=$(tail -n +"$first_section_line" "$file")
     else
-        # No ## found - take everything after the metadata block
-        # Find first blank line after the metadata, then take from there
-        content=""
+        # No ## found — preserve the body verbatim instead of dropping it.
+        # Skip the leading H1, the legacy **…** metadata lines, and blank lines,
+        # then emit everything from the first real body line onward.
+        content=$(awk '
+            seen { print; next }
+            /^# / { next }
+            /^\*\*/ { next }
+            /^[[:space:]]*$/ { next }
+            { seen = 1; print }
+        ' "$file")
     fi
 
-    # Write new content: frontmatter + H1 + blank line + content
+    # Write new content: frontmatter + H1 + blank line + content.
+    # Write to a temp file in the same directory then rename, so a mid-write
+    # kill can't leave a truncated file that the frontmatter skip-check would
+    # then treat as already migrated.
+    tmp_file="$file.tmp.$$"
     {
         echo "$frontmatter"
         echo ""
         echo "$h1_heading"
         echo ""
         echo "$content"
-    } > "$file"
+    } > "$tmp_file"
+    mv "$tmp_file" "$file"
 
     report_update
 done

--- a/skills/workflow-migrate/scripts/migrations/003-planning-frontmatter.sh
+++ b/skills/workflow-migrate/scripts/migrations/003-planning-frontmatter.sh
@@ -157,28 +157,43 @@ specification: $spec_value
 ---"
     fi
 
-    # Extract H1 heading (preserve original)
-    h1_heading=$(grep -m1 "^# " "$file")
+    # Extract H1 heading (preserve original). Guarded so a heading-less file
+    # can't abort the run under `set -eo pipefail`.
+    h1_heading=$(grep -m1 "^# " "$file" || true)
 
-    # Find line number of first ## heading (start of real content after metadata)
-    first_section_line=$(grep -n "^## " "$file" | head -1 | cut -d: -f1)
+    # Find line number of first ## heading (start of real content after metadata).
+    # Guarded: a file with no ## section must not fail the pipeline under pipefail.
+    first_section_line=$(grep -n "^## " "$file" | head -1 | cut -d: -f1 || true)
 
     # Get content from first ## onwards (preserves all content)
     if [ -n "$first_section_line" ]; then
-        content=$(tail -n +$first_section_line "$file")
+        content=$(tail -n +"$first_section_line" "$file")
     else
-        # No ## found - might be empty or malformed
-        content=""
+        # No ## found — preserve the body verbatim instead of dropping it.
+        # Skip the leading H1, the legacy **…** metadata lines, and blank lines,
+        # then emit everything from the first real body line onward.
+        content=$(awk '
+            seen { print; next }
+            /^# / { next }
+            /^\*\*/ { next }
+            /^[[:space:]]*$/ { next }
+            { seen = 1; print }
+        ' "$file")
     fi
 
-    # Write new content: frontmatter + H1 + blank line + content
+    # Write new content: frontmatter + H1 + blank line + content.
+    # Write to a temp file in the same directory then rename, so a mid-write
+    # kill can't leave a truncated file that the skip-check would then treat as
+    # already migrated.
+    tmp_file="$file.tmp.$$"
     {
         echo "$frontmatter"
         echo ""
         echo "$h1_heading"
         echo ""
         echo "$content"
-    } > "$file"
+    } > "$tmp_file"
+    mv "$tmp_file" "$file"
 
     report_update
 done

--- a/skills/workflow-migrate/scripts/migrations/004-sources-object-format.sh
+++ b/skills/workflow-migrate/scripts/migrations/004-sources-object-format.sh
@@ -175,13 +175,17 @@ ${new_sources_block}"
     # Uses awk to skip only the first two --- delimiters, preserving any --- in body content
     content=$(awk '/^---$/ && c<2 {c++; next} c>=2 {print}' "$file")
 
-    # Write new file
+    # Write new file to a temp file in the same directory then rename, so a
+    # mid-write kill can't leave a truncated file that the frontmatter
+    # skip-check would then treat as already migrated.
+    tmp_file="$file.tmp.$$"
     {
         echo "---"
         echo "$new_frontmatter"
         echo "---"
         echo "$content"
-    } > "$file"
+    } > "$tmp_file"
+    mv "$tmp_file" "$file"
 
     # Report appropriate message based on what was done
     if $has_sources_field; then

--- a/skills/workflow-migrate/scripts/migrations/005-plan-external-deps-frontmatter.sh
+++ b/skills/workflow-migrate/scripts/migrations/005-plan-external-deps-frontmatter.sh
@@ -208,13 +208,17 @@ ${planning_block}"
 ${new_deps_block}"
     fi
 
-    # Write the updated file
+    # Write the updated file to a temp file in the same directory then rename,
+    # so a mid-write kill can't leave a truncated file that the skip-check would
+    # then treat as already migrated.
+    tmp_file="$file.tmp.$$"
     {
         echo "---"
         echo "$final_frontmatter"
         echo "---"
         echo "$new_body"
-    } > "$file"
+    } > "$tmp_file"
+    mv "$tmp_file" "$file"
 
     if $has_deps; then
         report_update

--- a/skills/workflow-migrate/scripts/migrations/006-directory-restructure.sh
+++ b/skills/workflow-migrate/scripts/migrations/006-directory-restructure.sh
@@ -27,6 +27,15 @@ if [ -d "$SPEC_DIR" ]; then
     for file in "$SPEC_DIR"/*.md; do
         [ -f "$file" ] || continue
 
+        # Skip tracking/review files — only process specification documents.
+        # They are relocated into their topic directory by the inner tracking
+        # loop below; treating one as a topic manufactures a phantom item (and
+        # glob order visits {topic}-review-*.md before {topic}.md). Same guard
+        # as migrations 002/003/005.
+        case "$(basename "$file")" in
+            *-review-*|*-tracking*) continue ;;
+        esac
+
         name=$(basename "$file" .md)
 
         # Skip if already a directory (already migrated)
@@ -63,6 +72,15 @@ fi
 if [ -d "$PLAN_DIR" ]; then
     for file in "$PLAN_DIR"/*.md; do
         [ -f "$file" ] || continue
+
+        # Skip tracking/review files — only process plan documents. They are
+        # relocated into their topic directory by the inner tracking loop below;
+        # treating one as a topic manufactures a phantom item (and glob order
+        # visits {topic}-review-*.md before {topic}.md). Same guard as
+        # migrations 002/003/005.
+        case "$(basename "$file")" in
+            *-review-*|*-tracking*) continue ;;
+        esac
 
         name=$(basename "$file" .md)
 

--- a/skills/workflow-migrate/scripts/migrations/013-discussion-work-type.sh
+++ b/skills/workflow-migrate/scripts/migrations/013-discussion-work-type.sh
@@ -64,13 +64,17 @@ for file in "$DISC_DIR"/*.md; do
 work_type: greenfield"
     fi
 
-    # Write updated file
+    # Write updated file to a temp file in the same directory then rename, so a
+    # mid-write kill can't leave a truncated file that the frontmatter
+    # skip-check would then treat as already migrated.
+    tmp_file="$file.tmp.$$"
     {
         echo "---"
         echo "$new_frontmatter"
         echo "---"
         echo "$content"
-    } > "$file"
+    } > "$tmp_file"
+    mv "$tmp_file" "$file"
 
     report_update
 done

--- a/skills/workflow-migrate/scripts/migrations/014-specification-work-type.sh
+++ b/skills/workflow-migrate/scripts/migrations/014-specification-work-type.sh
@@ -64,13 +64,17 @@ for file in "$SPEC_DIR"/*/specification.md; do
 work_type: greenfield"
     fi
 
-    # Write updated file
+    # Write updated file to a temp file in the same directory then rename, so a
+    # mid-write kill can't leave a truncated file that the frontmatter
+    # skip-check would then treat as already migrated.
+    tmp_file="$file.tmp.$$"
     {
         echo "---"
         echo "$new_frontmatter"
         echo "---"
         echo "$content"
-    } > "$file"
+    } > "$tmp_file"
+    mv "$tmp_file" "$file"
 
     report_update
 done

--- a/skills/workflow-migrate/scripts/migrations/015-plan-work-type.sh
+++ b/skills/workflow-migrate/scripts/migrations/015-plan-work-type.sh
@@ -64,13 +64,17 @@ for file in "$PLAN_DIR"/*/plan.md; do
 work_type: greenfield"
     fi
 
-    # Write updated file
+    # Write updated file to a temp file in the same directory then rename, so a
+    # mid-write kill can't leave a truncated file that the frontmatter
+    # skip-check would then treat as already migrated.
+    tmp_file="$file.tmp.$$"
     {
         echo "---"
         echo "$new_frontmatter"
         echo "---"
         echo "$content"
-    } > "$file"
+    } > "$tmp_file"
+    mv "$tmp_file" "$file"
 
     report_update
 done

--- a/skills/workflow-migrate/scripts/migrations/016-work-unit-restructure.sh
+++ b/skills/workflow-migrate/scripts/migrations/016-work-unit-restructure.sh
@@ -534,8 +534,8 @@ while IFS= read -r name; do
         var fs = require('fs');
         var path = require('path');
 
-        var name = '$name';
-        var workType = '$wt';
+        var name = process.argv[1];
+        var workType = process.argv[2];
         var workDir = '.workflows/' + name;
 
         // Helper to extract frontmatter from a file
@@ -805,7 +805,7 @@ while IFS= read -r name; do
             path.join(workDir, 'manifest.json'),
             JSON.stringify(manifest, null, 2) + '\n'
         );
-    "
+    " "$name" "$wt"
     report_update
 
 done < "$_016_TMPDIR/wu_list"

--- a/skills/workflow-migrate/scripts/migrations/017-external-deps-object.sh
+++ b/skills/workflow-migrate/scripts/migrations/017-external-deps-object.sh
@@ -32,7 +32,7 @@ for manifest in .workflows/*/manifest.json; do
     # Use node to convert array → object in-place
     node -e "
         const fs = require('fs');
-        const data = JSON.parse(fs.readFileSync('$manifest', 'utf8'));
+        const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
         let changed = false;
 
         if (data.phases) {
@@ -66,16 +66,16 @@ for manifest in .workflows/*/manifest.json; do
         }
 
         if (changed) {
-            fs.writeFileSync('$manifest', JSON.stringify(data, null, 2) + '\n');
+            fs.writeFileSync(process.argv[1], JSON.stringify(data, null, 2) + '\n');
             process.stdout.write('changed');
         }
-    " 2>/dev/null
+    " "$manifest" 2>/dev/null
 
     if [ $? -eq 0 ]; then
         # Check if node reported a change (it writes 'changed' to stdout)
         result=$(node -e "
             const fs = require('fs');
-            const data = JSON.parse(fs.readFileSync('$manifest', 'utf8'));
+            const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
             let hasArray = false;
             if (data.phases) {
                 for (const [phase, pdata] of Object.entries(data.phases)) {
@@ -88,7 +88,7 @@ for manifest in .workflows/*/manifest.json; do
                 }
             }
             process.stdout.write(hasArray ? 'has_array' : 'ok');
-        " 2>/dev/null)
+        " "$manifest" 2>/dev/null)
 
         if [ "$result" = "ok" ]; then
             report_skip

--- a/skills/workflow-migrate/scripts/migrations/019-status-rename.sh
+++ b/skills/workflow-migrate/scripts/migrations/019-status-rename.sh
@@ -12,8 +12,10 @@
 
 WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
 
+# The orchestrator sources this script, so a top-level `exit` would terminate
+# the whole migration chain. Use `return` to bow out of just this migration.
 if [ ! -d "$WORKFLOWS_DIR" ]; then
-  exit 0
+  return 0
 fi
 
 for dir in "$WORKFLOWS_DIR"/*/; do

--- a/skills/workflow-migrate/scripts/migrations/020-normalise-terminal-status.sh
+++ b/skills/workflow-migrate/scripts/migrations/020-normalise-terminal-status.sh
@@ -9,8 +9,10 @@
 
 WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
 
+# The orchestrator sources this script, so a top-level `exit` would terminate
+# the whole migration chain. Use `return` to bow out of just this migration.
 if [ ! -d "$WORKFLOWS_DIR" ]; then
-  exit 0
+  return 0
 fi
 
 for dir in "$WORKFLOWS_DIR"/*/; do

--- a/skills/workflow-migrate/scripts/migrations/021-research-filename-rename.sh
+++ b/skills/workflow-migrate/scripts/migrations/021-research-filename-rename.sh
@@ -8,8 +8,10 @@
 
 WORKFLOWS_DIR="${PROJECT_DIR:-.}/.workflows"
 
+# The orchestrator sources this script, so a top-level `exit` would terminate
+# the whole migration chain. Use `return` to bow out of just this migration.
 if [ ! -d "$WORKFLOWS_DIR" ]; then
-  exit 0
+  return 0
 fi
 
 for dir in "$WORKFLOWS_DIR"/*/; do

--- a/skills/workflow-migrate/scripts/migrations/026-rename-review-artifacts.sh
+++ b/skills/workflow-migrate/scripts/migrations/026-rename-review-artifacts.sh
@@ -69,11 +69,20 @@ for manifest in "$WORKFLOWS_DIR"/*/manifest.json; do
       continue
     fi
 
-    # Sort qa-task files numerically
+    # Sort qa-task files numerically by the N in qa-task-{N}.md. The basename
+    # number is the only reliable key: sorting dash-split full paths keys on a
+    # field that shifts with kebab-case directory names, so >=10 tasks would
+    # sort lexicographically (qa-task-10 before qa-task-2). Emit "N<TAB>path",
+    # sort by the numeric key, then strip it.
     sorted_qa=()
     while IFS= read -r f; do
       sorted_qa+=("$f")
-    done < <(printf '%s\n' "${qa_files[@]}" | sort -t- -k3 -n)
+    done < <(
+      for f in "${qa_files[@]}"; do
+        n=$(basename "$f" | sed -n 's/^qa-task-\([0-9][0-9]*\)\.md$/\1/p')
+        printf '%s\t%s\n' "$n" "$f"
+      done | sort -n -k1,1 | cut -f2-
+    )
 
     # Validate counts match
     if [ ${#sorted_qa[@]} -ne ${#internal_ids[@]} ]; then

--- a/skills/workflow-migrate/scripts/migrations/027-rename-external-deps-task-id.sh
+++ b/skills/workflow-migrate/scripts/migrations/027-rename-external-deps-task-id.sh
@@ -31,7 +31,7 @@ for manifest in .workflows/*/manifest.json; do
 
     result=$(node -e "
         const fs = require('fs');
-        const data = JSON.parse(fs.readFileSync('$manifest', 'utf8'));
+        const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
         let changed = false;
 
         if (data.phases) {
@@ -53,12 +53,12 @@ for manifest in .workflows/*/manifest.json; do
         }
 
         if (changed) {
-            fs.writeFileSync('$manifest', JSON.stringify(data, null, 2) + '\n');
+            fs.writeFileSync(process.argv[1], JSON.stringify(data, null, 2) + '\n');
             process.stdout.write('updated');
         } else {
             process.stdout.write('skip');
         }
-    " 2>/dev/null)
+    " "$manifest" 2>/dev/null)
 
     if [ "$result" = "updated" ]; then
         report_update

--- a/skills/workflow-migrate/scripts/migrations/029-backfill-task-map.sh
+++ b/skills/workflow-migrate/scripts/migrations/029-backfill-task-map.sh
@@ -120,9 +120,23 @@ if [ -d "$CACHE_DIR/planning" ]; then
       fi
 
       mkdir -p "$new_dir"
-      cp -r "$topic_dir"* "$new_dir/" 2>/dev/null || true
-      rm -rf "$topic_dir"
-      report_update "$wu_name/$topic: moved cache to new structure"
+      # Copy entries (regular + dot-prefixed, skipping . / ..) and only remove
+      # the source once every copy succeeded — a failed cp must never destroy
+      # the cache. The old unquoted glob also skipped dotfiles; iterate to
+      # include them (same . / .. skip pattern as migration 011).
+      copy_ok=1
+      for item in "$topic_dir"* "$topic_dir".*; do
+        base=$(basename "$item")
+        [ "$base" = "." ] || [ "$base" = ".." ] && continue
+        [ ! -e "$item" ] && continue
+        cp -r "$item" "$new_dir/" 2>/dev/null || copy_ok=0
+      done
+      if [ "$copy_ok" -eq 1 ]; then
+        rm -rf "$topic_dir"
+        report_update "$wu_name/$topic: moved cache to new structure"
+      else
+        report_skip
+      fi
     done
 
     # Clean up empty wu_dir

--- a/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh
+++ b/skills/workflow-migrate/scripts/migrations/033-rename-inbox-to-dotinbox.sh
@@ -16,9 +16,16 @@ NEW_INBOX="$WORKFLOWS_DIR/.inbox"
 [ -d "$OLD_INBOX" ] || return 0
 
 if [ -d "$NEW_INBOX" ]; then
-  # Both exist — merge old into new
-  cp -rn "$OLD_INBOX/"* "$NEW_INBOX/" 2>/dev/null || true
-  cp -rn "$OLD_INBOX/".* "$NEW_INBOX/" 2>/dev/null || true
+  # Both exist — merge old into new. Iterate entries (regular + dot-prefixed)
+  # and copy each, skipping . and ..: on bash 3.2 the `.*` glob matches `.`
+  # and `..`, which would recursively copy OLD_INBOX into itself and drag the
+  # parent tree along. Same skip pattern as migration 011.
+  for item in "$OLD_INBOX"/* "$OLD_INBOX"/.*; do
+    base=$(basename "$item")
+    [ "$base" = "." ] || [ "$base" = ".." ] && continue
+    [ ! -e "$item" ] && continue
+    cp -rn "$item" "$NEW_INBOX/" 2>/dev/null || true
+  done
   rm -rf "$OLD_INBOX"
   report_update
 else

--- a/skills/workflow-migrate/scripts/migrations/034-show-clear-context-on-plan-accept.sh
+++ b/skills/workflow-migrate/scripts/migrations/034-show-clear-context-on-plan-accept.sh
@@ -20,6 +20,14 @@ if [ -f "$SETTINGS_FILE" ] && node -e "
   return 0
 fi
 
+# Treat an unparseable settings.json as a skip rather than crash the migration
+# chain over a hand-edited file (e.g. a trailing comma) — mirrors migration 046.
+if [ -f "$SETTINGS_FILE" ] && ! node -e "
+  JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+" "$SETTINGS_FILE" 2>/dev/null; then
+  return 0
+fi
+
 mkdir -p "$SETTINGS_DIR"
 
 if [ -f "$SETTINGS_FILE" ]; then

--- a/skills/workflow-migrate/scripts/migrations/040-rename-inception-to-discovery.sh
+++ b/skills/workflow-migrate/scripts/migrations/040-rename-inception-to-discovery.sh
@@ -47,10 +47,17 @@ for (const entry of entries) {
       let updated = false;
 
       if (Object.prototype.hasOwnProperty.call(m.phases, 'inception')) {
-        const merged = Object.assign({}, m.phases.inception, m.phases.discovery || {});
-        m.phases.discovery = merged;
-        delete m.phases.inception;
-        updated = true;
+        if (m.phases.discovery) {
+          // Partial prior run — both phases present. A shallow Object.assign
+          // would let discovery's items/dismissed/cache subtrees clobber
+          // inception's. Leave both in place for the admin to reconcile,
+          // mirroring the directory rename's skip-if-target-exists below.
+        } else {
+          const merged = Object.assign({}, m.phases.inception, m.phases.discovery || {});
+          m.phases.discovery = merged;
+          delete m.phases.inception;
+          updated = true;
+        }
       }
 
       const disc = m.phases.discovery;

--- a/skills/workflow-migrate/scripts/migrations/042-allow-workflows-writes.sh
+++ b/skills/workflow-migrate/scripts/migrations/042-allow-workflows-writes.sh
@@ -23,6 +23,14 @@ if [ -f "$SETTINGS_FILE" ] && node -e "
   return 0
 fi
 
+# Treat an unparseable settings.json as a skip rather than crash the migration
+# chain over a hand-edited file (e.g. a trailing comma) — mirrors migration 046.
+if [ -f "$SETTINGS_FILE" ] && ! node -e "
+  JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+" "$SETTINGS_FILE" 2>/dev/null; then
+  return 0
+fi
+
 mkdir -p "$SETTINGS_DIR"
 [ -f "$SETTINGS_FILE" ] || echo '{}' > "$SETTINGS_FILE"
 

--- a/skills/workflow-migrate/scripts/migrations/044-allow-workflows-mv.sh
+++ b/skills/workflow-migrate/scripts/migrations/044-allow-workflows-mv.sh
@@ -22,6 +22,14 @@ if [ -f "$SETTINGS_FILE" ] && node -e "
   return 0
 fi
 
+# Treat an unparseable settings.json as a skip rather than crash the migration
+# chain over a hand-edited file (e.g. a trailing comma) — mirrors migration 046.
+if [ -f "$SETTINGS_FILE" ] && ! node -e "
+  JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+" "$SETTINGS_FILE" 2>/dev/null; then
+  return 0
+fi
+
 mkdir -p "$SETTINGS_DIR"
 [ -f "$SETTINGS_FILE" ] || echo '{}' > "$SETTINGS_FILE"
 

--- a/tests/scripts/test-migration-001.sh
+++ b/tests/scripts/test-migration-001.sh
@@ -14,6 +14,9 @@ FAIL=0
 report_update() { : ; }
 report_skip() { : ; }
 
+# Portable inode read: GNU coreutils (stat -c) or BSD/macOS (stat -f).
+_file_inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null; }
+
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -521,6 +524,89 @@ TESTEOF
   teardown
 }
 
+# --- Hostile: Date present but no Status line — must not crash the chain ---
+# The file matches the legacy check on **Date** but has no **Status**. Under
+# `set -eo pipefail` the unguarded status grep used to abort the run.
+test_date_only_no_status() {
+  setup
+
+  cat > "$DISCUSSION_DIR/date-only.md" << 'EOF'
+# Discussion: Date Only
+
+**Date**: 2024-03-01
+
+## Context
+
+Some content.
+EOF
+
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/date-only.md")
+
+  assert_eq "date-only: migrated to frontmatter" "---" "$(head -1 "$DISCUSSION_DIR/date-only.md")"
+  assert_eq "date-only: status defaulted to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
+  assert_eq "date-only: date preserved" "true" "$(echo "$content" | grep -q '^date: 2024-03-01$' && echo true || echo false)"
+  assert_eq "date-only: body section preserved" "true" "$(echo "$content" | grep -q '^## Context$' && echo true || echo false)"
+
+  teardown
+}
+
+# --- Hostile: no ## heading, but a body — the body must be preserved ---
+# The old no-section fallback set content="" and rewrote the file as
+# frontmatter + H1 only, deleting the document body.
+test_no_section_preserves_body() {
+  setup
+
+  cat > "$DISCUSSION_DIR/no-section.md" << 'EOF'
+# Discussion: No Section
+
+**Date**: 2024-03-02
+**Status**: Concluded
+
+This is body prose with no section heading.
+
+More body content that must survive migration.
+EOF
+
+  run_migration
+  content=$(cat "$DISCUSSION_DIR/no-section.md")
+
+  assert_eq "no-section: first body line preserved" "true" "$(echo "$content" | grep -qF 'This is body prose with no section heading.' && echo true || echo false)"
+  assert_eq "no-section: later body line preserved" "true" "$(echo "$content" | grep -qF 'More body content that must survive migration.' && echo true || echo false)"
+  assert_eq "no-section: H1 preserved" "true" "$(echo "$content" | grep -q '^# Discussion: No Section$' && echo true || echo false)"
+
+  teardown
+}
+
+# --- Hostile (crash-safety): file replaced via tmp + atomic rename ---
+# The old `> "$file"` truncates in place (a mid-write kill leaves a truncated
+# file the skip-check treats as migrated). tmp-then-mv replaces the file with a
+# new inode atomically — the destination is never observed half-written.
+test_atomic_write_new_inode() {
+  setup
+
+  cat > "$DISCUSSION_DIR/atomic.md" << 'EOF'
+# Discussion: Atomic
+
+**Status**: Exploring
+
+## Context
+
+Body.
+EOF
+
+  local inode_before inode_after
+  inode_before=$(_file_inode "$DISCUSSION_DIR/atomic.md")
+  run_migration
+  inode_after=$(_file_inode "$DISCUSSION_DIR/atomic.md")
+
+  assert_eq "atomic: file replaced via tmp+rename (inode changes)" "true" "$([ "$inode_before" != "$inode_after" ] && echo true || echo false)"
+  assert_eq "atomic: no temp residue left" "false" "$(ls "$DISCUSSION_DIR"/*.tmp.* >/dev/null 2>&1 && echo true || echo false)"
+  assert_eq "atomic: content migrated" "---" "$(head -1 "$DISCUSSION_DIR/atomic.md")"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 001 tests..."
 echo ""
@@ -541,6 +627,9 @@ test_kebab_case_topic
 test_body_horizontal_rules
 test_special_chars
 test_exact_body_preservation
+test_date_only_no_status
+test_no_section_preserves_body
+test_atomic_write_new_inode
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-002.sh
+++ b/tests/scripts/test-migration-002.sh
@@ -14,6 +14,9 @@ FAIL=0
 report_update() { : ; }
 report_skip() { : ; }
 
+# Portable inode read: GNU coreutils (stat -c) or BSD/macOS (stat -f).
+_file_inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null; }
+
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -619,10 +622,97 @@ TESTEOF
   teardown
 }
 
+# --- Hostile: Type present but no Status line — must not crash the chain ---
+# The file matches the legacy check on **Type** but has no **Status**. Under
+# `set -eo pipefail` the unguarded status grep used to abort the run.
+test_type_only_no_status() {
+  setup
+
+  cat > "$SPEC_DIR/type-only.md" << 'EOF'
+# Specification: Type Only
+
+**Type**: feature
+**Last Updated**: 2024-03-01
+
+## Overview
+
+Spec content.
+EOF
+
+  run_migration
+  content=$(cat "$SPEC_DIR/type-only.md")
+
+  assert_eq "type-only: migrated to frontmatter" "---" "$(head -1 "$SPEC_DIR/type-only.md")"
+  assert_eq "type-only: status defaulted to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
+  assert_eq "type-only: type preserved" "true" "$(echo "$content" | grep -q '^type: feature$' && echo true || echo false)"
+  assert_eq "type-only: body section preserved" "true" "$(echo "$content" | grep -q '^## Overview$' && echo true || echo false)"
+
+  teardown
+}
+
+# --- Hostile: no ## heading, but a body — the body must be preserved ---
+# The old no-section fallback set content="" and rewrote the file as
+# frontmatter + H1 only, deleting the document body.
+test_no_section_preserves_body() {
+  setup
+
+  cat > "$SPEC_DIR/no-section.md" << 'EOF'
+# Specification: No Section
+
+**Status**: Complete
+**Type**: feature
+**Last Updated**: 2024-03-02
+
+This is spec body prose with no section heading.
+
+More requirements that must survive migration.
+EOF
+
+  run_migration
+  content=$(cat "$SPEC_DIR/no-section.md")
+
+  assert_eq "no-section: first body line preserved" "true" "$(echo "$content" | grep -qF 'This is spec body prose with no section heading.' && echo true || echo false)"
+  assert_eq "no-section: later body line preserved" "true" "$(echo "$content" | grep -qF 'More requirements that must survive migration.' && echo true || echo false)"
+  assert_eq "no-section: H1 preserved" "true" "$(echo "$content" | grep -q '^# Specification: No Section$' && echo true || echo false)"
+
+  teardown
+}
+
+# --- Hostile (crash-safety): file replaced via tmp + atomic rename ---
+test_atomic_write_new_inode() {
+  setup
+
+  cat > "$SPEC_DIR/atomic.md" << 'EOF'
+# Specification: Atomic
+
+**Status**: Building specification
+**Type**: feature
+**Last Updated**: 2024-01-15
+
+## Overview
+
+Content.
+EOF
+  local f="$SPEC_DIR/atomic.md"
+  local ib ia
+  ib=$(_file_inode "$f")
+  run_migration
+  ia=$(_file_inode "$f")
+
+  assert_eq "atomic: file replaced via tmp+rename (inode changes)" "true" "$([ "$ib" != "$ia" ] && echo true || echo false)"
+  assert_eq "atomic: no temp residue left" "false" "$(ls "$SPEC_DIR"/*.tmp.* >/dev/null 2>&1 && echo true || echo false)"
+  assert_eq "atomic: content migrated" "---" "$(head -1 "$f")"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 002 tests..."
 echo ""
 
+test_type_only_no_status
+test_no_section_preserves_body
+test_atomic_write_new_inode
 test_building_specification
 test_complete_status
 test_completed_status

--- a/tests/scripts/test-migration-003.sh
+++ b/tests/scripts/test-migration-003.sh
@@ -14,6 +14,9 @@ FAIL=0
 report_update() { : ; }
 report_skip() { : ; }
 
+# Portable inode read: GNU coreutils (stat -c) or BSD/macOS (stat -f).
+_file_inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null; }
+
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -673,10 +676,92 @@ TESTEOF
   teardown
 }
 
+# --- Hostile: no H1 heading — must not crash the chain ---
+# An inline-metadata plan with no `# ` heading used to abort the run at the
+# unguarded H1 grep under `set -eo pipefail`.
+test_no_h1_no_crash() {
+  setup
+
+  cat > "$PLAN_DIR/no-h1.md" << 'EOF'
+**Status**: draft
+**Date**: 2024-03-01
+
+## Overview
+
+Plan content.
+EOF
+
+  run_migration
+  content=$(cat "$PLAN_DIR/no-h1.md")
+
+  assert_eq "no-h1: migrated to frontmatter" "---" "$(head -1 "$PLAN_DIR/no-h1.md")"
+  assert_eq "no-h1: status mapped to in-progress" "true" "$(echo "$content" | grep -q '^status: in-progress$' && echo true || echo false)"
+  assert_eq "no-h1: body section preserved" "true" "$(echo "$content" | grep -q '^## Overview$' && echo true || echo false)"
+
+  teardown
+}
+
+# --- Hostile: no ## heading, but a body — the body must be preserved ---
+# The old no-section fallback set content="" and deleted the document body.
+test_no_section_preserves_body() {
+  setup
+
+  cat > "$PLAN_DIR/no-section.md" << 'EOF'
+# Implementation Plan: No Section
+
+**Status**: draft
+**Date**: 2024-03-02
+
+Body prose with no section heading.
+
+More plan content that must survive migration.
+EOF
+
+  run_migration
+  content=$(cat "$PLAN_DIR/no-section.md")
+
+  assert_eq "no-section: first body line preserved" "true" "$(echo "$content" | grep -qF 'Body prose with no section heading.' && echo true || echo false)"
+  assert_eq "no-section: later body line preserved" "true" "$(echo "$content" | grep -qF 'More plan content that must survive migration.' && echo true || echo false)"
+  assert_eq "no-section: H1 preserved" "true" "$(echo "$content" | grep -q '^# Implementation Plan: No Section$' && echo true || echo false)"
+
+  teardown
+}
+
+# --- Hostile (crash-safety): file replaced via tmp + atomic rename ---
+test_atomic_write_new_inode() {
+  setup
+
+  cat > "$PLAN_DIR/atomic.md" << 'EOF'
+# Implementation Plan: Atomic
+
+**Status**: draft
+**Date**: 2024-01-15
+**Specification**: `atomic.md`
+
+## Overview
+
+Content.
+EOF
+  local f="$PLAN_DIR/atomic.md"
+  local ib ia
+  ib=$(_file_inode "$f")
+  run_migration
+  ia=$(_file_inode "$f")
+
+  assert_eq "atomic: file replaced via tmp+rename (inode changes)" "true" "$([ "$ib" != "$ia" ] && echo true || echo false)"
+  assert_eq "atomic: no temp residue left" "false" "$(ls "$PLAN_DIR"/*.tmp.* >/dev/null 2>&1 && echo true || echo false)"
+  assert_eq "atomic: content migrated" "---" "$(head -1 "$f")"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 003 tests..."
 echo ""
 
+test_no_h1_no_crash
+test_no_section_preserves_body
+test_atomic_write_new_inode
 test_draft_with_partial_frontmatter
 test_ready_status
 test_in_progress_status

--- a/tests/scripts/test-migration-004.sh
+++ b/tests/scripts/test-migration-004.sh
@@ -14,6 +14,9 @@ FAIL=0
 report_update() { : ; }
 report_skip() { : ; }
 
+# Portable inode read: GNU coreutils (stat -c) or BSD/macOS (stat -f).
+_file_inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null; }
+
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -734,10 +737,47 @@ TESTEOF
   teardown
 }
 
+# --- Hostile (crash-safety): file replaced via tmp + atomic rename ---
+# The old `> "$file"` truncates in place; tmp-then-mv replaces the file with a
+# new inode atomically, so a mid-write kill can't leave a truncated file the
+# frontmatter skip-check would treat as migrated.
+test_atomic_write_new_inode() {
+  setup
+
+  cat > "$SPEC_DIR/atomic.md" << 'EOF'
+---
+topic: atomic
+status: concluded
+type: feature
+date: 2024-01-15
+sources:
+  - auth-flow
+---
+
+# Specification: Atomic
+
+## Overview
+
+Content.
+EOF
+  local f="$SPEC_DIR/atomic.md"
+  local ib ia
+  ib=$(_file_inode "$f")
+  run_migration
+  ia=$(_file_inode "$f")
+
+  assert_eq "atomic: file replaced via tmp+rename (inode changes)" "true" "$([ "$ib" != "$ia" ] && echo true || echo false)"
+  assert_eq "atomic: no temp residue left" "false" "$(ls "$SPEC_DIR"/*.tmp.* >/dev/null 2>&1 && echo true || echo false)"
+  assert_eq "atomic: sources converted to object" "true" "$(grep -qF -- '- name: auth-flow' "$f" && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 004 tests..."
 echo ""
 
+test_atomic_write_new_inode
 test_single_source
 test_multiple_sources
 test_quoted_sources

--- a/tests/scripts/test-migration-005.sh
+++ b/tests/scripts/test-migration-005.sh
@@ -14,6 +14,9 @@ FAIL=0
 report_update() { : ; }
 report_skip() { : ; }
 
+# Portable inode read: GNU coreutils (stat -c) or BSD/macOS (stat -f).
+_file_inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null; }
+
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -491,10 +494,51 @@ EOF
   teardown
 }
 
+# --- Hostile (crash-safety): file replaced via tmp + atomic rename ---
+# The old `> "$file"` truncates in place; tmp-then-mv replaces the file with a
+# new inode atomically, so a mid-write kill can't leave a truncated file the
+# skip-check would treat as migrated.
+test_atomic_write_new_inode() {
+  setup
+
+  cat > "$PLAN_DIR/atomic.md" << 'EOF'
+---
+topic: atomic
+status: in-progress
+date: 2024-01-15
+format: local-markdown
+specification: atomic.md
+---
+
+# Implementation Plan: Atomic
+
+## External Dependencies
+
+- payment-gateway: Payment processing for checkout
+
+## Phase 1: Setup
+
+Setup tasks.
+EOF
+  local f="$PLAN_DIR/atomic.md"
+  local ib ia
+  ib=$(_file_inode "$f")
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+  ia=$(_file_inode "$f")
+
+  assert_eq "atomic: file replaced via tmp+rename (inode changes)" "true" "$([ "$ib" != "$ia" ] && echo true || echo false)"
+  assert_eq "atomic: no temp residue left" "false" "$(ls "$PLAN_DIR"/*.tmp.* >/dev/null 2>&1 && echo true || echo false)"
+  assert_eq "atomic: deps moved to frontmatter" "true" "$(grep -q '^external_dependencies:' "$f" && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 005 tests..."
 echo ""
 
+test_atomic_write_new_inode
 test_unresolved_dep
 test_resolved_dep
 test_resolved_suffix

--- a/tests/scripts/test-migration-006.sh
+++ b/tests/scripts/test-migration-006.sh
@@ -379,6 +379,64 @@ EOF
   teardown
 }
 
+# --- Test 11: Tracking file is not made a phantom spec topic ---
+# {topic}-review-tracking-*.md sorts before {topic}.md, so the outer loop used
+# to visit it first and manufacture a phantom topic dir. It must instead be
+# relocated into the real topic's directory by the inner tracking loop.
+test_spec_tracking_not_phantom() {
+  setup
+
+  cat > "$SPEC_DIR/auth.md" << 'EOF'
+---
+topic: auth
+status: concluded
+type: feature
+date: 2024-01-15
+---
+
+# Specification: Auth
+EOF
+  echo "# QA tracking c1" > "$SPEC_DIR/auth-review-tracking-c1.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "real topic migrated" "true" "$([ -f "$SPEC_DIR/auth/specification.md" ] && echo true || echo false)"
+  assert_eq "tracking file relocated into topic dir" "true" "$([ -f "$SPEC_DIR/auth/review-tracking-c1.md" ] && echo true || echo false)"
+  assert_eq "no phantom topic directory" "false" "$([ -d "$SPEC_DIR/auth-review-tracking-c1" ] && echo true || echo false)"
+  assert_eq "original tracking file removed" "false" "$([ -f "$SPEC_DIR/auth-review-tracking-c1.md" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 12: Planning tracking file is not made a phantom plan topic ---
+test_plan_tracking_not_phantom() {
+  setup
+
+  cat > "$PLAN_DIR/auth.md" << 'EOF'
+---
+topic: auth
+status: in-progress
+date: 2024-02-20
+format: local-markdown
+specification: auth.md
+---
+
+# Implementation Plan: Auth
+EOF
+  echo "# QA tracking c1" > "$PLAN_DIR/auth-review-tracking-c1.md"
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "real topic migrated" "true" "$([ -f "$PLAN_DIR/auth/plan.md" ] && echo true || echo false)"
+  assert_eq "tracking file relocated into topic dir" "true" "$([ -f "$PLAN_DIR/auth/review-tracking-c1.md" ] && echo true || echo false)"
+  assert_eq "no phantom topic directory" "false" "$([ -d "$PLAN_DIR/auth-review-tracking-c1" ] && echo true || echo false)"
+  assert_eq "original tracking file removed" "false" "$([ -f "$PLAN_DIR/auth-review-tracking-c1.md" ] && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 006 tests..."
 echo ""
@@ -393,6 +451,8 @@ test_spec_field_updated
 test_spec_field_already_updated
 test_multiple_restructured
 test_idempotency
+test_spec_tracking_not_phantom
+test_plan_tracking_not_phantom
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-013.sh
+++ b/tests/scripts/test-migration-013.sh
@@ -17,6 +17,9 @@ FAIL=0
 report_update() { : ; }
 report_skip() { : ; }
 
+# Portable inode read: GNU coreutils (stat -c) or BSD/macOS (stat -f).
+_file_inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null; }
+
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -161,6 +164,34 @@ EOF
   teardown
 }
 
+# --- Hostile (crash-safety): file replaced via tmp + atomic rename ---
+# The old `> "$file"` truncates in place; tmp-then-mv replaces the file with a
+# new inode atomically, so a mid-write kill can't leave a truncated file the
+# frontmatter skip-check would treat as migrated.
+test_atomic_write_new_inode() {
+  setup
+
+  cat > "$TEST_DIR/.workflows/discussion/atomic.md" <<'EOF'
+---
+topic: atomic
+status: completed
+---
+
+# Atomic Discussion
+EOF
+  local f="$TEST_DIR/.workflows/discussion/atomic.md"
+  local ib ia
+  ib=$(_file_inode "$f")
+  run
+  ia=$(_file_inode "$f")
+
+  assert_eq "atomic: file replaced via tmp+rename (inode changes)" "true" "$([ "$ib" != "$ia" ] && echo true || echo false)"
+  assert_eq "atomic: no temp residue left" "false" "$(ls "$TEST_DIR/.workflows/discussion"/*.tmp.* >/dev/null 2>&1 && echo true || echo false)"
+  assert_eq "atomic: work_type added" "true" "$(grep -q '^work_type: greenfield' "$f" && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 013 tests..."
 echo ""
@@ -171,6 +202,7 @@ test_skips_no_frontmatter
 test_no_discussion_dir
 test_no_status_field
 test_body_preserved
+test_atomic_write_new_inode
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-014.sh
+++ b/tests/scripts/test-migration-014.sh
@@ -17,6 +17,9 @@ FAIL=0
 report_update() { : ; }
 report_skip() { : ; }
 
+# Portable inode read: GNU coreutils (stat -c) or BSD/macOS (stat -f).
+_file_inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null; }
+
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -169,6 +172,36 @@ EOF
   teardown
 }
 
+# --- Hostile (crash-safety): file replaced via tmp + atomic rename ---
+# The old `> "$file"` truncates in place; tmp-then-mv replaces the file with a
+# new inode atomically, so a mid-write kill can't leave a truncated file the
+# frontmatter skip-check would treat as migrated.
+test_atomic_write_new_inode() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/specification/atomic"
+  cat > "$TEST_DIR/.workflows/specification/atomic/specification.md" <<'EOF'
+---
+topic: atomic
+type: feature
+status: completed
+---
+
+# Atomic Specification
+EOF
+  local f="$TEST_DIR/.workflows/specification/atomic/specification.md"
+  local ib ia
+  ib=$(_file_inode "$f")
+  run
+  ia=$(_file_inode "$f")
+
+  assert_eq "atomic: file replaced via tmp+rename (inode changes)" "true" "$([ "$ib" != "$ia" ] && echo true || echo false)"
+  assert_eq "atomic: no temp residue left" "false" "$(ls "$TEST_DIR/.workflows/specification/atomic"/*.tmp.* >/dev/null 2>&1 && echo true || echo false)"
+  assert_eq "atomic: work_type added" "true" "$(grep -q '^work_type: greenfield' "$f" && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 014 tests..."
 echo ""
@@ -179,6 +212,7 @@ test_skips_no_frontmatter
 test_no_spec_dir
 test_no_type_field
 test_multiple_specs
+test_atomic_write_new_inode
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-015.sh
+++ b/tests/scripts/test-migration-015.sh
@@ -17,6 +17,9 @@ FAIL=0
 report_update() { : ; }
 report_skip() { : ; }
 
+# Portable inode read: GNU coreutils (stat -c) or BSD/macOS (stat -f).
+_file_inode() { stat -c %i "$1" 2>/dev/null || stat -f %i "$1" 2>/dev/null; }
+
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -164,6 +167,35 @@ EOF
   teardown
 }
 
+# --- Hostile (crash-safety): file replaced via tmp + atomic rename ---
+# The old `> "$file"` truncates in place; tmp-then-mv replaces the file with a
+# new inode atomically, so a mid-write kill can't leave a truncated file the
+# frontmatter skip-check would treat as migrated.
+test_atomic_write_new_inode() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/planning/atomic"
+  cat > "$TEST_DIR/.workflows/planning/atomic/plan.md" <<'EOF'
+---
+topic: atomic
+status: completed
+---
+
+# Atomic Plan
+EOF
+  local f="$TEST_DIR/.workflows/planning/atomic/plan.md"
+  local ib ia
+  ib=$(_file_inode "$f")
+  run
+  ia=$(_file_inode "$f")
+
+  assert_eq "atomic: file replaced via tmp+rename (inode changes)" "true" "$([ "$ib" != "$ia" ] && echo true || echo false)"
+  assert_eq "atomic: no temp residue left" "false" "$(ls "$TEST_DIR/.workflows/planning/atomic"/*.tmp.* >/dev/null 2>&1 && echo true || echo false)"
+  assert_eq "atomic: work_type added" "true" "$(grep -q '^work_type: greenfield' "$f" && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 015 tests..."
 echo ""
@@ -174,6 +206,7 @@ test_skips_no_frontmatter
 test_no_plan_dir
 test_no_status_field
 test_multiple_plans
+test_atomic_write_new_inode
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-016.sh
+++ b/tests/scripts/test-migration-016.sh
@@ -1545,6 +1545,40 @@ EOF
   teardown
 }
 
+# --- Test: topic name with a single quote — no node injection ---
+# The work-unit name is passed to the manifest-building node call via
+# process.argv. A quote in the name (previously interpolated into the source
+# string as var name = '...') would otherwise be a JS SyntaxError that crashes
+# the run after files have already moved.
+test_quote_in_topic_name() {
+  setup
+  mkdir -p "$TEST_DIR/.workflows/discussion"
+  cat > "$TEST_DIR/.workflows/discussion/user's-auth.md" << 'EOF'
+---
+topic: user's-auth
+status: concluded
+work_type: feature
+date: 2026-01-15
+---
+
+# Discussion: User's Auth
+
+We need auth.
+EOF
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  assert_eq "quoted-name: manifest.json created" "true" "$([ -f "$TEST_DIR/.workflows/user's-auth/manifest.json" ] && echo true || echo false)"
+  assert_eq "quoted-name: discussion moved as {name}.md" "true" "$([ -f "$TEST_DIR/.workflows/user's-auth/discussion/user's-auth.md" ] && echo true || echo false)"
+
+  local wu_name
+  wu_name=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).name)" "$TEST_DIR/.workflows/user's-auth/manifest.json" 2>/dev/null)
+  assert_eq "quoted-name: manifest name correct" "user's-auth" "$wu_name"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 016 tests..."
 echo ""
@@ -1582,6 +1616,7 @@ test_epic_spec_path
 test_superseded_spec
 test_research_subdirs
 test_gitkeep_empty
+test_quote_in_topic_name
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-017.sh
+++ b/tests/scripts/test-migration-017.sh
@@ -233,6 +233,39 @@ EOF
   teardown
 }
 
+# --- Test 7: Work-unit dir name with a single quote — no node injection ---
+# The manifest path is passed to node via process.argv, so a quote in the dir
+# name (interpolated into the source string previously) no longer breaks it.
+test_quote_in_work_unit_name() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/user's-auth"
+  cat > "$TEST_DIR/.workflows/user's-auth/manifest.json" << 'EOF'
+{
+  "name": "user's-auth",
+  "work_type": "feature",
+  "status": "active",
+  "phases": {
+    "planning": {
+      "status": "concluded",
+      "external_dependencies": [
+        { "topic": "billing", "state": "unresolved" }
+      ]
+    }
+  }
+}
+EOF
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  content=$(cat "$TEST_DIR/.workflows/user's-auth/manifest.json")
+  assert_eq "quoted-name: array converted to object" "true" "$(echo "$content" | grep -qF '"billing"' && echo true || echo false)"
+  assert_eq "quoted-name: topic field removed from values" "false" "$(echo "$content" | grep -qF '"topic"' && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 017 tests..."
 echo ""
@@ -243,6 +276,7 @@ test_epic_items
 test_idempotent
 test_skip_dot_dirs
 test_no_deps_unchanged
+test_quote_in_work_unit_name
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-019.sh
+++ b/tests/scripts/test-migration-019.sh
@@ -344,9 +344,26 @@ test_no_workflows() {
   setup
   rm -rf "$TEST_DIR/.workflows"
 
-  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
+  # The orchestrator sources migrations; mirror that here.
+  ( source "$MIGRATION" )
 
   assert_eq "exits cleanly" "true" "true"
+
+  teardown
+}
+
+# --- Sourced with no .workflows — returns, does not exit the caller ---
+# The orchestrator sources each migration; a top-level `exit` in the early guard
+# would kill the whole chain. `return` must bow out of just this migration.
+test_sourced_missing_workflows_does_not_exit_caller() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
+
+  local after="not-reached"
+  source "$MIGRATION"
+  after="reached"
+
+  assert_eq "caller continues past a sourced no-op migration" "reached" "$after"
 
   teardown
 }
@@ -400,6 +417,7 @@ test_multiple_work_units
 test_skip_dot_dirs
 test_idempotent
 test_no_workflows
+test_sourced_missing_workflows_does_not_exit_caller
 test_preserves_fields
 
 echo ""

--- a/tests/scripts/test-migration-020.sh
+++ b/tests/scripts/test-migration-020.sh
@@ -324,9 +324,26 @@ test_no_workflows() {
   setup
   rm -rf "$TEST_DIR/.workflows"
 
-  PROJECT_DIR="$TEST_DIR" bash "$MIGRATION"
+  # The orchestrator sources migrations; mirror that here.
+  ( source "$MIGRATION" )
 
   assert_eq "exits cleanly" "true" "true"
+
+  teardown
+}
+
+# --- Sourced with no .workflows — returns, does not exit the caller ---
+# The orchestrator sources each migration; a top-level `exit` in the early guard
+# would kill the whole chain. `return` must bow out of just this migration.
+test_sourced_missing_workflows_does_not_exit_caller() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
+
+  local after="not-reached"
+  source "$MIGRATION"
+  after="reached"
+
+  assert_eq "caller continues past a sourced no-op migration" "reached" "$after"
 
   teardown
 }
@@ -404,6 +421,7 @@ test_skip_dot_dirs
 test_idempotent
 test_preserves_fields
 test_no_workflows
+test_sourced_missing_workflows_does_not_exit_caller
 test_multiple_work_units
 test_mixed_epic
 

--- a/tests/scripts/test-migration-021.sh
+++ b/tests/scripts/test-migration-021.sh
@@ -131,9 +131,27 @@ test_no_workflows_dir() {
   setup
   rm -rf "$TEST_DIR/.workflows"
 
-  bash "$MIGRATION"
+  # The orchestrator sources migrations; mirror that here.
+  ( source "$MIGRATION" )
 
   assert_eq "no error" "true" "true"
+
+  teardown
+}
+
+# --- Test 7: Sourced with no .workflows — returns, does not exit the caller ---
+# The orchestrator sources each migration. A top-level `exit` in the early guard
+# would kill the whole chain; `return` must bow out of just this migration and
+# let the caller continue.
+test_sourced_missing_workflows_does_not_exit_caller() {
+  setup
+  rm -rf "$TEST_DIR/.workflows"
+
+  local after="not-reached"
+  source "$MIGRATION"
+  after="reached"
+
+  assert_eq "caller continues past a sourced no-op migration" "reached" "$after"
 
   teardown
 }
@@ -148,6 +166,7 @@ test_no_exploration
 test_target_exists
 test_skips_dot_dirs
 test_no_workflows_dir
+test_sourced_missing_workflows_does_not_exit_caller
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-026.sh
+++ b/tests/scripts/test-migration-026.sh
@@ -324,6 +324,37 @@ test_skips_dot_dirs() {
   teardown
 }
 
+# --- Test 14: >=10 tasks sort numerically, not lexicographically ---
+# qa-task-{N}.md files map positionally to plan tasks in table order, so they
+# must be sorted numerically. A lexicographic sort puts qa-task-10 before
+# qa-task-2, mismapping every renamed report. Content assertions pin the
+# mapping: report-1-N.md must carry qa-task-N's content.
+test_ge_ten_tasks_numeric_order() {
+  setup
+
+  local wu="big-review" topic="auto-cascade-parent-status"
+  create_manifest "$wu" "{\"name\":\"$wu\",\"work_type\":\"epic\",\"status\":\"in-progress\",\"phases\":{}}"
+
+  local ids=() args=() i
+  for i in 1 2 3 4 5 6 7 8 9 10 11; do
+    ids+=("$topic-1-$i")
+    args+=("t$i")
+  done
+  create_plan_with_tasks "$wu" "$topic" "${ids[@]}"
+  create_review_files "$wu" "$topic" "${args[@]}"
+
+  run_migration > /dev/null
+
+  local base="$TEST_DIR/.workflows/$wu/review/$topic"
+  assert_eq "report-1-2 carries task 2 (not task 10)" "QA findings for task 2" "$(cat "$base/report-1-2.md" 2>/dev/null)"
+  assert_eq "report-1-9 carries task 9" "QA findings for task 9" "$(cat "$base/report-1-9.md" 2>/dev/null)"
+  assert_eq "report-1-10 carries task 10" "QA findings for task 10" "$(cat "$base/report-1-10.md" 2>/dev/null)"
+  assert_eq "report-1-11 carries task 11" "QA findings for task 11" "$(cat "$base/report-1-11.md" 2>/dev/null)"
+  assert_eq "no qa-task files left" "false" "$([ -f "$base/qa-task-1.md" ] && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 026 tests..."
 echo ""
@@ -341,6 +372,7 @@ test_no_workflows_dir
 test_no_review_dir
 test_review_only
 test_skips_dot_dirs
+test_ge_ten_tasks_numeric_order
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-027.sh
+++ b/tests/scripts/test-migration-027.sh
@@ -339,6 +339,43 @@ EOF
   teardown
 }
 
+# --- Test 8: Work-unit dir name with a single quote — no node injection ---
+# The manifest path is passed to node via process.argv, so a quote in the dir
+# name (interpolated into the source string previously) no longer breaks it.
+test_quote_in_work_unit_name() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/user's-epic"
+  cat > "$TEST_DIR/.workflows/user's-epic/manifest.json" << 'EOF'
+{
+  "name": "user's-epic",
+  "work_type": "epic",
+  "status": "in-progress",
+  "phases": {
+    "planning": {
+      "items": {
+        "core": {
+          "external_dependencies": {
+            "auth": { "state": "resolved", "task_id": "auth-1-3" }
+          }
+        }
+      }
+    }
+  }
+}
+EOF
+
+  cd "$TEST_DIR"
+  source "$MIGRATION"
+
+  local content
+  content=$(cat "$TEST_DIR/.workflows/user's-epic/manifest.json")
+  assert_eq "quoted-name: task_id renamed to internal_id" "true" "$(echo "$content" | grep -qF '"internal_id": "auth-1-3"' && echo true || echo false)"
+  assert_eq "quoted-name: task_id field removed" "false" "$(echo "$content" | grep -qF '"task_id"' && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 027 tests..."
 echo ""
@@ -350,6 +387,7 @@ test_empty_deps
 test_skips_dot_dirs
 test_mixed_deps
 test_multiple_phases
+test_quote_in_work_unit_name
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-029.sh
+++ b/tests/scripts/test-migration-029.sh
@@ -335,6 +335,53 @@ PLAN
   teardown
 }
 
+# --- Test 7: Cache move carries dot-prefixed files (glob no longer skips them) ---
+# The old unquoted glob skipped dotfiles but rm -rf deleted the source dir,
+# losing them. The move must carry dotfiles too.
+test_cache_migration_dotfiles() {
+  setup
+  local cache_old="$TEST_DIR/.workflows/.cache/planning/myapp/portal"
+  mkdir -p "$cache_old"
+  echo "scratch" > "$cache_old/phase-1.md"
+  echo "hidden scratch" > "$cache_old/.notes"
+
+  local wu_dir="$TEST_DIR/.workflows/myapp"
+  mkdir -p "$wu_dir"
+  echo '{"name":"myapp","work_type":"feature","status":"in-progress","phases":{}}' > "$wu_dir/manifest.json"
+
+  source "$MIGRATION"
+
+  local new_dir="$TEST_DIR/.workflows/.cache/myapp/planning/portal"
+  assert_eq "cache: regular file moved" "true" "$([ -f "$new_dir/phase-1.md" ] && echo true || echo false)"
+  assert_eq "cache: dotfile moved" "true" "$([ -f "$new_dir/.notes" ] && echo true || echo false)"
+  assert_eq "cache: old dir removed" "false" "$([ -d "$TEST_DIR/.workflows/.cache/planning" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 8: A failed copy must not destroy the source cache ---
+# When any cp fails, the source dir must be left intact rather than rm -rf'd.
+test_cache_migration_copy_failure_preserves_source() {
+  setup
+  local cache_old="$TEST_DIR/.workflows/.cache/planning/myapp/portal"
+  mkdir -p "$cache_old"
+  echo "keep me" > "$cache_old/phase-1.md"
+  echo "unreadable" > "$cache_old/locked.md"
+  chmod 000 "$cache_old/locked.md"
+
+  local wu_dir="$TEST_DIR/.workflows/myapp"
+  mkdir -p "$wu_dir"
+  echo '{"name":"myapp","work_type":"feature","status":"in-progress","phases":{}}' > "$wu_dir/manifest.json"
+
+  source "$MIGRATION"
+
+  assert_eq "source dir preserved on copy failure" "true" "$([ -d "$cache_old" ] && echo true || echo false)"
+  assert_eq "readable file still in source" "true" "$([ -f "$cache_old/phase-1.md" ] && echo true || echo false)"
+
+  chmod 644 "$cache_old/locked.md" 2>/dev/null || true
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 029 tests..."
 echo ""
@@ -345,6 +392,8 @@ test_multi_phase
 test_idempotent
 test_cache_migration
 test_no_topic
+test_cache_migration_dotfiles
+test_cache_migration_copy_failure_preserves_source
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-033.sh
+++ b/tests/scripts/test-migration-033.sh
@@ -135,6 +135,32 @@ test_archived_moved() {
   teardown
 }
 
+# --- Test 7: Merge branch carries dot-entries without . / .. pollution ---
+# When both inbox/ and .inbox/ exist, the merge must copy dot-prefixed entries
+# (e.g. .archived/) into .inbox/ WITHOUT copying `.` (self, nesting .inbox/.inbox)
+# or `..` (parent tree). On bash 3.2 the `.*` glob matches `.` and `..`; the
+# guard must exclude them.
+test_merge_dotentry_no_pollution() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/inbox/.archived/ideas"
+  mkdir -p "$TEST_DIR/.workflows/.inbox/ideas"
+  echo "# Archived" > "$TEST_DIR/.workflows/inbox/.archived/ideas/2026-03-17--old.md"
+  echo "# Existing" > "$TEST_DIR/.workflows/.inbox/ideas/2026-03-19--keep.md"
+  # Sentinel in the parent tree — must never be dragged in via `..`.
+  echo "PARENT" > "$TEST_DIR/.workflows/PARENT_SENTINEL.md"
+
+  source "$MIGRATION"
+
+  assert_eq "dot-entry merged" "true" "$([ -f "$TEST_DIR/.workflows/.inbox/.archived/ideas/2026-03-17--old.md" ] && echo true || echo false)"
+  assert_eq "existing preserved" "true" "$([ -f "$TEST_DIR/.workflows/.inbox/ideas/2026-03-19--keep.md" ] && echo true || echo false)"
+  assert_eq "no self-nesting (.inbox/.inbox)" "false" "$([ -e "$TEST_DIR/.workflows/.inbox/.inbox" ] && echo true || echo false)"
+  assert_eq "no parent pollution" "false" "$([ -e "$TEST_DIR/.workflows/.inbox/PARENT_SENTINEL.md" ] && echo true || echo false)"
+  assert_eq "old inbox removed" "false" "$([ -d "$TEST_DIR/.workflows/inbox" ] && echo true || echo false)"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 033 tests..."
 echo ""
@@ -145,6 +171,7 @@ test_already_migrated
 test_merge
 test_merge_no_overwrite
 test_archived_moved
+test_merge_dotentry_no_pollution
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-034.sh
+++ b/tests/scripts/test-migration-034.sh
@@ -135,6 +135,28 @@ test_no_claude_dir() {
   teardown
 }
 
+# --- Unparseable settings.json (trailing comma) — skip, never crash ---
+# A hand-edited settings.json with a trailing comma must not brick the migration
+# chain. The migration skips (leaving the file untouched) rather than crashing.
+test_unparseable_settings_skips() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  printf '{\n  "showClearContextOnPlanAccept": true,\n}\n' > "$TEST_DIR/.claude/settings.json"
+  local before
+  before=$(cat "$TEST_DIR/.claude/settings.json")
+
+  local rc=0
+  ( source "$MIGRATION" ) || rc=$?
+  assert_eq "unparseable settings skipped without error" "0" "$rc"
+
+  local after
+  after=$(cat "$TEST_DIR/.claude/settings.json")
+  assert_eq "unparseable settings left byte-identical" "$before" "$after"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 034 tests..."
 echo ""
@@ -144,6 +166,7 @@ test_existing_settings
 test_already_set
 test_setting_false
 test_no_claude_dir
+test_unparseable_settings_skips
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-040.sh
+++ b/tests/scripts/test-migration-040.sh
@@ -301,7 +301,11 @@ JSON
   teardown
 }
 
-# --- Test 8: phases.discovery already exists — merged without loss ---
+# --- Test 8: phases.discovery already exists (partial prior run) — no clobber ---
+# A shallow Object.assign would let discovery's items overwrite inception's,
+# silently dropping inception's items (here: foo). The fix skips the merge when
+# discovery already exists, leaving both phases intact for the admin to
+# reconcile — no data loss either way.
 test_partial_already_migrated() {
   setup
 
@@ -320,17 +324,23 @@ JSON
 
   source "$MIGRATION"
 
-  local has_old=$(node -e "
+  local has_inception=$(node -e "
     const m = JSON.parse(require('fs').readFileSync('$wu_dir/manifest.json', 'utf8'));
     console.log(!!m.phases.inception);
   ")
-  assert_eq "inception removed after merge" "false" "$has_old"
+  assert_eq "inception left in place (not clobbered)" "true" "$has_inception"
 
-  local has_bar=$(node -e "
+  local foo_survives=$(node -e "
     const m = JSON.parse(require('fs').readFileSync('$wu_dir/manifest.json', 'utf8'));
-    console.log(!!(m.phases.discovery.items && m.phases.discovery.items.bar));
+    console.log(!!(m.phases.inception && m.phases.inception.items && m.phases.inception.items.foo));
   ")
-  assert_eq "discovery items preserved" "true" "$has_bar"
+  assert_eq "inception item 'foo' survives (no data loss)" "true" "$foo_survives"
+
+  local bar_survives=$(node -e "
+    const m = JSON.parse(require('fs').readFileSync('$wu_dir/manifest.json', 'utf8'));
+    console.log(!!(m.phases.discovery && m.phases.discovery.items && m.phases.discovery.items.bar));
+  ")
+  assert_eq "discovery item 'bar' survives" "true" "$bar_survives"
 
   teardown
 }

--- a/tests/scripts/test-migration-042.sh
+++ b/tests/scripts/test-migration-042.sh
@@ -156,6 +156,28 @@ test_no_claude_dir() {
   teardown
 }
 
+# --- Test 7: Unparseable settings.json (trailing comma) — skip, never crash ---
+# A hand-edited settings.json with a trailing comma must not brick the migration
+# chain. The migration skips (leaving the file untouched) rather than crashing.
+test_unparseable_settings_skips() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  printf '{\n  "permissions": {\n    "allow": ["Bash(git status:*)"],\n  }\n}\n' > "$TEST_DIR/.claude/settings.json"
+  local before
+  before=$(cat "$TEST_DIR/.claude/settings.json")
+
+  local rc=0
+  ( source "$MIGRATION" ) || rc=$?
+  assert_eq "unparseable settings skipped without error" "0" "$rc"
+
+  local after
+  after=$(cat "$TEST_DIR/.claude/settings.json")
+  assert_eq "unparseable settings left byte-identical" "$before" "$after"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 042 tests..."
 echo ""
@@ -166,6 +188,7 @@ test_already_present_skips
 test_partial_present
 test_idempotent
 test_no_claude_dir
+test_unparseable_settings_skips
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-044.sh
+++ b/tests/scripts/test-migration-044.sh
@@ -134,6 +134,28 @@ test_no_claude_dir() {
   teardown
 }
 
+# --- Unparseable settings.json (trailing comma) — skip, never crash ---
+# A hand-edited settings.json with a trailing comma must not brick the migration
+# chain. The migration skips (leaving the file untouched) rather than crashing.
+test_unparseable_settings_skips() {
+  setup
+
+  mkdir -p "$TEST_DIR/.claude"
+  printf '{\n  "permissions": {\n    "allow": ["Bash(git status:*)"],\n  }\n}\n' > "$TEST_DIR/.claude/settings.json"
+  local before
+  before=$(cat "$TEST_DIR/.claude/settings.json")
+
+  local rc=0
+  ( source "$MIGRATION" ) || rc=$?
+  assert_eq "unparseable settings skipped without error" "0" "$rc"
+
+  local after
+  after=$(cat "$TEST_DIR/.claude/settings.json")
+  assert_eq "unparseable settings left byte-identical" "$before" "$after"
+
+  teardown
+}
+
 # --- Run all tests ---
 echo "Running migration 044 tests..."
 echo ""
@@ -143,6 +165,7 @@ test_existing_settings_preserved
 test_already_present_skips
 test_idempotent
 test_no_claude_dir
+test_unparseable_settings_skips
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/scripts/test-migration-orchestrator.sh
+++ b/tests/scripts/test-migration-orchestrator.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+#
+# Tests for the migration orchestrator (migrate.sh)
+#
+# Covers the hardening that lets the fleet boot on stock macOS bash 3.2:
+#   - no `mapfile` (bash 4+) — the script discovery uses a 3.2-safe read loop
+#   - PROJECT_DIR is pinned to "." so a user-exported PROJECT_DIR can't redirect
+#     migrations at a different tree
+#
+# Run: bash tests/scripts/test-migration-orchestrator.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MIGRATE="$REPO_DIR/skills/workflow-migrate/scripts/migrate.sh"
+
+# Prefer the stock /bin/bash (3.2 on macOS) when available — that is the whole
+# point of the mapfile fix. Fall back to whatever `bash` resolves to elsewhere.
+SYSTEM_BASH="/bin/bash"
+[ -x "$SYSTEM_BASH" ] || SYSTEM_BASH="bash"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $label"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+setup() {
+  TEST_DIR=$(mktemp -d /tmp/migrate-orchestrator-test.XXXXXX)
+}
+
+teardown() {
+  rm -rf "$TEST_DIR"
+}
+
+# --- Test 1: Runs to completion under stock bash 3.2 (no mapfile) ---
+test_runs_under_system_bash() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+
+  local out rc
+  out=$(cd "$TEST_DIR" && "$SYSTEM_BASH" "$MIGRATE" 2>&1) && rc=0 || rc=$?
+
+  assert_eq "orchestrator exits cleanly under system bash" "0" "$rc"
+  assert_eq "no mapfile failure" "false" "$(echo "$out" | grep -qiE 'mapfile|command not found' && echo true || echo false)"
+  assert_eq "tracking file written" "true" "$([ -f "$TEST_DIR/.workflows/.state/migrations" ] && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 2: Idempotent — a second run makes no changes ---
+test_idempotent() {
+  setup
+
+  mkdir -p "$TEST_DIR/.workflows/.state"
+
+  (cd "$TEST_DIR" && "$SYSTEM_BASH" "$MIGRATE" >/dev/null 2>&1)
+  local out
+  out=$(cd "$TEST_DIR" && "$SYSTEM_BASH" "$MIGRATE" 2>&1)
+
+  assert_eq "second run reports no changes" "true" "$(echo "$out" | grep -qF '[SKIP] No changes needed' && echo true || echo false)"
+
+  teardown
+}
+
+# --- Test 3: PROJECT_DIR is pinned to "." — a hostile export can't redirect ---
+# Migration 019 renames a work-unit status active -> in-progress. With PROJECT_DIR
+# exported to a decoy tree, an unpinned orchestrator would migrate the decoy and
+# leave the real project untouched. The pin forces every migration onto ".".
+test_project_dir_pinned() {
+  setup
+
+  # Real project (cwd) — status active, must be migrated.
+  mkdir -p "$TEST_DIR/proj/.workflows/wu/phases"
+  printf '{"name":"wu","work_type":"feature","status":"active","phases":{}}\n' \
+    > "$TEST_DIR/proj/.workflows/wu/manifest.json"
+
+  # Decoy tree — status active, must be left untouched.
+  mkdir -p "$TEST_DIR/decoy/.workflows/wu2/phases"
+  printf '{"name":"wu2","work_type":"feature","status":"active","phases":{}}\n' \
+    > "$TEST_DIR/decoy/.workflows/wu2/manifest.json"
+
+  (cd "$TEST_DIR/proj" && PROJECT_DIR="$TEST_DIR/decoy" "$SYSTEM_BASH" "$MIGRATE" >/dev/null 2>&1)
+
+  local proj_status decoy_status
+  proj_status=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/proj/.workflows/wu/manifest.json")
+  decoy_status=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf8')).status)" "$TEST_DIR/decoy/.workflows/wu2/manifest.json")
+
+  assert_eq "real project migrated (active -> in-progress)" "in-progress" "$proj_status"
+  assert_eq "decoy tree untouched (still active)" "active" "$decoy_status"
+
+  teardown
+}
+
+# --- Run all tests ---
+echo "Running migration orchestrator tests..."
+echo "  (system bash: $("$SYSTEM_BASH" --version 2>/dev/null | head -1))"
+echo ""
+
+test_runs_under_system_bash
+test_idempotent
+test_project_dir_pinned
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Fixes the premerge-review BLOCKER — `migrate.sh` used `mapfile` (bash 4+), killing `engine boot` on stock-macOS bash 3.2 — plus crash-hardening across the shipped migrations: argv-passed names in 016/017/027 (no more `node -e` string injection), review/tracking-file exclusions in 006, basename-numeric sort in 026, guarded extractions and body-preserving fallbacks in 001–003, dotglob fix in 033, unparseable-settings skip in 034/042/044, `return` not `exit` in sourced guards, verified cache moves in 029, no-clobber 040, atomic tmp-then-mv rewrites, and a pinned `PROJECT_DIR`.

Every edit hardens a failure path only — byte-identical output on well-formed input, proven by the untouched fixture suites. 50 migration suites green under both bash 3.2.57 and 5.3.15 (1259 assertions); full node suite and CLI suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. #462
59. #463
60. **#464** 👈 current
61. #465
62. #466
63. #467
64. #468
65. #469
66. #470
67. #471
68. #472
69. #473
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->