### PR TITLE
fix(engine): close the validation and guard gaps from the adversarial review

### DIFF
--- a/skills/workflow-engine/scripts/domain/discovery-map.cjs
+++ b/skills/workflow-engine/scripts/domain/discovery-map.cjs
@@ -66,6 +66,7 @@ function lifecyclePhrase(lifecycle, researchState) {
  * @property {string} [summary]           add/edit: the value written
  * @property {string} [description]       add/edit: the value written
  * @property {boolean} [dismissed]        remove: name pushed onto the dismissed list
+ * @property {boolean} [brief_removed]    remove: the topic's brief file was deleted
  * @property {string} [renamed_from]      rename: the old name
  * @property {string[]} [preserved_fields] rename: every field carried across
  * @property {boolean} [matches_dismissed] rename: new name matches a dismissed entry (left alone)
@@ -295,7 +296,18 @@ function removeItem(cwd, workUnit, name) {
     if (!discovery.dismissed.includes(name)) discovery.dismissed.push(name);
 
     saveWorkUnitManifest(cwd, workUnit, manifest);
-    return { work_unit: workUnit, name, op: 'remove', dismissed: true, lifecycle: 'fresh', map_total: Object.keys(items).length };
+
+    // Drop the topic's brief — it's regenerable by design, and leaving it on
+    // disk would orphan the file and later block a `rename … <this-name>` on the
+    // brief-collision guard. Manifest first, file second (self-heals on retry).
+    const brief = path.join(cwd, '.workflows', workUnit, 'discovery', 'briefs', `${name}.md`);
+    let briefRemoved = false;
+    if (fs.existsSync(brief)) { fs.unlinkSync(brief); briefRemoved = true; }
+
+    /** @type {MapOpResult} */
+    const result = { work_unit: workUnit, name, op: 'remove', dismissed: true, lifecycle: 'fresh', map_total: Object.keys(items).length };
+    if (briefRemoved) result.brief_removed = true;
+    return result;
   });
 }
 
@@ -361,8 +373,12 @@ function renameItem(cwd, workUnit, oldName, newName) {
       /** @type {Record<string, unknown>} */ (item).brief_path = `discovery/briefs/${newName}.md`;
     }
 
-    if (briefOnDisk) fs.renameSync(oldBrief, newBrief);
+    // Manifest first, brief second: a manifest pointing at a not-yet-moved
+    // brief self-heals (the brief is regenerable), whereas a moved brief with
+    // the manifest still under the old name would strand the file and dangle
+    // the pointer.
     saveWorkUnitManifest(cwd, workUnit, manifest);
+    if (briefOnDisk) fs.renameSync(oldBrief, newBrief);
     /** @type {MapOpResult} */
     const result = {
       work_unit: workUnit,

--- a/skills/workflow-engine/scripts/domain/fields.cjs
+++ b/skills/workflow-engine/scripts/domain/fields.cjs
@@ -289,6 +289,16 @@ function deleteByPath(obj, segments) {
   }
   if (current == null || typeof current !== 'object') return false;
   const last = segments[segments.length - 1];
+  // Deleting an array index with `delete` leaves a literal null hole; splice
+  // instead so the element is truly removed and the array closes up. A
+  // non-numeric (or out-of-range) segment on an array is a miss, not a hole.
+  if (Array.isArray(current)) {
+    if (!/^(0|[1-9][0-9]*)$/.test(last)) return false;
+    const idx = Number(last);
+    if (idx >= current.length) return false;
+    current.splice(idx, 1);
+    return true;
+  }
   if (!(last in current)) return false;
   delete current[last];
   return true;

--- a/skills/workflow-engine/scripts/domain/fields.cjs
+++ b/skills/workflow-engine/scripts/domain/fields.cjs
@@ -151,17 +151,22 @@ function resolveWildcardTopic(manifest, phase, fieldSegments) {
 // Validation
 // ---------------------------------------------------------------------------
 
-/** @param {string} value */
+// The guarded validators accept a value of ANY type: a typed field's schema
+// declares a string vocabulary, so a non-string (number, boolean, ~→null,
+// object) is refused exactly as a bad string is. `JSON.stringify` renders the
+// offending value cleanly for every type and is byte-identical to the old
+// `"${value}"` for strings (`"foo"` either way).
+/** @param {*} value */
 function validateWorkType(value) {
-  if (!VALID_WORK_TYPES.includes(value)) {
-    fail(`Invalid work_type "${value}". Must be one of: ${VALID_WORK_TYPES.join(', ')}`);
+  if (typeof value !== 'string' || !VALID_WORK_TYPES.includes(value)) {
+    fail(`Invalid work_type ${JSON.stringify(value)}. Must be one of: ${VALID_WORK_TYPES.join(', ')}`);
   }
 }
 
-/** @param {string} value */
+/** @param {*} value */
 function validateWorkUnitStatus(value) {
-  if (!VALID_WORK_UNIT_STATUSES.includes(value)) {
-    fail(`Invalid status "${value}". Must be one of: ${VALID_WORK_UNIT_STATUSES.join(', ')}`);
+  if (typeof value !== 'string' || !VALID_WORK_UNIT_STATUSES.includes(value)) {
+    fail(`Invalid status ${JSON.stringify(value)}. Must be one of: ${VALID_WORK_UNIT_STATUSES.join(', ')}`);
   }
 }
 
@@ -172,27 +177,32 @@ function validatePhase(phase) {
   }
 }
 
-/** @param {string} value */
+/** @param {*} value */
 function validateGateMode(value) {
-  if (!VALID_GATE_MODES.includes(value)) {
-    fail(`Invalid gate mode "${value}". Must be one of: ${VALID_GATE_MODES.join(', ')}`);
+  if (typeof value !== 'string' || !VALID_GATE_MODES.includes(value)) {
+    fail(`Invalid gate mode ${JSON.stringify(value)}. Must be one of: ${VALID_GATE_MODES.join(', ')}`);
   }
 }
 
-/** @param {string} phase @param {string} value */
+/** @param {string} phase @param {*} value */
 function validatePhaseStatus(phase, value) {
   const valid = VALID_PHASE_STATUSES[phase];
   if (valid && valid.length === 0) {
     fail(`Phase "${phase}" items carry no status field — lifecycle is computed at render time; create map items with \`engine discovery-map add\``);
   }
-  if (valid && !valid.includes(value)) {
-    fail(`Invalid status "${value}" for phase "${phase}". Must be one of: ${valid.join(', ')}`);
+  if (valid && (typeof value !== 'string' || !valid.includes(value))) {
+    fail(`Invalid status ${JSON.stringify(value)} for phase "${phase}". Must be one of: ${valid.join(', ')}`);
   }
 }
 
 /**
- * Validate a set operation from the resolved internal path and value.
- * @param {string[]} segments @param {string} value
+ * Validate a set operation from the resolved internal path and value. Every
+ * planned write runs through here regardless of value type: a field whose
+ * schema declares a vocabulary is enforced against it even when the JSON-parsed
+ * value is a number, boolean, ~→null, array, or object — those are refused, not
+ * waved through. Untyped fields (counters, nullable pointers, task maps) match
+ * no guarded branch and pass, so legitimate non-string writes are unaffected.
+ * @param {string[]} segments @param {*} value
  */
 function validateSet(segments, value) {
   // Top-level status
@@ -652,11 +662,12 @@ function cmdSet(cwd, args) {
   requireWorkUnit(cwd, workUnit);
 
   // Validate every field before any write — a refused value fails the batch.
+  // Unconditional: the value is already JSON-parsed, so a guarded field must be
+  // checked whatever type that parse produced (a bare number/boolean/~ would
+  // otherwise slip past a string-only guard and corrupt a typed field).
   const planned = writes.map((write) => {
     const segments = resolveSegments(phase, topic, write.field.split('.'));
-    if (typeof write.value === 'string') {
-      validateSet(segments, write.value);
-    }
+    validateSet(segments, write.value);
     return { segments, value: write.value };
   });
 

--- a/skills/workflow-engine/scripts/domain/inbox.cjs
+++ b/skills/workflow-engine/scripts/domain/inbox.cjs
@@ -70,7 +70,15 @@ function parseInboxPath(given, { archived }) {
  */
 function parseAll(cwd, paths, opts) {
   const items = paths.map((p) => parseInboxPath(p, opts));
+  // Refuse duplicates here, before anything moves: two paths naming the same
+  // file both pass existence, then the second `renameSync` hits ENOENT after
+  // the first move already applied — a half-done, uncommitted transaction.
+  const seen = new Set();
   for (const item of items) {
+    if (seen.has(item.given)) {
+      throw new Error(`duplicate inbox path: "${item.given}"`);
+    }
+    seen.add(item.given);
     if (!fs.existsSync(path.join(cwd, item.given))) {
       throw new Error(`inbox file not found: "${item.given}"`);
     }

--- a/skills/workflow-engine/scripts/domain/tasks.cjs
+++ b/skills/workflow-engine/scripts/domain/tasks.cjs
@@ -238,9 +238,18 @@ function startTask(cwd, workUnit, topic, internalId) {
  */
 function fixAttempt(cwd, workUnit, topic, internalId, findingsFile) {
   safeName(internalId, 'internal id');
-  const { item, attempts, findings } = withWorkUnitLock(cwd, workUnit, () => {
+  const file = fixTrackingPath(cwd, workUnit, topic, internalId);
+  return withWorkUnitLock(cwd, workUnit, () => {
     const manifest = loadWorkUnitManifest(cwd, workUnit);
     const found = implementationItem(manifest, topic);
+    // A fix attempt records against the item's `current_task`. A mismatched id
+    // would bump the item-level `fix_attempts` (misattributing threshold state)
+    // and write a stray tracking file for a task that was never started. Refuse
+    // and point at `task start`.
+    if (found.current_task !== internalId) {
+      const current = found.current_task == null ? 'none' : `"${found.current_task}"`;
+      throw new Error(`"${internalId}" is not the current task (current_task is ${current}) — run \`task start ${internalId}\` first`);
+    }
     let content;
     try {
       content = fs.readFileSync(path.resolve(cwd, findingsFile), 'utf8');
@@ -248,20 +257,23 @@ function fixAttempt(cwd, workUnit, topic, internalId, findingsFile) {
       throw new Error(`findings file not found: ${findingsFile}`);
     }
 
-    const n = counterOf(found, 'fix_attempts') + 1;
-    found.fix_attempts = n;
+    const attempts = counterOf(found, 'fix_attempts') + 1;
+
+    // Append the findings and bump the counter under the SAME lock: no other
+    // writer interleaves, and the file (which drives crash-resume via
+    // hasInFlightPair) is written before the counter save so a crash can never
+    // leave the counter ahead of the tracking file.
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const existing = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+    const lead = existing === '' ? '' : existing.endsWith('\n') ? '\n' : '\n\n';
+    const body = content.endsWith('\n') ? content : content + '\n';
+    fs.writeFileSync(file, `${existing}${lead}## Attempt ${attempts}\n\n${body}`);
+
+    found.fix_attempts = attempts;
     saveWorkUnitManifest(cwd, workUnit, manifest);
-    return { item: found, attempts: n, findings: content };
+
+    return { attempts, threshold_reached: attempts >= FIX_THRESHOLD, fix_gate_mode: gateOf(found, 'fix_gate_mode') };
   });
-
-  const file = fixTrackingPath(cwd, workUnit, topic, internalId);
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  const existing = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
-  const lead = existing === '' ? '' : existing.endsWith('\n') ? '\n' : '\n\n';
-  const body = findings.endsWith('\n') ? findings : findings + '\n';
-  fs.writeFileSync(file, `${existing}${lead}## Attempt ${attempts}\n\n${body}`);
-
-  return { attempts, threshold_reached: attempts >= FIX_THRESHOLD, fix_gate_mode: gateOf(item, 'fix_gate_mode') };
 }
 
 /**

--- a/skills/workflow-engine/scripts/domain/transitions.cjs
+++ b/skills/workflow-engine/scripts/domain/transitions.cjs
@@ -121,6 +121,9 @@ function startTopic(cwd, workUnit, phase, topic) {
       throw new Error(`${phase} item "${topic}" is already completed — reopen it instead`);
     } else if (existing.status === 'cancelled') {
       throw new Error(`${phase} item "${topic}" is cancelled — reactivate it instead`);
+    } else if (existing.status === 'superseded') {
+      const by = 'superseded_by' in existing ? ` (by "${existing.superseded_by}")` : '';
+      throw new Error(`${phase} item "${topic}" is superseded${by} — supersession is terminal; work on the absorbing topic instead`);
     } else {
       existing.status = 'in-progress';
     }
@@ -148,6 +151,10 @@ function completeTopic(cwd, workUnit, phase, topic) {
     const item = phaseItem(manifest, phase, topic);
     if (item.status === 'cancelled') {
       throw new Error(`${phase} item "${topic}" is cancelled — reactivate it instead`);
+    }
+    if (item.status === 'superseded') {
+      const by = 'superseded_by' in item ? ` (by "${item.superseded_by}")` : '';
+      throw new Error(`${phase} item "${topic}" is superseded${by} — supersession is terminal; work on the absorbing topic instead`);
     }
     item.status = 'completed';
 

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -717,6 +717,13 @@ function runCli(argv) {
 }
 
 if (require.main === module) {
+  // A downstream reader closing early (`engine … | head -1`) makes the next
+  // stdout write raise EPIPE; without a handler Node prints an unhandled-error
+  // stack. Treat the closed pipe as a clean stop.
+  process.stdout.on('error', (err) => {
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'EPIPE') process.exit(0);
+    throw err;
+  });
   try {
     runCli(process.argv.slice(2));
   } catch (err) {

--- a/skills/workflow-engine/scripts/gateway.cjs
+++ b/skills/workflow-engine/scripts/gateway.cjs
@@ -70,7 +70,7 @@ function runGateway(handlers, argv = process.argv.slice(2)) {
       throw new Error('gateway: no `index` handler registered for the no-args call');
     }
     out = handlers.index();
-  } else if (typeof handlers[first] === 'function' && first !== 'fallback') {
+  } else if (Object.hasOwn(handlers, first) && typeof handlers[first] === 'function' && first !== 'fallback') {
     out = handlers[first](...rest);
   } else if (typeof handlers.fallback === 'function') {
     out = handlers.fallback(...argv);

--- a/skills/workflow-engine/scripts/kernel/manifest-io.cjs
+++ b/skills/workflow-engine/scripts/kernel/manifest-io.cjs
@@ -298,15 +298,22 @@ function acquireLockFile(lockFile, timeoutMessage, timeoutMs = LOCK_TIMEOUT_MS) 
       );
     }
 
-    // Busy wait (short)
-    const end = Date.now() + LOCK_RETRY_MS;
-    while (Date.now() < end) { /* spin */ }
+    // Sleep before retrying — a real synchronous wait, not a CPU spin.
+    sleepSync(LOCK_RETRY_MS);
   }
 }
 
 /** @param {string} lockFile */
 function releaseLockFile(lockFile) {
   try { fs.unlinkSync(lockFile); } catch { /* already gone */ }
+}
+
+// Block the thread for `ms` without burning CPU. Atomics.wait on a throwaway
+// zero-initialised SharedArrayBuffer int32 never gets notified, so it always
+// sleeps the full timeout — a real synchronous sleep, not a spin loop.
+/** @param {number} ms */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 /**

--- a/tests/scripts/test-engine-discovery-map.cjs
+++ b/tests/scripts/test-engine-discovery-map.cjs
@@ -328,6 +328,33 @@ describe('engine CLI: discovery-map operations', () => {
       runOk(dir, ['remove', 'payments', 'dismissed-name']);
       assert.deepStrictEqual(readManifest(dir).phases.discovery.dismissed, ['dismissed-name']);
     });
+
+    it('deletes the topic brief file (regenerable) and reports brief_removed', () => {
+      const briefsDir = path.join(dir, '.workflows', 'payments', 'discovery', 'briefs');
+      fs.mkdirSync(briefsDir, { recursive: true });
+      fs.writeFileSync(path.join(briefsDir, 'fresh-topic.md'), '# Brief: fresh-topic\n');
+      const res = runOk(dir, ['remove', 'payments', 'fresh-topic']);
+      assert.strictEqual(res.brief_removed, true);
+      assert.ok(!fs.existsSync(path.join(briefsDir, 'fresh-topic.md')));
+    });
+
+    it('omits brief_removed when the topic had no brief on disk', () => {
+      const res = runOk(dir, ['remove', 'payments', 'fresh-topic']);
+      assert.ok(!('brief_removed' in res));
+    });
+
+    it('frees the name for a later rename — the deleted brief no longer collides', () => {
+      const briefsDir = path.join(dir, '.workflows', 'payments', 'discovery', 'briefs');
+      fs.mkdirSync(briefsDir, { recursive: true });
+      fs.writeFileSync(path.join(briefsDir, 'fresh-topic.md'), '# Brief\n');
+      runOk(dir, ['remove', 'payments', 'fresh-topic']);
+      // Renaming another fresh item onto the freed (dismissed) name must NOT hit
+      // the brief-collision guard, since remove deleted the orphan brief.
+      const res = runOk(dir, ['rename', 'payments', 'rich-fresh', 'fresh-topic']);
+      assert.strictEqual(res.op, 'rename');
+      assert.strictEqual(res.matches_dismissed, true);
+      assert.strictEqual(readManifest(dir).phases.discovery.items['fresh-topic'] !== undefined, true);
+    });
   });
 
   describe('rename', () => {

--- a/tests/scripts/test-engine-gateway.cjs
+++ b/tests/scripts/test-engine-gateway.cjs
@@ -51,6 +51,29 @@ describe('gateway: verb dispatch', () => {
     assert.strictEqual(out, 'fb:my-work-unit\n');
   });
 
+  it('an inherited Object.prototype name is not a verb — it falls through to fallback', () => {
+    for (const inherited of ['toString', 'constructor', 'hasOwnProperty', 'valueOf']) {
+      const out = captureRun(
+        { index: () => '', view: (wu) => `view:${wu}`, fallback: (...argv) => `fb:${argv.join(',')}` },
+        [inherited, 'x']
+      );
+      assert.strictEqual(out, `fb:${inherited},x\n`, `${inherited} must not dispatch to the inherited method`);
+    }
+  });
+
+  it('with no fallback, an inherited name is an unknown-verb usage error — never [object Object]', () => {
+    const { spawnSync } = require('child_process');
+    const gw = require.resolve('../../skills/workflow-engine/scripts/gateway.cjs');
+    const res = spawnSync(
+      'node',
+      ['-e', `require(${JSON.stringify(gw)}).runGateway({ view: (w) => 'v:' + w }, ['toString']);`],
+      { encoding: 'utf8' }
+    );
+    assert.strictEqual(res.status, 1);
+    assert.strictEqual(res.stdout, '');
+    assert.match(res.stderr, /unknown verb "toString"/);
+  });
+
   it('missing index handler on a no-args call throws', () => {
     assert.throws(() => captureRun({ data: () => '' }, []), /no `index` handler/);
   });

--- a/tests/scripts/test-engine-manifest-fields.cjs
+++ b/tests/scripts/test-engine-manifest-fields.cjs
@@ -146,6 +146,19 @@ describe('engine manifest — reads keep the CLI stdout contract', () => {
     assert.match(res.stderr, /^Error: Invalid phase "cooking"/);
     assert.ok(!res.stderr.includes('"ok"'));
   });
+
+  it('a reader closing the pipe early (| head -1) exits cleanly — no EPIPE stack', () => {
+    // A large multi-line read so `head -1` closes stdout mid-write.
+    const big = { name: 'auth', work_type: 'feature', status: 'in-progress', phases: {} };
+    for (let i = 0; i < 5000; i++) big['field' + i] = 'value ' + i;
+    const wuDir = path.join(dir, '.workflows', 'auth');
+    fs.mkdirSync(wuDir, { recursive: true });
+    fs.writeFileSync(path.join(wuDir, 'manifest.json'), JSON.stringify(big, null, 2) + '\n');
+
+    const res = spawnSync('sh', ['-c', `node '${ENGINE}' manifest get auth | head -1`], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.stdout, '{\n');
+    assert.doesNotMatch(res.stderr, /EPIPE|ERR_STREAM|engine\.cjs:/);
+  });
 });
 
 describe('engine manifest — mutations answer with the engine JSON contract', () => {

--- a/tests/scripts/test-engine-manifest-fields.cjs
+++ b/tests/scripts/test-engine-manifest-fields.cjs
@@ -192,6 +192,40 @@ describe('engine manifest — mutations answer with the engine JSON contract', (
     assert.match(runFails(dir, ['set', 'ghost', 'status', 'completed']).error, /Work unit "ghost" not found/);
   });
 
+  it('a typed field refuses NON-string values — number, boolean, ~→null, object bypass nothing', () => {
+    writeWorkUnit(dir, 'auth', 'feature');
+    // The JSON-parsed value is a number/boolean/null/object here, not a string:
+    // the guard must refuse each just as it refuses a bad string.
+    assert.match(runFails(dir, ['set', 'auth', 'status', '123']).error, /Invalid status 123\b/);
+    assert.match(runFails(dir, ['set', 'auth', 'status', 'true']).error, /Invalid status true\b/);
+    assert.match(runFails(dir, ['set', 'auth', 'status', '~']).error, /Invalid status null\b/);
+    assert.match(runFails(dir, ['set', 'auth', 'work_type', '42']).error, /Invalid work_type 42\b/);
+    assert.match(runFails(dir, ['set', 'auth.planning.auth', 'task_gate_mode', '5']).error, /Invalid gate mode 5\b/);
+    assert.match(runFails(dir, ['set', 'auth.planning.auth', 'fix_gate_mode', '{}']).error, /Invalid gate mode \{\}/);
+    assert.match(runFails(dir, ['set', 'auth.discussion.auth', 'status', '3']).error, /Invalid status 3 for phase "discussion"/);
+    // None of the refused writes touched the manifest.
+    const m = readWorkUnit(dir, 'auth');
+    assert.strictEqual(m.status, 'in-progress');
+    assert.strictEqual(m.work_type, 'feature');
+  });
+
+  it('a NON-string status inside a batch fails the whole batch — nothing written', () => {
+    writeWorkUnit(dir, 'auth', 'feature');
+    const err = runFails(dir, ['set', 'auth', 'description', 'updated', 'status=99']);
+    assert.match(err.error, /Invalid status 99\b/);
+    assert.strictEqual(readWorkUnit(dir, 'auth').description, 'Fixture', 'batch must be all-or-nothing');
+  });
+
+  it('UNtyped fields still accept non-string values — counters, ~→null pointers, task maps', () => {
+    writeWorkUnit(dir, 'auth', 'feature');
+    assert.strictEqual(runJson(dir, ['set', 'auth.implementation.auth', 'fix_attempts', '3']).set.fix_attempts, 3);
+    assert.strictEqual(runJson(dir, ['set', 'auth.implementation.auth', 'current_task', '~']).set.current_task, null);
+    assert.deepStrictEqual(runJson(dir, ['set', 'auth.planning.auth', 'task_map', '{"a":"b"}']).set.task_map, { a: 'b' });
+    const item = readWorkUnit(dir, 'auth').phases.implementation.items.auth;
+    assert.strictEqual(item.fix_attempts, 3);
+    assert.strictEqual(item.current_task, null);
+  });
+
   it('push: appends (creating the array) and reports the new length', () => {
     writeWorkUnit(dir, 'auth', 'feature');
     const first = runJson(dir, ['push', 'auth', 'tags', 'v1']);

--- a/tests/scripts/test-engine-manifest-fields.cjs
+++ b/tests/scripts/test-engine-manifest-fields.cjs
@@ -268,6 +268,22 @@ describe('engine manifest — mutations answer with the engine JSON contract', (
     assert.match(runFails(dir, ['delete', 'auth', 'extra.a']).error, /not found/);
   });
 
+  it('delete on an array index splices — no null hole left behind', () => {
+    writeWorkUnit(dir, 'auth', 'feature', { imports: ['a.md', { path: 'b.md' }, 'c.md'] });
+    const res = runJson(dir, ['delete', 'auth', 'imports.0']);
+    assert.deepStrictEqual(res, { ok: true, path: 'auth', field: 'imports.0', deleted: true });
+    // The element is gone AND the array closed up — the classic `delete arr[0]`
+    // would leave [null, {...}, "c.md"].
+    assert.deepStrictEqual(readWorkUnit(dir, 'auth').imports, [{ path: 'b.md' }, 'c.md']);
+  });
+
+  it('delete on an out-of-range or non-numeric array segment is a miss, not a hole', () => {
+    writeWorkUnit(dir, 'auth', 'feature', { imports: ['a.md', 'b.md'] });
+    assert.match(runFails(dir, ['delete', 'auth', 'imports.5']).error, /not found/);
+    assert.match(runFails(dir, ['delete', 'auth', 'imports.foo']).error, /not found/);
+    assert.deepStrictEqual(readWorkUnit(dir, 'auth').imports, ['a.md', 'b.md']);
+  });
+
   it('project routing: set/push/pull/delete against the project manifest', () => {
     const set = runJson(dir, ['set', 'project.defaults.plan_format', 'tick']);
     assert.deepStrictEqual(set, { ok: true, path: 'project', set: { 'defaults.plan_format': 'tick' } });

--- a/tests/scripts/test-engine-manifest-io.cjs
+++ b/tests/scripts/test-engine-manifest-io.cjs
@@ -168,6 +168,21 @@ describe('manifest-io — shared lock constants and IO contract', () => {
     assert.strictEqual(fs.readFileSync(lock, 'utf8'), String(process.pid), 'fresh lock never touched');
   });
 
+  it('a contended timeout sleeps instead of spinning — CPU stays far below wall time', () => {
+    fs.mkdirSync(path.join(dir, 'unit'));
+    const lock = path.join(dir, 'unit', '.lock');
+    fs.writeFileSync(lock, String(process.pid)); // fresh — never breakable
+    const cpu0 = process.cpuUsage();
+    const wall0 = Date.now();
+    assert.throws(() => io.acquireLockFile(lock, 'Timed out', 400));
+    const wallMs = Date.now() - wall0;
+    const cpuMs = (() => { const c = process.cpuUsage(cpu0); return (c.user + c.system) / 1000; })();
+    // It blocks for the full timeout…
+    assert.ok(wallMs >= 350, `timed out too early: ${wallMs}ms`);
+    // …but a real sleep burns almost no CPU; a busy-wait would burn ~all of it.
+    assert.ok(cpuMs < wallMs * 0.5, `CPU ${cpuMs.toFixed(1)}ms of ${wallMs}ms wall — busy-wait regression?`);
+  });
+
   it('write sweeps orphaned temp files past TMP_STALE_MS and spares fresh ones', () => {
     fs.mkdirSync(path.join(dir, 'unit'));
     const orphan = path.join(dir, 'unit', '.manifest.json.11111.tmp');

--- a/tests/scripts/test-engine-manifest.sh
+++ b/tests/scripts/test-engine-manifest.sh
@@ -180,6 +180,34 @@ assert_exit_nonzero() {
     fi
 }
 
+# Assert the EXACT exit code, not merely non-zero — the read contract splits an
+# expected miss (exit 2) from a real error (exit 1), and mutations always fail
+# exit 1. Pinning the code distinctly means a regression collapsing 2 into 1
+# (or vice-versa) fails here instead of passing a lax non-zero check.
+assert_exit_code() {
+    local expected="$1"
+    local description="$2"
+    shift 2
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    cd "$TEST_DIR"
+    # `|| actual=$?` keeps a non-zero exit from tripping `set -e` and captures it.
+    local actual=0
+    node "$ENGINE_JS" manifest "$@" >/dev/null 2>&1 || actual=$?
+    if [ "$actual" = "$expected" ]; then
+        echo -e "  ${GREEN}✓${NC} $description"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+        return 0
+    else
+        echo -e "  ${RED}✗${NC} $description"
+        echo -e "    Expected exit: $expected"
+        echo -e "    Actual exit:   $actual"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+}
+
 # ============================================================================
 # WORK-UNIT DOCUMENT + RETIRED VERBS
 # ============================================================================
@@ -480,7 +508,7 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid phase names${NC}"
 setup_fixture
 create_wu phase-check feature "Phase"
-assert_exit_nonzero "Invalid phase rejected" set phase-check.cooking.phase-check status in-progress
+assert_exit_code 1 "Invalid phase rejected" set phase-check.cooking.phase-check status in-progress
 
 echo ""
 
@@ -489,8 +517,8 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid phase status${NC}"
 setup_fixture
 create_wu status-check feature "Status"
-assert_exit_nonzero "Invalid status for discussion rejected" set status-check.discussion.status-check status concluded
-assert_exit_nonzero "Invalid status for implementation rejected" set status-check.implementation.status-check status concluded
+assert_exit_code 1 "Invalid status for discussion rejected" set status-check.discussion.status-check status concluded
+assert_exit_code 1 "Invalid status for implementation rejected" set status-check.implementation.status-check status concluded
 
 echo ""
 
@@ -515,7 +543,7 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid gate modes${NC}"
 setup_fixture
 create_wu gate-check feature "Gate"
-assert_exit_nonzero "Invalid gate mode rejected" set gate-check.planning.gate-check task_gate_mode manual
+assert_exit_code 1 "Invalid gate mode rejected" set gate-check.planning.gate-check task_gate_mode manual
 
 echo ""
 
@@ -536,7 +564,7 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid work_type${NC}"
 setup_fixture
 create_wu wt-check feature "WT"
-assert_exit_nonzero "Invalid work_type on set rejected" set wt-check work_type project
+assert_exit_code 1 "Invalid work_type on set rejected" set wt-check work_type project
 
 echo ""
 
@@ -545,7 +573,7 @@ echo ""
 echo -e "${YELLOW}Test: set rejects invalid work unit status${NC}"
 setup_fixture
 create_wu ws-check feature "WS"
-assert_exit_nonzero "Invalid work unit status rejected" set ws-check status deleted
+assert_exit_code 1 "Invalid work unit status rejected" set ws-check status deleted
 
 echo ""
 
@@ -722,7 +750,7 @@ echo ""
 echo -e "${YELLOW}Test: item creation rejects invalid phase${NC}"
 setup_fixture
 create_wu bad-phase-epic epic "Bad"
-assert_exit_nonzero "Invalid phase in item creation rejected" set bad-phase-epic.cooking.soup status in-progress
+assert_exit_code 1 "Invalid phase in item creation rejected" set bad-phase-epic.cooking.soup status in-progress
 
 echo ""
 
@@ -869,7 +897,7 @@ echo ""
 
 echo -e "${YELLOW}Test: set on missing work unit errors${NC}"
 setup_fixture
-assert_exit_nonzero "Set on nonexistent work unit fails" set ghost status cancelled
+assert_exit_code 1 "Set on nonexistent work unit fails" set ghost status cancelled
 
 echo ""
 
@@ -886,7 +914,7 @@ echo ""
 
 echo -e "${YELLOW}Test: unknown command errors${NC}"
 setup_fixture
-assert_exit_nonzero "Unknown command rejected" destroy everything
+assert_exit_code 1 "Unknown command rejected" destroy everything
 
 echo ""
 
@@ -896,7 +924,7 @@ echo -e "${YELLOW}Test: epic item-level status validation${NC}"
 setup_fixture
 create_wu epic-validation epic "Validate items"
 run_cli set epic-validation.discussion.my-topic status in-progress >/dev/null 2>&1
-assert_exit_nonzero "Invalid item status rejected" set epic-validation.discussion.my-topic status concluded
+assert_exit_code 1 "Invalid item status rejected" set epic-validation.discussion.my-topic status concluded
 
 # Valid item status should work
 run_cli set epic-validation.discussion.my-topic status completed >/dev/null 2>&1
@@ -1001,7 +1029,7 @@ echo ""
 
 echo -e "${YELLOW}Test: exists with no args returns non-zero exit${NC}"
 setup_fixture
-assert_exit_nonzero "exists with no args fails" exists
+assert_exit_code 1 "exists with no args fails" exists
 
 echo ""
 
@@ -1173,7 +1201,7 @@ echo ""
 echo -e "${YELLOW}Test: delete errors on missing path${NC}"
 setup_fixture
 create_wu del-missing feature "Missing"
-assert_exit_nonzero "Delete missing path errors" delete del-missing nonexistent.deep.path
+assert_exit_code 1 "Delete missing path errors" delete del-missing nonexistent.deep.path
 
 echo ""
 
@@ -1181,7 +1209,7 @@ echo ""
 
 echo -e "${YELLOW}Test: delete errors on missing work unit${NC}"
 setup_fixture
-assert_exit_nonzero "Delete missing work unit errors" delete ghost-unit some.field
+assert_exit_code 1 "Delete missing work unit errors" delete ghost-unit some.field
 
 echo ""
 
@@ -1203,7 +1231,7 @@ echo ""
 echo -e "${YELLOW}Test: delete rejects invalid phase${NC}"
 setup_fixture
 create_wu del-badphase feature "Bad phase"
-assert_exit_nonzero "Delete invalid phase errors" delete del-badphase.cooking.del-badphase status
+assert_exit_code 1 "Delete invalid phase errors" delete del-badphase.cooking.del-badphase status
 
 echo ""
 
@@ -1626,7 +1654,7 @@ echo ""
 echo -e "${YELLOW}Test: bogus specification status rejected${NC}"
 setup_fixture
 create_wu bogus-spec epic "Bogus"
-assert_exit_nonzero "Invalid specification status rejected" \
+assert_exit_code 1 "Invalid specification status rejected" \
     set bogus-spec.specification.auth-flow status bogus
 
 echo ""
@@ -2098,6 +2126,37 @@ assert_equals "$exit_code" "1" "Corrupt work-unit JSON → exit 1"
 
 echo ""
 
+# ----------------------------------------------------------------------------
+
+echo -e "${YELLOW}Test: read/mutation exit-code contract, pinned distinctly (miss=2, error/mutation=1)${NC}"
+setup_fixture
+create_wu codes feature "Codes"
+run_cli set codes.planning.codes task_map.codes-1-1 ext-1 >/dev/null 2>&1
+
+# Reads — an EXPECTED miss is exit 2, distinct from a real error's exit 1. A
+# regression collapsing 2 into 1 must fail here, not slip past a non-zero check.
+assert_exit_code 2 "key-of value-not-found → exit 2 (expected miss)" \
+    key-of codes.planning.codes task_map ext-absent
+assert_exit_code 2 "resolve on a missing work unit → exit 2 (expected miss)" \
+    resolve ghost.discussion.ghost
+
+# Reads — a real error is exit 1, never 2.
+assert_exit_code 1 "get on an invalid phase → exit 1 (real error)" \
+    get codes.cooking.codes status
+assert_exit_code 1 "resolve on a non-indexed phase → exit 1 (real error)" \
+    resolve codes.planning.codes
+assert_exit_code 1 "key-of on a non-object path → exit 1 (real error)" \
+    key-of codes work_type feature
+
+# Mutations — always exit 1, whatever the underlying error's own code.
+assert_exit_code 1 "set invalid work_type → exit 1" set codes work_type bogus
+assert_exit_code 1 "set NON-string status → exit 1" set codes status 123
+assert_exit_code 1 "set on a missing work unit → exit 1" set ghost status completed
+assert_exit_code 1 "delete a missing path → exit 1" delete codes nope.deep.path
+assert_exit_code 1 "unknown command → exit 1" destroy everything
+
+echo ""
+
 # ============================================================================
 # DISCOVERY PHASE CROSS-WORK-TYPE TESTS
 # ============================================================================
@@ -2146,9 +2205,9 @@ setup_fixture
 for wt in epic feature bugfix quick-fix cross-cutting; do
     name="${wt//-/_}-disc-guard"
     create_wu "$name" "$wt" "Guard $wt"
-    assert_exit_nonzero "$wt: discovery item status completed rejected" \
+    assert_exit_code 1 "$wt: discovery item status completed rejected" \
         set "$name.discovery.topic-one" status completed
-    assert_exit_nonzero "$wt: discovery item status in-progress rejected" \
+    assert_exit_code 1 "$wt: discovery item status in-progress rejected" \
         set "$name.discovery.topic-one" status in-progress
 done
 

--- a/tests/scripts/test-engine-tasks.cjs
+++ b/tests/scripts/test-engine-tasks.cjs
@@ -259,7 +259,8 @@ describe('engine task fix-attempt', () => {
   beforeEach(() => {
     dir = setupFixture();
     const phases = planPhases();
-    phases.implementation = { items: { 'auth-flow': { status: 'in-progress', fix_attempts: 0, fix_gate_mode: 'gated' } } };
+    // current_task is the id being fixed — a fix attempt records against it.
+    phases.implementation = { items: { 'auth-flow': { status: 'in-progress', fix_attempts: 0, fix_gate_mode: 'gated', current_task: 'auth-flow-1-1' } } };
     createManifest(dir, 'auth', { phases });
   });
   afterEach(() => { cleanupFixture(dir); });
@@ -320,6 +321,18 @@ describe('engine task fix-attempt', () => {
 
   it('rejects a missing --findings-file flag', () => {
     assert.match(engineFails(dir, ['fix-attempt', 'auth', 'auth-flow', 'auth-flow-1-1']).error, /Usage: engine task fix-attempt/);
+  });
+
+  it('rejects an id that is not current_task — no counter bump, no stray tracking file', () => {
+    const before = readManifest(dir);
+    // current_task is auth-flow-1-1; a fix attempt against a different id must
+    // not increment the item-level counter or write that id's tracking file.
+    const err = engineFails(dir, ['fix-attempt', 'auth', 'auth-flow', 'auth-flow-1-2',
+      '--findings-file', writeFindings(dir, 'ISSUES:\n- stray\n')]);
+    assert.match(err.error, /"auth-flow-1-2" is not the current task \(current_task is "auth-flow-1-1"\) — run `task start auth-flow-1-2` first/);
+    assert.strictEqual(implItem(dir).fix_attempts, 0);
+    assert.ok(!fs.existsSync(trackingPath(dir, 'auth-flow-1-2')));
+    assert.deepStrictEqual(readManifest(dir), before, 'manifest untouched on a mismatched id');
   });
 });
 
@@ -637,7 +650,7 @@ describe('engine task gate sections', () => {
           fix_gate_mode: mode,
           analysis_gate_mode: mode,
           fix_attempts: attempts,
-          current_task: null,
+          current_task: 'auth-flow-1-1',
         },
       },
     };

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -874,6 +874,19 @@ describe('engine inbox archive / restore / delete', () => {
     assert.ok(fs.existsSync(path.join(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md')));
     assert.match(engineFails(dir, ['inbox', 'archive']).error, /Usage: engine inbox/);
   });
+
+  it('refuses a duplicate path in the set before any move — no half-applied state', () => {
+    const err = engineFails(dir, [
+      'inbox', 'archive',
+      '.workflows/.inbox/ideas/2026-06-01--smart-retry.md',
+      '.workflows/.inbox/ideas/2026-06-01--smart-retry.md',
+    ]);
+    assert.match(err.error, /duplicate inbox path/);
+    // The one real file never moved — the transaction refused up front.
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/.inbox/ideas/2026-06-01--smart-retry.md')));
+    assert.ok(!fs.existsSync(path.join(dir, '.workflows/.inbox/.archived/ideas/2026-06-01--smart-retry.md')));
+    assert.strictEqual(git(dir, ['status', '--porcelain']).trim(), '');
+  });
 });
 
 describe('engine commit', () => {

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -237,6 +237,17 @@ describe('engine topic start', () => {
     assert.match(err.error, /is cancelled — reactivate it instead/);
   });
 
+  it('rejects starting a superseded item — supersession is terminal, superseded_by preserved', () => {
+    engine(dir, ['topic', 'supersede', 'payments', 'research', 'auth-flow', '--by', 'fee-model']);
+    const err = engineFails(dir, ['topic', 'start', 'payments', 'research', 'auth-flow']);
+    assert.match(err.error, /is superseded \(by "fee-model"\) — supersession is terminal/);
+    // start must NOT resurrect the item — that would leave superseded_by dangling
+    // on an in-progress item, a state the render layer promises never to show.
+    const item = readManifest(dir, 'payments').phases.research.items['auth-flow'];
+    assert.strictEqual(item.status, 'superseded');
+    assert.strictEqual(item.superseded_by, 'fee-model');
+  });
+
   it('rejects unknown work unit, phase, and missing args — loud and specific', () => {
     assert.match(engineFails(dir, ['topic', 'start', 'ghost', 'research', 'auth-flow']).error, /manifest not found/);
     assert.match(engineFails(dir, ['topic', 'start', 'payments', 'nonsense', 'auth-flow']).error, /unknown or non-lifecycle phase "nonsense"/);
@@ -299,6 +310,17 @@ describe('engine topic complete', () => {
     engine(dir, ['topic', 'cancel', 'payments', 'research', 'auth-flow']);
     assert.match(engineFails(dir, ['topic', 'complete', 'payments', 'research', 'auth-flow']).error, /is cancelled — reactivate it instead/);
     assert.match(engineFails(dir, ['topic', 'complete', 'payments']).error, /Usage: engine topic complete/);
+  });
+
+  it('rejects completing a superseded item — supersession is terminal, superseded_by preserved', () => {
+    engine(dir, ['topic', 'supersede', 'payments', 'research', 'auth-flow', '--by', 'fee-model']);
+    const err = engineFails(dir, ['topic', 'complete', 'payments', 'research', 'auth-flow']);
+    assert.match(err.error, /is superseded \(by "fee-model"\) — supersession is terminal/);
+    // complete must NOT overwrite the terminal status and leave superseded_by
+    // dangling on a completed item.
+    const item = readManifest(dir, 'payments').phases.research.items['auth-flow'];
+    assert.strictEqual(item.status, 'superseded');
+    assert.strictEqual(item.superseded_by, 'fee-model');
   });
 
   it('round-trips with start: start → complete → resuming via start is still rejected', () => {


### PR DESCRIPTION
All repro-backed findings from the engine adversary: schema validation now runs for every write regardless of JSON type (non-string status/work_type/gate-mode values are refused, not waved through); `topic start`/`complete` refuse superseded items; `manifest delete` splices array indexes instead of leaving null holes; `task fix-attempt` refuses ids that aren't `current_task` and writes the tracking file inside the lock, before the counter; inbox transactions refuse duplicate paths; EPIPE exits cleanly; discovery-map rename saves the manifest before moving the brief and remove deletes the orphan brief; the lock wait is a real sleep (was a full-core spin — measured 9.6s CPU per 10s timeout); gateway dispatch uses `Object.hasOwn`.

New tests map one-to-one onto the fixes, and the shell contract suite now asserts exit 1 vs exit 2 distinctly. Node 1372/1372, manifest contract 281/281, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. #462
59. #463
60. #464
61. #465
62. **#466** 👈 current
63. #467
64. #468
65. #469
66. #470
67. #471
68. #472
69. #473
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->