### PR TITLE
fix(legacy-split): validate before mutating

### DIFF
--- a/skills/workflow-legacy-research-split/SKILL.md
+++ b/skills/workflow-legacy-research-split/SKILL.md
@@ -69,7 +69,38 @@ Initialise `applied_count = 0`, `abandoned_count = 0`, `errored_count = 0`.
 node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs {work_unit}
 ```
 
-Parse `qualifying_sources` from the JSON output.
+Parse `qualifying_sources`, `unsplittable`, and `stranded_sentinels` from the JSON output.
+
+Surface detect's advisories before routing on the qualifying set. Both are informational — neither blocks the qualifying flow.
+
+**If `stranded_sentinels` is non-empty:** a prior apply crashed mid-split, leaving these items marked in-progress. Detection excludes them, so they surface only here and need manual recovery.
+
+> *Output the next fenced block as a code block:*
+
+```
+  ⚑ Interrupted split(s) detected — a prior apply crashed mid-flight.
+    Clear each, then reopen the epic via /workflow-start to retry:
+
+@foreach(name in stranded_sentinels)
+    • {name}
+@endforeach
+
+    Per-item recovery is under "Recovery from Interrupted Apply"
+    at the end of this skill.
+```
+
+**If `unsplittable` is non-empty:** one or more migration-seeded sources carry names the split can't process — the engine rejects dots and slashes in map paths.
+
+> *Output the next fenced block as a code block:*
+
+```
+  ⚑ Unsplittable source(s) — rename each on the discovery map to a
+    kebab name, then reopen the epic to split:
+
+@foreach(src in unsplittable)
+    • {src.name} — {src.reason}
+@endforeach
+```
 
 #### If `qualifying_sources` is empty
 
@@ -186,9 +217,16 @@ Evaluate the branches below in order — error reporting takes precedence over c
 
 ## Recovery from Interrupted Apply
 
-If `apply.cjs` returns `ok: false`, the response's `recovery_hint` names the manual cleanup the failing stage requires. Common cleanups:
+An interrupted split leaves a `legacy_split_state` sentinel on the source's discovery item. It surfaces two ways:
+
+- **`apply.cjs` returned `ok: false`** — the response's `recovery_hint` names the cleanup the failing stage requires.
+- **Step 1 flagged a stranded sentinel** — a prior apply's process died between the sentinel write and the source-item delete. detect reports it under `stranded_sentinels`.
+
+Clear the sentinel and drop the cache:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.discovery.{stuck_source} legacy_split_state
 rm -rf .workflows/.cache/{work_unit}/legacy-split/{stuck_source}
 ```
+
+If the crash also renamed the source file to `{stuck_source}-superseded-{datetime}.md` and marked its research item `superseded`, restore those (or keep the superseded copy and re-add the discovery item) before re-attempting the split.

--- a/skills/workflow-legacy-research-split/scripts/apply.cjs
+++ b/skills/workflow-legacy-research-split/scripts/apply.cjs
@@ -31,6 +31,14 @@ function runGit(cwd, args) {
   return r.stdout;
 }
 
+// Index-truth check: does git track this path? Reads the index, so it answers
+// correctly even after the file has been moved on disk (the index still records
+// the old path until we stage the move).
+function isTracked(cwd, relPath) {
+  const r = spawnSync('git', ['ls-files', '--error-unmatch', '--', relPath], { cwd, encoding: 'utf8' });
+  return r.status === 0;
+}
+
 function makeDatetimeStamp() {
   // Filesystem-safe ISO-ish stamp: YYYY-MM-DDTHH-MM-SS, no colons.
   const d = new Date();
@@ -207,26 +215,37 @@ function apply(cwd, workUnit, currentSource) {
     };
   }
 
-  // Stage 6: git add + commit.
+  // Stage 6: git add + commit, scoped to exactly the split's paths.
+  const sourceRel = path.relative(cwd, sourceFile);
+  // Only reference the source's old path if git knows it. An untracked source
+  // (never committed) was renamed away in Stage 2, so the old path matches
+  // nothing on disk and nothing in the index — `git add` on it would fatal.
+  const sourceTracked = isTracked(cwd, sourceRel);
   const addPaths = [
     path.relative(cwd, path.join(wuDir, 'manifest.json')),
-    path.relative(cwd, sourceFile),
+    ...(sourceTracked ? [sourceRel] : []),
     path.relative(cwd, supersededFile),
     ...created.map(c => path.relative(cwd, c.path)),
   ];
 
   try {
     runGit(cwd, ['add', '-A', '--', ...addPaths]);
-    runGit(cwd, ['commit', '--allow-empty', '-m', `discovery(${workUnit}): legacy-split ${currentSource}`]);
+    // Pathspec-limit the commit so any files the user pre-staged for unrelated
+    // work don't get swept into the split commit.
+    runGit(cwd, ['commit', '--allow-empty', '-m', `discovery(${workUnit}): legacy-split ${currentSource}`, '--', ...addPaths]);
   } catch (e) {
+    const recovery_hint = sourceTracked
+      ? `commit failed (likely pre-commit hook). All file and manifest mutations are applied. ` +
+        `Resolve the hook issue, commit manually, then clean the cache: ` +
+        `rm -rf ${cacheDir}`
+      : `git staging failed — the source file ${sourceRel} was never committed, so its pre-split ` +
+        `history isn't in git. All file and manifest mutations are applied. Stage and commit the ` +
+        `split manually (git add .workflows/${workUnit}), then clean the cache: rm -rf ${cacheDir}`;
     return {
       ok: false,
       stage: 'git_commit',
       error: e.message,
-      recovery_hint:
-        `commit failed (likely pre-commit hook). All file and manifest mutations are applied. ` +
-        `Resolve the hook issue, commit manually, then clean the cache: ` +
-        `rm -rf ${cacheDir}`,
+      recovery_hint,
     };
   }
 

--- a/skills/workflow-legacy-research-split/scripts/apply.cjs
+++ b/skills/workflow-legacy-research-split/scripts/apply.cjs
@@ -196,11 +196,16 @@ function apply(cwd, workUnit, currentSource) {
       }
 
       // set auto-creates each item; discovery map items carry no status field.
+      // The four discovery fields batch into one locked write — the engine
+      // validates every pair before writing, so the item lands atomically.
       runCli(cwd, ['set', `${workUnit}.research.${theme.kebab_name}`, 'status', 'in-progress']);
-      runCli(cwd, ['set', `${workUnit}.discovery.${theme.kebab_name}`, 'routing', 'research']);
-      runCli(cwd, ['set', `${workUnit}.discovery.${theme.kebab_name}`, 'summary', theme.summary]);
-      runCli(cwd, ['set', `${workUnit}.discovery.${theme.kebab_name}`, 'description', theme.description]);
-      runCli(cwd, ['set', `${workUnit}.discovery.${theme.kebab_name}`, 'source', `legacy-split:${currentSource}`]);
+      runCli(cwd, [
+        'set', `${workUnit}.discovery.${theme.kebab_name}`,
+        'routing', 'research',
+        `summary=${theme.summary}`,
+        `description=${theme.description}`,
+        `source=legacy-split:${currentSource}`,
+      ]);
     }
   } catch (e) {
     return {

--- a/skills/workflow-legacy-research-split/scripts/detect.cjs
+++ b/skills/workflow-legacy-research-split/scripts/detect.cjs
@@ -8,6 +8,12 @@ const engine = require('../../workflow-engine/scripts/lib.cjs');
 const { loadManifest, fileExists } = engine.reads;
 const { phaseItems } = engine.derivations;
 
+// Theme/source names become engine dot-path segments and research filenames.
+// The engine rejects dots/slashes; the canonical map name is kebab. A source
+// whose name breaks this can never be split (apply fails at the sentinel set),
+// so surface it as unsplittable rather than re-offering it every epic open.
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
 function die(msg, code = 1) {
   process.stderr.write(`Error: ${msg}\n`);
   process.exit(code);
@@ -23,20 +29,37 @@ function detect(workUnit) {
   const researchByName = new Map(researchItems.map(it => [it.name, it]));
 
   const qualifying = [];
+  const unsplittable = [];       // candidates blocked by an illegal name
+  const strandedSentinels = [];  // items left mid-split by a crashed apply
   for (const item of discoveryItems) {
+    // A set sentinel means a prior apply set it and never cleared it (only
+    // possible via a hard crash between the sentinel write and the source-item
+    // delete). Surface it so the skill can prompt recovery — otherwise the item
+    // is invisible: excluded here and its file/research already renamed away.
+    if (item.legacy_split_state) {
+      strandedSentinels.push(item.name);
+      continue;
+    }
     const source = item.source || '';
     if (!source.includes('migration-seeded')) continue;
     if (item.routing !== 'research') continue;
-    if (item.legacy_split_state) continue;
     const research = researchByName.get(item.name);
     if (!research || research.status !== 'in-progress') continue;
     const filePath = path.join(cwd, '.workflows', workUnit, 'research', `${item.name}.md`);
     if (!fileExists(filePath)) continue;
+    // Would otherwise qualify, but an illegal name would break apply. Report it
+    // rather than silently dropping — the user renames the source to unblock it.
+    if (!NAME_RE.test(item.name)) {
+      unsplittable.push({ name: item.name, reason: `name must match ${NAME_RE.source} (engine dot-paths reject dots/slashes)` });
+      continue;
+    }
     qualifying.push(item.name);
   }
 
   qualifying.sort();
-  return { qualifying_sources: qualifying };
+  unsplittable.sort((a, b) => a.name.localeCompare(b.name));
+  strandedSentinels.sort();
+  return { qualifying_sources: qualifying, unsplittable, stranded_sentinels: strandedSentinels };
 }
 
 const args = process.argv.slice(2);

--- a/skills/workflow-legacy-research-split/scripts/validate.cjs
+++ b/skills/workflow-legacy-research-split/scripts/validate.cjs
@@ -22,6 +22,14 @@ const path = require('path');
 //   ]
 // }
 
+// Every theme name becomes an engine dot-path segment (`{wu}.discovery.{name}`)
+// and a research filename (`research/{name}.md`). The engine rejects dots and
+// slashes; the canonical map name is kebab. Enforce that shape BEFORE any
+// mutation — apply.cjs is only reached once validation passes, so a name that
+// would fail mid-apply (after the source is already renamed/deleted) is caught
+// here instead. Mirrors the discovery gateway's name legality.
+const NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+
 function die(msg, code = 1) {
   process.stderr.write(`Error: ${msg}\n`);
   process.exit(code);
@@ -42,6 +50,7 @@ function loadDiscoveryItemNames(cwd, workUnit) {
 function validate(cwd, workUnit, currentSource) {
   const cacheDir = path.join(cwd, '.workflows', '.cache', workUnit, 'legacy-split', currentSource);
   const planPath = path.join(cacheDir, 'plan.json');
+  const researchDir = path.join(cwd, '.workflows', workUnit, 'research');
   const errors = [];
 
   // For collision check: existing discovery items the cache must not duplicate.
@@ -98,6 +107,14 @@ function validate(cwd, workUnit, currentSource) {
     }
 
     if (typeof kebab === 'string' && kebab.trim() !== '') {
+      // Name legality: an illegal name breaks apply mid-flight — the engine
+      // rejects the dot-path (`{wu}.discovery.{name}`) or the research write
+      // fails on a slash, but only after the source has already been renamed
+      // and deleted. Refuse it here, before any mutation.
+      if (!NAME_RE.test(kebab)) {
+        errors.push(`theme '${kebab}' has an illegal name; must match ${NAME_RE.source}`);
+      }
+
       const filePath = path.join(cacheDir, `${kebab}.md`);
       if (!fs.existsSync(filePath)) {
         errors.push(`theme '${kebab}' has no cache file at ${kebab}.md`);
@@ -113,6 +130,15 @@ function validate(cwd, workUnit, currentSource) {
       // creation — the natural source-rename case).
       if (discoveryNames && discoveryNames.has(kebab) && kebab !== currentSource) {
         errors.push(`theme '${kebab}' collides with an existing discovery item; rename the theme`);
+      }
+
+      // Disk-collision check: apply.cjs writes each theme to research/{name}.md
+      // with writeFileSync, which clobbers any pre-existing file there. The
+      // discovery-item check above misses files that have no manifest item.
+      // The source's own file is exempt — apply renames it away before writing
+      // themes, so a theme reusing the source name is the source-rename case.
+      if (kebab !== currentSource && fs.existsSync(path.join(researchDir, `${kebab}.md`))) {
+        errors.push(`theme '${kebab}' would overwrite existing research file ${kebab}.md; rename the theme`);
       }
     }
   }

--- a/tests/scripts/test-legacy-research-split.cjs
+++ b/tests/scripts/test-legacy-research-split.cjs
@@ -511,6 +511,67 @@ describe('apply.cjs: end-to-end', () => {
     );
   });
 
+  it('pathspec-limits the commit — pre-staged unrelated files stay out', () => {
+    seedLegacyEpic('e1p', 'exploration');
+    writeCachePlan('e1p', 'exploration', [
+      { kebab_name: 'auth', summary: 'Auth', description: 'auth desc', _content: 'auth content' },
+    ]);
+    // User pre-stages an unrelated file for other work.
+    fs.writeFileSync(path.join(dir, 'unrelated.md'), 'user work in progress');
+    spawnSync('git', ['add', 'unrelated.md'], { cwd: dir });
+
+    const r = runScriptJson(APPLY_CLI, 'e1p', 'exploration');
+    assert.strictEqual(r.json.ok, true);
+
+    // The split commit must not contain the unrelated file.
+    const committed = spawnSync('git', ['show', '--pretty=format:', '--name-only', 'HEAD'],
+      { cwd: dir, encoding: 'utf8' }).stdout;
+    assert.ok(!committed.split('\n').includes('unrelated.md'),
+      `split commit unexpectedly included unrelated.md:\n${committed}`);
+    // It's still staged, uncommitted.
+    const staged = spawnSync('git', ['diff', '--cached', '--name-only'],
+      { cwd: dir, encoding: 'utf8' }).stdout.trim().split('\n');
+    assert.ok(staged.includes('unrelated.md'));
+  });
+
+  it('untracked source succeeds — no phantom old-path git add fatal', () => {
+    seedLegacyEpic('eu', 'exploration');
+    // Make the source untracked: remove it from git but keep it on disk.
+    spawnSync('git', ['rm', '--cached', '-q', '.workflows/eu/research/exploration.md'], { cwd: dir });
+    spawnSync('git', ['commit', '-q', '-m', 'untrack source'], { cwd: dir });
+
+    writeCachePlan('eu', 'exploration', [
+      { kebab_name: 'auth', summary: 'Auth', description: 'auth desc', _content: 'auth content' },
+    ]);
+
+    const r = runScriptJson(APPLY_CLI, 'eu', 'exploration');
+    assert.strictEqual(r.json.ok, true);
+    // New theme + superseded file committed.
+    const committed = spawnSync('git', ['show', '--pretty=format:', '--name-only', 'HEAD'],
+      { cwd: dir, encoding: 'utf8' }).stdout;
+    assert.ok(committed.includes('.workflows/eu/research/auth.md'));
+    assert.ok(committed.includes('exploration-superseded-'));
+  });
+
+  it('untracked source + failing hook gives an accurate (not pre-commit) hint', () => {
+    seedLegacyEpic('euh', 'exploration');
+    spawnSync('git', ['rm', '--cached', '-q', '.workflows/euh/research/exploration.md'], { cwd: dir });
+    spawnSync('git', ['commit', '-q', '-m', 'untrack source'], { cwd: dir });
+
+    writeCachePlan('euh', 'exploration', [
+      { kebab_name: 'auth', summary: 'Auth', description: 'auth desc', _content: 'auth content' },
+    ]);
+    const hookDir = path.join(dir, '.git', 'hooks');
+    fs.writeFileSync(path.join(hookDir, 'pre-commit'), '#!/bin/sh\nexit 1\n');
+    fs.chmodSync(path.join(hookDir, 'pre-commit'), 0o755);
+
+    const r = runScriptJson(APPLY_CLI, 'euh', 'exploration');
+    assert.strictEqual(r.json.ok, false);
+    assert.strictEqual(r.json.stage, 'git_commit');
+    assert.ok(r.json.recovery_hint.includes('never committed'));
+    assert.ok(!r.json.recovery_hint.includes('pre-commit hook'));
+  });
+
   it('handles topic-name source: source name reused by a theme', () => {
     seedLegacyEpic('e2', 'auth');
     writeCachePlan('e2', 'auth', [

--- a/tests/scripts/test-legacy-research-split.cjs
+++ b/tests/scripts/test-legacy-research-split.cjs
@@ -300,6 +300,68 @@ describe('validate.cjs: cache shape contract', () => {
     assert.strictEqual(r.json.ok, true);
   });
 
+  it('rejects a theme name containing a dot (engine dot-path hazard)', () => {
+    writeCachePlan('wu', 'src', [{ ...baseTheme(), kebab_name: 'api-v2.0' }]);
+    const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
+    assert.strictEqual(r.json.ok, false);
+    assert.ok(r.json.errors.some(e => e.includes("theme 'api-v2.0' has an illegal name")));
+  });
+
+  it('rejects a theme name containing a slash (filesystem hazard)', () => {
+    // Write plan.json directly — a slash in the name can't be a flat cache filename.
+    const cacheDir = path.join(dir, '.workflows', '.cache', 'wu', 'legacy-split', 'src');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.writeFileSync(path.join(cacheDir, 'plan.json'), JSON.stringify({
+      themes: [{ kebab_name: 'api/v2', summary: 's', description: 'd' }],
+    }));
+    const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
+    assert.strictEqual(r.json.ok, false);
+    assert.ok(r.json.errors.some(e => e.includes("theme 'api/v2' has an illegal name")));
+  });
+
+  it('rejects an uppercase / underscore theme name', () => {
+    writeCachePlan('wu', 'src', [{ ...baseTheme(), kebab_name: 'API_Design' }]);
+    const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
+    assert.strictEqual(r.json.ok, false);
+    assert.ok(r.json.errors.some(e => e.includes("theme 'API_Design' has an illegal name")));
+  });
+
+  it('rejects a theme name with a leading dash', () => {
+    writeCachePlan('wu', 'src', [{ ...baseTheme(), kebab_name: '-auth' }]);
+    const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
+    assert.strictEqual(r.json.ok, false);
+    assert.ok(r.json.errors.some(e => e.includes("theme '-auth' has an illegal name")));
+  });
+
+  it('accepts a clean kebab name with digits', () => {
+    writeCachePlan('wu', 'src', [{ ...baseTheme(), kebab_name: 'api-v2' }]);
+    const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
+    assert.strictEqual(r.json.ok, true);
+  });
+
+  it('rejects a theme that would overwrite an existing research file (no manifest item)', () => {
+    // A research file on disk with NO discovery/research manifest item — the
+    // discovery-collision check misses it, but apply's writeFileSync would clobber it.
+    writeResearchFile('wu', 'orphan', '# Orphan research\n\nPre-existing.');
+    writeCachePlan('wu', 'src', [{ ...baseTheme(), kebab_name: 'orphan' }]);
+    const r = runScriptJson(VALIDATE_CLI, 'wu', 'src');
+    assert.strictEqual(r.json.ok, false);
+    assert.ok(r.json.errors.some(e => e.includes("would overwrite existing research file orphan.md")));
+  });
+
+  it('allows a theme reusing the source name even though its file exists on disk', () => {
+    // src is 'auth'; research/auth.md exists (the source). apply renames it away
+    // before writing themes, so the disk-collision check exempts the source name.
+    writeManifest('wu', {
+      name: 'wu', work_type: 'epic', status: 'in-progress',
+      phases: { discovery: { items: { auth: { routing: 'research', source: 'migration-seeded' } } } },
+    });
+    writeResearchFile('wu', 'auth', '# Broad Research\n\nContent.');
+    writeCachePlan('wu', 'auth', [{ ...baseTheme() }]);  // baseTheme kebab_name === 'auth'
+    const r = runScriptJson(VALIDATE_CLI, 'wu', 'auth');
+    assert.strictEqual(r.json.ok, true);
+  });
+
   it('rejects malformed JSON in plan.json', () => {
     const cacheDir = path.join(dir, '.workflows', '.cache', 'wu', 'legacy-split', 'src');
     fs.mkdirSync(cacheDir, { recursive: true });

--- a/tests/scripts/test-legacy-research-split.cjs
+++ b/tests/scripts/test-legacy-research-split.cjs
@@ -572,6 +572,21 @@ describe('apply.cjs: end-to-end', () => {
     assert.ok(!r.json.recovery_hint.includes('pre-commit hook'));
   });
 
+  it('batched discovery set preserves summary/description containing "="', () => {
+    seedLegacyEpic('eb', 'exploration');
+    writeCachePlan('eb', 'exploration', [
+      { kebab_name: 'auth', summary: 'a = b tradeoff', description: 'x=y and p=q notes',
+        _content: 'auth content' },
+    ]);
+    const r = runScriptJson(APPLY_CLI, 'eb', 'exploration');
+    assert.strictEqual(r.json.ok, true);
+    const m = readManifest('eb');
+    assert.strictEqual(m.phases.discovery.items.auth.summary, 'a = b tradeoff');
+    assert.strictEqual(m.phases.discovery.items.auth.description, 'x=y and p=q notes');
+    assert.strictEqual(m.phases.discovery.items.auth.source, 'legacy-split:exploration');
+    assert.strictEqual(m.phases.discovery.items.auth.routing, 'research');
+  });
+
   it('handles topic-name source: source name reused by a theme', () => {
     seedLegacyEpic('e2', 'auth');
     writeCachePlan('e2', 'auth', [

--- a/tests/scripts/test-legacy-research-split.cjs
+++ b/tests/scripts/test-legacy-research-split.cjs
@@ -190,6 +190,38 @@ describe('detect.cjs: filter conditions', () => {
     const r = runScriptJson(DETECT_CLI, 'substr');
     assert.deepStrictEqual(r.json.qualifying_sources, ['foo']);
   });
+
+  it('surfaces an otherwise-qualifying source with an illegal (dotted) name as unsplittable', () => {
+    seedLegacyEpic('dotted', 'api.v2');
+    const r = runScriptJson(DETECT_CLI, 'dotted');
+    assert.deepStrictEqual(r.json.qualifying_sources, []);
+    assert.strictEqual(r.json.unsplittable.length, 1);
+    assert.strictEqual(r.json.unsplittable[0].name, 'api.v2');
+    assert.ok(r.json.unsplittable[0].reason.length > 0);
+  });
+
+  it('does not surface non-candidate illegal names as unsplittable', () => {
+    // Illegal name but not migration-seeded — it was never a split candidate.
+    seedLegacyEpic('notcand', 'api.v2', { source: 'discovery' });
+    const r = runScriptJson(DETECT_CLI, 'notcand');
+    assert.deepStrictEqual(r.json.qualifying_sources, []);
+    assert.deepStrictEqual(r.json.unsplittable, []);
+  });
+
+  it('surfaces a set legacy_split_state as a stranded sentinel', () => {
+    seedLegacyEpic('stranded', 'src', { legacy_split_state: 'in-progress' });
+    const r = runScriptJson(DETECT_CLI, 'stranded');
+    assert.deepStrictEqual(r.json.qualifying_sources, []);
+    assert.deepStrictEqual(r.json.stranded_sentinels, ['src']);
+  });
+
+  it('a clean run reports empty unsplittable and stranded lists', () => {
+    seedLegacyEpic('clean', 'exploration');
+    const r = runScriptJson(DETECT_CLI, 'clean');
+    assert.deepStrictEqual(r.json.qualifying_sources, ['exploration']);
+    assert.deepStrictEqual(r.json.unsplittable, []);
+    assert.deepStrictEqual(r.json.stranded_sentinels, []);
+  });
 });
 
 // ----- validate.cjs -----


### PR DESCRIPTION
Closes the destructive half-apply: theme names are charset-validated (`^[a-z0-9][a-z0-9-]*$`) before any mutation — a dotted name previously passed validation and then failed at Stage 5, after the source rename, research supersede, and discovery-item delete. Detect filters illegal names into an `unsplittable` list and surfaces stranded `legacy_split_state` sentinels from crashed applies; the split commit is pathspec-limited (no more sweeping the user's staged files); pre-existing research files on disk refuse the collision; untracked sources complete instead of fataling with a misdiagnosed hint; per-theme engine calls batched 6→3.

Suite extended 39→47 tests, full node suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. #462
59. #463
60. #464
61. #465
62. #466
63. #467
64. **#468** 👈 current
65. #469
66. #470
67. #471
68. #472
69. #473
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->