### PR TITLE
fix(implementation,review,formats): delivery-stage prose defects

### DIFF
--- a/.claude/skills/create-output-format/SKILL.md
+++ b/.claude/skills/create-output-format/SKILL.md
@@ -8,16 +8,28 @@ disable-model-invocation: true
 
 Scaffold a new output format adapter for the workflow-planning-process workflow. Each format adapter is a directory of 5 files, one per concern.
 
+---
+
 ## Step 1: Gather Information
 
-Before writing anything, understand the tool. Ask the user for:
+Before writing anything, understand the tool. You need two things from the user:
 
 1. **What is the tool/system called?**
 2. **Documentation links** — official docs, API references, MCP server docs, anything relevant
 
-If the user provided these upfront, skip straight to research.
+#### If the user provided these upfront
 
-### Research
+→ Proceed to **Step 1.1: Research**.
+
+#### Otherwise
+
+Ask the user for both items above.
+
+**STOP.** Wait for user response before proceeding.
+
+→ Proceed to **Step 1.1: Research**.
+
+### Step 1.1: Research
 
 Fetch and read all provided documentation using WebFetch. From the docs, establish:
 
@@ -31,17 +43,27 @@ Fetch and read all provided documentation using WebFetch. From the docs, establi
 - Benefits and trade-offs vs simpler approaches
 - Any constraints or limitations
 
-### Clarify Gaps
+→ Proceed to **Step 1.2: Clarify Gaps**.
+
+### Step 1.2: Clarify Gaps
 
 Present what you've learned as a summary and ask the user to confirm or correct. Use AskUserQuestion to clarify anything the documentation didn't cover or left ambiguous — motivation for choosing this format, preferred interface if multiple exist, setup specifics, etc.
 
 Suggest a kebab-case format key based on the tool name and confirm with the user.
 
-Do not proceed until the user confirms your understanding.
+**STOP.** Wait for user response before proceeding.
+
+→ Proceed to **Step 2**.
+
+---
 
 ## Step 2: Understand the Contract
 
 Read **[references/contract.md](references/contract.md)** — this defines the 5-file interface every format must implement.
+
+→ Proceed to **Step 3**.
+
+---
 
 ## Step 3: Create the Format Directory
 
@@ -50,6 +72,10 @@ Create the directory at:
 ```
 skills/workflow-planning-process/references/output-formats/{format-key}/
 ```
+
+→ Proceed to **Step 4**.
+
+---
 
 ## Step 4: Write the Files
 
@@ -67,35 +93,36 @@ For each file:
 
 1. Start from the scaffolding template structure
 2. Replace all `{placeholder}` tokens with format-specific content from your gathered information
-3. Remove template guidance comments (lines starting with `<!-- -->`)
+3. Remove template guidance comments — the HTML comment lines, `<!-- ... -->`
 4. Include concrete commands, API calls, or MCP operations — not vague descriptions
+
+→ Proceed to **Step 5**.
+
+---
 
 ## Step 5: Register the Format
 
-`skills/workflow-planning-process/references/output-formats.md` renders a numbered selection menu. Register the new format with three edits, using the next available number `{N}`:
+`skills/workflow-planning-process/references/output-formats.md` renders a numbered selection menu. Register the new format with two edits, using the next available number `{N}`:
 
-1. **Listing** — append an entry to the "Available output formats" code block:
-
-   ```
-   {N}. {Format Name}
-      {One-line description.}
-      {Requirements — external tools/accounts, or "No external tools required."}
-      Best for: {ideal use cases}
-   ```
-
-2. **Menu** — append an option to the selection menu block:
+1. **Menu** — append an option to the selection menu block, folding the format's identity into the description:
 
    ```
-   - **`{N}`** — {Format Name}
+   - **`{N}`** — {Format Name} — {one-line description}; {requirements, or "no external tools"}. Best for {ideal use cases}.
    ```
 
-3. **Branch** — append a routing branch after the existing `#### If` branches:
+2. **Branch** — append a routing branch after the existing `#### If` branches:
 
    ```markdown
    #### If `{N}`
 
    Set `chosen-format` = `{format-key}`.
+
+   → Return to caller.
    ```
+
+→ Proceed to **Step 6**.
+
+---
 
 ## Step 6: Validate
 

--- a/.claude/skills/create-output-format/references/contract.md
+++ b/.claude/skills/create-output-format/references/contract.md
@@ -1,5 +1,9 @@
 # Output Format Contract
 
+*Reference for **[create-output-format](../SKILL.md)***
+
+---
+
 Every output format adapter is a directory of 5 files, each serving a specific concern.
 
 ## Required Files
@@ -12,6 +16,8 @@ Every output format adapter is a directory of 5 files, each serving a specific c
 | `updating.md` | Modifying tasks — status, content, properties |
 | `graph.md` | Task graph — priority and dependencies across tasks |
 
+**Header exemption.** `about.md` opens with the adapter attribution line (`*Output format adapter for …*`). The per-concern files — `authoring.md`, `reading.md`, `updating.md`, `graph.md` — are read by many callers (the planning process, the task-authoring and graphing agents, implementation, and review), so they carry no attribution line: each begins with its `# {Format}: {Concern}` title and goes straight into content.
+
 ## File Specifications
 
 ### about.md
@@ -23,8 +29,8 @@ Must include:
 - **Format name and description** — what this format is
 - **Benefits** — why choose this format
 - **Setup** — installation, configuration, prerequisites
-- **Output Location** — where tasks are stored
 - **Structure Mapping** — how workflow concepts (topic, phase, task) map to the format's entities
+- **Output Location** — where tasks are stored
 
 ### authoring.md
 

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -62,6 +62,8 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 1. **No autonomous decisions on spec deviations** — when the executor reports a blocker or spec deviation, present to user and STOP. Never resolve on the user's behalf.
 2. **All git operations are the orchestrator's responsibility** — agents never commit, stage, or interact with git.
 
+---
+
 ## Step 0: Resume Detection
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -192,6 +192,8 @@ Analysis cycle {N}: {K} proposed tasks
 
 → Proceed to **G. Route on Results**.
 
+#### Otherwise
+
 Present the next pending task:
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-implementation-process/references/environment-setup.md
+++ b/skills/workflow-implementation-process/references/environment-setup.md
@@ -44,8 +44,14 @@ I should follow before implementing?
 
 **STOP.** Wait for user response.
 
-If they provide instructions, save them to `.workflows/.state/environment-setup.md` and follow them.
+**If they provide instructions:**
 
-If they say no setup is needed, create `.workflows/.state/environment-setup.md` with "No special setup required." and commit. This prevents asking the same question in future sessions.
+Save them to `.workflows/.state/environment-setup.md` and follow them.
+
+→ Return to caller.
+
+**If they say no setup is needed:**
+
+Create `.workflows/.state/environment-setup.md` with "No special setup required." and commit. This prevents asking the same question in future sessions.
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/invoke-analysis.md
+++ b/skills/workflow-implementation-process/references/invoke-analysis.md
@@ -22,14 +22,14 @@ This captures all files touched by this topic's task commits (internal IDs embed
 
 ## Dispatch All Three Agents
 
-> **CRITICAL — dispatch with clean context.** Pass each agent **only** the seven inputs listed below. Do **not** include prior cycle findings, summaries of what earlier cycles caught or missed, your own hunches, or any framing that suggests where to look. Each cycle must run independently — cross-cycle synthesis happens in the synthesizer, not in the agents. Priming biases results (a clean cycle-N report after a high-finding cycle-(N-1) is a red flag, not convergence).
+> **CRITICAL**: Dispatch with clean context. Pass each agent **only** the seven inputs listed below. Do **not** include prior cycle findings, summaries of what earlier cycles caught or missed, your own hunches, or any framing that suggests where to look. Each cycle must run independently — cross-cycle synthesis happens in the synthesizer, not in the agents. Priming biases results (a clean cycle-N report after a high-finding cycle-(N-1) is a red flag, not convergence).
 
 Dispatch **all three in parallel** via the Task tool. Each agent receives the same inputs:
 
 1. **Implementation files** — the file list from scope identification
 2. **Specification path** — from the specification (if available)
 3. **Project skill paths** — from `project_skills` in the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} project_skills`)
-4. **code-quality.md path** — `code-quality.md`
+4. **code-quality.md path** — `.claude/skills/workflow-implementation-process/references/code-quality.md`
 5. **Work unit** — the work unit name (for path construction)
 6. **Topic name** — the implementation topic
 7. **Cycle number** — from `analysis_cycle_total` in the manifest: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} analysis_cycle_total`
@@ -54,6 +54,17 @@ Each agent knows its own output path convention and writes findings independentl
 
 > **CHECKPOINT**: Do not proceed until all three agents have returned.
 
-Each agent writes its findings to its own output file and returns a brief status. If any agent fails (error, timeout), record the failure and continue — the synthesizer works with whatever findings files are available.
+Each agent writes its findings to its own output file and returns a brief status:
+
+```
+STATUS: findings | clean
+FINDINGS_COUNT: {N}
+SUMMARY: {1 sentence}
+```
+
+- `findings`: the agent recorded issues in its output file
+- `clean`: the agent found nothing to report
+
+If any agent fails (error, timeout), record the failure and continue — the synthesizer works with whatever findings files are available.
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -16,15 +16,15 @@ Check the work type:
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
 ```
 
-#### If work_type is `quick-fix`
+#### If `work_type` is `quick-fix`
 
-Use **verification-workflow.md** (`verification-workflow.md`) as the workflow reference (item 1 below).
+Use **verification-workflow.md** (`.claude/skills/workflow-implementation-process/references/verification-workflow.md`) as the workflow reference (item 1 below).
 
 → Proceed to **Invoke the Agent**.
 
 #### Otherwise
 
-Use **tdd-workflow.md** (`tdd-workflow.md`) as the workflow reference (item 1 below).
+Use **tdd-workflow.md** (`.claude/skills/workflow-implementation-process/references/tdd-workflow.md`) as the workflow reference (item 1 below).
 
 → Proceed to **Invoke the Agent**.
 
@@ -35,7 +35,7 @@ Use **tdd-workflow.md** (`tdd-workflow.md`) as the workflow reference (item 1 be
 **Every invocation** — initial or re-attempt — includes these file paths:
 
 1. **Workflow reference**: the file determined above
-2. **code-quality.md**: `code-quality.md`
+2. **code-quality.md**: `.claude/skills/workflow-implementation-process/references/code-quality.md`
 3. **Specification path**: from the specification (if available)
 4. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} project_skills`)
 5. **Task content**: normalised task content (see [task-normalisation.md](task-normalisation.md))

--- a/skills/workflow-implementation-process/references/linter-setup.md
+++ b/skills/workflow-implementation-process/references/linter-setup.md
@@ -24,31 +24,24 @@ Set `source` = `topic`.
 
 #### Otherwise
 
-Check if project-level default `linters` exists via `engine manifest`:
+Check whether a project-level default `linters` exists and read its value via `engine manifest`:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists project.defaults.linters
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defaults.linters
 ```
 
 **If `false`:**
 
 → Proceed to **C. Discovery**.
 
-**If `true`:**
-
-Read project default `linters` via `engine manifest`:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defaults.linters
-```
-
-**If project default is populated:**
+**If `true` and project default is populated:**
 
 Set `source` = `project`.
 
 → Proceed to **B. Confirm Linters**.
 
-**If project default is empty:**
+**If `true` and project default is empty:**
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-implementation-process/references/load-plan-adapter.md
+++ b/skills/workflow-implementation-process/references/load-plan-adapter.md
@@ -8,7 +8,7 @@
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format
    ```
-2. Load the format's adapter files from `../workflow-planning-process/references/output-formats/{format}/`:
+2. Load the format's adapter files from `../../workflow-planning-process/references/output-formats/{format}/`:
    - **about.md** — prerequisites and setup instructions
    - **reading.md** — how to read tasks from the plan
    - **updating.md** — how to mark task progress

--- a/skills/workflow-implementation-process/references/project-skills-discovery.md
+++ b/skills/workflow-implementation-process/references/project-skills-discovery.md
@@ -20,31 +20,24 @@ Set `source` = `topic`.
 
 #### Otherwise
 
-Check if project-level default `project_skills` exists via `engine manifest`:
+Check whether a project-level default `project_skills` exists and read its value via `engine manifest`:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists project.defaults.project_skills
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defaults.project_skills
 ```
 
 **If `false`:**
 
 → Proceed to **C. Discovery**.
 
-**If `true`:**
-
-Read project default `project_skills` via `engine manifest`:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defaults.project_skills
-```
-
-**If project default is populated:**
+**If `true` and project default is populated:**
 
 Set `source` = `project`.
 
 → Proceed to **B. Confirm Skills**.
 
-**If project default is empty:**
+**If `true` and project default is empty:**
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -58,11 +58,17 @@ Emit the `MENU: blocked tasks` section carried by this session's most recent `ta
 
 **If `proceed`:**
 
-Treat the first blocked task as the available task — continue with the *If a task is available* flow below.
+Treat the first blocked task as the available task.
+
+→ Proceed to the **If a task is available** flow below.
 
 **If `skip`:**
 
-Take the first blocked task and → Proceed to **H. Update Progress and Commit** (mark task as skipped). Stage A re-detects any remaining blocked tasks on the loop back.
+Take the first blocked task as the one to skip.
+
+→ Proceed to **H. Update Progress and Commit** (mark task as skipped).
+
+Stage A re-detects any remaining blocked tasks on the loop back.
 
 **If `stop`:**
 
@@ -169,7 +175,7 @@ Record the attempt via the engine (increments `fix_attempts` and appends the fin
 node .claude/skills/workflow-engine/scripts/engine.cjs task fix-attempt {work_unit} {topic} {internal_id} --findings-file .workflows/.cache/{work_unit}/implementation/{topic}/attempt-findings.md
 ```
 
-`{N}` below is the response's `attempts`.
+`{N}` below is the response's `attempts`. The response also carries the `MENU: fix gate` section that **F. Fix Approval Gate** emits — never emit it here.
 
 #### If the response's `threshold_reached` is `true`
 
@@ -312,6 +318,8 @@ Include the user's feedback when re-invoking.
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs task complete {work_unit} {topic} {internal_id} --phase {N} --next-task '{next_task_id or ~}' [--skipped] [--phase-complete]
 ```
+
+The response also carries the `MENU: blocked tasks` section that **A. Retrieve Next Task** emits — never emit it here.
 
 **Internal ID convention**: The internal ID used with the engine and in commit messages MUST use the format `{topic}-{phase_id}-{task_id}`. If only the format adapter's external ID is at hand, pass `--external {external_id}` in place of `{internal_id}` — the engine resolves it through the plan's task map and reports the internal id in its response.
 

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -79,6 +79,8 @@ This process constructs a plan from a specification. A plan consists of:
 
 Follow every step in sequence. No steps are optional.
 
+---
+
 ## Step 0: Resume Detection
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-planning-process/references/output-formats.md
+++ b/skills/workflow-planning-process/references/output-formats.md
@@ -6,36 +6,15 @@
 
 **IMPORTANT**: Only offer formats listed below. Do not invent or suggest formats that don't have corresponding directories in the [output-formats/](output-formats/) directory.
 
-> *Output the next fenced block as a code block:*
-
-```
-Available output formats:
-
-  1. Tick
-     CLI task management with native dependency graph and priority.
-     Requires Tick CLI installation.
-     Best for: AI-driven workflows needing structured task tracking
-
-  2. Local Markdown
-     Task files stored as markdown in the planning directory.
-     No external tools required.
-     Best for: simple features, small plans, quick iterations
-
-  3. Linear
-     Tasks managed as Linear issues within a Linear project.
-     Requires Linear account and MCP server.
-     Best for: teams already using Linear, collaborative projects
-```
-
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Select a format:
+Select an output format:
 
-- **`1`** — Tick
-- **`2`** — Local Markdown
-- **`3`** — Linear
+- **`1`** — Tick — CLI task management with a native dependency graph and priority; requires the Tick CLI. Best for AI-driven workflows needing structured task tracking.
+- **`2`** — Local Markdown — task files stored as markdown in the planning directory; no external tools. Best for simple features, small plans, quick iterations.
+- **`3`** — Linear — tasks managed as Linear issues in a Linear project; requires a Linear account and MCP server. Best for teams already using Linear.
 · · · · · · · · · · · ·
 ```
 
@@ -45,10 +24,16 @@ Select a format:
 
 Set `chosen-format` = `tick`.
 
+→ Return to caller.
+
 #### If `2`
 
 Set `chosen-format` = `local-markdown`.
 
+→ Return to caller.
+
 #### If `3`
 
 Set `chosen-format` = `linear`.
+
+→ Return to caller.

--- a/skills/workflow-planning-process/references/output-formats/linear/about.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/about.md
@@ -20,7 +20,15 @@ Requires the Linear MCP server to be configured.
 
 Check if Linear MCP is available by looking for Linear tools. If not configured, inform the user that Linear MCP is required for this format.
 
-Ask the user: **Which team should own this project?** Resolve the team's ID via the Linear MCP (`list_teams`), then persist it as a project default so every later phase can reach it:
+> *Output the next fenced block as a code block:*
+
+```
+Which team should own this project?
+```
+
+**STOP.** Wait for user response.
+
+Resolve the team's ID via the Linear MCP (`list_teams`), then persist it as a project default so every later phase can reach it:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.defaults.linear_team_id {team_id}

--- a/skills/workflow-planning-process/references/output-formats/linear/authoring.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/authoring.md
@@ -2,6 +2,12 @@
 
 Uses the official Linear MCP server (`https://mcp.linear.app/mcp`). Tool names below reflect this server — verify available tools if using a different implementation.
 
+#### If Linear MCP is unavailable
+
+Inform the user that authoring cannot proceed without Linear MCP access. Suggest checking the MCP configuration, or switching formats via the planning process.
+
+**STOP.** Do not proceed — terminal condition.
+
 ## Identifiers
 
 `{team_id}` is the project default `linear_team_id` (persisted during setup — see about.md); `{project_id}` is the plan's `external_id`; phase and task issue UUIDs are recorded in `task_map`:
@@ -107,13 +113,12 @@ When creating issues, if something is unclear:
 
 The official Linear MCP server does not support deletion. Ask the user to delete the Linear project manually via the Linear UI.
 
-> "The Linear project **{project:(titlecase)}** needs to be deleted before restarting. Please delete it in the Linear UI (Project Settings → Delete project), then confirm so I can proceed."
+> *Output the next fenced block as a code block:*
+
+```
+The Linear project {project:(titlecase)} needs to be deleted before
+restarting. Please delete it in the Linear UI (Project Settings →
+Delete project), then confirm so I can proceed.
+```
 
 **STOP.** Wait for user response.
-
-### Fallback
-
-If Linear MCP is unavailable:
-- Inform the user
-- Cannot proceed without MCP access
-- Suggest checking MCP configuration or switching to local markdown

--- a/skills/workflow-planning-process/references/output-formats/tick/authoring.md
+++ b/skills/workflow-planning-process/references/output-formats/tick/authoring.md
@@ -79,7 +79,7 @@ After every `tick create`, run `tick show <tick-id>` and confirm that the title,
 
 #### If any field is empty or wrong
 
-Load **[updating.md](updating.md)** and follow its instructions to correct the field using `tick update`.
+→ Load **[updating.md](updating.md)** and follow its instructions to correct the field using `tick update`.
 
 ## Task Properties
 
@@ -106,9 +106,9 @@ tick list --parent <phase-tick-id>
 
 ### Type
 
-Optional. Set via `--type`. Valid types: `bug`, `feature`, `task`, `chore`. Use `bug` for bugfix work types, `feature` for feature work types, and `task` or `chore` as appropriate for individual tasks within any work type. Doesn't hurt to set — adds useful categorisation at no cost.
+Optional. Set via `--type`. Valid types: `bug`, `feature`, `task`, `chore`. Use `bug` for bugfix work types, `feature` for feature work types, and `task` or `chore` as appropriate for individual tasks within any work type.
 
-### Tags
+### Labels / Tags
 
 Optional — not necessary in most cases, but available if needed. Set via `--tags` with comma-separated, kebab-case values. Tags provide additional categorisation beyond the parent/child hierarchy. Filter tasks by tag:
 

--- a/skills/workflow-planning-process/references/output-formats/tick/updating.md
+++ b/skills/workflow-planning-process/references/output-formats/tick/updating.md
@@ -34,7 +34,7 @@ To update a task's properties:
 
 After every `tick update`, run `tick show <tick-id>` and confirm that the updated fields were set correctly. If any field is empty or wrong, re-run the update.
 
-## Phase / Parent Status (Auto-Cascade)
+## Phase Completion
 
 Tick automatically cascades status changes through the parent/child hierarchy. **Do not manually update phase or topic parent status** — tick handles it.
 

--- a/skills/workflow-review-process/references/present-review.md
+++ b/skills/workflow-review-process/references/present-review.md
@@ -152,7 +152,7 @@ Any questions before proceeding?
 
 **STOP.** Wait for user response.
 
-#### If user asks a question
+#### If ask a question
 
 Answer the question using the review file, QA task files, specification, and plan as context.
 
@@ -235,7 +235,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit --inbox -m "review
 Apply every item in the `### Do now` subsection of `report.md`:
 
 1. Make each described edit at its `file:line`. Stay within the scope of the note — no opportunistic changes.
-2. Run the project's linters; when any change touched a code or test file, also run the test suite (see the project skills loaded in Step 3 and the topic's configured linters).
+2. Run the project's linters; when any change touched a code or test file, also run the test suite (see the project skills loaded in Step 3 and the topic's configured linters). These are project-specific commands, so they fall outside this skill's allowed-tools and prompt for approval when run.
 3. If a change fails verification, revert that single change and re-tag its item `[quickfix]` in `report.md` — leave the rest applied.
 
 Commit the applied changes with raw git — the fixes touch project files outside the work unit, so the scoped helper cannot cover them. Stage the touched files and the work unit (for any report re-tags), then commit:

--- a/skills/workflow-review-process/references/produce-review.md
+++ b/skills/workflow-review-process/references/produce-review.md
@@ -13,7 +13,11 @@ Write the review to `.workflows/{work_unit}/review/{topic}/report.md`. The revie
 - **Request Changes** — Missing requirements, broken functionality, inadequate tests
 - **Comments Only** — Minor suggestions, non-blocking observations
 
-### Categorizing and Clustering Recommendations
+→ Proceed to **A. Categorizing and Clustering Recommendations**.
+
+---
+
+## A. Categorizing and Clustering Recommendations
 
 When writing the `## Recommendations` section, read the NON-BLOCKING NOTES from all `report-*.md` files and group them by their category tags:
 
@@ -36,7 +40,11 @@ A clustered item:
 
 Order subsections `### Do now`, `### Quick-fixes`, `### Ideas`, `### Bugs`. Only include subsections with at least one item. Number items sequentially across all subsections (do not reset per category). Omit the entire `## Recommendations` section if no notes survive.
 
-### Commit and Continue
+→ Proceed to **B. Commit and Continue**.
+
+---
+
+## B. Commit and Continue
 
 Commit:
 

--- a/skills/workflow-review-process/references/read-plans.md
+++ b/skills/workflow-review-process/references/read-plans.md
@@ -17,7 +17,7 @@ For each plan:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
    ```
-5. Load the format's reading adapter from `../workflow-planning-process/references/output-formats/{format}/reading.md` — this tells you how to locate and read individual task files
+5. Load the format's reading adapter from `../../workflow-planning-process/references/output-formats/{format}/reading.md` — this tells you how to locate and read individual task files
 6. Extract all tasks across all phases
 
 → Return to caller.

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -229,6 +229,8 @@ Review synthesis cycle {N}: {K} proposed tasks
 
 → Proceed to **E. Route on Results**.
 
+#### Otherwise
+
 Present the next pending task:
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -56,6 +56,8 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 2. **No acceptance criteria** — mechanical changes are verified by test baselines and completeness checks, not by acceptance criteria.
 3. **No agents** — scoping writes specs and tasks directly, without invoking planning agents or review cycles.
 
+---
+
 ## Step 0: Resume Detection
 
 > *Output the next fenced block as a code block:*


### PR DESCRIPTION
Headline: the plan-format adapter load chain was broken by a one-level-short relative path in `load-plan-adapter.md` and `read-plans.md` — implementation and review resolve tick/linear/local-markdown through those files. Also: `#### Otherwise` wrapping for else-path task presentation, flattened triple-nested conditionals, deferred-section restatements at two engine call sites, installed-form paths for stateless agent briefs, the analysts' STATUS contract defined at the invocation site, output-formats menu single-sourcing with branch routing, Linear's team ask gets a real STOP gate, `## Phase Completion` heading alignment, and the create-output-format skill brought fully onto conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. #462
59. #463
60. #464
61. #465
62. #466
63. #467
64. #468
65. #469
66. **#470** 👈 current
67. #471
68. #472
69. #473
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->