### PR TITLE
fix(research,discussion,scoping,nav): exploration and navigation prose defects

### DIFF
--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -21,6 +21,19 @@ This skill receives context from the calling processing skill:
 
 ## Step 1: Read Work Type and Run Discovery
 
+> *Output the next fenced block as a code block:*
+
+```
+── Read Work Type and Run Discovery ─────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reading the work unit's type, then computing the next phase
+> from pipeline state when it isn't already known.
+```
+
 Read work type from the manifest:
 
 ```bash
@@ -52,6 +65,19 @@ The output contains `next_phase`, `completed_phases` (in pipeline order), and `r
 ---
 
 ## Step 2: Route to Continuation Reference
+
+> *Output the next fenced block as a code block:*
+
+```
+── Route to Continuation Reference ──────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Handing off to the continuation that builds the plan-mode
+> handoff for whatever phase comes next.
+```
 
 Based on the completed phase and work type, load the appropriate continuation reference. The completed-phase check runs first so an epic concluding discovery routes to the deterministic discovery continuation; non-discovery epic completions fall through to the work-type branches below.
 

--- a/skills/workflow-continue-bugfix/SKILL.md
+++ b/skills/workflow-continue-bugfix/SKILL.md
@@ -80,11 +80,11 @@ If discovery output is already displayed, it has been run on your behalf.
 
 Parse the discovery output to understand:
 
-**From the `=== BUGFIXES ===` section:**
+**From the `=== BUGFIXES (N) ===` section:**
 - one line per active bugfix — `{name}: {phase_label}`
 - `count` — the header count of active bugfixes
 
-**From the `=== COMPLETED ===` / `=== CANCELLED ===` sections:**
+**From the `=== COMPLETED (N) ===` / `=== CANCELLED (N) ===` sections:**
 - one line per closed bugfix — `{name} (last phase: {phase})`
 - `completed_count` / `cancelled_count` — the header counts
 

--- a/skills/workflow-continue-bugfix/references/select-bugfix.md
+++ b/skills/workflow-continue-bugfix/references/select-bugfix.md
@@ -24,7 +24,7 @@ Display active bugfixes and let the user select one.
 @endif
 ```
 
-Build from the discovery output's `=== BUGFIXES ===` section. Each bugfix shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
+Build from the discovery output's `=== BUGFIXES (N) ===` section. Each bugfix shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-continue-bugfix/references/validate-selection.md
+++ b/skills/workflow-continue-bugfix/references/validate-selection.md
@@ -6,7 +6,7 @@
 
 Validate the selected work unit against the discovery output.
 
-#### If `work_unit` not found in the `=== BUGFIXES ===` section
+#### If `work_unit` not found in the `=== BUGFIXES (N) ===` section
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-continue-cross-cutting/SKILL.md
+++ b/skills/workflow-continue-cross-cutting/SKILL.md
@@ -80,11 +80,11 @@ If discovery output is already displayed, it has been run on your behalf.
 
 Parse the discovery output to understand:
 
-**From the `=== CROSS-CUTTING ===` section:**
+**From the `=== CROSS-CUTTING (N) ===` section:**
 - one line per active cross-cutting concern — `{name}: {phase_label}`
 - `count` — the header count of active cross-cutting concerns
 
-**From the `=== COMPLETED ===` / `=== CANCELLED ===` sections:**
+**From the `=== COMPLETED (N) ===` / `=== CANCELLED (N) ===` sections:**
 - one line per closed cross-cutting concern — `{name} (last phase: {phase})`
 - `completed_count` / `cancelled_count` — the header counts
 

--- a/skills/workflow-continue-cross-cutting/references/select-cross-cutting.md
+++ b/skills/workflow-continue-cross-cutting/references/select-cross-cutting.md
@@ -24,7 +24,7 @@ Display active cross-cutting concerns and let the user select one.
 @endif
 ```
 
-Build from the discovery output's `=== CROSS-CUTTING ===` section. Each shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
+Build from the discovery output's `=== CROSS-CUTTING (N) ===` section. Each shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-continue-cross-cutting/references/validate-selection.md
+++ b/skills/workflow-continue-cross-cutting/references/validate-selection.md
@@ -6,7 +6,7 @@
 
 Validate the selected work unit against the discovery output.
 
-#### If `work_unit` not found in the `=== CROSS-CUTTING ===` section
+#### If `work_unit` not found in the `=== CROSS-CUTTING (N) ===` section
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -80,11 +80,11 @@ If discovery output is already displayed, it has been run on your behalf.
 
 Parse the discovery output to understand:
 
-**From the `=== EPICS ===` section:**
+**From the `=== EPICS (N) ===` section:**
 - one line per active epic — `{name}: {active_phases}` (phases with items; `(no phases)` when none)
 - `count` — the header count of active epics
 
-**From the `=== COMPLETED ===` / `=== CANCELLED ===` sections:**
+**From the `=== COMPLETED (N) ===` / `=== CANCELLED (N) ===` sections:**
 - one line per closed epic — `{name} (last phase: {phase})`
 - `completed_count` / `cancelled_count` — the header counts
 
@@ -176,7 +176,18 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Backfill
 
-Silent gate. Detects whether any one-time-per-project recovery work is needed; loads the dispatching reference only when work fires.
+> *Output the next fenced block as a code block:*
+
+```
+── Backfill ─────────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Checking for one-time recovery work — legacy research splits
+> or discovery-map rows missing a summary or description.
+```
 
 ```bash
 node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs {work_unit}

--- a/skills/workflow-continue-epic/references/select-epic.md
+++ b/skills/workflow-continue-epic/references/select-epic.md
@@ -24,7 +24,7 @@ Display active epics and let the user select one.
 @endif
 ```
 
-Build from the discovery output's `=== EPICS ===` section. Each epic shows `name` (titlecased) and a comma-separated list of `active_phases` (titlecased). Blank line between each numbered item.
+Build from the discovery output's `=== EPICS (N) ===` section. Each epic shows `name` (titlecased) and a comma-separated list of `active_phases` (titlecased). Blank line between each numbered item.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-continue-epic/references/validate-selection.md
+++ b/skills/workflow-continue-epic/references/validate-selection.md
@@ -6,7 +6,7 @@
 
 Validate the selected work unit against the discovery output, then load its state surface.
 
-#### If `work_unit` not found in the `=== EPICS ===` section
+#### If `work_unit` not found in the `=== EPICS (N) ===` section
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-continue-feature/SKILL.md
+++ b/skills/workflow-continue-feature/SKILL.md
@@ -80,11 +80,11 @@ If discovery output is already displayed, it has been run on your behalf.
 
 Parse the discovery output to understand:
 
-**From the `=== FEATURES ===` section:**
+**From the `=== FEATURES (N) ===` section:**
 - one line per active feature — `{name}: {phase_label}`
 - `count` — the header count of active features
 
-**From the `=== COMPLETED ===` / `=== CANCELLED ===` sections:**
+**From the `=== COMPLETED (N) ===` / `=== CANCELLED (N) ===` sections:**
 - one line per closed feature — `{name} (last phase: {phase})`
 - `completed_count` / `cancelled_count` — the header counts
 

--- a/skills/workflow-continue-feature/references/select-feature.md
+++ b/skills/workflow-continue-feature/references/select-feature.md
@@ -24,7 +24,7 @@ Display active features and let the user select one.
 @endif
 ```
 
-Build from the discovery output's `=== FEATURES ===` section. Each feature shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
+Build from the discovery output's `=== FEATURES (N) ===` section. Each feature shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-continue-feature/references/validate-selection.md
+++ b/skills/workflow-continue-feature/references/validate-selection.md
@@ -6,7 +6,7 @@
 
 Validate the selected work unit against the discovery output.
 
-#### If `work_unit` not found in the `=== FEATURES ===` section
+#### If `work_unit` not found in the `=== FEATURES (N) ===` section
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-continue-quickfix/SKILL.md
+++ b/skills/workflow-continue-quickfix/SKILL.md
@@ -80,11 +80,11 @@ If discovery output is already displayed, it has been run on your behalf.
 
 Parse the discovery output to understand:
 
-**From the `=== QUICK-FIXES ===` section:**
+**From the `=== QUICK-FIXES (N) ===` section:**
 - one line per active quick-fix — `{name}: {phase_label}`
 - `count` — the header count of active quick-fixes
 
-**From the `=== COMPLETED ===` / `=== CANCELLED ===` sections:**
+**From the `=== COMPLETED (N) ===` / `=== CANCELLED (N) ===` sections:**
 - one line per closed quick-fix — `{name} (last phase: {phase})`
 - `completed_count` / `cancelled_count` — the header counts
 

--- a/skills/workflow-continue-quickfix/references/select-quickfix.md
+++ b/skills/workflow-continue-quickfix/references/select-quickfix.md
@@ -24,7 +24,7 @@ Display active quick-fixes and let the user select one.
 @endif
 ```
 
-Build from the discovery output's `=== QUICK-FIXES ===` section. Each quick-fix shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
+Build from the discovery output's `=== QUICK-FIXES (N) ===` section. Each quick-fix shows `name` (titlecased) and `phase_label` (titlecased). Blank line between each numbered item.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-continue-quickfix/references/validate-selection.md
+++ b/skills/workflow-continue-quickfix/references/validate-selection.md
@@ -6,7 +6,7 @@
 
 Validate the selected work unit against the discovery output.
 
-#### If `work_unit` not found in the `=== QUICK-FIXES ===` section
+#### If `work_unit` not found in the `=== QUICK-FIXES (N) ===` section
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -4,7 +4,7 @@
 
 ---
 
-Ask each question below **one at a time**. After each, **STOP** and wait for the user's response before proceeding.
+Ask each question below **one at a time**. After each, stop and wait for the user's response before proceeding.
 
 ---
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -10,7 +10,7 @@ Act as **expert software architect** participating in discussions AND **document
 
 ## Purpose in the Workflow
 
-Follows research (or starts the pipeline for features). Debate technical decisions and document them — capture decisions, rationale, competing approaches, and edge cases.
+The decision phase, entered from discovery — or from research when it ran. Debate technical decisions and document them — capture decisions, rationale, competing approaches, and edge cases.
 
 ### What This Skill Needs
 

--- a/skills/workflow-discussion-process/references/discussion-guidelines.md
+++ b/skills/workflow-discussion-process/references/discussion-guidelines.md
@@ -14,7 +14,7 @@
 
 **On length**: Discussions can be thousands of lines. Length = whatever needed to fully capture discussion, debates, edge cases, false paths. Terseness preferred, but comprehensive documentation more important. Don't summarize — document.
 
-See **[meeting-assistant.md](meeting-assistant.md)** for the dual-role approach (expert architect + documentation assistant).
+→ Load **[meeting-assistant.md](meeting-assistant.md)** and follow its instructions as written — the dual-role approach (expert architect + documentation assistant).
 
 ## Organic Flow
 
@@ -34,7 +34,7 @@ The conversation follows the thinking, not a checklist. Subtopics emerge, get ex
 
 **Don't**: Transcribe verbatim, write code/implementation, create build phases, skip context
 
-See **[guidelines.md](guidelines.md)** for best practices and anti-hallucination techniques.
+→ Load **[guidelines.md](guidelines.md)** and follow its instructions as written — best practices and anti-hallucination techniques.
 
 ## Write to Disk and Commit Frequently
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -248,7 +248,7 @@ Convergence is the natural end state — not a forced conclusion. The discussion
 node .claude/skills/workflow-discussion-process/scripts/gateway.cjs map {work_unit} {topic}
 ```
 
-Its DATA section carries the convergence facts: `all_decided` and `review_cycles`.
+Its DATA section carries the convergence facts: `all_decided` and `review_cycles`. The DISPLAY section isn't emitted here — this flow reads DATA only.
 
 #### If `review_cycles` is 0
 
@@ -265,8 +265,6 @@ Dispatch a review agent as a foreground task (not background — results are nee
 → Return to **B. Session Loop**.
 
 #### If `review_cycles` is at least 1
-
-**When convergence is reached** (`all_decided` is true):
 
 > *Output the next fenced block as a code block:*
 
@@ -311,7 +309,7 @@ node .claude/skills/workflow-discussion-process/scripts/gateway.cjs map {work_un
 
 Its DATA section carries everything this flow needs: `all_decided`, `unresolved`, `review_cycles`.
 
-**If `review_cycles` is 0:**
+#### If `review_cycles` is 0
 
 > *Output the next fenced block as a code block:*
 
@@ -323,7 +321,7 @@ Its DATA section carries everything this flow needs: `all_decided`, `unresolved`
 
 Dispatch a review agent as a foreground task (not background — results are needed before concluding). Follow **A. Dispatch** in review-agent.md but omit `run_in_background`. When results return, delegate to **B. Check and Surface** in review-agent.md — the shared surfacing protocol applies the never-dump rules and presents findings one at a time. Then continue with the conclusion flow below.
 
-**If `review_cycles` is at least 1:**
+#### If `review_cycles` is at least 1
 
 Continue with the conclusion flow below.
 

--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -43,7 +43,7 @@ Don't rely on your memory of what you wrote earlier. Pay particular attention to
 
 ## B. Compare and Reconcile
 
-Walk the conversation against the document and check three dimensions:
+Walk the conversation against the document and check four dimensions:
 
 1. **Undocumented substance** — threads, tangents, trade-offs, edge cases, provisional positions, or concerns that came up in conversation but never made it into a subtopic section or the Summary. Not verbatim — the *substance* of what was explored. This is the most common failure mode as sessions grow long and later exchanges crowd out earlier ones. Journey sections are especially vulnerable: they're supposed to capture the arc of how a decision was reached, and it's easy to write them tersely after the fact in a way that skips the actual back-and-forth.
 

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -14,15 +14,15 @@ The **never-dump rules apply in full**. Findings are raised one at a time via th
 
 **Synthesis findings drain first.** Scan `.workflows/.cache/{work_unit}/discussion/{topic}/` for `synthesis-*.md` files with `status: pending` or `status: acknowledged` — perspective-council tensions that never finished surfacing during the session would otherwise be dropped at conclusion.
 
-**If any such file exists:**
+#### If any such file exists
 
 Surface one tension via **D. Check and Surface** in **[perspective-agents.md](perspective-agents.md)**, then bounce back to the session so the user can engage.
 
 → Return to **[the skill](../SKILL.md)** for **Step 5**.
 
-**Otherwise:**
+#### Otherwise
 
-Find the most recent review file in `.workflows/.cache/{work_unit}/discussion/{topic}/` by set number.
+Find the most recent review file in `.workflows/.cache/{work_unit}/discussion/{topic}/` by set number, then branch on its `status:` below.
 
 #### If no review files exist
 

--- a/skills/workflow-discussion-process/references/guidelines.md
+++ b/skills/workflow-discussion-process/references/guidelines.md
@@ -90,3 +90,5 @@ Before marking discussion complete:
 - ✅ Confidence stated where uncertain
 - ✅ No hallucination
 - ✅ Open threads noted in Summary
+
+→ Return to caller.

--- a/skills/workflow-discussion-process/references/initialize-discussion.md
+++ b/skills/workflow-discussion-process/references/initialize-discussion.md
@@ -28,6 +28,9 @@
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map add {work_unit} {topic} {subtopic}
    ```
-6. Commit the discussion file and manifest
+6. Commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discussion({work_unit}): initialize {topic} discussion"
+   ```
 
 → Return to caller.

--- a/skills/workflow-discussion-process/references/meeting-assistant.md
+++ b/skills/workflow-discussion-process/references/meeting-assistant.md
@@ -109,3 +109,5 @@ The file on disk is the work product. Context compaction will destroy conversati
 Give them: Context (why), direction (what), trade-offs (constraints), rationale (why X over Y), false paths (what not to try)
 
 Your job ends at documentation. Planning team creates implementation plan.
+
+→ Return to caller.

--- a/skills/workflow-discussion-process/references/perspective-agents.md
+++ b/skills/workflow-discussion-process/references/perspective-agents.md
@@ -53,6 +53,8 @@ This decision sits on a {tension description} tension. Want to explore both lens
 
 Continue the discussion without perspectives.
 
+→ Return to caller.
+
 #### If `yes`
 
 → Proceed to **B. Dispatch Perspective Agents**.

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-investigation-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(git status), Bash(git log)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/.cache/), Bash(ls .workflows/.cache/), Bash(git status), Bash(git log), Bash(git blame), Bash(git diff), Bash(git bisect), Bash(grep)
 ---
 
 # Investigation Process

--- a/skills/workflow-investigation-process/references/synthesis-agent.md
+++ b/skills/workflow-investigation-process/references/synthesis-agent.md
@@ -39,11 +39,15 @@ Why It Wasn't Caught:
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
+> An independent agent will trace the code to validate the
+> root cause hypothesis before confirming.
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
 · · · · · · · · · · · ·
 Root cause documented. Run synthesis validation?
-
-An independent agent will trace the code to validate the
-root cause hypothesis before confirming.
 
 - **`y`/`yes`** — Run synthesis validation
 - **`s`/`skip`** — Skip straight to findings review

--- a/skills/workflow-knowledge/references/contextual-query.md
+++ b/skills/workflow-knowledge/references/contextual-query.md
@@ -34,7 +34,7 @@ node .claude/skills/workflow-knowledge/scripts/knowledge.cjs query "<framing 1>"
 
 #### If the command exits with a non-zero code
 
-Load **[knowledge-usage.md](knowledge-usage.md)** for **D. Query failure handling** and follow its instructions. When D returns:
+→ Load **[knowledge-usage.md](knowledge-usage.md)** for **D. Query failure handling** and follow its instructions. When D returns:
 
 - **If the user chose `skip`** — no results to interpret. → Return to caller.
 - **If a retry succeeded** — results are now available. → Proceed to **C. Interpret the results**.

--- a/skills/workflow-legacy-research-split/SKILL.md
+++ b/skills/workflow-legacy-research-split/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash(node .claude/skills/workflow-legacy-research-split/scripts/d
 
 Act as **curator + interviewer**. Walk the user through decomposing broad research files — each holding multiple themes — into topic-scoped files plus matching discovery-map items.
 
-### What This Skill Needs
+**Parameters**:
 
 - **Work unit** (required) — the epic to normalise. Passed by `workflow-continue-epic` Step 5.
 

--- a/skills/workflow-legacy-research-split/references/dialog.md
+++ b/skills/workflow-legacy-research-split/references/dialog.md
@@ -4,7 +4,7 @@
 
 ---
 
-Drive the per-source iteration: read source, identify themes, early sanity gate, draft cache, propose, edit, validate, apply. Edit operations live in their own lettered sections (K–P) dispatched from G.
+Drive the per-source iteration: read source, identify themes, early sanity gate, draft cache, propose, edit, validate, apply. Edit operations live in their own lettered sections (K, M–P) dispatched from G.
 
 ## A. Iterate
 

--- a/skills/workflow-research-entry/references/gather-context.md
+++ b/skills/workflow-research-entry/references/gather-context.md
@@ -6,7 +6,7 @@
 
 ## A. Seed Idea
 
-Ask each question below **one at a time**. After each, **STOP** and wait for the user's response before proceeding.
+Ask each question below **one at a time**. After each, stop and wait for the user's response before proceeding.
 
 > *Output the next fenced block as a code block:*
 
@@ -49,22 +49,6 @@ Where should we start?
 
 - Technical feasibility? Market landscape? Business model?
 - Or just talk it through and see where it goes?
-```
-
-**STOP.** Wait for user response.
-
-→ Proceed to **D. Final Context**.
-
----
-
-## D. Final Context
-
-> *Output the next fenced block as a code block:*
-
-```
-Any constraints or context I should know about upfront?
-
-(Or "none" if we're starting fresh)
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -10,7 +10,7 @@ Act as **research partner** with broad expertise spanning technical, product, bu
 
 ## Purpose in the Workflow
 
-First phase in the pipeline — explore feasibility (technical, business, market), validate assumptions, and document findings before discussion begins.
+The exploration phase, entered from discovery — explore feasibility (technical, business, market), validate assumptions, and document findings before discussion begins.
 
 ### What This Skill Needs
 

--- a/skills/workflow-research-process/references/document-review.md
+++ b/skills/workflow-research-process/references/document-review.md
@@ -33,7 +33,7 @@ Pull the current state fresh into context — don't rely on your memory of what 
 
 ## B. Compare and Reconcile
 
-Walk the conversation against the document and check three dimensions:
+Walk the conversation against the document and check four dimensions:
 
 1. **Undocumented substance** — threads, insights, constraints, open questions, tradeoffs, or preliminary positions that came up in conversation but never made it into the document. Not verbatim — the *substance* of what was explored. This is the most common failure mode as sessions grow long and later exchanges crowd out earlier ones.
 

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -14,15 +14,15 @@ The **never-dump rules apply in full**. Findings are raised one at a time via th
 
 **Deep-dive findings drain first.** Scan `.workflows/.cache/{work_unit}/research/{topic}/` for `deep-dive-*.md` files with `status: pending` or `status: acknowledged` — thread findings that never finished surfacing during the session would otherwise be dropped at conclusion.
 
-**If any such file exists:**
+#### If any such file exists
 
 Surface one finding via **C. Check and Surface** in **[deep-dive-agent.md](deep-dive-agent.md)**, then bounce back to the session so the user can engage.
 
 → Return to **[the skill](../SKILL.md)** for **Step 6**.
 
-**Otherwise:**
+#### Otherwise
 
-Find the most recent review file in `.workflows/.cache/{work_unit}/research/{topic}/` by set number.
+Find the most recent review file in `.workflows/.cache/{work_unit}/research/{topic}/` by set number, then branch on its `status:` below.
 
 #### If no review files exist
 

--- a/skills/workflow-research-process/references/topic-completion.md
+++ b/skills/workflow-research-process/references/topic-completion.md
@@ -18,6 +18,8 @@ The current topic is converging — tradeoffs are clear, it's approaching decisi
 
 ```
 · · · · · · · · · · · ·
+This topic looks ready to conclude.
+
 - **`c`/`conclude`** — Mark this topic as complete, ready for discussion
 - **`k`/`keep`** — Keep digging, there's more to understand
 · · · · · · · · · · · ·

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -33,7 +33,7 @@ Want to split these into separate research files?
 
 **STOP.** Wait for user response.
 
-#### If yes
+#### If `yes`
 
 For each split topic:
 
@@ -66,7 +66,7 @@ Then offer the user a choice of which topic to continue with:
 Which topic would you like to continue with?
 
 @foreach(topic in available_topics)
-**{N}. {topic:(titlecase)}** — {status:[in-progress]}
+- **`{N}`** — {topic:(titlecase)} [in-progress]
 @endforeach
 
 Select an option (enter number):
@@ -75,8 +75,10 @@ Select an option (enter number):
 
 **STOP.** Wait for user response.
 
+Make the selected topic the active session focus — continue in its research file at `.workflows/{work_unit}/research/{selected_topic}.md`.
+
 → Return to caller.
 
-#### If no
+#### If `no`
 
 → Return to caller.

--- a/skills/workflow-scoping-process/references/complexity-check.md
+++ b/skills/workflow-scoping-process/references/complexity-check.md
@@ -14,9 +14,13 @@ Assess whether this change is genuinely quick-fix material. Evaluate against the
 
 ## A. Evaluate
 
-If all criteria are met — proceed without comment.
+#### If all criteria are met
 
 → Return to caller.
+
+#### Otherwise
+
+→ Proceed to **B. Complexity Warning**.
 
 ## B. Complexity Warning
 

--- a/skills/workflow-scoping-process/references/gather-context.md
+++ b/skills/workflow-scoping-process/references/gather-context.md
@@ -14,7 +14,13 @@ Gather targeted context about the mechanical change. Read the work's seed and th
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} description
 ```
 
-If the seed and description already capture what, where, and why — skip to the complexity check. Otherwise, ask targeted questions.
+#### If the seed and description already capture what, where, and why
+
+→ Return to caller.
+
+#### Otherwise
+
+→ Proceed to **B. Targeted Questions**.
 
 ## B. Targeted Questions
 
@@ -33,6 +39,6 @@ A few questions to scope this change:
 
 **STOP.** Wait for user response.
 
-If answers are clear and complete, proceed. If gaps remain, ask one follow-up — no more than 2 exchanges total. Quick-fixes should be explainable in a sentence or two.
+Ask one follow-up only if gaps remain — 2 exchanges total at most, since a quick-fix should be explainable in a sentence or two.
 
 → Return to caller.

--- a/skills/workflow-scoping-process/references/write-specification.md
+++ b/skills/workflow-scoping-process/references/write-specification.md
@@ -35,7 +35,7 @@ Create the specification file at `.workflows/{work_unit}/specification/{topic}/s
 {- Any additional checks specific to this change}
 ```
 
-Present the spec to the user:
+Confirm the spec was written:
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -12,7 +12,7 @@ The fold preserves the **full** rerouted context — each entry becomes real wor
 
 The caller provides these via context before loading:
 
-- `work_unit` — the epic. Always present.
+- `work_unit` — the work unit. Always present.
 - `topic` — the current topic, whose artefact is drained.
 - `phase` — `discussion` or `research`. Selects the artefact path and the fold shape.
 

--- a/skills/workflow-start/references/inbox-working-set.md
+++ b/skills/workflow-start/references/inbox-working-set.md
@@ -99,7 +99,7 @@ The `ADDABLE` table in the working-set DATA lists the inbox items not already in
 
 #### If the triggering message already named the item(s) to add
 
-Match each named item against the `ADDABLE` table — by title, or by the number if the user referenced one. If any reference is ambiguous or unmatched, → Proceed to **Otherwise**. Otherwise append the matched items' paths to the working set.
+Match each named item against the `ADDABLE` table — by title, or by the number if the user referenced one. If any reference is ambiguous or unmatched, treat the request as unmatched and follow **Otherwise** below. Otherwise append the matched items' paths to the working set.
 
 → Return to **A. Render the Working Set**.
 
@@ -123,7 +123,7 @@ Resolve each chosen number to its `ADDABLE` row and append the row's path to the
 
 #### If the triggering message already named the item(s) to drop
 
-Resolve each named item against the working set by title or description. If any reference is ambiguous or unmatched, → Proceed to **Otherwise**. Otherwise remove the resolved items (they stay in the inbox):
+Resolve each named item against the working set by title or description. If any reference is ambiguous or unmatched, treat the request as unmatched and follow **Otherwise** below. Otherwise remove the resolved items (they stay in the inbox):
 
 **If the set is now empty:**
 


### PR DESCRIPTION
Exploration-cluster findings: topic-splitting no longer drops the user's selected topic after the split; scoping's gather-context loses its banned "skip to" (which silently bypassed the contextual query step); research-entry stops asking the constraints question twice; discussion's soft "See" references become binding Loads with proper exits; workflow-bridge gains its missing step markers and signposts (sole outlier repo-wide); continue-epic's Step 5 gets marked; the section-label prose across all five continue-* skills matches the gateways' `(N)` count suffixes; plus the audited M/L-tier fixes across research, discussion, investigation, and shared references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. #462
59. #463
60. #464
61. #465
62. #466
63. #467
64. #468
65. #469
66. #470
67. **#471** 👈 current
68. #472
69. #473
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->