### PR TITLE
polish: scout wins — dead tables, handler dedup, lazy detail, boot commit scope

### DIFF
--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -8,19 +8,6 @@ Route a bugfix to its next pipeline phase, with an option to revisit earlier pha
 
 Bugfix pipeline: Investigation → Specification → Planning → Implementation → Review
 
-## Phase Routing
-
-Use `next_phase` from discovery output to determine the target skill:
-
-| next_phase | Target Skill |
-|------------|--------------|
-| investigation | workflow-investigation-entry |
-| specification | workflow-specification-entry |
-| planning | workflow-planning-entry |
-| implementation | workflow-implementation-entry |
-| review | workflow-review-entry |
-| done | (terminal) |
-
 ## A. Check Terminal
 
 #### If `next_phase` is `done`

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -8,17 +8,6 @@ Route a cross-cutting concern to its next pipeline phase, with an option to revi
 
 Cross-cutting pipeline: (Research) → Discussion → Specification (terminal)
 
-## Phase Routing
-
-Use `next_phase` from discovery output to determine the target skill:
-
-| next_phase | Target Skill |
-|------------|--------------|
-| research | workflow-research-entry |
-| discussion | workflow-discussion-entry |
-| specification | workflow-specification-entry |
-| done | (terminal) |
-
 ## A. Check Terminal
 
 #### If `next_phase` is `done`

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -115,22 +115,7 @@ Epic Completed
 
 ## F. Enter Plan Mode
 
-Section E returned the selected entry's `action`, `topic`, and `route` (stored by epic-display-and-menu.md **C. Route Selection**). The stored `route` is the authoritative skill invocation — the plan file carries it verbatim. Never reconstruct an invocation from the phase name; not every selection maps to a `workflow-{phase}-entry` skill. The routes resolve as follows:
-
-| Selection | Route |
-|-----------|-------|
-| Continue discussion | `/workflow-discussion-entry epic {work_unit} {topic}` |
-| Continue specification | `/workflow-specification-entry epic {work_unit} {topic}` |
-| Continue plan | `/workflow-planning-entry epic {work_unit} {topic}` |
-| Continue implementation | `/workflow-implementation-entry epic {work_unit} {topic}` |
-| Continue research | `/workflow-research-entry epic {work_unit} {topic}` |
-| Continue discovery | `/workflow-discovery epic {work_unit}` |
-| Start specification | `/workflow-specification-entry epic {work_unit}` |
-| Start planning for {topic} | `/workflow-planning-entry epic {work_unit} {topic}` |
-| Start implementation of {topic} | `/workflow-implementation-entry epic {work_unit} {topic}` |
-| Start review for {topic} | `/workflow-review-entry epic {work_unit} {topic}` |
-| Start new research | `/workflow-research-entry epic {work_unit}` |
-| Start new discussion | `/workflow-discussion-entry epic {work_unit}` |
+Section E returned the selected entry's `action`, `topic`, and `route` (stored by epic-display-and-menu.md **C. Route Selection**). The stored `route` is the authoritative skill invocation — the plan file carries it verbatim. Never reconstruct an invocation from the phase name; not every selection maps to a `workflow-{phase}-entry` skill. Continue discovery → `/workflow-discovery epic {work_unit}` — the only selection that doesn't route to an entry skill; every other route comes from the stored `route` verbatim.
 
 Skills receive positional arguments: `$0` = work_type, `$1` = work_unit, `$2` = topic (optional).
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -8,20 +8,6 @@ Route a feature to its next pipeline phase, with an option to revisit earlier ph
 
 Feature pipeline: (Research) → Discussion → Specification → Planning → Implementation → Review
 
-## Phase Routing
-
-Use `next_phase` from discovery output to determine the target skill:
-
-| next_phase | Target Skill |
-|------------|--------------|
-| research | workflow-research-entry |
-| discussion | workflow-discussion-entry |
-| specification | workflow-specification-entry |
-| planning | workflow-planning-entry |
-| implementation | workflow-implementation-entry |
-| review | workflow-review-entry |
-| done | (terminal) |
-
 ## A. Check Terminal
 
 #### If `next_phase` is `done`

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -8,17 +8,6 @@ Route a quick-fix to its next pipeline phase, with an option to revisit earlier 
 
 Quick-fix pipeline: Scoping → Implementation → Review
 
-## Phase Routing
-
-Use `next_phase` from discovery output to determine the target skill:
-
-| next_phase | Target Skill |
-|------------|--------------|
-| scoping | workflow-scoping-entry |
-| implementation | workflow-implementation-entry |
-| review | workflow-review-entry |
-| done | (terminal) |
-
 ## A. Check Terminal
 
 #### If `next_phase` is `done`

--- a/skills/workflow-continue-epic/scripts/gateway.cjs
+++ b/skills/workflow-continue-epic/scripts/gateway.cjs
@@ -53,11 +53,22 @@ function discover(cwd, workUnit) {
       }
     }
 
-    epics.push({
-      name: m.name,
-      active_phases: activePhases,
-      detail: engine.detail.epicDetail(cwd, m),
+    // The detail build checksums every completed research + discussion file.
+    // Only the scoped / view / sub-view flows read `detail`; the index dump
+    // reads just name + active_phases. Defer the build to first access — a
+    // non-enumerable, memoised getter — so the index dump never pays for it,
+    // while scoped callers get the identical object on demand.
+    const epic = { name: m.name, active_phases: activePhases };
+    let detail;
+    let detailBuilt = false;
+    Object.defineProperty(epic, 'detail', {
+      enumerable: false,
+      get() {
+        if (!detailBuilt) { detail = engine.detail.epicDetail(cwd, m); detailBuilt = true; }
+        return detail;
+      },
     });
+    epics.push(epic);
   }
 
   // Load completed/cancelled epics (only in list mode, not detail mode)

--- a/skills/workflow-engine/scripts/domain/boot.cjs
+++ b/skills/workflow-engine/scripts/domain/boot.cjs
@@ -111,6 +111,28 @@ function boot(cwd) {
 
   /** @type {string[]} */
   const warnings = [];
+
+  // Migrations reach past .workflows: some edit .claude/settings.json
+  // (permission/hook plumbing) and the repo-root .gitignore. The skill's
+  // .workflows-scoped migration commit misses those, leaving them dirty after
+  // boot for some later unrelated commit to sweep up. When migrations changed,
+  // commit whichever of the two exist on disk — existence-guarded, since a
+  // `git add` on a nonexistent path errors (the same lesson commit.cjs's
+  // KB_DIR guard encodes) and an all-clean stage simply commits nothing. The
+  // migration files are already applied, so a commit failure is a warning,
+  // never a block.
+  if (migrations.changed) {
+    try {
+      const configSpecs = ['.claude/settings.json', '.gitignore']
+        .filter((p) => fs.existsSync(path.join(cwd, p)));
+      if (configSpecs.length > 0) {
+        commitScoped(cwd, configSpecs, 'chore: apply workflow migration config changes');
+      }
+    } catch (err) {
+      warnings.push(`migration config commit failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   const check = spawnKnowledge(cwd, ['check']);
   const ready = !check.error && check.status === 0 && (check.stdout || '').trim() === 'ready';
 

--- a/skills/workflow-start/references/knowledge-gate.md
+++ b/skills/workflow-start/references/knowledge-gate.md
@@ -49,19 +49,7 @@ Run:
 node .claude/skills/workflow-knowledge/scripts/knowledge.cjs setup --from-system
 ```
 
-**If the command succeeded:**
-
-→ Proceed to **E. Confirm and Continue**.
-
-**If the command failed with "no OpenAI API key found" or an authentication error (HTTP 401/403 — the stored key is missing, revoked, or wrong for this endpoint):**
-
-→ Proceed to **D. Store the API Key**.
-
-**If the command failed for any other reason:**
-
-Surface the reported error verbatim. The knowledge base could not be initialised — the workflow cannot proceed.
-
-**STOP.** Do not proceed — terminal condition.
+→ Proceed to **G. Handle Setup Result** with origin = `B`.
 
 #### If `different`
 
@@ -133,19 +121,7 @@ Run with the chosen model (`text-embedding-3-small` for "default"):
 node .claude/skills/workflow-knowledge/scripts/knowledge.cjs setup --provider openai --model {model}
 ```
 
-**If the command succeeded:**
-
-→ Proceed to **E. Confirm and Continue**.
-
-**If the command failed with "no OpenAI API key found" or an authentication error (HTTP 401/403):**
-
-→ Proceed to **D. Store the API Key**.
-
-**If the command failed for any other reason:**
-
-Surface the reported error verbatim. The knowledge base could not be initialised — the workflow cannot proceed.
-
-**STOP.** Do not proceed — terminal condition.
+→ Proceed to **G. Handle Setup Result** with origin = `C-openai`.
 
 #### If `compatible`
 
@@ -169,21 +145,7 @@ node .claude/skills/workflow-knowledge/scripts/knowledge.cjs setup --provider op
 
 Keyless endpoints are fine — a key stored in the credentials file is picked up automatically.
 
-**If the command succeeded:**
-
-→ Proceed to **E. Confirm and Continue**.
-
-**If the command failed with an authentication error (HTTP 401/403):**
-
-The endpoint wants a key.
-
-→ Proceed to **D. Store the API Key**.
-
-**If the command failed for any other reason:**
-
-Surface the reported error verbatim. The knowledge base could not be initialised — the workflow cannot proceed.
-
-**STOP.** Do not proceed — terminal condition.
+→ Proceed to **G. Handle Setup Result** with origin = `C-compatible`.
 
 #### If `keyword`
 
@@ -193,15 +155,7 @@ Run:
 node .claude/skills/workflow-knowledge/scripts/knowledge.cjs setup --keyword-only
 ```
 
-**If the command succeeded:**
-
-→ Proceed to **E. Confirm and Continue**.
-
-**If the command failed:**
-
-Surface the reported error verbatim. The knowledge base could not be initialised — the workflow cannot proceed.
-
-**STOP.** Do not proceed — terminal condition.
+→ Proceed to **G. Handle Setup Result** with origin = `keyword`.
 
 #### If `terminal`
 
@@ -253,17 +207,17 @@ Ready to retry?
 
 #### If `done`
 
-Re-run the setup command whose key failure routed here and handle its result exactly as its branch prescribes — including routing back to this section if the key is still unresolvable. Skip the originating branch's menus and questions; its values are already collected.
+Re-run the setup command whose key failure routed here — `origin` names it — skipping the originating branch's menus and questions; its values are already collected. The re-run lands back at **G** to handle the fresh result.
 
-**If routed from B's `yes` branch:**
+**If `origin` is `B`:**
 
 → Return to **B. Use Existing Configuration** for the `yes` branch's setup command.
 
-**If routed from C's `openai` branch:**
+**If `origin` is `C-openai`:**
 
 → Return to **C. Choose a Mode** for the `openai` branch's setup command.
 
-**If routed from C's `compatible` branch:**
+**If `origin` is `C-compatible`:**
 
 → Return to **C. Choose a Mode** for the `compatible` branch's setup command.
 
@@ -275,15 +229,7 @@ Run:
 node .claude/skills/workflow-knowledge/scripts/knowledge.cjs setup --keyword-only
 ```
 
-**If the command succeeded:**
-
-→ Proceed to **E. Confirm and Continue**.
-
-**If the command failed:**
-
-Surface the reported error verbatim. The knowledge base could not be initialised — the workflow cannot proceed.
-
-**STOP.** Do not proceed — terminal condition.
+→ Proceed to **G. Handle Setup Result** with origin = `keyword`.
 
 ## E. Confirm and Continue
 
@@ -360,3 +306,23 @@ Knowledge base ready — {provider} · {model}.
 The wizard did not complete. Surface the boot response's detail.
 
 → Return to **A. Route**.
+
+## G. Handle Setup Result
+
+The setup command just ran. Branch on its result. `origin` names the branch that ran it — the authentication path routes back through **D** to that origin's command.
+
+#### If the command succeeded
+
+→ Return to **E. Confirm and Continue**.
+
+#### If the command failed with an authentication error (HTTP 401/403), or — for an openai provider — with "no OpenAI API key found"
+
+The stored key is missing, revoked, or wrong for this endpoint. Keyword-only origins never reach here: `--keyword-only` performs no authentication, so its only failure is the "any other reason" path below.
+
+→ Return to **D. Store the API Key** with origin = `{origin}`.
+
+#### If the command failed for any other reason
+
+Surface the reported error verbatim. The knowledge base could not be initialised — the workflow cannot proceed.
+
+**STOP.** Do not proceed — terminal condition.

--- a/tests/scripts/test-engine-boot.cjs
+++ b/tests/scripts/test-engine-boot.cjs
@@ -59,6 +59,19 @@ if (mode === 'update') {
     'You MUST now follow the migration skill instructions to STOP and let the user review.\\n' +
     'Follow the explicit instructions in the migration skill before proceeding.\\n'
   );
+} else if (mode === 'update-config') {
+  fs.mkdirSync('.workflows/.state', { recursive: true });
+  fs.mkdirSync('.claude', { recursive: true });
+  fs.appendFileSync('.workflows/.state/migrations', '046\\n');
+  fs.writeFileSync('.claude/settings.json', '{"permissions":{}}\\n');
+  fs.appendFileSync('.gitignore', '.DS_Store\\n');
+  process.stdout.write(
+    '\\n' +
+    '1 migration(s) applied, 3 file(s) updated.\\n' +
+    '\\n' +
+    '---STOP_GATE: FILES_UPDATED---\\n' +
+    'You MUST now follow the migration skill instructions to STOP and let the user review.\\n'
+  );
 } else if (mode === 'fail') {
   process.stdout.write('partial output before the failure\\n');
   process.stderr.write('boom: migration 099 exploded\\n');
@@ -168,6 +181,39 @@ describe('engine boot', () => {
     // The migration landed in the project's .workflows tree.
     assert.ok(fs.existsSync(path.join(fix.project, '.workflows/payments/marker.md')));
     assert.match(git(fix.project, ['status', '--porcelain', '--', '.workflows']), /marker\.md/);
+  });
+
+  it('a migration touching config files commits settings.json and .gitignore, leaving .workflows to the skill', () => {
+    const res = runEngine(fix.engine, fix.project, ['boot'], { STUB_MIGRATE_MODE: 'update-config' });
+
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.migrations.changed, true);
+    // Boot commits exactly the two config paths the skill's .workflows-scoped
+    // migration commit would otherwise leave dirty.
+    assert.strictEqual(git(fix.project, ['log', '-1', '--pretty=%s']).trim(), 'chore: apply workflow migration config changes');
+    const show = git(fix.project, ['show', '--name-only', '--pretty=format:', 'HEAD']).trim().split('\n').sort();
+    assert.deepStrictEqual(show, ['.claude/settings.json', '.gitignore']);
+    // The .workflows changes stay uncommitted — the skill's reviewed commit owns them.
+    assert.match(git(fix.project, ['status', '--porcelain', '--', '.workflows']), /\.workflows\/\.state/);
+  });
+
+  it('no migrations ran: dirty config files are left untouched, never committed by boot', () => {
+    // Track a config baseline, then dirty both files with no migration running.
+    writeFile(fix.project, '.claude/settings.json', '{"permissions":{}}\n');
+    writeFile(fix.project, '.gitignore', 'node_modules\n');
+    git(fix.project, ['add', '-A']);
+    git(fix.project, ['commit', '-q', '-m', 'config baseline']);
+    writeFile(fix.project, '.claude/settings.json', '{"permissions":{"allow":["x"]}}\n');
+    writeFile(fix.project, '.gitignore', 'node_modules\n.DS_Store\n');
+
+    const res = runEngine(fix.engine, fix.project, ['boot']);
+
+    assert.strictEqual(res.migrations.changed, false);
+    // Both stay dirty; HEAD is still the baseline, not a config commit.
+    const status = git(fix.project, ['status', '--porcelain']);
+    assert.match(status, /\.claude\/settings\.json/);
+    assert.match(status, /\.gitignore/);
+    assert.strictEqual(git(fix.project, ['log', '-1', '--pretty=%s']).trim(), 'config baseline');
   });
 
   it('knowledge not-ready is terminal: no init, no commit, setup stays a human choice', () => {


### PR DESCRIPTION
Four verified improvement-scout wins: the bridge's contradictory 12-row reconstructed-invocation table collapses to its one genuine exception (plus the redundant per-type Phase Routing tables); knowledge-gate's five pasted setup-result handlers become one parameterised section (one copy had already silently diverged); continue-epic's index dump defers `epicDetail` behind a lazy getter so it no longer checksums every completed artifact per invocation (output byte-verified identical); and `engine boot` now commits the config files migrations touch (`.claude/settings.json`, root `.gitignore`) — existence-guarded, only when migrations ran, closing the dirt main's unscoped commit used to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. #462
59. #463
60. #464
61. #465
62. #466
63. #467
64. #468
65. #469
66. #470
67. #471
68. #472
69. **#473** 👈 current
70. #474
71. #475
72. #476
73. #477
74. #478
<!-- stack:links:end -->