### PR TITLE
perf(skills): batch and collapse redundant engine calls across prose

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -63,23 +63,25 @@ Store work_unit for the handoff.
 
 #### If `topic` resolved
 
-Check if discussion phase entry exists:
+Read the discussion phase status:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.discussion.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} status
 ```
 
-**If exists (`true`):**
+Store the result as `phase_status`.
 
-→ Proceed to **Step 2** (Validate Phase).
-
-**If not exists (`false` — new entry):**
+**If empty (no discussion entry — new entry):**
 
 Set `source = "topic-provided"`.
 
 Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
 
 → Proceed to **Step 3** (Gather Context).
+
+**Otherwise (an entry exists):**
+
+→ Proceed to **Step 2** (Validate Phase).
 
 #### If no `topic`
 
@@ -94,6 +96,14 @@ What topic would you like to discuss?
 Kebab-case the response, store as `{topic}`. Set `source = "fresh"`.
 
 Silently derive `direct_entry_summary` (one-line) and `direct_entry_description` (one or two paragraphs) from the user's response. Do not render anything — these are local variables passed to `ensure-discovery-item` in Step 2. The derivation is part of the same Claude turn that kebab-cases the response; no separate STOP gate.
+
+Read the discussion phase status for the resolved topic — a freshly named topic is usually empty, but this catches a collision with an existing discussion:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} status
+```
+
+Store the result as `phase_status`.
 
 → Proceed to **Step 2** (Validate Phase).
 
@@ -116,7 +126,7 @@ Silently derive `direct_entry_summary` (one-line) and `direct_entry_description`
 
 Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`. On the direct-entry path (`source = "fresh"`), also pass summary = `{direct_entry_summary}`, description = `{direct_entry_description}`. On the topic-resolved path, omit both — the caller didn't derive them.
 
-Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
+Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `{phase_status}`.
 
 → Proceed to **Step 3**.
 

--- a/skills/workflow-discussion-entry/references/validate-phase.md
+++ b/skills/workflow-discussion-entry/references/validate-phase.md
@@ -4,15 +4,9 @@
 
 ---
 
-Check if a discussion already exists for this work unit and topic.
+Check whether a discussion already exists for this work unit and topic. Branch on the `phase_status` the caller read in Step 1 — no re-read.
 
-Use `engine manifest` to check discussion phase state:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic}
-```
-
-#### If output is empty (discussion doesn't exist — fresh start)
+#### If `phase_status` is empty (discussion doesn't exist — fresh start)
 
 Nothing to validate — `source` keeps the value set in Step 1.
 

--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -10,11 +10,7 @@ This step invokes the `workflow-implementation-task-executor` agent (`../../../a
 
 ## Determine Workflow Reference
 
-Check the work type:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
-```
+Use `work_type` from session context — read once at the task loop's entry (**[task-loop.md](task-loop.md)**), not per invocation.
 
 #### If `work_type` is `quick-fix`
 
@@ -37,9 +33,9 @@ Use **tdd-workflow.md** (`.claude/skills/workflow-implementation-process/referen
 1. **Workflow reference**: the file determined above
 2. **code-quality.md**: `.claude/skills/workflow-implementation-process/references/code-quality.md`
 3. **Specification path**: from the specification (if available)
-4. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} project_skills`)
+4. **Project skill paths**: from session context — the `project_skills` discovered in Step 3 (Project Skills Discovery)
 5. **Task content**: normalised task content (see [task-normalisation.md](task-normalisation.md))
-6. **Linter commands**: from `linters` in the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} linters`) (if configured)
+6. **Linter commands**: from session context — the `linters` configured in Step 4 (Linter Discovery), if any
 
 **Re-attempts after review feedback** additionally include:
 7. **User-approved review notes**: verbatim or as modified by the user

--- a/skills/workflow-implementation-process/references/linter-setup.md
+++ b/skills/workflow-implementation-process/references/linter-setup.md
@@ -24,24 +24,23 @@ Set `source` = `topic`.
 
 #### Otherwise
 
-Check whether a project-level default `linters` exists and read its value via `engine manifest`:
+Read the project-level default `linters` via `engine manifest`:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists project.defaults.linters
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defaults.linters
 ```
 
-**If `false`:**
+**If output is empty (never set):**
 
 → Proceed to **C. Discovery**.
 
-**If `true` and project default is populated:**
+**If output is a populated array:**
 
 Set `source` = `project`.
 
 → Proceed to **B. Confirm Linters**.
 
-**If `true` and project default is empty:**
+**If output is `[]` (previously skipped):**
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -20,6 +20,12 @@ H. Update progress + phase check + commit
 
 **Engine gate sections**: `engine task` responses carry rendered `=== DISPLAY … ===` / `=== MENU … ===` sections after their JSON line — the loop's state-derived gates, parameterised from manifest state. Emit a section only where a stage below prescribes it: DISPLAY verbatim as a code block, MENU verbatim as markdown (not a code block). A section is everything beneath its `===` marker up to the next marker or the end of the response — the marker lines themselves are never emitted. Section content is emitted byte-for-byte — never redrawn, reflowed, or re-derived.
 
+Read `work_type` once here at loop entry — it selects the executor's workflow reference (TDD vs verification) for every task and never changes mid-loop, so **[invoke-executor.md](invoke-executor.md)** consumes it from session context rather than re-reading it per invocation:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
+```
+
 ---
 
 ## A. Retrieve Next Task

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -57,21 +57,23 @@ Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, top
 
 Investigation is always bugfix work_type. Store work_unit for the handoff.
 
-Check if the investigation phase entry exists:
+Read the investigation phase status:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.investigation.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.investigation.{topic} status
 ```
 
-**If exists (`true`):**
+Store the result as `phase_status`.
 
-→ Proceed to **Step 2** (Validate Phase).
-
-**If not exists (`false`):**
+**If empty (no investigation entry):**
 
 Set source="new".
 
 → Proceed to **Step 3** (Gather Bug Context).
+
+**Otherwise (an entry exists):**
+
+→ Proceed to **Step 2** (Validate Phase).
 
 ---
 
@@ -90,7 +92,7 @@ Set source="new".
 > in progress, or completed.
 ```
 
-Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
+Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `{phase_status}`.
 
 #### If source is `continue`
 

--- a/skills/workflow-investigation-entry/references/validate-phase.md
+++ b/skills/workflow-investigation-entry/references/validate-phase.md
@@ -4,11 +4,7 @@
 
 ---
 
-Check investigation status via `engine manifest`:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.investigation.{topic}
-```
+Branch on the `phase_status` the caller read in Step 1 — no re-read.
 
 #### If status is `in-progress`
 

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -49,10 +49,11 @@ Context refresh (compaction) summarizes the conversation, losing procedural deta
 2. **Read all tracking and state files** for the current topic — the planning file (`.workflows/{work_unit}/planning/{topic}/planning.md`), task detail files (`phase-{N}-tasks.md`), task files via the format's reading.md, plan review tracking files (`review-*-tracking-c*.md`), and manifest state. If a task detail file contains `pending` tasks, you are mid-authoring for that phase — resume the approval loop in author-tasks.md.
 3. **Check git state.** Run `git status` and `git log --oneline -10` to see recent commits. Commit messages follow a conventional pattern that reveals what was completed.
 4. **Announce your position** to the user before continuing: what step you believe you're at, what's been completed, and what comes next. Wait for confirmation.
-5. **Check gate modes** via `engine manifest` — if `auto`, the user previously opted in during this session. Preserve these values.
-   - `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_list_gate_mode`
-   - `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} author_gate_mode`
-   - `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} finding_gate_mode`
+5. **Check gate modes** via `engine manifest`:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic}
+   ```
+   Check `task_list_gate_mode`, `author_gate_mode`, and `finding_gate_mode` — if any is `auto`, the user previously opted in during this session. Preserve these values.
 
 Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
 
@@ -96,32 +97,18 @@ Follow every step in sequence. No steps are optional.
 > pick up where you left off or start fresh.
 ```
 
-Check if a planning entry exists in the manifest:
+Read the planning entry from the manifest as one subtree — empty means no entry exists:
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.planning.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic}
 ```
 
-#### If planning entry does not exist
+#### If output is empty (no planning entry)
 
 → Proceed to **Step 1**.
 
-#### If planning entry exists
+#### Otherwise (planning entry exists)
 
-Check the planning status via `engine manifest`:
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} status
-```
-
-Note the current phase and task position from the manifest:
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} phase
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task
-```
-
-Check `spec_commit` from the manifest:
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} spec_commit
-```
+The subtree carries the current `phase` and `task` position (for the resume prompt below) and the `spec_commit` baseline (for spec-change detection).
 
 Load **[spec-change-detection.md](references/spec-change-detection.md)** and follow its instructions as written. Then present the user with an informed choice:
 

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -218,23 +218,15 @@ For each approved task in the task detail file, in order:
 
 1. Read the task content from the task detail file
 2. Write to the output format (format-specific — see the format's **[authoring.md](output-formats/{format}/authoring.md)**)
-3. Record the internal ID → external ID mapping in the manifest:
+3. Record the task's manifest updates in one batched write, all under `{work_unit}.planning.{topic}`:
+   - `task_map.{internal_id}` — this task's external ID
+   - `task` — the next pending task's internal ID (the next phase's position is set by **D. Advance Phase** when this was the phase's last task)
+
+   On the **phase's first task**, fold the once-per-phase phase mapping into the same write — `task_map.{phase_internal_id}` = the phase's external ID (declared in the format's **[authoring.md](output-formats/{format}/authoring.md)** Phase Structure section); it is identical for every task in the phase, so it is written once, not per task. And on the very first task authored for the plan, when the manifest's `external_id` is still empty, also fold in `external_id` = the plan's external identifier as exposed by the output format. Drop each extra field from a task's write once it no longer applies — the phase mapping after the phase's first task, the plan `external_id` once it is set.
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{internal_id} {external_id}
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{internal_id} {external_id} task={next_task_id} task_map.{phase_internal_id}={phase_external_id} external_id={plan_external_id}
    ```
-4. If the manifest's `external_id` is empty, set it to the external identifier for the plan as exposed by the output format:
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} external_id {external_id}
-   ```
-5. Record the phase's internal ID → external ID mapping in the manifest (the external identifier is declared in the format's **[authoring.md](output-formats/{format}/authoring.md)** Phase Structure section):
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{phase_internal_id} {phase_external_id}
-   ```
-6. Advance the manifest planning position to the next pending task (or next phase if this was the last task):
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task {next_task_id}
-   ```
-7. Commit with raw git — the format's task storage may live outside the work unit, so the scoped helper cannot cover it. Stage the format's storage and the work unit, then commit:
+4. Commit with raw git — the format's task storage may live outside the work unit, so the scoped helper cannot cover it. Stage the format's storage and the work unit, then commit:
    ```bash
    git add -- .workflows/{work_unit} {format task storage paths}
    git commit -m "planning({work_unit}): author task {internal_id} ({task name})"

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -48,10 +48,9 @@ Invoke `workflow-planning-phase-designer` with these file paths:
 
 The agent returns phases only — goals, ordering rationale, and acceptance criteria. **Task lists are designed separately in a later step; do not request or include them.** Write the phase structure directly to the planning file body.
 
-Update the manifest planning position:
+Update the manifest planning position — one batched write:
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} phase 1
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task '~'
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} phase 1 task='~'
 ```
 
 Commit:

--- a/skills/workflow-planning-process/references/initialize-plan.md
+++ b/skills/workflow-planning-process/references/initialize-plan.md
@@ -57,18 +57,10 @@ Project default format is **{format}**. Use the same format?
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} planning {topic}
    ```
-4. Set metadata in the manifest:
+4. Set the planning metadata — every same-path field in one batched write, then the project default (a different path, so its own call):
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} format {chosen-format}
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} format {chosen-format} spec_commit={commit-hash} task_list_gate_mode=gated author_gate_mode=gated finding_gate_mode=gated review_cycle=0 phase=1 task='~' task_map='{}'
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.defaults.plan_format {chosen-format}
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} spec_commit {commit-hash}
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_list_gate_mode gated
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} author_gate_mode gated
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} finding_gate_mode gated
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} review_cycle 0
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} phase 1
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task '~'
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map '{}'
    ```
 
 5. Commit — the project default lands in `.workflows/manifest.json`, outside the work unit, so use the whole-tree scope:

--- a/skills/workflow-planning-process/references/invoke-review-integrity.md
+++ b/skills/workflow-planning-process/references/invoke-review-integrity.md
@@ -14,8 +14,8 @@ Invoke `workflow-planning-review-integrity` with:
 
 1. **Review criteria path**: `review-integrity.md` (in this directory)
 2. **Planning file path**: `.workflows/{work_unit}/planning/{topic}/planning.md`
-3. **Format reading.md path**: read `format` from manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format`), then pass **[output-formats/{format}/reading.md](output-formats/{format}/reading.md)**
-4. **Cycle number**: current `review_cycle` from the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} review_cycle`)
+3. **Format reading.md path**: **[output-formats/{format}/reading.md](output-formats/{format}/reading.md)** — `format` is already in session context (read during session setup)
+4. **Cycle number**: the current cycle number `{N}` the caller recorded in **A. Cycle Initialization**
 5. **Topic name**: the topic/work-unit name
 6. **Task design path**: `task-design.md`
 

--- a/skills/workflow-planning-process/references/invoke-review-traceability.md
+++ b/skills/workflow-planning-process/references/invoke-review-traceability.md
@@ -15,8 +15,8 @@ Invoke `workflow-planning-review-traceability` with:
 1. **Review criteria path**: `review-traceability.md` (in this directory)
 2. **Specification path**: `.workflows/{work_unit}/specification/{topic}/specification.md`
 3. **Planning file path**: `.workflows/{work_unit}/planning/{topic}/planning.md`
-4. **Format reading.md path**: read `format` from manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format`), then pass **[output-formats/{format}/reading.md](output-formats/{format}/reading.md)**
-5. **Cycle number**: current `review_cycle` from the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} review_cycle`)
+4. **Format reading.md path**: **[output-formats/{format}/reading.md](output-formats/{format}/reading.md)** — `format` is already in session context (read during session setup)
+5. **Cycle number**: the current cycle number `{N}` the caller recorded in **A. Cycle Initialization**
 6. **Topic name**: the topic/work-unit name
 7. **Task design path**: `task-design.md`
 

--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -148,10 +148,9 @@ Do not advance the manifest position — the phase is unauthored and remains the
 
 ## D. Advance Phase
 
-Advance the manifest planning position to the next phase:
+Advance the manifest planning position to the next phase — one batched write:
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} phase {N+1}
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task '~'
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} phase {N+1} task='~'
 ```
 
 Commit:

--- a/skills/workflow-planning-process/references/session-setup.md
+++ b/skills/workflow-planning-process/references/session-setup.md
@@ -9,11 +9,9 @@
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format
    ```
 2. Load the format's **[about.md](output-formats/{format}/about.md)** and **[authoring.md](output-formats/{format}/authoring.md)**
-3. Reset gate modes to `gated` in the manifest:
+3. Reset gate modes to `gated` in the manifest — one batched write:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_list_gate_mode gated
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} author_gate_mode gated
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} finding_gate_mode gated
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_list_gate_mode gated author_gate_mode=gated finding_gate_mode=gated
    ```
 
 Never touch `spec_commit` here — it is the baseline spec-change detection diffs against, stamped at plan initialization and re-stamped only when the plan concludes.

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -103,19 +103,21 @@ Silently derive `direct_entry_summary` (one-line) and `direct_entry_description`
 
 Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`. On the direct-entry path (no topic supplied as `$2`), also pass summary = `{direct_entry_summary}`, description = `{direct_entry_description}`. When the topic was provided by the caller, omit both — the caller didn't derive them.
 
-Check if the research phase entry exists:
+Read the research phase status:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.research.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{topic} status
 ```
 
-#### If exists (`true`)
+Store the result as `phase_status`.
 
-→ Proceed to **Step 3**.
-
-#### If not exists (`false`)
+#### If output is empty (no research entry)
 
 → Proceed to **Step 4**.
+
+#### Otherwise
+
+→ Proceed to **Step 3**.
 
 ---
 
@@ -134,7 +136,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_uni
 > or completed.
 ```
 
-Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
+Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `{phase_status}`.
 
 → Proceed to **Step 5**.
 

--- a/skills/workflow-research-entry/references/validate-phase.md
+++ b/skills/workflow-research-entry/references/validate-phase.md
@@ -4,11 +4,7 @@
 
 ---
 
-Check research status via `engine manifest`:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{topic} status
-```
+Branch on the `phase_status` the caller read in Step 2 — no re-read.
 
 #### If status is `completed`
 

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -91,13 +91,7 @@ Gather coverage state. Read `completed_tasks` from the implementation manifest:
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} completed_tasks
 ```
 
-Check if `reviewed_tasks` exists in the review manifest:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.review.{topic} reviewed_tasks
-```
-
-If `true`, read it:
+Read `reviewed_tasks` from the review manifest — empty stdout means it was never recorded:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.review.{topic} reviewed_tasks

--- a/skills/workflow-specification-process/references/initialize-specification.md
+++ b/skills/workflow-specification-process/references/initialize-specification.md
@@ -50,13 +50,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 
 ## C. Set Review State
 
-Set review state and gate modes (both branches):
+Set review state and gate modes (both branches) — one batched write, all same-path fields:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} review_cycle 0
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} finding_gate_mode gated
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} construction_gate_mode gated
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} date $(date +%Y-%m-%d)
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} review_cycle 0 finding_gate_mode=gated construction_gate_mode=gated date=$(date +%Y-%m-%d)
 ```
 
 Commit:

--- a/skills/workflow-specification-process/references/session-setup.md
+++ b/skills/workflow-specification-process/references/session-setup.md
@@ -6,11 +6,10 @@
 
 ## Reset Gate Modes
 
-Reset `finding_gate_mode` and `construction_gate_mode` to `gated` via `engine manifest`:
+Reset `finding_gate_mode` and `construction_gate_mode` to `gated` in one batched write:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} finding_gate_mode gated
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} construction_gate_mode gated
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} finding_gate_mode gated construction_gate_mode=gated
 ```
 
 ## Register Consult References

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -99,13 +99,15 @@ Set `topic` to the user's input.
 
 ## D. Research Check
 
-Read the feature's research items with their statuses:
+Read the feature's manifest once as a full dump — sections D, E, and F all derive their values from this single read:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get '{selected.name}.research.*' status
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {selected.name}
 ```
 
-#### If output is empty (no research)
+Take the feature's research items from `phases.research.items`.
+
+#### If there are no research items
 
 Set `has_research` = false.
 
@@ -121,12 +123,7 @@ Set `has_research` = true and `research_item_count` to the number of items. Name
 
 ## E. Imports and Seeds Check
 
-Read the feature's imports and seeds lists:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {selected.name} imports
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {selected.name} seeds
-```
+Take the top-level `imports` and `seeds` arrays from the manifest dump.
 
 Default `has_imports` = `false` / `imports_count` = 0, and `has_seeds` = `false` / `seeds_count` = 0 — then, for each non-empty JSON array, set the flag `true` and the count to its length. Filename collisions in the target epic's directories are resolved by the engine; entries move with their original timestamps and seed provenance.
 
@@ -136,13 +133,7 @@ Default `has_imports` = `false` / `imports_count` = 0, and `has_seeds` = `false`
 
 ## F. Confirm
 
-Read the discussion status:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {selected.name}.discussion.{selected.name} status
-```
-
-Store the result as `discussion_status`.
+Take the discussion item's status (`phases.discussion.items.{selected.name}.status`) from the manifest dump. Store the result as `discussion_status`.
 
 > *Output the next fenced block as a code block:*
 


### PR DESCRIPTION
Twelve verified call-collapses, semantics identical: planning init 10 sets → 2 (batched); spec init and both session-setups batched; author-tasks stops re-recording the phase mapping per task; planning/review Step 0 exists+N-gets → one subtree get; absorb's confirm display 4 gets → one manifest dump; linter-setup and invoke-executor shed per-invocation reads; the plan reviewers take in-context values; all three entry skills read phase status once and hand it to validate-phase. Non-empty branches use Otherwise so every status routes exactly as the old exists-check did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #383
2. #384
3. #385
4. #386
5. #387
6. #388
7. #389
8. #399
9. #400
10. #401
11. #402
12. #403
13. #404
14. #405
15. #406
16. #407
17. #408
18. #409
19. #411
20. #412
21. #413
22. #414
23. #415
24. #416
25. #417
26. #418
27. #419
28. #420
29. #421
30. #422
31. #423
32. #424
33. #425
34. #426
35. #427
36. #428
37. #429
38. #430
39. #431
40. #432
41. #433
42. #434
43. #435
44. #452
45. #453
46. #454
47. #455
48. #456
49. #457
50. #448
51. #449
52. #450
53. #451
54. #458
55. #459
56. #460
57. #461
58. #462
59. #463
60. #464
61. #465
62. #466
63. #467
64. #468
65. #469
66. #470
67. #471
68. #472
69. #473
70. #474
71. **#475** 👈 current
72. #476
73. #477
74. #478
<!-- stack:links:end -->