### PR TITLE
fix(engine): map-less epics surface discovery, not a phantom phase

### DIFF
--- a/skills/workflow-engine/scripts/domain/epic-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/epic-detail.cjs
@@ -115,6 +115,7 @@ const EPIC_DETAIL_PHASES = ['discovery', 'research', 'discussion', 'specificatio
  * @property {string[]} unaccounted_discussions
  * @property {string[]} reopened_discussions
  * @property {MapRow[]} discovery_map
+ * @property {string|null} active_session  in-progress discovery session number, or null
  * @property {string|null} convergence_state  `in-progress` | `settled` | null (no map)
  * @property {boolean} needs_sequencing
  * @property {MapSummary|null} map_summary
@@ -349,6 +350,8 @@ function epicDetail(cwd, manifest) {
     unaccounted_discussions: unaccountedDiscussions,
     reopened_discussions: reopenedDiscussions,
     discovery_map: discoveryMap,
+    active_session: (manifest.phases && manifest.phases.discovery && typeof manifest.phases.discovery.active_session === 'string')
+      ? manifest.phases.discovery.active_session : null,
     convergence_state: convergenceState,
     needs_sequencing: builtMap.needs_sequencing,
     map_summary: mapSummary,

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -272,9 +272,12 @@ function epicDashboard(workUnit, detail, opts = {}) {
   const hasMap = detail.discovery_map.length > 0;
   const phaseNames = Object.keys(detail.phases);
 
-  // Brand-new epic — nothing started anywhere.
+  // Brand-new epic — nothing started anywhere. Point at the one true door.
   if (!hasMap && phaseNames.length === 0) {
-    return box(titlecase(workUnit)) + 'No work started yet.';
+    return box(titlecase(workUnit))
+      + 'No work started yet.\n\n'
+      + flaggedCallout('Run discovery to shape the topic map — research and discussion start from there.')
+      + '\n';
   }
 
   /** @type {string[]} stage blocks, each ending with a single \n */
@@ -463,6 +466,16 @@ function commandOptions(workUnit, detail, hasMap) {
       label: `Analyze / regroup discussions — ${desc}`,
     });
   }
+  // Discovery is reachable in EVERY map state: with a map it refines the
+  // map; without one it is how the map gets built — the map-less epic is the
+  // state that needs the route most, so it leads the menu there.
+  /** @type {MenuKey} */
+  const discoveryOpt = {
+    key: 'i', word: 'discovery', action: 'continue_discovery', topic: null,
+    route: `/workflow-discovery epic ${workUnit}`,
+    label: hasMap ? 'Continue discovery' : 'Run discovery — shape the topic map',
+  };
+  if (!hasMap) opts.push(discoveryOpt);
   opts.push({
     key: 'd', word: 'discuss', action: 'new_discussion', topic: null,
     route: `/workflow-discussion-entry epic ${workUnit}`,
@@ -473,13 +486,7 @@ function commandOptions(workUnit, detail, hasMap) {
     route: `/workflow-research-entry epic ${workUnit}`,
     label: hasMap ? 'Start research on a new topic' : 'Start new research',
   });
-  if (hasMap) {
-    opts.push({
-      key: 'i', word: 'discovery', action: 'continue_discovery', topic: null,
-      route: `/workflow-discovery epic ${workUnit}`,
-      label: 'Continue discovery',
-    });
-  }
+  if (hasMap) opts.push(discoveryOpt);
   if (detail.completed.length > 0) {
     opts.push({ key: 'c', word: 'completed', action: 'resume_completed', topic: null, route: null, label: 'Resume a completed topic' });
   }
@@ -524,6 +531,12 @@ function pickRecommendation(detail, numbered, options, hasMap) {
   }
 
   // No-map branch — recommendation by phase completion state.
+  // Brand-new epic (no phase work at all): discovery is the recommendation.
+  if (Object.values(detail.phases).every((items) => items.length === 0)) {
+    const discoveryOpt = options.find((o) => o.action === 'continue_discovery');
+    if (discoveryOpt) discoveryOpt.recommended = true;
+    return null;
+  }
   const proposedEntry = numbered.find((e) => e.action === 'start_specification');
   if (proposedEntry) return proposedEntry;
 

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -473,8 +473,17 @@ function commandOptions(workUnit, detail, hasMap) {
   const discoveryOpt = {
     key: 'i', word: 'discovery', action: 'continue_discovery', topic: null,
     route: `/workflow-discovery epic ${workUnit}`,
-    label: hasMap ? 'Continue discovery' : 'Run discovery — shape the topic map',
+    // An open session marker outranks map state: the user left a session
+    // mid-flight, and discovery's resume gate is waiting for them.
+    label: detail.active_session
+      ? `Resume the in-progress discovery session (session-${detail.active_session})`
+      : (hasMap ? 'Continue discovery' : 'Run discovery — shape the topic map'),
   };
+  if (detail.active_session && hasMap) {
+    // resume leads even on a populated map; the !hasMap unshift below already
+    // leads for map-less epics
+    opts.push(discoveryOpt);
+  }
   if (!hasMap) opts.push(discoveryOpt);
   opts.push({
     key: 'd', word: 'discuss', action: 'new_discussion', topic: null,
@@ -486,7 +495,7 @@ function commandOptions(workUnit, detail, hasMap) {
     route: `/workflow-research-entry epic ${workUnit}`,
     label: hasMap ? 'Start research on a new topic' : 'Start new research',
   });
-  if (hasMap) opts.push(discoveryOpt);
+  if (hasMap && !detail.active_session) opts.push(discoveryOpt);
   if (detail.completed.length > 0) {
     opts.push({ key: 'c', word: 'completed', action: 'resume_completed', topic: null, route: null, label: 'Resume a completed topic' });
   }
@@ -514,6 +523,13 @@ function liveItems(detail, phase) {
  */
 function pickRecommendation(detail, numbered, options, hasMap) {
   const sOption = options.find((o) => o.action === 'analyze_discussions');
+
+  // An interrupted discovery session outranks every other recommendation —
+  // the user left mid-thought and the resume gate is waiting.
+  if (detail.active_session) {
+    const discoveryOpt = options.find((o) => o.action === 'continue_discovery');
+    if (discoveryOpt) { discoveryOpt.recommended = true; return null; }
+  }
 
   if (hasMap) {
     if (detail.convergence_state === 'in-progress') {

--- a/skills/workflow-engine/scripts/domain/start.cjs
+++ b/skills/workflow-engine/scripts/domain/start.cjs
@@ -230,6 +230,13 @@ function startDetail(cwd) {
         }
       }
       unit.active_phases = activePhases;
+      // An epic with no phase items AND no discovery map is still in
+      // discovery — the pipeline walk (which excludes discovery) would
+      // otherwise report it as ready for its first empty phase.
+      if (activePhases.length === 0 && phaseItems(m, 'discovery').length === 0) {
+        unit.next_phase = 'discovery';
+        unit.phase_label = 'in discovery';
+      }
       epics.push(unit);
     } else if (m.work_type === 'bugfix') {
       bugfixes.push(unit);

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -464,6 +464,14 @@ describe('epic projections: menu', () => {
     assert.ok(rendered.includes('— Continue "Roles" — implementation (Phase 2, 3 task(s) completed)'), rendered);
   });
 
+  it('an open discovery session leads the menu as resume, regardless of map state', () => {
+    const d = detailFor(dir, 'resumable', { work_type: 'epic' });
+    d.active_session = '001';
+    const { keys, rendered } = epicMenu('resumable', d);
+    assert.strictEqual(keys[0].key, 'i');
+    assert.ok(rendered.includes('- **`i`/`discovery`** — Resume the in-progress discovery session (session-001) (recommended)'));
+  });
+
   it('brand-new epic menu leads with recommended discovery', () => {
     const d = detailFor(dir, 'fresh', { work_type: 'epic' });
     const { keys, rendered } = epicMenu('fresh', d);

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -201,7 +201,7 @@ describe('epic projections: dashboard (no-map and brand-new branches)', () => {
     ].join('\n')));
   });
 
-  it('renders the brand-new-epic branch', () => {
+  it('renders the brand-new-epic branch with the discovery callout', () => {
     const d = detailFor(dir, 'fresh-epic', { work_type: 'epic' });
     assert.strictEqual(
       epicDashboard('fresh-epic', d),
@@ -211,6 +211,10 @@ describe('epic projections: dashboard (no-map and brand-new branches)', () => {
         '●───────────────────────────────────────────────●',
         '',
         'No work started yet.',
+        '',
+        '  ⚑ Run discovery to shape the topic map — research and',
+        '    discussion start from there.',
+        '',
       ].join('\n')
     );
   });
@@ -460,14 +464,15 @@ describe('epic projections: menu', () => {
     assert.ok(rendered.includes('— Continue "Roles" — implementation (Phase 2, 3 task(s) completed)'), rendered);
   });
 
-  it('brand-new epic menu offers only the always-present command options', () => {
+  it('brand-new epic menu leads with recommended discovery', () => {
     const d = detailFor(dir, 'fresh', { work_type: 'epic' });
     const { keys, rendered } = epicMenu('fresh', d);
-    assert.deepStrictEqual(keys.map((k) => k.key), ['d', 'r']);
+    assert.deepStrictEqual(keys.map((k) => k.key), ['i', 'd', 'r']);
     assert.strictEqual(rendered, [
       '· · · · · · · · · · · ·',
       'What would you like to do?',
       '',
+      '- **`i`/`discovery`** — Run discovery — shape the topic map (recommended)',
       '- **`d`/`discuss`** — Start new discussion',
       '- **`r`/`research`** — Start new research',
       '',

--- a/tests/scripts/test-engine-start-projections.cjs
+++ b/tests/scripts/test-engine-start-projections.cjs
@@ -141,13 +141,13 @@ describe('start projections: overview', () => {
     assert.ok(out.includes('\nInbox: 1 idea, 2 quick-fixes\n'));
   });
 
-  it('epic with no phase items falls back to its phase label', () => {
+  it('epic with no phase items and no map reports In Discovery', () => {
     createManifest(dir, 'fresh-epic', { work_type: 'epic' });
     assert.strictEqual(startOverview(startDetail(dir)), [
       ...BOX,
       'Epics:',
       '  1. Fresh Epic',
-      '     └─ Ready For Discussion',
+      '     └─ In Discovery',
       '',
     ].join('\n'));
   });


### PR DESCRIPTION
Found live in the first real v0.6.0 session. Three fixes for map-less/interrupted epics:

1. The start overview claimed "Ready For Discussion" for an epic with no phase items — the pipeline walk excludes discovery, so an untouched epic computed its first empty phase as next. Now reports "In Discovery" (pre-existing at v0.5.13 parity).
2. The epic dashboard's `i`/discovery option was gated on `hasMap` — inverted, hiding the discovery route in exactly the state that needs it. Now always present; on a map-less epic it leads with `(recommended)` and the empty dashboard carries a callout.
3. An open discovery session (`active_session` marker) now surfaces on the dashboard: the option reads "Resume the in-progress discovery session (session-NNN)", leads the menu, and outranks every other recommendation regardless of map state. Previously discovery's resume gate was armed but unreachable — the interrupted session was invisible from the dashboard.

Honest history: an earlier version of this PR's narrative claimed the live project's session marker had been destroyed by a manual rename — that was wrong (a filtered jq query hid the field); the marker was intact all along, which is precisely why fix 3 matters: reachability was the only thing missing. Verified against the live project's copied state; four tests updated/added; full suite green (1445).

🤖 Generated with [Claude Code](https://claude.com/claude-code)