### PR TITLE
fix(skills): load-directive footers state the return condition

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -440,7 +440,7 @@ Decompose these steps into **sub-steps** using H3 decimal numbering:
 
 ### Step 0.1: Casing Conventions
 Load **[casing-conventions.md](...)** and follow its instructions as written.
-→ Proceed to **Step 0.2**.
+→ On return, proceed to **Step 0.2**.
 
 ### Step 0.2: Boot
 
@@ -640,7 +640,7 @@ Step 0: Run Migrations (always inline)
 ---
 Step 1: {Name}
 Load directive → reference file
-→ Proceed to Step 2.
+→ On return, proceed to Step 2.
 ---
 Step 2: {Name}
 Load directive → reference file
@@ -657,14 +657,15 @@ Load directive → reference file
 
 Load **[name.md](references/name.md)** and follow its instructions as written.
 
-→ Proceed to **Step N+1**.
+→ On return, proceed to **Step N+1**.
 ```
 
 Rules:
 - No arrow (`→`) before the Load line — it's the step's content, not a routing instruction
 - Bold the markdown link: `**[name.md](path)**`
-- `→ Proceed to` appears after the Load directive, separated by a blank line
-- The final step has no `→ Proceed to` (it's terminal)
+- `→ On return, proceed to` is the footer after a Load directive, separated by a blank line — the loaded reference runs to completion (its STOP gates and loops included) before the proceed applies. A bare `→ Proceed to` here reads as the immediate next action and overshoots the reference
+- When a `**STOP.**` gate or a bold conditional sits between the Load directive and the routing line, the routing is keyed to the user's response or the branch, not the return — those use the bare `→ Proceed to`
+- The final step has no routing footer (it's terminal)
 - Within reference files routing to other reference files, use `→` before Load (it IS a routing instruction in that context)
 
 **Parameter passing**: When a shared reference needs context from the caller, append `with` followed by named assignments. String literals and variable values are both backtick-wrapped; variables use curly brace placeholders:
@@ -704,6 +705,7 @@ No other verbs — never `→ Go to`, `→ Jump to`, `→ Skip to`, `→ Continu
 |---|---|
 | `→ Proceed to **Step N**.` | Next step in the backbone |
 | `→ Proceed to **B. Section Name**.` | Next lettered section in a reference file |
+| `→ On return, proceed to **Step N**.` | Footer after a Load directive — applies when the loaded reference returns (see Load Directive Format) |
 
 
 #### Backward (within a file)

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -44,7 +44,7 @@ node .claude/skills/workflow-continue-epic/scripts/gateway.cjs {work_unit}
 
 Hold the refreshed output as the most recent discovery output for the remaining sections.
 
-→ Proceed to **D. Check All-Done**.
+→ On return, proceed to **D. Check All-Done**.
 
 #### Otherwise
 
@@ -109,7 +109,7 @@ Epic Completed
 
 > **CHECKPOINT**: Do not proceed until the above has returned with the user's selection.
 
-→ Proceed to **F. Enter Plan Mode**.
+→ On return, proceed to **F. Enter Plan Mode**.
 
 ---
 

--- a/skills/workflow-continue-bugfix/SKILL.md
+++ b/skills/workflow-continue-bugfix/SKILL.md
@@ -50,7 +50,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
-→ Proceed to **Step 1**.
+→ On return, proceed to **Step 1**.
 
 ---
 
@@ -150,7 +150,7 @@ Store the work_unit.
 
 Load **[select-bugfix.md](references/select-bugfix.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -170,7 +170,7 @@ Load **[select-bugfix.md](references/select-bugfix.md)** and follow its instruct
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -190,7 +190,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 Load **[bugfix-display-and-menu.md](references/bugfix-display-and-menu.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 

--- a/skills/workflow-continue-cross-cutting/SKILL.md
+++ b/skills/workflow-continue-cross-cutting/SKILL.md
@@ -50,7 +50,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
-→ Proceed to **Step 1**.
+→ On return, proceed to **Step 1**.
 
 ---
 
@@ -150,7 +150,7 @@ Store the work_unit.
 
 Load **[select-cross-cutting.md](references/select-cross-cutting.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -170,7 +170,7 @@ Load **[select-cross-cutting.md](references/select-cross-cutting.md)** and follo
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -190,7 +190,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 Load **[cross-cutting-display-and-menu.md](references/cross-cutting-display-and-menu.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -50,7 +50,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
-→ Proceed to **Step 1**.
+→ On return, proceed to **Step 1**.
 
 ---
 
@@ -150,7 +150,7 @@ Store the work_unit.
 
 Load **[select-epic.md](references/select-epic.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -170,7 +170,7 @@ Load **[select-epic.md](references/select-epic.md)** and follow its instructions
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -228,7 +228,7 @@ Read `analysis_caches` from the most recent discovery output. Load **[topic-disc
 
 On return, `new_arrivals` is populated for Step 8 to render the callout.
 
-→ Proceed to **Step 7**.
+→ On return, proceed to **Step 7**.
 
 ---
 
@@ -258,7 +258,7 @@ On return, re-run discovery so the display sees the new order:
 node .claude/skills/workflow-continue-epic/scripts/gateway.cjs {work_unit}
 ```
 
-→ Proceed to **Step 8**.
+→ On return, proceed to **Step 8**.
 
 #### Otherwise
 
@@ -284,7 +284,7 @@ The map is already sequenced.
 
 Load **[epic-display-and-menu.md](references/epic-display-and-menu.md)** with new_arrivals = `{new_arrivals}`.
 
-→ Proceed to **Step 9**.
+→ On return, proceed to **Step 9**.
 
 ---
 

--- a/skills/workflow-continue-epic/references/backfill-checks.md
+++ b/skills/workflow-continue-epic/references/backfill-checks.md
@@ -38,7 +38,7 @@ Re-filter `discovery_map` for rows where `summary=absent` or `description=absent
 
 Load **[summary-backfill.md](summary-backfill.md)** with work_unit = `{work_unit}`, items_to_recover = `{items_to_recover}`.
 
-→ Proceed to **C. Advise Restart**.
+→ On return, proceed to **C. Advise Restart**.
 
 #### If `items_to_recover` is empty
 

--- a/skills/workflow-continue-feature/SKILL.md
+++ b/skills/workflow-continue-feature/SKILL.md
@@ -50,7 +50,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
-→ Proceed to **Step 1**.
+→ On return, proceed to **Step 1**.
 
 ---
 
@@ -150,7 +150,7 @@ Store the work_unit.
 
 Load **[select-feature.md](references/select-feature.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -170,7 +170,7 @@ Load **[select-feature.md](references/select-feature.md)** and follow its instru
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -190,7 +190,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 Load **[feature-display-and-menu.md](references/feature-display-and-menu.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 

--- a/skills/workflow-continue-quickfix/SKILL.md
+++ b/skills/workflow-continue-quickfix/SKILL.md
@@ -50,7 +50,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
-→ Proceed to **Step 1**.
+→ On return, proceed to **Step 1**.
 
 ---
 
@@ -150,7 +150,7 @@ Store the work_unit.
 
 Load **[select-quickfix.md](references/select-quickfix.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -170,7 +170,7 @@ Load **[select-quickfix.md](references/select-quickfix.md)** and follow its inst
 
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -190,7 +190,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 Load **[quickfix-display-and-menu.md](references/quickfix-display-and-menu.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 

--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -113,7 +113,7 @@ New work — nothing is on disk yet; pre-confirmation shaping is ephemeral.
 
 Load **[detection-core.md](references/detection-core.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -134,7 +134,7 @@ Load **[detection-core.md](references/detection-core.md)** and follow its instru
 
 Load **[opener-pattern.md](references/opener-pattern.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -155,7 +155,7 @@ Load **[opener-pattern.md](references/opener-pattern.md)** and follow its instru
 
 Load **[shape-and-confirm.md](references/shape-and-confirm.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -195,7 +195,7 @@ Load **[confirm-trigger.md](references/confirm-trigger.md)** and follow its inst
 
 Load **[resume-detection.md](references/resume-detection.md)** and follow its instructions as written.
 
-→ Proceed to **Step 7**.
+→ On return, proceed to **Step 7**.
 
 ---
 
@@ -255,7 +255,7 @@ If `session_number` was not already set (no resume at Step 6, no `macro_continua
 
 Load **[initialize-discovery.md](references/initialize-discovery.md)** and follow its instructions as written.
 
-→ Proceed to **Step 9**.
+→ On return, proceed to **Step 9**.
 
 ---
 
@@ -276,7 +276,7 @@ Load **[initialize-discovery.md](references/initialize-discovery.md)** and follo
 
 Load **[discovery-guidelines.md](references/discovery-guidelines.md)** and follow its instructions as written.
 
-→ Proceed to **Step 10**.
+→ On return, proceed to **Step 10**.
 
 ---
 
@@ -298,7 +298,7 @@ Load **[discovery-guidelines.md](references/discovery-guidelines.md)** and follo
 
 Load **[session-loop.md](references/session-loop.md)** and follow its instructions as written.
 
-→ Proceed to **Step 11**.
+→ On return, proceed to **Step 11**.
 
 ---
 
@@ -320,7 +320,7 @@ Load **[session-loop.md](references/session-loop.md)** and follow its instructio
 
 Load **[document-review.md](references/document-review.md)** and follow its instructions as written.
 
-→ Proceed to **Step 12**.
+→ On return, proceed to **Step 12**.
 
 ---
 
@@ -341,7 +341,7 @@ Load **[document-review.md](references/document-review.md)** and follow its inst
 
 Load **[confirm-and-persist.md](references/confirm-and-persist.md)** and follow its instructions as written.
 
-→ Proceed to **Step 14**.
+→ On return, proceed to **Step 14**.
 
 ---
 
@@ -365,7 +365,7 @@ Reached only for single-phase work — feature, cross-cutting, bugfix, quick-fix
 
 Load **[first-phase-routing.md](references/first-phase-routing.md)** and follow its instructions as written.
 
-→ Proceed to **Step 14**.
+→ On return, proceed to **Step 14**.
 
 ---
 
@@ -388,7 +388,7 @@ Reached before concluding by both paths — the epic topic path from Step 12, th
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 15**.
+→ On return, proceed to **Step 15**.
 
 ---
 

--- a/skills/workflow-discovery/references/confirm-trigger.md
+++ b/skills/workflow-discovery/references/confirm-trigger.md
@@ -12,7 +12,7 @@ Inputs held from earlier steps: committed `work_type`, shaped one-line `descript
 
 Load **[name-resolution.md](name-resolution.md)** and follow its instructions as written. On return, `work_unit` is confirmed and collision-free.
 
-→ Proceed to **B. Author the Session Log**.
+→ On return, proceed to **B. Author the Session Log**.
 
 ## B. Author the Session Log
 

--- a/skills/workflow-discovery/references/map-operations.md
+++ b/skills/workflow-discovery/references/map-operations.md
@@ -114,7 +114,7 @@ Branch on `result`:
 - `matches-dismissed` — allowed. A Rename target that matches a dismissed name leaves the dismissed entry alone; the new active item simply exists alongside it as historical record.
 - `ok` — proceed.
 
-→ Proceed to **C. Apply**.
+→ On return, proceed to **C. Apply**.
 
 ## C. Apply
 

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -149,7 +149,7 @@ No fixed cadence — follow the conversation, not a checklist. **The loop is the
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): exploration notes — session-{session_number:03d}"
    ```
 
-→ Proceed to **C. Harvest** when the user pulls the harvest (a harvest pull recognised in step 2). Otherwise loop within **B** — convergence (step 4) cues the nudge but stays in the loop.
+→ On return, proceed to **C. Harvest** when the user pulls the harvest (a harvest pull recognised in step 2). Otherwise loop within **B** — convergence (step 4) cues the nudge but stays in the loop.
 
 ## C. Harvest
 

--- a/skills/workflow-discovery/references/topic-synthesis.md
+++ b/skills/workflow-discovery/references/topic-synthesis.md
@@ -54,7 +54,7 @@ Every candidate folded into an existing map item, or the exploration surfaced no
 
 For each topic in the synthesised set, propose `research` or `discussion` based on cues from how the user framed it during exploration. The proposal is tentative — the user can flip it at the confirmation gate in **E**.
 
-→ Proceed to **E. Render Proposal**.
+→ On return, proceed to **E. Render Proposal**.
 
 ## E. Render Proposal
 

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -77,11 +77,11 @@ Set `source = "topic-provided"`.
 
 Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
 
-→ Proceed to **Step 3** (Gather Context).
+→ On return, proceed to **Step 3** (Gather Context).
 
 **Otherwise (an entry exists):**
 
-→ Proceed to **Step 2** (Validate Phase).
+→ On return, proceed to **Step 2** (Validate Phase).
 
 #### If no `topic`
 
@@ -128,7 +128,7 @@ Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery
 
 Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `{phase_status}`.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -176,7 +176,7 @@ No usable carrier — the log is missing or has no **Exploration**. Gather conte
 
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 #### If `work_type` is `epic`
 
@@ -192,7 +192,7 @@ The topic was started fresh, not shaped on the map — there is no curated carri
 
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 **Otherwise:**
 
@@ -202,7 +202,7 @@ Load **[read-brief-context.md](../workflow-shared/references/read-brief-context.
 
 Do not re-ask; live conversation context, when present, supplements the carrier.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -103,7 +103,7 @@ Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)*
 
 Load **[initialize-discussion.md](references/initialize-discussion.md)** and follow its instructions as written.
 
-→ Proceed to **Step 2**.
+→ On return, proceed to **Step 2**.
 
 ---
 
@@ -124,7 +124,7 @@ Load **[initialize-discussion.md](references/initialize-discussion.md)** and fol
 
 Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -145,7 +145,7 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -166,7 +166,7 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 
 Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -192,7 +192,7 @@ Load **[discussion-session.md](references/discussion-session.md)** and follow it
 
 *Knowledge-base nudge — before committing to a direction on a new subtopic, or when a decision might echo one made elsewhere, run a quick query. See **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)**.*
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 
@@ -213,7 +213,7 @@ Load **[discussion-session.md](references/discussion-session.md)** and follow it
 
 Load **[final-review.md](references/final-review.md)** and follow its instructions as written.
 
-→ Proceed to **Step 7**.
+→ On return, proceed to **Step 7**.
 
 ---
 
@@ -234,7 +234,7 @@ Load **[final-review.md](references/final-review.md)** and follow its instructio
 
 Load **[document-review.md](references/document-review.md)** and follow its instructions as written.
 
-→ Proceed to **Step 8**.
+→ On return, proceed to **Step 8**.
 
 ---
 
@@ -254,7 +254,7 @@ Load **[document-review.md](references/document-review.md)** and follow its inst
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 9**.
+→ On return, proceed to **Step 9**.
 
 ---
 

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -144,7 +144,7 @@ When the agent returns:
 
 → Load **[final-review-menu.md](../../workflow-shared/references/final-review-menu.md)** with cache_dir = `.workflows/.cache/{work_unit}/discussion/{topic}`, cache_glob = `review-*.md`, findings_key = `findings`.
 
-→ Proceed to **D. Route Next**.
+→ On return, proceed to **D. Route Next**.
 
 ---
 

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -83,7 +83,7 @@ Store work_unit for the handoff.
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -104,7 +104,7 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 Load **[validate-dependencies.md](references/validate-dependencies.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -125,7 +125,7 @@ Load **[validate-dependencies.md](references/validate-dependencies.md)** and fol
 
 Load **[environment-check.md](references/environment-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -122,7 +122,7 @@ Found existing implementation for "{topic:(titlecase)}". Resuming from previous 
 
 Load **[environment-setup.md](references/environment-setup.md)** and follow its instructions as written.
 
-→ Proceed to **Step 2**.
+→ On return, proceed to **Step 2**.
 
 ---
 
@@ -143,7 +143,7 @@ Load **[environment-setup.md](references/environment-setup.md)** and follow its 
 
 Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -164,7 +164,7 @@ Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its 
 
 Load **[project-skills-discovery.md](references/project-skills-discovery.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -185,7 +185,7 @@ Load **[project-skills-discovery.md](references/project-skills-discovery.md)** a
 
 Load **[linter-setup.md](references/linter-setup.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -208,7 +208,7 @@ Load **[linter-setup.md](references/linter-setup.md)** and follow its instructio
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 
@@ -290,7 +290,7 @@ Load **[analysis-loop.md](references/analysis-loop.md)** and follow its instruct
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 9**.
+→ On return, proceed to **Step 9**.
 
 ---
 

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -200,7 +200,7 @@ Notes (non-blocking):
 {NOTES from reviewer}
 ```
 
-→ Proceed to **F. Fix Approval Gate**.
+→ On return, proceed to **F. Fix Approval Gate**.
 
 #### If the response's `threshold_reached` is `false`
 

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -135,7 +135,7 @@ Starting investigation: {work_unit:(titlecase)}
 
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -117,7 +117,7 @@ Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)*
 
 Load **[initialize-investigation.md](references/initialize-investigation.md)** and follow its instructions as written.
 
-→ Proceed to **Step 2**.
+→ On return, proceed to **Step 2**.
 
 ---
 
@@ -138,7 +138,7 @@ Load **[initialize-investigation.md](references/initialize-investigation.md)** a
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -163,7 +163,7 @@ Document symptoms in the investigation file as you gather them. Commit after eac
 
 When symptoms are sufficiently understood to begin code analysis:
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -184,7 +184,7 @@ When symptoms are sufficiently understood to begin code analysis:
 
 Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -207,7 +207,7 @@ Load **[analysis-patterns.md](references/analysis-patterns.md)** and use its tec
 
 Document findings in the investigation file as you analyze. Commit after each significant finding.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 
@@ -258,7 +258,7 @@ Document in the investigation file and commit.
 
 Load **[synthesis-agent.md](references/synthesis-agent.md)** and follow its instructions as written.
 
-→ Proceed to **Step 8**.
+→ On return, proceed to **Step 8**.
 
 ---
 
@@ -279,7 +279,7 @@ Load **[synthesis-agent.md](references/synthesis-agent.md)** and follow its inst
 
 Load **[findings-review.md](references/findings-review.md)** and follow its instructions as written.
 
-→ Proceed to **Step 9**.
+→ On return, proceed to **Step 9**.
 
 ---
 
@@ -299,7 +299,7 @@ Load **[findings-review.md](references/findings-review.md)** and follow its inst
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 10**.
+→ On return, proceed to **Step 10**.
 
 ---
 

--- a/skills/workflow-legacy-research-split/SKILL.md
+++ b/skills/workflow-legacy-research-split/SKILL.md
@@ -139,7 +139,7 @@ Qualifying source files (in-progress, migration-seeded):
 
 Load **[dialog.md](references/dialog.md)** and follow its instructions as written. dialog.md drives the per-source iteration until `remaining` is empty, updating counters on each outcome.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 

--- a/skills/workflow-legacy-research-split/references/dialog.md
+++ b/skills/workflow-legacy-research-split/references/dialog.md
@@ -64,7 +64,7 @@ For each candidate theme, build a tentative entry:
 
 Hold these in working memory. Do NOT write any cache files yet.
 
-→ Proceed to **D. Confirm Theme List**.
+→ On return, proceed to **D. Confirm Theme List**.
 
 ## D. Confirm Theme List
 

--- a/skills/workflow-planning-entry/SKILL.md
+++ b/skills/workflow-planning-entry/SKILL.md
@@ -82,7 +82,7 @@ Store work_unit for the handoff.
 
 Load **[validate-spec.md](references/validate-spec.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -130,7 +130,7 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -176,7 +176,7 @@ If spec-change-detection reported changes, carry them into the walkthrough: reco
 
 Load **[initialize-plan.md](references/initialize-plan.md)** and follow its instructions as written.
 
-→ Proceed to **Step 2**.
+→ On return, proceed to **Step 2**.
 
 ---
 
@@ -197,7 +197,7 @@ Load **[initialize-plan.md](references/initialize-plan.md)** and follow its inst
 
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -219,7 +219,7 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 
 Load **[planning-principles.md](references/planning-principles.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -241,7 +241,7 @@ Load **[planning-principles.md](references/planning-principles.md)** and follow 
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -262,7 +262,7 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 
@@ -284,7 +284,7 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 Load **[plan-construction.md](references/plan-construction.md)** and follow its instructions as written.
 
-→ Proceed to **Step 7**.
+→ On return, proceed to **Step 7**.
 
 ---
 
@@ -305,7 +305,7 @@ Load **[plan-construction.md](references/plan-construction.md)** and follow its 
 
 Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow its instructions as written.
 
-→ Proceed to **Step 8**.
+→ On return, proceed to **Step 8**.
 
 ---
 
@@ -332,7 +332,7 @@ Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow it
 
 Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follow its instructions as written.
 
-→ Proceed to **Step 9**.
+→ On return, proceed to **Step 9**.
 
 ---
 
@@ -354,7 +354,7 @@ Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follo
 
 Load **[plan-review.md](references/plan-review.md)** and follow its instructions as written.
 
-→ Proceed to **Step 10**.
+→ On return, proceed to **Step 10**.
 
 ---
 
@@ -374,7 +374,7 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 11**.
+→ On return, proceed to **Step 11**.
 
 ---
 

--- a/skills/workflow-planning-process/references/initialize-plan.md
+++ b/skills/workflow-planning-process/references/initialize-plan.md
@@ -45,7 +45,7 @@ Project default format is **{format}**. Use the same format?
 
 → Load **[output-formats.md](output-formats.md)** and follow its instructions as written.
 
-→ Proceed to **C. Register Plan**.
+→ On return, proceed to **C. Register Plan**.
 
 ---
 

--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -32,7 +32,7 @@ and designing or authoring anything still pending. You'll approve at
 every stage.
 ```
 
-→ Proceed to **B. Process Current Phase**.
+→ On return, proceed to **B. Process Current Phase**.
 
 ---
 
@@ -49,7 +49,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 → Load **[define-tasks.md](define-tasks.md)** and follow its instructions as written.
 
-→ Proceed to **C. Author Phase Tasks**.
+→ On return, proceed to **C. Author Phase Tasks**.
 
 #### If the phase has a task table and `task_list_gate_mode` is `auto`
 
@@ -97,7 +97,7 @@ Approve this task list?
 
 → Load **[define-tasks.md](define-tasks.md)** and follow its instructions as written.
 
-→ Proceed to **C. Author Phase Tasks**.
+→ On return, proceed to **C. Author Phase Tasks**.
 
 **If the user navigates:**
 

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -97,7 +97,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "pl
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
 
-→ Proceed to **D. Plan Integrity Review**.
+→ On return, proceed to **D. Plan Integrity Review**.
 
 ---
 
@@ -115,7 +115,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "pl
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
 
-→ Proceed to **E. Re-Loop Prompt**.
+→ On return, proceed to **E. Re-Loop Prompt**.
 
 ---
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -138,7 +138,7 @@ Store the result as `phase_status`.
 
 Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `{phase_status}`.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -178,7 +178,7 @@ No usable carrier — the log is missing or has no **Exploration**. Gather conte
 
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 #### If `work_type` is `epic`
 
@@ -194,7 +194,7 @@ The topic was started fresh, not shaped on the map — there is no curated carri
 
 Load **[gather-context.md](references/gather-context.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 **Otherwise:**
 
@@ -204,7 +204,7 @@ Load **[read-brief-context.md](../workflow-shared/references/read-brief-context.
 
 Do not re-ask; live conversation context, when present, supplements the carrier.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -96,7 +96,7 @@ Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)*
 
 Load **[initialize-research.md](references/initialize-research.md)** and follow its instructions as written.
 
-→ Proceed to **Step 2**.
+→ On return, proceed to **Step 2**.
 
 ---
 
@@ -117,7 +117,7 @@ Load **[initialize-research.md](references/initialize-research.md)** and follow 
 
 Load **[file-strategy.md](references/file-strategy.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -138,7 +138,7 @@ Load **[file-strategy.md](references/file-strategy.md)** and follow its instruct
 
 Load **[research-guidelines.md](references/research-guidelines.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -159,7 +159,7 @@ Load **[research-guidelines.md](references/research-guidelines.md)** and follow 
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -180,7 +180,7 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 
 Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -144,7 +144,7 @@ When the agent returns:
 
 → Load **[final-review-menu.md](../../workflow-shared/references/final-review-menu.md)** with cache_dir = `.workflows/.cache/{work_unit}/research/{topic}`, cache_glob = `review-*.md`, findings_key = `findings`.
 
-→ Proceed to **D. Route Next**.
+→ On return, proceed to **D. Route Next**.
 
 ---
 

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -83,7 +83,7 @@ Store work_unit for the handoff.
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -220,7 +220,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} r
 
 Load **[read-plans.md](references/read-plans.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -241,7 +241,7 @@ Load **[read-plans.md](references/read-plans.md)** and follow its instructions a
 
 Load **[load-project-skills.md](references/load-project-skills.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -264,7 +264,7 @@ Load **[load-project-skills.md](references/load-project-skills.md)** and follow 
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -288,7 +288,7 @@ Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and fol
 
 *Knowledge-base nudge — use only for cross-work-unit consistency checks ("does this mirror how similar decisions were made elsewhere?"). Consistency with the current spec is already in scope — no KB needed. See **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)**.*
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 
@@ -309,7 +309,7 @@ Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and fol
 
 Load **[produce-review.md](references/produce-review.md)** and follow its instructions as written.
 
-→ Proceed to **Step 7**.
+→ On return, proceed to **Step 7**.
 
 ---
 
@@ -330,7 +330,7 @@ Load **[produce-review.md](references/produce-review.md)** and follow its instru
 
 Load **[present-review.md](references/present-review.md)** and follow its instructions as written.
 
-→ Proceed to **Step 8**.
+→ On return, proceed to **Step 8**.
 
 ---
 
@@ -350,7 +350,7 @@ Load **[present-review.md](references/present-review.md)** and follow its instru
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 9**.
+→ On return, proceed to **Step 9**.
 
 ---
 

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -358,7 +358,7 @@ git add -- .workflows/{work_unit} {format task storage paths}
 git commit -m "review({work_unit}): add review remediation ({K} tasks)"
 ```
 
-→ Proceed to **G. Re-open Implementation**.
+→ On return, proceed to **G. Re-open Implementation**.
 
 ---
 

--- a/skills/workflow-scoping-entry/SKILL.md
+++ b/skills/workflow-scoping-entry/SKILL.md
@@ -79,7 +79,7 @@ Store work_unit for the handoff.
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -232,7 +232,7 @@ Apply the requested edits — the spec and `planning.md` directly, task file con
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
-→ Proceed to **Step 2**.
+→ On return, proceed to **Step 2**.
 
 ---
 
@@ -255,7 +255,7 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 
 *Knowledge-base nudge — if the change touches an area with prior discussions, investigations, or specs, query the knowledge base while gathering context. A "mechanical change" often has a history. See **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)**.*
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -276,7 +276,7 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 
 Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -297,7 +297,7 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 
 Load **[complexity-check.md](references/complexity-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -318,7 +318,7 @@ Load **[complexity-check.md](references/complexity-check.md)** and follow its in
 
 Load **[write-specification.md](references/write-specification.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 
@@ -338,7 +338,7 @@ Load **[write-specification.md](references/write-specification.md)** and follow 
 
 Load **[select-format.md](references/select-format.md)** and follow its instructions as written.
 
-→ Proceed to **Step 7**.
+→ On return, proceed to **Step 7**.
 
 ---
 
@@ -359,7 +359,7 @@ Load **[select-format.md](references/select-format.md)** and follow its instruct
 
 Load **[write-tasks.md](references/write-tasks.md)** and follow its instructions as written.
 
-→ Proceed to **Step 8**.
+→ On return, proceed to **Step 8**.
 
 ---
 

--- a/skills/workflow-shared/references/discovery-gap-analysis.md
+++ b/skills/workflow-shared/references/discovery-gap-analysis.md
@@ -78,7 +78,7 @@ Assign each candidate a `routing` value.
 
 A single analysis may emit a mix of routings — apply the criteria per candidate.
 
-→ Proceed to **D. Filter and Stage**.
+→ On return, proceed to **D. Filter and Stage**.
 
 ## D. Filter and Stage
 

--- a/skills/workflow-shared/references/research-analysis.md
+++ b/skills/workflow-shared/references/research-analysis.md
@@ -52,7 +52,7 @@ Assign each candidate a `routing` value.
 
 A single analysis may emit a mix of routings — apply the criteria per candidate.
 
-→ Proceed to **C. Anchor to Existing Discussions**.
+→ On return, proceed to **C. Anchor to Existing Discussions**.
 
 ## C. Anchor to Existing Discussions
 

--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -77,7 +77,7 @@ Stamp the cache (a decline-all pass still stamps, so the analysis won't re-fire)
 
 → Load **[research-analysis.md](research-analysis.md)** for **E. Update Cache** and follow its instructions. When it returns:
 
-→ Proceed to **C. Run Gap Analysis if Stale**.
+→ On return, proceed to **C. Run Gap Analysis if Stale**.
 
 **If `gate_outcome` is `deferred`:**
 
@@ -117,7 +117,7 @@ Stamp the cache (a decline-all pass still stamps, so the analysis won't re-fire)
 
 → Load **[discovery-gap-analysis.md](discovery-gap-analysis.md)** for **E. Update Cache** and follow its instructions. When it returns:
 
-→ Proceed to **D. Dedupe Sources**.
+→ On return, proceed to **D. Dedupe Sources**.
 
 **If `gate_outcome` is `deferred`:**
 

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -105,7 +105,7 @@ A section is everything beneath its `===` marker up to the next marker — the m
 
 Load **[validate-source.md](references/validate-source.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -126,7 +126,7 @@ Load **[validate-source.md](references/validate-source.md)** and follow its inst
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -166,7 +166,7 @@ Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructio
 
 Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -121,7 +121,7 @@ Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)*
 
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
 
-→ Proceed to **Step 2**.
+→ On return, proceed to **Step 2**.
 
 ---
 
@@ -142,7 +142,7 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 Load **[initialize-specification.md](references/initialize-specification.md)** and follow its instructions as written.
 
-→ Proceed to **Step 3**.
+→ On return, proceed to **Step 3**.
 
 ---
 
@@ -164,7 +164,7 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
 
-→ Proceed to **Step 4**.
+→ On return, proceed to **Step 4**.
 
 ---
 
@@ -185,7 +185,7 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 
 Load **[specification-principles.md](references/specification-principles.md)** and follow its instructions as written.
 
-→ Proceed to **Step 5**.
+→ On return, proceed to **Step 5**.
 
 ---
 
@@ -207,7 +207,7 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 
 Load **[spec-construction.md](references/spec-construction.md)** and follow its instructions as written.
 
-→ Proceed to **Step 6**.
+→ On return, proceed to **Step 6**.
 
 ---
 
@@ -234,7 +234,7 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 
 Load **[dependencies.md](references/dependencies.md)** and follow its instructions as written.
 
-→ Proceed to **Step 7**.
+→ On return, proceed to **Step 7**.
 
 ---
 
@@ -256,7 +256,7 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 
 Load **[spec-review.md](references/spec-review.md)** and follow its instructions as written.
 
-→ Proceed to **Step 8**.
+→ On return, proceed to **Step 8**.
 
 ---
 
@@ -277,7 +277,7 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
-→ Proceed to **Step 9**.
+→ On return, proceed to **Step 9**.
 
 ---
 

--- a/skills/workflow-specification-process/references/initialize-specification.md
+++ b/skills/workflow-specification-process/references/initialize-specification.md
@@ -12,7 +12,7 @@ Create the file at `.workflows/{work_unit}/specification/{topic}/specification.m
 
 Write the file **before** any manifest change. If a crash interrupts here the item stays `proposed` with a file on disk — the resume path recovers it on the next run via restart.
 
-→ Proceed to **B. Register or Flip the Item**.
+→ On return, proceed to **B. Register or Flip the Item**.
 
 ---
 

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -120,7 +120,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "sp
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
 
-→ Proceed to **D. Phase 2 — Gap Analysis**.
+→ On return, proceed to **D. Phase 2 — Gap Analysis**.
 
 ---
 
@@ -147,7 +147,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "sp
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
 
-→ Proceed to **E. Re-Loop Prompt**.
+→ On return, proceed to **E. Re-Loop Prompt**.
 
 ---
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -64,7 +64,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
-→ Proceed to **Step 0.2**.
+→ On return, proceed to **Step 0.2**.
 
 ### Step 0.2: Boot
 

--- a/skills/workflow-start/references/view-plan.md
+++ b/skills/workflow-start/references/view-plan.md
@@ -55,7 +55,7 @@ Use `external_id` as the plan-level parent identifier when following the format 
 
 → Load **[reading.md](../../workflow-planning-process/references/output-formats/{format}/reading.md)** and follow its instructions as written.
 
-→ Proceed to **C. Display Summary**.
+→ On return, proceed to **C. Display Summary**.
 
 ---
 

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -249,7 +249,7 @@ function checkBannedNav(files) {
 
 function checkRouting(files) {
   const out = [];
-  const routeRe = /→\s*(?:Proceed to|Return to)\s+\*\*([^*]+)\*\*/g;
+  const routeRe = /→\s*(?:Proceed to|On return, proceed to|Return to)\s+\*\*([^*]+)\*\*/g;
   for (const file of files) {
     const lines = readLines(file);
     // Headings are collected from every line (not fence-filtered): a heading
@@ -423,6 +423,44 @@ function checkAttribution(files) {
 }
 
 // ---------------------------------------------------------------------------
+// Check 11 — Load-directive footers state the return condition. Within a
+// heading-delimited segment (fences excluded), a Load **[...]** directive
+// followed by a bare "→ Proceed to **" footer must use the conditional
+// "→ On return, proceed to **" form — the bare form reads as the immediate
+// next action and overshoots the reference. An intervening **STOP.** gate or
+// bold conditional breaks the seam: the routing there is keyed to the user's
+// response or a sibling branch, so the bare form is sanctioned.
+// ---------------------------------------------------------------------------
+
+function checkLoadFooters(files) {
+  const out = [];
+  for (const file of files) {
+    const lines = readLines(file);
+    const { inFence } = parseFences(lines);
+    let loadSeen = false;
+    lines.forEach((line, i) => {
+      if (inFence[i] || /^\s*```/.test(line)) return;
+      if (/^#{1,6}\s/.test(line) || /\*\*STOP\.\*\*/.test(line) || /^\*\*If /.test(line)) {
+        loadSeen = false;
+        return;
+      }
+      if (/Load \*\*\[/.test(line)) {
+        loadSeen = true;
+        return;
+      }
+      if (loadSeen && /^\s*→ Proceed to \*\*/.test(line)) {
+        out.push({
+          file,
+          line: i + 1,
+          message: 'bare "→ Proceed to" after a Load directive — use "→ On return, proceed to"',
+        });
+      }
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Registry + reporting
 // ---------------------------------------------------------------------------
 
@@ -437,6 +475,7 @@ const CHECKS = [
   ['8: H1 category rule', checkH1Category],
   ['9: Zero Output Rule byte-identity', checkZeroOutput],
   ['10: reference-file attribution', checkAttribution],
+  ['11: load-directive footers (On return)', checkLoadFooters],
 ];
 
 function report(violations) {
@@ -583,6 +622,9 @@ test('check 6 (routing) — catches dangling targets, skips exempt shapes', () =
     const badStep = write(dir, 'skills/x/a.md', '## Step 1: Start\n\n→ Proceed to **Step 9**.\n');
     assert.strictEqual(checkRouting([badStep]).length, 1, 'dangling Step target must be caught');
 
+    const badOnReturn = write(dir, 'skills/x/ar.md', '## Step 1: Start\n\n→ On return, proceed to **Step 9**.\n');
+    assert.strictEqual(checkRouting([badOnReturn]).length, 1, 'dangling On-return target must be caught');
+
     const badLettered = write(dir, 'skills/x/b.md', '## A. First\n\n→ Proceed to **Z. Missing**.\n');
     assert.strictEqual(checkRouting([badLettered]).length, 1, 'dangling lettered target must be caught');
 
@@ -657,5 +699,44 @@ test('check 10 (attribution) — catches missing/wrong attribution, skips output
 
     const of = write(dir, 'skills/workflow-planning-process/references/output-formats/tick/reading.md', '# Reading\n\n## Listing Tasks\n');
     assert.strictEqual(checkAttribution([of]).length, 0, 'output-format adapters must be exempt');
+  });
+});
+
+test('check 11 (load footers) — catches bare proceed after a load, permits gated/branch/fenced shapes', () => {
+  withTemp((dir) => {
+    const bad = write(
+      dir,
+      'skills/x/SKILL.md',
+      '## Step 1: A\n\nLoad **[a.md](references/a.md)** and follow its instructions as written.\n\n→ Proceed to **Step 2**.\n\n## Step 2: B\n'
+    );
+    assert.strictEqual(checkLoadFooters([bad]).length, 1, 'bare proceed after a load must be caught');
+
+    const good = write(
+      dir,
+      'skills/x/ok.md',
+      '## Step 1: A\n\nLoad **[a.md](references/a.md)** and follow its instructions as written.\n\n→ On return, proceed to **Step 2**.\n\n## Step 2: B\n\n→ Proceed to **Step 1**.\n'
+    );
+    assert.strictEqual(checkLoadFooters([good]).length, 0, 'conditional footer and load-free proceed must pass');
+
+    const gated = write(
+      dir,
+      'skills/x/gated.md',
+      '## A. First\n\nLoad **[a.md](a.md)** and follow its instructions as written.\n\n**STOP.** Wait for user response.\n\n→ Proceed to **B. Next**.\n\n## B. Next\n'
+    );
+    assert.strictEqual(checkLoadFooters([gated]).length, 0, 'STOP between load and proceed re-keys the footer — bare must pass');
+
+    const branch = write(
+      dir,
+      'skills/x/branch.md',
+      '## A. First\n\nLoad **[a.md](a.md)** and follow its instructions as written.\n\n**If nothing to recover:**\n\n→ Proceed to **B. Next**.\n\n## B. Next\n'
+    );
+    assert.strictEqual(checkLoadFooters([branch]).length, 0, 'bold conditional between load and proceed must pass');
+
+    const fenced = write(
+      dir,
+      'skills/x/fenced.md',
+      '```\nLoad **[a.md](a.md)** and follow its instructions as written.\n\n→ Proceed to **Step 2**.\n```\n'
+    );
+    assert.strictEqual(checkLoadFooters([fenced]).length, 0, 'fenced illustrative seam must be exempt');
   });
 });


### PR DESCRIPTION
A bare `→ Proceed to **Step N+1**` directly beneath a `Load **[x.md]** and follow its instructions as written` line reads as the *immediate next action*. An agent in step-header cadence can overshoot the loaded reference and emit the next step's header before the reference takes control — observed live on the fumi epic: discovery Step 10 (Session Loop) briefly emitted Step 11's `── Document Review ──` header before self-correcting into the resume brief. With ~100 of these seams across the corpus, that misfire class was structural, not a one-off.

## Change

- **Footer states the return condition**: `→ On return, proceed to **Step N+1**.` — 141 seams converted across 44 files (backbones + references). Pure phrasing; zero semantic change.
- **Sanctioned bare forms preserved**: a `**STOP.**` gate or bold conditional between the load and the routing line re-keys the routing to the user's response or a sibling branch — those 15 seams keep `→ Proceed to`.
- **CONVENTIONS.md**: canonical Load Directive Format (which taught the trap), sub-step example, backbone sketch, and the forward-routing table updated.
- **Linter**: new check 11 enforces the rule with the same STOP/branch/fence exemptions, so the pattern cannot re-enter; check 6 (routing-target existence) now also resolves targets in the conditional form.

## Test plan

- `node --test tests/scripts/test-conventions-lint.cjs` — 23/23, including corpus-clean for check 11 (sweep and lint agree on every site) and negative fixtures for the bad/gated/branch/fenced shapes.
- `npm test` — 1448/1448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)