### PR TITLE
docs(conventions): step chrome is earned — silent steps and conditional chrome

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -78,7 +78,14 @@ Status displays use the phase title at the top of the same code block, followed 
 
 ### Step Markers
 
-Em-dash framed progress indicators. Embedded at each step boundary — never instructed once at the top of a file. Short left side, long right side to fill width. Every step in a skill gets a marker, even if the step has no explicit output — Claude's visible processing (reading files, running commands, thinking) IS the user experience, and the marker labels that activity. Every step marker must be followed by a signpost blockquote explaining what the step does and why — the marker names the step, the signpost explains it.
+Em-dash framed progress indicators. Embedded at the step boundaries that earn them — never instructed once at the top of a file. Short left side, long right side to fill width.
+
+**Markers are earned, not automatic.** A step carries a marker only when the user gets something between it and the next visible output: an interaction (menu, `**STOP.**` gate), substantive watchable activity (analysis, agent dispatch, engine transactions, multi-file work), or rendered content. Consecutive markers with nothing between them read as step-by-step progress that isn't happening — noise, not orientation.
+
+- **Silent step**: a step whose body is plumbing — loading a reference, one quick command, evaluating a branch — keeps its `## Step N` heading (routing target, load boundary) but authors no marker and no signpost. The step renders nothing.
+- **Conditional chrome**: a step whose common path is a no-op places its marker and signpost inside the branch that acts, not at step entry. The no-op path renders nothing — a header announcing a non-event is the noise this rule exists to prevent.
+
+Every step marker must be followed by a signpost blockquote explaining what the step does and why — the marker names the step, the signpost explains it.
 
 ```
 ── Construct Specification ─────────────────────
@@ -427,7 +434,8 @@ Sequential: `## Step 0`, `## Step 1`, `## Step 2`, etc.
 - **Step 0** hosts initialisation; `workflow-start` runs migrations and the knowledge gate via `engine boot`
 - Steps are separated by `---` horizontal rules
 - Each step completes fully before the next begins
-- User-facing step markers (see Display & Output Conventions → Step Markers) use names only — no numbers. They are embedded at each step boundary, including steps with no explicit output (Claude's visible processing labels the activity for the user)
+- User-facing step markers (see Display & Output Conventions → Step Markers) use names only — no numbers. Only steps that earn chrome carry them; silent steps produce no user-facing output
+- When consecutive steps always run together — nothing routes into the later step and no gate sits between them — they are one step; author them as one
 
 ### Sub-Steps (Early Setup Steps Only)
 


### PR DESCRIPTION
Stack 1/4 of the ceremony-collapse work (traces: fumi discovery resume, portal continue-epic — four consecutive headers emitted before any activity in both).

## The rule change

The old rule made markers mandatory at every step boundary ("even if the step has no explicit output"). Written when every step was assumed to have watchable processing; in practice, load-only and branch-only steps cluster at skill entries, producing header runs over ~1s of plumbing. Two costs: the display grammar claims step-by-step progress that is not happening, and consecutive model-authored headers with nothing between them establish the continuation rhythm behind the Document Review overshoot class.

New rule — **markers are earned**:

- Chrome only where the user gets an interaction, substantive watchable activity, or rendered content before the next visible output.
- **Silent step** — heading stays (routing target, load boundary), no marker/signpost authored, renders nothing.
- **Conditional chrome** — a step whose common path is a no-op puts chrome inside the branch that acts; a header announcing a non-event renders nothing.
- **Merge** — consecutive steps that always run together with no gate between them are authored as one step.

## Stack plan

1. **This PR** — the rulebook alone, so the rule and its application review separately.
2. discovery + continue-epic swept per the agreed census (15→8 and 10→2 markers).
3. The continue-* clone family.
4. Entry skills + processing setup runs, **plus the lint check** (a marker-carrying step whose body is only a load directive must fail) — lint lands last because the linter's corpus-clean invariant only holds once the sweep is complete.

## Test plan

- `node --test tests/scripts/test-conventions-lint.cjs` — 23/23 (no corpus changes in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#482** 👈 current
2. #484
3. #485
4. #486
<!-- stack:links:end -->