### PR TITLE
refactor(skills): earned chrome — discovery and continue-epic swept

### DIFF
--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -36,18 +36,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialisation ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading shared display conventions for this session.
-```
-
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 1**.
@@ -55,18 +43,6 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 ---
 
 ## Step 1: Discovery State
-
-> *Output the next fenced block as a code block:*
-
-```
-── Run Discovery ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Scanning for active epics and their current progress.
-```
 
 !`node .claude/skills/workflow-continue-epic/scripts/gateway.cjs`
 
@@ -97,18 +73,6 @@ The per-epic state surface (`all_done`, `analysis_caches`, `needs_sequencing`, t
 ---
 
 ## Step 2: Check Count and Arguments
-
-> *Output the next fenced block as a code block:*
-
-```
-── Check State ──────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking if there are any epics in progress.
-```
 
 #### If `count` is 0
 
@@ -156,18 +120,6 @@ Load **[select-epic.md](references/select-epic.md)** and follow its instructions
 
 ## Step 4: Validate Selection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Selection ───────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Confirming the selected epic exists and is active.
-```
-
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -175,19 +127,6 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 ---
 
 ## Step 5: Backfill
-
-> *Output the next fenced block as a code block:*
-
-```
-── Backfill ─────────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking for one-time recovery work — legacy research splits
-> or discovery-map rows missing a summary or description.
-```
 
 ```bash
 node .claude/skills/workflow-legacy-research-split/scripts/detect.cjs {work_unit}
@@ -203,6 +142,19 @@ Then read `discovery_map` from the most recent discovery output and filter for r
 
 #### Otherwise
 
+> *Output the next fenced block as a code block:*
+
+```
+── Backfill ─────────────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> One-time recovery work found — legacy research splits or
+> discovery-map rows missing a summary or description.
+```
+
 Load **[backfill-checks.md](references/backfill-checks.md)** with work_unit = `{work_unit}`, qualifying_sources = `{qualifying_sources}`, items_to_recover = `{items_to_recover}`.
 
 backfill-checks is terminal when it fires — it commits the recovery work and stops, advising the user to `/clear` and re-run `/workflow-start`. Do not proceed to Step 6 on this branch.
@@ -210,19 +162,6 @@ backfill-checks is terminal when it fires — it commits the recovery work and s
 ---
 
 ## Step 6: Topic Discovery
-
-> *Output the next fenced block as a code block:*
-
-```
-── Topic Discovery ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking whether completed research or discussion has new themes
-> to surface onto the discovery map.
-```
 
 Read `analysis_caches` from the most recent discovery output. Load **[topic-discovery-dispatch.md](../workflow-shared/references/topic-discovery-dispatch.md)** with work_unit = `{work_unit}`, analysis_caches = `{analysis_caches}`.
 
@@ -234,6 +173,10 @@ On return, `new_arrivals` is populated for Step 8 to render the callout.
 
 ## Step 7: Sequence Map
 
+Read `needs_sequencing` from the most recent discovery output.
+
+#### If `needs_sequencing` is true
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -243,12 +186,8 @@ On return, `new_arrivals` is populated for Step 8 to render the callout.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Assigning a suggested execution order to the discovery map's topics.
+> Assigning a suggested execution order to the map's topics.
 ```
-
-Read `needs_sequencing` from the most recent discovery output.
-
-#### If `needs_sequencing` is true
 
 Load **[sequence-discovery-map.md](../workflow-shared/references/sequence-discovery-map.md)** with work_unit = `{work_unit}`.
 
@@ -262,8 +201,6 @@ node .claude/skills/workflow-continue-epic/scripts/gateway.cjs {work_unit}
 
 #### Otherwise
 
-The map is already sequenced.
-
 → Proceed to **Step 8**.
 
 ---
@@ -273,7 +210,7 @@ The map is already sequenced.
 > *Output the next fenced block as a code block:*
 
 ```
-── Display State and Menu ───────────────────────
+── Epic State ───────────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -289,18 +226,6 @@ Load **[epic-display-and-menu.md](references/epic-display-and-menu.md)** with ne
 ---
 
 ## Step 9: Route Selection
-
-> *Output the next fenced block as a code block:*
-
-```
-── Route Selection ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the selected phase for this epic.
-```
 
 Invoke the `route` stored for the user's selection — the selected `ACTIONS` entry's route from epic-display-and-menu.md (e.g. `/workflow-discussion-entry epic {work_unit} {topic}`). Selections with route `(internal)` resolve inside that reference and never reach this step.
 

--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -61,19 +61,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 1: Dispatch
 
-> *Output the next fenced block as a code block:*
-
-```
-── Dispatch ─────────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Determining the invocation mode — brand-new work, or re-shaping
-> an existing epic's map.
-```
-
 Read the positional arguments:
 
 - `$0` — **work_type pre-seed**: one of `epic` / `feature` / `bugfix` / `quick-fix` / `cross-cutting`, or `none` (the `s`/start path, no hint). A hint, not a given — still confirmed in new mode.
@@ -97,19 +84,6 @@ New work — nothing is on disk yet; pre-confirmation shaping is ephemeral.
 ---
 
 ## Step 2: Load Detection Core
-
-> *Output the next fenced block as a code block:*
-
-```
-── Load Detection Core ──────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Getting ready to work out what kind of work this is — feature,
-> bugfix, epic, quick-fix, or cross-cutting.
-```
 
 Load **[detection-core.md](references/detection-core.md)** and follow its instructions as written.
 
@@ -180,19 +154,6 @@ Load **[confirm-trigger.md](references/confirm-trigger.md)** and follow its inst
 
 ## Step 6: Resume Detection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Resume Detection ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking whether an earlier session for this epic was left
-> unfinished.
-```
-
 Load **[resume-detection.md](references/resume-detection.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 7**.
@@ -200,19 +161,6 @@ Load **[resume-detection.md](references/resume-detection.md)** and follow its in
 ---
 
 ## Step 7: Run Discovery
-
-> *Output the next fenced block as a code block:*
-
-```
-── Run Discovery ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the discovery map for the session — the topics so far
-> and anything previously dismissed.
-```
 
 Run discovery for the work unit:
 
@@ -240,19 +188,6 @@ If `session_number` was not already set (no resume at Step 6, no `macro_continua
 
 ## Step 8: Initialize Discovery
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialize Discovery ─────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Setting up the discovery session. The session log is written on
-> the first change, not up front.
-```
-
 Load **[initialize-discovery.md](references/initialize-discovery.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 9**.
@@ -260,19 +195,6 @@ Load **[initialize-discovery.md](references/initialize-discovery.md)** and follo
 ---
 
 ## Step 9: Load Discovery Guidelines
-
-> *Output the next fenced block as a code block:*
-
-```
-── Load Discovery Guidelines ────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the guidelines for shaping topics — how to explore, and
-> what to leave for later phases.
-```
 
 Load **[discovery-guidelines.md](references/discovery-guidelines.md)** and follow its instructions as written.
 
@@ -285,7 +207,7 @@ Load **[discovery-guidelines.md](references/discovery-guidelines.md)** and follo
 > *Output the next fenced block as a code block:*
 
 ```
-── Session Loop ─────────────────────────────────
+── Discovery Session ────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -372,19 +294,6 @@ Load **[first-phase-routing.md](references/first-phase-routing.md)** and follow 
 ## Step 14: Compliance Self-Check
 
 Reached before concluding by both paths — the epic topic path from Step 12, the single-phase endpoint from Step 13.
-
-> *Output the next fenced block as a code block:*
-
-```
-── Compliance Self-Check ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the session followed the discovery conventions before
-> moving on.
-```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 

--- a/skills/workflow-discovery/references/resume-detection.md
+++ b/skills/workflow-discovery/references/resume-detection.md
@@ -22,6 +22,19 @@ No prior session is in progress. `session_number` will be set at Step 7 from dis
 
 The output is the in-progress session number string (e.g. `002`) — the prior session was interrupted before finalisation.
 
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> An earlier discovery session for this epic was left unfinished —
+> choose whether to pick it up or start fresh.
+```
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```


### PR DESCRIPTION
Stack 2/4 (base: #482, the rulebook). Applies the agreed census to the two backbones we watched misbehave.

## workflow-discovery — 15 markers → 8

| Step | Treatment |
|---|---|
| 1 Dispatch, 2 Load Detection Core, 7 Run Discovery, 8 Initialize, 9 Load Guidelines | Silenced — headings stay for routing, no chrome |
| 6 Resume Detection | Demoted — marker+signpost now render inside the found-a-session branch, right above the continue/restart menu; epics with no open session render nothing |
| 10 Session Loop | Header renamed **`── Discovery Session ──`** — now the single beat fronting the whole setup run |
| 14 Compliance Self-Check | Silenced — `compliance-check.md` is already conditional ("no issues → proceed silently"), so chrome appears only via its findings display |
| 3 Open, 4 Shape/Confirm, 5 Confirm Trigger, 11 Document Review, 12 Confirm+Persist, 13 Single-Phase Endpoint, 15 Conclude | Keep |

The fumi resume replayed under this: resume menu → `continue` → one header → briefing. The four-header run that trained the overshoot cadence is gone.

## workflow-continue-epic — 10 markers → 2 (+2 conditional)

| Step | Treatment |
|---|---|
| 0 Initialisation, 1 Discovery State, 2 Check Count, 4 Validate, 6 Topic Discovery, 9 Route | Silenced — terminal/error displays in the references self-orient |
| 5 Backfill, 7 Sequence Map | Conditional chrome — marker+signpost moved inside the acting branch; the common no-op path renders nothing (including the "map is already sequenced" narration fumi surfaced) |
| 3 Select Epic | Keep — genuine interactive beat |
| 8 Display | Keep, renamed **`── Epic State ──`** |

User experience becomes: title → (selection if needed) → state tree → menu.

## Test plan

- `node --test tests/scripts/test-conventions-lint.cjs` — 23/23 (marker widths of the two renamed/moved headers verified by check 2).
- `npm test` — 1448/1448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #482
2. **#484** 👈 current
3. #485
4. #486
<!-- stack:links:end -->