### PR TITLE
refactor(skills): earned chrome — continue-* clone family swept

### DIFF
--- a/skills/workflow-continue-bugfix/SKILL.md
+++ b/skills/workflow-continue-bugfix/SKILL.md
@@ -36,18 +36,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialisation ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading shared display conventions for this session.
-```
-
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 1**.
@@ -55,18 +43,6 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 ---
 
 ## Step 1: Discovery State
-
-> *Output the next fenced block as a code block:*
-
-```
-── Run Discovery ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Scanning for active bugfixes and their current progress.
-```
 
 !`node .claude/skills/workflow-continue-bugfix/scripts/gateway.cjs`
 
@@ -97,18 +73,6 @@ Anything richer (next phase, completed phases, revisit routes) comes from the `v
 ---
 
 ## Step 2: Check Count and Arguments
-
-> *Output the next fenced block as a code block:*
-
-```
-── Check State ──────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking if there are any bugfixes in progress.
-```
 
 #### If `count` is 0
 
@@ -156,18 +120,6 @@ Load **[select-bugfix.md](references/select-bugfix.md)** and follow its instruct
 
 ## Step 4: Validate Selection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Selection ───────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Confirming the selected bugfix exists and is active.
-```
-
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -179,7 +131,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 > *Output the next fenced block as a code block:*
 
 ```
-── Display State and Menu ───────────────────────
+── Bugfix State ─────────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -195,18 +147,6 @@ Load **[bugfix-display-and-menu.md](references/bugfix-display-and-menu.md)** and
 ---
 
 ## Step 6: Route Selection
-
-> *Output the next fenced block as a code block:*
-
-```
-── Route Selection ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the selected phase for this bugfix.
-```
 
 Invoke the `route` stored for the user's selection — the selected `ACTIONS` entry's route from bugfix-display-and-menu.md (e.g. `/workflow-specification-entry bugfix {work_unit}`).
 

--- a/skills/workflow-continue-cross-cutting/SKILL.md
+++ b/skills/workflow-continue-cross-cutting/SKILL.md
@@ -36,18 +36,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialisation ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading shared display conventions for this session.
-```
-
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 1**.
@@ -55,18 +43,6 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 ---
 
 ## Step 1: Discovery State
-
-> *Output the next fenced block as a code block:*
-
-```
-── Run Discovery ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Scanning for active cross-cutting concerns and their progress.
-```
 
 !`node .claude/skills/workflow-continue-cross-cutting/scripts/gateway.cjs`
 
@@ -97,18 +73,6 @@ Anything richer (next phase, completed phases, revisit routes) comes from the `v
 ---
 
 ## Step 2: Check Count and Arguments
-
-> *Output the next fenced block as a code block:*
-
-```
-── Check State ──────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking if there are any cross-cutting concerns in progress.
-```
 
 #### If `count` is 0
 
@@ -156,18 +120,6 @@ Load **[select-cross-cutting.md](references/select-cross-cutting.md)** and follo
 
 ## Step 4: Validate Selection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Selection ───────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Confirming the selected concern exists and is active.
-```
-
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -179,7 +131,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 > *Output the next fenced block as a code block:*
 
 ```
-── Display State and Menu ───────────────────────
+── Cross-Cutting State ──────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -195,18 +147,6 @@ Load **[cross-cutting-display-and-menu.md](references/cross-cutting-display-and-
 ---
 
 ## Step 6: Route Selection
-
-> *Output the next fenced block as a code block:*
-
-```
-── Route Selection ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the selected phase for this concern.
-```
 
 Invoke the `route` stored for the user's selection — the selected `ACTIONS` entry's route from cross-cutting-display-and-menu.md (e.g. `/workflow-discussion-entry cross-cutting {work_unit}`).
 

--- a/skills/workflow-continue-feature/SKILL.md
+++ b/skills/workflow-continue-feature/SKILL.md
@@ -36,18 +36,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialisation ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading shared display conventions for this session.
-```
-
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 1**.
@@ -55,18 +43,6 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 ---
 
 ## Step 1: Discovery State
-
-> *Output the next fenced block as a code block:*
-
-```
-── Run Discovery ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Scanning for active features and their current progress.
-```
 
 !`node .claude/skills/workflow-continue-feature/scripts/gateway.cjs`
 
@@ -97,18 +73,6 @@ Anything richer (next phase, completed phases, revisit routes) comes from the `v
 ---
 
 ## Step 2: Check Count and Arguments
-
-> *Output the next fenced block as a code block:*
-
-```
-── Check State ──────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking if there are any features in progress.
-```
 
 #### If `count` is 0
 
@@ -156,18 +120,6 @@ Load **[select-feature.md](references/select-feature.md)** and follow its instru
 
 ## Step 4: Validate Selection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Selection ───────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Confirming the selected feature exists and is active.
-```
-
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -179,7 +131,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 > *Output the next fenced block as a code block:*
 
 ```
-── Display State and Menu ───────────────────────
+── Feature State ────────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -195,18 +147,6 @@ Load **[feature-display-and-menu.md](references/feature-display-and-menu.md)** a
 ---
 
 ## Step 6: Route Selection
-
-> *Output the next fenced block as a code block:*
-
-```
-── Route Selection ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the selected phase for this feature.
-```
 
 Invoke the `route` stored for the user's selection — the selected `ACTIONS` entry's route from feature-display-and-menu.md (e.g. `/workflow-specification-entry feature {work_unit}`).
 

--- a/skills/workflow-continue-quickfix/SKILL.md
+++ b/skills/workflow-continue-quickfix/SKILL.md
@@ -36,18 +36,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialisation ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading shared display conventions for this session.
-```
-
 Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 1**.
@@ -55,18 +43,6 @@ Load **[casing-conventions.md](../workflow-shared/references/casing-conventions.
 ---
 
 ## Step 1: Discovery State
-
-> *Output the next fenced block as a code block:*
-
-```
-── Run Discovery ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Scanning for active quick-fixes and their current progress.
-```
 
 !`node .claude/skills/workflow-continue-quickfix/scripts/gateway.cjs`
 
@@ -97,18 +73,6 @@ Anything richer (next phase, completed phases, revisit routes) comes from the `v
 ---
 
 ## Step 2: Check Count and Arguments
-
-> *Output the next fenced block as a code block:*
-
-```
-── Check State ──────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking if there are any quick-fixes in progress.
-```
 
 #### If `count` is 0
 
@@ -156,18 +120,6 @@ Load **[select-quickfix.md](references/select-quickfix.md)** and follow its inst
 
 ## Step 4: Validate Selection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Selection ───────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Confirming the selected quick-fix exists and is active.
-```
-
 Load **[validate-selection.md](references/validate-selection.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -179,7 +131,7 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 > *Output the next fenced block as a code block:*
 
 ```
-── Display State and Menu ───────────────────────
+── Quick-Fix State ──────────────────────────────
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -195,18 +147,6 @@ Load **[quickfix-display-and-menu.md](references/quickfix-display-and-menu.md)**
 ---
 
 ## Step 6: Route Selection
-
-> *Output the next fenced block as a code block:*
-
-```
-── Route Selection ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the selected phase for this quick-fix.
-```
 
 Invoke the `route` stored for the user's selection — the selected `ACTIONS` entry's route from quickfix-display-and-menu.md (e.g. `/workflow-implementation-entry quick-fix {work_unit}`).
 


### PR DESCRIPTION
Stack 3/4 (base: #484). Mechanical replication of the continue-epic treatment across its four structural clones — the files are step-for-step identical, so the sweep was scripted with a hard invariant (exactly 5 strips + 1 rename per file, fails loudly otherwise).

Per backbone: Initialisation / Discovery State / Check Count / Validate Selection / Route Selection go silent (headings stay for routing; terminal and error displays in the references self-orient), Select keeps its interactive beat, and the display marker becomes the per-type state header — `── Bugfix State ──`, `── Feature State ──`, `── Quick-Fix State ──`, `── Cross-Cutting State ──`.

Experience per skill becomes: title → (selection if needed) → state display → menu.

`-244/+4` across the four files.

## Test plan

- `node --test tests/scripts/test-conventions-lint.cjs` — 23/23 (all four renamed markers width-verified by check 2).
- `npm test` — 1448/1448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #482
2. #484
3. **#485** 👈 current
4. #486
<!-- stack:links:end -->