### PR TITLE
refactor(skills): earned chrome — entry skills, processing setup runs, lint

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -43,19 +43,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
-> *Output the next fenced block as a code block:*
-
-```
-── Parse Arguments ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the handoff context and determining which
-> discussion to work with.
-```
-
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -110,19 +97,6 @@ Store the result as `phase_status`.
 ---
 
 ## Step 2: Validate Phase
-
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Phase ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the status of this discussion — new,
-> in progress, or completed.
-```
 
 Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`. On the direct-entry path (`source = "fresh"`), also pass summary = `{direct_entry_summary}`, description = `{direct_entry_description}`. On the topic-resolved path, omit both — the caller didn't derive them.
 
@@ -207,18 +181,5 @@ Do not re-ask; live conversation context, when present, supplements the carrier.
 ---
 
 ## Step 4: Invoke the Skill
-
-> *Output the next fenced block as a code block:*
-
-```
-── Invoke Discussion ────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the discussion process with all
-> gathered context.
-```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -53,6 +53,14 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
+Check if the discussion file exists at `.workflows/{work_unit}/discussion/{topic}.md`.
+
+#### If no file exists
+
+→ Proceed to **Step 1**.
+
+#### If file exists
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -62,17 +70,9 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Checking for an existing discussion. If one exists, you can
-> pick up where you left off or start fresh.
+> An in-progress discussion file exists for this topic — choose
+> whether to pick it up or start fresh.
 ```
-
-Check if the discussion file exists at `.workflows/{work_unit}/discussion/{topic}.md`.
-
-#### If no file exists
-
-→ Proceed to **Step 1**.
-
-#### If file exists
 
 Show the current map state so the continue-or-restart choice is informed:
 
@@ -88,19 +88,6 @@ Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)*
 
 ## Step 1: Initialize Discussion
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialize Discussion ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Creating the discussion file and seeding the Discussion Map
-> with initial subtopics from your context.
-```
-
 Load **[initialize-discussion.md](references/initialize-discussion.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 2**.
@@ -108,19 +95,6 @@ Load **[initialize-discussion.md](references/initialize-discussion.md)** and fol
 ---
 
 ## Step 2: Load Discussion Guidelines
-
-> *Output the next fenced block as a code block:*
-
-```
-── Load Discussion Guidelines ───────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the guidelines that shape how the discussion
-> is structured and documented.
-```
 
 Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and follow its instructions as written.
 
@@ -130,19 +104,6 @@ Load **[discussion-guidelines.md](references/discussion-guidelines.md)** and fol
 
 ## Step 3: Knowledge Usage
 
-> *Output the next fenced block as a code block:*
-
-```
-── Knowledge Usage ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the usage guide for the knowledge base so
-> proactive querying is available throughout the discussion.
-```
-
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 4**.
@@ -150,19 +111,6 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 ---
 
 ## Step 4: Contextual Query
-
-> *Output the next fenced block as a code block:*
-
-```
-── Contextual Query ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the knowledge base for prior work that relates
-> to this discussion topic before the session begins.
-```
 
 Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.md)** and follow its instructions as written.
 
@@ -239,18 +187,6 @@ Load **[document-review.md](references/document-review.md)** and follow its inst
 ---
 
 ## Step 8: Compliance Self-Check
-
-> *Output the next fenced block as a code block:*
-
-```
-── Compliance Self-Check ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Verifying the discussion file follows workflow conventions.
-```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -44,19 +44,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
-> *Output the next fenced block as a code block:*
-
-```
-── Parse Arguments ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the handoff context to identify which
-> topic to implement.
-```
-
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -68,19 +55,6 @@ Store work_unit for the handoff.
 
 ## Step 2: Validate Phase
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Phase ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking that a completed plan exists and determining
-> where implementation left off.
-```
-
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 3**.
@@ -88,19 +62,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 3: Check Dependencies
-
-> *Output the next fenced block as a code block:*
-
-```
-── Check Dependencies ───────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Verifying that cross-plan dependencies are satisfied
-> before implementation begins.
-```
 
 Load **[validate-dependencies.md](references/validate-dependencies.md)** and follow its instructions as written.
 
@@ -110,19 +71,6 @@ Load **[validate-dependencies.md](references/validate-dependencies.md)** and fol
 
 ## Step 4: Check Environment
 
-> *Output the next fenced block as a code block:*
-
-```
-── Check Environment ────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking for any environment setup instructions
-> that need to be in place before coding begins.
-```
-
 Load **[environment-check.md](references/environment-check.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -130,18 +78,5 @@ Load **[environment-check.md](references/environment-check.md)** and follow its 
 ---
 
 ## Step 5: Invoke the Skill
-
-> *Output the next fenced block as a code block:*
-
-```
-── Invoke Implementation ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the implementation process with
-> plan, specification, and environment context.
-```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -66,20 +66,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Resume Detection ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking for existing implementation progress. If a
-> previous session exists, gates and counters will be reset
-> for this session.
-```
-
 Initialize or resume implementation tracking (idempotent — creates the manifest entry with default gates and counters, or resets the gate modes and session counters of an existing one; lifetime counters and progress are preserved):
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs task init {work_unit} {topic}
@@ -107,19 +93,6 @@ Found existing implementation for "{topic:(titlecase)}". Resuming from previous 
 
 ## Step 1: Environment Setup
 
-> *Output the next fenced block as a code block:*
-
-```
-── Environment Setup ────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking for environment setup instructions. Any
-> first-time setup will be handled before tasks begin.
-```
-
 Load **[environment-setup.md](references/environment-setup.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 2**.
@@ -127,19 +100,6 @@ Load **[environment-setup.md](references/environment-setup.md)** and follow its 
 ---
 
 ## Step 2: Read Plan + Load Plan Adapter
-
-> *Output the next fenced block as a code block:*
-
-```
-── Read Plan ────────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the plan and loading the format adapter.
-> This determines how tasks are extracted and tracked.
-```
 
 Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its instructions as written.
 
@@ -149,19 +109,6 @@ Load **[load-plan-adapter.md](references/load-plan-adapter.md)** and follow its 
 
 ## Step 3: Project Skills Discovery
 
-> *Output the next fenced block as a code block:*
-
-```
-── Project Skills Discovery ─────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Discovering project-level skills that agents should
-> use during implementation.
-```
-
 Load **[project-skills-discovery.md](references/project-skills-discovery.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 4**.
@@ -170,19 +117,6 @@ Load **[project-skills-discovery.md](references/project-skills-discovery.md)** a
 
 ## Step 4: Linter Discovery
 
-> *Output the next fenced block as a code block:*
-
-```
-── Linter Discovery ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Discovering linters and formatters that should be
-> run after each task to ensure code quality.
-```
-
 Load **[linter-setup.md](references/linter-setup.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -190,21 +124,6 @@ Load **[linter-setup.md](references/linter-setup.md)** and follow its instructio
 ---
 
 ## Step 5: Knowledge Usage
-
-> *Output the next fenced block as a code block:*
-
-```
-── Knowledge Usage ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the usage guide for the knowledge base. Implementation reads
-> the code as the source of truth for *what* exists — the guide
-> documents the rare cases where the KB is useful for the *why*
-> behind an existing pattern.
-```
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
@@ -275,18 +194,6 @@ Load **[analysis-loop.md](references/analysis-loop.md)** and follow its instruct
 ---
 
 ## Step 8: Compliance Self-Check
-
-> *Output the next fenced block as a code block:*
-
-```
-── Compliance Self-Check ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Verifying the implementation follows workflow conventions.
-```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -39,19 +39,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them.
 
 ## Step 1: Parse Arguments
 
-> *Output the next fenced block as a code block:*
-
-```
-── Parse Arguments ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the handoff context and checking for existing
-> investigation work.
-```
-
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -78,19 +65,6 @@ Set source="new".
 ---
 
 ## Step 2: Validate Phase
-
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Phase ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the status of this investigation — new,
-> in progress, or completed.
-```
 
 Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `{phase_status}`.
 
@@ -140,18 +114,5 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 ---
 
 ## Step 4: Invoke the Skill
-
-> *Output the next fenced block as a code block:*
-
-```
-── Invoke Investigation ─────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the investigation process to analyse
-> the bug and find the root cause.
-```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -81,6 +81,14 @@ The investigation file is your memory. Context compaction is lossy — what's no
 
 ## Step 0: Resume Detection
 
+Check if the investigation file exists at `.workflows/{work_unit}/investigation/{topic}.md`.
+
+#### If no file exists
+
+→ Proceed to **Step 1**.
+
+#### If file exists
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -90,36 +98,15 @@ The investigation file is your memory. Context compaction is lossy — what's no
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Checking for an existing investigation. If one exists, you can
-> pick up where you left off or start fresh.
+> An in-progress investigation file exists for this topic —
+> choose whether to pick it up or start fresh.
 ```
-
-Check if the investigation file exists at `.workflows/{work_unit}/investigation/{topic}.md`.
-
-#### If no file exists
-
-→ Proceed to **Step 1**.
-
-#### If file exists
 
 Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `investigation`, file = `.workflows/{work_unit}/investigation/{topic}.md`, continue_step = `Step 2`, restart_targets = `the investigation file`, commit = `investigation({work_unit}): restart investigation`.
 
 ---
 
 ## Step 1: Initialize Investigation
-
-> *Output the next fenced block as a code block:*
-
-```
-── Initialize Investigation ─────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Creating the investigation file and recording the initial
-> bug context.
-```
 
 Load **[initialize-investigation.md](references/initialize-investigation.md)** and follow its instructions as written.
 
@@ -128,19 +115,6 @@ Load **[initialize-investigation.md](references/initialize-investigation.md)** a
 ---
 
 ## Step 2: Knowledge Usage
-
-> *Output the next fenced block as a code block:*
-
-```
-── Knowledge Usage ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the usage guide for the knowledge base so
-> proactive querying is available throughout the investigation.
-```
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
@@ -174,19 +148,6 @@ When symptoms are sufficiently understood to begin code analysis:
 ---
 
 ## Step 4: Contextual Query
-
-> *Output the next fenced block as a code block:*
-
-```
-── Contextual Query ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the knowledge base for prior investigations or
-> related work that matches the symptoms just gathered.
-```
 
 Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.md)** and follow its instructions as written.
 
@@ -357,18 +318,6 @@ Load **[fix-validation.md](references/fix-validation.md)** and follow its instru
 ---
 
 ## Step 12: Compliance Self-Check
-
-> *Output the next fenced block as a code block:*
-
-```
-── Compliance Self-Check ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Verifying the investigation file follows workflow conventions.
-```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 

--- a/skills/workflow-planning-entry/SKILL.md
+++ b/skills/workflow-planning-entry/SKILL.md
@@ -43,19 +43,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
-> *Output the next fenced block as a code block:*
-
-```
-── Parse Arguments ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the handoff context to identify which
-> topic to plan.
-```
-
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -67,19 +54,6 @@ Store work_unit for the handoff.
 
 ## Step 2: Validate Specification
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Specification ───────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking that a completed specification exists
-> for this topic.
-```
-
 Load **[validate-spec.md](references/validate-spec.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 3**.
@@ -87,19 +61,6 @@ Load **[validate-spec.md](references/validate-spec.md)** and follow its instruct
 ---
 
 ## Step 3: Validate Phase
-
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Phase ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking whether a plan already exists for this
-> topic.
-```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
@@ -115,19 +76,6 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ## Step 4: Cross-Cutting Context
 
-> *Output the next fenced block as a code block:*
-
-```
-── Cross-Cutting Context ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading any cross-cutting specifications that apply
-> to this plan.
-```
-
 Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -135,18 +83,5 @@ Load **[cross-cutting-context.md](references/cross-cutting-context.md)** and fol
 ---
 
 ## Step 5: Invoke the Skill
-
-> *Output the next fenced block as a code block:*
-
-```
-── Invoke Planning ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the planning process with
-> specification and context.
-```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -84,19 +84,6 @@ Follow every step in sequence. No steps are optional.
 
 ## Step 0: Resume Detection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Resume Detection ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking for an existing plan. If one exists, you can
-> pick up where you left off or start fresh.
-```
-
 Read the planning entry from the manifest as one subtree — empty means no entry exists:
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic}
@@ -107,6 +94,19 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 → Proceed to **Step 1**.
 
 #### Otherwise (planning entry exists)
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> An in-progress plan exists for this topic — choose whether
+> to pick it up or start fresh.
+```
 
 The subtree carries the current `phase` and `task` position (for the resume prompt below) and the `spec_commit` baseline (for spec-change detection).
 
@@ -161,19 +161,6 @@ If spec-change-detection reported changes, carry them into the walkthrough: reco
 
 ## Step 1: Initialize Plan
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialize Plan ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Setting up the plan. Selecting an output format and creating
-> the planning file structure.
-```
-
 Load **[initialize-plan.md](references/initialize-plan.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 2**.
@@ -181,19 +168,6 @@ Load **[initialize-plan.md](references/initialize-plan.md)** and follow its inst
 ---
 
 ## Step 2: Session Setup
-
-> *Output the next fenced block as a code block:*
-
-```
-── Session Setup ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading context from previous work. Reading the specification
-> and any existing planning progress.
-```
 
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
 
@@ -203,20 +177,6 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 
 ## Step 3: Load Planning Principles
 
-> *Output the next fenced block as a code block:*
-
-```
-── Load Planning Principles ─────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the guidelines for how plans are structured.
-> These ensure tasks are well-scoped, testable, and sequenced
-> correctly.
-```
-
 Load **[planning-principles.md](references/planning-principles.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 4**.
@@ -225,20 +185,6 @@ Load **[planning-principles.md](references/planning-principles.md)** and follow 
 
 ## Step 4: Knowledge Usage
 
-> *Output the next fenced block as a code block:*
-
-```
-── Knowledge Usage ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the usage guide for the knowledge base. Planning operates
-> from the spec as the golden source — the guide documents the narrow
-> cases where a KB query is warranted, and those where it is not.
-```
-
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -246,19 +192,6 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 ---
 
 ## Step 5: Verify Source Material
-
-> *Output the next fenced block as a code block:*
-
-```
-── Verify Source Material ───────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the specification that drives this plan. Everything
-> in the plan traces back to the specification.
-```
 
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
 
@@ -311,6 +244,12 @@ Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow it
 
 ## Step 8: Resolve External Dependencies
 
+#### If work_type is not `epic`
+
+→ Proceed to **Step 9**.
+
+#### Otherwise
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -320,15 +259,9 @@ Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow it
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Checking for dependencies on other plans. For epics,
-> tasks in one plan may depend on tasks in another.
+> Checking for dependencies on other plans — tasks in one plan
+> may depend on tasks in another.
 ```
-
-#### If work_type is not `epic`
-
-→ Proceed to **Step 9**.
-
-#### Otherwise
 
 Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follow its instructions as written.
 
@@ -359,18 +292,6 @@ Load **[plan-review.md](references/plan-review.md)** and follow its instructions
 ---
 
 ## Step 10: Compliance Self-Check
-
-> *Output the next fenced block as a code block:*
-
-```
-── Compliance Self-Check ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Verifying the plan follows workflow conventions.
-```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -43,19 +43,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
-> *Output the next fenced block as a code block:*
-
-```
-── Parse Arguments ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the handoff context and determining which
-> research topic to work with.
-```
-
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -89,18 +76,6 @@ Silently derive `direct_entry_summary` (one-line) and `direct_entry_description`
 
 ## Step 2: Check Phase Entry
 
-> *Output the next fenced block as a code block:*
-
-```
-── Check Phase Entry ────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking if research already exists for this topic.
-```
-
 Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `research`. On the direct-entry path (no topic supplied as `$2`), also pass summary = `{direct_entry_summary}`, description = `{direct_entry_description}`. When the topic was provided by the caller, omit both — the caller didn't derive them.
 
 Read the research phase status:
@@ -122,19 +97,6 @@ Store the result as `phase_status`.
 ---
 
 ## Step 3: Validate Phase
-
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Phase ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the status of this research — in progress
-> or completed.
-```
 
 Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `{phase_status}`.
 
@@ -209,18 +171,5 @@ Do not re-ask; live conversation context, when present, supplements the carrier.
 ---
 
 ## Step 5: Invoke the Skill
-
-> *Output the next fenced block as a code block:*
-
-```
-── Invoke Research ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the research process with all
-> gathered context.
-```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -54,6 +54,14 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
+Check if the research file exists at `.workflows/{work_unit}/research/{topic}.md`.
+
+#### If no file exists
+
+→ Proceed to **Step 1**.
+
+#### If file exists
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -63,36 +71,15 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Checking for existing research. If it exists, you can
-> pick up where you left off or start fresh.
+> An in-progress research file exists for this topic — choose
+> whether to pick it up or start fresh.
 ```
-
-Check if the research file exists at `.workflows/{work_unit}/research/{topic}.md`.
-
-#### If no file exists
-
-→ Proceed to **Step 1**.
-
-#### If file exists
 
 Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `research`, file = `.workflows/{work_unit}/research/{topic}.md`, continue_step = `Step 2`, restart_targets = `the research file and the phase cache directory (rm -rf .workflows/.cache/{work_unit}/research/{topic}/) — stale agent results would poison the restarted session's review gates`, commit = `research({work_unit}): restart research`.
 
 ---
 
 ## Step 1: Initialize Research
-
-> *Output the next fenced block as a code block:*
-
-```
-── Initialize Research ──────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Creating the research file and seeding it with initial
-> context from the handoff.
-```
 
 Load **[initialize-research.md](references/initialize-research.md)** and follow its instructions as written.
 
@@ -102,19 +89,6 @@ Load **[initialize-research.md](references/initialize-research.md)** and follow 
 
 ## Step 2: File Strategy
 
-> *Output the next fenced block as a code block:*
-
-```
-── File Strategy ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Confirming where the research file lives — one topic,
-> one file.
-```
-
 Load **[file-strategy.md](references/file-strategy.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 3**.
@@ -122,19 +96,6 @@ Load **[file-strategy.md](references/file-strategy.md)** and follow its instruct
 ---
 
 ## Step 3: Research Guidelines
-
-> *Output the next fenced block as a code block:*
-
-```
-── Research Guidelines ──────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the guidelines that shape how research is
-> conducted and documented.
-```
 
 Load **[research-guidelines.md](references/research-guidelines.md)** and follow its instructions as written.
 
@@ -144,19 +105,6 @@ Load **[research-guidelines.md](references/research-guidelines.md)** and follow 
 
 ## Step 4: Knowledge Usage
 
-> *Output the next fenced block as a code block:*
-
-```
-── Knowledge Usage ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the usage guide for the knowledge base so
-> proactive querying is available throughout the phase.
-```
-
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 5**.
@@ -164,19 +112,6 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 ---
 
 ## Step 5: Contextual Query
-
-> *Output the next fenced block as a code block:*
-
-```
-── Contextual Query ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the knowledge base for prior work that relates
-> to this research topic before the session begins.
-```
 
 Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.md)** and follow its instructions as written.
 

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -44,19 +44,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
-> *Output the next fenced block as a code block:*
-
-```
-── Parse Arguments ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the handoff context to identify which
-> topic to review.
-```
-
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -68,19 +55,6 @@ Store work_unit for the handoff.
 
 ## Step 2: Validate Phase
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Phase ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking that a completed plan and implementation
-> exist for this topic.
-```
-
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 3**.
@@ -88,18 +62,5 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 3: Invoke the Skill
-
-> *Output the next fenced block as a code block:*
-
-```
-── Invoke Review ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the review process to validate the
-> implementation against the specification and plan.
-```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -64,6 +64,14 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
+Check if a review file exists at `.workflows/{work_unit}/review/{topic}/report.md`.
+
+#### If no review file exists
+
+→ Proceed to **Step 1**.
+
+#### If review file exists
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -73,17 +81,9 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Checking for an existing review. If one exists, you can
-> continue reviewing unreviewed tasks or start fresh.
+> An in-progress review exists for this topic — choose whether
+> to pick it up or start fresh.
 ```
-
-Check if a review file exists at `.workflows/{work_unit}/review/{topic}/report.md`.
-
-#### If no review file exists
-
-→ Proceed to **Step 1**.
-
-#### If review file exists
 
 Gather coverage state. Read `completed_tasks` from the implementation manifest:
 
@@ -169,18 +169,6 @@ Set `unreviewed_tasks` = `[{list of unreviewed internal IDs}]`.
 
 ## Step 1: Initialize Review
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialize Review ────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Registering the review phase in the manifest.
-```
-
 Check if review phase is registered in manifest:
 
 ```bash
@@ -205,19 +193,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} r
 
 ## Step 2: Read Plan(s) and Specification(s)
 
-> *Output the next fenced block as a code block:*
-
-```
-── Read Plans and Specifications ────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the plan and specification that the
-> implementation was built from.
-```
-
 Load **[read-plans.md](references/read-plans.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 3**.
@@ -226,19 +201,6 @@ Load **[read-plans.md](references/read-plans.md)** and follow its instructions a
 
 ## Step 3: Load Project Skills
 
-> *Output the next fenced block as a code block:*
-
-```
-── Load Project Skills ──────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading project-level skills that inform
-> quality expectations.
-```
-
 Load **[load-project-skills.md](references/load-project-skills.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 4**.
@@ -246,21 +208,6 @@ Load **[load-project-skills.md](references/load-project-skills.md)** and follow 
 ---
 
 ## Step 4: Knowledge Usage
-
-> *Output the next fenced block as a code block:*
-
-```
-── Knowledge Usage ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the usage guide for the knowledge base. Review verifies
-> against the current spec — that's in scope without the KB. The guide
-> documents the narrow case where a cross-work-unit consistency check
-> is warranted.
-```
 
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
@@ -335,18 +282,6 @@ Load **[present-review.md](references/present-review.md)** and follow its instru
 ---
 
 ## Step 8: Compliance Self-Check
-
-> *Output the next fenced block as a code block:*
-
-```
-── Compliance Self-Check ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Verifying the review follows workflow conventions.
-```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 

--- a/skills/workflow-scoping-entry/SKILL.md
+++ b/skills/workflow-scoping-entry/SKILL.md
@@ -40,19 +40,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
-> *Output the next fenced block as a code block:*
-
-```
-── Parse Arguments ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the handoff context to identify which
-> quick-fix to scope.
-```
-
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -64,19 +51,6 @@ Store work_unit for the handoff.
 
 ## Step 2: Validate Phase
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Phase ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking if scoping has already been started for
-> this quick-fix.
-```
-
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 3**.
@@ -84,18 +58,5 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 ---
 
 ## Step 3: Invoke the Skill
-
-> *Output the next fenced block as a code block:*
-
-```
-── Invoke Scoping ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the scoping process. This will gather
-> context, build a spec, and create the plan in one pass.
-```
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -60,20 +60,6 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
-> *Output the next fenced block as a code block:*
-
-```
-── Resume Detection ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking for existing scoping work. If a spec and plan
-> already exist, you can adjust them, rescope from scratch,
-> or skip ahead.
-```
-
 Check if a specification already exists:
 
 ```bash
@@ -85,6 +71,19 @@ ls .workflows/{work_unit}/specification/{topic}/specification.md 2>/dev/null && 
 → Proceed to **Step 1**.
 
 #### If specification exists
+
+> *Output the next fenced block as a code block:*
+
+```
+── Resume Detection ─────────────────────────────
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> An in-progress scoping specification exists — choose whether
+> to pick it up or start fresh.
+```
 
 Read the plan and scoping statuses:
 
@@ -217,19 +216,6 @@ Apply the requested edits — the spec and `planning.md` directly, task file con
 
 ## Step 1: Knowledge Usage
 
-> *Output the next fenced block as a code block:*
-
-```
-── Knowledge Usage ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the usage guide for the knowledge base so
-> proactive querying is available while scoping the change.
-```
-
 Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 2**.
@@ -261,19 +247,6 @@ Load **[gather-context.md](references/gather-context.md)** and follow its instru
 
 ## Step 3: Contextual Query
 
-> *Output the next fenced block as a code block:*
-
-```
-── Contextual Query ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking the knowledge base for prior discussions, investigations,
-> or specs that touch the area being changed.
-```
-
 Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 4**.
@@ -281,19 +254,6 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 ---
 
 ## Step 4: Complexity Check
-
-> *Output the next fenced block as a code block:*
-
-```
-── Complexity Check ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Assessing whether this change fits the quick-fix model.
-> If it's too complex, it should be promoted to a feature.
-```
 
 Load **[complexity-check.md](references/complexity-check.md)** and follow its instructions as written.
 

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -44,19 +44,6 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 
 ## Step 1: Parse Arguments
 
-> *Output the next fenced block as a code block:*
-
-```
-── Parse Arguments ──────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reading the handoff context and determining which
-> specification to work with.
-```
-
 Arguments: work_type = `$0`, work_unit = `$1`, topic = `$2` (optional).
 Resolve topic: topic = `$2`, or if not provided and work_type is not `epic`, topic = `$1`.
 
@@ -90,19 +77,6 @@ A section is everything beneath its `===` marker up to the next marker — the m
 
 ## Step 2: Validate Source Material
 
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Source Material ─────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking that the required source material is ready
-> — completed discussions or investigations.
-```
-
 Load **[validate-source.md](references/validate-source.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 3**.
@@ -110,19 +84,6 @@ Load **[validate-source.md](references/validate-source.md)** and follow its inst
 ---
 
 ## Step 3: Validate Phase
-
-> *Output the next fenced block as a code block:*
-
-```
-── Validate Phase ───────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking whether a specification already exists
-> for this topic.
-```
 
 Load **[validate-phase.md](references/validate-phase.md)** and follow its instructions as written.
 
@@ -132,37 +93,11 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ## Step 4: Invoke the Skill
 
-> *Output the next fenced block as a code block:*
-
-```
-── Invoke Specification ─────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Handing off to the specification process with all
-> gathered context.
-```
-
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.
 
 ---
 
 ## Step 5: Check Prerequisites
-
-> *Output the next fenced block as a code block:*
-
-```
-── Check Prerequisites ──────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Verifying that completed discussions are available
-> to build specifications from.
-```
 
 Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow its instructions as written.
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -78,6 +78,14 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
+Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
+
+#### If no file exists
+
+→ Proceed to **Step 1**.
+
+#### If file exists
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -87,37 +95,15 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Checking for an existing specification. If one exists, you can
-> pick up where you left off or start fresh.
+> An in-progress specification exists for this topic — choose
+> whether to pick it up or start fresh.
 ```
-
-Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
-
-#### If no file exists
-
-→ Proceed to **Step 1**.
-
-#### If file exists
 
 Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `specification`, file = `.workflows/{work_unit}/specification/{topic}/specification.md`, continue_step = `Step 3`, restart_targets = `the specification file and all review tracking files (review-*-tracking-c*.md) in .workflows/{work_unit}/specification/{topic}/`, restart_resets = `every sources.{name}.status and consult_references.{name}.status row under {work_unit}.specification.{topic} to pending via engine manifest set — initialization never overwrites an existing row, so without this reset the fresh file would never get its content re-extracted`, commit = `spec({work_unit}): restart specification`.
 
 ---
 
 ## Step 1: Verify Source Material
-
-> *Output the next fenced block as a code block:*
-
-```
-── Verify Source Material ───────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Checking your discussions and research are ready. The
-> specification is built from these — if anything's missing or
-> incomplete, we'll flag it now.
-```
 
 Load **[verify-source-material.md](references/verify-source-material.md)** and follow its instructions as written.
 
@@ -127,19 +113,6 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 ## Step 2: Initialize Specification
 
-> *Output the next fenced block as a code block:*
-
-```
-── Initialize Specification ─────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Creating the specification file. Setting up the document
-> structure that we'll populate together in the next step.
-```
-
 Load **[initialize-specification.md](references/initialize-specification.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 3**.
@@ -148,20 +121,6 @@ Load **[initialize-specification.md](references/initialize-specification.md)** a
 
 ## Step 3: Session Setup
 
-> *Output the next fenced block as a code block:*
-
-```
-── Session Setup ────────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading context from previous work. Reading your source
-> material and any existing progress so we're working from the
-> full picture.
-```
-
 Load **[session-setup.md](references/session-setup.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 4**.
@@ -169,19 +128,6 @@ Load **[session-setup.md](references/session-setup.md)** and follow its instruct
 ---
 
 ## Step 4: Load Specification Principles
-
-> *Output the next fenced block as a code block:*
-
-```
-── Load Specification Principles ────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Loading the guidelines for how specifications are built.
-> These ensure consistency and completeness across the document.
-```
 
 Load **[specification-principles.md](references/specification-principles.md)** and follow its instructions as written.
 
@@ -213,6 +159,12 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 
 ## Step 6: Document Dependencies
 
+#### If work_type is not `epic`
+
+→ Proceed to **Step 7**.
+
+#### Otherwise
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -222,15 +174,9 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Recording cross-topic dependencies. For epics, specifications
-> may depend on each other — this step captures those relationships.
+> Recording cross-topic dependencies — for epics, specifications
+> may depend on each other.
 ```
-
-#### If work_type is not `epic`
-
-→ Proceed to **Step 7**.
-
-#### Otherwise
 
 Load **[dependencies.md](references/dependencies.md)** and follow its instructions as written.
 
@@ -261,19 +207,6 @@ Load **[spec-review.md](references/spec-review.md)** and follow its instructions
 ---
 
 ## Step 8: Compliance Self-Check
-
-> *Output the next fenced block as a code block:*
-
-```
-── Compliance Self-Check ────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Verifying the specification follows workflow conventions.
-> A quick internal check before we wrap up.
-```
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -461,6 +461,85 @@ function checkLoadFooters(files) {
 }
 
 // ---------------------------------------------------------------------------
+// Check 12 — earned chrome, decidable slice. A backbone step whose only
+// substance is a single Load directive must not carry a step marker when the
+// loaded reference is inert (no STOP gate, no rendering instruction) — pure
+// plumbing earns no chrome. Steps with conditional structure (H4), extra
+// substance, interactive references, or unresolvable/parameterised targets
+// are out of scope: those are the judgment tier.
+// ---------------------------------------------------------------------------
+
+// A reference is inert iff it shows the user nothing and does nothing
+// watchable: no STOP gate, no rendering instruction, no bash fence — and
+// every reference it Loads (resolvable, non-parameterised) is inert too.
+// Anything unresolvable is conservatively treated as not inert.
+function isInertRef(p, visited) {
+  if (visited.has(p)) return true; // cycle: no new activity on this path
+  visited.add(p);
+  if (!fs.existsSync(p)) return false;
+  const text = fs.readFileSync(p, 'utf8');
+  if (/\*\*STOP\.\*\*/.test(text) || /Output the next fenced block/.test(text) || /^```bash/m.test(text)) return false;
+  const loadRe = /Load \*\*\[[^\]]+\]\(([^)]+)\)\*\*/g;
+  let m;
+  while ((m = loadRe.exec(text))) {
+    const target = m[1].split('#')[0];
+    if (target.includes('{')) return false;
+    if (!isInertRef(path.resolve(path.dirname(p), target), visited)) return false;
+  }
+  return true;
+}
+
+function checkInertLoadChrome(files) {
+  const out = [];
+  for (const file of files) {
+    if (!file.endsWith('SKILL.md')) continue;
+    const dir = path.dirname(file);
+    const lines = readLines(file);
+    const { inFence } = parseFences(lines);
+    const starts = [];
+    lines.forEach((line, i) => {
+      if (!inFence[i] && /^## Step /.test(line)) starts.push(i);
+    });
+    for (const start of starts) {
+      let end = lines.length;
+      for (let j = start + 1; j < lines.length; j++) {
+        if (!inFence[j] && /^## /.test(lines[j])) { end = j; break; }
+      }
+      let markerLine = -1;
+      for (let j = start; j < end; j++) {
+        if (inFence[j] && /^── .+ ─+$/.test(lines[j])) markerLine = j;
+      }
+      if (markerLine === -1) continue;
+      const substance = [];
+      let structured = false;
+      for (let j = start + 1; j < end; j++) {
+        if (inFence[j] || /^\s*```/.test(lines[j])) continue;
+        const t = lines[j].trim();
+        if (t === '' || t === '---') continue;
+        if (/^> \*Output the next fenced block/.test(t)) continue;
+        if (/^→ /.test(t)) continue;
+        if (/^#{3,4} /.test(t)) { structured = true; break; }
+        substance.push(t);
+      }
+      if (structured || substance.length !== 1) continue;
+      const lm = substance[0].match(/^Load \*\*\[[^\]]+\]\(([^)]+)\)\*\*/);
+      if (!lm) continue;
+      const target = lm[1].split('#')[0];
+      if (target.includes('{')) continue;
+      const p = path.resolve(dir, target);
+      if (!fs.existsSync(p)) continue;
+      if (!isInertRef(p, new Set())) continue;
+      out.push({
+        file,
+        line: markerLine + 1,
+        message: `marker on a load-only step whose reference (${target}) renders nothing — chrome is earned, not automatic`,
+      });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Registry + reporting
 // ---------------------------------------------------------------------------
 
@@ -476,6 +555,7 @@ const CHECKS = [
   ['9: Zero Output Rule byte-identity', checkZeroOutput],
   ['10: reference-file attribution', checkAttribution],
   ['11: load-directive footers (On return)', checkLoadFooters],
+  ['12: earned chrome (inert load-only steps)', checkInertLoadChrome],
 ];
 
 function report(violations) {
@@ -738,5 +818,41 @@ test('check 11 (load footers) — catches bare proceed after a load, permits gat
       '```\nLoad **[a.md](a.md)** and follow its instructions as written.\n\n→ Proceed to **Step 2**.\n```\n'
     );
     assert.strictEqual(checkLoadFooters([fenced]).length, 0, 'fenced illustrative seam must be exempt');
+  });
+});
+
+test('check 12 (inert load chrome) — catches unearned markers, skips interactive/structured shapes', () => {
+  withTemp((dir) => {
+    const marker = ('── Load Things ').padEnd(49, '─');
+    const step = (body) =>
+      '## Step 1: Load Things\n\n> *Output the next fenced block as a code block:*\n\n```\n' +
+      marker +
+      '\n```\n\n> *Output the next fenced block as markdown (not a code block):*\n\n```\n> Loading things.\n```\n\n' +
+      body +
+      '\n→ On return, proceed to **Step 2**.\n\n## Step 2: Next\n';
+
+    write(dir, 'skills/x/references/inert.md', '# Inert\n\nRead the file. Hold values in memory.\n');
+    write(dir, 'skills/x/references/interactive.md', '# Interactive\n\n**STOP.** Wait for user response.\n');
+
+    const bad = write(dir, 'skills/x/SKILL.md', step('Load **[inert.md](references/inert.md)** and follow its instructions as written.\n'));
+    const v = checkInertLoadChrome([bad]);
+    assert.strictEqual(v.length, 1, 'marker on inert load-only step must be caught');
+    assert.match(v[0].message, /inert\.md/);
+
+    const good = write(dir, 'skills/y/SKILL.md', step('Load **[interactive.md](../x/references/interactive.md)** and follow its instructions as written.\n'));
+    assert.strictEqual(checkInertLoadChrome([good]).length, 0, 'interactive reference keeps its marker');
+
+    const silent = write(
+      dir,
+      'skills/z/SKILL.md',
+      '## Step 1: Load Things\n\nLoad **[inert.md](../x/references/inert.md)** and follow its instructions as written.\n\n→ On return, proceed to **Step 2**.\n\n## Step 2: Next\n'
+    );
+    assert.strictEqual(checkInertLoadChrome([silent]).length, 0, 'silent load-only step must pass');
+
+    const structured = write(dir, 'skills/w/SKILL.md', step('#### If ready\n\nLoad **[inert.md](../x/references/inert.md)** and follow its instructions as written.\n'));
+    assert.strictEqual(checkInertLoadChrome([structured]).length, 0, 'H4-structured step is judgment tier — skipped');
+
+    const unresolvable = write(dir, 'skills/v/SKILL.md', step('Load **[gone.md](references/gone.md)** and follow its instructions as written.\n'));
+    assert.strictEqual(checkInertLoadChrome([unresolvable]).length, 0, 'unresolvable target must be skipped');
   });
 });


### PR DESCRIPTION
Stack 4/4 (base: #485). The final sweep plus the lint that locks the rule in. `-1015/+89` across 16 backbones, then the lint work.

## Census applied

**Entry skills (8)** — no phase titles of their own; every parse/validate/check/invoke step silenced (their references render errors and blocked-states themselves, which self-orient). Kept: the `Gather Context` interaction beats (research/discussion/investigation bug-context/scoping via processing) and spec-entry's `Route Based on State` (renders the scenario selection menus).

**Processing skills (8)** — the setup cluster silenced everywhere it appeared: initialize, session setup, load-guidelines/principles, knowledge usage, contextual query, verify source material, read plan/specs, project-skills + linter discovery, compliance self-check (its shared reference is already "no issues → no output"). Demotions:

- **Resume Detection ×7** — marker + found-voice signpost move inside the artifact-exists branch, directly above the shared resume menu; fresh entries render nothing. Implementation instead keeps its own existing "Found existing implementation… Resuming" line and gets a full strip.
- **Document Dependencies (spec) / Resolve External Dependencies (planning)** — epic-only steps; chrome now renders only on the epic branch.

Kept throughout: session loops, construction beats, task/analysis loops, reviews, QA, sign-offs, conclude steps — including all of #483's new investigation arc (plan, sign-off, fix discussion, fix validation), which are genuine interaction/activity beats.

## Lint check 12

A marker on a step whose only substance is a single Load directive fails when the loaded reference is **transitively inert** — no `**STOP.**`, no rendering instruction, no bash fence, through nested Loads (unresolvable/parameterised targets conservatively skipped; H4-structured steps are judgment tier and out of scope).

Worth reading in the diff: the first draft (direct-file, STOP/render only) flagged three corpus sites — `produce-review.md`, `write-tasks.md` (both do the phase's core work via bash), and `route-scenario.md` (renders menus via nested display refs). Real chrome-earners the crude heuristic couldn't see; the transitive/bash-aware version passes them and still catches pure-prose loads. Negative fixtures cover: unearned marker caught, interactive ref passes, silent step passes, H4 skipped, unresolvable skipped.

## Test plan

- `node --test tests/scripts/test-conventions-lint.cjs` — 25/25, corpus clean under check 12.
- `npm test` — 1450/1450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #482
2. #484
3. #485
4. **#486** 👈 current
<!-- stack:links:end -->