### PR TITLE
fix(investigation): resume-aware gates — announce position, don't re-litigate

### DIFF
--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -124,6 +124,14 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 
 ## Step 3: Symptom Gathering
 
+#### If the Symptoms section is already populated
+
+Resuming — don't re-interview. Fold in anything new the user has mentioned this session (commit if the file changed).
+
+→ Proceed to **Step 4**.
+
+#### Otherwise
+
 > *Output the next fenced block as a code block:*
 
 ```
@@ -166,9 +174,9 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> A quick recon pass to form hypotheses, then agreement on where
-> to look and how collaboratively to work before deep tracing
-> begins.
+> Forming hypotheses and agreeing where to look and how
+> collaboratively to work — or re-confirming the existing plan
+> when resuming — before deep tracing begins.
 ```
 
 Load **[investigation-plan.md](references/investigation-plan.md)** and follow its instructions as written.

--- a/skills/workflow-investigation-process/references/investigation-plan.md
+++ b/skills/workflow-investigation-process/references/investigation-plan.md
@@ -6,6 +6,10 @@
 
 Form hypotheses and agree the shape of the analysis before deep tracing begins. The seed material, symptoms, and knowledge base results often carry a strong lead — recon turns them into an explicit plan the user can steer.
 
+**If the Hypotheses section already holds an agreed plan** (a checkpoint depth and at least one hypothesis) — this is a resume:
+
+→ Proceed to **D. Resume Position**.
+
 ## A. Recon
 
 A bounded first pass — enough to form hypotheses, never the investigation itself:
@@ -78,3 +82,46 @@ Incorporate the changes — add or drop hypotheses, re-order trace lines, switch
 Write the agreed plan into the Hypotheses section of the investigation file: the checkpoint depth, then each hypothesis with status `[suspected]` and its basis. Commit (`investigation({work_unit}): investigation plan`).
 
 → Return to caller.
+
+---
+
+## D. Resume Position
+
+The plan was agreed in an earlier session — re-render the position from the ledger; never re-run recon over settled state.
+
+> *Output the next fenced block as a code block:*
+
+```
+Investigation Plan: {work_unit} (resumed)
+
+Board:
+  • {hypothesis} [{status}]
+  • ...
+
+Depth: {depth:[straight-through|check-ins]}
+
+Remaining: {unresolved hypotheses and open trace lines, or "all hypotheses resolved"}
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Picking up where we left off — still good?
+
+- **`y`/`yes`** — Continue as agreed
+- **Revise** — Tell me what to change: hypotheses, trace lines, or depth
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `yes`
+
+→ Return to caller.
+
+#### If the user revises
+
+Incorporate the changes into the ledger — existing statuses preserved, new hypotheses enter as `[suspected]` — and commit.
+
+→ Return to **D. Resume Position**.


### PR DESCRIPTION
## Problem

Follow-up to #483. On `continue`, resume detection lands at Step 2 and the flow walks forward — but the steps are written as first-pass interactions. Two gates re-fire with no new decision behind them:

- **Symptom Gathering** may re-interview the user over fully documented symptoms — nothing told it they were settled.
- **Investigation Plan** (new in #483) *always* ran recon and asked "does this plan look right?" as a first-time approval — even when the plan was agreed in an earlier session. Every resume re-litigated a settled decision.

## Change

Keep the single resume entry point (`continue_step = Step 2`, house-consistent); make the two interactive steps resume-aware:

- **Step 3**: if the Symptoms section is already populated, short-circuit to Step 4 — fold in anything new the user mentioned this session, no re-interview. Chrome sits inside the interview branch per the earned-chrome convention; the resume path renders nothing.
- **Investigation Plan**: a prelude guard (Hypotheses ledger with an agreed checkpoint depth) routes to a new **D. Resume Position** — the current board rendered from the ledger (hypothesis statuses, depth, what remains) with a `continue as agreed / revise` gate. The redundant first-time approval becomes a genuine position announcement, matching the compaction-recovery protocol's "announce your position". Revisions fold into the ledger with existing statuses preserved; recon never re-runs over settled state.

A fully-resolved ledger flows naturally onward: Step 6 has nothing left to trace and falls through to synthesis.

`npm test`: 1450 pass, 0 fail (includes the earned-chrome and load-footer lint checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)