### PR TITLE
refactor(discovery): dump carries description/seeds/imports — initialize reads, not spawns

### DIFF
--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -173,6 +173,8 @@ Hold the output in conversation context as **the most recent discovery output**.
 - `discovery_map` — per-topic `tier`, `lifecycle`, `current_phase`, `routing`, `source`, `summary`
 - `map_summary` — counts string used for the opener render
 - `dismissed` — names previously removed from the map
+- `description` — the work-unit one-liner
+- `seeds` / `imports` — the work unit's seed material entries (paths relative to `.workflows/{work_unit}/`), read by Step 8 and the session loop's launchpad branch
 - `session_logs` — every session log's number + path (ascending); read from this rather than re-globbing (used by continuity-load.md)
 - `next_session_number` — used to set `session_number` for fresh entries
 

--- a/skills/workflow-discovery/references/initialize-discovery.md
+++ b/skills/workflow-discovery/references/initialize-discovery.md
@@ -5,7 +5,7 @@
 ---
 
 1. Ensure the session-log and briefs directories exist: `mkdir -p .workflows/{work_unit}/discovery/sessions/ .workflows/{work_unit}/discovery/briefs/` (safe to re-run).
-2. Hold the following in conversation memory — they parameterise the session log when it is eventually written; the session loop's opener and seed/import-launchpad branch read them:
+2. Hold the following in conversation memory — the lazy session-log write records them in the log's header sections ([template.md](template.md) → *Description*, *Seeds*, *Imports*), and the session loop's opener and seed/import-launchpad branch read them:
    - `session_number` — set before this step (Step 6 on resume, Step 7 for a fresh session, or the confirm-trigger for a new epic).
    - `description` — from the most recent discovery output.
    - `seeds` — from the most recent discovery output (may be empty — treat as "none"). The work unit's origin when it was promoted from the inbox.

--- a/skills/workflow-discovery/references/initialize-discovery.md
+++ b/skills/workflow-discovery/references/initialize-discovery.md
@@ -5,20 +5,11 @@
 ---
 
 1. Ensure the session-log and briefs directories exist: `mkdir -p .workflows/{work_unit}/discovery/sessions/ .workflows/{work_unit}/discovery/briefs/` (safe to re-run).
-2. Read the work-unit `description`, `seeds` list, and `imports` list from the manifest — they are not carried in the discovery output, and the session loop's opener and seed/import-launchpad branch read them:
-
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} description
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} seeds
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} imports
-   ```
-
-   `get` returns empty on an absent field — treat an empty `seeds`/`imports` as "none".
-3. Hold the following in conversation memory — they parameterise the session log when it is eventually written:
+2. Hold the following in conversation memory — they parameterise the session log when it is eventually written; the session loop's opener and seed/import-launchpad branch read them:
    - `session_number` — set before this step (Step 6 on resume, Step 7 for a fresh session, or the confirm-trigger for a new epic).
-   - `description` — the value read above.
-   - `seeds` — the value read above (may be empty). The work unit's origin when it was promoted from the inbox.
-   - `imports` — the value read above (may be empty).
+   - `description` — from the most recent discovery output.
+   - `seeds` — from the most recent discovery output (may be empty — treat as "none"). The work unit's origin when it was promoted from the inbox.
+   - `imports` — from the most recent discovery output (may be empty — treat as "none").
    - `map_state_at_start` — `map_summary` from the most recent discovery output. Write `(empty — first session)` when the map is empty.
 
 **Do not create the session log file here.** For a new epic the confirm-trigger already wrote `session-001.md`; otherwise the file is conjured lazily on the first state change — see [template.md](template.md) → *Lazy creation and finalisation*.

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -10,7 +10,7 @@ State-driven branches in **A. Open** pick the opening shape; **B. Session Loop**
 
 ## A. Open
 
-Read `discovery_map` and `dismissed` from the most recent discovery output. `imports` was read from the manifest and is already held in conversation memory (Step 8). Read `session_number` and any active file path from the resume state set at Step 6.
+Read `discovery_map` and `dismissed` from the most recent discovery output. `description`, `seeds`, and `imports` are carried in the same output and already held in conversation memory (Step 8). Read `session_number` and any active file path from the resume state set at Step 6.
 
 #### If `macro_continuation` is set (new epic, just confirmed)
 

--- a/skills/workflow-discovery/scripts/gateway.cjs
+++ b/skills/workflow-discovery/scripts/gateway.cjs
@@ -51,11 +51,14 @@ function discover(cwd, workUnit) {
   };
   return {
     work_unit: workUnit,
+    description: typeof manifest.description === 'string' && manifest.description !== '' ? manifest.description : null,
     discovery_map: map,
     map_summary: summary,
     needs_sequencing,
     dismissed,
     active_session: activeSession,
+    seeds: Array.isArray(manifest.seeds) ? manifest.seeds : [],
+    imports: Array.isArray(manifest.imports) ? manifest.imports : [],
     session_logs: listSessionLogs(cwd, workUnit),
     analysis_caches: analysisCaches,
     next_session_number: nextSessionNumber,
@@ -63,8 +66,9 @@ function discover(cwd, workUnit) {
 }
 
 // The thin scoped dump: the map (rows + counts), the dismissed list, the
-// session-log index, analysis-cache statuses, and the next session number —
-// exactly what the session loop, map operations, continuity load, and the
+// work unit's manifest context (description, seeds, imports), the session-log
+// index, analysis-cache statuses, and the next session number — exactly what
+// the session loop, initialize step, map operations, continuity load, and the
 // shared topic-discovery dispatch read. Rendering is map-view's concern.
 function format(result) {
   if (result.error) {
@@ -72,6 +76,7 @@ function format(result) {
   }
   const lines = [];
   lines.push(`=== DISCOVERY: ${result.work_unit} ===`);
+  lines.push(`description: ${result.description === null ? '(none)' : result.description}`);
 
   const s = result.map_summary;
   lines.push(`map_summary: ${s.total} topics — ${s.decided} decided, ${s.in_flight} in-flight, ${s.ready} ready, ${s.fresh} fresh, ${s.handled} handled, ${s.cancelled} cancelled`);
@@ -96,6 +101,26 @@ function format(result) {
   } else {
     for (const name of result.dismissed) {
       lines.push(`  - ${name}`);
+    }
+  }
+
+  const seeds = result.seeds || [];
+  lines.push(`seeds (${seeds.length}):`);
+  if (seeds.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const entry of seeds) {
+      lines.push(`  - ${entry.path}${entry.source ? ` (source: ${entry.source})` : ''}`);
+    }
+  }
+
+  const imports = result.imports || [];
+  lines.push(`imports (${imports.length}):`);
+  if (imports.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const entry of imports) {
+      lines.push(`  - ${entry.path}`);
     }
   }
 

--- a/tests/scripts/test-gateway-for-discovery-skill.cjs
+++ b/tests/scripts/test-gateway-for-discovery-skill.cjs
@@ -577,6 +577,51 @@ describe('workflow-discovery format', () => {
     assert.match(out, /=== DISCOVERY: payments ===/);
   });
 
+  // --- description / seeds / imports (manifest context carried in the dump) ---
+
+  it('renders the work-unit description beneath the header', () => {
+    createManifest(dir, 'payments', { work_type: 'epic', description: 'Payments overhaul epic' });
+    const out = format(discover(dir, 'payments'));
+    assert.match(out, /=== DISCOVERY: payments ===\ndescription: Payments overhaul epic/);
+  });
+
+  it('renders "(none)" for a missing or empty description', () => {
+    createManifest(dir, 'payments', { work_type: 'epic', description: '' });
+    const out = format(discover(dir, 'payments'));
+    assert.match(out, /description: \(none\)/);
+    assert.strictEqual(discover(dir, 'payments').description, null);
+  });
+
+  it('renders seeds entries with path and source, imports with path', () => {
+    createManifest(dir, 'payments', {
+      work_type: 'epic',
+      seeds: [{ path: 'seeds/2026-07-01--pay-idea.md', source: 'inbox:idea' }],
+      imports: [{ path: 'imports/notes.md' }],
+    });
+    const result = discover(dir, 'payments');
+    assert.deepStrictEqual(result.seeds, [{ path: 'seeds/2026-07-01--pay-idea.md', source: 'inbox:idea' }]);
+    assert.deepStrictEqual(result.imports, [{ path: 'imports/notes.md' }]);
+    const out = format(result);
+    assert.match(out, /seeds \(1\):\n {2}- seeds\/2026-07-01--pay-idea\.md \(source: inbox:idea\)/);
+    assert.match(out, /imports \(1\):\n {2}- imports\/notes\.md/);
+  });
+
+  it('renders "(none)" seeds/imports and defaults to empty arrays when the fields are absent', () => {
+    createManifest(dir, 'payments', { work_type: 'epic' });
+    const result = discover(dir, 'payments');
+    assert.deepStrictEqual(result.seeds, []);
+    assert.deepStrictEqual(result.imports, []);
+    const out = format(result);
+    assert.match(out, /seeds \(0\):\n {2}\(none\)/);
+    assert.match(out, /imports \(0\):\n {2}\(none\)/);
+  });
+
+  it('a seed entry without a source renders bare', () => {
+    createManifest(dir, 'payments', { work_type: 'epic', seeds: [{ path: 'seeds/x.md' }] });
+    const out = format(discover(dir, 'payments'));
+    assert.match(out, /seeds \(1\):\n {2}- seeds\/x\.md\n/);
+  });
+
   // --- map_summary line ---
 
   it('map_summary line includes total and all six counts', () => {
@@ -767,10 +812,15 @@ describe('workflow-discovery format', () => {
     const out = format(discover(dir, 'payments'));
     assert.strictEqual(out, [
       '=== DISCOVERY: payments ===',
+      'description: Test: payments',
       'map_summary: 0 topics — 0 decided, 0 in-flight, 0 ready, 0 fresh, 0 handled, 0 cancelled',
       'discovery_map (0):',
       '  (empty)',
       'dismissed (0):',
+      '  (none)',
+      'seeds (0):',
+      '  (none)',
+      'imports (0):',
       '  (none)',
       'session_logs (0):',
       '  (none)',
@@ -799,12 +849,17 @@ describe('workflow-discovery format', () => {
     const out = format(discover(dir, 'payments'));
     assert.strictEqual(out, [
       '=== DISCOVERY: payments ===',
+      'description: Test: payments',
       'map_summary: 2 topics — 0 decided, 1 in-flight, 0 ready, 1 fresh, 0 handled, 0 cancelled',
       'discovery_map (2):',
       '  - ◐ auth-flow [researching] routing=research phase=research — OAuth vs sessions',
       '  - ○ billing [fresh] routing=discussion source=gap-analysis',
       'dismissed (1):',
       '  - old-thing',
+      'seeds (0):',
+      '  (none)',
+      'imports (0):',
+      '  (none)',
       'session_logs (2):',
       '  - 001 .workflows/payments/discovery/sessions/session-001.md',
       '  - 002 .workflows/payments/discovery/sessions/session-002.md',


### PR DESCRIPTION
Ledger item (spotted by Lee during the earned-chrome review): `initialize-discovery.md` drove three separate `engine manifest get` spawns — description, seeds, imports — for values the discovery gateway dump was already positioned to serve in the same snapshot Step 7 runs.

## Change

- `gateway.cjs discover()` returns `description` (null when absent/empty), `seeds`, `imports` (empty arrays when absent); `format()` renders them — `description:` beneath the header, `seeds`/`imports` blocks after `dismissed` with `(none)` placeholders and `path (source: …)` entries.
- `initialize-discovery.md` loses its three-command bash block — the values are read from the most recent discovery output already in context.
- `session-loop.md` provenance note and the SKILL.md Step 7 field list updated to match.

Zero new spawns anywhere; three fewer model-driven engine calls per discovery session.

**Out of scope, noted**: 8 other `manifest get {work_unit} description|seeds` call sites exist in entry skills + `seed-context.md` — flows that never run the discovery gateway, so folding them is a separate per-gateway consolidation (added to the ledger).

## Test plan

- `tests/scripts/test-gateway-for-discovery-skill.cjs`: new coverage for the three fields (values, defaults, render shapes, source-less seed); the two byte-exact dump pins updated — they caught the shape change exactly as designed.
- `npm test` — 1455/1455. `npm run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)