### PR TITLE
feat(engine): finding + findings-summary surfaces — review-findings loop unified

### DIFF
--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -165,7 +165,11 @@ engine commit --workflows -m "<message>"
 ```bash
 engine render resume-gate <wu>.<phase>.<topic> [--triage <N>]     # shared continue/restart gate; --triage adds the undrained-concerns warning above the menu
 engine render task-list <wu>.planning.<topic> --file <payload>    # planning task-list gate; payload {phase, phase_name, tasks: [{name, summary, edge_cases?}]}
+engine render findings-summary <wu>.<phase>.<topic> --file <payload>  # review-findings overview; payload {review_label, items: [{title, tag, summary}]}
+engine render finding <wu>.<phase>.<topic> --file <payload>       # one finding + its gate; payload {n, total, title, meta, details, diff|content, apply_label?, applied_label?, feedback_hint?}
 ```
+
+The `finding` surface serves both review-findings loops (planning and specification) with per-consumer labels in the payload. Its diff presentation returns the boxed frame as three sections — frame open, diff body (emitted as a ` ```diff ` fence so the host's colouring survives), frame close — with the frame borders computed from the content width.
 
 The `render` group also keeps its dev/debug primitives (`signpost`, `box`, `wrap`, `tree`) — authoring aids only, never called from skill flows.
 

--- a/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
@@ -122,16 +122,18 @@ function treeList(items, { indent = '     ', width = 72 } = {}) {
  * Boxed content frame (`╭─ Title ──…──╮` / `╰──…──╯`): top and bottom rules
  * whose width is computed from the actual content, so the border always
  * reaches the frame's widest line — never a fixed-length rule stopping short.
+ * Capped at `maxWidth` so the border itself never wraps in a terminal:
+ * unwrappable content (diff lines) may overflow past a capped border.
  * Content lines render as-is between the rules (no side walls).
  * @param {string} title
  * @param {string[]} contentLines pre-wrapped content
- * @param {{minWidth?: number}} [opts]
+ * @param {{minWidth?: number, maxWidth?: number}} [opts]
  * @returns {string}
  */
-function boxedFrame(title, contentLines, { minWidth = 53 } = {}) {
+function boxedFrame(title, contentLines, { minWidth = 53, maxWidth = 100 } = {}) {
   const head = `╭─ ${title} `;
   const contentMax = contentLines.reduce((m, l) => Math.max(m, [...l].length), 0);
-  const width = Math.max(minWidth, [...head].length + 1, contentMax);
+  const width = Math.min(maxWidth, Math.max(minWidth, [...head].length + 1, contentMax));
   const top = head + '─'.repeat(Math.max(1, width - [...head].length - 1)) + '╮';
   const bottom = '╰' + '─'.repeat(width - 2) + '╯';
   return [top, ...contentLines, bottom].join('\n');

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -12,7 +12,7 @@ const fs = require('fs');
 const path = require('path');
 const { loadManifest } = require('./reads.cjs');
 const { titlecase } = require('./conventions.cjs');
-const { section, menu, cmdOption, promptOption, callout, subDetail, treeList } = require('./projections/surfaces.cjs');
+const { section, menu, cmdOption, promptOption, callout, subDetail, treeList, boxedFrame } = require('./projections/surfaces.cjs');
 
 /**
  * Parse a 3-segment dotpath `work_unit.phase.topic`, validating the work unit
@@ -178,10 +178,151 @@ function taskList(cwd, { dotpath, file }) {
   return parts.join('\n');
 }
 
+// ---------------------------------------------------------------------------
+// findings-summary / finding — the review-findings loop shared by the
+// planning and specification review flows. Findings live in markdown tracking
+// files, which the model reads (the engine never parses markdown) and hands
+// over as a JSON payload; the gate mode is manifest state at the address.
+// The diff presentation splits the boxed frame around the diff body so the
+// host's `diff` fence colouring survives — frame borders are computed from
+// the actual content width.
+// ---------------------------------------------------------------------------
+
+/** @param {string} cwd @param {string} file @param {string} surface @returns {any} */
+function readJsonPayload(cwd, file, surface) {
+  let raw;
+  try {
+    raw = fs.readFileSync(path.resolve(cwd, file), 'utf8');
+  } catch {
+    throw new Error(`render ${surface}: payload file not found: ${file}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`render ${surface}: payload is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** @param {unknown} v @returns {v is string} */
+function isFilled(v) {
+  return typeof v === 'string' && v.trim() !== '';
+}
+
+/** @param {unknown} v @param {string} surface @param {string} field @returns {string[]} */
+function stringLines(v, surface, field) {
+  if (!Array.isArray(v) || v.some((l) => typeof l !== 'string')) {
+    throw new Error(`render ${surface}: "${field}" must be an array of strings`);
+  }
+  return v;
+}
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, file?: string}} args
+ * @returns {string}
+ */
+function findingsSummary(cwd, { dotpath, file }) {
+  if (!file) throw new Error('render findings-summary: --file <payload.json> is required');
+  resolveAddress(cwd, dotpath, 'findings-summary');
+  const p = readJsonPayload(cwd, file, 'findings-summary');
+  if (!isFilled(p.review_label)) throw new Error('render findings-summary: "review_label" must be a non-empty string');
+  if (!Array.isArray(p.items) || p.items.length === 0) {
+    throw new Error('render findings-summary: "items" must be a non-empty array of {title, tag, summary}');
+  }
+  const lines = [`${p.review_label} — ${p.items.length} item${p.items.length === 1 ? '' : 's'} found`, ''];
+  p.items.forEach((it, i) => {
+    for (const field of ['title', 'tag', 'summary']) {
+      if (!isFilled(it[field])) throw new Error(`render findings-summary: item ${i + 1} is missing "${field}"`);
+    }
+    lines.push(`${i + 1}. ${it.title} (${it.tag})`);
+    lines.push(subDetail(it.summary));
+    if (i < p.items.length - 1) lines.push('');
+  });
+  lines.push('', "Let's work through these one at a time, starting with #1.");
+  return section('DISPLAY: findings summary', 'emit verbatim as a code block', lines.join('\n'));
+}
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, file?: string}} args
+ * @returns {string}
+ */
+function finding(cwd, { dotpath, file }) {
+  if (!file) throw new Error('render finding: --file <payload.json> is required');
+  const { phase, topic, manifest } = resolveAddress(cwd, dotpath, 'finding');
+  const p = readJsonPayload(cwd, file, 'finding');
+
+  if (!Number.isInteger(p.n) || p.n < 1) throw new Error('render finding: "n" must be a positive integer');
+  if (!Number.isInteger(p.total) || p.total < p.n) throw new Error('render finding: "total" must be an integer ≥ "n"');
+  if (!isFilled(p.title)) throw new Error('render finding: "title" must be a non-empty string');
+  if (!Array.isArray(p.meta) || p.meta.some((m) => !Array.isArray(m) || m.length !== 2 || !isFilled(m[0]) || !isFilled(String(m[1])))) {
+    throw new Error('render finding: "meta" must be an array of [label, value] pairs');
+  }
+  if (!isFilled(p.details)) throw new Error('render finding: "details" must be a non-empty string');
+  if (p.diff && p.content) throw new Error('render finding: pass "diff" or "content", not both');
+
+  const applyLabel = isFilled(p.apply_label) ? p.apply_label : 'Apply verbatim';
+  const appliedLabel = isFilled(p.applied_label) ? p.applied_label : 'approved. Applied.';
+  const feedbackHint = isFilled(p.feedback_hint) ? p.feedback_hint : 'Tell me what to change before approving';
+
+  const parts = [];
+
+  const head = [`**Finding ${p.n} of ${p.total}: ${p.title}**`, ''];
+  for (const [label, value] of p.meta) head.push(`- **${label}**: ${value}`);
+  head.push('', `**Details**: ${p.details}`);
+  parts.push(section('DISPLAY: finding', 'emit verbatim as markdown', head.join('\n')));
+
+  if (p.diff) {
+    const body = [
+      ...stringLines(p.diff.context_above || [], 'finding', 'diff.context_above').map((l) => ` ${l}`),
+      ...stringLines(p.diff.current || [], 'finding', 'diff.current').map((l) => `-${l}`),
+      ...stringLines(p.diff.proposed || [], 'finding', 'diff.proposed').map((l) => `+${l}`),
+      ...stringLines(p.diff.context_below || [], 'finding', 'diff.context_below').map((l) => ` ${l}`),
+    ];
+    if (body.length === 0) throw new Error('render finding: "diff" must carry at least one current/proposed line');
+    const framed = boxedFrame(`Finding ${p.n}: ${p.title}`, body).split('\n');
+    parts.push(section('DISPLAY: diff frame open', 'emit verbatim as a code block, directly above the diff', framed[0]));
+    parts.push(section('DISPLAY: diff', 'emit verbatim as a diff code block (```diff fence)', framed.slice(1, -1).join('\n')));
+    parts.push(section('DISPLAY: diff frame close', 'emit verbatim as a code block, directly below the diff', framed[framed.length - 1]));
+  } else if (p.content) {
+    if (!isFilled(p.content.label)) throw new Error('render finding: "content.label" must be a non-empty string');
+    const lines = stringLines(p.content.lines, 'finding', 'content.lines');
+    if (lines.length === 0) throw new Error('render finding: "content.lines" must be non-empty');
+    parts.push(section('DISPLAY: finding content', 'emit verbatim as markdown', [`**${p.content.label}**:`, ...lines].join('\n')));
+  }
+
+  const items = (((manifest.phases || {})[phase] || {}).items || {})[topic] || {};
+  const gateMode = items.finding_gate_mode === 'auto' ? 'auto' : 'gated';
+
+  if (gateMode === 'auto') {
+    parts.push(section(
+      'DISPLAY: finding auto-approved',
+      'emit verbatim as a code block after applying the fix',
+      `Finding ${p.n} of ${p.total}: ${p.title} — ${appliedLabel}`,
+    ));
+  } else {
+    const options = [cmdOption('y', 'yes', applyLabel)];
+    if (p.diff) options.push(cmdOption('v', 'view full', 'Show full Current and Proposed content'));
+    options.push(
+      cmdOption('a', 'auto', 'Approve this and all remaining findings automatically'),
+      cmdOption('s', 'skip', 'Leave as-is, move to next finding'),
+      promptOption('Provide feedback', feedbackHint),
+    );
+    parts.push(section(
+      'MENU: finding gate',
+      'emit verbatim as markdown, then STOP for the user\'s response',
+      menu(`**Finding ${p.n} of ${p.total}: ${p.title}**`, options),
+    ));
+  }
+  return parts.join('\n');
+}
+
 /** The catalogue: surface name → handler. @type {Record<string, (cwd: string, args: {dotpath: string} & Record<string, string|undefined>) => string>} */
 const SURFACES = {
   'resume-gate': resumeGate,
   'task-list': taskList,
+  'findings-summary': findingsSummary,
+  'finding': finding,
 };
 
 /**

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -154,6 +154,8 @@ Commands:
   commit --workflows -m <message>
   render resume-gate <wu.phase.topic> [--triage N]
   render task-list   <wu.planning.topic> --file <payload.json>
+  render findings-summary <wu.phase.topic> --file <payload.json>
+  render finding          <wu.phase.topic> --file <payload.json>
   render signpost <label> [--style step|substep] [--width N]     (dev aid)
   render box <title> [--width N]                                 (dev aid)
   render wrap <text> [--width N] [--prefix STR]                  (dev aid)

--- a/skills/workflow-planning-process/references/process-review-findings.md
+++ b/skills/workflow-planning-process/references/process-review-findings.md
@@ -30,21 +30,16 @@ Read the tracking file at the path returned by the agent (`TRACKING_FILE`).
 
 ## A. Summary
 
-> *Output the next fenced block as a code block:*
+Write the summary payload to `.workflows/.cache/{work_unit}/planning/{topic}/findings-summary.json` with the Write tool — one item per finding from the tracking file:
 
-```
-{Review type} Review — {N} items found
-
-1. {title} ({type or severity}) — {change_type}
-   {1-2 line summary from the Details field}
-
-2. ...
+```json
+{"review_label": "{Review type} Review", "items": [{"title": "…", "tag": "{type or severity} — {change_type}", "summary": "{1-2 line summary from the Details field}"}]}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Let's work through these one at a time, starting with #1.
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render findings-summary {work_unit}.planning.{topic} --file .workflows/.cache/{work_unit}/planning/{topic}/findings-summary.json
 ```
 
 → Proceed to **B. Process One Item at a Time**.
@@ -57,79 +52,24 @@ Work through each finding **sequentially**. For each finding: present it, show t
 
 ### Present Finding
 
-Show the finding metadata, read directly from the tracking file:
+Write the finding payload to `.workflows/.cache/{work_unit}/planning/{topic}/finding-current.json` with the Write tool, from the tracking file:
 
-> *Output the next fenced block as markdown (not a code block):*
+- `n`, `total`, `title` — the finding's position and Brief Title.
+- `meta` — `[label, value]` pairs: for traceability, Type / Spec Reference / Plan Reference / Change Type; for integrity, Severity / Plan Reference / Category / Change Type.
+- `details` — the Details field.
+- For Change Type `update-task`, `add-to-task`, or `remove-from-task`: `diff` — `{"context_above": […], "current": […], "proposed": […], "context_below": […]}` with only the changed lines and 2 context lines each side.
+- For Change Type `add-task`, `add-phase`, `remove-task`, or `remove-phase`: `content` — `{"label": "Proposed" | "Current", "lines": […]}` with the full content as written by the review agent.
+- `apply_label`: `"Apply to the plan verbatim"` · `applied_label`: `"approved. Applied to plan."`
 
-```
-**Finding {N} of {total}: {Brief Title}**
+Render, then emit each returned section verbatim at its marked instruction — the diff body as a ` ```diff ` fence between the frame rules:
 
-@if(review_type = traceability)
-- **Type**: Missing from plan | Hallucinated content | Incomplete coverage
-- **Spec Reference**: {from tracking file}
-- **Plan Reference**: {from tracking file}
-- **Change Type**: {from tracking file}
-@else
-- **Severity**: Critical | Important | Minor
-- **Plan Reference**: {from tracking file}
-- **Category**: {from tracking file}
-- **Change Type**: {from tracking file}
-@endif
-
-**Details**: {from tracking file}
-```
-
-Then present the content based on **Change Type**:
-
-**If Change Type is `update-task`, `add-to-task`, or `remove-from-task`:**
-
-Present the changes as a diff. Read Current and Proposed from the tracking file. Show only the changed lines with 2 lines of context above and below:
-
-> *Output the next fenced block as a code block:*
-
-```
-╭─ Finding {N}: {Brief Title} ──────────────────────╮
-```
-
-> *Output the next fenced block as a code block:*
-
-```diff
- {2 context lines above}
--{lines from Current}
-+{lines from Proposed}
- {2 context lines below}
-```
-
-> *Output the next fenced block as a code block:*
-
-```
-╰───────────────────────────────────────────────────╯
-```
-
-**If Change Type is `add-task`, `add-phase`, `remove-task`, or `remove-phase`:**
-
-Present full content from the tracking file. Include **Proposed** for additions, **Current** for removals — as written by the review agent:
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-@if(Change Type is add-task or add-phase)
-**Proposed**:
-{from tracking file — the new content}
-@else
-**Current**:
-{from tracking file — the content being removed}
-@endif
-```
-
-### Check Gate Mode
-
-Check `finding_gate_mode` via `engine manifest`:
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} finding_gate_mode
+node .claude/skills/workflow-engine/scripts/engine.cjs render finding {work_unit}.planning.{topic} --file .workflows/.cache/{work_unit}/planning/{topic}/finding-current.json
 ```
 
-#### If `finding_gate_mode` is `auto`
+The response carries the finding presentation plus the surface for the current gate mode.
+
+#### If the response carried `DISPLAY: finding auto-approved`
 
 1. Apply the fix to the plan (use **Proposed** content exactly as in tracking file)
 2. Keep `task_map` current — for `add-task`/`add-phase`, record each new internal ID → external ID mapping; for `remove-task`/`remove-phase`, delete each removed ID's entry:
@@ -139,12 +79,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
    ```
 3. Update the tracking file: set resolution to "Fixed"
 4. Commit the tracking file and plan changes
-
-> *Output the next fenced block as a code block:*
-
-```
-Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
-```
+5. Emit the `DISPLAY: finding auto-approved` section now, per its marker.
 
 **If pending findings remain:**
 
@@ -154,35 +89,19 @@ Finding {N} of {total}: {Brief Title} — approved. Applied to plan.
 
 → Proceed to **C. After All Findings Processed**.
 
-#### If `finding_gate_mode` is `gated`
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-**Finding {N} of {total}: {Brief Title}**
-
-- **`y`/`yes`** — Apply to the plan verbatim
-@if(Change Type is update-task, add-to-task, or remove-from-task)
-- **`v`/`view full`** — Show full Current and Proposed content
-@endif
-- **`a`/`auto`** — Approve this and all remaining findings automatically
-- **`s`/`skip`** — Leave as-is, move to next finding
-- **Provide feedback** — Tell me what to change before approving
-· · · · · · · · · · · ·
-```
+#### If the response carried `MENU: finding gate`
 
 **STOP.** Wait for user response.
 
 #### If `view full`
 
-Re-present the finding's **Current** and **Proposed** content in full from the tracking file. Then re-present the approval menu.
+Re-present the finding's **Current** and **Proposed** content in full from the tracking file. Then re-emit the `MENU: finding gate` section.
 
-→ Return to **B. Process One Item at a Time**.
+**STOP.** Wait for user response.
 
 #### If the user provides feedback
 
-Incorporate feedback and update the tracking file with the revised content. Re-present the finding using the same presentation format (diff or full) as the original.
+Incorporate feedback and update the tracking file with the revised content. Rewrite the payload to match and re-render the finding.
 
 → Return to **B. Process One Item at a Time**.
 

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -30,21 +30,16 @@ Read the tracking file and count pending findings.
 
 ## A. Summary
 
-> *Output the next fenced block as a code block:*
+Write the summary payload to `.workflows/.cache/{work_unit}/specification/{topic}/findings-summary.json` with the Write tool — one item per finding from the tracking file:
 
-```
-{review_type} — {N} items found
-
-1. {title} ({category})
-   {1-2 line summary from the Details field}
-
-2. ...
+```json
+{"review_label": "{review_type}", "items": [{"title": "…", "tag": "{category}", "summary": "{1-2 line summary from the Details field}"}]}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Let's work through these one at a time, starting with #1.
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render findings-summary {work_unit}.specification.{topic} --file .workflows/.cache/{work_unit}/specification/{topic}/findings-summary.json
 ```
 
 → Proceed to **B. Process One Item at a Time**.
@@ -57,76 +52,31 @@ Work through each finding **sequentially**. For each finding: present it, show t
 
 ### Present Finding
 
-Show the finding metadata, read directly from the tracking file:
+Write the finding payload to `.workflows/.cache/{work_unit}/specification/{topic}/finding-current.json` with the Write tool, from the tracking file:
 
-> *Output the next fenced block as markdown (not a code block):*
+- `n`, `total`, `title` — the finding's position and titlecased brief title.
+- `meta` — `[label, value]` pairs: Source / Category / Affects, plus Priority for Gap Analysis findings.
+- `details` — the Details field.
+- If Category is `Enhancement to existing topic` and a Current field is present: `diff` — `{"context_above": […], "current": […], "proposed": […], "context_below": […]}` with only the changed lines and 2 context lines each side (Proposed Addition as the proposed lines).
+- Otherwise: `content` — `{"label": "Proposed Addition", "lines": […]}` with the content to add.
+- `apply_label`: `"Add to the specification verbatim"` · `applied_label`: `"approved. Added to specification."` · `feedback_hint`: `"Adjust before approving"`
 
-```
-**Finding {N} of {total}: {brief_title:(titlecase)}**
+Render, then emit each returned section verbatim at its marked instruction — the diff body as a ` ```diff ` fence between the frame rules:
 
-- **Source**: {from tracking file}
-- **Category**: {from tracking file}
-@if(review_type = Gap Analysis)
-- **Priority**: Critical | Important | Minor
-@endif
-- **Affects**: {from tracking file}
-
-**Details**: {from tracking file}
-```
-
-Then present the content based on **Category**:
-
-**If Category is `Enhancement to existing topic` and Current field is present:**
-
-Present the changes as a diff. Read Current and Proposed Addition from the tracking file. Show only the changed lines with 2 lines of context above and below:
-
-> *Output the next fenced block as a code block:*
-
-```
-╭─ Finding {N}: {brief_title:(titlecase)} ──────────╮
-```
-
-> *Output the next fenced block as a code block:*
-
-```diff
- {2 context lines above}
--{lines from Current}
-+{lines from Proposed Addition}
- {2 context lines below}
-```
-
-> *Output the next fenced block as a code block:*
-
-```
-╰───────────────────────────────────────────────────╯
-```
-
-**Otherwise:**
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**Proposed Addition**:
-{from tracking file — the content to add to the specification}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render finding {work_unit}.specification.{topic} --file .workflows/.cache/{work_unit}/specification/{topic}/finding-current.json
 ```
 
 **For potential gaps** (items not directly from source material): you're asking questions rather than proposing content. If the user wants to address a gap, discuss it, then present what you'd add for approval.
 
-### Check Gate Mode
+The response carries the finding presentation plus the surface for the current gate mode.
 
-Check `finding_gate_mode` via `engine manifest` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic} finding_gate_mode`).
-
-#### If `finding_gate_mode` is `auto`
+#### If the response carried `DISPLAY: finding auto-approved`
 
 1. Log the proposed content to the specification verbatim
 2. Update the tracking file: set resolution to "Approved"
 3. Commit
-
-> *Output the next fenced block as a code block:*
-
-```
-Finding {N} of {total}: {brief_title:(titlecase)} — approved. Added to specification.
-```
+4. Emit the `DISPLAY: finding auto-approved` section now, per its marker.
 
 **If pending findings remain:**
 
@@ -136,35 +86,19 @@ Finding {N} of {total}: {brief_title:(titlecase)} — approved. Added to specifi
 
 → Proceed to **C. After All Findings Processed**.
 
-#### If `finding_gate_mode` is `gated`
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-**Finding {N} of {total}: {brief_title:(titlecase)}**
-
-- **`y`/`yes`** — Add to the specification verbatim
-@if(Category is Enhancement to existing topic and Current field is present)
-- **`v`/`view full`** — Show full Current and Proposed Addition content
-@endif
-- **`a`/`auto`** — Approve this and all remaining findings automatically
-- **`s`/`skip`** — Leave as-is, move to next finding
-- **Provide feedback** — Adjust before approving
-· · · · · · · · · · · ·
-```
+#### If the response carried `MENU: finding gate`
 
 **STOP.** Wait for user response.
 
 #### If `view full`
 
-Re-present the finding's **Current** and **Proposed Addition** content in full from the tracking file. Then re-present the approval menu.
+Re-present the finding's **Current** and **Proposed Addition** content in full from the tracking file. Then re-emit the `MENU: finding gate` section.
 
-→ Return to **B. Process One Item at a Time**.
+**STOP.** Wait for user response.
 
 #### If the user provides feedback
 
-Incorporate feedback and update the tracking file with the revised content. Re-present the finding using the same presentation format (diff or full) as the original.
+Incorporate feedback and update the tracking file with the revised content. Rewrite the payload to match and re-render the finding.
 
 → Return to **B. Process One Item at a Time**.
 

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -248,9 +248,125 @@ describe('render task-list', () => {
   });
 });
 
+describe('render findings-summary', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  it('renders the numbered overview with subDetail summaries byte-exactly', () => {
+    const file = writePayload(dir, 's.json', {
+      review_label: 'Integrity Review',
+      items: [
+        { title: 'Missing Outcome field', tag: 'Minor — add-to-task', summary: 'Task 1-1 lacks the required Outcome field.' },
+        { title: 'Orphaned dependency', tag: 'Important — update-task', summary: 'Task 2-3 depends on a removed task.' },
+      ],
+    });
+    const out = renderSurface(dir, 'findings-summary', { dotpath: 'pay.planning.portal', file });
+    assert.strictEqual(out, [
+      '=== DISPLAY: findings summary (emit verbatim as a code block) ===',
+      'Integrity Review — 2 items found',
+      '',
+      '1. Missing Outcome field (Minor — add-to-task)',
+      '   · Task 1-1 lacks the required Outcome field.',
+      '',
+      '2. Orphaned dependency (Important — update-task)',
+      '   · Task 2-3 depends on a removed task.',
+      '',
+      "Let's work through these one at a time, starting with #1.",
+      '',
+    ].join('\n'));
+  });
+
+  it('validates loudly', () => {
+    assert.throws(() => renderSurface(dir, 'findings-summary', { dotpath: 'pay.planning.portal', file: writePayload(dir, 'a.json', { review_label: 'X', items: [] }) }), /"items" must be a non-empty array/);
+    assert.throws(() => renderSurface(dir, 'findings-summary', { dotpath: 'pay.planning.portal', file: writePayload(dir, 'b.json', { review_label: 'X', items: [{ title: 't', tag: 'g' }] }) }), /item 1 is missing "summary"/);
+  });
+});
+
+describe('render finding', () => {
+  let dir;
+  const base = {
+    n: 1, total: 2, title: 'Missing Outcome field',
+    meta: [['Severity', 'Minor'], ['Change Type', 'add-to-task']],
+    details: 'The canonical template requires Outcome.',
+  };
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress', finding_gate_mode: 'gated' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  it('renders meta, framed diff (open/body/close), and the gate menu when gated', () => {
+    const file = writePayload(dir, 'f.json', {
+      ...base,
+      diff: { context_above: ['**Solution**: shared adapter.'], current: [], proposed: ['**Outcome**: lands at a live shell.'], context_below: ['**Do**:'] },
+      apply_label: 'Apply to the plan verbatim',
+    });
+    const out = renderSurface(dir, 'finding', { dotpath: 'pay.planning.portal', file });
+    assert.ok(out.startsWith([
+      '=== DISPLAY: finding (emit verbatim as markdown) ===',
+      '**Finding 1 of 2: Missing Outcome field**',
+      '',
+      '- **Severity**: Minor',
+      '- **Change Type**: add-to-task',
+      '',
+      '**Details**: The canonical template requires Outcome.',
+      '',
+    ].join('\n')));
+    const frameOpen = out.split('\n').find((l) => l.startsWith('╭─ Finding 1: Missing Outcome field '));
+    assert.ok(frameOpen && frameOpen.endsWith('╮'));
+    assert.strictEqual([...frameOpen].length, 53, 'short content renders at the minimum frame width');
+    assert.ok(out.includes('=== DISPLAY: diff (emit verbatim as a diff code block (```diff fence)) ===\n **Solution**: shared adapter.\n+**Outcome**: lands at a live shell.\n **Do**:'));
+    assert.ok(out.includes('=== MENU: finding gate'));
+    assert.ok(out.includes('- **`v`/`view full`** — Show full Current and Proposed content'), 'diff findings offer view full');
+    assert.ok(out.includes('- **`y`/`yes`** — Apply to the plan verbatim'));
+    assert.ok(out.includes('- **Provide feedback** — Tell me what to change before approving'));
+  });
+
+  it('caps the frame border at maxWidth for unwrappable content', () => {
+    const file = writePayload(dir, 'f.json', { ...base, diff: { current: [], proposed: ['x'.repeat(150)] } });
+    const out = renderSurface(dir, 'finding', { dotpath: 'pay.planning.portal', file });
+    const frameOpen = out.split('\n').find((l) => l.startsWith('╭─'));
+    assert.strictEqual([...frameOpen].length, 100, 'frame borders never exceed the cap');
+  });
+
+  it('content variant renders as markdown without view full; auto mode returns the applied line', () => {
+    writeManifest(dir, 'pay', { phases: { specification: { items: { portal: { status: 'in-progress', finding_gate_mode: 'auto' } } } } });
+    const file = writePayload(dir, 'f.json', {
+      ...base,
+      content: { label: 'Proposed Addition', lines: ['New spec section body.'] },
+      applied_label: 'approved. Added to specification.',
+    });
+    const out = renderSurface(dir, 'finding', { dotpath: 'pay.specification.portal', file });
+    assert.ok(out.includes('=== DISPLAY: finding content (emit verbatim as markdown) ===\n**Proposed Addition**:\nNew spec section body.'));
+    assert.ok(out.includes('=== DISPLAY: finding auto-approved (emit verbatim as a code block after applying the fix) ===\nFinding 1 of 2: Missing Outcome field — approved. Added to specification.'));
+    assert.ok(!out.includes('MENU: finding gate'));
+    assert.ok(!out.includes('view full'));
+  });
+
+  it('validates loudly: shape, exclusivity, and empty diff', () => {
+    const cases = [
+      [{ ...base, n: 0 }, /"n" must be a positive integer/],
+      [{ ...base, total: 0 }, /"total" must be an integer/],
+      [{ ...base, meta: [['x']] }, /"meta" must be an array of \[label, value\] pairs/],
+      [{ ...base, details: ' ' }, /"details" must be a non-empty string/],
+      [{ ...base, diff: { current: [], proposed: [] }, content: { label: 'X', lines: ['y'] } }, /pass "diff" or "content", not both/],
+      [{ ...base, diff: { current: [], proposed: [] } }, /"diff" must carry at least one/],
+      [{ ...base, content: { label: 'X', lines: [] } }, /"content.lines" must be non-empty/],
+    ];
+    cases.forEach(([payload, re], i) => {
+      const file = writePayload(dir, `bad-${i}.json`, payload);
+      assert.throws(() => renderSurface(dir, 'finding', { dotpath: 'pay.planning.portal', file }), re);
+    });
+  });
+});
+
 describe('catalogue dispatch', () => {
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding\)/);
   });
 });
 


### PR DESCRIPTION
Stage 2 of the render-surfaces programme (design log: #489; base: #490). The findings/approval family: one surface pair now serves both review-findings loops — `workflow-planning-process` and `workflow-specification-process` carried near-identical ~240-line reference twins whose displays, frames, and gate menus all now come from the engine.

## Surfaces

**`render findings-summary <wu>.<phase>.<topic> --file <payload>`** — the numbered overview (`{review_label} — N items found`), summaries in the `·` subsection grammar, and the working-through line, one section.

**`render finding <wu>.<phase>.<topic> --file <payload>`** — one finding end-to-end:
- `DISPLAY: finding` — title, `[label, value]` meta pairs (each consumer's own vocabulary), details.
- The proposal, either as `DISPLAY: finding content` (markdown, full content) or as the **framed diff in three sections** — frame open, diff body emitted as a ` ```diff ` fence (colouring survives), frame close. Borders computed from actual content width (the Portal defect, fixed user-visibly) and capped at 100 so a border never wraps; unwrappable diff lines may overflow past the cap.
- The gate: `MENU: finding gate` when `finding_gate_mode` is gated (with `v`/`view full` offered only for diff findings) or `DISPLAY: finding auto-approved` when auto — per-consumer apply/applied/feedback labels ride in the payload.

Contract notes: tracking files are markdown, so per D2 the model reads them and hands validated JSON (11 loud validation cases); the gate-mode read and branch left both prose files entirely.

## Test plan

- 12 new tests: byte-exact summary, gated diff render (frame min-width, view-full presence), maxWidth border cap, content+auto variant, loud validation for both surfaces.
- `npm test` — 1485/1485. Typecheck + conventions lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #495
2. #490
3. **#491** 👈 current
4. #492
5. #493
6. #496
7. #497
8. #498
9. #499
10. #500
11. #501
<!-- stack:links:end -->