### PR TITLE
feat(engine): task-gate surfaces — proposed-task, tasks-overview, author-task-gate, phase-tree

### DIFF
--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -167,9 +167,13 @@ engine render resume-gate <wu>.<phase>.<topic> [--triage <N>]     # shared conti
 engine render task-list <wu>.planning.<topic> --file <payload>    # planning task-list gate; payload {phase, phase_name, tasks: [{name, summary, edge_cases?}]}
 engine render findings-summary <wu>.<phase>.<topic> --file <payload>  # review-findings overview; payload {review_label, items: [{title, tag, summary}]}
 engine render finding <wu>.<phase>.<topic> --file <payload>       # one finding + its gate; payload {n, total, title, meta, details, diff|content, apply_label?, applied_label?, feedback_hint?}
+engine render proposed-task <wu>.<phase>.<topic> --file <payload> --gate gated|auto [--comment-hint STR]  # analysis/review synthesis task + its gate; payload {current, total, title, severity, sources, problem, solution, outcome, steps, criteria, tests}
+engine render tasks-overview <wu>.<phase>.<topic> --file <payload>    # proposed-tasks cycle overview; payload {label, tasks: [{title, severity}]}
+engine render author-task-gate <wu>.planning.<topic> --m N --total N --title STR   # task-authoring approval menu (the detail itself is a verbatim file emission the flow owns)
+engine render phase-tree <wu>.planning.<topic> --file <payload> [--approve]        # D5 phase structure tree; payload {phases: [{name, detail?: [[label, value]]}]}; --approve appends the structure gate
 ```
 
-The `finding` surface serves both review-findings loops (planning and specification) with per-consumer labels in the payload. Its diff presentation returns the boxed frame as three sections — frame open, diff body (emitted as a ` ```diff ` fence so the host's colouring survives), frame close — with the frame borders computed from the content width.
+The `finding` surface serves both review-findings loops (planning and specification) with per-consumer labels in the payload; `proposed-task` serves both synthesis loops (implementation analysis, review actions) the same way — its gate mode rides as a flag because one consumer carries the mode in the cycle response and the other in staging-file frontmatter. `task-list` takes `--variant existing` for plan-construction's review-of-existing-tables gate (no auto-opt-in option; "confirmed" phrasing). The `finding` surface's diff presentation returns the boxed frame as three sections — frame open, diff body (emitted as a ` ```diff ` fence so the host's colouring survives), frame close — with the frame borders computed from the content width.
 
 The `render` group also keeps its dev/debug primitives (`signpost`, `box`, `wrap`, `tree`) — authoring aids only, never called from skill flows.
 

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -129,14 +129,15 @@ function readTaskListPayload(cwd, file) {
 
 /**
  * @param {string} cwd
- * @param {{dotpath: string, file?: string}} args
+ * @param {{dotpath: string, file?: string, variant?: string}} args
  * @returns {string} sections
  */
-function taskList(cwd, { dotpath, file }) {
+function taskList(cwd, { dotpath, file, variant: variantArg }) {
   if (!file) throw new Error('render task-list: --file <payload.json> is required');
   const { topic, manifest } = resolveAddress(cwd, dotpath, 'task-list');
   const payload = readTaskListPayload(cwd, file);
 
+  const variant = variantArg === 'existing' ? 'existing' : 'fresh';
   const items = (((manifest.phases || {}).planning || {}).items || {})[topic] || {};
   const gateMode = items.task_list_gate_mode === 'auto' ? 'auto' : 'gated';
 
@@ -161,16 +162,199 @@ function taskList(cwd, { dotpath, file }) {
     parts.push(section(
       'DISPLAY: task list auto-approved',
       'emit verbatim as a code block, then proceed without a gate',
-      `Phase ${payload.phase}: ${payload.phase_name} — task list approved. Proceeding to authoring.`,
+      variant === 'existing'
+        ? `Phase ${payload.phase}: ${payload.phase_name} — task list confirmed. Proceeding to authoring.`
+        : `Phase ${payload.phase}: ${payload.phase_name} — task list approved. Proceeding to authoring.`,
     ));
   } else {
+    const options = variant === 'existing'
+      ? [
+          cmdOption('y', 'yes', 'Proceed to authoring'),
+          promptOption('Tell me what to change', 'which tasks to revise in this phase'),
+          promptOption('Navigate', 'Tell me where to go: a different phase or task, or the leading edge'),
+        ]
+      : [
+          cmdOption('y', 'yes', 'Proceed to authoring'),
+          cmdOption('a', 'auto', 'Approve this and all remaining task list gates automatically'),
+          promptOption('Tell me what to change', 'which tasks to reorder, split, merge, add, edit, or remove'),
+          promptOption('Navigate', 'Tell me where to go: a different phase or task, or the leading edge'),
+        ];
     parts.push(section(
       'MENU: task list gate',
       'emit verbatim as markdown, then STOP for the user\'s response',
-      menu('Approve this task list?', [
-        cmdOption('y', 'yes', 'Proceed to authoring'),
-        cmdOption('a', 'auto', 'Approve this and all remaining task list gates automatically'),
-        promptOption('Tell me what to change', 'which tasks to reorder, split, merge, add, edit, or remove'),
+      menu('Approve this task list?', options),
+    ));
+  }
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// proposed-task / tasks-overview — the analysis and review synthesis loops'
+// shared task presentation (their prose templates were byte-identical twins).
+// Gate mode rides as a flag, not an address read: one consumer carries it in
+// the cycle response, the other in staging-file frontmatter — the surface
+// guarantees the form of both outputs, the flow owns the mode.
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, file?: string, gate?: string, 'comment-hint'?: string}} args
+ * @returns {string}
+ */
+function proposedTask(cwd, args) {
+  const { dotpath, file, gate } = args;
+  if (!file) throw new Error('render proposed-task: --file <payload.json> is required');
+  if (gate !== 'gated' && gate !== 'auto') throw new Error('render proposed-task: --gate must be "gated" or "auto"');
+  resolveAddress(cwd, dotpath, 'proposed-task');
+  const p = readJsonPayload(cwd, file, 'proposed-task');
+
+  if (!Number.isInteger(p.current) || p.current < 1) throw new Error('render proposed-task: "current" must be a positive integer');
+  if (!Number.isInteger(p.total) || p.total < p.current) throw new Error('render proposed-task: "total" must be an integer ≥ "current"');
+  for (const field of ['title', 'severity', 'sources', 'problem', 'solution', 'outcome']) {
+    if (!isFilled(p[field])) throw new Error(`render proposed-task: "${field}" must be a non-empty string`);
+  }
+  const blocks = {};
+  for (const field of ['steps', 'criteria', 'tests']) {
+    const lines = stringLines(p[field], 'proposed-task', field);
+    if (lines.length === 0) throw new Error(`render proposed-task: "${field}" must be non-empty`);
+    blocks[field] = lines;
+  }
+
+  const body = [
+    `**Task ${p.current}/${p.total}: ${p.title}** (${p.severity})`,
+    `Sources: ${p.sources}`,
+    '',
+    `**Problem**: ${p.problem}`,
+    `**Solution**: ${p.solution}`,
+    `**Outcome**: ${p.outcome}`,
+    '',
+    '**Do**:',
+    ...blocks.steps,
+    '',
+    '**Acceptance Criteria**:',
+    ...blocks.criteria,
+    '',
+    '**Tests**:',
+    ...blocks.tests,
+  ];
+  const parts = [section('DISPLAY: proposed task', 'emit verbatim as markdown', body.join('\n'))];
+
+  if (gate === 'auto') {
+    parts.push(section(
+      'DISPLAY: task auto-approved',
+      'emit verbatim as a code block after recording the approval',
+      `Task ${p.current} of ${p.total}: ${p.title} — approved [auto].`,
+    ));
+  } else {
+    const hint = isFilled(args['comment-hint']) ? args['comment-hint'] : 'Tell me what to change';
+    parts.push(section(
+      'MENU: task approval',
+      'emit verbatim as markdown, then STOP for the user\'s response',
+      menu('Approve this task?', [
+        cmdOption('y', 'yes', 'Approve this task'),
+        cmdOption('a', 'auto', 'Approve this and all remaining tasks automatically'),
+        cmdOption('s', 'skip', 'Skip this task'),
+        promptOption('Comment', hint),
+      ]),
+    ));
+  }
+  return parts.join('\n');
+}
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, file?: string}} args
+ * @returns {string}
+ */
+function tasksOverview(cwd, { dotpath, file }) {
+  if (!file) throw new Error('render tasks-overview: --file <payload.json> is required');
+  resolveAddress(cwd, dotpath, 'tasks-overview');
+  const p = readJsonPayload(cwd, file, 'tasks-overview');
+  if (!isFilled(p.label)) throw new Error('render tasks-overview: "label" must be a non-empty string');
+  if (!Array.isArray(p.tasks) || p.tasks.length === 0) {
+    throw new Error('render tasks-overview: "tasks" must be a non-empty array of {title, severity}');
+  }
+  const lines = [`${p.label}: ${p.tasks.length} proposed task${p.tasks.length === 1 ? '' : 's'}`, ''];
+  p.tasks.forEach((t, i) => {
+    if (!isFilled(t.title) || !isFilled(t.severity)) {
+      throw new Error(`render tasks-overview: task ${i + 1} needs "title" and "severity"`);
+    }
+    lines.push(`  ${i + 1}. ${t.title} (${t.severity})`);
+  });
+  return section('DISPLAY: tasks overview', 'emit verbatim as a code block', lines.join('\n'));
+}
+
+// ---------------------------------------------------------------------------
+// author-task-gate — the planning task-authoring per-task menu. The task
+// detail itself is a verbatim file emission the flow owns; only the gate
+// renders here. Scalars ride as flags.
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, m?: string, total?: string, title?: string}} args
+ * @returns {string}
+ */
+function authorTaskGate(cwd, { dotpath, m, total, title }) {
+  resolveAddress(cwd, dotpath, 'author-task-gate');
+  const mN = parseInt(m || '', 10);
+  const totalN = parseInt(total || '', 10);
+  if (!Number.isInteger(mN) || mN < 1) throw new Error('render author-task-gate: --m must be a positive integer');
+  if (!Number.isInteger(totalN) || totalN < mN) throw new Error('render author-task-gate: --total must be an integer ≥ --m');
+  if (!isFilled(title)) throw new Error('render author-task-gate: --title is required');
+  return section(
+    'MENU: author task gate',
+    'emit verbatim as markdown, then STOP for the user\'s response',
+    menu(`**Task ${mN} of ${totalN}: ${title}**`, [
+      cmdOption('y', 'yes', 'Write it to the plan'),
+      cmdOption('a', 'auto', 'Approve this and all remaining tasks automatically'),
+      promptOption('Tell me what to change', 'what to revise in this task'),
+      promptOption('Navigate', 'Tell me where to go: a different phase or task, or the leading edge'),
+    ]),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// phase-tree — the multi-phase structure display (D5): numbered phase nodes
+// with wrapped tree children, one visual grammar with the task list beneath.
+// `--approve` appends the phase-structure approval menu.
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, file?: string, approve?: string}} args
+ * @returns {string}
+ */
+function phaseTree(cwd, args) {
+  const { dotpath, file } = args;
+  if (!file) throw new Error('render phase-tree: --file <payload.json> is required');
+  resolveAddress(cwd, dotpath, 'phase-tree');
+  const p = readJsonPayload(cwd, file, 'phase-tree');
+  if (!Array.isArray(p.phases) || p.phases.length === 0) {
+    throw new Error('render phase-tree: "phases" must be a non-empty array of {name, detail?}');
+  }
+  const count = p.phases.length;
+  const lines = [`Phase structure — ${count} phase${count === 1 ? '' : 's'}.`, ''];
+  p.phases.forEach((ph, i) => {
+    if (!isFilled(ph.name)) throw new Error(`render phase-tree: phase ${i + 1} needs "name"`);
+    lines.push(`${i + 1}. ${ph.name}`);
+    if (ph.detail !== undefined) {
+      if (!Array.isArray(ph.detail) || ph.detail.length === 0
+        || ph.detail.some((d) => !Array.isArray(d) || d.length !== 2 || !isFilled(d[0]) || !isFilled(String(d[1])))) {
+        throw new Error(`render phase-tree: phase ${i + 1} "detail" must be a non-empty array of [label, value] pairs`);
+      }
+      lines.push(treeList(ph.detail.map(([label, value]) => `${label}: ${value}`), { indent: '   ' }));
+    }
+    if (i < count - 1) lines.push('');
+  });
+  const parts = [section('DISPLAY: phase tree', 'emit verbatim as a code block', lines.join('\n'))];
+  if ('approve' in args) {
+    parts.push(section(
+      'MENU: phase structure gate',
+      'emit verbatim as markdown, then STOP for the user\'s response',
+      menu('Approve this phase structure?', [
+        cmdOption('y', 'yes', 'Proceed to task breakdown'),
+        promptOption('Tell me what to change', 'which phases to reorder, split, merge, add, edit, or remove'),
         promptOption('Navigate', 'Tell me where to go: a different phase or task, or the leading edge'),
       ]),
     ));
@@ -323,6 +507,10 @@ const SURFACES = {
   'task-list': taskList,
   'findings-summary': findingsSummary,
   'finding': finding,
+  'proposed-task': proposedTask,
+  'tasks-overview': tasksOverview,
+  'author-task-gate': authorTaskGate,
+  'phase-tree': phaseTree,
 };
 
 /**

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -156,6 +156,10 @@ Commands:
   render task-list   <wu.planning.topic> --file <payload.json>
   render findings-summary <wu.phase.topic> --file <payload.json>
   render finding          <wu.phase.topic> --file <payload.json>
+  render proposed-task    <wu.phase.topic> --file <payload.json> --gate gated|auto [--comment-hint STR]
+  render tasks-overview   <wu.phase.topic> --file <payload.json>
+  render author-task-gate <wu.planning.topic> --m N --total N --title STR
+  render phase-tree       <wu.planning.topic> --file <payload.json> [--approve]
   render signpost <label> [--style step|substep] [--width N]     (dev aid)
   render box <title> [--width N]                                 (dev aid)
   render wrap <text> [--width N] [--prefix STR]                  (dev aid)
@@ -649,12 +653,15 @@ function runCommit(argv) {
 /** @param {string[]} argv */
 function runRender(argv) {
   const [command, ...rest] = argv;
-  const { opts, positional } = parseArgs(rest);
+  const { opts, flags, positional } = parseArgs(rest, ['approve']);
   const width = opts.width !== undefined ? parseInt(opts.width, 10) : WIDTH;
 
   if (Object.hasOwn(SURFACES, command)) {
     try {
-      respondSections(renderSurface(process.cwd(), command, { dotpath: positional[0], ...opts }));
+      /** @type {{dotpath: string} & Record<string, string|undefined>} */
+      const args = { dotpath: positional[0], ...opts };
+      if (flags.has('approve')) args.approve = '1';
+      respondSections(renderSurface(process.cwd(), command, args));
     } catch (err) {
       failJson(err);
     }

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -173,13 +173,10 @@ impl({work_unit}): analysis cycle {N} — synthesis
 
 Read the staging file from `.workflows/{work_unit}/implementation/{topic}/analysis-tasks-c{cycle-number}.md`.
 
-> *Output the next fenced block as a code block:*
+Write the overview payload to `.workflows/.cache/{work_unit}/implementation/{topic}/tasks-overview.json` with the Write tool (`{"label": "Analysis cycle {N}", "tasks": [{"title": "…", "severity": "…"}]}`), render, and emit the section verbatim:
 
-```
-Analysis cycle {N}: {K} proposed tasks
-
-  1. {title} ({severity})
-  2. {title} ({severity})
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render tasks-overview {work_unit}.implementation.{topic} --file .workflows/.cache/{work_unit}/implementation/{topic}/tasks-overview.json
 ```
 
 → Proceed to **F. Process Task**.
@@ -194,56 +191,19 @@ Analysis cycle {N}: {K} proposed tasks
 
 #### Otherwise
 
-Present the next pending task:
+Present the next pending task. Write its payload to `.workflows/.cache/{work_unit}/implementation/{topic}/proposed-task.json` with the Write tool — `{"current": …, "total": …, "title": "…", "severity": "…", "sources": "…", "problem": "…", "solution": "…", "outcome": "…", "steps": […], "criteria": […], "tests": […]}` from the staging file — then render with the gate mode carried by this cycle's response (or `auto` if the user opted in at a previous task this cycle), and emit each section verbatim at its marked instruction:
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**Task {current}/{total}: {title}** ({severity})
-Sources: {sources}
-
-**Problem**: {problem}
-**Solution**: {solution}
-**Outcome**: {outcome}
-
-**Do**:
-{steps}
-
-**Acceptance Criteria**:
-{criteria}
-
-**Tests**:
-{tests}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render proposed-task {work_unit}.implementation.{topic} --file .workflows/.cache/{work_unit}/implementation/{topic}/proposed-task.json --gate {analysis_gate_mode} --comment-hint "Provide feedback to adjust"
 ```
 
-Branch on the `analysis_gate_mode` carried by this cycle's response (or `auto` if the user opted in at a previous task this cycle).
+#### If the response carried `DISPLAY: task auto-approved`
 
-#### If `analysis_gate_mode` is `auto`
-
-Update `status: approved` in the staging file.
-
-> *Output the next fenced block as a code block:*
-
-```
-Task {current} of {total}: {title} — approved [auto].
-```
+Update `status: approved` in the staging file, then emit the section per its marker.
 
 → Return to **F. Process Task**.
 
-#### If `analysis_gate_mode` is `gated`
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Approve this task?
-
-- **`y`/`yes`** — Approve this task
-- **`a`/`auto`** — Approve this and all remaining tasks automatically
-- **`s`/`skip`** — Skip this task
-- **Comment** — Provide feedback to adjust
-· · · · · · · · · · · ·
-```
+#### If the response carried `MENU: task approval`
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -133,17 +133,10 @@ Present the full task content:
 {task detail from task detail file}
 ```
 
-> *Output the next fenced block as markdown (not a code block):*
+Render the gate and emit the section verbatim:
 
-```
-· · · · · · · · · · · ·
-**Task {M} of {total}: {Task Name}**
-
-- **`y`/`yes`** — Write it to the plan
-- **`a`/`auto`** — Approve this and all remaining tasks automatically
-- **Tell me what to change** — what to revise in this task
-- **Navigate** — Tell me where to go: a different phase or task, or the leading edge
-· · · · · · · · · · · ·
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render author-task-gate {work_unit}.planning.{topic} --m {M} --total {total} --title "{Task Name}"
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -64,18 +64,16 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "pl
 
 ## B. Review and Approve
 
-Present the phase structure to the user as rendered markdown (not in a code block). Then, separately, present the choices:
+Write the phase-tree payload to `.workflows/.cache/{work_unit}/planning/{topic}/phase-tree.json` with the Write tool — one entry per phase from the planning file, each with its goal (and other one-line detail rows worth surfacing, e.g. acceptance criteria):
 
-> *Output the next fenced block as markdown (not a code block):*
-
+```json
+{"phases": [{"name": "…", "detail": [["Goal", "…"], ["Criteria", "…"]]}]}
 ```
-· · · · · · · · · · · ·
-Approve this phase structure?
 
-- **`y`/`yes`** — Proceed to task breakdown
-- **Tell me what to change** — which phases to reorder, split, merge, add, edit, or remove
-- **Navigate** — Tell me where to go: a different phase or task, or the leading edge
-· · · · · · · · · · · ·
+Render and emit each section verbatim at its marked instruction:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-tree {work_unit}.planning.{topic} --file .workflows/.cache/{work_unit}/planning/{topic}/phase-tree.json --approve
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -40,56 +40,27 @@ every stage.
 
 Work through each phase in order. Check the current phase's state.
 
-Check `task_list_gate_mode` via `engine manifest`:
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_list_gate_mode
-```
-
 #### If the phase has no task table in the planning file
 
 → Load **[define-tasks.md](define-tasks.md)** and follow its instructions as written.
 
 → On return, proceed to **C. Author Phase Tasks**.
 
-#### If the phase has a task table and `task_list_gate_mode` is `auto`
+#### If the phase has a task table
 
-> *Output the next fenced block as markdown (not a code block):*
+Write the task-list payload to `.workflows/.cache/{work_unit}/planning/{topic}/task-list-phase-{N}.json` with the Write tool (`{"phase": {N}, "phase_name": "{Phase Name}", "tasks": [{"name": "…", "summary": "…", "edge_cases": ["…"]}]}` from the planning file's task table), render, and emit each section verbatim at its marked instruction:
 
-```
-**Phase {N}: {Phase Name}** — {M} tasks.
-
-{task list from the planning file}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render task-list {work_unit}.planning.{topic} --file .workflows/.cache/{work_unit}/planning/{topic}/task-list-phase-{N}.json --variant existing
 ```
 
-> *Output the next fenced block as a code block:*
+The response carries the task-list display plus the surface for the current gate mode.
 
-```
-Phase {N}: {Phase Name} — task list confirmed. Proceeding to authoring.
-```
+**If the response carried `DISPLAY: task list auto-approved`:**
 
 → Proceed to **C. Author Phase Tasks**.
 
-#### If the phase has a task table and `task_list_gate_mode` is `gated`
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**Phase {N}: {Phase Name}** — {M} tasks.
-
-{task list from the planning file}
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Approve this task list?
-
-- **`y`/`yes`** — Proceed to authoring
-- **Tell me what to change** — which tasks to revise in this phase
-- **Navigate** — Tell me where to go: a different phase or task, or the leading edge
-· · · · · · · · · · · ·
-```
+**If the response carried `MENU: task list gate`:**
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -210,13 +210,10 @@ Invoke the workflow-bridge skill to enter plan mode with continuation instructio
 
 Read the staging file from `.workflows/{work_unit}/implementation/{topic}/review-tasks-c{cycle-number}.md`.
 
-> *Output the next fenced block as a code block:*
+Write the overview payload to `.workflows/.cache/{work_unit}/review/{topic}/tasks-overview.json` with the Write tool (`{"label": "Review synthesis cycle {N}", "tasks": [{"title": "…", "severity": "…"}]}`), render, and emit the section verbatim:
 
-```
-Review synthesis cycle {N}: {K} proposed tasks
-
-  1. {title} ({severity})
-  2. {title} ({severity})
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render tasks-overview {work_unit}.review.{topic} --file .workflows/.cache/{work_unit}/review/{topic}/tasks-overview.json
 ```
 
 → Proceed to **D. Process Task**.
@@ -231,56 +228,19 @@ Review synthesis cycle {N}: {K} proposed tasks
 
 #### Otherwise
 
-Present the next pending task:
+Present the next pending task. Write its payload to `.workflows/.cache/{work_unit}/review/{topic}/proposed-task.json` with the Write tool — `{"current": …, "total": …, "title": "…", "severity": "…", "sources": "…", "problem": "…", "solution": "…", "outcome": "…", "steps": […], "criteria": […], "tests": […]}` from the staging file — then render with the `gate_mode` from the staging-file frontmatter, and emit each section verbatim at its marked instruction:
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**Task {current}/{total}: {title}** ({severity})
-Sources: {sources}
-
-**Problem**: {problem}
-**Solution**: {solution}
-**Outcome**: {outcome}
-
-**Do**:
-{steps}
-
-**Acceptance Criteria**:
-{criteria}
-
-**Tests**:
-{tests}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render proposed-task {work_unit}.review.{topic} --file .workflows/.cache/{work_unit}/review/{topic}/proposed-task.json --gate {gate_mode}
 ```
 
-Check `gate_mode` in the staging file frontmatter (`gated` or `auto`).
+#### If the response carried `DISPLAY: task auto-approved`
 
-#### If `gate_mode` is `auto`
-
-Update `status: approved` in the staging file.
-
-> *Output the next fenced block as a code block:*
-
-```
-Task {current} of {total}: {title} — approved [auto].
-```
+Update `status: approved` in the staging file, then emit the section per its marker.
 
 → Return to **D. Process Task**.
 
-#### If `gate_mode` is `gated`
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Approve this task?
-
-- **`y`/`yes`** — Approve this task
-- **`a`/`auto`** — Approve this and all remaining tasks automatically
-- **`s`/`skip`** — Skip this task
-- **Comment** — Tell me what to change
-· · · · · · · · · · · ·
-```
+#### If the response carried `MENU: task approval`
 
 **STOP.** Wait for user response.
 

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -364,9 +364,203 @@ describe('render finding', () => {
   });
 });
 
+describe('render proposed-task', () => {
+  let dir;
+  const payload = {
+    current: 2, total: 3, title: 'Fix adapter leak', severity: 'Important',
+    sources: 'reviewer cycle 1',
+    problem: 'The adapter never closes.', solution: 'Close on detach.', outcome: 'No leaked handles.',
+    steps: ['1. Add Close()', '2. Call it on detach'],
+    criteria: ['- no leaked handles after detach'],
+    tests: ['- detach closes the adapter'],
+  };
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { implementation: { items: { portal: { status: 'in-progress' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  it('renders the task detail plus the approval menu when gated, byte-exactly', () => {
+    const file = writePayload(dir, 'p.json', payload);
+    const out = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'gated' });
+    assert.strictEqual(out, [
+      '=== DISPLAY: proposed task (emit verbatim as markdown) ===',
+      '**Task 2/3: Fix adapter leak** (Important)',
+      'Sources: reviewer cycle 1',
+      '',
+      '**Problem**: The adapter never closes.',
+      '**Solution**: Close on detach.',
+      '**Outcome**: No leaked handles.',
+      '',
+      '**Do**:',
+      '1. Add Close()',
+      '2. Call it on detach',
+      '',
+      '**Acceptance Criteria**:',
+      '- no leaked handles after detach',
+      '',
+      '**Tests**:',
+      '- detach closes the adapter',
+      '',
+      "=== MENU: task approval (emit verbatim as markdown, then STOP for the user's response) ===",
+      DOTS,
+      'Approve this task?',
+      '',
+      '- **`y`/`yes`** — Approve this task',
+      '- **`a`/`auto`** — Approve this and all remaining tasks automatically',
+      '- **`s`/`skip`** — Skip this task',
+      '- **Comment** — Tell me what to change',
+      DOTS,
+      '',
+    ].join('\n'));
+  });
+
+  it('honours a custom comment hint and the auto gate', () => {
+    const file = writePayload(dir, 'p.json', payload);
+    const gated = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'gated', 'comment-hint': 'Provide feedback to adjust' });
+    assert.ok(gated.includes('- **Comment** — Provide feedback to adjust'));
+    const auto = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'auto' });
+    assert.ok(auto.includes('=== DISPLAY: task auto-approved (emit verbatim as a code block after recording the approval) ===\nTask 2 of 3: Fix adapter leak — approved [auto].'));
+    assert.ok(!auto.includes('MENU: task approval'));
+  });
+
+  it('requires --gate and validates the payload loudly', () => {
+    const file = writePayload(dir, 'p.json', payload);
+    assert.throws(() => renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file }), /--gate must be "gated" or "auto"/);
+    const noTests = writePayload(dir, 'bad.json', { ...payload, tests: [] });
+    assert.throws(() => renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file: noTests, gate: 'gated' }), /"tests" must be non-empty/);
+    const noProblem = writePayload(dir, 'bad2.json', { ...payload, problem: '' });
+    assert.throws(() => renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file: noProblem, gate: 'gated' }), /"problem" must be a non-empty string/);
+  });
+});
+
+describe('render tasks-overview', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { implementation: { items: { portal: { status: 'in-progress' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  it('renders the cycle overview byte-exactly', () => {
+    const file = writePayload(dir, 'o.json', { label: 'Analysis cycle 2', tasks: [{ title: 'Fix leak', severity: 'Important' }, { title: 'Add test', severity: 'Minor' }] });
+    const out = renderSurface(dir, 'tasks-overview', { dotpath: 'pay.implementation.portal', file });
+    assert.strictEqual(out, [
+      '=== DISPLAY: tasks overview (emit verbatim as a code block) ===',
+      'Analysis cycle 2: 2 proposed tasks',
+      '',
+      '  1. Fix leak (Important)',
+      '  2. Add test (Minor)',
+      '',
+    ].join('\n'));
+  });
+
+  it('validates loudly', () => {
+    const file = writePayload(dir, 'o.json', { label: 'X', tasks: [{ title: 't' }] });
+    assert.throws(() => renderSurface(dir, 'tasks-overview', { dotpath: 'pay.implementation.portal', file }), /task 1 needs "title" and "severity"/);
+  });
+});
+
+describe('render author-task-gate', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  it('renders the authoring menu byte-exactly', () => {
+    const out = renderSurface(dir, 'author-task-gate', { dotpath: 'pay.planning.portal', m: '2', total: '5', title: 'Wrap command' });
+    assert.strictEqual(out, [
+      "=== MENU: author task gate (emit verbatim as markdown, then STOP for the user's response) ===",
+      DOTS,
+      '**Task 2 of 5: Wrap command**',
+      '',
+      '- **`y`/`yes`** — Write it to the plan',
+      '- **`a`/`auto`** — Approve this and all remaining tasks automatically',
+      '- **Tell me what to change** — what to revise in this task',
+      '- **Navigate** — Tell me where to go: a different phase or task, or the leading edge',
+      DOTS,
+      '',
+    ].join('\n'));
+  });
+
+  it('validates the scalars loudly', () => {
+    assert.throws(() => renderSurface(dir, 'author-task-gate', { dotpath: 'pay.planning.portal', m: '0', total: '5', title: 'X' }), /--m must be a positive integer/);
+    assert.throws(() => renderSurface(dir, 'author-task-gate', { dotpath: 'pay.planning.portal', m: '2', total: '1', title: 'X' }), /--total must be an integer/);
+    assert.throws(() => renderSurface(dir, 'author-task-gate', { dotpath: 'pay.planning.portal', m: '1', total: '2' }), /--title is required/);
+  });
+});
+
+describe('render phase-tree', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  it('renders numbered phase nodes with wrapped tree detail, byte-exactly', () => {
+    const file = writePayload(dir, 'ph.json', {
+      phases: [
+        { name: 'Adapter Wrapper', detail: [['Goal', 'burst windows land at a live shell'], ['Criteria', 'no dead-end prompt']] },
+        { name: 'Regression Net', detail: [['Goal', 'attach flows pinned by tests']] },
+      ],
+    });
+    const out = renderSurface(dir, 'phase-tree', { dotpath: 'pay.planning.portal', file });
+    assert.strictEqual(out, [
+      '=== DISPLAY: phase tree (emit verbatim as a code block) ===',
+      'Phase structure — 2 phases.',
+      '',
+      '1. Adapter Wrapper',
+      '   ├─ Goal: burst windows land at a live shell',
+      '   └─ Criteria: no dead-end prompt',
+      '',
+      '2. Regression Net',
+      '   └─ Goal: attach flows pinned by tests',
+      '',
+    ].join('\n'));
+  });
+
+  it('appends the structure gate with --approve; long detail wraps with the gutter', () => {
+    const file = writePayload(dir, 'ph.json', {
+      phases: [{ name: 'X', detail: [['Goal', 'goal '.repeat(30).trim()], ['Criteria', 'done']] }],
+    });
+    const out = renderSurface(dir, 'phase-tree', { dotpath: 'pay.planning.portal', file, approve: '1' });
+    assert.ok(out.includes('MENU: phase structure gate'));
+    assert.ok(out.includes('- **`y`/`yes`** — Proceed to task breakdown'));
+    const lines = out.split('\n');
+    const goalIdx = lines.findIndex((l) => l.startsWith('   ├─ Goal:'));
+    assert.ok(lines[goalIdx + 1].startsWith('   │  goal'), 'wrapped detail carries the gutter');
+  });
+
+  it('validates loudly', () => {
+    assert.throws(() => renderSurface(dir, 'phase-tree', { dotpath: 'pay.planning.portal', file: writePayload(dir, 'a.json', { phases: [] }) }), /"phases" must be a non-empty array/);
+    assert.throws(() => renderSurface(dir, 'phase-tree', { dotpath: 'pay.planning.portal', file: writePayload(dir, 'b.json', { phases: [{ name: 'X', detail: [] }] }) }), /"detail" must be a non-empty array/);
+  });
+});
+
+describe('render task-list --variant existing', () => {
+  let dir;
+  beforeEach(() => { dir = setup(); });
+  afterEach(() => teardown(dir));
+
+  it('gated menu drops the auto option; auto mode says confirmed', () => {
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress', task_list_gate_mode: 'gated' } } } } });
+    const file = writePayload(dir, 'tl.json', { phase: 1, phase_name: 'X', tasks: [{ name: 'A', summary: 'b' }] });
+    const gated = renderSurface(dir, 'task-list', { dotpath: 'pay.planning.portal', file, variant: 'existing' });
+    assert.ok(gated.includes('- **Tell me what to change** — which tasks to revise in this phase'));
+    assert.ok(!gated.includes('`a`/`auto`'), 'existing variant offers no auto opt-in');
+
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress', task_list_gate_mode: 'auto' } } } } });
+    const auto = renderSurface(dir, 'task-list', { dotpath: 'pay.planning.portal', file, variant: 'existing' });
+    assert.ok(auto.includes('Phase 1: X — task list confirmed. Proceeding to authoring.'));
+  });
+});
+
 describe('catalogue dispatch', () => {
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding, proposed-task, tasks-overview, author-task-gate, phase-tree\)/);
   });
 });
 


### PR DESCRIPTION
Stage 3 of the render-surfaces programme (design log: #489; base: #491). The task-gate family plus the D5 phase tree.

## Surfaces

- **`proposed-task`** — the analysis loop (implementation) and review actions loop carried byte-identical 15-line task displays, approval menus, and auto lines; now one payload surface. Gate mode is a `--gate` flag rather than an address read — deliberately: one consumer carries the mode in the cycle response, the other in staging-file frontmatter, so the flow owns the mode and the surface owns the form. Per-consumer comment hint (`--comment-hint`).
- **`tasks-overview`** — the proposed-tasks cycle overview both loops shared.
- **`author-task-gate`** — planning's per-task authoring menu (scalars as flags; the task detail itself remains a verbatim file emission the flow owns).
- **`phase-tree`** — D5 lands: `Phase structure — N phases.` with numbered phase nodes and wrapped `[label, value]` tree detail rows through `treeList`; `--approve` appends the structure gate. `define-phases` gets shaped output for the first time (its previous instruction was "present as rendered markdown", freeform).
- **`task-list --variant existing`** — plan-construction's twin gate reuses the stage-1 surface: same display, "confirmed" auto phrasing, gated menu without the auto opt-in (matching its existing-tables semantics); its `task_list_gate_mode` read left the prose.

Five consumer swaps: analysis-loop, review-actions-loop, author-tasks, plan-construction, define-phases.

## Test plan

- 13 new tests: byte-exact renders for all four surfaces (incl. the wrapped-detail gutter in the phase tree), gate-flag validation, variant behaviour, loud payload validation.
- `npm test` — 1496/1496. Typecheck + conventions lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #495
2. #490
3. #491
4. **#492** 👈 current
5. #493
6. #496
7. #497
8. #498
9. #499
10. #500
11. #501
<!-- stack:links:end -->