### PR TITLE
feat(engine): discovery-map add-batch + cache purge at close (D7 one-call)

### DIFF
--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -20,26 +20,29 @@ No new topics — this is an edits-only or browse-only session.
 
 #### Otherwise
 
-For each topic on the working list, in synthesised order:
+Write the whole topic set to `.workflows/.cache/{work_unit}/discovery/topics.json` with the Write tool — one entry per topic, in synthesised order:
 
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map add {work_unit} {topic} {research|discussion} --summary "{one-line summary}" --description "{paragraphs}"
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.discovery.{topic} brief_path "discovery/briefs/{topic}.md"
+```json
+[{"name": "{topic}", "routing": "{research|discussion}", "summary": "{one-line summary}", "description": "{paragraphs}", "brief_path": "discovery/briefs/{topic}.md"}]
 ```
 
-Append `--force-dismissed` for a name the synthesis DATA flagged `matches_dismissed=true` — the user's confirmation at the synthesis gate is the re-add decision; the engine clears the dismissed entry as part of the add.
+Set `"force_dismissed": true` on an entry whose name the synthesis DATA flagged `matches_dismissed=true` — the user's confirmation at the synthesis gate is the re-add decision; the engine clears the dismissed entry as part of the add.
 
-Summary and description come from the synthesis — derived from the exploration in topic-synthesis. Single-quote any value containing characters zsh would interpret — backticks, `$`, `[]`, `{}`, `~`. Description may span paragraphs.
+Persist the set in one transaction:
 
-If any command fails, surface the error and stop before the commit so the user can recover.
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map add-batch {work_unit} --file .workflows/.cache/{work_unit}/discovery/topics.json
+```
+
+The batch is atomic — a failing entry means nothing was persisted; fix the payload and re-run. Surface any error and stop before the commit so the user can recover.
 
 Notes:
 
 - The topic name is the manifest dict key (the `{topic}` path segment). There is no separate `name` field to set.
 - `routing` is the value confirmed by the user at the synthesis gate.
-- `--source` defaults to `discovery`, marking topics the user surfaced during discovery — distinct from items added later with other provenance (e.g. `research-analysis`, `gap-analysis`). Omit it here.
-- The last map-operation response's `map_total` is `{T}` for the Conclusion line in **C** — no re-read needed.
-- `brief_path` is an opaque field set by a post-create `set` — never an `add` flag. It records where the topic's brief lives; the brief file itself was written at harvest by [brief-synthesis.md](brief-synthesis.md).
+- Batch entries always land with `source: discovery`, marking topics the user surfaced during discovery — distinct from items added later with other provenance (e.g. `research-analysis`, `gap-analysis`).
+- The response's `map_total` is `{T}` for the Conclusion line in **C**, and `added` lists every persisted topic — no re-read needed.
+- `brief_path` records where the topic's brief lives; the brief file itself was written at harvest by [brief-synthesis.md](brief-synthesis.md).
 
 → Proceed to **B. Write Topics Identified**.
 

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -92,6 +92,7 @@ The per-item map operations write the manifest with no git commit (the calling s
 ```bash
 engine discovery-map sequence <work-unit> <topic>=<order> [<topic>=<order> …]   # suggested execution order, scoped commit
 engine discovery-map add <work-unit> <name> <research|discussion> (--summary <text> [--description <text>] | --backfill) [--source <tag>] [--force-dismissed]
+engine discovery-map add-batch <work-unit> --file <topics.json>   # whole topic set, one lock/save — atomic; entries {name, routing, summary, description?, brief_path?, force_dismissed?}; source always `discovery`
 engine discovery-map edit <work-unit> <name> [--summary <text>] [--description <text>]
 engine discovery-map remove <work-unit> <name>       # fresh only; name lands on the dismissed list
 engine discovery-map rename <work-unit> <old> <new>  # fresh only; every field preserved, brief file + brief_path follow

--- a/skills/workflow-engine/scripts/domain/discovery-map.cjs
+++ b/skills/workflow-engine/scripts/domain/discovery-map.cjs
@@ -245,6 +245,88 @@ function addItem(cwd, workUnit, name, { routing, source = 'discovery', summary, 
 }
 
 /**
+ * Add a whole topic set in one transaction — one lock, one load, one save.
+ * The batch form for the harvest (D7: one task, one call): every entry is
+ * validated before anything is applied, so a failing entry means nothing
+ * persisted — never a partial map. Entries may carry `brief_path` (recorded
+ * on the item, replacing the per-topic follow-up set) and `force_dismissed`
+ * (per-entry re-add confirmation). No git commit — the calling flow's commit
+ * covers the batch.
+ * @param {string} cwd project root
+ * @param {string} workUnit
+ * @param {{name: string, routing: string, summary: string, description?: string, brief_path?: string, force_dismissed?: boolean}[]} entries
+ * @returns {{work_unit: string, op: string, added: {name: string, routing: string, lifecycle: string}[], undismissed: string[], map_total: number}}
+ */
+function addItemsBatch(cwd, workUnit, entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error('add-batch: entries must be a non-empty array of {name, routing, summary, description?, brief_path?, force_dismissed?}');
+  }
+  entries.forEach((e, i) => {
+    const at = `entry ${i + 1}`;
+    if (!e || typeof e !== 'object') throw new Error(`add-batch: ${at} must be an object`);
+    if (!e.name || /[./]/.test(e.name)) {
+      throw new Error(`add-batch: ${at} — "${e.name}" is not a legal topic name (dots and slashes break manifest addressing)`);
+    }
+    if (!e.routing || !VALID_ROUTINGS.includes(e.routing)) {
+      throw new Error(`add-batch: ${at} ("${e.name}") — unknown routing ${JSON.stringify(e.routing ?? null)} (${VALID_ROUTINGS.join('|')})`);
+    }
+    if (typeof e.summary !== 'string' || e.summary.trim() === '') {
+      throw new Error(`add-batch: ${at} ("${e.name}") — "summary" must be a non-empty string`);
+    }
+    for (const opt of ['description', 'brief_path']) {
+      if (e[opt] !== undefined && (typeof e[opt] !== 'string' || e[opt].trim() === '')) {
+        throw new Error(`add-batch: ${at} ("${e.name}") — "${opt}" must be a non-empty string when present`);
+      }
+    }
+  });
+  const names = entries.map((e) => e.name);
+  const dupe = names.find((n, i) => names.indexOf(n) !== i);
+  if (dupe) throw new Error(`add-batch: "${dupe}" appears more than once in the batch`);
+
+  return withWorkUnitLock(cwd, workUnit, () => {
+    const manifest = loadWorkUnitManifest(cwd, workUnit);
+    const phases = ensureContainer(manifest, 'phases', 'phases');
+    const discovery = ensureContainer(phases, 'discovery', 'phases.discovery');
+    ensureContainer(discovery, 'items', 'phases.discovery.items');
+    const dismissed = Array.isArray(discovery.dismissed) ? discovery.dismissed : [];
+
+    // Validate the whole batch against current state before applying any of it.
+    for (const e of entries) {
+      if (discovery.items[e.name]) {
+        throw new Error(`add-batch: "${e.name}" is already on the map — nothing was added; edit it, or pick a different name`);
+      }
+      if (dismissed.includes(e.name) && !e.force_dismissed) {
+        throw new Error(`add-batch: "${e.name}" was previously dismissed from this map — nothing was added; confirm the re-add with the user, then set force_dismissed on the entry`);
+      }
+    }
+
+    /** @type {string[]} */
+    const undismissed = [];
+    for (const e of entries) {
+      if (dismissed.includes(e.name)) undismissed.push(e.name);
+      /** @type {Record<string, unknown>} */
+      const item = { routing: e.routing, source: 'discovery', summary: e.summary };
+      if (e.description !== undefined) item.description = e.description;
+      if (e.brief_path !== undefined) item.brief_path = e.brief_path;
+      discovery.items[e.name] = item;
+    }
+    if (undismissed.length > 0) {
+      discovery.dismissed = dismissed.filter((n) => !undismissed.includes(n));
+    }
+
+    saveWorkUnitManifest(cwd, workUnit, manifest);
+
+    return {
+      work_unit: workUnit,
+      op: 'add-batch',
+      added: entries.map((e) => ({ name: e.name, routing: e.routing, lifecycle: computeTopicLifecycle(manifest, e.name).lifecycle })),
+      undismissed,
+      map_total: Object.keys(discovery.items).length,
+    };
+  });
+}
+
+/**
  * Set `summary` and/or `description` on a map item — at least one required.
  * Allowed at any lifecycle. No git commit.
  * @param {string} cwd project root
@@ -472,4 +554,4 @@ function unhandleItem(cwd, workUnit, name) {
   });
 }
 
-module.exports = { sequenceMap, addItem, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem };
+module.exports = { sequenceMap, addItem, addItemsBatch, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem };

--- a/skills/workflow-engine/scripts/domain/workunit-absorb.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-absorb.cjs
@@ -279,6 +279,7 @@ function absorbWorkUnit(cwd, feature, { into, topic }) {
   });
 
   fs.rmSync(path.join(cwd, '.workflows', feature), { recursive: true, force: true });
+  fs.rmSync(path.join(cwd, '.workflows', '.cache', feature), { recursive: true, force: true });
 
   // KB: drop the feature's chunks, index the moved artifacts at their epic
   // identities (completed phase artifacts; imports and seeds always).

--- a/skills/workflow-engine/scripts/domain/workunit-lifecycle.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-lifecycle.cjs
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+
 // ---------------------------------------------------------------------------
 // Domain ring: work-unit lifecycle transitions — complete, cancel,
 // reactivate, and pivot, each a single transaction from the caller's
@@ -69,6 +72,16 @@ function assertLegalStatus(status) {
  *   completion vs pipeline-terminal vs review-skipped), so it arrives via -m
  * @returns {WorkUnitLifecycleResult}
  */
+
+// Cache is work-unit-lifetime scratch: load-bearing while the unit is open
+// (it survives context refresh mid-loop), garbage the moment it closes.
+// Purging at close also protects reactivation — stale tracking files would
+// poison reopened gates. Disk-only: the cache is gitignored.
+/** @param {string} cwd @param {string} workUnit */
+function purgeCache(cwd, workUnit) {
+  fs.rmSync(path.join(cwd, '.workflows', '.cache', workUnit), { recursive: true, force: true });
+}
+
 function completeWorkUnit(cwd, workUnit, { message }) {
   assertLegalStatus('completed');
   const { completedAt, previous } = withWorkUnitLock(cwd, workUnit, () => {
@@ -87,6 +100,7 @@ function completeWorkUnit(cwd, workUnit, { message }) {
     saveWorkUnitManifest(cwd, workUnit, loaded);
     return { completedAt: stamped, previous: from };
   });
+  purgeCache(cwd, workUnit);
 
   /** @type {string[]} */
   const warnings = [];
@@ -124,6 +138,7 @@ function cancelWorkUnit(cwd, workUnit) {
 
     saveWorkUnitManifest(cwd, workUnit, manifest);
   });
+  purgeCache(cwd, workUnit);
 
   /** @type {string[]} */
   const warnings = [];

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -22,7 +22,7 @@ const { signpost, box, wrapWithPrefix, renderTree, WIDTH } = require('./kernel/r
 const { commitScopedWithKb } = require('./domain/commit.cjs');
 const { recordSubtopicAdd, recordSubtopicState, SUBTOPIC_STATES } = require('./domain/discussion-map.cjs');
 const { VALID_ROUTINGS } = require('./kernel/manifest-schema.cjs');
-const { sequenceMap, addItem, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem } = require('./domain/discovery-map.cjs');
+const { sequenceMap, addItem, addItemsBatch, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem } = require('./domain/discovery-map.cjs');
 const { startTopic, completeTopic, reopenTopic, supersedeTopic, cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
 const { initTasks, startTask, fixAttempt, completeTask, analysisCycle } = require('./domain/tasks.cjs');
 const taskSections = require('./domain/projections/tasks.cjs');
@@ -125,6 +125,7 @@ Commands:
   discovery-map add <work-unit> <name> <research|discussion>
                 (--summary <text> [--description <text>] | --backfill)
                 [--source <tag>] [--force-dismissed]
+  discovery-map add-batch <work-unit> --file <topics.json>
   discovery-map edit <work-unit> <name> [--summary <text>] [--description <text>]
   discovery-map remove <work-unit> <name>
   discovery-map rename <work-unit> <old> <new>
@@ -330,6 +331,18 @@ function runDiscoveryMap(argv) {
   try {
     const { opts, flags, positional } = parseArgs(rest, ['force-dismissed', 'backfill']);
     const [workUnit] = positional;
+    if (command === 'add-batch') {
+      if (!workUnit) throw new Error('Usage: engine discovery-map add-batch <work-unit> --file <topics.json>');
+      if (!opts.file) throw new Error('discovery-map add-batch: --file <topics.json> is required');
+      let parsed;
+      try {
+        parsed = JSON.parse(fs.readFileSync(path.resolve(cwd, opts.file), 'utf8'));
+      } catch (err) {
+        throw new Error(`discovery-map add-batch: cannot read payload: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      respond(addItemsBatch(cwd, workUnit, parsed));
+      return;
+    }
     if (command === 'sequence') {
       if (!workUnit || positional.length < 2) {
         throw new Error('Usage: engine discovery-map sequence <work-unit> <topic>=<order> [<topic>=<order> …]');

--- a/tests/scripts/test-engine-discovery-map.cjs
+++ b/tests/scripts/test-engine-discovery-map.cjs
@@ -278,6 +278,69 @@ describe('engine CLI: discovery-map operations', () => {
     });
   });
 
+  describe('add-batch', () => {
+    /** Write a payload file and return its relative path. */
+    function payload(dir, entries) {
+      fs.writeFileSync(path.join(dir, 'topics.json'), JSON.stringify(entries));
+      return 'topics.json';
+    }
+
+    it('adds the whole set in one transaction — brief_path recorded, source always discovery, one map_total', () => {
+      const file = payload(dir, [
+        { name: 'menu-management', routing: 'research', summary: 's1', description: 'd1', brief_path: 'discovery/briefs/menu-management.md' },
+        { name: 'pricing', routing: 'discussion', summary: 's2' },
+      ]);
+      const res = runOk(dir, ['add-batch', 'payments', '--file', file]);
+      assert.deepStrictEqual(res, {
+        ok: true, work_unit: 'payments', op: 'add-batch',
+        added: [
+          { name: 'menu-management', routing: 'research', lifecycle: 'fresh' },
+          { name: 'pricing', routing: 'discussion', lifecycle: 'fresh' },
+        ],
+        undismissed: [], map_total: 10,
+      });
+      const m = readManifest(dir);
+      assert.deepStrictEqual(m.phases.discovery.items['menu-management'], {
+        routing: 'research', source: 'discovery', summary: 's1', description: 'd1', brief_path: 'discovery/briefs/menu-management.md',
+      });
+      assert.deepStrictEqual(m.phases.discovery.items['pricing'], {
+        routing: 'discussion', source: 'discovery', summary: 's2',
+      });
+    });
+
+    it('is atomic — a collision on any entry means nothing is added', () => {
+      const before = JSON.stringify(readManifest(dir).phases.discovery.items);
+      const file = payload(dir, [
+        { name: 'brand-new-topic', routing: 'research', summary: 's' },
+        { name: 'fresh-topic', routing: 'research', summary: 'collides with an existing item' },
+      ]);
+      const res = runFail(dir, ['add-batch', 'payments', '--file', file]);
+      assert.match(res.error, /"fresh-topic" is already on the map — nothing was added/);
+      assert.strictEqual(JSON.stringify(readManifest(dir).phases.discovery.items), before, 'no partial writes');
+    });
+
+    it('honours per-entry force_dismissed and refuses a dismissed name without it', () => {
+      runOk(dir, ['add', 'payments', 'doomed', 'research', '--summary', 's']);
+      runOk(dir, ['remove', 'payments', 'doomed']);
+      const refuse = runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'doomed', routing: 'research', summary: 's' }])]);
+      assert.match(refuse.error, /previously dismissed .* set force_dismissed/);
+      const res = runOk(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'doomed', routing: 'research', summary: 's', force_dismissed: true }])]);
+      assert.deepStrictEqual(res.undismissed, ['doomed']);
+      assert.ok(!(readManifest(dir).phases.discovery.dismissed || []).includes('doomed'));
+    });
+
+    it('validates loudly before touching state: routing, names, summaries, in-batch dupes, payload shape', () => {
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [])]).error, /non-empty array/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'a.b', routing: 'research', summary: 's' }])]).error, /not a legal topic name/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'ok', routing: 'nope', summary: 's' }])]).error, /unknown routing/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'ok', routing: 'research', summary: ' ' }])]).error, /"summary" must be a non-empty string/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [
+        { name: 'twice', routing: 'research', summary: 's' }, { name: 'twice', routing: 'research', summary: 's' },
+      ])]).error, /"twice" appears more than once/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', 'missing.json']).error, /cannot read payload/);
+    });
+  });
+
   describe('edit', () => {
     it('sets summary, echoes it with the lifecycle and map_total', () => {
       const res = runOk(dir, ['edit', 'payments', 'fresh-topic', '--summary', 'new blurb']);

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -580,6 +580,15 @@ describe('engine workunit complete', () => {
     assert.match(git(dir, ['status', '--porcelain']), /\?\? unrelated\.txt/);
   });
 
+  it('purges the work unit\'s cache dir wholesale — and only its own', () => {
+    fs.mkdirSync(path.join(dir, '.workflows', '.cache', 'auth-flow', 'planning', 'auth-flow'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.workflows', '.cache', 'auth-flow', 'planning', 'auth-flow', 'tracking.md'), 'scratch');
+    fs.mkdirSync(path.join(dir, '.workflows', '.cache', 'other-unit'), { recursive: true });
+    engine(dir, ['workunit', 'complete', 'auth-flow', '-m', 'workflow(auth-flow): complete feature pipeline']);
+    assert.strictEqual(fs.existsSync(path.join(dir, '.workflows', '.cache', 'auth-flow')), false, 'own cache purged');
+    assert.strictEqual(fs.existsSync(path.join(dir, '.workflows', '.cache', 'other-unit')), true, 'sibling cache untouched');
+  });
+
   it('rejects an already-completed unit and routes a cancelled unit through reactivate', () => {
     engine(dir, ['workunit', 'complete', 'auth-flow', '-m', 'workflow(auth-flow): mark as completed']);
     assert.match(
@@ -629,6 +638,13 @@ describe('engine workunit cancel', () => {
   let dir;
   beforeEach(() => { dir = setupFeatureFixture(); });
   afterEach(() => { cleanupFixture(dir); });
+
+  it('purges the work unit\'s cache dir', () => {
+    fs.mkdirSync(path.join(dir, '.workflows', '.cache', 'auth-flow'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.workflows', '.cache', 'auth-flow', 'scratch.json'), '{}');
+    engine(dir, ['workunit', 'cancel', 'auth-flow']);
+    assert.strictEqual(fs.existsSync(path.join(dir, '.workflows', '.cache', 'auth-flow')), false);
+  });
 
   it('sets status cancelled, removes KB chunks (failure is a warning), commits the fixed message', () => {
     const res = engine(dir, ['workunit', 'cancel', 'auth-flow']);

--- a/tests/scripts/test-engine-workunit-absorb.cjs
+++ b/tests/scripts/test-engine-workunit-absorb.cjs
@@ -176,7 +176,10 @@ describe('engine workunit absorb — happy path', () => {
   it('moves everything, mirrors statuses, deletes the feature, commits all three pathspecs once', () => {
     fix = setupFixture();
     writeFile(fix.project, 'unrelated.txt', 'outside the scope\n');
+    fs.mkdirSync(path.join(fix.project, '.workflows', '.cache', 'auth-flow'), { recursive: true });
+    fs.writeFileSync(path.join(fix.project, '.workflows', '.cache', 'auth-flow', 'scratch.json'), '{}');
     const res = engine(fix, ABSORB);
+    assert.strictEqual(fs.existsSync(path.join(fix.project, '.workflows', '.cache', 'auth-flow')), false, "absorbed feature's cache purged");
 
     assert.deepStrictEqual(res, {
       ok: true,


### PR DESCRIPTION
Stage 5a of the render-surfaces programme (design log: #489; base: #493) — the first two D7 deliveries.

## discovery-map add-batch

`engine discovery-map add-batch <wu> --file <topics.json>` — the whole harvest in one transaction. Entries `{name, routing, summary, description?, brief_path?, force_dismissed?}`; **all validation runs before anything applies** (illegal name, unknown routing, collision, dismissed-without-force, in-batch duplicate → loud error, zero writes — never a partial map). `brief_path` rides on the entry, so the per-topic `manifest set` follow-up dies with the loop: the fumi harvest's 48 sequential calls (24 adds + 24 sets, the run that produced the `$E` aliasing incident) become **one call**. `confirm-and-persist.md` swaps to payload + single call, and its zsh-quoting caveats leave with the argv.

## Cache purge at work-unit close

`workunit complete` / `cancel` / `absorb` remove `.workflows/.cache/{wu}/` wholesale — cache is work-unit-lifetime scratch (survives context refresh during active work, garbage at close). Disk-only (gitignored), and reactivation-safe: purging is what *protects* reopened gates from stale tracking files.

## Test plan

- add-batch: happy path (brief_path recorded, source pinned to `discovery`, map_total), **atomicity under mid-batch collision (state byte-compared before/after)**, per-entry force_dismissed + refusal, six loud validation cases, payload-read failure.
- purge: complete purges own cache and leaves siblings; cancel purges; absorb purges the absorbed feature's cache.
- `npm test` — 1508/1508. Typecheck + conventions lint clean.

The two call-chain audit reports (15 further repeated-call sites; the shell-construction cluster) are recorded in the design log for stage 5b scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #490
2. #491
3. #492
4. #493
5. **#495** 👈 current
<!-- stack:links:end -->