### PR TITLE
feat(engine): transaction confirmation sections — lifecycle verbs carry their own chrome

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -540,6 +540,10 @@ Rules:
 - If double-nesting would occur, flatten by combining the parent and child conditions into a single bold conditional
 - Every conditional branch must include its own routing instruction (`→ Proceed to` or `→ Return to`). Never place routing outside a conditional expecting it to apply to all branches — each branch is self-contained. Even if multiple branches route to the same destination, each states it explicitly.
 
+### Command Preludes
+
+Any decision an invocation depends on — a flag choice, a derived parameter, a value to substitute — is stated **before** the fenced command, never after. A step-executing reader runs the command when it reaches it; guidance placed below the fence arrives too late.
+
 ### Navigation Arrows
 
 Use `→` for flow control between steps or to external files:

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -15,14 +15,10 @@ Bugfix pipeline: Investigation → Specification → Planning → Implementation
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline" --pipeline
 ```
 
-Render and emit the section verbatim:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render pipeline-complete {work_unit}
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -51,14 +47,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render early-completion-g
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline (review skipped)"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline (review skipped)" --pipeline --skipped-review
 ```
 
-Render and emit the section verbatim:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render pipeline-complete {work_unit} --skipped-review
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -15,14 +15,10 @@ Cross-cutting pipeline: (Research) → Discussion → Specification (terminal)
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline" --pipeline
 ```
 
-Render and emit the section verbatim:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render pipeline-complete {work_unit}
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -71,14 +71,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render epic-all-done-gate
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete epic pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete epic pipeline" --pipeline
 ```
 
-Render and emit the section verbatim:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render pipeline-complete {work_unit}
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -15,14 +15,10 @@ Feature pipeline: (Research) → Discussion → Specification → Planning → I
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline" --pipeline
 ```
 
-Render and emit the section verbatim:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render pipeline-complete {work_unit}
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -51,14 +47,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render early-completion-g
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline (review skipped)"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline (review skipped)" --pipeline --skipped-review
 ```
 
-Render and emit the section verbatim:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render pipeline-complete {work_unit} --skipped-review
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -15,14 +15,10 @@ Quick-fix pipeline: Scoping → Implementation → Review
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline" --pipeline
 ```
 
-Render and emit the section verbatim:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render pipeline-complete {work_unit}
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -51,14 +47,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render early-completion-g
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline (review skipped)"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline (review skipped)" --pipeline --skipped-review
 ```
 
-Render and emit the section verbatim:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render pipeline-complete {work_unit} --skipped-review
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-bugfix/references/select-bugfix.md
+++ b/skills/workflow-continue-bugfix/references/select-bugfix.md
@@ -8,7 +8,11 @@
 
 Display active bugfixes and let the user select one.
 
-The index dump already carries the selection surfaces. Emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker. No auto-select, even with one item.
+Read the most recent index dump (re-run after any loop-back that changed state).
+
+**If it carries no selection sections** (no active bugfixes remain — possible after a loop-back cancelled or completed the last one): render the caller's no-bugfixes-in-progress terminal from its Step 2 and stop there.
+
+Otherwise emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker — from the most recent dump only, never a stale earlier one. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-cross-cutting/references/select-cross-cutting.md
+++ b/skills/workflow-continue-cross-cutting/references/select-cross-cutting.md
@@ -8,7 +8,11 @@
 
 Display active cross-cutting concerns and let the user select one.
 
-The index dump already carries the selection surfaces. Emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker. No auto-select, even with one item.
+Read the most recent index dump (re-run after any loop-back that changed state).
+
+**If it carries no selection sections** (no active cross-cutting concerns remain — possible after a loop-back cancelled or completed the last one): render the caller's no-cross-cutting-in-progress terminal from its Step 2 and stop there.
+
+Otherwise emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker — from the most recent dump only, never a stale earlier one. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -220,21 +220,7 @@ Run the cancel transaction — one command stashes the current status, marks the
 node .claude/skills/workflow-engine/scripts/engine.cjs topic cancel {work_unit} {phase} {topic}
 ```
 
-The JSON response reports `status`, `committed`, and `warnings`. If `warnings` is non-empty, display them — the cancellation is already recorded:
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ Knowledge removal warning
-  {warning}
-  The topic is cancelled. You can run knowledge remove manually later.
-```
-
-> *Output the next fenced block as a code block:*
-
-```
-Cancelled "{topic:(titlecase)}" in {phase}.
-```
+Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
 
 → Return to **A. State Display and Menu**.
 
@@ -264,20 +250,6 @@ Store the selected entry's `phase` and `topic`. Run the reactivate transaction �
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reactivate {work_unit} {phase} {topic}
 ```
 
-The JSON response reports the restored `status`, `committed`, and `warnings`. If `warnings` is non-empty, display them — the reactivation is already recorded:
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ Knowledge indexing warning
-  {warning}
-  The artifact is saved. Indexing can be retried later.
-```
-
-> *Output the next fenced block as a code block:*
-
-```
-Reactivated "{topic:(titlecase)}" in {phase}. Status restored to {status}.
-```
+Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
 
 → Return to **A. State Display and Menu**.

--- a/skills/workflow-continue-epic/references/select-epic.md
+++ b/skills/workflow-continue-epic/references/select-epic.md
@@ -8,7 +8,11 @@
 
 Display active epics and let the user select one.
 
-The index dump already carries the selection surfaces. Emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker. No auto-select, even with one item.
+Read the most recent index dump (re-run after any loop-back that changed state).
+
+**If it carries no selection sections** (no active epics remain — possible after a loop-back cancelled or completed the last one): render the caller's no-epics-in-progress terminal from its Step 2 and stop there.
+
+Otherwise emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker — from the most recent dump only, never a stale earlier one. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-feature/references/select-feature.md
+++ b/skills/workflow-continue-feature/references/select-feature.md
@@ -8,7 +8,11 @@
 
 Display active features and let the user select one.
 
-The index dump already carries the selection surfaces. Emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker. No auto-select, even with one item.
+Read the most recent index dump (re-run after any loop-back that changed state).
+
+**If it carries no selection sections** (no active features remain — possible after a loop-back cancelled or completed the last one): render the caller's no-features-in-progress terminal from its Step 2 and stop there.
+
+Otherwise emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker — from the most recent dump only, never a stale earlier one. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-continue-quickfix/references/select-quickfix.md
+++ b/skills/workflow-continue-quickfix/references/select-quickfix.md
@@ -8,7 +8,11 @@
 
 Display active quick-fixes and let the user select one.
 
-The index dump already carries the selection surfaces. Emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker. No auto-select, even with one item.
+Read the most recent index dump (re-run after any loop-back that changed state).
+
+**If it carries no selection sections** (no active quick-fixes remain — possible after a loop-back cancelled or completed the last one): render the caller's no-quick-fixes-in-progress terminal from its Step 2 and stop there.
+
+Otherwise emit its `DISPLAY: selection` and `MENU: selection` sections verbatim, each per its marker — from the most recent dump only, never a stale earlier one. No auto-select, even with one item.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -19,6 +19,8 @@ Every command follows six rules — new commands must too:
 5. **Mappings are `key=value` pairs** (`discovery-map sequence {wu} {topic}={order} …`).
 6. **A reserved word sharing a slot with user-named values must be a flag** — why `commit --inbox`/`--workflows` are flags beside positional `commit {work-unit}`.
 
+One carve-out: the **`render` surface catalogue** passes every non-address scalar as a flag (`--gate`, `--phase`, `--m`, `--variant`, …), including required closed vocabularies — the address is the only positional. Uniformity across the thirteen surfaces beats rule 2 there.
+
 ## Commands
 
 **`boot`** — the entry pipeline: runs `workflow-migrate/scripts/migrate.cjs` (resolved relative to the engine, cwd = project root), then `knowledge check`, then `knowledge compact` when ready — one call in place of the sequential Step 0 commands. Response: `{"ok": true, "migrations": {"changed": false, "output": "<trimmed report>"}, "knowledge": "ready"|"not-ready", "compacted": false, "kb_committed": null, "warnings": []}`. `migrations.changed` mirrors the orchestrator's own files-updated signal; `output` is the report with the prose stop-gate lines stripped (update counts kept). A failing migrate.cjs is a hard error (`{ok:false}` on stderr, exit 1) — migrations must never half-run silently. A failing `check` reports `not-ready`, and boot never initialises anything itself: a not-ready response additionally carries `"system_config": {"status": "valid"|"absent"|"invalid", "provider": <name|null>, "model": <name|null>}` — read from `~/.config/workflows/config.json` only, never the credentials file, so no secret can enter the response — which the calling skill's knowledge gate branches on to drive `knowledge setup` conversationally. A failing `compact` lands in `warnings`, never blocks. When the store is ready, knowledge-store dirt boot finds is committed scoped to `.workflows/.knowledge` (`chore(knowledge): initialise store` for untracked store files — the first boot after a `knowledge setup` run; `chore(knowledge): compact store` otherwise; sha in `kb_committed`, commit failure a warning). The conversational pieces (migration summary, review gate, the knowledge gate) stay in the calling skill.
@@ -68,7 +70,7 @@ engine manifest resolve <work-unit>.<phase>[.<topic>]    # artifact paths for KB
 
 ```bash
 engine workunit create <work-unit> <work-type> --description <text> (--session-log-file <path> | --no-session-log) [--import <path> …] [--seed <path> …]
-engine workunit complete <work-unit> -m "<message>"
+engine workunit complete <work-unit> -m "<message>" [--pipeline [--skipped-review]]   # --pipeline: the bridge context — the confirmation section is the "{Type} Completed" banner
 engine workunit cancel <work-unit>
 engine workunit reactivate <work-unit>
 engine workunit pivot <work-unit>
@@ -173,7 +175,6 @@ engine render proposed-task <wu>.<phase>.<topic> --file <payload> --gate gated|a
 engine render tasks-overview <wu>.<phase>.<topic> --file <payload>    # proposed-tasks cycle overview; payload {label, tasks: [{title, severity}]}
 engine render author-task-gate <wu>.planning.<topic> --m N --total N --title STR   # task-authoring approval menu (the detail itself is a verbatim file emission the flow owns)
 engine render phase-tree <wu>.planning.<topic> --file <payload> [--approve]        # D5 phase structure tree; payload {phases: [{name, detail?: [[label, value]]}]}; --approve appends the structure gate
-engine render pipeline-complete <wu> [--skipped-review]           # work-unit-level: "{Type} Completed" display, body by work_type / skip flag
 engine render phase-completed <wu> --phase <phase>                # one-line phase-completed display
 engine render early-completion-gate <wu>                          # bridge gate: proceed to review / complete without review
 engine render revisit-gate <wu> --prev <phase> --next <phase>     # bridge gate: proceed to next / revisit an earlier phase
@@ -186,4 +187,4 @@ The `finding` surface serves both review-findings loops (planning and specificat
 
 The `render` group also keeps its dev/debug primitives (`signpost`, `box`, `wrap`, `tree`) — authoring aids only, never called from skill flows.
 
-**Rendering is not a runtime CLI concern.** Static chrome (signposts, boxes, gate rules) lives as literal blocks in skill prose; parameterised chrome is rendered in-process by projections. No skill flow calls a render command at runtime — the `render` command group in `engine.cjs` is a development/debugging utility only (e.g. generating a correct literal while authoring prose).
+**Static chrome stays literal in skill prose; everything parameterised or state-branching renders in code** — adapter-side via projections, shared runtime surfaces via the `render` catalogue above, transaction chrome via the verbs' own appended sections. Only the `render` group's dev primitives (`signpost`, `box`, `wrap`, `tree`) are authoring aids never called from flows.

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -160,6 +160,8 @@ engine commit --inbox -m "<message>"
 engine commit --workflows -m "<message>"
 ```
 
+**Transaction confirmation sections.** The lifecycle verbs append labelled sections after their JSON line, the same pattern as the `task` gate sections: `workunit complete`/`cancel`/`reactivate` carry `DISPLAY: confirmation` (cancel/reactivate preceded by `DISPLAY: kb warning` when `warnings` is non-empty); `topic cancel`/`reactivate` likewise; `workunit absorb` carries the post-absorption summary, `promote` the promotion summary, and `pivot` a `DISPLAY: kb warning` (when warranted) plus `MENU: pivot continuation`. The JSON line stays the machine contract; the calling flow emits each section verbatim at its marker's named moment and never parses it for decisions.
+
 **`render`** — the surface catalogue (`domain/render.cjs`): named runtime surfaces returning demarcated `=== DISPLAY: … ===` / `=== MENU: … ===` sections the calling flow emits verbatim at each marker's named moment. Address-backed values come from the manifest (JSON state only — the engine never parses markdown artifacts); judgment content arrives as a JSON payload file written to the phase cache with the Write tool and validated loudly per-field. Gate-mode branching happens inside the surface: the response carries the menu when the mode is `gated` and the auto-proceed line when it is `auto` — the calling flow branches on which section arrived, never on the mode itself. No git commit; nothing is written.
 
 ```bash

--- a/skills/workflow-engine/scripts/domain/projections/selection.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/selection.cjs
@@ -1,9 +1,11 @@
 'use strict';
 
-// Shared selection projection for the continue-* navigation skills — the
+// ---------------------------------------------------------------------------
+// Domain ring: shared selection projection for the continue-* navigation skills — the
 // pick-list DISPLAY and MENU sections every type's gateway appends to its
 // index dump. One composition, five type configs: the clone-family factory
 // for the selection step.
+// ---------------------------------------------------------------------------
 
 const { titlecase, titlecaseLabel } = require('../conventions.cjs');
 const { section, dotFrame, cmdOption } = require('./surfaces.cjs');
@@ -82,6 +84,7 @@ function selectionSections(type, units, counts) {
       ? `Continue "${titlecase(u.name)}"`
       : `Continue "${titlecase(u.name)}" — ${u.phase_label}`));
   });
+  menuLines.push('');
   if (closed) menuLines.push(cmdOption(String(units.length + 1), null, cfg.view));
   menuLines.push(cmdOption('m', 'manage', cfg.manage), '', 'Select an option:');
 

--- a/skills/workflow-engine/scripts/domain/projections/start.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/start.cjs
@@ -16,8 +16,8 @@
 // ---------------------------------------------------------------------------
 
 const { box } = require('../../kernel/render.cjs');
-const { titlecase, capitalise, titlecaseLabel } = require('../conventions.cjs');
-const { dotFrame: dotMenu, cmdOption, promptOption, rangeOption } = require('./surfaces.cjs');
+const { titlecase, titlecaseLabel } = require('../conventions.cjs');
+const { dotFrame: dotMenu, cmdOption, promptOption, rangeOption, section: labelled } = require('./surfaces.cjs');
 
 /** @typedef {import('../start.cjs').StartDetail} StartDetail */
 /** @typedef {import('../start.cjs').WorkUnitEntry} WorkUnitEntry */
@@ -26,10 +26,6 @@ const { dotFrame: dotMenu, cmdOption, promptOption, rangeOption } = require('./s
 /** @typedef {import('../inbox-set.cjs').WorkingSetDetail} WorkingSetDetail */
 /** @typedef {import('../workunit-manage.cjs').ManageDetail} ManageDetail */
 
-/** One labelled `=== NAME (instruction) ===` deferred section. @param {string} name @param {string} instruction @param {string} body */
-function labelled(name, instruction, body) {
-  return `=== ${name} (${instruction}) ===\n${body.replace(/\n+$/, '')}\n`;
-}
 
 /**
  * @typedef {object} StartMenuKey

--- a/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
@@ -1,10 +1,12 @@
 'use strict';
 
-// Shared render-surface primitives — the single builder every engine-rendered
+// ---------------------------------------------------------------------------
+// Domain ring: shared render-surface primitives — the single builder every engine-rendered
 // menu, callout, and content frame flows through. The skill-visible formatting
 // rules (CONVENTIONS.md: dot frames, option syntax, callout flags, boxed
 // frames) exist in code exactly once, here; restyling a surface class is a
 // one-place change.
+// ---------------------------------------------------------------------------
 
 const { wrap } = require('../../kernel/render.cjs');
 

--- a/skills/workflow-engine/scripts/domain/projections/transactions.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/transactions.cjs
@@ -1,0 +1,148 @@
+'use strict';
+
+// Transaction confirmation sections — the DISPLAY/MENU blocks that follow a
+// lifecycle verb's JSON response (the labelled-section pattern the task verbs
+// established). The response line stays the machine contract; these sections
+// are the user-facing confirmation the calling flow emits verbatim at its
+// prescribed moment. Warnings render above confirmations, exactly as the
+// prose templates they replace.
+
+const { titlecase } = require('../conventions.cjs');
+const { section } = require('./surfaces.cjs');
+
+/**
+ * The ⚑ warning block: label line, one indented line per warning, and the
+ * reassurance tail. Null when there are no warnings.
+ * @param {string} label @param {string[] | undefined} warnings @param {string} tail
+ * @returns {string | null}
+ */
+function warningBlock(label, warnings, tail) {
+  if (!Array.isArray(warnings) || warnings.length === 0) return null;
+  const lines = [`⚑ ${label}`, ...warnings.map((w) => `  ${w}`), `  ${tail}`];
+  return section('DISPLAY: kb warning', 'emit verbatim as a code block, above the confirmation', lines.join('\n'));
+}
+
+/** @param {string} body @param {string} [instruction] */
+function confirmation(body, instruction = 'emit verbatim as a code block after the response') {
+  return section('DISPLAY: confirmation', instruction, body);
+}
+
+/** @param {(string | null)[]} parts */
+function joined(parts) {
+  return parts.filter(Boolean).join('\n');
+}
+
+/**
+ * workunit complete / cancel / reactivate.
+ * @param {'complete'|'cancel'|'reactivate'} verb
+ * @param {{work_unit: string, warnings?: string[]}} result
+ * @returns {string}
+ */
+function workunitLifecycleSections(verb, result) {
+  const name = titlecase(result.work_unit);
+  if (verb === 'complete') {
+    return confirmation(`"${name}" marked as completed.`);
+  }
+  if (verb === 'cancel') {
+    return joined([
+      warningBlock('Knowledge removal warning', result.warnings,
+        'The work unit is cancelled. The removal has been queued and will retry automatically on the next `knowledge remove` or `knowledge compact` call.'),
+      confirmation(`"${name}" marked as cancelled.`),
+    ]);
+  }
+  return joined([
+    warningBlock('Knowledge indexing warning', result.warnings, 'Indexing can be retried later.'),
+    confirmation(`"${name}" reactivated.`),
+  ]);
+}
+
+/**
+ * topic cancel / reactivate.
+ * @param {'cancel'|'reactivate'} verb
+ * @param {{topic: string, phase: string, status?: string, warnings?: string[]}} result
+ * @returns {string}
+ */
+function topicLifecycleSections(verb, result) {
+  const name = titlecase(result.topic);
+  if (verb === 'cancel') {
+    return joined([
+      warningBlock('Knowledge removal warning', result.warnings,
+        'The topic is cancelled. You can run knowledge remove manually later.'),
+      confirmation(`Cancelled "${name}" in ${result.phase}.`),
+    ]);
+  }
+  return joined([
+    warningBlock('Knowledge indexing warning', result.warnings, 'The artifact is saved. Indexing can be retried later.'),
+    confirmation(`Reactivated "${name}" in ${result.phase}. Status restored to ${result.status}.`),
+  ]);
+}
+
+/**
+ * workunit absorb — the post-absorption summary.
+ * @param {{feature: string, epic: string, topic: string, research?: unknown[], seeds?: unknown[], imports?: unknown[], warnings?: string[]}} result
+ * @returns {string}
+ */
+function absorbSections(result) {
+  const lines = [
+    'Absorbed into Epic',
+    '',
+    `  Topic "${titlecase(result.topic)}" added to ${titlecase(result.epic)}.`,
+    '',
+    '  • Discussion: moved',
+  ];
+  if (Array.isArray(result.research) && result.research.length > 0) lines.push('  • Research: moved');
+  if (Array.isArray(result.seeds) && result.seeds.length > 0) lines.push('  • Seed: moved');
+  if (Array.isArray(result.imports) && result.imports.length > 0) lines.push('  • Imports: moved');
+  lines.push('  • Feature: removed');
+  return joined([
+    warningBlock('Knowledge sync warning', result.warnings, 'The feature is absorbed. Indexing can be retried later.'),
+    confirmation(lines.join('\n')),
+  ]);
+}
+
+/**
+ * workunit promote — the promotion summary.
+ * @param {{work_unit: string, topic: string, cc_work_unit: string, warnings?: string[]}} result
+ * @returns {string}
+ */
+function promoteSections(result) {
+  const lines = [
+    'Promoted to Cross-Cutting',
+    '',
+    `"${titlecase(result.topic)}" has been promoted to its own cross-cutting work unit.`,
+    '',
+    `  Work unit: ${result.cc_work_unit}`,
+    `  Source: ${result.work_unit}`,
+    '  Discussion files: moved',
+    '  Specification: moved',
+    '  Epic status: promoted',
+  ];
+  return joined([
+    warningBlock('Knowledge warning', result.warnings,
+      'The promotion is committed. The knowledge base will catch up on the next sync.'),
+    confirmation(lines.join('\n')),
+  ]);
+}
+
+/**
+ * workunit pivot — warning plus the continuation menu.
+ * @param {{work_unit: string, warnings?: string[]}} result
+ * @returns {string}
+ */
+function pivotSections(result) {
+  const name = titlecase(result.work_unit);
+  const { menu, cmdOption } = require('./surfaces.cjs');
+  return joined([
+    warningBlock('Knowledge indexing warning', result.warnings, 'The pivot is complete. Indexing can be retried later.'),
+    section(
+      'MENU: pivot continuation',
+      "emit verbatim as markdown, then STOP for the user's response",
+      menu(`**${name}** converted from feature to epic.`, [
+        cmdOption('c', 'continue', `Continue ${name} as epic`),
+        cmdOption('b', 'back', 'Return to previous view'),
+      ]),
+    ),
+  ]);
+}
+
+module.exports = { workunitLifecycleSections, topicLifecycleSections, absorbSections, promoteSections, pivotSections };

--- a/skills/workflow-engine/scripts/domain/projections/transactions.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/transactions.cjs
@@ -1,14 +1,16 @@
 'use strict';
 
-// Transaction confirmation sections — the DISPLAY/MENU blocks that follow a
+// ---------------------------------------------------------------------------
+// Domain ring: transaction confirmation sections — the DISPLAY/MENU blocks that follow a
 // lifecycle verb's JSON response (the labelled-section pattern the task verbs
 // established). The response line stays the machine contract; these sections
 // are the user-facing confirmation the calling flow emits verbatim at its
 // prescribed moment. Warnings render above confirmations, exactly as the
 // prose templates they replace.
+// ---------------------------------------------------------------------------
 
 const { titlecase } = require('../conventions.cjs');
-const { section } = require('./surfaces.cjs');
+const { section, callout, menu, cmdOption } = require('./surfaces.cjs');
 
 /**
  * The ⚑ warning block: label line, one indented line per warning, and the
@@ -18,8 +20,8 @@ const { section } = require('./surfaces.cjs');
  */
 function warningBlock(label, warnings, tail) {
   if (!Array.isArray(warnings) || warnings.length === 0) return null;
-  const lines = [`⚑ ${label}`, ...warnings.map((w) => `  ${w}`), `  ${tail}`];
-  return section('DISPLAY: kb warning', 'emit verbatim as a code block, above the confirmation', lines.join('\n'));
+  const lines = [label, ...warnings.flatMap((w) => String(w).split('\n')), tail];
+  return section('DISPLAY: kb warning', 'emit verbatim as a code block, above the confirmation', callout(lines));
 }
 
 /** @param {string} body @param {string} [instruction] */
@@ -32,16 +34,35 @@ function joined(parts) {
   return parts.filter(Boolean).join('\n');
 }
 
+/** @type {Record<string, string>} */
+const TYPE_LABELS = {
+  feature: 'Feature',
+  bugfix: 'Bugfix',
+  'quick-fix': 'Quick-Fix',
+  'cross-cutting': 'Cross-Cutting',
+  epic: 'Epic',
+};
+
 /**
- * workunit complete / cancel / reactivate.
+ * workunit complete / cancel / reactivate. `complete` in pipeline context
+ * (the bridge) renders the full "{Type} Completed" banner instead of the
+ * one-line confirmation — one transaction, its own chrome.
  * @param {'complete'|'cancel'|'reactivate'} verb
- * @param {{work_unit: string, warnings?: string[]}} result
+ * @param {{work_unit: string, work_type?: string, warnings?: string[]}} result
+ * @param {{pipeline?: boolean, skippedReview?: boolean}} [opts]
  * @returns {string}
  */
-function workunitLifecycleSections(verb, result) {
+function workunitLifecycleSections(verb, result, { pipeline = false, skippedReview = false } = {}) {
   const name = titlecase(result.work_unit);
   if (verb === 'complete') {
-    return confirmation(`"${name}" marked as completed.`);
+    if (!pipeline) return confirmation(`"${name}" marked as completed.`);
+    const typeLabel = TYPE_LABELS[result.work_type || ''] || titlecase(String(result.work_type || ''));
+    const body = skippedReview
+      ? `"${name}" completed — review skipped.`
+      : result.work_type === 'epic'
+        ? `"${name}" has completed all topics through review.`
+        : `"${name}" has completed all pipeline phases.`;
+    return confirmation(`${typeLabel} Completed\n\n${body}`);
   }
   if (verb === 'cancel') {
     return joined([
@@ -125,23 +146,28 @@ function promoteSections(result) {
 }
 
 /**
- * workunit pivot — warning plus the continuation menu.
+ * workunit pivot — the kb warning, plus the continuation menu only when the
+ * caller asked for it (`--continuation-menu`, the manage flow's menu step).
+ * The off-topic reroute paths pivot mid-session with no menu step — an
+ * unconditional menu would derail them.
  * @param {{work_unit: string, warnings?: string[]}} result
+ * @param {{continuationMenu?: boolean}} [opts]
  * @returns {string}
  */
-function pivotSections(result) {
+function pivotSections(result, { continuationMenu = false } = {}) {
   const name = titlecase(result.work_unit);
-  const { menu, cmdOption } = require('./surfaces.cjs');
   return joined([
     warningBlock('Knowledge indexing warning', result.warnings, 'The pivot is complete. Indexing can be retried later.'),
-    section(
-      'MENU: pivot continuation',
-      "emit verbatim as markdown, then STOP for the user's response",
-      menu(`**${name}** converted from feature to epic.`, [
-        cmdOption('c', 'continue', `Continue ${name} as epic`),
-        cmdOption('b', 'back', 'Return to previous view'),
-      ]),
-    ),
+    continuationMenu
+      ? section(
+          'MENU: pivot continuation',
+          "emit verbatim as markdown, then STOP for the user's response",
+          menu(`**${name}** converted from feature to epic.`, [
+            cmdOption('c', 'continue', `Continue ${name} as epic`),
+            cmdOption('b', 'back', 'Return to previous view'),
+          ]),
+        )
+      : null,
   ]);
 }
 

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -340,7 +340,7 @@ function phaseTree(cwd, args) {
     lines.push(`${i + 1}. ${ph.name}`);
     if (ph.detail !== undefined) {
       if (!Array.isArray(ph.detail) || ph.detail.length === 0
-        || ph.detail.some((d) => !Array.isArray(d) || d.length !== 2 || !isFilled(d[0]) || !isFilled(String(d[1])))) {
+        || ph.detail.some((d) => !Array.isArray(d) || d.length !== 2 || !isFilled(d[0]) || !(typeof d[1] === 'number' || isFilled(d[1])))) {
         throw new Error(`render phase-tree: phase ${i + 1} "detail" must be a non-empty array of [label, value] pairs`);
       }
       lines.push(treeList(ph.detail.map(([label, value]) => `${label}: ${value}`), { indent: '   ' }));
@@ -354,6 +354,7 @@ function phaseTree(cwd, args) {
       'emit verbatim as markdown, then STOP for the user\'s response',
       menu('Approve this phase structure?', [
         cmdOption('y', 'yes', 'Proceed to task breakdown'),
+        cmdOption('v', 'view full', 'Show the full phase structure — goals, ordering rationale, acceptance criteria'),
         promptOption('Tell me what to change', 'which phases to reorder, split, merge, add, edit, or remove'),
         promptOption('Navigate', 'Tell me where to go: a different phase or task, or the leading edge'),
       ]),
@@ -380,11 +381,16 @@ function readJsonPayload(cwd, file, surface) {
   } catch {
     throw new Error(`render ${surface}: payload file not found: ${file}`);
   }
+  let parsed;
   try {
-    return JSON.parse(raw);
+    parsed = JSON.parse(raw);
   } catch (err) {
     throw new Error(`render ${surface}: payload is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
   }
+  if (parsed === null || typeof parsed !== 'object') {
+    throw new Error(`render ${surface}: payload must be a JSON object or array`);
+  }
+  return parsed;
 }
 
 /** @param {unknown} v @returns {v is string} */
@@ -439,7 +445,7 @@ function finding(cwd, { dotpath, file }) {
   if (!Number.isInteger(p.n) || p.n < 1) throw new Error('render finding: "n" must be a positive integer');
   if (!Number.isInteger(p.total) || p.total < p.n) throw new Error('render finding: "total" must be an integer ≥ "n"');
   if (!isFilled(p.title)) throw new Error('render finding: "title" must be a non-empty string');
-  if (!Array.isArray(p.meta) || p.meta.some((m) => !Array.isArray(m) || m.length !== 2 || !isFilled(m[0]) || !isFilled(String(m[1])))) {
+  if (!Array.isArray(p.meta) || p.meta.some((m) => !Array.isArray(m) || m.length !== 2 || !isFilled(m[0]) || !(typeof m[1] === 'number' || isFilled(m[1])))) {
     throw new Error('render finding: "meta" must be an array of [label, value] pairs');
   }
   if (!isFilled(p.details)) throw new Error('render finding: "details" must be a non-empty string');
@@ -463,7 +469,9 @@ function finding(cwd, { dotpath, file }) {
       ...stringLines(p.diff.proposed || [], 'finding', 'diff.proposed').map((l) => `+${l}`),
       ...stringLines(p.diff.context_below || [], 'finding', 'diff.context_below').map((l) => ` ${l}`),
     ];
-    if (body.length === 0) throw new Error('render finding: "diff" must carry at least one current/proposed line');
+    if ((p.diff.current || []).length + (p.diff.proposed || []).length === 0) {
+      throw new Error('render finding: "diff" must carry at least one current/proposed line');
+    }
     const framed = boxedFrame(`Finding ${p.n}: ${p.title}`, body).split('\n');
     parts.push(section('DISPLAY: diff frame open', 'emit verbatim as a code block, directly above the diff', framed[0]));
     parts.push(section('DISPLAY: diff', 'emit verbatim as a diff code block (```diff fence)', framed.slice(1, -1).join('\n')));
@@ -529,28 +537,6 @@ function resolveWorkUnit(cwd, dotpath, surface) {
   if (!manifest) throw new Error(`render ${surface}: work unit "${dotpath}" not found`);
   const typeLabel = TYPE_LABELS[manifest.work_type] || titlecase(String(manifest.work_type || ''));
   return { workUnit: dotpath, manifest, typeLabel };
-}
-
-/**
- * @param {string} cwd
- * @param {{dotpath: string} & Record<string, string|undefined>} args
- * @returns {string}
- */
-function pipelineComplete(cwd, args) {
-  const { workUnit, manifest, typeLabel } = resolveWorkUnit(cwd, args.dotpath, 'pipeline-complete');
-  const wu = titlecase(workUnit);
-  const body = 'skipped-review' in args
-    ? `"${wu}" completed — review skipped.`
-    : manifest.work_type === 'epic'
-      ? `"${wu}" has completed all topics through review.`
-      : `"${wu}" has completed all pipeline phases.`;
-  return section(
-    'DISPLAY: pipeline complete',
-    'emit verbatim as a code block after the workunit complete command',
-    `${typeLabel} Completed
-
-${body}`,
-  );
 }
 
 /**
@@ -631,7 +617,6 @@ const SURFACES = {
   'tasks-overview': tasksOverview,
   'author-task-gate': authorTaskGate,
   'phase-tree': phaseTree,
-  'pipeline-complete': pipelineComplete,
   'phase-completed': phaseCompleted,
   'early-completion-gate': earlyCompletionGate,
   'revisit-gate': revisitGate,

--- a/skills/workflow-engine/scripts/domain/workunit-lifecycle.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-lifecycle.cjs
@@ -46,6 +46,7 @@ function assertLegalStatus(status) {
 /**
  * @typedef {object} WorkUnitLifecycleResult
  * @property {string} work_unit
+ * @property {string} [work_type]  complete: the unit's work type (drives the pipeline banner)
  * @property {string} status     the work unit's status after the transition
  * @property {string} [completed_at]      complete: the stamped date
  * @property {string} [previous_status]   reactivate: the status the unit came from
@@ -71,7 +72,7 @@ function assertLegalStatus(status) {
  */
 function completeWorkUnit(cwd, workUnit, { message }) {
   assertLegalStatus('completed');
-  const { completedAt, previous } = withWorkUnitLock(cwd, workUnit, () => {
+  const { completedAt, previous, workType } = withWorkUnitLock(cwd, workUnit, () => {
     const loaded = loadWorkUnitManifest(cwd, workUnit);
     if (loaded.status === 'completed') {
       throw new Error(`work unit "${workUnit}" is already completed`);
@@ -85,7 +86,7 @@ function completeWorkUnit(cwd, workUnit, { message }) {
     loaded.completed_at = stamped;
 
     saveWorkUnitManifest(cwd, workUnit, loaded);
-    return { completedAt: stamped, previous: from };
+    return { completedAt: stamped, previous: from, workType: loaded.work_type };
   });
 
   /** @type {string[]} */
@@ -96,7 +97,7 @@ function completeWorkUnit(cwd, workUnit, { message }) {
 
   const committed = commitScopedWithKb(cwd, `.workflows/${workUnit}`, message);
   /** @type {WorkUnitLifecycleResult} */
-  const result = { work_unit: workUnit, status: 'completed', completed_at: completedAt, committed, warnings };
+  const result = { work_unit: workUnit, work_type: workType, status: 'completed', completed_at: completedAt, committed, warnings };
   noteIfNothingCommitted(result, committed);
   return result;
 }

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -26,6 +26,7 @@ const { sequenceMap, addItem, editItem, removeItem, renameItem, rerouteItem, han
 const { startTopic, completeTopic, reopenTopic, supersedeTopic, cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
 const { initTasks, startTask, fixAttempt, completeTask, analysisCycle } = require('./domain/tasks.cjs');
 const taskSections = require('./domain/projections/tasks.cjs');
+const txSections = require('./domain/projections/transactions.cjs');
 const { archiveItems, restoreItems, deleteItems } = require('./domain/inbox.cjs');
 const { stampAnalysisCache } = require('./domain/cache.cjs');
 const { boot } = require('./domain/boot.cjs');
@@ -250,28 +251,38 @@ function runWorkunit(argv) {
       if (!workUnit || !message) {
         throw new Error('Usage: engine workunit complete <work-unit> -m <message>');
       }
-      respond(completeWorkUnit(process.cwd(), workUnit, { message }));
+      const res = completeWorkUnit(process.cwd(), workUnit, { message });
+      respond(res);
+      respondSections(txSections.workunitLifecycleSections('complete', res));
     } else if (command === 'cancel' || command === 'reactivate' || command === 'pivot') {
       const [workUnit, ...extra] = rest;
       if (!workUnit || extra.length > 0) {
         throw new Error(`Usage: engine workunit ${command} <work-unit>`);
       }
       const fn = command === 'cancel' ? cancelWorkUnit : command === 'reactivate' ? reactivateWorkUnit : pivotWorkUnit;
-      respond(fn(process.cwd(), workUnit));
+      const res = fn(process.cwd(), workUnit);
+      respond(res);
+      respondSections(command === 'pivot'
+        ? txSections.pivotSections(res)
+        : txSections.workunitLifecycleSections(command, res));
     } else if (command === 'absorb') {
       const { opts, positional } = parseArgs(rest);
       const [feature] = positional;
       if (!feature || positional.length !== 1 || !opts.into || !opts.topic) {
         throw new Error('Usage: engine workunit absorb <feature> --into <epic> --topic <name>');
       }
-      respond(absorbWorkUnit(process.cwd(), feature, { into: opts.into, topic: opts.topic }));
+      const res = absorbWorkUnit(process.cwd(), feature, { into: opts.into, topic: opts.topic });
+      respond(res);
+      respondSections(txSections.absorbSections(res));
     } else if (command === 'promote') {
       const { opts, positional } = parseArgs(rest);
       const [workUnit, topic] = positional;
       if (!workUnit || !topic || positional.length !== 2 || !opts.to || !opts.description) {
         throw new Error('Usage: engine workunit promote <work-unit> <topic> --to <cc-work-unit> --description <text>');
       }
-      respond(promoteWorkUnit(process.cwd(), workUnit, topic, { to: opts.to, description: opts.description }));
+      const res = promoteWorkUnit(process.cwd(), workUnit, topic, { to: opts.to, description: opts.description });
+      respond(res);
+      respondSections(txSections.promoteSections(res));
     } else {
       throw new Error('Usage: engine workunit <create|complete|cancel|reactivate|pivot|absorb|promote> …');
     }
@@ -478,7 +489,11 @@ function runTopic(argv) {
     if (!workUnit || !phase || !topic) {
       throw new Error(`Usage: engine topic ${command} <work-unit> <phase> <topic>`);
     }
-    respond(fn(process.cwd(), workUnit, phase, topic));
+    const res = fn(process.cwd(), workUnit, phase, topic);
+    respond(res);
+    if (command === 'cancel' || command === 'reactivate') {
+      respondSections(txSections.topicLifecycleSections(command, res));
+    }
   } catch (err) {
     failJson(err);
   }

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -114,10 +114,10 @@ Commands:
   manifest resolve <work-unit>.<phase>[.<topic>]
   workunit create <work-unit> <work-type> --description <text> --session-log-file <path>|--no-session-log
                   [--import <path> …] [--seed <path> …]
-  workunit complete <work-unit> -m <message>
+  workunit complete <work-unit> -m <message> [--pipeline [--skipped-review]]
   workunit cancel <work-unit>
   workunit reactivate <work-unit>
-  workunit pivot <work-unit>
+  workunit pivot <work-unit> [--continuation-menu]
   workunit absorb <feature> --into <epic> --topic <name>
   workunit promote <work-unit> <topic> --to <cc-work-unit> --description <text>
   discussion-map add <work-unit> <topic> <subtopic> [--parent <subtopic>]
@@ -161,7 +161,6 @@ Commands:
   render tasks-overview   <wu.phase.topic> --file <payload.json>
   render author-task-gate <wu.planning.topic> --m N --total N --title STR
   render phase-tree       <wu.planning.topic> --file <payload.json> [--approve]
-  render pipeline-complete <wu> [--skipped-review]
   render phase-completed   <wu> --phase <phase>
   render early-completion-gate <wu>
   render revisit-gate      <wu> --prev <phase> --next <phase>
@@ -242,28 +241,33 @@ function runWorkunit(argv) {
     } else if (command === 'complete') {
       /** @type {string|null} */ let workUnit = null;
       /** @type {string|null} */ let message = null;
+      const completeFlags = new Set();
       for (let i = 0; i < rest.length; i++) {
         const a = rest[i];
         if (a === '-m' || a === '--message') message = rest[++i];
+        else if (a === '--pipeline' || a === '--skipped-review') completeFlags.add(a.slice(2));
         else if (workUnit === null) workUnit = a;
         else throw new Error(`unexpected argument "${a}"`);
       }
       if (!workUnit || !message) {
-        throw new Error('Usage: engine workunit complete <work-unit> -m <message>');
+        throw new Error('Usage: engine workunit complete <work-unit> -m <message> [--pipeline [--skipped-review]]');
       }
       const res = completeWorkUnit(process.cwd(), workUnit, { message });
       respond(res);
-      respondSections(txSections.workunitLifecycleSections('complete', res));
+      respondSections(txSections.workunitLifecycleSections('complete', res, {
+        pipeline: completeFlags.has('pipeline'),
+        skippedReview: completeFlags.has('skipped-review'),
+      }));
     } else if (command === 'cancel' || command === 'reactivate' || command === 'pivot') {
       const [workUnit, ...extra] = rest;
-      if (!workUnit || extra.length > 0) {
-        throw new Error(`Usage: engine workunit ${command} <work-unit>`);
+      if (!workUnit || (extra.length > 0 && !(command === 'pivot' && extra.every((a) => a === '--continuation-menu')))) {
+        throw new Error(`Usage: engine workunit ${command} <work-unit>${command === 'pivot' ? ' [--continuation-menu]' : ''}`);
       }
       const fn = command === 'cancel' ? cancelWorkUnit : command === 'reactivate' ? reactivateWorkUnit : pivotWorkUnit;
       const res = fn(process.cwd(), workUnit);
       respond(res);
       respondSections(command === 'pivot'
-        ? txSections.pivotSections(res)
+        ? txSections.pivotSections(res, { continuationMenu: extra.includes('--continuation-menu') })
         : txSections.workunitLifecycleSections(command, res));
     } else if (command === 'absorb') {
       const { opts, positional } = parseArgs(rest);

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -78,6 +78,12 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render phase-tree {work_u
 
 **STOP.** Wait for user response.
 
+#### If `view full`
+
+Present the full phase structure from the planning file as rendered markdown (not a code block) — goals, ordering rationale, acceptance criteria as the designer wrote them. Then re-emit the `MENU: phase structure gate` section.
+
+**STOP.** Wait for user response.
+
 #### If the user provides feedback
 
 Re-invoke `workflow-planning-phase-designer` with all original inputs PLUS:

--- a/skills/workflow-planning-process/references/define-tasks.md
+++ b/skills/workflow-planning-process/references/define-tasks.md
@@ -71,11 +71,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render task-list {work_un
 
 The response carries the task-list display plus the surface for the current gate mode. Emit each section verbatim at its marked instruction.
 
-#### If the response carries `DISPLAY: task list auto-approved`
+#### If the response carried `DISPLAY: task list auto-approved`
 
 → Proceed to **C. Finalize Approval**.
 
-#### If the response carries `MENU: task list gate`
+#### If the response carried `MENU: task list gate`
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-shared/references/pivot-to-epic.md
+++ b/skills/workflow-shared/references/pivot-to-epic.md
@@ -15,9 +15,11 @@ The caller provides this via context before loading:
 ## A. Run the Pivot
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit pivot {work_unit}
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit pivot {work_unit} [--continuation-menu]
 ```
 
-Emit the response's `DISPLAY: kb warning` section when present, verbatim per its marker. (The response's `MENU: pivot continuation` section is emitted by the caller at its menu step.)
+Pass `--continuation-menu` only when the caller's flow has a menu step for the response's `MENU: pivot continuation` section (the manage flow does; the off-topic reroute paths do not — they continue their session and must omit the flag).
+
+Emit the response's `DISPLAY: kb warning` section when present, verbatim per its marker. (With `--continuation-menu`, the response also carries `MENU: pivot continuation` — the caller emits it at its menu step.)
 
 → Return to caller.

--- a/skills/workflow-shared/references/pivot-to-epic.md
+++ b/skills/workflow-shared/references/pivot-to-epic.md
@@ -14,11 +14,11 @@ The caller provides this via context before loading:
 
 ## A. Run the Pivot
 
+Pass `--continuation-menu` only when the caller's flow has a menu step for the response's `MENU: pivot continuation` section (the manage flow does; the off-topic reroute paths do not — they continue their session and must omit the flag).
+
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit pivot {work_unit} [--continuation-menu]
 ```
-
-Pass `--continuation-menu` only when the caller's flow has a menu step for the response's `MENU: pivot continuation` section (the manage flow does; the off-topic reroute paths do not — they continue their session and must omit the flag).
 
 Emit the response's `DISPLAY: kb warning` section when present, verbatim per its marker. (With `--continuation-menu`, the response also carries `MENU: pivot continuation` — the caller emits it at its menu step.)
 

--- a/skills/workflow-shared/references/pivot-to-epic.md
+++ b/skills/workflow-shared/references/pivot-to-epic.md
@@ -18,14 +18,6 @@ The caller provides this via context before loading:
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit pivot {work_unit}
 ```
 
-If the JSON response's `warnings` is non-empty, display them — the conversion is already recorded and committed:
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ Knowledge indexing warning
-  {warning}
-  The pivot is complete. Indexing can be retried later.
-```
+Emit the response's `DISPLAY: kb warning` section when present, verbatim per its marker. (The response's `MENU: pivot continuation` section is emitted by the caller at its menu step.)
 
 → Return to caller.

--- a/skills/workflow-specification-process/references/promote-to-cross-cutting.md
+++ b/skills/workflow-specification-process/references/promote-to-cross-cutting.md
@@ -34,33 +34,11 @@ One engine transaction owns the promotion: it creates the cross-cutting work uni
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit promote {work_unit} {topic} --to {cc_work_unit} --description "{one-line summary from spec}"
 ```
 
-If the response's `warnings` is non-empty, display them but do not block — the promotion is already recorded and committed; knowledge-base removals are queued automatically (retry on the next `knowledge remove` / `knowledge compact`), and failed indexing can be retried later:
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ Knowledge warning
-  {warnings}
-  The promotion is committed. The knowledge base will catch up on the next sync.
-```
-
 → Proceed to **C. Display**.
 
 ## C. Display
 
-> *Output the next fenced block as a code block:*
-
-```
-Promoted to Cross-Cutting
-
-"{topic:(titlecase)}" has been promoted to its own cross-cutting work unit.
-
-  Work unit: {cc_work_unit}
-  Source: {work_unit}
-  Discussion files: moved
-  Specification: moved
-  Epic status: promoted
-```
+Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
 
 Invoke the bridge for the EPIC (not the cc work unit — the epic continues its pipeline):
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -213,47 +213,13 @@ The refusal names the blocking condition; nothing was touched — relay the erro
 
 → Return to caller.
 
-#### If `warnings` is non-empty
-
-Display them — the absorption is already recorded and committed:
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ Knowledge sync warning
-  {warning}
-  The feature is absorbed. Indexing can be retried later.
-```
-
-→ Proceed to **H. Post-Absorption**.
-
-#### Otherwise
-
 → Proceed to **H. Post-Absorption**.
 
 ---
 
 ## H. Post-Absorption
 
-> *Output the next fenced block as a code block:*
-
-```
-Absorbed into Epic
-
-  Topic "{topic:(titlecase)}" added to {target_epic:(titlecase)}.
-
-  • Discussion: moved
-@if(has_research)
-  • Research: moved
-@endif
-@if(has_seeds)
-  • Seed: moved
-@endif
-@if(has_imports)
-  • Imports: moved
-@endif
-  • Feature: removed
-```
+Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -213,6 +213,10 @@ The refusal names the blocking condition; nothing was touched — relay the erro
 
 → Return to caller.
 
+#### Otherwise
+
+The command succeeded.
+
 → Proceed to **H. Post-Absorption**.
 
 ---

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -77,7 +77,7 @@ Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 #### If user chose `p`/`pivot`
 
-Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{selected.name}`.
+Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{selected.name}`, continuation_menu = `true` (pass `--continuation-menu` on the pivot command).
 
 Emit the pivot response's `MENU: pivot continuation` section verbatim per its marker.
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -71,11 +71,7 @@ Run the complete transaction — one command sets `status: completed`, stamps `c
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {selected.name} -m "workflow({selected.name}): mark as completed"
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-"{selected.name:(titlecase)}" marked as completed.
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 → Return to caller.
 
@@ -83,16 +79,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {select
 
 Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{selected.name}`.
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-**{selected.name:(titlecase)}** converted from feature to epic.
-
-- **`c`/`continue`** — Continue {selected.name:(titlecase)} as epic
-- **`b`/`back`** — Return to previous view
-· · · · · · · · · · · ·
-```
+Emit the pivot response's `MENU: pivot continuation` section verbatim per its marker.
 
 **STOP.** Wait for user response.
 
@@ -126,21 +113,7 @@ Run the cancel transaction — one command sets `status: cancelled`, removes the
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit cancel {selected.name}
 ```
 
-The JSON response reports `status`, `committed`, and `warnings`. If `warnings` is non-empty, display them — the cancellation is already recorded:
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ Knowledge removal warning
-  {warning}
-  The work unit is cancelled. The removal has been queued and will retry automatically on the next `knowledge remove` or `knowledge compact` call.
-```
-
-> *Output the next fenced block as a code block:*
-
-```
-"{selected.name:(titlecase)}" marked as cancelled.
-```
+Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
 
 → Return to caller.
 

--- a/skills/workflow-start/references/view-completed.md
+++ b/skills/workflow-start/references/view-completed.md
@@ -70,21 +70,7 @@ Run the reactivate transaction — one command restores `status: in-progress`, c
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit reactivate {selected.name}
 ```
 
-The JSON response reports `previous_status`, `committed`, and `warnings`. If `warnings` is non-empty, display them — the reactivation is already recorded:
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ Knowledge indexing warning
-  {warning}
-  Indexing can be retried later.
-```
-
-> *Output the next fenced block as a code block:*
-
-```
-"{selected.name:(titlecase)}" reactivated.
-```
+Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
 
 → Return to caller.
 

--- a/tests/scripts/test-engine-manifest-io.cjs
+++ b/tests/scripts/test-engine-manifest-io.cjs
@@ -72,7 +72,9 @@ function makeStale(file) {
 
 /** Run the engine expecting success; returns the parsed JSON response. */
 function engine(dir, args) {
-  return JSON.parse(execFileSync('node', [ENGINE, ...args], { cwd: dir, encoding: 'utf8' }).trim());
+  const out = execFileSync('node', [ENGINE, ...args], { cwd: dir, encoding: 'utf8' });
+  const nl = out.indexOf('\n');
+  return JSON.parse((nl === -1 ? out : out.slice(0, nl)).trim());
 }
 
 /** @param {number} ms */

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -582,6 +582,7 @@ describe('selection projection', () => {
       '',
       '- **`1`** — Continue "Crash" — specification (in-progress)',
       '- **`2`** — Continue "Leak" — investigation (in-progress)',
+      '',
       '- **`3`** — View completed & cancelled bugfixes',
       "- **`m`/`manage`** — Manage a bugfix's lifecycle",
       '',
@@ -613,18 +614,6 @@ describe('bridge continuation surfaces', () => {
   });
   afterEach(() => teardown(dir));
 
-  it('pipeline-complete varies body by work_type and skip flag', () => {
-    assert.ok(renderSurface(dir, 'pipeline-complete', { dotpath: 'pay' })
-      .includes('Feature Completed\n\n"Pay" has completed all pipeline phases.'));
-    assert.ok(renderSurface(dir, 'pipeline-complete', { dotpath: 'pay', 'skipped-review': '1' })
-      .includes('"Pay" completed — review skipped.'));
-    writeManifest(dir, 'ep', { work_type: 'epic' });
-    assert.ok(renderSurface(dir, 'pipeline-complete', { dotpath: 'ep' })
-      .includes('Epic Completed\n\n"Ep" has completed all topics through review.'));
-    writeManifest(dir, 'qf', { work_type: 'quick-fix' });
-    assert.ok(renderSurface(dir, 'pipeline-complete', { dotpath: 'qf' }).includes('Quick-Fix Completed'));
-  });
-
   it('gates render byte-stable menus', () => {
     const early = renderSurface(dir, 'early-completion-gate', { dotpath: 'pay' });
     assert.ok(early.includes('Implementation completed for "Pay".'));
@@ -642,16 +631,122 @@ describe('bridge continuation surfaces', () => {
   });
 
   it('work-unit addressing is loud on dotted paths, unknown units, and missing flags', () => {
-    assert.throws(() => renderSurface(dir, 'pipeline-complete', { dotpath: 'pay.review.pay' }), /must be a bare <work_unit>/);
-    assert.throws(() => renderSurface(dir, 'pipeline-complete', { dotpath: 'nope' }), /work unit "nope" not found/);
+    assert.throws(() => renderSurface(dir, 'phase-completed', { dotpath: 'pay.review.pay', phase: 'review' }), /must be a bare <work_unit>/);
+    assert.throws(() => renderSurface(dir, 'phase-completed', { dotpath: 'nope', phase: 'review' }), /work unit "nope" not found/);
     assert.throws(() => renderSurface(dir, 'revisit-gate', { dotpath: 'pay', next: 'planning' }), /--prev is required/);
     assert.throws(() => renderSurface(dir, 'phase-completed', { dotpath: 'pay' }), /--phase is required/);
   });
 });
 
+describe('review fixes — gap coverage', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress', finding_gate_mode: 'gated' } } }, specification: { items: { portal: { status: 'in-progress', finding_gate_mode: 'auto' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  const base = { n: 1, total: 1, title: 'T', meta: [['Severity', 'Minor']], details: 'D' };
+
+  it('finding content × gated renders the menu WITHOUT view full', () => {
+    const file = writePayload(dir, 'f.json', { ...base, content: { label: 'Proposed Addition', lines: ['x'] } });
+    const out = renderSurface(dir, 'finding', { dotpath: 'pay.planning.portal', file });
+    assert.ok(out.includes('MENU: finding gate'));
+    assert.ok(!out.includes('view full'), 'content findings offer no view-full option');
+  });
+
+  it('finding diff × auto renders the framed diff plus the applied line, no menu', () => {
+    const file = writePayload(dir, 'f.json', { ...base, diff: { current: [], proposed: ['new line'] } });
+    const out = renderSurface(dir, 'finding', { dotpath: 'pay.specification.portal', file });
+    assert.ok(out.includes('DISPLAY: diff frame open'));
+    assert.ok(out.includes('DISPLAY: finding auto-approved'));
+    assert.ok(!out.includes('MENU: finding gate'));
+  });
+
+  it('null payload is a loud named error, not a TypeError', () => {
+    const file = writePayload(dir, 'n.json', 'null');
+    for (const surface of ['finding', 'findings-summary', 'proposed-task', 'tasks-overview', 'phase-tree']) {
+      assert.throws(
+        () => renderSurface(dir, surface, { dotpath: 'pay.planning.portal', file, gate: 'gated' }),
+        /payload must be a JSON object or array/,
+        surface,
+      );
+    }
+  });
+
+  it('a context-only diff is refused loudly', () => {
+    const file = writePayload(dir, 'f.json', { ...base, diff: { context_above: ['ctx'], current: [], proposed: [] } });
+    assert.throws(() => renderSurface(dir, 'finding', { dotpath: 'pay.planning.portal', file }), /"diff" must carry at least one current\/proposed line/);
+  });
+
+  it('null meta values and null phase-tree detail values are refused', () => {
+    const bad = writePayload(dir, 'm.json', { ...base, meta: [['Severity', null]] });
+    assert.throws(() => renderSurface(dir, 'finding', { dotpath: 'pay.planning.portal', file: bad }), /"meta" must be an array of \[label, value\] pairs/);
+    const badTree = writePayload(dir, 'pt.json', { phases: [{ name: 'X', detail: [['Goal', null]] }] });
+    assert.throws(() => renderSurface(dir, 'phase-tree', { dotpath: 'pay.planning.portal', file: badTree }), /"detail" must be a non-empty array of \[label, value\] pairs/);
+  });
+
+  it('phase-tree --approve menu offers view full', () => {
+    const file = writePayload(dir, 'pt.json', { phases: [{ name: 'X' }] });
+    const out = renderSurface(dir, 'phase-tree', { dotpath: 'pay.planning.portal', file, approve: '1' });
+    assert.ok(out.includes('- **`v`/`view full`** — Show the full phase structure — goals, ordering rationale, acceptance criteria'));
+  });
+});
+
+describe('titlecaseLabel', () => {
+  const { titlecaseLabel } = require('../../skills/workflow-engine/scripts/domain/conventions.cjs');
+  it('capitalises runs in place, preserving punctuation', () => {
+    assert.strictEqual(titlecaseLabel('discussion (in-progress)'), 'Discussion (In-Progress)');
+    assert.strictEqual(titlecaseLabel('finalising — quick-fix'), 'Finalising — Quick-Fix');
+    assert.strictEqual(titlecaseLabel('phase 2 (done)'), 'Phase 2 (Done)');
+  });
+});
+
+describe('CLI boundary — engine render via subprocess', () => {
+  const { execFileSync, spawnSync } = require('child_process');
+  const ENGINE = path.join(__dirname, '../../skills/workflow-engine/scripts/engine.cjs');
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', {
+      work_type: 'feature',
+      phases: {
+        discussion: { items: { pay: { status: 'in-progress' } } },
+        planning: { items: { pay: { status: 'in-progress', task_list_gate_mode: 'auto' } } },
+      },
+    });
+  });
+  afterEach(() => teardown(dir));
+
+  function run(args) {
+    return execFileSync('node', [ENGINE, 'render', ...args], { cwd: dir, encoding: 'utf8' });
+  }
+
+  it('flags survive argv: --triage, --variant, --approve, --gate, scalar flags', () => {
+    assert.ok(run(['resume-gate', 'pay.discussion.pay', '--triage', '2']).includes('2 rerouted concern(s)'));
+    const tl = writePayload(dir, 'tl.json', { phase: 1, phase_name: 'X', tasks: [{ name: 'A', summary: 's' }] });
+    assert.ok(run(['task-list', 'pay.planning.pay', '--file', tl, '--variant', 'existing']).includes('task list confirmed'));
+    const pt = writePayload(dir, 'pt.json', { phases: [{ name: 'P' }] });
+    assert.ok(run(['phase-tree', 'pay.planning.pay', '--file', pt, '--approve']).includes('MENU: phase structure gate'));
+    const task = writePayload(dir, 'task.json', { current: 1, total: 1, title: 'T', severity: 'Minor', sources: 's', problem: 'p', solution: 's', outcome: 'o', steps: ['1'], criteria: ['c'], tests: ['t'] });
+    assert.ok(run(['proposed-task', 'pay.planning.pay', '--file', task, '--gate', 'auto']).includes('approved [auto]'));
+    assert.ok(run(['author-task-gate', 'pay.planning.pay', '--m', '1', '--total', '2', '--title', 'T']).includes('**Task 1 of 2: T**'));
+    assert.ok(run(['revisit-gate', 'pay', '--prev', 'discussion', '--next', 'specification']).includes('Discussion completed for "Pay".'));
+    assert.ok(run(['phase-completed', 'pay', '--phase', 'discussion']).includes('Discussion completed for "Pay".'));
+    assert.ok(run(['early-completion-gate', 'pay']).includes('Complete without review'));
+    assert.ok(run(['epic-all-done-gate', 'pay']).includes('Mark this epic as completed'));
+  });
+
+  it('surface errors surface as failJson on stderr with exit 1', () => {
+    const res = spawnSync('node', [ENGINE, 'render', 'proposed-task', 'pay.planning.pay', '--file', 'missing.json', '--gate', 'nope'], { cwd: dir, encoding: 'utf8' });
+    assert.strictEqual(res.status, 1);
+    assert.match(JSON.parse(res.stderr.trim()).error, /--gate must be "gated" or "auto"/);
+  });
+});
+
 describe('catalogue dispatch', () => {
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding, proposed-task, tasks-overview, author-task-gate, phase-tree, pipeline-complete, phase-completed, early-completion-gate, revisit-gate, epic-all-done-gate\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding, proposed-task, tasks-overview, author-task-gate, phase-tree, phase-completed, early-completion-gate, revisit-gate, epic-all-done-gate\)/);
   });
 });
 

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -585,6 +585,25 @@ describe('engine workunit complete', () => {
     assert.strictEqual(lastMessage(dir), 'workflow(auth-flow): complete feature pipeline');
     // Scoped: the unrelated file stays uncommitted.
     assert.match(git(dir, ['status', '--porcelain']), /\?\? unrelated\.txt/);
+    // Confirmation section rides after the JSON line; work_type now in the response.
+    assert.strictEqual(res.work_type, 'feature');
+    assert.match(engine.lastSections, /=== DISPLAY: confirmation \(emit verbatim as a code block after the response\) ===\n"Auth Flow" marked as completed\./);
+  });
+
+  it('--pipeline renders the "{Type} Completed" banner instead of the one-liner; --skipped-review varies the body', () => {
+    engine(dir, ['workunit', 'complete', 'auth-flow', '-m', 'workflow(auth-flow): complete feature pipeline', '--pipeline']);
+    assert.match(engine.lastSections, /Feature Completed\n\n"Auth Flow" has completed all pipeline phases\./);
+    assert.ok(!engine.lastSections.includes('marked as completed'));
+
+    engine(dir, ['workunit', 'reactivate', 'auth-flow']);
+    engine(dir, ['workunit', 'complete', 'auth-flow', '-m', 'workflow(auth-flow): re-complete (review skipped)', '--pipeline', '--skipped-review']);
+    assert.match(engine.lastSections, /Feature Completed\n\n"Auth Flow" completed — review skipped\./);
+  });
+
+  it('reactivate carries its confirmation section', () => {
+    engine(dir, ['workunit', 'cancel', 'auth-flow']);
+    engine(dir, ['workunit', 'reactivate', 'auth-flow']);
+    assert.match(engine.lastSections, /"Auth Flow" reactivated\./);
   });
 
   it('rejects an already-completed unit and routes a cancelled unit through reactivate', () => {
@@ -653,7 +672,8 @@ describe('engine workunit cancel', () => {
     assert.strictEqual(m.completed_at, undefined);
     assert.strictEqual(lastMessage(dir), 'workflow(auth-flow): mark as cancelled');
     // Sections: warning above confirmation, both after the JSON line.
-    assert.match(engine.lastSections, /⚑ Knowledge removal warning[\s\S]*The work unit is cancelled\./);
+    // Conventions-form callout: 2-space flag, 4-space continuations.
+    assert.match(engine.lastSections, /  ⚑ Knowledge removal warning\n(    .+\n)+    The work unit is cancelled\./);
     assert.match(engine.lastSections, /"Auth Flow" marked as cancelled\./);
   });
 

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -61,8 +61,13 @@ function readManifest(dir, wu) {
 
 /** Run the engine expecting success; returns the parsed JSON response. */
 function engine(dir, args) {
-  return JSON.parse(execFileSync('node', [ENGINE, ...args], { cwd: dir, encoding: 'utf8' }).trim());
+  const out = execFileSync('node', [ENGINE, ...args], { cwd: dir, encoding: 'utf8' });
+  const nl = out.indexOf('\n');
+  const res = JSON.parse((nl === -1 ? out : out.slice(0, nl)).trim());
+  engine.lastSections = nl === -1 ? '' : out.slice(nl + 1);
+  return res;
 }
+engine.lastSections = '';
 
 /** Run the engine expecting failure; returns the parsed stderr JSON. */
 function engineFails(dir, args) {
@@ -124,6 +129,7 @@ describe('engine topic cancel', () => {
       source: 'discovery',
     });
     assert.strictEqual(lastMessage(dir), 'workflow(payments): cancel auth-flow (research)');
+    assert.match(engine.lastSections, /Cancelled "Auth Flow" in research\./);
   });
 
   it('rejects cancelling an already-cancelled topic', () => {
@@ -169,6 +175,7 @@ describe('engine topic reactivate', () => {
     assert.strictEqual(res.warnings.length, 1);
     assert.match(res.warnings[0], /knowledge index failed/);
     assert.strictEqual(lastMessage(dir), 'workflow(payments): reactivate session-model (discussion)');
+    assert.match(engine.lastSections, /⚑ Knowledge indexing warning[\s\S]*Reactivated "Session Model" in discussion\. Status restored to completed\./);
   });
 
   it('rejects reactivating a non-cancelled topic', () => {
@@ -645,6 +652,9 @@ describe('engine workunit cancel', () => {
     assert.strictEqual(m.status, 'cancelled');
     assert.strictEqual(m.completed_at, undefined);
     assert.strictEqual(lastMessage(dir), 'workflow(auth-flow): mark as cancelled');
+    // Sections: warning above confirmation, both after the JSON line.
+    assert.match(engine.lastSections, /⚑ Knowledge removal warning[\s\S]*The work unit is cancelled\./);
+    assert.match(engine.lastSections, /"Auth Flow" marked as cancelled\./);
   });
 
   it('rejects an already-cancelled unit and routes a completed unit through reactivate', () => {

--- a/tests/scripts/test-engine-workunit-absorb.cjs
+++ b/tests/scripts/test-engine-workunit-absorb.cjs
@@ -198,7 +198,17 @@ describe('engine workunit absorb — happy path', () => {
       committed: shortHead(fix),
       warnings: [],
     });
-    assert.match(engine.lastSections, /Absorbed into Epic[\s\S]*• Discussion: moved[\s\S]*• Feature: removed/);
+    assert.match(engine.lastSections, new RegExp([
+      'Absorbed into Epic',
+      '',
+      '  Topic "Auth" added to Payments\\.',
+      '',
+      '  • Discussion: moved',
+      '  • Research: moved',
+      '  • Seed: moved',
+      '  • Imports: moved',
+      '  • Feature: removed',
+    ].join('\\n')));
 
     // Files landed at their epic identities; the feature directory is gone.
     assert.strictEqual(fs.readFileSync(path.join(fix.project, '.workflows/payments/discussion/auth.md'), 'utf8'), '# Discussion\n');

--- a/tests/scripts/test-engine-workunit-absorb.cjs
+++ b/tests/scripts/test-engine-workunit-absorb.cjs
@@ -118,8 +118,12 @@ function engine(fix, args, env = {}) {
     encoding: 'utf8',
     env: { ...process.env, ...env },
   });
-  return JSON.parse(out.trim());
+  const nl = out.indexOf('\n');
+  const res = JSON.parse((nl === -1 ? out : out.slice(0, nl)).trim());
+  engine.lastSections = nl === -1 ? '' : out.slice(nl + 1);
+  return res;
 }
+engine.lastSections = '';
 
 /** Run the engine expecting failure; returns the parsed stderr JSON. */
 function engineFails(fix, args, env = {}) {
@@ -194,6 +198,7 @@ describe('engine workunit absorb — happy path', () => {
       committed: shortHead(fix),
       warnings: [],
     });
+    assert.match(engine.lastSections, /Absorbed into Epic[\s\S]*• Discussion: moved[\s\S]*• Feature: removed/);
 
     // Files landed at their epic identities; the feature directory is gone.
     assert.strictEqual(fs.readFileSync(path.join(fix.project, '.workflows/payments/discussion/auth.md'), 'utf8'), '# Discussion\n');

--- a/tests/scripts/test-engine-workunit-pivot.cjs
+++ b/tests/scripts/test-engine-workunit-pivot.cjs
@@ -161,7 +161,9 @@ describe('engine workunit pivot — happy path', () => {
       committed: shortHead(fix),
       warnings: [],
     });
-    assert.match(engine.lastSections, /MENU: pivot continuation[\s\S]*converted from feature to epic/);
+    // The continuation menu is opt-in (--continuation-menu, the manage flow);
+    // the off-topic reroute paths run the bare verb and must see no menu.
+    assert.ok(!engine.lastSections.includes('MENU: pivot continuation'), 'bare pivot must not emit the continuation menu');
 
     const m = readManifest(fix, 'auth-flow');
     assert.strictEqual(m.work_type, 'epic');

--- a/tests/scripts/test-engine-workunit-pivot.cjs
+++ b/tests/scripts/test-engine-workunit-pivot.cjs
@@ -96,8 +96,12 @@ function engine(fix, args, env = {}) {
     encoding: 'utf8',
     env: { ...process.env, ...env },
   });
-  return JSON.parse(out.trim());
+  const nl = out.indexOf('\n');
+  const res = JSON.parse((nl === -1 ? out : out.slice(0, nl)).trim());
+  engine.lastSections = nl === -1 ? '' : out.slice(nl + 1);
+  return res;
 }
+engine.lastSections = '';
 
 /** Run the engine expecting failure; returns the parsed stderr JSON. */
 function engineFails(fix, args, env = {}) {
@@ -157,6 +161,7 @@ describe('engine workunit pivot — happy path', () => {
       committed: shortHead(fix),
       warnings: [],
     });
+    assert.match(engine.lastSections, /MENU: pivot continuation[\s\S]*converted from feature to epic/);
 
     const m = readManifest(fix, 'auth-flow');
     assert.strictEqual(m.work_type, 'epic');

--- a/tests/scripts/test-engine-workunit-promote.cjs
+++ b/tests/scripts/test-engine-workunit-promote.cjs
@@ -200,7 +200,17 @@ describe('engine workunit promote — happy path', () => {
       committed: shortHead(fix),
       warnings: [],
     });
-    assert.match(engine.lastSections, /Promoted to Cross-Cutting[\s\S]*Epic status: promoted/);
+    assert.match(engine.lastSections, new RegExp([
+      'Promoted to Cross-Cutting',
+      '',
+      '"[^"]+" has been promoted to its own cross-cutting work unit\\.',
+      '',
+      '  Work unit: .+',
+      '  Source: .+',
+      '  Discussion files: moved',
+      '  Specification: moved',
+      '  Epic status: promoted',
+    ].join('\\n')));
 
     // The spec directory moved whole — tracking file included — and the
     // source discussions landed at their cc identities; the epic keeps

--- a/tests/scripts/test-engine-workunit-promote.cjs
+++ b/tests/scripts/test-engine-workunit-promote.cjs
@@ -116,8 +116,12 @@ function engine(fix, args, env = {}) {
     encoding: 'utf8',
     env: { ...process.env, ...env },
   });
-  return JSON.parse(out.trim());
+  const nl = out.indexOf('\n');
+  const res = JSON.parse((nl === -1 ? out : out.slice(0, nl)).trim());
+  engine.lastSections = nl === -1 ? '' : out.slice(nl + 1);
+  return res;
 }
+engine.lastSections = '';
 
 /** Run the engine expecting failure; returns the parsed stderr JSON. */
 function engineFails(fix, args, env = {}) {
@@ -196,6 +200,7 @@ describe('engine workunit promote — happy path', () => {
       committed: shortHead(fix),
       warnings: [],
     });
+    assert.match(engine.lastSections, /Promoted to Cross-Cutting[\s\S]*Epic status: promoted/);
 
     // The spec directory moved whole — tracking file included — and the
     // source discussions landed at their cc identities; the epic keeps

--- a/tests/scripts/test-gateway-for-workflow-continue-bugfix.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-bugfix.cjs
@@ -190,6 +190,7 @@ describe('workflow-continue-bugfix format', () => {
       '',
       '- **`1`** — Continue "Crash" — specification (in-progress)',
       '- **`2`** — Continue "Leak" — investigation (in-progress)',
+      '',
       '- **`3`** — View completed & cancelled bugfixes',
       "- **`m`/`manage`** — Manage a bugfix's lifecycle",
       '',

--- a/tests/scripts/test-gateway-for-workflow-continue-cross-cutting.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-cross-cutting.cjs
@@ -165,6 +165,7 @@ describe('workflow-continue-cross-cutting format', () => {
       '',
       '- **`1`** — Continue "Caching" — specification (in-progress)',
       '- **`2`** — Continue "Error Handling" — discussion (in-progress)',
+      '',
       '- **`3`** — View completed & cancelled cross-cutting concerns',
       "- **`m`/`manage`** — Manage a cross-cutting concern's lifecycle",
       '',

--- a/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
@@ -1419,6 +1419,7 @@ describe('workflow-continue-epic format (index dump)', () => {
       '',
       '- **`1`** — Continue "V1"',
       '- **`2`** — Continue "V2"',
+      '',
       '- **`3`** — View completed & cancelled epics',
       "- **`m`/`manage`** — Manage an epic's lifecycle",
       '',

--- a/tests/scripts/test-gateway-for-workflow-continue-feature.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-feature.cjs
@@ -278,6 +278,7 @@ describe('workflow-continue-feature format', () => {
       '',
       '- **`1`** — Continue "Auth" — specification (in-progress)',
       '- **`2`** — Continue "Dark Mode" — discussion (in-progress)',
+      '',
       '- **`3`** — View completed & cancelled features',
       "- **`m`/`manage`** — Manage a feature's lifecycle",
       '',

--- a/tests/scripts/test-gateway-for-workflow-continue-quickfix.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-quickfix.cjs
@@ -184,6 +184,7 @@ describe('workflow-continue-quickfix format', () => {
       '',
       '- **`1`** — Continue "Bump Dep" — scoping (in-progress)',
       '- **`2`** — Continue "Rename Api" — implementation (in-progress)',
+      '',
       '- **`3`** — View completed & cancelled quick-fixes',
       "- **`m`/`manage`** — Manage a quick-fix's lifecycle",
       '',


### PR DESCRIPTION
Stage 6a of the render-surfaces programme (design log: #489; base: #493). Single concern: the ~20 confirmation/warning displays that followed lifecycle transactions in prose now ride on the transactions themselves — the labelled-section pattern the `task` verbs established.

## What appends what

| Verb | Sections |
|---|---|
| `workunit complete` | `DISPLAY: confirmation` ("X" marked as completed.) |
| `workunit cancel` / `reactivate` | `DISPLAY: kb warning` (when `warnings` non-empty, with the verb's reassurance tail) + `DISPLAY: confirmation` |
| `topic cancel` / `reactivate` | same pair, topic-phrased (incl. "Status restored to …") |
| `workunit absorb` | kb warning + the post-absorption summary (bullet rows derived from the response's moved research/seeds/imports) |
| `workunit promote` | kb warning + the promotion summary |
| `workunit pivot` | kb warning + `MENU: pivot continuation` (continue-as-epic / back) |

Six references swapped to section emission: manage-work-unit, view-completed, epic-display-and-menu (topic cancel/reactivate), absorb-into-epic, promote-to-cross-cutting, pivot-to-epic. The `@if(has_research)`-style directives in the absorb summary died — the engine derives the rows from its own response.

**Deliberately excluded**: inbox confirmations — their texts use item *titles*, which live in the inbox markdown (H1s); rendering them engine-side would require markdown parsing (D2). They stay prose pending the static-sweep decision.

## Test plan

- Suite helpers (transactions, absorb, pivot, promote, manifest-io) parse the first line as the JSON contract and capture the section tail; positive pins added for every verb's sections (warning-above-confirmation ordering included).
- `npm test` — 1502/1502. Typecheck + conventions lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #490
2. #491
3. #492
4. #493
5. **#496** 👈 current
6. #497
7. #498
8. #499
9. #500
10. #501
<!-- stack:links:end -->