### PR TITLE
feat(engine): entry-gate + phase-note — entry validation derives engine-side

### DIFF
--- a/skills/workflow-continue-bugfix/references/validate-selection.md
+++ b/skills/workflow-continue-bugfix/references/validate-selection.md
@@ -8,13 +8,7 @@ Validate the selected work unit against the discovery output.
 
 #### If `work_unit` not found in the `=== BUGFIXES (N) ===` section
 
-> *Output the next fenced block as a code block:*
-
-```
-No active bugfix named "{work_unit}" found.
-
-Run /workflow-start to see available bugfixes or begin a new one.
-```
+The `view` snapshot for an unknown name carries the terminal display. Emit its `DISPLAY: not found` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-bugfix/scripts/gateway.cjs
+++ b/skills/workflow-continue-bugfix/scripts/gateway.cjs
@@ -37,7 +37,8 @@ function view(workUnit) {
   const result = discover(process.cwd());
   const unit = (result.bugfixes || []).find((u) => u.name === workUnit);
   if (!unit) {
-    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active bugfix with this name' });
+    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active bugfix with this name' })
+      + engine.project.selectionNotFound(TYPE, workUnit || '(missing)');
   }
   const menu = engine.project.workUnitMenu(TYPE, unit);
   return [

--- a/skills/workflow-continue-cross-cutting/references/validate-selection.md
+++ b/skills/workflow-continue-cross-cutting/references/validate-selection.md
@@ -8,13 +8,7 @@ Validate the selected work unit against the discovery output.
 
 #### If `work_unit` not found in the `=== CROSS-CUTTING (N) ===` section
 
-> *Output the next fenced block as a code block:*
-
-```
-No active cross-cutting concern named "{work_unit}" found.
-
-Run /workflow-start to see available concerns or begin a new one.
-```
+The `view` snapshot for an unknown name carries the terminal display. Emit its `DISPLAY: not found` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-cross-cutting/scripts/gateway.cjs
+++ b/skills/workflow-continue-cross-cutting/scripts/gateway.cjs
@@ -37,7 +37,8 @@ function view(workUnit) {
   const result = discover(process.cwd());
   const unit = (result.cross_cutting || []).find((u) => u.name === workUnit);
   if (!unit) {
-    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active cross-cutting concern with this name' });
+    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active cross-cutting concern with this name' })
+      + engine.project.selectionNotFound(TYPE, workUnit || '(missing)');
   }
   const menu = engine.project.workUnitMenu(TYPE, unit);
   return [

--- a/skills/workflow-continue-epic/references/validate-selection.md
+++ b/skills/workflow-continue-epic/references/validate-selection.md
@@ -8,13 +8,7 @@ Validate the selected work unit against the discovery output, then load its stat
 
 #### If `work_unit` not found in the `=== EPICS (N) ===` section
 
-> *Output the next fenced block as a code block:*
-
-```
-No active epic named "{work_unit}" found.
-
-Run /workflow-start to see available epics or begin a new one.
-```
+The scoped snapshot for an unknown name carries the terminal display. Emit its `DISPLAY: not found` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-epic/scripts/gateway.cjs
+++ b/skills/workflow-continue-epic/scripts/gateway.cjs
@@ -165,7 +165,8 @@ function view(workUnit, newArrivalsJson) {
   const result = discover(process.cwd(), workUnit);
   const e = result.epics[0];
   if (!e) {
-    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active epic with this name' });
+    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active epic with this name' })
+      + engine.project.selectionNotFound('epic', workUnit || '(missing)');
   }
   const d = e.detail;
 
@@ -222,7 +223,8 @@ function subView(workUnit, projection) {
   const result = discover(process.cwd(), workUnit);
   const e = result.epics[0];
   if (!e) {
-    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active epic with this name' });
+    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active epic with this name' })
+      + engine.project.selectionNotFound('epic', workUnit || '(missing)');
   }
   const view = projection(e.name, e.detail);
 

--- a/skills/workflow-continue-feature/references/validate-selection.md
+++ b/skills/workflow-continue-feature/references/validate-selection.md
@@ -8,13 +8,7 @@ Validate the selected work unit against the discovery output.
 
 #### If `work_unit` not found in the `=== FEATURES (N) ===` section
 
-> *Output the next fenced block as a code block:*
-
-```
-No active feature named "{work_unit}" found.
-
-Run /workflow-start to see available features or begin a new one.
-```
+The `view` snapshot for an unknown name carries the terminal display. Emit its `DISPLAY: not found` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-feature/scripts/gateway.cjs
+++ b/skills/workflow-continue-feature/scripts/gateway.cjs
@@ -37,7 +37,8 @@ function view(workUnit) {
   const result = discover(process.cwd());
   const unit = (result.features || []).find((u) => u.name === workUnit);
   if (!unit) {
-    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active feature with this name' });
+    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active feature with this name' })
+      + engine.project.selectionNotFound(TYPE, workUnit || '(missing)');
   }
   const menu = engine.project.workUnitMenu(TYPE, unit);
   return [

--- a/skills/workflow-continue-quickfix/references/validate-selection.md
+++ b/skills/workflow-continue-quickfix/references/validate-selection.md
@@ -8,13 +8,7 @@ Validate the selected work unit against the discovery output.
 
 #### If `work_unit` not found in the `=== QUICK-FIXES (N) ===` section
 
-> *Output the next fenced block as a code block:*
-
-```
-No active quick-fix named "{work_unit}" found.
-
-Run /workflow-start to see available quick-fixes or begin a new one.
-```
+The `view` snapshot for an unknown name carries the terminal display. Emit its `DISPLAY: not found` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-quickfix/scripts/gateway.cjs
+++ b/skills/workflow-continue-quickfix/scripts/gateway.cjs
@@ -37,7 +37,8 @@ function view(workUnit) {
   const result = discover(process.cwd());
   const unit = (result.quick_fixes || []).find((u) => u.name === workUnit);
   if (!unit) {
-    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active quick-fix with this name' });
+    return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active quick-fix with this name' })
+      + engine.project.selectionNotFound(TYPE, workUnit || '(missing)');
   }
   const menu = engine.project.workUnitMenu(TYPE, unit);
   return [

--- a/skills/workflow-discussion-entry/references/validate-phase.md
+++ b/skills/workflow-discussion-entry/references/validate-phase.md
@@ -14,10 +14,10 @@ Nothing to validate — `source` keeps the value set in Step 1.
 
 #### If discussion exists and status is `in-progress`
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Resuming discussion: {topic:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.discussion.{topic} --verb Resuming
 ```
 
 Set source="continue".
@@ -34,10 +34,10 @@ Reopen it:
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} discussion {topic}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Reopening discussion: {topic:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.discussion.{topic} --verb Reopening
 ```
 
 Set source="continue".

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -179,6 +179,8 @@ engine render phase-completed <wu> --phase <phase>                # one-line pha
 engine render early-completion-gate <wu>                          # bridge gate: proceed to review / complete without review
 engine render revisit-gate <wu> --prev <phase> --next <phase>     # bridge gate: proceed to next / revisit an earlier phase
 engine render epic-all-done-gate <wu>                             # bridge gate: mark epic completed / return to menu
+engine render phase-note <wu>.<phase>.<topic> --verb <Word> [--noun <word>]   # entry one-liner: "{Word} {noun|phase}: {Topic}"
+engine render entry-gate <wu>.<phase>.<topic>                     # prerequisite verdict, engine-derived: empty = clear; blocked = the terminal DISPLAY: entry blocker (planning: spec status incl. superseded/promoted; implementation: plan; review: plan+implementation; specification: work-type-aware source material)
 ```
 
 The bridge continuation surfaces take a bare `<work_unit>` address (work-unit-level, type read from the manifest). The continue-* selection step is not a `render` surface: each navigation gateway's index dump appends `DISPLAY: selection` / `MENU: selection` sections from the shared selection projection — emitted only at the select step, per their markers.

--- a/skills/workflow-engine/scripts/domain/projections/selection.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/selection.cjs
@@ -93,4 +93,27 @@ function selectionSections(type, units, counts) {
     + section('MENU: selection', "emit verbatim as markdown only at the select step, then STOP for the user's response", dotFrame(menuLines));
 }
 
-module.exports = { selectionSections, SELECT_CONFIG };
+/** Per-type wording for the invalid-selection terminal display. */
+const NOT_FOUND = {
+  feature: ['feature', 'features'],
+  bugfix: ['bugfix', 'bugfixes'],
+  'quick-fix': ['quick-fix', 'quick-fixes'],
+  'cross-cutting': ['cross-cutting concern', 'concerns'],
+  epic: ['epic', 'epics'],
+};
+
+/**
+ * The view verb's invalid-selection terminal display.
+ * @param {string} type @param {string} workUnit
+ * @returns {string}
+ */
+function selectionNotFound(type, workUnit) {
+  const [singular, plural] = NOT_FOUND[type] || [type, `${type}s`];
+  return section(
+    'DISPLAY: not found',
+    'emit verbatim as a code block, then STOP — terminal condition',
+    `No active ${singular} named "${workUnit}" found.\n\nRun /workflow-start to see available ${plural} or begin a new one.`,
+  );
+}
+
+module.exports = { selectionSections, selectionNotFound, SELECT_CONFIG };

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -607,6 +607,201 @@ function epicAllDoneGate(cwd, { dotpath }) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// phase-note — the entry skills' one-line status notes (Resuming / Starting /
+// Reopening …). Address-backed; the verb is the caller's word, the noun
+// defaults to the phase segment (planning overrides with "plan").
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, verb?: string, noun?: string}} args
+ * @returns {string}
+ */
+function phaseNote(cwd, { dotpath, verb, noun }) {
+  const { phase, topic } = resolveAddress(cwd, dotpath, 'phase-note');
+  if (!isFilled(verb)) throw new Error('render phase-note: --verb is required (e.g. Resuming, Reopening, Starting)');
+  return section(
+    'DISPLAY: phase note',
+    'emit verbatim as a code block',
+    `${verb} ${isFilled(noun) ? noun : phase}: ${titlecase(topic)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// entry-gate — the entry skills' prerequisite check. The engine derives the
+// verdict from manifest state (the reads and the branch leave the prose):
+// an empty response means clear — proceed; a blocked response carries the
+// terminal blocker display.
+// ---------------------------------------------------------------------------
+
+/** @param {any} manifest @param {string} phase @param {string} topic */
+function itemOf(manifest, phase, topic) {
+  return (((manifest.phases || {})[phase] || {}).items || {})[topic];
+}
+
+/** @param {string} title @param {string[]} bodyLines */
+function blocker(title, bodyLines) {
+  return section(
+    'DISPLAY: entry blocker',
+    'emit verbatim as a code block, then STOP — terminal condition',
+    [title, '', ...bodyLines].join('\n'),
+  );
+}
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string}} args
+ * @returns {string} blocker sections, or '' when the entry is clear
+ */
+function entryGate(cwd, { dotpath }) {
+  const { phase, topic, manifest } = resolveAddress(cwd, dotpath, 'entry-gate');
+  const t = titlecase(topic);
+
+  if (phase === 'planning') {
+    const spec = itemOf(manifest, 'specification', topic);
+    const status = spec && spec.status;
+    if (!status) {
+      return blocker('Specification Missing', [
+        `No specification found for "${t}".`,
+        '',
+        'The specification must be completed before planning can begin.',
+      ]);
+    }
+    if (status === 'in-progress') {
+      return blocker('Specification In Progress', [
+        `The specification for "${t}" is not yet completed.`,
+        '',
+        'The specification must be completed before planning can begin.',
+      ]);
+    }
+    if (status === 'proposed') {
+      return blocker('Specification Not Started', [
+        `"${t}" is a proposed grouping — the specification`,
+        "hasn't been started yet.",
+        '',
+        'Start the specification first, then return to planning once it',
+        'completes.',
+      ]);
+    }
+    if (status === 'superseded') {
+      return blocker('Specification Superseded', [
+        `The specification for "${t}" was consolidated into`,
+        `"${titlecase(String(spec.superseded_by || ''))}".`,
+        '',
+        'Plan the superseding specification instead.',
+      ]);
+    }
+    if (status === 'promoted') {
+      return blocker('Specification Promoted', [
+        `"${t}" was promoted to the cross-cutting work unit`,
+        `"${spec.promoted_to}". Cross-cutting specifications inform other plans —`,
+        'they are not planned directly.',
+      ]);
+    }
+    return '';
+  }
+
+  if (phase === 'implementation') {
+    const plan = itemOf(manifest, 'planning', topic);
+    if (!plan || !plan.status) {
+      return blocker('Plan Missing', [
+        `No plan found for "${t}".`,
+        '',
+        'A completed plan is required for implementation.',
+      ]);
+    }
+    if (plan.status !== 'completed') {
+      return blocker('Plan Not Completed', [`The plan for "${t}" is not yet completed.`]);
+    }
+    return '';
+  }
+
+  if (phase === 'review') {
+    if (!itemOf(manifest, 'planning', topic)) {
+      return blocker('Plan Missing', [
+        `No plan found for "${t}".`,
+        '',
+        'A completed plan and completed implementation are required for review.',
+      ]);
+    }
+    const impl = itemOf(manifest, 'implementation', topic);
+    if (!impl) {
+      return blocker('Implementation Missing', [
+        `No implementation found for "${t}".`,
+        '',
+        'A completed implementation is required for review.',
+      ]);
+    }
+    if (impl.status !== 'completed') {
+      return blocker('Implementation Not Complete', [`The implementation for "${t}" is not yet completed.`]);
+    }
+    return '';
+  }
+
+  if (phase === 'specification') {
+    const wu = titlecase(manifest.name || topic);
+    const workType = manifest.work_type;
+    if (workType === 'bugfix') {
+      const inv = itemOf(manifest, 'investigation', topic);
+      if (!inv) {
+        return blocker('Source Material Missing', [
+          `No investigation found for "${wu}".`,
+          '',
+          'A completed investigation is required before specification can begin.',
+        ]);
+      }
+      if (inv.status !== 'completed') {
+        return blocker('Investigation In Progress', [
+          `The investigation for "${wu}" is not yet completed.`,
+          '',
+          'The investigation must be completed before specification can begin.',
+        ]);
+      }
+      return '';
+    }
+    if (workType === 'epic') {
+      const items = ((manifest.phases || {}).discussion || {}).items || {};
+      const names = Object.keys(items);
+      if (names.length === 0) {
+        return blocker('Source Material Missing', [
+          `No discussions found for "${wu}".`,
+          '',
+          'At least one completed discussion is required before specification can begin.',
+        ]);
+      }
+      if (!names.some((n) => items[n] && items[n].status === 'completed')) {
+        return blocker('No Completed Discussions', [
+          `No completed discussions found for "${wu}".`,
+          '',
+          'At least one completed discussion is required before specification can begin.',
+          'Run /workflow-start to continue an in-progress discussion.',
+        ]);
+      }
+      return '';
+    }
+    // feature / cross-cutting: the topic's own discussion.
+    const disc = itemOf(manifest, 'discussion', topic);
+    if (!disc) {
+      return blocker('Source Material Missing', [
+        `No discussion found for "${wu}".`,
+        '',
+        'A completed discussion is required before specification can begin.',
+      ]);
+    }
+    if (disc.status !== 'completed') {
+      return blocker('Discussion In Progress', [
+        `The discussion for "${wu}" is not yet completed.`,
+        '',
+        'The discussion must be completed before specification can begin.',
+      ]);
+    }
+    return '';
+  }
+
+  throw new Error(`render entry-gate: no prerequisite rules for phase "${phase}" (planning|implementation|review|specification)`);
+}
+
 /** The catalogue: surface name → handler. @type {Record<string, (cwd: string, args: {dotpath: string} & Record<string, string|undefined>) => string>} */
 const SURFACES = {
   'resume-gate': resumeGate,
@@ -618,6 +813,8 @@ const SURFACES = {
   'author-task-gate': authorTaskGate,
   'phase-tree': phaseTree,
   'phase-completed': phaseCompleted,
+  'phase-note': phaseNote,
+  'entry-gate': entryGate,
   'early-completion-gate': earlyCompletionGate,
   'revisit-gate': revisitGate,
   'epic-all-done-gate': epicAllDoneGate,

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -162,6 +162,8 @@ Commands:
   render author-task-gate <wu.planning.topic> --m N --total N --title STR
   render phase-tree       <wu.planning.topic> --file <payload.json> [--approve]
   render phase-completed   <wu> --phase <phase>
+  render phase-note        <wu.phase.topic> --verb <Word> [--noun <word>]
+  render entry-gate        <wu.phase.topic>      (planning|implementation|review|specification)
   render early-completion-gate <wu>
   render revisit-gate      <wu> --prev <phase> --next <phase>
   render epic-all-done-gate <wu>

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -95,6 +95,7 @@ module.exports = {
   },
   project: {
     selectionSections: selectionProjections.selectionSections,
+    selectionNotFound: selectionProjections.selectionNotFound,
     epicDashboard: epicProjections.epicDashboard,
     epicKey: epicProjections.epicKey,
     epicMenu: epicProjections.epicMenu,

--- a/skills/workflow-implementation-entry/references/validate-phase.md
+++ b/skills/workflow-implementation-entry/references/validate-phase.md
@@ -8,37 +8,21 @@ Check if plan exists and is ready.
 
 ## A. Plan Check
 
+The engine derives the verdict from manifest state:
+
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} status
+node .claude/skills/workflow-engine/scripts/engine.cjs render entry-gate {work_unit}.implementation.{topic}
 ```
 
-#### If output is empty (plan doesn't exist)
+#### If the response carried `DISPLAY: entry blocker`
 
-> *Output the next fenced block as a code block:*
-
-```
-Plan Missing
-
-No plan found for "{topic:(titlecase)}".
-
-A completed plan is required for implementation.
-```
+Emit the section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan status is not `completed`
+#### If the response is empty
 
-> *Output the next fenced block as a code block:*
-
-```
-Plan Not Completed
-
-The plan for "{topic:(titlecase)}" is not yet completed.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-#### If plan status is `completed`
+The plan is completed.
 
 → Proceed to **B. Implementation Check**.
 
@@ -62,10 +46,10 @@ Reopen it:
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} implementation {topic}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Reopening implementation: {topic:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.implementation.{topic} --verb Reopening
 ```
 
 → Return to caller.

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -97,10 +97,10 @@ Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `
 
 The bug was shaped in discovery. Read the durable carrier as the seed — the manifest `description` and the latest discovery session log (`.workflows/{work_unit}/discovery/sessions/session-NNN.md`, highest-numbered) — and seed the investigation from it. Do not re-ask; live conversation context, when present, supplements the carrier.
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Starting investigation: {work_unit:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.investigation.{topic} --verb Starting
 ```
 
 → Proceed to **Step 4**.

--- a/skills/workflow-investigation-entry/references/validate-phase.md
+++ b/skills/workflow-investigation-entry/references/validate-phase.md
@@ -8,10 +8,10 @@ Branch on the `phase_status` the caller read in Step 1 — no re-read.
 
 #### If status is `in-progress`
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Resuming investigation: {work_unit:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.investigation.{topic} --verb Resuming
 ```
 
 Set source="continue".
@@ -26,10 +26,10 @@ Reopen it:
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} investigation {topic}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Reopening investigation: {work_unit:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.investigation.{topic} --verb Reopening
 ```
 
 Set source="continue".

--- a/skills/workflow-planning-entry/references/validate-phase.md
+++ b/skills/workflow-planning-entry/references/validate-phase.md
@@ -45,10 +45,10 @@ Reopen it:
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} planning {topic}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Reopening plan: {topic:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.planning.{topic} --verb Reopening --noun plan
 ```
 
 Set source="existing".

--- a/skills/workflow-planning-entry/references/validate-spec.md
+++ b/skills/workflow-planning-entry/references/validate-spec.md
@@ -4,85 +4,20 @@
 
 ---
 
-Check if specification exists and is ready using `engine manifest`.
+Check the specification prerequisite — the engine derives the verdict from manifest state:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs render entry-gate {work_unit}.planning.{topic}
 ```
 
-#### If specification phase doesn't exist or has no status
+#### If the response is empty
 
-> *Output the next fenced block as a code block:*
-
-```
-Specification Missing
-
-No specification found for "{topic:(titlecase)}".
-
-The specification must be completed before planning can begin.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-#### If specification exists but status is `in-progress`
-
-> *Output the next fenced block as a code block:*
-
-```
-Specification In Progress
-
-The specification for "{topic:(titlecase)}" is not yet completed.
-
-The specification must be completed before planning can begin.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-#### If specification exists and status is `proposed`
-
-> *Output the next fenced block as a code block:*
-
-```
-Specification Not Started
-
-"{topic:(titlecase)}" is a proposed grouping — the specification
-hasn't been started yet.
-
-Start the specification first, then return to planning once it
-completes.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-#### If specification exists and status is `superseded`
-
-> *Output the next fenced block as a code block:*
-
-```
-Specification Superseded
-
-The specification for "{topic:(titlecase)}" was consolidated into
-"{superseded_by:(titlecase)}".
-
-Plan the superseding specification instead.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-#### If specification exists and status is `promoted`
-
-> *Output the next fenced block as a code block:*
-
-```
-Specification Promoted
-
-"{topic:(titlecase)}" was promoted to the cross-cutting work unit
-"{promoted_to}". Cross-cutting specifications inform other plans —
-they are not planned directly.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-#### If specification exists and status is `completed`
+The specification is completed — clear to plan.
 
 → Return to caller.
+
+#### If the response carried `DISPLAY: entry blocker`
+
+Emit the section verbatim per its marker.
+
+**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-research-entry/references/validate-phase.md
+++ b/skills/workflow-research-entry/references/validate-phase.md
@@ -14,10 +14,10 @@ Reopen it:
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} research {topic}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Reopening research: {topic:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.research.{topic} --verb Reopening
 ```
 
 Set source="continue".
@@ -28,10 +28,10 @@ Set source="continue".
 
 #### If status is `in-progress`
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Resuming research: {topic:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.research.{topic} --verb Resuming
 ```
 
 Set source="continue".

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -4,71 +4,25 @@
 
 ---
 
-Check if plan and implementation exist and are ready via `engine manifest`.
+Check if plan and implementation exist and are ready.
 
-## A. Existence Checks
+## A. Prerequisite Gate
+
+The engine derives the verdict from manifest state:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.planning.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs render entry-gate {work_unit}.review.{topic}
 ```
 
-#### If plan doesn't exist (`false`)
+#### If the response carried `DISPLAY: entry blocker`
 
-> *Output the next fenced block as a code block:*
-
-```
-Plan Missing
-
-No plan found for "{topic:(titlecase)}".
-
-A completed plan and completed implementation are required for review.
-```
+Emit the section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 
-#### If plan exists (`true`)
+#### If the response is empty
 
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.implementation.{topic}
-```
-
-**If implementation doesn't exist (`false`):**
-
-> *Output the next fenced block as a code block:*
-
-```
-Implementation Missing
-
-No implementation found for "{topic:(titlecase)}".
-
-A completed implementation is required for review.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-**If implementation exists (`true`):**
-
-→ Proceed to **B. Implementation Status**.
-
-## B. Implementation Status
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} status
-```
-
-#### If implementation status is not `completed`
-
-> *Output the next fenced block as a code block:*
-
-```
-Implementation Not Complete
-
-The implementation for "{topic:(titlecase)}" is not yet completed.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-#### If implementation status is `completed`
+Plan and implementation are completed.
 
 → Proceed to **C. Review State**.
 

--- a/skills/workflow-scoping-entry/references/validate-phase.md
+++ b/skills/workflow-scoping-entry/references/validate-phase.md
@@ -26,10 +26,10 @@ Reopen it:
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} scoping {topic}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Reopening scoping: {topic:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.scoping.{topic} --verb Reopening
 ```
 
 → Return to caller.

--- a/skills/workflow-specification-entry/references/validate-phase.md
+++ b/skills/workflow-specification-entry/references/validate-phase.md
@@ -24,10 +24,10 @@ The grouping exists as a proposed item; the process skill flips it to in-progres
 
 #### If the status is `in-progress`
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Resuming specification: {work_unit:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.specification.{topic} --verb Resuming
 ```
 
 Set verb = "Continuing".
@@ -42,10 +42,10 @@ Reopen it:
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reopen {work_unit} specification {topic}
 ```
 
-> *Output the next fenced block as a code block:*
+Render and emit the section verbatim:
 
-```
-Reopening specification: {work_unit:(titlecase)}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-note {work_unit}.specification.{topic} --verb Reopening
 ```
 
 Set verb = "Continuing".

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -4,149 +4,20 @@
 
 ---
 
-Check if source material exists and is ready.
+Check the source-material prerequisite — the engine derives the verdict from manifest state (work-type-aware: discussions for feature/cross-cutting, the investigation for bugfix, at least one completed discussion for epic):
 
-#### If `work_type` is `feature`
-
-Check if discussion exists and is completed. Read status via `engine manifest`: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} status`.
-
-**If discussion doesn't exist:**
-
-> *Output the next fenced block as a code block:*
-
-```
-Source Material Missing
-
-No discussion found for "{work_unit:(titlecase)}".
-
-A completed discussion is required before specification can begin.
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render entry-gate {work_unit}.specification.{topic}
 ```
 
-**STOP.** Do not proceed — terminal condition.
+#### If the response is empty
 
-**If discussion exists but status is "in-progress":**
-
-> *Output the next fenced block as a code block:*
-
-```
-Discussion In Progress
-
-The discussion for "{work_unit:(titlecase)}" is not yet completed.
-
-The discussion must be completed before specification can begin.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-**If discussion exists and status is "completed":**
+Source material is ready.
 
 → Return to caller.
 
-#### If `work_type` is `bugfix`
+#### If the response carried `DISPLAY: entry blocker`
 
-Check if investigation exists and is completed. Read status via `engine manifest`: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.investigation.{topic} status`.
-
-**If investigation doesn't exist:**
-
-> *Output the next fenced block as a code block:*
-
-```
-Source Material Missing
-
-No investigation found for "{work_unit:(titlecase)}".
-
-A completed investigation is required before specification can begin.
-```
+Emit the section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
-
-**If investigation exists but status is "in-progress":**
-
-> *Output the next fenced block as a code block:*
-
-```
-Investigation In Progress
-
-The investigation for "{work_unit:(titlecase)}" is not yet completed.
-
-The investigation must be completed before specification can begin.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-**If investigation exists and status is "completed":**
-
-→ Return to caller.
-
-#### If `work_type` is `epic`
-
-Check if at least one completed discussion exists for this work unit. Read discussion phase items via `engine manifest`: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion`.
-
-**If no discussions exist:**
-
-> *Output the next fenced block as a code block:*
-
-```
-Source Material Missing
-
-No discussions found for "{work_unit:(titlecase)}".
-
-At least one completed discussion is required before specification can begin.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-**If no completed discussions exist:**
-
-> *Output the next fenced block as a code block:*
-
-```
-No Completed Discussions
-
-No completed discussions found for "{work_unit:(titlecase)}".
-
-At least one completed discussion is required before specification can begin.
-Run /workflow-start to continue an in-progress discussion.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-**If at least one completed discussion exists:**
-
-→ Return to caller.
-
-#### If `work_type` is `cross-cutting`
-
-Check if discussion exists and is completed. Read status via `engine manifest`: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} status`.
-
-**If discussion doesn't exist:**
-
-> *Output the next fenced block as a code block:*
-
-```
-Source Material Missing
-
-No discussion found for "{work_unit:(titlecase)}".
-
-A completed discussion is required before specification can begin.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-**If discussion exists but status is "in-progress":**
-
-> *Output the next fenced block as a code block:*
-
-```
-Discussion In Progress
-
-The discussion for "{work_unit:(titlecase)}" is not yet completed.
-
-The discussion must be completed before specification can begin.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-**If discussion exists and status is "completed":**
-
-→ Return to caller.

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -744,9 +744,109 @@ describe('CLI boundary — engine render via subprocess', () => {
   });
 });
 
+describe('render phase-note', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { planning: { items: { 'auth-flow': { status: 'completed' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  it('renders the one-liner with the phase noun by default and an override when given', () => {
+    assert.strictEqual(renderSurface(dir, 'phase-note', { dotpath: 'pay.research.auth-flow', verb: 'Resuming' }),
+      '=== DISPLAY: phase note (emit verbatim as a code block) ===\nResuming research: Auth Flow\n');
+    assert.ok(renderSurface(dir, 'phase-note', { dotpath: 'pay.planning.auth-flow', verb: 'Reopening', noun: 'plan' })
+      .includes('Reopening plan: Auth Flow'));
+    assert.throws(() => renderSurface(dir, 'phase-note', { dotpath: 'pay.research.auth-flow' }), /--verb is required/);
+  });
+});
+
+describe('render entry-gate', () => {
+  let dir;
+  beforeEach(() => { dir = setup(); });
+  afterEach(() => teardown(dir));
+
+  function manifestWith(phases, workType = 'feature') {
+    writeManifest(dir, 'pay', { work_type: workType, phases });
+  }
+
+  it('planning: every specification state maps to its blocker; completed is clear', () => {
+    manifestWith({});
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification Missing\n\nNo specification found for "Auth"\./);
+    manifestWith({ specification: { items: { auth: { status: 'in-progress' } } } });
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification In Progress/);
+    manifestWith({ specification: { items: { auth: { status: 'proposed' } } } });
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification Not Started[\s\S]*proposed grouping/);
+    manifestWith({ specification: { items: { auth: { status: 'superseded', superseded_by: 'core-auth' } } } });
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification Superseded[\s\S]*"Core Auth"/);
+    manifestWith({ specification: { items: { auth: { status: 'promoted', promoted_to: 'cc-auth' } } } });
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification Promoted[\s\S]*"cc-auth"/);
+    manifestWith({ specification: { items: { auth: { status: 'completed' } } } });
+    assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), '');
+  });
+
+  it('implementation and review derive their plan/implementation blockers', () => {
+    manifestWith({});
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.implementation.auth' }), /Plan Missing[\s\S]*A completed plan is required for implementation\./);
+    manifestWith({ planning: { items: { auth: { status: 'in-progress' } } } });
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.implementation.auth' }), /Plan Not Completed/);
+    manifestWith({ planning: { items: { auth: { status: 'completed' } } } });
+    assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.implementation.auth' }), '');
+
+    manifestWith({});
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /Plan Missing[\s\S]*plan and completed implementation are required for review\./);
+    manifestWith({ planning: { items: { auth: { status: 'completed' } } } });
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /Implementation Missing/);
+    manifestWith({ planning: { items: { auth: { status: 'completed' } } }, implementation: { items: { auth: { status: 'in-progress' } } } });
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /Implementation Not Complete/);
+    manifestWith({ planning: { items: { auth: { status: 'completed' } } }, implementation: { items: { auth: { status: 'completed' } } } });
+    assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), '');
+  });
+
+  it('specification is work-type-aware: feature discussion, bugfix investigation, epic any-completed', () => {
+    manifestWith({}, 'feature');
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /Source Material Missing\n\nNo discussion found for "Pay"\./);
+    manifestWith({ discussion: { items: { auth: { status: 'in-progress' } } } }, 'feature');
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /Discussion In Progress/);
+    manifestWith({ discussion: { items: { auth: { status: 'completed' } } } }, 'feature');
+    assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), '');
+
+    manifestWith({}, 'bugfix');
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /No investigation found/);
+    manifestWith({ investigation: { items: { auth: { status: 'in-progress' } } } }, 'bugfix');
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /Investigation In Progress/);
+
+    manifestWith({}, 'epic');
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /No discussions found/);
+    manifestWith({ discussion: { items: { a: { status: 'in-progress' }, b: { status: 'in-progress' } } } }, 'epic');
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /No Completed Discussions[\s\S]*continue an in-progress discussion/);
+    manifestWith({ discussion: { items: { a: { status: 'completed' } } } }, 'epic');
+    assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), '');
+  });
+
+  it('an unsupported phase is a loud error', () => {
+    manifestWith({});
+    assert.throws(() => renderSurface(dir, 'entry-gate', { dotpath: 'pay.discussion.auth' }), /no prerequisite rules for phase "discussion"/);
+  });
+});
+
+describe('selection not-found display', () => {
+  const { selectionNotFound } = require('../../skills/workflow-engine/scripts/domain/projections/selection.cjs');
+  it('renders the per-type terminal byte-exactly', () => {
+    assert.strictEqual(selectionNotFound('cross-cutting', 'ghost'), [
+      '=== DISPLAY: not found (emit verbatim as a code block, then STOP — terminal condition) ===',
+      'No active cross-cutting concern named "ghost" found.',
+      '',
+      'Run /workflow-start to see available concerns or begin a new one.',
+      '',
+    ].join('\n'));
+    assert.ok(selectionNotFound('quick-fix', 'x').includes('available quick-fixes'));
+  });
+});
+
 describe('catalogue dispatch', () => {
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding, proposed-task, tasks-overview, author-task-gate, phase-tree, phase-completed, early-completion-gate, revisit-gate, epic-all-done-gate\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding, proposed-task, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate\)/);
   });
 });
 


### PR DESCRIPTION
Stage 6b of the render-surfaces programme (design log: #489; base: #496). The last surface family: entry prerequisite validation moves from prose read-and-branch to engine derivation.

## Surfaces

**`render entry-gate <wu>.<phase>.<topic>`** — full absorption: the engine reads the manifest and returns either an **empty response** (clear — the flow proceeds) or the terminal `DISPLAY: entry blocker`. State machines per target phase:
- **planning** — every specification status mapped: missing, in-progress, proposed ("Not Started"), superseded (naming the superseding topic), promoted (naming the cc unit); completed = clear.
- **implementation** — plan missing / not completed.
- **review** — plan missing / implementation missing / implementation not complete.
- **specification** — work-type-aware: feature & cross-cutting check the topic's discussion; bugfix the investigation; epic requires at least one completed discussion (with the distinct no-discussions vs none-completed blocks).

`validate-spec.md` (6 conditional blocks + a manifest read) and `validate-source.md` (4 work-type branches × 2-3 blocks + reads) each collapse to one call and two branches; implementation/review `validate-phase` drop their read-and-branch prerequisite sections. Every blocker text byte-matches the old prose.

**`render phase-note <wu>.<phase>.<topic> --verb <Word> [--noun <word>]`** — the entry one-liners (Resuming/Reopening/Starting …), ten templates swapped across seven entries (planning keeps its "Reopening plan" wording via `--noun`).

**Selection not-found** — the continue-* `view` snapshot for an unknown name now appends the per-type terminal display; five `validate-selection` references emit the section instead of authoring it.

## Test plan

- entry-gate: the full state matrix — 6 planning states, 3 implementation, 4 review, and the work-type-aware specification set including both epic variants; unsupported phase is loud.
- phase-note default/override/validation; not-found byte-exact per type.
- `npm test` — 1518/1518. Typecheck + conventions lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #490
2. #491
3. #492
4. #493
5. #496
6. **#497** 👈 current
7. #498
8. #499
9. #500
10. #501
<!-- stack:links:end -->