### PR TITLE
feat(engine): resume-gate variants + entry-gate --own + phase-completed --paths (7b)

### DIFF
--- a/skills/workflow-continue-bugfix/references/bugfix-display-and-menu.md
+++ b/skills/workflow-continue-bugfix/references/bugfix-display-and-menu.md
@@ -58,16 +58,10 @@ Store the entry's `action` and `route`.
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline" --pipeline
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-Bugfix Completed
-
-"{work_unit:(titlecase)}" has completed all pipeline phases.
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-cross-cutting/references/cross-cutting-display-and-menu.md
+++ b/skills/workflow-continue-cross-cutting/references/cross-cutting-display-and-menu.md
@@ -58,16 +58,10 @@ Store the entry's `action` and `route`.
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline" --pipeline
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-Cross-Cutting Completed
-
-"{work_unit:(titlecase)}" has completed all pipeline phases.
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-feature/references/feature-display-and-menu.md
+++ b/skills/workflow-continue-feature/references/feature-display-and-menu.md
@@ -58,16 +58,10 @@ Store the entry's `action` and `route`.
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline" --pipeline
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-Feature Completed
-
-"{work_unit:(titlecase)}" has completed all pipeline phases.
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-quickfix/references/quickfix-display-and-menu.md
+++ b/skills/workflow-continue-quickfix/references/quickfix-display-and-menu.md
@@ -58,16 +58,10 @@ Store the entry's `action` and `route`.
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline"
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline" --pipeline
 ```
 
-> *Output the next fenced block as a code block:*
-
-```
-Quick-Fix Completed
-
-"{work_unit:(titlecase)}" has completed all pipeline phases.
-```
+Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-discovery/references/resume-detection.md
+++ b/skills/workflow-discovery/references/resume-detection.md
@@ -35,15 +35,10 @@ The output is the in-progress session number string (e.g. `002`) — the prior s
 > choose whether to pick it up or start fresh.
 ```
 
-> *Output the next fenced block as markdown (not a code block):*
+Render the resume menu and emit its section verbatim per its marker:
 
-```
-· · · · · · · · · · · ·
-Found an in-progress discovery session for **{work_unit:(titlecase)}** at `session-{active_session}.md`.
-
-- **`c`/`continue`** — Pick up where you left off
-- **`r`/`restart`** — Discard the interrupted log and start a new session (map edits already applied stay applied — only their session record is lost)
-· · · · · · · · · · · ·
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render resume-gate {work_unit} --variant session
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -167,7 +167,7 @@ engine commit --workflows -m "<message>"
 **`render`** — the surface catalogue (`domain/render.cjs`): named runtime surfaces returning demarcated `=== DISPLAY: … ===` / `=== MENU: … ===` sections the calling flow emits verbatim at each marker's named moment. Address-backed values come from the manifest (JSON state only — the engine never parses markdown artifacts); judgment content arrives as a JSON payload file written to the phase cache with the Write tool and validated loudly per-field. Gate-mode branching happens inside the surface: the response carries the menu when the mode is `gated` and the auto-proceed line when it is `auto` — the calling flow branches on which section arrived, never on the mode itself. No git commit; nothing is written.
 
 ```bash
-engine render resume-gate <wu>.<phase>.<topic> [--triage <N>]     # shared continue/restart gate; --triage adds the undrained-concerns warning above the menu
+engine render resume-gate <wu>.<phase>.<topic> [--triage <N>] [--variant plan|review|scoping|session]  # the resume-menu family: default = shared continue/restart gate (--triage adds the undrained-concerns warning); plan derives the position parenthetical from the planning item; review derives coverage from reviewed/completed task arrays; scoping renders the revisit wording; session takes a bare <wu> and renders the interrupted-discovery-session menu
 engine render task-list <wu>.planning.<topic> --file <payload>    # planning task-list gate; payload {phase, phase_name, tasks: [{name, summary, edge_cases?}]}
 engine render findings-summary <wu>.<phase>.<topic> --file <payload>  # review-findings overview; payload {review_label, items: [{title, tag, summary}]}
 engine render finding <wu>.<phase>.<topic> --file <payload>       # one finding + its gate; payload {n, total, title, meta, details, diff|content, apply_label?, applied_label?, feedback_hint?}
@@ -175,12 +175,12 @@ engine render proposed-task <wu>.<phase>.<topic> --file <payload> --gate gated|a
 engine render tasks-overview <wu>.<phase>.<topic> --file <payload>    # proposed-tasks cycle overview; payload {label, tasks: [{title, severity}]}
 engine render author-task-gate <wu>.planning.<topic> --m N --total N --title STR   # task-authoring approval menu (the detail itself is a verbatim file emission the flow owns)
 engine render phase-tree <wu>.planning.<topic> --file <payload> [--approve]        # D5 phase structure tree; payload {phases: [{name, detail?: [[label, value]]}]}; --approve appends the structure gate
-engine render phase-completed <wu> --phase <phase>                # one-line phase-completed display
+engine render phase-completed <wu> --phase <phase> [--paths]      # one-line phase-completed display; --paths appends the derived spec/plan artifact paths (scoping's conclusion)
 engine render early-completion-gate <wu>                          # bridge gate: proceed to review / complete without review
 engine render revisit-gate <wu> --prev <phase> --next <phase>     # bridge gate: proceed to next / revisit an earlier phase
 engine render epic-all-done-gate <wu>                             # bridge gate: mark epic completed / return to menu
 engine render phase-note <wu>.<phase>.<topic> --verb <Word> [--noun <word>]   # entry one-liner: "{Word} {noun|phase}: {Topic}"
-engine render entry-gate <wu>.<phase>.<topic>                     # prerequisite verdict, engine-derived: empty = clear; blocked = the terminal DISPLAY: entry blocker (planning: spec status incl. superseded/promoted; implementation: plan; review: plan+implementation; specification: work-type-aware source material)
+engine render entry-gate <wu>.<phase>.<topic> [--own]             # prerequisite verdict, engine-derived: empty = clear; blocked = the terminal DISPLAY: entry blocker (planning: spec status incl. superseded/promoted; implementation: plan; review: plan+implementation; specification: work-type-aware source material). --own (specification only) checks the topic's OWN terminal statuses instead — superseded/promoted at phase entry
 ```
 
 The bridge continuation surfaces take a bare `<work_unit>` address (work-unit-level, type read from the manifest). The continue-* selection step is not a `render` surface: each navigation gateway's index dump appends `DISPLAY: selection` / `MENU: selection` sections from the shared selection projection — emitted only at the select step, per their markers.

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -45,8 +45,85 @@ function resolveAddress(cwd, dotpath, surface) {
  * @param {{dotpath: string, triage?: string}} args
  * @returns {string} sections
  */
-function resumeGate(cwd, { dotpath, triage }) {
-  const { phase, topic } = resolveAddress(cwd, dotpath, 'resume-gate');
+const RESUME_MENU_INSTRUCTION = "emit verbatim as markdown, then STOP for the user's response";
+
+/**
+ * The resume-menu family. The default renders the shared phase-resume menu;
+ * variants derive their consumer's label and options from state at the same
+ * address: `plan` (position parenthetical from the planning item), `review`
+ * (coverage counts from reviewed/completed task arrays), `scoping` (the
+ * revisit wording), `session` (bare work-unit address, the interrupted
+ * discovery session).
+ * @param {string} cwd
+ * @param {{dotpath: string, triage?: string, variant?: string}} args
+ * @returns {string}
+ */
+function resumeGate(cwd, args) {
+  const { dotpath, triage, variant } = args;
+  if (variant !== undefined && !['plan', 'review', 'scoping', 'session'].includes(variant)) {
+    throw new Error(`render resume-gate: --variant must be "plan", "review", "scoping", or "session", got "${variant}"`);
+  }
+  if (variant !== undefined && triage !== undefined) {
+    throw new Error('render resume-gate: --triage only applies to the default variant');
+  }
+  if (variant === 'session') {
+    const { workUnit, manifest } = resolveWorkUnit(cwd, dotpath, 'resume-gate');
+    const active = ((manifest.phases || {}).discovery || {}).active_session;
+    if (active === undefined || active === null || String(active).trim() === '') {
+      throw new Error('render resume-gate: no active discovery session to resume');
+    }
+    return section('MENU: resume gate', RESUME_MENU_INSTRUCTION, menu(
+      `Found an in-progress discovery session for **${titlecase(workUnit)}** at \`session-${active}.md\`.`,
+      [
+        cmdOption('c', 'continue', 'Pick up where you left off'),
+        cmdOption('r', 'restart', 'Discard the interrupted log and start a new session (map edits already applied stay applied — only their session record is lost)'),
+      ],
+    ));
+  }
+  const { phase, topic, manifest } = resolveAddress(cwd, dotpath, 'resume-gate');
+  const t = titlecase(topic);
+  if (variant === 'plan') {
+    const item = itemOf(manifest, 'planning', topic) || {};
+    const pos = isFilled(String(item.phase ?? '')) && isFilled(String(item.task ?? ''))
+      ? ` (previously reached phase ${item.phase}, task ${item.task})` : '';
+    return section('MENU: resume gate', RESUME_MENU_INSTRUCTION, menu(
+      `Found existing plan for **${t}**${pos}.`,
+      [
+        cmdOption('c', 'continue', 'Walk through the plan from the start. You can review, amend, or navigate at any point — including straight to the leading edge.'),
+        cmdOption('r', 'restart', 'Erase all planning work for this topic and start fresh. This deletes the planning file, authored tasks, and clears manifest state. Other topics are unaffected.'),
+      ],
+    ));
+  }
+  if (variant === 'review') {
+    const reviewItem = itemOf(manifest, 'review', topic) || {};
+    const implItem = itemOf(manifest, 'implementation', topic) || {};
+    const reviewed = Array.isArray(reviewItem.reviewed_tasks) ? reviewItem.reviewed_tasks.length : null;
+    const completed = Array.isArray(implItem.completed_tasks) ? implItem.completed_tasks.length : 0;
+    if (reviewed !== null && completed - reviewed > 0) {
+      const unreviewed = completed - reviewed;
+      return section('MENU: resume gate', RESUME_MENU_INSTRUCTION, menu(
+        `Found existing review for **${t}**.\nReview covered ${reviewed} of ${completed} tasks. ${unreviewed} task(s) not yet reviewed.`,
+        [
+          cmdOption('c', 'continue', `Review the ${unreviewed} unreviewed tasks`),
+          cmdOption('r', 'restart', `Delete review, re-review all ${completed} tasks`),
+        ],
+      ));
+    }
+    const label = `Found existing review for **${t}**.` + (reviewed !== null ? `\nAll ${completed} tasks have been reviewed.` : '');
+    return section('MENU: resume gate', RESUME_MENU_INSTRUCTION, menu(label, [
+      cmdOption('c', 'continue', 'Continue from current review state'),
+      cmdOption('r', 'restart', 'Delete review, start fresh'),
+    ]));
+  }
+  if (variant === 'scoping') {
+    return section('MENU: resume gate', RESUME_MENU_INSTRUCTION, menu(
+      `Found completed scoping for **${t}** — spec and plan are in place.`,
+      [
+        cmdOption('c', 'continue', 'Adjust the existing spec and plan'),
+        cmdOption('r', 'restart', 'Erase the spec, plan, and task files, then rescope from scratch'),
+      ],
+    ));
+  }
   const parts = [];
   if (triage !== undefined) {
     const n = parseInt(triage, 10);
@@ -539,16 +616,19 @@ function resolveWorkUnit(cwd, dotpath, surface) {
 
 /**
  * @param {string} cwd
- * @param {{dotpath: string, phase?: string}} args
+ * @param {{dotpath: string, phase?: string, paths?: string}} args
  * @returns {string}
  */
-function phaseCompleted(cwd, { dotpath, phase }) {
+function phaseCompleted(cwd, { dotpath, phase, paths }) {
   const { workUnit } = resolveWorkUnit(cwd, dotpath, 'phase-completed');
   if (!isFilled(phase)) throw new Error('render phase-completed: --phase is required');
+  const artefacts = paths
+    ? `\n\n  Spec: .workflows/${workUnit}/specification/${workUnit}/specification.md\n  Plan: .workflows/${workUnit}/planning/${workUnit}/`
+    : '';
   return section(
     'DISPLAY: phase completed',
     'emit verbatim as a code block',
-    `${titlecase(phase)} completed for "${titlecase(workUnit)}".`,
+    `${titlecase(phase)} completed for "${titlecase(workUnit)}".${artefacts}`,
   );
 }
 
@@ -649,12 +729,34 @@ function blocker(title, bodyLines) {
 
 /**
  * @param {string} cwd
- * @param {{dotpath: string}} args
+ * @param {{dotpath: string, own?: string}} args
  * @returns {string} blocker sections, or '' when the entry is clear
  */
-function entryGate(cwd, { dotpath }) {
+function entryGate(cwd, { dotpath, own }) {
   const { phase, topic, manifest } = resolveAddress(cwd, dotpath, 'entry-gate');
   const t = titlecase(topic);
+
+  if (own) {
+    // --own checks the topic's OWN terminal statuses at phase entry, not its
+    // prerequisites — the entry flow's routing handles the live statuses.
+    if (phase !== 'specification') {
+      throw new Error(`render entry-gate: --own is only supported for specification, got "${phase}"`);
+    }
+    const spec = itemOf(manifest, 'specification', topic) || {};
+    if (spec.status === 'superseded') {
+      return blocker('Specification Superseded', [
+        `The specification for "${t}" was consolidated into`,
+        `"${titlecase(String(spec.superseded_by || ''))}". Work on that specification instead.`,
+      ]);
+    }
+    if (spec.status === 'promoted') {
+      return blocker('Specification Promoted', [
+        `"${t}" was promoted to the cross-cutting work unit`,
+        `"${spec.promoted_to}". Continue it from that work unit.`,
+      ]);
+    }
+    return '';
+  }
 
   if (phase === 'planning') {
     const spec = itemOf(manifest, 'specification', topic);

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -153,7 +153,7 @@ Commands:
   commit <work-unit> -m <message>
   commit --inbox -m <message>
   commit --workflows -m <message>
-  render resume-gate <wu.phase.topic> [--triage N]
+  render resume-gate <wu.phase.topic> [--triage N] [--variant plan|review|scoping|session]  (session: bare <wu>)
   render task-list   <wu.planning.topic> --file <payload.json>
   render findings-summary <wu.phase.topic> --file <payload.json>
   render finding          <wu.phase.topic> --file <payload.json>
@@ -161,9 +161,9 @@ Commands:
   render tasks-overview   <wu.phase.topic> --file <payload.json>
   render author-task-gate <wu.planning.topic> --m N --total N --title STR
   render phase-tree       <wu.planning.topic> --file <payload.json> [--approve]
-  render phase-completed   <wu> --phase <phase>
+  render phase-completed   <wu> --phase <phase> [--paths]
   render phase-note        <wu.phase.topic> --verb <Word> [--noun <word>]
-  render entry-gate        <wu.phase.topic>      (planning|implementation|review|specification)
+  render entry-gate        <wu.phase.topic> [--own]  (planning|implementation|review|specification)
   render early-completion-gate <wu>
   render revisit-gate      <wu> --prev <phase> --next <phase>
   render epic-all-done-gate <wu>
@@ -681,7 +681,7 @@ function runCommit(argv) {
 /** @param {string[]} argv */
 function runRender(argv) {
   const [command, ...rest] = argv;
-  const { opts, flags, positional } = parseArgs(rest, ['approve', 'skipped-review']);
+  const { opts, flags, positional } = parseArgs(rest, ['approve', 'skipped-review', 'own', 'paths']);
   const width = opts.width !== undefined ? parseInt(opts.width, 10) : WIDTH;
 
   if (Object.hasOwn(SURFACES, command)) {
@@ -690,6 +690,8 @@ function runRender(argv) {
       const args = { dotpath: positional[0], ...opts };
       if (flags.has('approve')) args.approve = '1';
       if (flags.has('skipped-review')) args['skipped-review'] = '1';
+      if (flags.has('own')) args.own = '1';
+      if (flags.has('paths')) args.paths = '1';
       respondSections(renderSurface(process.cwd(), command, args));
     } catch (err) {
       failJson(err);

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -110,21 +110,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 The subtree carries the current `phase` and `task` position (for the resume prompt below) and the `spec_commit` baseline (for spec-change detection).
 
-Load **[spec-change-detection.md](references/spec-change-detection.md)** and follow its instructions as written. Then present the user with an informed choice:
+Load **[spec-change-detection.md](references/spec-change-detection.md)** and follow its instructions as written. Then present the informed choice — emit the spec-change summary as markdown, then render the resume menu (the position parenthetical derives from the planning item) and emit its section verbatim per its marker:
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-Found existing plan for **{topic:(titlecase)}** (previously reached phase {N}, task {M}).
-
-{spec change summary from spec-change-detection.md}
-
-· · · · · · · · · · · ·
-How would you like to proceed?
-
-- **`c`/`continue`** — Walk through the plan from the start. You can review, amend, or navigate at any point — including straight to the leading edge.
-- **`r`/`restart`** — Erase all planning work for this topic and start fresh. This deletes the planning file, authored tasks, and clears manifest state. Other topics are unaffected.
-· · · · · · · · · · · ·
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render resume-gate {work_unit}.planning.{topic} --variant plan
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -97,36 +97,10 @@ Read `reviewed_tasks` from the review manifest — empty stdout means it was nev
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.review.{topic} reviewed_tasks
 ```
 
-Compare `completed_tasks` against `reviewed_tasks`. Let {C} = total completed, {R} = reviewed, {U} = unreviewed ({C} − {R}).
+Render the resume menu — the engine derives review coverage from the two arrays — and emit its section verbatim per its marker:
 
-**If `reviewed_tasks` exists and unreviewed tasks remain:**
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-Found existing review for **{topic:(titlecase)}**.
-Review covered {R} of {C} tasks. {U} task(s) not yet reviewed.
-
-· · · · · · · · · · · ·
-- **`c`/`continue`** — Review the {U} unreviewed tasks
-- **`r`/`restart`** — Delete review, re-review all {C} tasks
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-**Otherwise** (all tasks reviewed, or no tracking data):
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-Found existing review for **{topic:(titlecase)}**.
-@if(reviewed_tasks exists) All {C} tasks have been reviewed. @endif
-
-· · · · · · · · · · · ·
-- **`c`/`continue`** — Continue from current review state
-- **`r`/`restart`** — Delete review, start fresh
-· · · · · · · · · · · ·
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render resume-gate {work_unit}.review.{topic} --variant review
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -94,15 +94,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 **If plan status is `completed` and scoping status is `in-progress`** (reopened for revisit):
 
-> *Output the next fenced block as markdown (not a code block):*
+Render the resume menu and emit its section verbatim per its marker:
 
-```
-· · · · · · · · · · · ·
-Found completed scoping for **{topic:(titlecase)}** — spec and plan are in place.
-
-- **`c`/`continue`** — Adjust the existing spec and plan
-- **`r`/`restart`** — Erase the spec, plan, and task files, then rescope from scratch
-· · · · · · · · · · · ·
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render resume-gate {work_unit}.scoping.{topic} --variant scoping
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-scoping-process/references/conclude-scoping.md
+++ b/skills/workflow-scoping-process/references/conclude-scoping.md
@@ -4,13 +4,10 @@
 
 ---
 
-> *Output the next fenced block as a code block:*
+Render the completion display — the artifact paths derive from the work unit — and emit its section verbatim per its marker:
 
-```
-Scoping complete for "{topic:(titlecase)}".
-
-  Spec: .workflows/{work_unit}/specification/{topic}/specification.md
-  Plan: .workflows/{work_unit}/planning/{topic}/
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render phase-completed {work_unit} --phase scoping --paths
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-specification-entry/references/validate-phase.md
+++ b/skills/workflow-specification-entry/references/validate-phase.md
@@ -52,28 +52,12 @@ Set verb = "Continuing".
 
 → Return to caller.
 
-#### If the status is `superseded`
+#### If the status is `superseded` or `promoted`
 
-> *Output the next fenced block as a code block:*
+Render the terminal blocker — the engine derives which from the item's status — and emit the section verbatim per its marker:
 
-```
-Specification Superseded
-
-The specification for "{topic:(titlecase)}" was consolidated into
-"{superseded_by:(titlecase)}". Work on that specification instead.
-```
-
-**STOP.** Do not proceed — terminal condition.
-
-#### If the status is `promoted`
-
-> *Output the next fenced block as a code block:*
-
-```
-Specification Promoted
-
-"{topic:(titlecase)}" was promoted to the cross-cutting work unit
-"{promoted_to}". Continue it from that work unit.
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render entry-gate {work_unit}.specification.{topic} --own
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -124,6 +124,78 @@ describe('render resume-gate', () => {
     assert.throws(() => renderSurface(dir, 'resume-gate', { dotpath: 'pay.discussion' }), /address must be <work_unit>\.<phase>\.<topic>/);
     assert.throws(() => renderSurface(dir, 'resume-gate', { dotpath: 'nope.discussion.x' }), /work unit "nope" not found/);
   });
+
+  it('rejects an unknown variant and --triage combined with a variant', () => {
+    assert.throws(() => renderSurface(dir, 'resume-gate', { dotpath: 'pay.discussion.auth-flow', variant: 'nope' }), /--variant must be "plan", "review", "scoping", or "session"/);
+    assert.throws(() => renderSurface(dir, 'resume-gate', { dotpath: 'pay.scoping.auth-flow', variant: 'scoping', triage: '2' }), /--triage only applies to the default variant/);
+  });
+});
+
+describe('render resume-gate variants', () => {
+  let dir;
+  beforeEach(() => { dir = setup(); });
+  afterEach(() => teardown(dir));
+
+  it('plan derives the position parenthetical from the planning item', () => {
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress', phase: 3, task: 2 } } } } });
+    const out = renderSurface(dir, 'resume-gate', { dotpath: 'pay.planning.portal', variant: 'plan' });
+    assert.ok(out.includes('Found existing plan for **Portal** (previously reached phase 3, task 2).'));
+    assert.ok(out.includes('- **`c`/`continue`** — Walk through the plan from the start. You can review, amend, or navigate at any point — including straight to the leading edge.'));
+    assert.ok(out.includes('- **`r`/`restart`** — Erase all planning work for this topic and start fresh. This deletes the planning file, authored tasks, and clears manifest state. Other topics are unaffected.'));
+  });
+
+  it('plan omits the parenthetical when the position fields are absent', () => {
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress' } } } } });
+    const out = renderSurface(dir, 'resume-gate', { dotpath: 'pay.planning.portal', variant: 'plan' });
+    assert.ok(out.includes('Found existing plan for **Portal**.\n'));
+    assert.ok(!out.includes('previously reached'));
+  });
+
+  it('review renders the coverage menu while unreviewed tasks remain', () => {
+    writeManifest(dir, 'pay', { phases: {
+      implementation: { items: { portal: { status: 'completed', completed_tasks: ['a', 'b', 'c'] } } },
+      review: { items: { portal: { status: 'in-progress', reviewed_tasks: ['a'] } } },
+    } });
+    const out = renderSurface(dir, 'resume-gate', { dotpath: 'pay.review.portal', variant: 'review' });
+    assert.ok(out.includes('Found existing review for **Portal**.\nReview covered 1 of 3 tasks. 2 task(s) not yet reviewed.'));
+    assert.ok(out.includes('- **`c`/`continue`** — Review the 2 unreviewed tasks'));
+    assert.ok(out.includes('- **`r`/`restart`** — Delete review, re-review all 3 tasks'));
+  });
+
+  it('review renders the all-reviewed menu when coverage is complete, and the bare menu with no tracking', () => {
+    writeManifest(dir, 'pay', { phases: {
+      implementation: { items: { portal: { status: 'completed', completed_tasks: ['a', 'b'] } } },
+      review: { items: { portal: { status: 'in-progress', reviewed_tasks: ['a', 'b'] } } },
+    } });
+    const all = renderSurface(dir, 'resume-gate', { dotpath: 'pay.review.portal', variant: 'review' });
+    assert.ok(all.includes('Found existing review for **Portal**.\nAll 2 tasks have been reviewed.'));
+    assert.ok(all.includes('- **`c`/`continue`** — Continue from current review state'));
+
+    writeManifest(dir, 'pay', { phases: { review: { items: { portal: { status: 'in-progress' } } } } });
+    const bare = renderSurface(dir, 'resume-gate', { dotpath: 'pay.review.portal', variant: 'review' });
+    assert.ok(bare.includes('Found existing review for **Portal**.\n\n'), 'no tracking — label only, no coverage line');
+    assert.ok(bare.includes('- **`r`/`restart`** — Delete review, start fresh'));
+  });
+
+  it('scoping renders the revisit wording', () => {
+    writeManifest(dir, 'pay', { phases: { scoping: { items: { pay: { status: 'in-progress' } } } } });
+    const out = renderSurface(dir, 'resume-gate', { dotpath: 'pay.scoping.pay', variant: 'scoping' });
+    assert.ok(out.includes('Found completed scoping for **Pay** — spec and plan are in place.'));
+    assert.ok(out.includes('- **`c`/`continue`** — Adjust the existing spec and plan'));
+    assert.ok(out.includes('- **`r`/`restart`** — Erase the spec, plan, and task files, then rescope from scratch'));
+  });
+
+  it('session takes a bare work-unit address and reads the active-session marker', () => {
+    writeManifest(dir, 'pay', { phases: { discovery: { active_session: '002', items: {} } } });
+    const out = renderSurface(dir, 'resume-gate', { dotpath: 'pay', variant: 'session' });
+    assert.ok(out.includes('Found an in-progress discovery session for **Pay** at `session-002.md`.'));
+    assert.ok(out.includes('- **`r`/`restart`** — Discard the interrupted log and start a new session (map edits already applied stay applied — only their session record is lost)'));
+  });
+
+  it('session is loud when no active session exists', () => {
+    writeManifest(dir, 'pay', { phases: { discovery: { items: {} } } });
+    assert.throws(() => renderSurface(dir, 'resume-gate', { dotpath: 'pay', variant: 'session' }), /no active discovery session to resume/);
+  });
 });
 
 describe('render task-list', () => {
@@ -805,6 +877,65 @@ describe('render entry-gate', () => {
   it('an unsupported phase is a loud error', () => {
     manifestWith({});
     assert.throws(() => renderSurface(dir, 'entry-gate', { dotpath: 'pay.discussion.auth' }), /no prerequisite rules for phase "discussion"/);
+  });
+});
+
+describe('render entry-gate --own', () => {
+  let dir;
+  beforeEach(() => { dir = setup(); });
+  afterEach(() => teardown(dir));
+
+  function specWith(item) {
+    writeManifest(dir, 'pay', { work_type: 'epic', phases: { specification: { items: { auth: item } } } });
+  }
+
+  it('renders the superseded and promoted terminals byte-exactly', () => {
+    specWith({ status: 'superseded', superseded_by: 'core-auth' });
+    assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth', own: '1' }), [
+      '=== DISPLAY: entry blocker (emit verbatim as a code block, then STOP — terminal condition) ===',
+      'Specification Superseded',
+      '',
+      'The specification for "Auth" was consolidated into',
+      '"Core Auth". Work on that specification instead.',
+      '',
+    ].join('\n'));
+    specWith({ status: 'promoted', promoted_to: 'auth-platform' });
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth', own: '1' }),
+      /Specification Promoted\n\n"Auth" was promoted to the cross-cutting work unit\n"auth-platform"\. Continue it from that work unit\./);
+  });
+
+  it('is clear for live statuses and a missing item', () => {
+    for (const item of [{ status: 'in-progress' }, { status: 'completed' }, { status: 'proposed' }]) {
+      specWith(item);
+      assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth', own: '1' }), '');
+    }
+    writeManifest(dir, 'pay', { work_type: 'epic', phases: {} });
+    assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth', own: '1' }), '');
+  });
+
+  it('is loud outside specification', () => {
+    writeManifest(dir, 'pay', { work_type: 'feature', phases: {} });
+    assert.throws(() => renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth', own: '1' }), /--own is only supported for specification/);
+  });
+});
+
+describe('render phase-completed --paths', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'hotfix', { work_type: 'quick-fix', phases: {} });
+  });
+  afterEach(() => teardown(dir));
+
+  it('appends the derived spec and plan paths', () => {
+    assert.strictEqual(renderSurface(dir, 'phase-completed', { dotpath: 'hotfix', phase: 'scoping', paths: '1' }), [
+      '=== DISPLAY: phase completed (emit verbatim as a code block) ===',
+      'Scoping completed for "Hotfix".',
+      '',
+      '  Spec: .workflows/hotfix/specification/hotfix/specification.md',
+      '  Plan: .workflows/hotfix/planning/hotfix/',
+      '',
+    ].join('\n'));
   });
 });
 


### PR DESCRIPTION
Stage 7b of the render-surfaces programme (design log: #489; base: #499). The classification census's class 2: ten templated prose sites folding onto surfaces this stack already built.

## What

**`resume-gate` becomes the resume-menu family** (`--variant`):
- `plan` — planning's resume menu; the "(previously reached phase N, task M)" parenthetical derives from the planning item (omitted when absent). The spec-change summary stays prose — judgment — emitted above the menu.
- `review` — both review resume shapes derived engine-side from `reviewed_tasks`/`completed_tasks`: the coverage menu ("Review covered R of C tasks…") while unreviewed tasks remain, else the all-reviewed/bare menu. The prose @if/count arithmetic is gone.
- `scoping` — the revisit wording.
- `session` — bare work-unit address; the interrupted-discovery-session menu from the `active_session` marker.

**`entry-gate --own`** (specification only) — the topic's OWN terminal statuses at entry: superseded naming its successor, promoted naming its cross-cutting unit. The two validate-phase terminal branches collapse to one branch, one call.

**`phase-completed --paths`** — scoping's conclusion display with the derived spec/plan paths. Deliberate unification: "Scoping complete for" → canonical "Scoping completed for".

**The four continue-* finalise blocks deleted** — `workunit complete` gains `--pipeline` at those four call sites and the transaction's existing banner renders byte-identically ("Bugfix/Cross-Cutting/Feature/Quick-Fix Completed").

## Test plan

- Variant matrix: plan with/without position; review coverage, all-reviewed, and no-tracking shapes; scoping; session found/missing-loud; unknown-variant and triage-with-variant loud.
- entry-gate --own: superseded byte-exact, promoted, live statuses clear, non-specification loud.
- phase-completed --paths byte-exact.
- `npm test` — 1528/1528. Typecheck + conventions lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #490
2. #491
3. #492
4. #493
5. #496
6. #497
7. #498
8. #499
9. **#500** 👈 current
10. #501
<!-- stack:links:end -->