### PR TITLE
test(conventions): templated-fence ratchet — check 13 lands D4 (7c)

### DIFF
--- a/skills/workflow-engine/scripts/domain/projections/transactions.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/transactions.cjs
@@ -166,7 +166,8 @@ function promoteSections(result) {
 function pivotSections(result, { continuationMenu = false } = {}) {
   const name = titlecase(result.work_unit);
   return joined([
-    warningBlock('Knowledge indexing warning', result.warnings, 'The pivot is complete. Indexing can be retried later.'),
+    warningBlock('Knowledge indexing warning', result.warnings,
+      'The pivot is complete. Indexing can be retried later.', 'emit verbatim as a code block'),
     continuationMenu
       ? section(
           'MENU: pivot continuation',

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -40,11 +40,6 @@ function resolveAddress(cwd, dotpath, surface) {
 // parses) and rides as a scalar flag.
 // ---------------------------------------------------------------------------
 
-/**
- * @param {string} cwd
- * @param {{dotpath: string, triage?: string}} args
- * @returns {string} sections
- */
 const RESUME_MENU_INSTRUCTION = "emit verbatim as markdown, then STOP for the user's response";
 
 /**
@@ -84,8 +79,16 @@ function resumeGate(cwd, args) {
   const t = titlecase(topic);
   if (variant === 'plan') {
     const item = itemOf(manifest, 'planning', topic) || {};
-    const pos = isFilled(String(item.phase ?? '')) && isFilled(String(item.task ?? ''))
-      ? ` (previously reached phase ${item.phase}, task ${item.task})` : '';
+    // Partial fill is a real state — define-phases advances `phase` and nulls
+    // `task`; keep the known phase anchor rather than dropping the whole
+    // parenthetical.
+    const hasPhase = isFilled(String(item.phase ?? ''));
+    const hasTask = isFilled(String(item.task ?? ''));
+    const pos = hasPhase
+      ? hasTask
+        ? ` (previously reached phase ${item.phase}, task ${item.task})`
+        : ` (previously reached phase ${item.phase})`
+      : '';
     return section('MENU: resume gate', RESUME_MENU_INSTRUCTION, menu(
       `Found existing plan for **${t}**${pos}.`,
       [
@@ -752,7 +755,7 @@ function entryGate(cwd, { dotpath, own }) {
     if (spec.status === 'promoted') {
       return blocker('Specification Promoted', [
         `"${t}" was promoted to the cross-cutting work unit`,
-        `"${spec.promoted_to}". Continue it from that work unit.`,
+        `"${String(spec.promoted_to || '')}". Continue it from that work unit.`,
       ]);
     }
     return '';
@@ -795,7 +798,7 @@ function entryGate(cwd, { dotpath, own }) {
     if (status === 'promoted') {
       return blocker('Specification Promoted', [
         `"${t}" was promoted to the cross-cutting work unit`,
-        `"${spec.promoted_to}". Cross-cutting specifications inform other plans —`,
+        `"${String(spec.promoted_to || '')}". Cross-cutting specifications inform other plans —`,
         'they are not planned directly.',
       ]);
     }

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -574,7 +574,7 @@ const RATCHET_PINS = {
   'skills/workflow-implementation-process/references/project-skills-discovery.md': 2,
   'skills/workflow-implementation-process/references/task-loop.md': 7,
   'skills/workflow-investigation-entry/references/gather-context.md': 1,
-  'skills/workflow-investigation-process/references/analysis-checkpoints.md': 2,
+  'skills/workflow-investigation-process/references/analysis-checkpoints.md': 3,
   'skills/workflow-investigation-process/references/conclude-investigation.md': 1,
   'skills/workflow-investigation-process/references/findings-signoff.md': 1,
   'skills/workflow-investigation-process/references/fix-exploration.md': 1,
@@ -625,7 +625,7 @@ const RATCHET_PINS = {
   'skills/workflow-specification-process/SKILL.md': 1,
   'skills/workflow-specification-process/references/process-review-findings.md': 4,
   'skills/workflow-specification-process/references/spec-completion.md': 1,
-  'skills/workflow-specification-process/references/spec-construction.md': 2,
+  'skills/workflow-specification-process/references/spec-construction.md': 3,
   'skills/workflow-specification-process/references/spec-review.md': 2,
   'skills/workflow-start/SKILL.md': 1,
   'skills/workflow-start/references/absorb-into-epic.md': 4,
@@ -639,11 +639,14 @@ const RATCHET_PINS = {
 // Count a file's templated menu/display fences: a rendering-instruction line,
 // its following fence, marker/signpost kinds excluded, templated = placeholder
 // syntax or an @if/@foreach directive (the render-surfaces census scanner).
+// The trigger matches ANY instruction form ("as a code block", "as markdown",
+// "as a ` ```diff ` code block", future variants) — an instruction-form miss
+// would silently exempt that family from the ratchet.
 function countTemplatedSites(file) {
   const lines = readLines(file);
   let n = 0;
   for (let i = 0; i < lines.length; i++) {
-    if (!/^> \*Output the next fenced block as (a code block|markdown)/.test(lines[i])) continue;
+    if (!/^> \*Output the next fenced block as /.test(lines[i])) continue;
     let j = i + 1;
     while (j < lines.length && lines[j].trim() === '') j++;
     if (j >= lines.length || !/^\s*```/.test(lines[j])) continue;
@@ -654,7 +657,11 @@ function countTemplatedSites(file) {
     const text = content.join('\n');
     const isMarker = content.length === 1 && /^(── |·· )/.test(content[0]);
     const isSignpost = content.every((l) => l.trim() === '' || l.startsWith('>'));
-    const templated = /\{[a-z_][a-z0-9_.:|()\[\]\- ]*\}/i.test(text) || /@if|@foreach/.test(text);
+    // Templated = any single-line braced token or directive. Deliberately
+    // wider than the template-placeholder grammar: `{2 context lines}` and
+    // `{removed/changed lines}` are placeholders too, and a narrow class
+    // would let them slip the ratchet as "static".
+    const templated = /\{[^{}\n]+\}/.test(text) || /@if|@foreach/.test(text);
     if (!isMarker && !isSignpost && templated) n++;
     i = k;
   }
@@ -1040,5 +1047,12 @@ test('check 13 (templated-fence ratchet) — catches drift both ways, skips stat
         instr + '```\n> Working on {topic} — questions about gaps\n> and contradictions follow.\n```\n'
     );
     assert.strictEqual(checkTemplatedRatchet([chrome], {}).length, 0, 'templated markers and signposts are chrome, out of scope');
+
+    const diffForm = write(
+      dir,
+      'skills/x/e.md',
+      '> *Output the next fenced block as a ` ```diff ` code block:*\n\n```diff\n {context}\n-{removed lines}\n+{new lines}\n```\n'
+    );
+    assert.strictEqual(checkTemplatedRatchet([diffForm], {}).length, 1, 'the diff-form instruction is inside the ratchet');
   });
 });

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -565,7 +565,7 @@ const RATCHET_PINS = {
   'skills/workflow-discussion-entry/references/gather-context-fresh.md': 1,
   'skills/workflow-discussion-entry/references/gather-context.md': 1,
   'skills/workflow-discussion-process/references/conclude-discussion.md': 1,
-  'skills/workflow-discussion-process/references/discussion-session.md': 4,
+  'skills/workflow-discussion-process/references/discussion-session.md': 5,
   'skills/workflow-discussion-process/references/perspective-agents.md': 2,
   'skills/workflow-implementation-entry/references/check-dependencies.md': 4,
   'skills/workflow-implementation-process/SKILL.md': 1,
@@ -600,7 +600,7 @@ const RATCHET_PINS = {
   'skills/workflow-planning-process/references/resolve-dependencies.md': 1,
   'skills/workflow-research-process/references/conclude-research.md': 1,
   'skills/workflow-research-process/references/deep-dive-agent.md': 2,
-  'skills/workflow-research-process/references/epic-session.md': 2,
+  'skills/workflow-research-process/references/epic-session.md': 3,
   'skills/workflow-research-process/references/feature-session.md': 2,
   'skills/workflow-research-process/references/topic-splitting.md': 2,
   'skills/workflow-review-process/references/present-review.md': 7,
@@ -624,7 +624,7 @@ const RATCHET_PINS = {
   'skills/workflow-specification-entry/references/display-single.md': 1,
   'skills/workflow-specification-process/SKILL.md': 1,
   'skills/workflow-specification-process/references/process-review-findings.md': 4,
-  'skills/workflow-specification-process/references/spec-completion.md': 1,
+  'skills/workflow-specification-process/references/spec-completion.md': 2,
   'skills/workflow-specification-process/references/spec-construction.md': 3,
   'skills/workflow-specification-process/references/spec-review.md': 2,
   'skills/workflow-start/SKILL.md': 1,
@@ -646,7 +646,9 @@ function countTemplatedSites(file) {
   const lines = readLines(file);
   let n = 0;
   for (let i = 0; i < lines.length; i++) {
-    if (!/^> \*Output the next fenced block as /.test(lines[i])) continue;
+    // Leading whitespace allowed: instructions nested under list items are
+    // real render sites too (anchoring at column 0 hid three of them).
+    if (!/^\s*> \*Output the next fenced block as /.test(lines[i])) continue;
     let j = i + 1;
     while (j < lines.length && lines[j].trim() === '') j++;
     if (j >= lines.length || !/^\s*```/.test(lines[j])) continue;

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -540,6 +540,158 @@ function checkInertLoadChrome(files) {
 }
 
 // ---------------------------------------------------------------------------
+// Check 13 — Templated-fence ratchet (render-surfaces D4). A templated
+// menu/display fence in prose is a violation: state-derivable output renders
+// from the engine. The corpus's remaining sites — sanctioned judgment,
+// artefact echoes, chrome one-liners, and the not-yet-converted families —
+// are pinned per file below. Any drift fails: a NEW templated fence must
+// become an engine surface (or be pinned deliberately, with the PR saying
+// why); a converted site must shrink its pin, so the ratchet only tightens.
+// Markers and signposts are chrome, out of scope. Static fences (no
+// placeholders, no directives) are always fine.
+// ---------------------------------------------------------------------------
+
+/** @type {Record<string, number>} */
+const RATCHET_PINS = {
+  'skills/workflow-continue-epic/references/epic-display-and-menu.md': 3,
+  'skills/workflow-continue-epic/references/summary-backfill.md': 3,
+  'skills/workflow-discovery/references/confirm-trigger.md': 1,
+  'skills/workflow-discovery/references/map-operations.md': 9,
+  'skills/workflow-discovery/references/name-resolution.md': 2,
+  'skills/workflow-discovery/references/opener-pattern.md': 1,
+  'skills/workflow-discovery/references/session-loop.md': 1,
+  'skills/workflow-discovery/references/show-dismissed.md': 1,
+  'skills/workflow-discussion-entry/references/gather-context-continue.md': 1,
+  'skills/workflow-discussion-entry/references/gather-context-fresh.md': 1,
+  'skills/workflow-discussion-entry/references/gather-context.md': 1,
+  'skills/workflow-discussion-process/references/conclude-discussion.md': 1,
+  'skills/workflow-discussion-process/references/discussion-session.md': 4,
+  'skills/workflow-discussion-process/references/perspective-agents.md': 2,
+  'skills/workflow-implementation-entry/references/check-dependencies.md': 4,
+  'skills/workflow-implementation-process/SKILL.md': 1,
+  'skills/workflow-implementation-process/references/analysis-loop.md': 1,
+  'skills/workflow-implementation-process/references/linter-setup.md': 2,
+  'skills/workflow-implementation-process/references/project-skills-discovery.md': 2,
+  'skills/workflow-implementation-process/references/task-loop.md': 7,
+  'skills/workflow-investigation-entry/references/gather-context.md': 1,
+  'skills/workflow-investigation-process/references/analysis-checkpoints.md': 2,
+  'skills/workflow-investigation-process/references/conclude-investigation.md': 1,
+  'skills/workflow-investigation-process/references/findings-signoff.md': 1,
+  'skills/workflow-investigation-process/references/fix-exploration.md': 1,
+  'skills/workflow-investigation-process/references/fix-validation.md': 2,
+  'skills/workflow-investigation-process/references/investigation-plan.md': 2,
+  'skills/workflow-investigation-process/references/root-cause-validation.md': 2,
+  'skills/workflow-knowledge/references/knowledge-usage.md': 1,
+  'skills/workflow-legacy-research-split/SKILL.md': 3,
+  'skills/workflow-legacy-research-split/references/dialog.md': 7,
+  'skills/workflow-log-bug/SKILL.md': 1,
+  'skills/workflow-log-idea/SKILL.md': 1,
+  'skills/workflow-log-quickfix/SKILL.md': 1,
+  'skills/workflow-planning-entry/references/cross-cutting-context.md': 2,
+  'skills/workflow-planning-process/references/analyze-task-graph.md': 3,
+  'skills/workflow-planning-process/references/author-tasks.md': 6,
+  'skills/workflow-planning-process/references/conclude-plan.md': 1,
+  'skills/workflow-planning-process/references/define-tasks.md': 1,
+  'skills/workflow-planning-process/references/initialize-plan.md': 1,
+  'skills/workflow-planning-process/references/output-formats/linear/authoring.md': 1,
+  'skills/workflow-planning-process/references/plan-construction.md': 3,
+  'skills/workflow-planning-process/references/plan-review.md': 2,
+  'skills/workflow-planning-process/references/process-review-findings.md': 1,
+  'skills/workflow-planning-process/references/resolve-dependencies.md': 1,
+  'skills/workflow-research-process/references/conclude-research.md': 1,
+  'skills/workflow-research-process/references/deep-dive-agent.md': 2,
+  'skills/workflow-research-process/references/epic-session.md': 2,
+  'skills/workflow-research-process/references/feature-session.md': 2,
+  'skills/workflow-research-process/references/topic-splitting.md': 2,
+  'skills/workflow-review-process/references/present-review.md': 7,
+  'skills/workflow-scoping-process/SKILL.md': 2,
+  'skills/workflow-scoping-process/references/complexity-check.md': 1,
+  'skills/workflow-scoping-process/references/gather-context.md': 1,
+  'skills/workflow-scoping-process/references/select-format.md': 1,
+  'skills/workflow-scoping-process/references/write-specification.md': 1,
+  'skills/workflow-shared/references/analysis-approval-gate.md': 4,
+  'skills/workflow-shared/references/background-agent-surfacing.md': 3,
+  'skills/workflow-shared/references/compliance-check.md': 1,
+  'skills/workflow-shared/references/convergence-analysis.md': 1,
+  'skills/workflow-shared/references/drain-triage.md': 1,
+  'skills/workflow-shared/references/final-review-menu.md': 1,
+  'skills/workflow-shared/references/topic-name-validation.md': 1,
+  'skills/workflow-shared/references/triage-landing.md': 2,
+  'skills/workflow-specification-entry/references/confirm-continue.md': 4,
+  'skills/workflow-specification-entry/references/confirm-create.md': 3,
+  'skills/workflow-specification-entry/references/confirm-refine.md': 2,
+  'skills/workflow-specification-entry/references/confirm-unify.md': 2,
+  'skills/workflow-specification-entry/references/display-single.md': 1,
+  'skills/workflow-specification-process/SKILL.md': 1,
+  'skills/workflow-specification-process/references/process-review-findings.md': 4,
+  'skills/workflow-specification-process/references/spec-completion.md': 1,
+  'skills/workflow-specification-process/references/spec-construction.md': 2,
+  'skills/workflow-specification-process/references/spec-review.md': 2,
+  'skills/workflow-start/SKILL.md': 1,
+  'skills/workflow-start/references/absorb-into-epic.md': 4,
+  'skills/workflow-start/references/inbox-archived.md': 5,
+  'skills/workflow-start/references/inbox-working-set.md': 3,
+  'skills/workflow-start/references/knowledge-gate.md': 4,
+  'skills/workflow-start/references/view-completed.md': 1,
+  'skills/workflow-start/references/view-plan.md': 2,
+};
+
+// Count a file's templated menu/display fences: a rendering-instruction line,
+// its following fence, marker/signpost kinds excluded, templated = placeholder
+// syntax or an @if/@foreach directive (the render-surfaces census scanner).
+function countTemplatedSites(file) {
+  const lines = readLines(file);
+  let n = 0;
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^> \*Output the next fenced block as (a code block|markdown)/.test(lines[i])) continue;
+    let j = i + 1;
+    while (j < lines.length && lines[j].trim() === '') j++;
+    if (j >= lines.length || !/^\s*```/.test(lines[j])) continue;
+    const start = j + 1;
+    let k = start;
+    while (k < lines.length && !/^\s*```/.test(lines[k])) k++;
+    const content = lines.slice(start, k);
+    const text = content.join('\n');
+    const isMarker = content.length === 1 && /^(── |·· )/.test(content[0]);
+    const isSignpost = content.every((l) => l.trim() === '' || l.startsWith('>'));
+    const templated = /\{[a-z_][a-z0-9_.:|()\[\]\- ]*\}/i.test(text) || /@if|@foreach/.test(text);
+    if (!isMarker && !isSignpost && templated) n++;
+    i = k;
+  }
+  return n;
+}
+
+function checkTemplatedRatchet(files, pins = RATCHET_PINS) {
+  const out = [];
+  const seen = new Set();
+  for (const file of files) {
+    const key = rel(file);
+    const expected = pins[key] || 0;
+    const actual = countTemplatedSites(file);
+    seen.add(key);
+    if (actual > expected) {
+      out.push({
+        file,
+        line: 1,
+        message: `${actual} templated menu/display fence(s), ${expected} pinned — render new output from the engine (render-surfaces D4); a genuinely judgment-only site is pinned deliberately, with the PR saying why`,
+      });
+    } else if (actual < expected) {
+      out.push({
+        file,
+        line: 1,
+        message: `${actual} templated menu/display fence(s), ${expected} pinned — a site was converted; shrink its pin (the ratchet only tightens)`,
+      });
+    }
+  }
+  for (const key of Object.keys(pins)) {
+    if (!seen.has(key)) {
+      out.push({ file: path.join(REPO, key), line: 1, message: 'pinned file no longer exists — remove its pin' });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Registry + reporting
 // ---------------------------------------------------------------------------
 
@@ -556,6 +708,7 @@ const CHECKS = [
   ['10: reference-file attribution', checkAttribution],
   ['11: load-directive footers (On return)', checkLoadFooters],
   ['12: earned chrome (inert load-only steps)', checkInertLoadChrome],
+  ['13: templated-fence ratchet (render-surfaces D4)', checkTemplatedRatchet],
 ];
 
 function report(violations) {
@@ -854,5 +1007,38 @@ test('check 12 (inert load chrome) — catches unearned markers, skips interacti
 
     const unresolvable = write(dir, 'skills/v/SKILL.md', step('Load **[gone.md](references/gone.md)** and follow its instructions as written.\n'));
     assert.strictEqual(checkInertLoadChrome([unresolvable]).length, 0, 'unresolvable target must be skipped');
+  });
+});
+
+test('check 13 (templated-fence ratchet) — catches drift both ways, skips static/marker/signpost', () => {
+  withTemp((dir) => {
+    const instr = '> *Output the next fenced block as markdown (not a code block):*\n\n';
+    const templatedMenu = instr + '```\n· · · · · · · · · · · ·\nContinue "{topic}"?\n\n- **`y`/`yes`**\n· · · · · · · · · · · ·\n```\n';
+
+    const fresh = write(dir, 'skills/x/a.md', templatedMenu);
+    const v1 = checkTemplatedRatchet([fresh], {});
+    assert.strictEqual(v1.length, 1, 'unpinned templated fence must be caught');
+    assert.match(v1[0].message, /render new output from the engine/);
+
+    assert.strictEqual(checkTemplatedRatchet([fresh], { [rel(fresh)]: 1 }).length, 0, 'pinned site is sanctioned');
+
+    const v2 = checkTemplatedRatchet([fresh], { [rel(fresh)]: 2 });
+    assert.strictEqual(v2.length, 1, 'stale over-pin must be caught');
+    assert.match(v2[0].message, /shrink its pin/);
+
+    const v3 = checkTemplatedRatchet([fresh], { [rel(fresh)]: 1, 'skills/gone/b.md': 1 });
+    assert.strictEqual(v3.length, 1, 'pin for a deleted file must be caught');
+    assert.match(v3[0].message, /no longer exists/);
+
+    const statik = write(dir, 'skills/x/c.md', instr + '```\n· · · · · · · · · · · ·\nProceed?\n- **`y`/`yes`**\n· · · · · · · · · · · ·\n```\n');
+    assert.strictEqual(checkTemplatedRatchet([statik], {}).length, 0, 'static menu is always fine');
+
+    const chrome = write(
+      dir,
+      'skills/x/d.md',
+      '> *Output the next fenced block as a code block:*\n\n```\n── Review (cycle {N}) ──────────────────────────\n```\n\n' +
+        instr + '```\n> Working on {topic} — questions about gaps\n> and contradictions follow.\n```\n'
+    );
+    assert.strictEqual(checkTemplatedRatchet([chrome], {}).length, 0, 'templated markers and signposts are chrome, out of scope');
   });
 });

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -151,6 +151,12 @@ describe('render resume-gate variants', () => {
     assert.ok(!out.includes('previously reached'));
   });
 
+  it('plan keeps the phase anchor when only the phase is known (post-advance interrupt)', () => {
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress', phase: 3, task: null } } } } });
+    const out = renderSurface(dir, 'resume-gate', { dotpath: 'pay.planning.portal', variant: 'plan' });
+    assert.ok(out.includes('Found existing plan for **Portal** (previously reached phase 3).'));
+  });
+
   it('review renders the coverage menu while unreviewed tasks remain', () => {
     writeManifest(dir, 'pay', { phases: {
       implementation: { items: { portal: { status: 'completed', completed_tasks: ['a', 'b', 'c'] } } },
@@ -763,6 +769,7 @@ describe('CLI boundary — engine render via subprocess', () => {
       phases: {
         discussion: { items: { pay: { status: 'in-progress' } } },
         planning: { items: { pay: { status: 'in-progress', task_list_gate_mode: 'auto' } } },
+        specification: { items: { pay: { status: 'superseded', superseded_by: 'core' } } },
       },
     });
   });
@@ -785,6 +792,10 @@ describe('CLI boundary — engine render via subprocess', () => {
     assert.ok(run(['phase-completed', 'pay', '--phase', 'discussion']).includes('Discussion completed for "Pay".'));
     assert.ok(run(['early-completion-gate', 'pay']).includes('Complete without review'));
     assert.ok(run(['epic-all-done-gate', 'pay']).includes('Mark this epic as completed'));
+    assert.ok(run(['entry-gate', 'pay.specification.pay', '--own']).includes('Specification Superseded'),
+      '--own must survive boolean-flag registration through argv');
+    assert.ok(run(['phase-completed', 'pay', '--phase', 'scoping', '--paths']).includes('  Spec: .workflows/pay/specification/pay/specification.md'),
+      '--paths must survive boolean-flag registration through argv');
   });
 
   it('surface errors surface as failJson on stderr with exit 1', () => {
@@ -916,6 +927,13 @@ describe('render entry-gate --own', () => {
   it('is loud outside specification', () => {
     writeManifest(dir, 'pay', { work_type: 'feature', phases: {} });
     assert.throws(() => renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth', own: '1' }), /--own is only supported for specification/);
+  });
+
+  it('a promoted item missing its target degrades to an empty quoted name, never "undefined"', () => {
+    specWith({ status: 'promoted' });
+    const out = renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth', own: '1' });
+    assert.ok(out.includes('"". Continue it from that work unit.'));
+    assert.ok(!out.includes('undefined'));
   });
 });
 

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -263,6 +263,35 @@ describe('engine topic start', () => {
   });
 });
 
+describe('pipeline completion banner matrix', () => {
+  const { workunitLifecycleSections } = require('../../skills/workflow-engine/scripts/domain/projections/transactions.cjs');
+  const banner = (wt, opts) => workunitLifecycleSections('complete', { work_unit: 'pay-x', work_type: wt }, { pipeline: true, ...opts });
+
+  it('every work-type label and both body variants render', () => {
+    assert.ok(banner('feature').includes('Feature Completed\n\n"Pay X" has completed all pipeline phases.'));
+    assert.ok(banner('bugfix').includes('Bugfix Completed\n\n"Pay X" has completed all pipeline phases.'));
+    assert.ok(banner('quick-fix').includes('Quick-Fix Completed\n\n"Pay X" has completed all pipeline phases.'));
+    assert.ok(banner('cross-cutting').includes('Cross-Cutting Completed\n\n"Pay X" has completed all pipeline phases.'));
+    assert.ok(banner('epic').includes('Epic Completed\n\n"Pay X" has completed all topics through review.'));
+    assert.ok(banner('epic', { skippedReview: true }).includes('Epic Completed\n\n"Pay X" completed — review skipped.'));
+  });
+});
+
+describe('topic verbs without section folds', () => {
+  let dir;
+  beforeEach(() => { dir = setupEpicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('start, reopen, and supersede append nothing — only complete/cancel/reactivate fold sections', () => {
+    engine(dir, ['topic', 'start', 'payments', 'research', 'brand-new']);
+    assert.strictEqual(engine.lastSections, '', 'start appends no sections');
+    engine(dir, ['topic', 'reopen', 'payments', 'research', 'fee-model']);
+    assert.strictEqual(engine.lastSections, '', 'reopen appends no sections');
+    engine(dir, ['topic', 'supersede', 'payments', 'research', 'fee-model', '--by', 'auth-flow']);
+    assert.strictEqual(engine.lastSections, '', 'supersede appends no sections — its removal warning stays in the JSON');
+  });
+});
+
 describe('engine topic complete', () => {
   let dir;
   beforeEach(() => { dir = setupEpicFixture(); });


### PR DESCRIPTION
Stage 7c — the closing PR of the render-surfaces stack (design log: #489; base: #500). D3 and D4 decided and landed.

## D4 — the ratchet lint (check 13)

"A templated menu/display fence in prose is a violation" — now mechanical. The census scanner (rendering-instruction line → following fence; markers/signposts excluded as chrome; templated = placeholder syntax or `@if`/`@foreach`) counts per file and compares against `RATCHET_PINS`, the 174 remaining sites across 81 files. Drift fails **both ways**:

- count above pin → "render new output from the engine — a genuinely judgment-only site is pinned deliberately, with the PR saying why"
- count below pin → "a site was converted; shrink its pin (the ratchet only tightens)"
- pin for a deleted file → prune

So no new templated fence can land silently, every conversion shows up as a shrinking diff, and the pin map always mirrors reality. Zero-false-positive doctrine holds: counts, not line numbers, so unrelated edits never trip it.

## D3 — static menus stay prose

Decided (a): the 83 static menus (conclude gates, y/n confirms, mode choices) have none of the failure class the programme kills — no placeholder to misfill, no state to drift from — and their grammar is already under checks 3–5. Converting them would be ~30 catalogue entries of fixed text: surfaces earned by nothing.

## Test plan

- Corpus clean at the 174-site pin map (i.e., the lint passes on the stack as it stands).
- Negative fixtures: unpinned templated menu caught; pinned site sanctioned; stale over-pin caught with the shrink message; deleted-file pin caught; static menu, templated marker, and templated signpost all correctly out of scope.
- `npm test` — 1528/1528 (lint suite 27/27). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #490
2. #491
3. #492
4. #493
5. #496
6. #497
7. #498
8. #499
9. #500
10. **#501** 👈 current
<!-- stack:links:end -->