### PR TITLE
feat(engine): discovery-map add-batch — the harvest persists in one call (D7)

### DIFF
--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -20,26 +20,29 @@ No new topics — this is an edits-only or browse-only session.
 
 #### Otherwise
 
-For each topic on the working list, in synthesised order:
+Write the whole topic set to `.workflows/.cache/{work_unit}/discovery/topics.json` with the Write tool — one entry per topic, in synthesised order:
 
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map add {work_unit} {topic} {research|discussion} --summary "{one-line summary}" --description "{paragraphs}"
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.discovery.{topic} brief_path "discovery/briefs/{topic}.md"
+```json
+[{"name": "{topic}", "routing": "{research|discussion}", "summary": "{one-line summary}", "description": "{paragraphs}", "brief_path": "discovery/briefs/{topic}.md"}]
 ```
 
-Append `--force-dismissed` for a name the synthesis DATA flagged `matches_dismissed=true` — the user's confirmation at the synthesis gate is the re-add decision; the engine clears the dismissed entry as part of the add.
+Set `"force_dismissed": true` on an entry whose name the synthesis DATA flagged `matches_dismissed=true` — the user's confirmation at the synthesis gate is the re-add decision; the engine clears the dismissed entry as part of the add.
 
-Summary and description come from the synthesis — derived from the exploration in topic-synthesis. Single-quote any value containing characters zsh would interpret — backticks, `$`, `[]`, `{}`, `~`. Description may span paragraphs.
+Persist the set in one transaction:
 
-If any command fails, surface the error and stop before the commit so the user can recover.
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs discovery-map add-batch {work_unit} --file .workflows/.cache/{work_unit}/discovery/topics.json
+```
+
+The batch is atomic — a failing entry means nothing was persisted; fix the payload and re-run. Surface any error and stop before the commit so the user can recover.
 
 Notes:
 
 - The topic name is the manifest dict key (the `{topic}` path segment). There is no separate `name` field to set.
 - `routing` is the value confirmed by the user at the synthesis gate.
-- `--source` defaults to `discovery`, marking topics the user surfaced during discovery — distinct from items added later with other provenance (e.g. `research-analysis`, `gap-analysis`). Omit it here.
-- The last map-operation response's `map_total` is `{T}` for the Conclusion line in **C** — no re-read needed.
-- `brief_path` is an opaque field set by a post-create `set` — never an `add` flag. It records where the topic's brief lives; the brief file itself was written at harvest by [brief-synthesis.md](brief-synthesis.md).
+- Batch entries always land with `source: discovery`, marking topics the user surfaced during discovery — distinct from items added later with other provenance (e.g. `research-analysis`, `gap-analysis`).
+- The response's `map_total` is `{T}` for the Conclusion line in **C**, and `added` lists every persisted topic — no re-read needed.
+- `brief_path` records where the topic's brief lives; the brief file itself was written at harvest by [brief-synthesis.md](brief-synthesis.md).
 
 → Proceed to **B. Write Topics Identified**.
 

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -94,6 +94,7 @@ The per-item map operations write the manifest with no git commit (the calling s
 ```bash
 engine discovery-map sequence <work-unit> <topic>=<order> [<topic>=<order> …]   # suggested execution order, scoped commit
 engine discovery-map add <work-unit> <name> <research|discussion> (--summary <text> [--description <text>] | --backfill) [--source <tag>] [--force-dismissed]
+engine discovery-map add-batch <work-unit> --file <topics.json>   # whole topic set, one lock/save — atomic; entries {name, routing, summary, description?, brief_path?, force_dismissed?}; source always `discovery`
 engine discovery-map edit <work-unit> <name> [--summary <text>] [--description <text>]
 engine discovery-map remove <work-unit> <name>       # fresh only; name lands on the dismissed list
 engine discovery-map rename <work-unit> <old> <new>  # fresh only; every field preserved, brief file + brief_path follow

--- a/skills/workflow-engine/scripts/domain/discovery-map.cjs
+++ b/skills/workflow-engine/scripts/domain/discovery-map.cjs
@@ -245,6 +245,88 @@ function addItem(cwd, workUnit, name, { routing, source = 'discovery', summary, 
 }
 
 /**
+ * Add a whole topic set in one transaction — one lock, one load, one save.
+ * The batch form for the harvest (D7: one task, one call): every entry is
+ * validated before anything is applied, so a failing entry means nothing
+ * persisted — never a partial map. Entries may carry `brief_path` (recorded
+ * on the item, replacing the per-topic follow-up set) and `force_dismissed`
+ * (per-entry re-add confirmation). No git commit — the calling flow's commit
+ * covers the batch.
+ * @param {string} cwd project root
+ * @param {string} workUnit
+ * @param {{name: string, routing: string, summary: string, description?: string, brief_path?: string, force_dismissed?: boolean}[]} entries
+ * @returns {{work_unit: string, op: string, added: {name: string, routing: string, lifecycle: string}[], undismissed: string[], map_total: number}}
+ */
+function addItemsBatch(cwd, workUnit, entries) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    throw new Error('add-batch: entries must be a non-empty array of {name, routing, summary, description?, brief_path?, force_dismissed?}');
+  }
+  entries.forEach((e, i) => {
+    const at = `entry ${i + 1}`;
+    if (!e || typeof e !== 'object') throw new Error(`add-batch: ${at} must be an object`);
+    if (!e.name || /[./]/.test(e.name)) {
+      throw new Error(`add-batch: ${at} — "${e.name}" is not a legal topic name (dots and slashes break manifest addressing)`);
+    }
+    if (!e.routing || !VALID_ROUTINGS.includes(e.routing)) {
+      throw new Error(`add-batch: ${at} ("${e.name}") — unknown routing ${JSON.stringify(e.routing ?? null)} (${VALID_ROUTINGS.join('|')})`);
+    }
+    if (typeof e.summary !== 'string' || e.summary.trim() === '') {
+      throw new Error(`add-batch: ${at} ("${e.name}") — "summary" must be a non-empty string`);
+    }
+    for (const opt of ['description', 'brief_path']) {
+      if (e[opt] !== undefined && (typeof e[opt] !== 'string' || e[opt].trim() === '')) {
+        throw new Error(`add-batch: ${at} ("${e.name}") — "${opt}" must be a non-empty string when present`);
+      }
+    }
+  });
+  const names = entries.map((e) => e.name);
+  const dupe = names.find((n, i) => names.indexOf(n) !== i);
+  if (dupe) throw new Error(`add-batch: "${dupe}" appears more than once in the batch`);
+
+  return withWorkUnitLock(cwd, workUnit, () => {
+    const manifest = loadWorkUnitManifest(cwd, workUnit);
+    const phases = ensureContainer(manifest, 'phases', 'phases');
+    const discovery = ensureContainer(phases, 'discovery', 'phases.discovery');
+    ensureContainer(discovery, 'items', 'phases.discovery.items');
+    const dismissed = Array.isArray(discovery.dismissed) ? discovery.dismissed : [];
+
+    // Validate the whole batch against current state before applying any of it.
+    for (const e of entries) {
+      if (discovery.items[e.name]) {
+        throw new Error(`add-batch: "${e.name}" is already on the map — nothing was added; edit it, or pick a different name`);
+      }
+      if (dismissed.includes(e.name) && !e.force_dismissed) {
+        throw new Error(`add-batch: "${e.name}" was previously dismissed from this map — nothing was added; confirm the re-add with the user, then set force_dismissed on the entry`);
+      }
+    }
+
+    /** @type {string[]} */
+    const undismissed = [];
+    for (const e of entries) {
+      if (dismissed.includes(e.name)) undismissed.push(e.name);
+      /** @type {Record<string, unknown>} */
+      const item = { routing: e.routing, source: 'discovery', summary: e.summary };
+      if (e.description !== undefined) item.description = e.description;
+      if (e.brief_path !== undefined) item.brief_path = e.brief_path;
+      discovery.items[e.name] = item;
+    }
+    if (undismissed.length > 0) {
+      discovery.dismissed = dismissed.filter((n) => !undismissed.includes(n));
+    }
+
+    saveWorkUnitManifest(cwd, workUnit, manifest);
+
+    return {
+      work_unit: workUnit,
+      op: 'add-batch',
+      added: entries.map((e) => ({ name: e.name, routing: e.routing, lifecycle: computeTopicLifecycle(manifest, e.name).lifecycle })),
+      undismissed,
+      map_total: Object.keys(discovery.items).length,
+    };
+  });
+}
+
+/**
  * Set `summary` and/or `description` on a map item — at least one required.
  * Allowed at any lifecycle. No git commit.
  * @param {string} cwd project root
@@ -472,4 +554,4 @@ function unhandleItem(cwd, workUnit, name) {
   });
 }
 
-module.exports = { sequenceMap, addItem, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem };
+module.exports = { sequenceMap, addItem, addItemsBatch, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem };

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -22,7 +22,7 @@ const { signpost, box, wrapWithPrefix, renderTree, WIDTH } = require('./kernel/r
 const { commitScopedWithKb } = require('./domain/commit.cjs');
 const { recordSubtopicAdd, recordSubtopicState, SUBTOPIC_STATES } = require('./domain/discussion-map.cjs');
 const { VALID_ROUTINGS } = require('./kernel/manifest-schema.cjs');
-const { sequenceMap, addItem, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem } = require('./domain/discovery-map.cjs');
+const { sequenceMap, addItem, addItemsBatch, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem } = require('./domain/discovery-map.cjs');
 const { startTopic, completeTopic, reopenTopic, supersedeTopic, cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
 const { initTasks, startTask, fixAttempt, completeTask, analysisCycle } = require('./domain/tasks.cjs');
 const taskSections = require('./domain/projections/tasks.cjs');
@@ -126,6 +126,7 @@ Commands:
   discovery-map add <work-unit> <name> <research|discussion>
                 (--summary <text> [--description <text>] | --backfill)
                 [--source <tag>] [--force-dismissed]
+  discovery-map add-batch <work-unit> --file <topics.json>
   discovery-map edit <work-unit> <name> [--summary <text>] [--description <text>]
   discovery-map remove <work-unit> <name>
   discovery-map rename <work-unit> <old> <new>
@@ -347,6 +348,18 @@ function runDiscoveryMap(argv) {
   try {
     const { opts, flags, positional } = parseArgs(rest, ['force-dismissed', 'backfill']);
     const [workUnit] = positional;
+    if (command === 'add-batch') {
+      if (!workUnit) throw new Error('Usage: engine discovery-map add-batch <work-unit> --file <topics.json>');
+      if (!opts.file) throw new Error('discovery-map add-batch: --file <topics.json> is required');
+      let parsed;
+      try {
+        parsed = JSON.parse(fs.readFileSync(path.resolve(cwd, opts.file), 'utf8'));
+      } catch (err) {
+        throw new Error(`discovery-map add-batch: cannot read payload: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      respond(addItemsBatch(cwd, workUnit, parsed));
+      return;
+    }
     if (command === 'sequence') {
       if (!workUnit || positional.length < 2) {
         throw new Error('Usage: engine discovery-map sequence <work-unit> <topic>=<order> [<topic>=<order> …]');

--- a/tests/scripts/test-engine-discovery-map.cjs
+++ b/tests/scripts/test-engine-discovery-map.cjs
@@ -278,6 +278,69 @@ describe('engine CLI: discovery-map operations', () => {
     });
   });
 
+  describe('add-batch', () => {
+    /** Write a payload file and return its relative path. */
+    function payload(dir, entries) {
+      fs.writeFileSync(path.join(dir, 'topics.json'), JSON.stringify(entries));
+      return 'topics.json';
+    }
+
+    it('adds the whole set in one transaction — brief_path recorded, source always discovery, one map_total', () => {
+      const file = payload(dir, [
+        { name: 'menu-management', routing: 'research', summary: 's1', description: 'd1', brief_path: 'discovery/briefs/menu-management.md' },
+        { name: 'pricing', routing: 'discussion', summary: 's2' },
+      ]);
+      const res = runOk(dir, ['add-batch', 'payments', '--file', file]);
+      assert.deepStrictEqual(res, {
+        ok: true, work_unit: 'payments', op: 'add-batch',
+        added: [
+          { name: 'menu-management', routing: 'research', lifecycle: 'fresh' },
+          { name: 'pricing', routing: 'discussion', lifecycle: 'fresh' },
+        ],
+        undismissed: [], map_total: 10,
+      });
+      const m = readManifest(dir);
+      assert.deepStrictEqual(m.phases.discovery.items['menu-management'], {
+        routing: 'research', source: 'discovery', summary: 's1', description: 'd1', brief_path: 'discovery/briefs/menu-management.md',
+      });
+      assert.deepStrictEqual(m.phases.discovery.items['pricing'], {
+        routing: 'discussion', source: 'discovery', summary: 's2',
+      });
+    });
+
+    it('is atomic — a collision on any entry means nothing is added', () => {
+      const before = JSON.stringify(readManifest(dir).phases.discovery.items);
+      const file = payload(dir, [
+        { name: 'brand-new-topic', routing: 'research', summary: 's' },
+        { name: 'fresh-topic', routing: 'research', summary: 'collides with an existing item' },
+      ]);
+      const res = runFail(dir, ['add-batch', 'payments', '--file', file]);
+      assert.match(res.error, /"fresh-topic" is already on the map — nothing was added/);
+      assert.strictEqual(JSON.stringify(readManifest(dir).phases.discovery.items), before, 'no partial writes');
+    });
+
+    it('honours per-entry force_dismissed and refuses a dismissed name without it', () => {
+      runOk(dir, ['add', 'payments', 'doomed', 'research', '--summary', 's']);
+      runOk(dir, ['remove', 'payments', 'doomed']);
+      const refuse = runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'doomed', routing: 'research', summary: 's' }])]);
+      assert.match(refuse.error, /previously dismissed .* set force_dismissed/);
+      const res = runOk(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'doomed', routing: 'research', summary: 's', force_dismissed: true }])]);
+      assert.deepStrictEqual(res.undismissed, ['doomed']);
+      assert.ok(!(readManifest(dir).phases.discovery.dismissed || []).includes('doomed'));
+    });
+
+    it('validates loudly before touching state: routing, names, summaries, in-batch dupes, payload shape', () => {
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [])]).error, /non-empty array/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'a.b', routing: 'research', summary: 's' }])]).error, /not a legal topic name/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'ok', routing: 'nope', summary: 's' }])]).error, /unknown routing/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [{ name: 'ok', routing: 'research', summary: ' ' }])]).error, /"summary" must be a non-empty string/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', payload(dir, [
+        { name: 'twice', routing: 'research', summary: 's' }, { name: 'twice', routing: 'research', summary: 's' },
+      ])]).error, /"twice" appears more than once/);
+      assert.match(runFail(dir, ['add-batch', 'payments', '--file', 'missing.json']).error, /cannot read payload/);
+    });
+  });
+
   describe('edit', () => {
     it('sets summary, echoes it with the lifecycle and map_total', () => {
       const res = runOk(dir, ['edit', 'payments', 'fresh-topic', '--summary', 'new blurb']);


### PR DESCRIPTION
Stack root of the batching programme (design log: #504). The pilot: the fumi-incident site.

## Why

The discovery harvest prescribed 2×N sequential engine calls (per-topic `add` + `brief_path` set). At N=24 the model aliased the engine path into `$E` to cope; zsh does not word-split unquoted parameters, and every call died with exit 127 — plus a sequential run can die halfway, leaving a partial map. Contract C1–C3 from the design log: per-verb batch form, payload by file, validated loudly before any mutation, one lock/write/commit-scope.

## What

- **`discovery-map add-batch <wu> --file <topics.json>`** — entries `{name, routing, summary, description?, brief_path?, force_dismissed?}`. Validation is exhaustive and pre-mutation: per-entry shape with the entry named in the error, in-batch duplicate names, existing-map collisions, dismissed names lacking `force_dismissed`. A failing entry means nothing persisted. One lock, one load, one save; `brief_path` lands with the entry (the old follow-up `manifest set` per topic is gone). The response carries `added[]` (with computed lifecycles), `undismissed[]`, and `map_total` — no re-read.
- **Harvest swap** (`confirm-and-persist.md` A): write the topic set as JSON with the Write tool, one call. The zsh-quoting guidance is deleted because the hazard no longer exists.
- Recovered from the closed #495 tip (`b683fea7`), re-cut to just this change per the census-first re-plan.

## Test plan

- Batch happy path (items, brief_path, dismissed-clearing with force flag, map_total), atomicity (bad entry N leaves entries 1..N-1 unpersisted), per-entry loud validation, duplicate-in-batch, collision and dismissed refusals.
- `npm test` 1547/1547 · typecheck · conventions lint 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#505** 👈 current
2. #506
3. #507
4. #508
5. #509
6. #510
7. #512
8. #513
9. #514
10. #515
11. #516
12. #517
13. #518
14. #519
15. #520
16. #521
17. #522
18. #523
<!-- stack:links:end -->