### PR TITLE
refactor(prose): task-map family folds onto existing batch forms (D7, stage 3)

### DIFF
--- a/skills/workflow-planning-process/references/process-review-findings.md
+++ b/skills/workflow-planning-process/references/process-review-findings.md
@@ -72,10 +72,12 @@ The response carries the finding presentation plus the surface for the current g
 #### If the response carried `DISPLAY: finding auto-approved`
 
 1. Apply the fix to the plan (use **Proposed** content exactly as in tracking file)
-2. Keep `task_map` current — for `add-task`/`add-phase`, record each new internal ID → external ID mapping; for `remove-task`/`remove-phase`, delete each removed ID's entry:
+2. Keep `task_map` current in ONE call for the whole finding — for `add-task`/`add-phase`, batch every new mapping as field pairs in a single `set`; for `remove-task`/`remove-phase` (or a mixed change), write the finding's ops to `.workflows/.cache/{work_unit}/planning/{topic}/task-map-ops.json` with the Write tool and apply once:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{internal_id} {external_id}
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.planning.{topic} task_map.{internal_id}
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{internal_id} {external_id} task_map.{internal_id_2}={external_id_2}
+   ```
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest apply {work_unit} --file .workflows/.cache/{work_unit}/planning/{topic}/task-map-ops.json
    ```
 3. Update the tracking file: set resolution to "Fixed"
 4. Commit the tracking file and plan changes

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -66,25 +66,17 @@ Capture the current git commit hash: `git rev-parse HEAD`
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} planning {topic}
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} format {chosen-format}
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.defaults.plan_format {chosen-format}
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} spec_commit {commit-hash}
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_list_gate_mode auto
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} author_gate_mode auto
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} finding_gate_mode auto
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} review_cycle 0
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} phase 1
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task '~'
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map '{}'
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} external_id {external_id}
-node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} planning {topic}
 ```
 
-Register the task_map entries. Map the phase's internal ID (`{topic}-1`) to its external ID, then each task's internal_id to external_id:
+Then register everything — settings, position, and the whole task map — in ONE batched set (one lock, one write): the fixed fields, the phase mapping (`task_map.{topic}-1` = the phase's external ID), and one `task_map.{internal_id}={external_id}` pair per task:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{topic}-1 {phase_external_id}
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{internal_id} {external_id}
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} format {chosen-format} spec_commit={commit-hash} task_list_gate_mode=auto author_gate_mode=auto finding_gate_mode=auto review_cycle=0 phase=1 task='~' external_id={plan_external_id} task_map.{topic}-1={phase_external_id} task_map.{internal_id}={external_id}
+```
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} planning {topic}
 ```
 
 The plan-level `external_id`, the phase external ID, and per-task external IDs are all determined by the format's authoring instructions (see the Plan Structure, Phase Structure, and Task Storage sections).


### PR DESCRIPTION
Stage 3 of the batching programme (design log: #504; base: #506). The task-map family — and the stage where contract C5 (cheaper-class-first) pays off: **zero new engine code**.

## What

- **scoping `write-tasks`**: the 13-call register fence (11 sequential `manifest set`s to the *same dotpath* + lifecycle) and the separate per-task task_map registration loop collapse to `topic start` + **one multi-field `set`** carrying settings, position, the phase mapping, and every task mapping as field pairs + `topic complete`. This is the site whose shape the portal transcript showed being improvised as a shell for-loop.
- **planning `process-review-findings`**: each finding's task_map upkeep is now one call — multi-field `set` for added mappings, `manifest apply` (stage 2) when removals or mixed changes are involved. Per-finding commit cadence unchanged (each finding is its own approval + durability unit).
- **`author-tasks` G reclassified** in the census: its per-task commit is a *deliberate durability boundary* — a crash loses at most the in-flight task, and the plan resume gate reads the `task` position each iteration advances — and its manifest write was already a single batched set. By design, not a violation; collapsing it would regress recovery. Its dynamic `git add` argv remains stage-5 material.

## Test plan

Prose-only: `npm test` 1552/1552, conventions lint 27/27, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. **#507** 👈 current
4. #508
5. #509
6. #510
7. #512
8. #513
9. #514
10. #515
11. #516
12. #517
13. #518
14. #519
15. #520
16. #521
17. #522
18. #523
<!-- stack:links:end -->