### PR TITLE
refactor(prose): dump/read folds — subtree gets replace per-topic loops (D7, stage 5)

### DIFF
--- a/skills/workflow-discovery/references/brief-synthesis.md
+++ b/skills/workflow-discovery/references/brief-synthesis.md
@@ -38,44 +38,41 @@ Drawn from discovery session(s) {coarse session range}.
 
 This section applies only to restructures **within the session's working list** — the set the harvest shaped and the user confirmed. Committed map items outside the working list are never restructured by a harvest (map edits go through map-operations, which owns its own log entries); their briefs are untouched here. When the confirmed working list restructured a topic that already carried a brief, keep brief files and `brief_path` pointers in step with the confirmed set. Apply whichever operations occurred — split, merge, and drop are independent, and more than one may apply in a single harvest. This section removes only what the restructuring orphaned.
 
-**Split** — a parent topic became two or more children. The children's briefs are written in **A**; remove the parent's:
+Collect the orphaned topics across every operation that occurred — **split** orphans the parent (children's briefs are written in **A**), **merge** orphans each absorbed topic (the merged topic's brief is written in **A**), **drop** orphans the removed topic — then clean them all up in two calls: one `rm -f` naming every orphaned brief file, and one `apply` deleting every `brief_path` pointer:
 
 ```bash
-rm -f .workflows/{work_unit}/discovery/briefs/{parent}.md
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.discovery.{parent} brief_path
+rm -f .workflows/{work_unit}/discovery/briefs/{parent}.md .workflows/{work_unit}/discovery/briefs/{absorbed}.md
 ```
 
-**Merge** — two or more topics were absorbed into one merged topic. The merged topic's brief is written in **A**; for each absorbed topic, remove its brief:
+```json
+[{"op": "delete", "path": "{work_unit}.discovery.{parent}", "field": "brief_path"}]
+```
 
 ```bash
-rm -f .workflows/{work_unit}/discovery/briefs/{absorbed}.md
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.discovery.{absorbed} brief_path
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest apply {work_unit} --file .workflows/.cache/{work_unit}/discovery/brief-cleanup-ops.json
 ```
 
-**Drop** — a topic was removed from the set:
-
-```bash
-rm -f .workflows/{work_unit}/discovery/briefs/{topic}.md
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.discovery.{topic} brief_path
-```
-
-New topics with no prior brief need no cleanup. `delete` fails loudly when the field is absent — run it only for a topic that actually carried a `brief_path` (a committed map topic with a prior brief); skip it otherwise. The `rm -f` is safe to run unconditionally.
+New topics with no prior brief need no cleanup. A `delete` op fails the whole batch when the field is absent — include only topics that actually carried a `brief_path` (committed map topics with a prior brief); the `rm -f` paths are safe to include unconditionally. Write the ops file with the Write tool.
 
 → Proceed to **C. Propagation**.
 
 ## C. Propagation
 
-Flag downstream work, never overwrite it. For each brief **regenerated** in **A** (the topic already had a brief before this harvest), check whether downstream research or discussion work exists for that topic:
+Flag downstream work, never overwrite it. Read both downstream phases once — every topic's items in two calls, however many briefs regenerated:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{topic}
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion
 ```
 
-A topic routes to one of the two. If either returns a non-empty item, flag it to reconcile:
+For each brief **regenerated** in **A** (the topic already had a brief before this harvest), check the subtrees for that topic's item — a topic routes to one of the two. Collect a flag op for every hit, then persist them in one call (skip when none; write the ops file with the Write tool):
+
+```json
+[{"op": "set", "path": "{work_unit}.{research|discussion}.{topic}", "fields": {"reconcile_needed": true}}]
+```
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.{research|discussion}.{topic} reconcile_needed true
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest apply {work_unit} --file .workflows/.cache/{work_unit}/discovery/reconcile-ops.json
 ```
 
 This is a signal, not a rewrite — it never touches the downstream artifact's content. Soft can prompt re-examination; it can never overwrite hard. The downstream phase surfaces the flag when it next runs. First-write briefs have no prior downstream work — skip them.

--- a/skills/workflow-review-process/references/read-plans.md
+++ b/skills/workflow-review-process/references/read-plans.md
@@ -6,18 +6,17 @@
 
 Read all plan(s) provided for the selected scope.
 
+Read every plan's settings in one call — the planning subtree carries each topic's `format` and `external_id`:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning
+```
+
 For each plan:
 1. Read the plan — understand phases, tasks, and acceptance criteria
 2. Read the linked specification — load design context
-3. Read the plan's `format` via `engine manifest`:
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format
-   ```
-4. Read the plan's `external_id` via `engine manifest`:
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
-   ```
-5. Load the format's reading adapter from `../../workflow-planning-process/references/output-formats/{format}/reading.md` — this tells you how to locate and read individual task files
-6. Extract all tasks across all phases
+3. Take the plan's `format` and `external_id` from the subtree read above
+4. Load the format's reading adapter from `../../workflow-planning-process/references/output-formats/{format}/reading.md` — this tells you how to locate and read individual task files
+5. Extract all tasks across all phases
 
 → Return to caller.

--- a/skills/workflow-shared/references/sequence-discovery-map.md
+++ b/skills/workflow-shared/references/sequence-discovery-map.md
@@ -34,11 +34,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} 
 
 Take the live topic names from the caller's most recent discovery output — every `discovery_map` row whose tier is neither `⊘` (cancelled) nor `⊙` (handled). Handled topics are non-actionable — a research umbrella that fanned out — so they get no execution order, the same as cancelled.
 
-For richer context, read each live topic's `summary` and `description` from the manifest:
+For richer context, read the whole discovery subtree once — every topic's `summary` and `description` arrive in one call:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discovery.{topic} summary
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discovery.{topic} description
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discovery
 ```
 
 → Proceed to **C. Assign and Write Order**.


### PR DESCRIPTION
Stage 5 of the batching programme (design log: #504; base: #508). The dump/read-fold class — and like stage 3, C5 keeps it at **zero engine code**: `manifest get <wu>.<phase>` has always returned the whole subtree; the prose just never leaned on it.

## What

- **sequence-discovery-map** — the 2×N per-topic `summary`/`description` gets become one `{wu}.discovery` subtree read (the dump's rows deliberately stay lean — `description_present` only — so the subtree get is the right channel for the full text).
- **read-plans** (review) — per-plan `format`/`external_id` gets become one `{wu}.planning` subtree read before the loop; the per-plan loop keeps only the judgment work.
- **brief-synthesis** — both halves:
  - *Lifecycle*: split/merge/drop cleanup collects every orphaned brief, then two calls total — one `rm -f` naming all files, one `apply` deleting all `brief_path` pointers (the loud-on-absent guard preserved: only topics that carried the pointer enter the payload).
  - *Propagation*: reads research+discussion subtrees once (2 calls for any N), collects `reconcile_needed` flags, lands them in one `apply`.

## Test plan

Prose-only: `npm test` 1556/1556, conventions lint 27/27, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. #507
4. #508
5. **#509** 👈 current
6. #510
7. #512
8. #513
9. #514
10. #515
11. #516
12. #517
13. #518
14. #519
15. #520
16. #521
17. #522
18. #523
<!-- stack:links:end -->