### PR TITLE
feat(engine): commit --plan — plan storage stages from recorded state (D7, stage 6)

### DIFF
--- a/.claude/skills/create-output-format/references/contract.md
+++ b/.claude/skills/create-output-format/references/contract.md
@@ -40,6 +40,7 @@ Must include:
 
 - **Plan Structure** — how to create the plan-level entity in the format (project, directory, top-level task, etc.) and what external identifier it produces. Every format must declare this, even when the identifier equals the internal topic name.
 - **Phase Structure** — how to create phase-level entities (parent tasks, parent issues, directories, etc.) and what external identifier each produces. Every format must declare this, even when the identifier equals the internal phase ID.
+- **Storage Pathspecs** — the git pathspecs the format writes outside the work unit, as a JSON array (`[]` when everything lives inside the work unit or off-disk). Recorded as `storage_paths` at plan init; `engine commit --plan` stages them.
 - **Task Storage** — how to create a task (file path, API call, etc.) with a complete example showing the full task template
 - **Task Properties** — properties set during authoring:
   - **Status** — available values and their meanings

--- a/.claude/skills/create-output-format/references/scaffolding/authoring.md
+++ b/.claude/skills/create-output-format/references/scaffolding/authoring.md
@@ -3,6 +3,10 @@
 <!-- Instructions for creating plan structure and individual tasks -->
 <!-- This file is used by the planning process and task authoring agent — do NOT include priority or dependency info -->
 
+## Storage Pathspecs
+
+`[…]` — {the pathspecs this format writes outside the work unit; `[]` when none}
+
 ## Plan Structure
 
 <!-- How to create the plan-level entity and what external identifier it produces -->

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -157,10 +157,10 @@ engine inbox delete <path> [<path> …]    # git rm archived items
 engine cache stamp <work-unit> (research-analysis|gap-analysis)
 ```
 
-**`commit`** — the scoped commit helper: `git add -- .workflows/{wu}` (`.workflows/.inbox` with `--inbox`, or the whole `.workflows` tree with `--workflows` — migrations touch many work units plus `.workflows/.state`) plus commit. Every engine-made commit — this helper and every transaction — also stages `.workflows/.knowledge` when it exists (exists-guarded, `domain/commit.cjs`): transactions dirty the store as a side effect of their knowledge sync, and that dirt belongs with the write that produced it. A clean tree is fine: `{"ok": true, "committed": null, "note": "nothing to commit"}`, exit 0.
+**`commit`** — the scoped commit helper: `git add -- .workflows/{wu}` (`.workflows/.inbox` with `--inbox`, or the whole `.workflows` tree with `--workflows` — migrations touch many work units plus `.workflows/.state`) plus commit. Every engine-made commit — this helper and every transaction — also stages `.workflows/.knowledge` when it exists (exists-guarded, `domain/commit.cjs`): transactions dirty the store as a side effect of their knowledge sync, and that dirt belongs with the write that produced it. A clean tree is fine: `{"ok": true, "committed": null, "note": "nothing to commit"}`, exit 0. `--plan <topic>` widens the scope with the plan's declared storage: it stages `.workflows/manifest.json` and every `storage_paths` entry recorded on the planning item at plan init (the format's authoring doc declares them; entries are validated relative-only and skipped when neither on disk nor tracked, while deleted-but-tracked paths still stage their deletions). A planning item without `storage_paths` (pre-upgrade plan) fails loudly with the one-line repair. Code never rides a `--plan` commit — implementation's code commits stay with the session and raw git.
 
 ```bash
-engine commit <work-unit> -m "<message>"
+engine commit <work-unit> -m "<message>" [--plan <topic>]
 engine commit --inbox -m "<message>"
 engine commit --workflows -m "<message>"
 ```

--- a/skills/workflow-engine/scripts/domain/fields.cjs
+++ b/skills/workflow-engine/scripts/domain/fields.cjs
@@ -237,6 +237,27 @@ function validateSet(segments, value) {
       validatePhaseStatus(phase, value);
       return;
     }
+
+    // phases.<phase>.items.<item>.storage_paths — the format's declared
+    // pathspecs, staged by `engine commit --plan`. Guarded at write time so a
+    // bad entry can never reach a commit: relative, no traversal, never the
+    // whole tree.
+    if (segments.length === 5 && segments[2] === 'items' && segments[4] === 'storage_paths') {
+      validateStoragePaths(value);
+      return;
+    }
+  }
+}
+
+/** @param {*} value */
+function validateStoragePaths(value) {
+  if (!Array.isArray(value) || value.some((p) => typeof p !== 'string')) {
+    fail(`Invalid storage_paths ${JSON.stringify(value)}. Must be an array of relative pathspec strings (may be empty)`);
+  }
+  for (const p of value) {
+    if (p === '' || p === '.' || p.startsWith('/') || p.split('/').includes('..')) {
+      fail(`Invalid storage_paths entry ${JSON.stringify(p)}: pathspecs are relative, never ".", "..", or absolute`);
+    }
   }
 }
 

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -153,7 +153,7 @@ Commands:
   inbox restore <path> [<path> …]
   inbox delete <path> [<path> …]
   cache stamp <work-unit> (research-analysis|gap-analysis)
-  commit <work-unit> -m <message>
+  commit <work-unit> -m <message> [--plan <topic>]
   commit --inbox -m <message>
   commit --workflows -m <message>
   render resume-gate <wu.phase.topic> [--triage N] [--variant plan|review|scoping|session]  (session: bare <wu>)
@@ -657,22 +657,24 @@ function runCommit(argv) {
   try {
     /** @type {string|null} */ let workUnit = null;
     /** @type {string|null} */ let message = null;
+    /** @type {string|null} */ let plan = null;
     let inbox = false;
     let workflows = false;
     for (let i = 0; i < argv.length; i++) {
       const a = argv[i];
       if (a === '-m' || a === '--message') message = argv[++i];
+      else if (a === '--plan') plan = argv[++i];
       else if (a === '--inbox') inbox = true;
       else if (a === '--workflows') workflows = true;
       else if (workUnit === null) workUnit = a;
       else throw new Error(`unexpected argument "${a}"`);
     }
     const scopeCount = [inbox, workflows, workUnit !== null].filter(Boolean).length;
-    if (!message || scopeCount !== 1) {
-      throw new Error('Usage: engine commit <work-unit> -m <message> | engine commit --inbox -m <message> | engine commit --workflows -m <message>');
+    if (!message || scopeCount !== 1 || (plan !== null && workUnit === null) || plan === '') {
+      throw new Error('Usage: engine commit <work-unit> -m <message> [--plan <topic>] | engine commit --inbox -m <message> | engine commit --workflows -m <message>');
     }
     const cwd = process.cwd();
-    let scope;
+    /** @type {string|string[]} */ let scope;
     if (workflows) {
       scope = '.workflows';
     } else if (inbox) {
@@ -684,6 +686,41 @@ function runCommit(argv) {
         throw new Error(`no work unit directory: .workflows/${wu}`);
       }
       scope = `.workflows/${wu}`;
+      if (plan !== null) {
+        // --plan: the plan's declared storage pathspecs (recorded at plan
+        // init from the format's authoring doc) plus the project manifest
+        // (plan init writes project defaults). A pathspec that neither exists
+        // on disk nor has index entries is skipped — `git add` would refuse
+        // it — while a deleted-but-tracked path still stages its deletions
+        // (the restart-cleanup commits depend on that).
+        const manifestFile = path.join(cwd, '.workflows', wu, 'manifest.json');
+        /** @type {any} */ let planItem;
+        try {
+          planItem = JSON.parse(fs.readFileSync(manifestFile, 'utf8')).phases?.planning?.items?.[plan];
+        } catch {
+          throw new Error(`commit --plan: cannot read .workflows/${wu}/manifest.json`);
+        }
+        if (!planItem) throw new Error(`commit --plan: no planning item "${plan}" in "${wu}"`);
+        const declared = planItem.storage_paths;
+        if (!Array.isArray(declared) || declared.some((p) => typeof p !== 'string')) {
+          throw new Error(`commit --plan: planning item "${plan}" has no storage_paths — a pre-upgrade plan; record the format's declared pathspecs once: engine manifest set ${wu}.planning.${plan} storage_paths '[…]' (the format's authoring.md names them; '[]' when it stores inside the work unit)`);
+        }
+        for (const p of declared) {
+          if (p === '' || p === '.' || p.startsWith('/') || p.split('/').includes('..')) {
+            throw new Error(`commit --plan: illegal storage_paths entry ${JSON.stringify(p)} — pathspecs are relative, never ".", "..", or absolute`);
+          }
+        }
+        const { execFileSync } = require('child_process');
+        const stageable = ['.workflows/manifest.json', ...declared].filter((p) => {
+          if (fs.existsSync(path.join(cwd, p))) return true;
+          try {
+            return execFileSync('git', ['ls-files', '--', p], { cwd, encoding: 'utf8' }).trim() !== '';
+          } catch {
+            return false;
+          }
+        });
+        scope = [scope, ...stageable];
+      }
     }
     const committed = commitScopedWithKb(cwd, scope, message);
     if (committed === null) respond({ committed: null, note: 'nothing to commit' });

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -261,7 +261,7 @@ impl({work_unit}): analysis cycle {N} — tasks skipped
 
 > **CHECKPOINT**: Do not proceed until the task writer has returned.
 
-Commit all analysis and plan changes:
+Commit all analysis and plan changes with raw git — stage the analysis outputs, the plan's `storage_paths` (recorded on the planning item), and the work unit, then commit:
 
 ```
 impl({work_unit}): add analysis phase {N} ({K} tasks)

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -329,7 +329,7 @@ The response also carries the `MENU: blocked tasks` section that **A. Retrieve N
 
 **Internal ID convention**: The internal ID used with the engine and in commit messages MUST use the format `{topic}-{phase_id}-{task_id}`. If only the format adapter's external ID is at hand, pass `--external {external_id}` in place of `{internal_id}` — the engine resolves it through the plan's task map and reports the internal id in its response.
 
-**Commit all changes** with raw git — stage the task's code and tests, the plan format's tracking state, and the work unit's manifest, then commit:
+**Commit all changes** with raw git — stage the task's code and tests, the plan's `storage_paths` (recorded on the planning item), and the work unit's manifest, then commit:
 
 ```
 impl({work_unit}): T{internal_id} — {brief description}

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -138,9 +138,9 @@ If spec-change-detection reported changes, carry them into the walkthrough: reco
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.planning items.{topic}
    ```
-6. Commit with raw git — the format's cleanup may remove task storage outside the work unit, so the scoped helper cannot cover it. Stage the work unit and every path the cleanup touched, then commit:
+6. Commit with raw git — the planning item was just deleted, so `--plan` has nothing to read; stage the work unit and the plan's `storage_paths` (from the manifest subtree read during resume detection), then commit:
    ```bash
-   git add -- .workflows/{work_unit} {paths the format cleanup touched}
+   git add -- .workflows/{work_unit} {storage_paths}
    git commit -m "planning({work_unit}): restart planning"
    ```
 

--- a/skills/workflow-planning-process/references/analyze-task-graph.md
+++ b/skills/workflow-planning-process/references/analyze-task-graph.md
@@ -79,11 +79,10 @@ The agent will clear all existing graph data and re-analyze from scratch.
 
 **If `yes`:**
 
-Commit with raw git — the graph data lands in the format's task storage, which may live outside the work unit, so the scoped helper cannot cover it:
+Commit — `--plan` stages the work unit and the plan's declared storage in one scoped call:
 
 ```bash
-git add -- .workflows/{work_unit} {format task storage paths}
-git commit -m "planning({work_unit}): analyze task dependencies and priorities"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): analyze task dependencies and priorities" --plan {topic}
 ```
 
 → Return to caller.
@@ -151,11 +150,10 @@ The agent will clear all existing graph data and re-analyze from scratch.
 
 **If `yes`:**
 
-Commit with raw git — the graph data lands in the format's task storage, which may live outside the work unit, so the scoped helper cannot cover it:
+Commit — `--plan` stages the work unit and the plan's declared storage in one scoped call:
 
 ```bash
-git add -- .workflows/{work_unit} {format task storage paths}
-git commit -m "planning({work_unit}): analyze task dependencies and priorities"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): analyze task dependencies and priorities" --plan {topic}
 ```
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -219,10 +219,9 @@ For each approved task in the task detail file, in order:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task_map.{internal_id}={external_id} task={next_task_id} task_map.{phase_internal_id}={phase_external_id} external_id={plan_external_id}
    ```
-4. Commit with raw git — the format's task storage may live outside the work unit, so the scoped helper cannot cover it. Stage the format's storage and the work unit, then commit:
+4. Commit — `--plan` stages the work unit, the project manifest, and the plan's declared storage in one scoped call:
    ```bash
-   git add -- .workflows/{work_unit} {format task storage paths}
-   git commit -m "planning({work_unit}): author task {internal_id} ({task name})"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): author task {internal_id} ({task name})" --plan {topic}
    ```
 
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-planning-process/references/initialize-plan.md
+++ b/skills/workflow-planning-process/references/initialize-plan.md
@@ -57,15 +57,15 @@ Project default format is **{format}**. Use the same format?
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} planning {topic}
    ```
-4. Set the planning metadata — every same-path field in one batched write, then the project default (a different path, so its own call):
+4. Set the planning metadata — every same-path field in one batched write, then the project default (a different path, so its own call). `storage_paths` is the format's declared pathspec array from its **[authoring.md](output-formats/{chosen-format}/authoring.md)** Storage Pathspecs section (`'[]'` when the format stores inside the work unit or off-disk):
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} format={chosen-format} spec_commit={commit-hash} task_list_gate_mode=gated author_gate_mode=gated finding_gate_mode=gated review_cycle=0 phase=1 task='~' task_map='{}'
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} format={chosen-format} spec_commit={commit-hash} task_list_gate_mode=gated author_gate_mode=gated finding_gate_mode=gated review_cycle=0 phase=1 task='~' task_map='{}' storage_paths='{format storage pathspecs}'
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.defaults.plan_format {chosen-format}
    ```
 
-5. Commit — the project default lands in `.workflows/manifest.json`, outside the work unit, so use the whole-tree scope:
+5. Commit — `--plan` stages the work unit, the project manifest, and the plan's declared storage in one scoped call:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "planning({work_unit}): initialize plan"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): initialize plan" --plan {topic}
    ```
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/output-formats/linear/authoring.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/authoring.md
@@ -18,6 +18,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map
 ```
 
+## Storage Pathspecs
+
+`[]` — tasks live in Linear; nothing lands on disk.
+
 ## Plan Structure
 
 Create a Linear project — this is the plan-level entity:

--- a/skills/workflow-planning-process/references/output-formats/local-markdown/authoring.md
+++ b/skills/workflow-planning-process/references/output-formats/local-markdown/authoring.md
@@ -1,5 +1,9 @@
 # Local Markdown: Authoring
 
+## Storage Pathspecs
+
+`[]` — every artifact lives inside the work unit; the scoped commit covers it.
+
 ## Plan Structure
 
 The plan is represented by the `tasks/` directory at `.workflows/{work_unit}/planning/{topic}/tasks/`. Create this directory when authoring the first task. The external identifier is the topic name (`{topic}`).

--- a/skills/workflow-planning-process/references/output-formats/tick/authoring.md
+++ b/skills/workflow-planning-process/references/output-formats/tick/authoring.md
@@ -18,6 +18,10 @@ You should never do the following:
 
 If a description contains double quotes, escape them with `\"`. That's it.
 
+## Storage Pathspecs
+
+`[".tick/"]` — the task store lives at the project root, outside the work unit. Recorded as `storage_paths` at plan init; `engine commit --plan` stages it.
+
 ## Plan Structure
 
 Create the topic task — this is the plan-level entity in tick. Always set `--refs` to store the workflow's internal ID.

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -276,11 +276,10 @@ Filter staging file to tasks with `status: approved`.
 
 > **CHECKPOINT**: Do not proceed until the task writer has returned.
 
-Commit all changes (staging file, plan tasks, task_map updates) with raw git — the format's task storage may live outside the work unit, so the scoped helper cannot cover it. Stage the format's storage and the work unit, then commit:
+Commit all changes (staging file, plan tasks, task_map updates) — `--plan` stages the work unit and the plan's declared storage in one scoped call:
 
 ```bash
-git add -- .workflows/{work_unit} {format task storage paths}
-git commit -m "review({work_unit}): add review remediation ({K} tasks)"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): add review remediation ({K} tasks)" --plan {topic}
 ```
 
 → On return, proceed to **G. Re-open Implementation**.

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -172,20 +172,18 @@ Apply the requested edits — the spec and `planning.md` directly, task file con
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} scoping {topic}
    ```
-3. Commit with raw git — the format's task storage may live outside the work unit, so the scoped helper cannot cover it:
+3. Commit — `--plan` stages the work unit, the project manifest, and the plan's declared storage in one scoped call (the knowledge store rides along automatically):
    ```bash
-   git add -- .workflows/{work_unit} .workflows/.knowledge {format task storage paths touched}
-   git commit -m "scoping({work_unit}): adjust specification and plan"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "scoping({work_unit}): adjust specification and plan" --plan {topic}
    ```
 
 → Proceed to **Step 8**.
 
 #### If `restart`
 
-1. Read the `format` and the plan's `external_id` from the manifest:
+1. Read the planning item once — `format`, `external_id`, and `storage_paths` all ride the subtree:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} format
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} external_id
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic}
    ```
 2. Load the format's **[authoring.md](../workflow-planning-process/references/output-formats/{format}/authoring.md)**
 3. Follow the authoring file's cleanup instructions to remove authored tasks for this topic — the cleanup targets the entity identified by `external_id`
@@ -199,9 +197,9 @@ Apply the requested edits — the spec and `planning.md` directly, task file con
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.specification items.{topic}
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.planning items.{topic}
    ```
-7. Commit with raw git — the format's cleanup may remove task storage outside the work unit, so the scoped helper cannot cover it. Stage the work unit, the knowledge store, and every path the cleanup touched, then commit:
+7. Commit with raw git — the planning item was just deleted, so `--plan` has nothing to read; stage the work unit, the knowledge store, and the `storage_paths` read in step 1, then commit:
    ```bash
-   git add -- .workflows/{work_unit} .workflows/.knowledge {paths the format cleanup touched}
+   git add -- .workflows/{work_unit} .workflows/.knowledge {storage_paths}
    git commit -m "scoping({work_unit}): restart scoping"
    ```
 

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -72,7 +72,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.defa
 Then register everything — settings, position, and the whole task map — in ONE batched set (one lock, one write): the fixed fields, the phase mapping (`task_map.{topic}-1` = the phase's external ID), and one `task_map.{internal_id}={external_id}` pair per task:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} format={chosen-format} spec_commit={commit-hash} task_list_gate_mode=auto author_gate_mode=auto finding_gate_mode=auto review_cycle=0 phase=1 task='~' external_id={plan_external_id} task_map.{topic}-1={phase_external_id} task_map.{internal_id}={external_id}
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} format={chosen-format} spec_commit={commit-hash} task_list_gate_mode=auto author_gate_mode=auto finding_gate_mode=auto review_cycle=0 phase=1 task='~' external_id={plan_external_id} task_map.{topic}-1={phase_external_id} task_map.{internal_id}={external_id} storage_paths='{format storage pathspecs}'
 ```
 
 ```bash
@@ -88,11 +88,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} s
 node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} scoping {topic}
 ```
 
-Commit all scoping artifacts with raw git — the project default lands in `.workflows/manifest.json` and the format's task storage may live outside the work unit, so the scoped helper cannot cover them:
+Commit all scoping artifacts — `--plan` stages the work unit, the project manifest, and the plan's declared storage in one scoped call:
 
 ```bash
-git add -- .workflows/manifest.json .workflows/{work_unit} {format task storage paths}
-git commit -m "scoping({work_unit}): specification and plan"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "scoping({work_unit}): specification and plan" --plan {topic}
 ```
 
 → Return to caller.

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -1010,6 +1010,55 @@ describe('engine commit', () => {
     assert.strictEqual(lastMessage(dir), 'workflow(inbox): capture y');
   });
 
+  it('--plan stages the recorded storage paths and the project manifest alongside the work unit', () => {
+    const m = JSON.parse(fs.readFileSync(path.join(dir, '.workflows/payments/manifest.json'), 'utf8'));
+    m.phases = { ...(m.phases || {}), planning: { items: { auth: { status: 'in-progress', storage_paths: ['.tick/'] } } } };
+    fs.writeFileSync(path.join(dir, '.workflows/payments/manifest.json'), JSON.stringify(m, null, 2) + '\n');
+    writeFile(dir, '.tick/tasks-auth.jsonl', '{"id":"auth-1-1"}\n');
+    writeFile(dir, '.workflows/manifest.json', JSON.stringify({ work_units: { payments: { work_type: 'epic' } }, defaults: { plan_format: 'x' } }) + '\n');
+    writeFile(dir, 'unrelated.txt', 'outside the scope\n');
+
+    const res = engine(dir, ['commit', 'payments', '-m', 'planning(payments): author task auth-1-1', '--plan', 'auth']);
+    assert.strictEqual(res.committed, shortHead(dir));
+    const staged = git(dir, ['show', '--name-only', 'HEAD']);
+    assert.match(staged, /\.tick\/tasks-auth\.jsonl/);
+    assert.match(staged, /\.workflows\/manifest\.json/);
+    assert.match(git(dir, ['status', '--porcelain']), /\?\? unrelated\.txt/, 'code never rides a --plan commit');
+  });
+
+  it('--plan with empty storage_paths is the plain scoped commit plus project manifest', () => {
+    const m = JSON.parse(fs.readFileSync(path.join(dir, '.workflows/payments/manifest.json'), 'utf8'));
+    m.phases = { ...(m.phases || {}), planning: { items: { auth: { status: 'in-progress', storage_paths: [] } } } };
+    fs.writeFileSync(path.join(dir, '.workflows/payments/manifest.json'), JSON.stringify(m, null, 2) + '\n');
+    const res = engine(dir, ['commit', 'payments', '-m', 'planning(payments): initialize plan', '--plan', 'auth']);
+    assert.strictEqual(res.committed, shortHead(dir));
+  });
+
+  it('--plan stages tracked deletions of a storage path removed from disk (restart cleanup)', () => {
+    const m = JSON.parse(fs.readFileSync(path.join(dir, '.workflows/payments/manifest.json'), 'utf8'));
+    m.phases = { ...(m.phases || {}), planning: { items: { auth: { status: 'in-progress', storage_paths: ['.tick/'] } } } };
+    fs.writeFileSync(path.join(dir, '.workflows/payments/manifest.json'), JSON.stringify(m, null, 2) + '\n');
+    writeFile(dir, '.tick/tasks-auth.jsonl', '{"id":"auth-1-1"}\n');
+    commitAll(dir, 'seed tick storage');
+    fs.rmSync(path.join(dir, '.tick'), { recursive: true, force: true });
+
+    const res = engine(dir, ['commit', 'payments', '-m', 'planning(payments): restart plan', '--plan', 'auth']);
+    assert.strictEqual(res.committed, shortHead(dir));
+    assert.match(git(dir, ['show', '--name-only', 'HEAD']), /\.tick\/tasks-auth\.jsonl/, 'deletion staged');
+    assert.strictEqual(git(dir, ['status', '--porcelain']).trim(), '', 'no stray dirt');
+  });
+
+  it('--plan is loud on a missing planning item, missing storage_paths, and illegal entries', () => {
+    assert.match(engineFails(dir, ['commit', 'payments', '-m', 'x', '--plan', 'ghost']).error, /no planning item "ghost"/);
+    const m = JSON.parse(fs.readFileSync(path.join(dir, '.workflows/payments/manifest.json'), 'utf8'));
+    m.phases = { ...(m.phases || {}), planning: { items: { auth: { status: 'in-progress' } } } };
+    fs.writeFileSync(path.join(dir, '.workflows/payments/manifest.json'), JSON.stringify(m, null, 2) + '\n');
+    assert.match(engineFails(dir, ['commit', 'payments', '-m', 'x', '--plan', 'auth']).error, /has no storage_paths — a pre-upgrade plan/);
+    m.phases.planning.items.auth.storage_paths = ['../evil'];
+    fs.writeFileSync(path.join(dir, '.workflows/payments/manifest.json'), JSON.stringify(m, null, 2) + '\n');
+    assert.match(engineFails(dir, ['commit', 'payments', '-m', 'x', '--plan', 'auth']).error, /illegal storage_paths entry/);
+  });
+
   it('rejects a missing message, missing scope, and bad work unit names', () => {
     assert.match(engineFails(dir, ['commit', 'payments']).error, /Usage: engine commit/);
     assert.match(engineFails(dir, ['commit', '-m', 'msg']).error, /Usage: engine commit/);


### PR DESCRIPTION
Stage 6 of the batching programme (design log: #504; base: #509) — the shell-construction cluster, per the plan agreed with Lee: storage knowledge recorded once in the manifest, derived by the engine forever.

## What

- **Formats declare**: each `authoring.md` gains a Storage Pathspecs section (tick: `[".tick/"]`; local-markdown/linear: `[]`). Format names stay inside format directories — the never-list rule holds; the engine carries zero format knowledge. The create-output-format contract + scaffolding require the section for future formats.
- **Init records**: `storage_paths` lands on the planning item in the uniform init batch (initialize-plan, scoping write-tasks). `validateSet` guards it at write time — array of relative pathspecs, never `.`, `..`, or absolute.
- **The engine derives**: `engine commit <wu> -m "…" --plan <topic>` stages `.workflows/{wu}` + `.workflows/manifest.json` + the recorded pathspecs. Entries neither on disk nor tracked are skipped (`git add` is fatal on nothing-matched); deleted-but-tracked paths still stage their deletions — the restart cleanups depend on that. A pre-upgrade plan without the field fails loudly with the one-line repair command in the error.
- **Six sites swap** to `--plan` (initialize-plan — also dropping its whole-tree `--workflows` scope, author-tasks per-task, analyze-task-graph ×2, write-tasks, scoping adjust, review remediation). **Two restart cleanups stay raw git** — they delete the planning item before committing, so `--plan` has nothing to read — but now stage `{storage_paths}` read from state at restart start. **Code-led commits stay raw git by design** (the engine must never be able to sweep code); their staging narratives now name the recorded field.

## Test plan

- `--plan`: tick-style storage staged alongside wu + project manifest while unrelated code stays out; empty declaration = plain scoped commit; tracked-deletion staging (restart shape) with zero stray dirt; loud on missing item, missing field (with repair hint), and traversal/absolute entries.
- `validateSet` storage_paths guard via the existing set matrix.
- `npm test` 1560/1560 · `test:cli` green · conventions lint 27/27 · typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. #507
4. #508
5. #509
6. **#510** 👈 current
7. #512
8. #513
9. #514
10. #515
11. #516
12. #517
13. #518
14. #519
15. #520
16. #521
17. #522
18. #523
<!-- stack:links:end -->