### PR TITLE
refactor(prose): skill-handoff convergence — one grammar, bridge plan integrity

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -690,6 +690,20 @@ Rules:
 → Load **[name.md](path)** with param = `literal`, other = `{variable}`.
 ```
 
+### Loading, Invoking, and the Bridge
+
+Three mechanisms move a flow forward; never blur them:
+
+- **Loading a reference** reads a file into the running context — progressive disclosure, nothing more. No parameters pass mechanically: state the variables in prose before the Load (`with topic = `{topic}``) and the loaded file references them, already in context.
+- **Invoking a skill** is a Skill tool call at a boundary (entry → process, phase end → bridge). It adds the skill's instructions to the running context — **nothing is cleared**. Arguments pass only when the skill expects them; context already holds the rest. The canonical form is an imperative **before** the payload fence, naming the skill and the mechanism, with the fence as pure arguments and nothing after it (a skill-invoking exit is terminal — no STOP, no routing):
+
+  ```
+  Invoke the **workflow-x** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+  ```
+
+  Never place the imperative after the fence (it arrives too late — the command-prelude rule), and never inside it (a fence is payload; an instruction buried there gets printed, not executed).
+- **The bridge** (`workflow-bridge`) owns the only context-clearing handoff: phase → phase via plan mode. Within a phase, context is never cleared. The bridge's plan content is a verbatim template — see the bridge skill; enrichment poisons the fresh context it is designed to feed.
+
 ### Reference File Structure
 
 ```markdown

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -695,11 +695,13 @@ Rules:
 Three mechanisms move a flow forward; never blur them:
 
 - **Loading a reference** reads a file into the running context — progressive disclosure, nothing more. No parameters pass mechanically: state the variables in prose before the Load (`with topic = `{topic}``) and the loaded file references them, already in context.
-- **Invoking a skill** is a Skill tool call at a boundary (entry → process, phase end → bridge). It adds the skill's instructions to the running context — **nothing is cleared**. Arguments pass only when the skill expects them; context already holds the rest. The canonical form is an imperative **before** the payload fence, naming the skill and the mechanism, with the fence as pure arguments and nothing after it (a skill-invoking exit is terminal — no STOP, no routing):
+- **Invoking a skill** is a Skill tool call at a boundary (entry → process, phase end → bridge). It adds the skill's instructions to the running context — **nothing is cleared**. Two argument forms, by what the skill declares:
+  - **Positional arguments** (the skill declares `$0`/`$1`/… — entry skills, the bridge): show the literal command — ``Invoke `/workflow-bridge {work_unit} {completed_phase}`.`` When an argument is conditional, write the whole command per branch — two complete commands beat one annotated one.
+  - **Handoff context block** (process-skill handoffs): an imperative **before** the payload fence, the fence as pure content, nothing after it (a skill-invoking exit is terminal — no STOP, no routing):
 
-  ```
-  Invoke the **workflow-x** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
-  ```
+    ```
+    Invoke the **workflow-x** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+    ```
 
   Never place the imperative after the fence (it arrives too late — the command-prelude rule), and never inside it (a fence is payload; an instruction buried there gets printed, not executed).
 - **The bridge** (`workflow-bridge`) owns the only context-clearing handoff: phase → phase via plan mode. Within a phase, context is never cleared. The bridge's plan content is a verbatim template — see the bridge skill; enrichment poisons the fresh context it is designed to feed.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -696,7 +696,7 @@ Three mechanisms move a flow forward; never blur them:
 
 - **Loading a reference** reads a file into the running context — progressive disclosure, nothing more. No parameters pass mechanically: state the variables in prose before the Load (`with topic = `{topic}``) and the loaded file references them, already in context.
 - **Invoking a skill** is a Skill tool call at a boundary (entry → process, phase end → bridge). It adds the skill's instructions to the running context — **nothing is cleared**. Two argument forms, by what the skill declares:
-  - **Positional arguments** (the skill declares `$0`/`$1`/… — entry skills, the bridge): show the literal command — ``Invoke `/workflow-bridge {work_unit} {completed_phase}`.`` When an argument is conditional, write the whole command per branch — two complete commands beat one annotated one.
+  - **Positional arguments** (the skill declares `$0`/`$1`/… — entry skills, the bridge): show the literal command — ``Invoke `/workflow-bridge {work_unit} {completed_phase}`.`` When an argument is conditional, resolve it in prose first — absence as the literal `none` where the receiving skill declares that convention — then show one literal command with every argument in place.
   - **Handoff context block** (process-skill handoffs): an imperative **before** the payload fence, the fence as pure content, nothing after it (a skill-invoking exit is terminal — no STOP, no routing):
 
     ```

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -12,10 +12,10 @@ This skill is invoked when a phase concludes — to create a plan-mode handoff t
 
 ## Instructions
 
-This skill receives context from the calling processing skill:
-- **Work unit**: The work unit name (directory under `.workflows/`) = `{work_unit}`
-- **Completed phase**: The phase that just completed — `discovery` or any later phase = `{completed_phase}`
-- **Next phase** (optional): supplied when the caller already knows the destination — discovery handing a single-phase work type to its first phase = `{next_phase}`. Other callers omit it and the continuation computes the next phase from discovery output.
+This skill takes its parameters as Skill-tool arguments — `work_unit=<name> completed_phase=<phase> [next_phase=<phase>]`:
+- **work_unit**: the work unit name (directory under `.workflows/`) = `{work_unit}`
+- **completed_phase**: the phase that just completed — `discovery` or any later phase = `{completed_phase}`
+- **next_phase** (optional): supplied when the caller already knows the destination — discovery handing a single-phase work type to its first phase = `{next_phase}`. Other callers omit it and the continuation computes the next phase from discovery output.
 
 ---
 

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -15,7 +15,7 @@ This skill is invoked when a phase concludes — to create a plan-mode handoff t
 This skill receives positional arguments:
 - `$0` — **work_unit**: the work unit name (directory under `.workflows/`). Held downstream as `{work_unit}`.
 - `$1` — **completed_phase**: the phase that just completed — `discovery` or any later phase. Held downstream as `{completed_phase}`.
-- `$2` — **next_phase** (optional): supplied when the caller already knows the destination — discovery handing a single-phase work type to its first phase. Held downstream as `{next_phase}`. Absent means the continuation computes the next phase from discovery output.
+- `$2` — **next_phase** (optional): supplied when the caller already knows the destination — discovery handing a single-phase work type to its first phase. Held downstream as `{next_phase}`. Absent or the literal `none` means the continuation computes the next phase from discovery output.
 
 ---
 

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -12,10 +12,10 @@ This skill is invoked when a phase concludes — to create a plan-mode handoff t
 
 ## Instructions
 
-This skill takes its parameters as Skill-tool arguments — `work_unit=<name> completed_phase=<phase> [next_phase=<phase>]`:
-- **work_unit**: the work unit name (directory under `.workflows/`) = `{work_unit}`
-- **completed_phase**: the phase that just completed — `discovery` or any later phase = `{completed_phase}`
-- **next_phase** (optional): supplied when the caller already knows the destination — discovery handing a single-phase work type to its first phase = `{next_phase}`. Other callers omit it and the continuation computes the next phase from discovery output.
+This skill receives positional arguments:
+- `$0` — **work_unit**: the work unit name (directory under `.workflows/`). Held downstream as `{work_unit}`.
+- `$1` — **completed_phase**: the phase that just completed — `discovery` or any later phase. Held downstream as `{completed_phase}`.
+- `$2` — **next_phase** (optional): supplied when the caller already knows the destination — discovery handing a single-phase work type to its first phase. Held downstream as `{next_phase}`. Absent means the continuation computes the next phase from discovery output.
 
 ---
 

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -110,7 +110,7 @@ Set `target_phase` = the number's phase in `revisitable_phases`.
 
 ## F. Enter Plan Mode
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Bugfix: {work_unit}
@@ -126,7 +126,7 @@ The skill will skip discovery and proceed directly to validation.
 
 ## How to proceed
 
-Clear context and continue.
+**To the human**: approve with **"Clear context and continue"** — this project's setup keeps that plan-mode option enabled. A fresh context will follow the Next Step above.
 ```
 
 Call the `ExitPlanMode` tool to present the plan to the user for approval.

--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -110,7 +110,7 @@ Set `target_phase` = the number's phase in `revisitable_phases`.
 
 ## F. Enter Plan Mode
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file — resolve the conditionals and placeholders, then output the result **verbatim: it is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Bugfix: {work_unit}

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -76,7 +76,7 @@ Set `target_phase` = the number's phase in `revisitable_phases`.
 
 ## E. Enter Plan Mode
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file — resolve the conditionals and placeholders, then output the result **verbatim: it is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Cross-Cutting: {work_unit}

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -76,7 +76,7 @@ Set `target_phase` = the number's phase in `revisitable_phases`.
 
 ## E. Enter Plan Mode
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Cross-Cutting: {work_unit}
@@ -92,7 +92,7 @@ The skill will skip discovery and proceed directly to validation.
 
 ## How to proceed
 
-Clear context and continue.
+**To the human**: approve with **"Clear context and continue"** — this project's setup keeps that plan-mode option enabled. A fresh context will follow the Next Step above.
 ```
 
 Call the `ExitPlanMode` tool to present the plan to the user for approval.

--- a/skills/workflow-bridge/references/discovery-continuation.md
+++ b/skills/workflow-bridge/references/discovery-continuation.md
@@ -20,7 +20,7 @@ The destination is **given, not derived** — discovery is the first phase, so t
 
 ## B. Return to the Epic Menu
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Epic: {work_unit}
@@ -35,14 +35,14 @@ The epic menu will render the discovery map and let you start, continue, or refi
 
 ## How to proceed
 
-Clear context and continue.
+**To the human**: approve with **"Clear context and continue"** — this project's setup keeps that plan-mode option enabled. A fresh context will follow the Next Step above.
 ```
 
 Call the `ExitPlanMode` tool to present the plan to the user for approval.
 
 ## C. Hand Off to the First Phase
 
-The discovery endpoint supplied `next_phase` (`research` / `discussion` / `investigation` / `scoping`). Call the `EnterPlanMode` tool, then write the following content to the plan file:
+The discovery endpoint supplied `next_phase` (`research` / `discussion` / `investigation` / `scoping`). Call the `EnterPlanMode` tool, then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Start {next_phase:(titlecase)}: {work_unit}
@@ -57,7 +57,7 @@ The entry skill reads the durable carrier — the discovery session log and the 
 
 ## How to proceed
 
-Clear context and continue.
+**To the human**: approve with **"Clear context and continue"** — this project's setup keeps that plan-mode option enabled. A fresh context will follow the Next Step above.
 ```
 
 Call the `ExitPlanMode` tool to present the plan to the user for approval.

--- a/skills/workflow-bridge/references/discovery-continuation.md
+++ b/skills/workflow-bridge/references/discovery-continuation.md
@@ -20,7 +20,7 @@ The destination is **given, not derived** — discovery is the first phase, so t
 
 ## B. Return to the Epic Menu
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file — resolve the conditionals and placeholders, then output the result **verbatim: it is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Epic: {work_unit}
@@ -42,7 +42,7 @@ Call the `ExitPlanMode` tool to present the plan to the user for approval.
 
 ## C. Hand Off to the First Phase
 
-The discovery endpoint supplied `next_phase` (`research` / `discussion` / `investigation` / `scoping`). Call the `EnterPlanMode` tool, then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
+The discovery endpoint supplied `next_phase` (`research` / `discussion` / `investigation` / `scoping`). Call the `EnterPlanMode` tool, then write the following content to the plan file — resolve the conditionals and placeholders, then output the result **verbatim: it is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Start {next_phase:(titlecase)}: {work_unit}

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -110,7 +110,7 @@ Skills receive positional arguments: `$0` = work_type, `$1` = work_unit, `$2` = 
 
 #### If topic is present
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Epic: {selected_phase:(titlecase)}
@@ -126,14 +126,14 @@ The skill will skip discovery and proceed directly to validation.
 
 ## How to proceed
 
-Clear context and continue.
+**To the human**: approve with **"Clear context and continue"** — this project's setup keeps that plan-mode option enabled. A fresh context will follow the Next Step above.
 ```
 
 Call the `ExitPlanMode` tool to present the plan to the user for approval.
 
 #### If topic is absent
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Epic: {selected_phase:(titlecase)}
@@ -149,7 +149,7 @@ Arguments: work_type = epic, work_unit = {work_unit}
 
 ## How to proceed
 
-Clear context and continue.
+**To the human**: approve with **"Clear context and continue"** — this project's setup keeps that plan-mode option enabled. A fresh context will follow the Next Step above.
 ```
 
 Call the `ExitPlanMode` tool to present the plan to the user for approval.

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -110,7 +110,7 @@ Skills receive positional arguments: `$0` = work_type, `$1` = work_unit, `$2` = 
 
 #### If topic is present
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file — resolve the conditionals and placeholders, then output the result **verbatim: it is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Epic: {selected_phase:(titlecase)}
@@ -133,7 +133,7 @@ Call the `ExitPlanMode` tool to present the plan to the user for approval.
 
 #### If topic is absent
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file — resolve the conditionals and placeholders, then output the result **verbatim: it is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Epic: {selected_phase:(titlecase)}

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -110,7 +110,7 @@ Set `target_phase` = the number's phase in `revisitable_phases`.
 
 ## F. Enter Plan Mode
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Feature: {work_unit}
@@ -126,7 +126,7 @@ The skill will skip discovery and proceed directly to validation.
 
 ## How to proceed
 
-Clear context and continue.
+**To the human**: approve with **"Clear context and continue"** — this project's setup keeps that plan-mode option enabled. A fresh context will follow the Next Step above.
 ```
 
 Call the `ExitPlanMode` tool to present the plan to the user for approval.

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -110,7 +110,7 @@ Set `target_phase` = the number's phase in `revisitable_phases`.
 
 ## F. Enter Plan Mode
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file — resolve the conditionals and placeholders, then output the result **verbatim: it is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Feature: {work_unit}

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -110,7 +110,7 @@ Set `target_phase` = the number's phase in `revisitable_phases`.
 
 ## F. Enter Plan Mode
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file — resolve the conditionals and placeholders, then output the result **verbatim: it is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Quick-Fix: {work_unit}

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -110,7 +110,7 @@ Set `target_phase` = the number's phase in `revisitable_phases`.
 
 ## F. Enter Plan Mode
 
-Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file:
+Call the `EnterPlanMode` tool to enter plan mode. Then write the following content to the plan file **verbatim — this is the complete plan**. Plan mode's usual job does not apply here: nothing to investigate, verify, or design, and nothing learned this session is added — the next context is designed to start empty, and additions bias it. The one sanctioned addition: anything the user explicitly asked to carry forward goes under a final `## User instructions` heading, after the template:
 
 ```
 # Continue Quick-Fix: {work_unit}
@@ -126,7 +126,7 @@ The skill will skip discovery and proceed directly to validation.
 
 ## How to proceed
 
-Clear context and continue.
+**To the human**: approve with **"Clear context and continue"** — this project's setup keeps that plan-mode option enabled. A fresh context will follow the Next Step above.
 ```
 
 Call the `ExitPlanMode` tool to present the plan to the user for approval.

--- a/skills/workflow-discovery/references/conclude-discovery.md
+++ b/skills/workflow-discovery/references/conclude-discovery.md
@@ -35,7 +35,5 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "di
 Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: discovery
-@if(next_phase is set) Next phase: {next_phase} @endif
+work_unit={work_unit} completed_phase=discovery @if(next_phase is set) next_phase={next_phase} @endif
 ```

--- a/skills/workflow-discovery/references/conclude-discovery.md
+++ b/skills/workflow-discovery/references/conclude-discovery.md
@@ -32,4 +32,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "di
 > step in a clean context.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} discovery`@if(next_phase is set) plus the third argument `{next_phase}` @endif.
+**If `next_phase` is set:** Invoke `/workflow-bridge {work_unit} discovery {next_phase}`.
+
+**If not:** Invoke `/workflow-bridge {work_unit} discovery`.

--- a/skills/workflow-discovery/references/conclude-discovery.md
+++ b/skills/workflow-discovery/references/conclude-discovery.md
@@ -32,12 +32,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "di
 > step in a clean context.
 ```
 
+Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
+
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: discovery
 @if(next_phase is set) Next phase: {next_phase} @endif
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
-
-**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-discovery/references/conclude-discovery.md
+++ b/skills/workflow-discovery/references/conclude-discovery.md
@@ -32,8 +32,4 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "di
 > step in a clean context.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=discovery @if(next_phase is set) next_phase={next_phase} @endif
-```
+Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} discovery`@if(next_phase is set) plus the third argument `{next_phase}` @endif.

--- a/skills/workflow-discovery/references/conclude-discovery.md
+++ b/skills/workflow-discovery/references/conclude-discovery.md
@@ -32,6 +32,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "di
 > step in a clean context.
 ```
 
-**If `next_phase` is set:** Invoke `/workflow-bridge {work_unit} discovery {next_phase}`.
+`next_phase` is the destination the endpoint supplied, or the literal `none` when it supplied nothing (the bridge treats `none` as absent and computes the destination itself).
 
-**If not:** Invoke `/workflow-bridge {work_unit} discovery`.
+Invoke `/workflow-bridge {work_unit} discovery {next_phase}` via the Skill tool.

--- a/skills/workflow-discussion-entry/references/invoke-skill.md
+++ b/skills/workflow-discussion-entry/references/invoke-skill.md
@@ -34,6 +34,10 @@ When the read returns non-empty, append the Description block shown in each sour
 
 #### If source is `topic-provided-with-research`
 
+The `Description:` block is omitted when `description` is null or empty.
+
+Invoke the **workflow-discussion-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
@@ -46,26 +50,24 @@ Topic context: {brief orientation from user context}
 
 Description:
 {description text — paragraph or two, preserved as-is}
-
-Invoke the workflow-discussion-process skill.
 ```
 
-The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
-
 #### If source is `continue`
+
+No description load for `continue` — resuming an existing session, no need to re-prime.
+
+Invoke the **workflow-discussion-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
 Source: existing discussion
 Output: {output_path}
-
-Invoke the workflow-discussion-process skill.
 ```
 
-No description load for `continue` — resuming an existing session, no need to re-prime. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
-
 #### If source is `fresh` or `topic-provided`
+
+Invoke the **workflow-discussion-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Discussion session for: {topic}
@@ -75,8 +77,5 @@ Output: {output_path}
 
 Description:
 {description text — paragraph or two, preserved as-is}
-
-Invoke the workflow-discussion-process skill.
 ```
 
-The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-discussion-process](../../workflow-discussion-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -48,7 +48,7 @@ Conclude this discussion and mark as completed?
 
 Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
 
-4. Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
+4. Hand off to the pipeline bridge:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -57,11 +57,7 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 > synthesise your decisions into a formal document.
 ```
 
-```
-work_unit={work_unit} completed_phase=discussion
-```
-
-**STOP.** Do not proceed — terminal condition.
+Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} discussion`.
 
 #### If `no`
 

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -58,8 +58,7 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 ```
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: discussion
+work_unit={work_unit} completed_phase=discussion
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -48,7 +48,7 @@ Conclude this discussion and mark as completed?
 
 Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
 
-4. Invoke the bridge:
+4. Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -60,8 +60,6 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: discussion
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -57,7 +57,7 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 > synthesise your decisions into a formal document.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} discussion`.
+Invoke `/workflow-bridge {work_unit} discussion`.
 
 #### If `no`
 

--- a/skills/workflow-implementation-entry/references/invoke-skill.md
+++ b/skills/workflow-implementation-entry/references/invoke-skill.md
@@ -23,6 +23,8 @@ Check if implementation already exists:
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.implementation.{topic}
 ```
 
+Invoke the **workflow-implementation-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Implementation session for: {topic}
 Work unit: {work_unit}
@@ -34,8 +36,3 @@ Implementation: {exists:[true|false]}
 
 Dependencies: {All satisfied | List any notes}
 Environment: {Setup required | No special setup required}
-
-Invoke the workflow-implementation-process skill.
-```
-
-Invoke the [workflow-implementation-process](../../workflow-implementation-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -43,5 +43,3 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "im
 ```
 
 Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} implementation`.
-
-**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -42,10 +42,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "im
 > your work against the specification and plan.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=implementation
-```
+Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} implementation`.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -42,13 +42,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "im
 > your work against the specification and plan.
 ```
 
-Invoke the bridge:
+Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: implementation
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -42,4 +42,4 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "im
 > your work against the specification and plan.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} implementation`.
+Invoke `/workflow-bridge {work_unit} implementation`.

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -45,8 +45,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "im
 Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: implementation
+work_unit={work_unit} completed_phase=implementation
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-investigation-entry/references/invoke-skill.md
+++ b/skills/workflow-investigation-entry/references/invoke-skill.md
@@ -20,6 +20,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} 
 
 Fill the Bug context from that carrier (discovery path) or the `gather-context` answers (logless path) — it primes the process, not a full report; `workflow-investigation-process` does the deep symptom gathering (Step 3) and a knowledge-base query (Step 4):
 
+Invoke the **workflow-investigation-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Investigation session for: {work_unit}
 
@@ -30,11 +32,6 @@ Bug context:
 - Actual behavior: {from the carrier / gather-context}
 - Initial context: {error messages, reproduction steps — from the carrier / gather-context, or "(none captured yet)"}
 
-Invoke the workflow-investigation-process skill.
-```
-
-Invoke the [workflow-investigation-process](../../workflow-investigation-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
-
 #### If source is `continue`
 
 ```
@@ -42,8 +39,3 @@ Investigation session for: {work_unit}
 
 Source: existing investigation
 Output: .workflows/{work_unit}/investigation/{topic}.md
-
-Invoke the workflow-investigation-process skill.
-```
-
-Invoke the [workflow-investigation-process](../../workflow-investigation-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -58,13 +58,11 @@ The investigation is completed. Root cause and fix direction are documented.
 > the fix approach into a document that drives planning.
 ```
 
-5. Invoke the bridge:
+5. Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: investigation
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -58,4 +58,4 @@ The investigation is completed. Root cause and fix direction are documented.
 > the fix approach into a document that drives planning.
 ```
 
-5. Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} investigation`.
+5. Invoke `/workflow-bridge {work_unit} investigation`.

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -58,10 +58,6 @@ The investigation is completed. Root cause and fix direction are documented.
 > the fix approach into a document that drives planning.
 ```
 
-5. Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=investigation
-```
+5. Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} investigation`.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -61,8 +61,7 @@ The investigation is completed. Root cause and fix direction are documented.
 5. Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: investigation
+work_unit={work_unit} completed_phase=investigation
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -59,5 +59,3 @@ The investigation is completed. Root cause and fix direction are documented.
 ```
 
 5. Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} investigation`.
-
-**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-planning-entry/references/invoke-skill.md
+++ b/skills/workflow-planning-entry/references/invoke-skill.md
@@ -12,6 +12,8 @@ This skill's purpose is now fulfilled. Construct the handoff and invoke the proc
 
 #### If creating fresh plan (no existing plan)
 
+Invoke the **workflow-planning-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Planning session for: {topic}
 Work unit: {work_unit}
@@ -19,11 +21,6 @@ Work unit: {work_unit}
 Specification: .workflows/{work_unit}/specification/{topic}/specification.md
 Additional context: {summary of user's additional context, or "none"}
 Cross-cutting references: {list of applicable cross-cutting specs with brief summaries, or "none"}
-
-Invoke the workflow-planning-process skill.
-```
-
-Invoke the [workflow-planning-process](../../workflow-planning-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### If continuing or reviewing existing plan
 
@@ -34,8 +31,3 @@ Work unit: {work_unit}
 Specification: .workflows/{work_unit}/specification/{topic}/specification.md
 Existing plan: .workflows/{work_unit}/planning/{topic}/planning.md
 Cross-cutting references: {list of applicable cross-cutting specs with brief summaries, or "none"}
-
-Invoke the workflow-planning-process skill.
-```
-
-Invoke the [workflow-planning-process](../../workflow-planning-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -58,4 +58,4 @@ Status has been marked as `completed`. The plan is ready for implementation.
 > these tasks using TDD — tests first, then code.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} planning`.
+Invoke `/workflow-bridge {work_unit} planning`.

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -61,8 +61,7 @@ Status has been marked as `completed`. The plan is ready for implementation.
 Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: planning
+work_unit={work_unit} completed_phase=planning
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -58,13 +58,11 @@ Status has been marked as `completed`. The plan is ready for implementation.
 > these tasks using TDD — tests first, then code.
 ```
 
-Invoke the bridge:
+Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: planning
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -58,10 +58,6 @@ Status has been marked as `completed`. The plan is ready for implementation.
 > these tasks using TDD — tests first, then code.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=planning
-```
+Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} planning`.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-planning-process/references/conclude-plan.md
+++ b/skills/workflow-planning-process/references/conclude-plan.md
@@ -59,5 +59,3 @@ Status has been marked as `completed`. The plan is ready for implementation.
 ```
 
 Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} planning`.
-
-**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-research-entry/references/invoke-skill.md
+++ b/skills/workflow-research-entry/references/invoke-skill.md
@@ -32,19 +32,23 @@ When the read returns non-empty, append the Description block shown in each sour
 
 #### If source is `continue`
 
+No description load for `continue` — resuming an existing session, no need to re-prime.
+
+The `Description:` block is omitted when `description` is null or empty.
+
+Invoke the **workflow-research-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Research session for: {topic}
 Work unit: {work_unit}
 
 Source: existing research
 Output: .workflows/{work_unit}/research/{resolved_filename}
-
-Invoke the workflow-research-process skill.
 ```
 
-No description load for `continue` — resuming an existing session, no need to re-prime. Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
-
 #### Otherwise
+
+Invoke the **workflow-research-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Research session for: {topic}
@@ -60,8 +64,5 @@ Context:
 
 Description:
 {description text — paragraph or two, preserved as-is}
-
-Invoke the workflow-research-process skill.
 ```
 
-The `Description:` block is omitted when `description` is null or empty. Invoke the [workflow-research-process](../../workflow-research-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -41,4 +41,4 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 > to make decisions about architecture and approach.
 ```
 
-4. Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} research`.
+4. Invoke `/workflow-bridge {work_unit} research`.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -45,8 +45,6 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
    ```
    Pipeline bridge for: {work_unit}
    Completed phase: research
-
-   Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
    ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -43,8 +43,7 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 
 4. Invoke the `/workflow-bridge` skill:
    ```
-   Pipeline bridge for: {work_unit}
-   Completed phase: research
+   work_unit={work_unit} completed_phase=research
    ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -42,5 +42,3 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 ```
 
 4. Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} research`.
-
-**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -41,9 +41,6 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 > to make decisions about architecture and approach.
 ```
 
-4. Invoke the `/workflow-bridge` skill:
-   ```
-   work_unit={work_unit} completed_phase=research
-   ```
+4. Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} research`.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-review-entry/references/invoke-skill.md
+++ b/skills/workflow-review-entry/references/invoke-skill.md
@@ -13,6 +13,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 ```
 
 **Handoff:**
+Invoke the **workflow-review-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Review session
 Work unit: {work_unit}
@@ -24,8 +26,3 @@ Plans to review:
     topic: {topic}
     format: {format}
     specification: .workflows/{work_unit}/specification/{topic}/specification.md (exists: {true|false})
-
-Invoke the workflow-review-process skill.
-```
-
-Invoke the [workflow-review-process](../../workflow-review-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -44,13 +44,11 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — Invoke the bridge:
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: review
-
-Invoke the workflow-bridge skill to enter plan mode with completion confirmation.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -97,13 +95,11 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — Invoke the bridge:
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: review
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -150,13 +146,11 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — Invoke the bridge:
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: review
-
-Invoke the workflow-bridge skill to enter plan mode with completion confirmation.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -189,13 +183,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "re
 No actionable tasks synthesized. Review complete.
 ```
 
-**Pipeline continuation** — Invoke the bridge:
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: review
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -290,13 +282,11 @@ Commit the staging file updates:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — tasks skipped"
 ```
 
-**Pipeline continuation** — Invoke the bridge:
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: review
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -44,7 +44,7 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
+**Pipeline continuation** — Invoke `/workflow-bridge {work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -90,7 +90,7 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
+**Pipeline continuation** — Invoke `/workflow-bridge {work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -136,7 +136,7 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
+**Pipeline continuation** — Invoke `/workflow-bridge {work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -168,7 +168,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "re
 No actionable tasks synthesized. Review complete.
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
+**Pipeline continuation** — Invoke `/workflow-bridge {work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -262,7 +262,7 @@ Commit the staging file updates:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — tasks skipped"
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
+**Pipeline continuation** — Invoke `/workflow-bridge {work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -44,11 +44,7 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=review
-```
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -94,11 +90,7 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=review
-```
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -144,11 +136,7 @@ Commit the completion:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=review
-```
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -180,11 +168,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "re
 No actionable tasks synthesized. Review complete.
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=review
-```
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -278,11 +262,7 @@ Commit the staging file updates:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — tasks skipped"
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=review
-```
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} review`.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -47,8 +47,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "re
 **Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: review
+work_unit={work_unit} completed_phase=review
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -98,8 +97,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "re
 **Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: review
+work_unit={work_unit} completed_phase=review
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -149,8 +147,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "re
 **Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: review
+work_unit={work_unit} completed_phase=review
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -186,8 +183,7 @@ No actionable tasks synthesized. Review complete.
 **Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: review
+work_unit={work_unit} completed_phase=review
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -285,8 +281,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "re
 **Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: review
+work_unit={work_unit} completed_phase=review
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-scoping-entry/references/invoke-skill.md
+++ b/skills/workflow-scoping-entry/references/invoke-skill.md
@@ -22,12 +22,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} 
 
 Construct the handoff:
 
+Invoke the **workflow-scoping-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Scoping session for: {topic}
 Work unit: {work_unit}
 Description: {description}
-
-Invoke the workflow-scoping-process skill.
-```
-
-Invoke the [workflow-scoping-process](../../workflow-scoping-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-scoping-process/references/conclude-scoping.md
+++ b/skills/workflow-scoping-process/references/conclude-scoping.md
@@ -17,6 +17,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render phase-completed {w
 > these tasks using the verification workflow.
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} scoping`.
+**Pipeline continuation** — Invoke `/workflow-bridge {work_unit} scoping`.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-scoping-process/references/conclude-scoping.md
+++ b/skills/workflow-scoping-process/references/conclude-scoping.md
@@ -20,8 +20,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render phase-completed {w
 **Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: scoping
+work_unit={work_unit} completed_phase=scoping
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-scoping-process/references/conclude-scoping.md
+++ b/skills/workflow-scoping-process/references/conclude-scoping.md
@@ -17,10 +17,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render phase-completed {w
 > these tasks using the verification workflow.
 ```
 
-**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=scoping
-```
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} scoping`.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-scoping-process/references/conclude-scoping.md
+++ b/skills/workflow-scoping-process/references/conclude-scoping.md
@@ -17,13 +17,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render phase-completed {w
 > these tasks using the verification workflow.
 ```
 
-**Pipeline continuation** — Invoke the bridge:
+**Pipeline continuation** — invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: scoping
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-entry/references/handoffs/continue-completed.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue-completed.md
@@ -4,7 +4,11 @@
 
 ---
 
-This skill's purpose is now fulfilled. Invoke the [workflow-specification-process](../../../workflow-specification-process/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
+This skill's purpose is now fulfilled.
+
+Omit the `Consult references` block when the grouping owes none.
+
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Specification session for: {Title Case Name}
@@ -21,9 +25,4 @@ Consult references (read narrowly — do not extract):
 - .workflows/{work_unit}/discussion/{ref-topic}.md — {slice hint}
 
 Context: This specification was previously completed. New source discussions have been identified. Extract and incorporate their content while maintaining consistency with the existing specification.
-
----
-Invoke the workflow-specification-process skill.
 ```
-
-Omit the `Consult references` block when the grouping owes none.

--- a/skills/workflow-specification-entry/references/handoffs/continue.md
+++ b/skills/workflow-specification-entry/references/handoffs/continue.md
@@ -4,7 +4,11 @@
 
 ---
 
-This skill's purpose is now fulfilled. Invoke the [workflow-specification-process](../../../workflow-specification-process/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
+This skill's purpose is now fulfilled.
+
+Omit the `Consult references` block when the grouping owes none.
+
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Specification session for: {Title Case Name}
@@ -19,9 +23,4 @@ Consult references (read narrowly — do not extract):
 - .workflows/{work_unit}/discussion/{ref-topic}.md — {slice hint}
 
 Context: This specification already exists. Review and refine it based on the source discussions.
-
----
-Invoke the workflow-specification-process skill.
 ```
-
-Omit the `Consult references` block when the grouping owes none.

--- a/skills/workflow-specification-entry/references/handoffs/create-with-incorporation.md
+++ b/skills/workflow-specification-entry/references/handoffs/create-with-incorporation.md
@@ -4,7 +4,11 @@
 
 ---
 
-This skill's purpose is now fulfilled. Invoke the [workflow-specification-process](../../../workflow-specification-process/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
+This skill's purpose is now fulfilled.
+
+Omit the `Consult references` block when the grouping owes none. A proposed grouping is never an "existing specification to incorporate" — it has no file; absorbing it is a delete handled by reconcile, not a supersede.
+
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Specification session for: {Title Case Name}
@@ -26,9 +30,4 @@ Context: This consolidates multiple sources. The existing specification should b
 After the specification is complete, mark the incorporated specs as superseded via the engine — only specs whose status is not `proposed`:
 
     node .claude/skills/workflow-engine/scripts/engine.cjs topic supersede {work_unit} specification {source-topic} --by {topic}
-
----
-Invoke the workflow-specification-process skill.
 ```
-
-Omit the `Consult references` block when the grouping owes none. A proposed grouping is never an "existing specification to incorporate" — it has no file; absorbing it is a delete handled by reconcile, not a supersede.

--- a/skills/workflow-specification-entry/references/handoffs/create.md
+++ b/skills/workflow-specification-entry/references/handoffs/create.md
@@ -4,7 +4,11 @@
 
 ---
 
-This skill's purpose is now fulfilled. Invoke the [workflow-specification-process](../../../workflow-specification-process/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
+This skill's purpose is now fulfilled.
+
+Omit the `Consult references` block when the grouping owes none.
+
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Specification session for: {Title Case Name}
@@ -17,9 +21,4 @@ Consult references (read narrowly — do not extract):
 - .workflows/{work_unit}/discussion/{ref-topic}.md — {slice hint}
 
 Output: .workflows/{work_unit}/specification/{topic}/specification.md
-
----
-Invoke the workflow-specification-process skill.
 ```
-
-Omit the `Consult references` block when the grouping owes none.

--- a/skills/workflow-specification-entry/references/handoffs/unify-with-incorporation.md
+++ b/skills/workflow-specification-entry/references/handoffs/unify-with-incorporation.md
@@ -4,7 +4,9 @@
 
 ---
 
-This skill's purpose is now fulfilled. Invoke the [workflow-specification-process](../../../workflow-specification-process/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
+This skill's purpose is now fulfilled.
+
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Specification session for: Unified
@@ -25,9 +27,6 @@ Context: This consolidates all discussions into a single unified specification. 
 After the unified specification is complete, mark the incorporated specs as superseded via the engine — only specs whose status is not `proposed`:
 
     node .claude/skills/workflow-engine/scripts/engine.cjs topic supersede {work_unit} specification {source-topic} --by unified
-
----
-Invoke the workflow-specification-process skill.
 ```
 
 A proposed grouping is never an "existing specification to incorporate" — it has no file; reconcile already removed the other proposed items as deletes when the unified item was created.

--- a/skills/workflow-specification-entry/references/handoffs/unify.md
+++ b/skills/workflow-specification-entry/references/handoffs/unify.md
@@ -4,7 +4,9 @@
 
 ---
 
-This skill's purpose is now fulfilled. Invoke the [workflow-specification-process](../../../workflow-specification-process/SKILL.md) skill for your next instructions. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed.
+This skill's purpose is now fulfilled.
+
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Specification session for: Unified
@@ -15,7 +17,4 @@ Sources:
 ...
 
 Output: .workflows/{work_unit}/specification/unified/specification.md
-
----
-Invoke the workflow-specification-process skill.
 ```

--- a/skills/workflow-specification-entry/references/invoke-skill.md
+++ b/skills/workflow-specification-entry/references/invoke-skill.md
@@ -12,6 +12,8 @@ This skill's purpose is now fulfilled. Construct the handoff and invoke the proc
 
 #### If `work_type` is `feature`
 
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Specification session for: {work_unit}
 
@@ -20,11 +22,6 @@ Source material:
 
 Work unit: {work_unit}
 Action: {verb} specification
-
-Invoke the workflow-specification-process skill.
-```
-
-Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### If `work_type` is `bugfix`
 
@@ -37,14 +34,11 @@ Source material:
 Work unit: {work_unit}
 Action: {verb} specification
 
-Invoke the workflow-specification-process skill.
-```
-
-Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
-
 #### If `work_type` is `epic`
 
 Read the spec's source discussions from the manifest: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic} sources`. List each source discussion file.
+
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Specification session for: {topic}
@@ -57,11 +51,6 @@ Source material:
 Work unit: {work_unit}
 Topic: {topic}
 Action: {verb} specification
-
-Invoke the workflow-specification-process skill.
-```
-
-Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.
 
 #### If `work_type` is `cross-cutting`
 
@@ -76,8 +65,3 @@ Source material:
 
 Work unit: {work_unit}
 Action: {verb} specification
-
-Invoke the workflow-specification-process skill.
-```
-
-Invoke the [workflow-specification-process](../../workflow-specification-process/SKILL.md) skill. Do not act on the gathered information until the skill is loaded — it contains the instructions for how to proceed. Terminal.

--- a/skills/workflow-specification-process/references/promote-to-cross-cutting.md
+++ b/skills/workflow-specification-process/references/promote-to-cross-cutting.md
@@ -42,4 +42,4 @@ Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLA
 
 Invoke the bridge for the EPIC (not the cc work unit — the epic continues its pipeline):
 
-Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
+Invoke `/workflow-bridge {work_unit} specification`.

--- a/skills/workflow-specification-process/references/promote-to-cross-cutting.md
+++ b/skills/workflow-specification-process/references/promote-to-cross-cutting.md
@@ -42,8 +42,6 @@ Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLA
 
 Invoke the bridge for the EPIC (not the cc work unit — the epic continues its pipeline):
 
-```
-work_unit={work_unit} completed_phase=specification
-```
+Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-process/references/promote-to-cross-cutting.md
+++ b/skills/workflow-specification-process/references/promote-to-cross-cutting.md
@@ -43,5 +43,3 @@ Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLA
 Invoke the bridge for the EPIC (not the cc work unit — the epic continues its pipeline):
 
 Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
-
-**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-process/references/promote-to-cross-cutting.md
+++ b/skills/workflow-specification-process/references/promote-to-cross-cutting.md
@@ -45,8 +45,6 @@ Invoke the bridge for the EPIC (not the cc work unit — the epic continues its 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: specification
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-process/references/promote-to-cross-cutting.md
+++ b/skills/workflow-specification-process/references/promote-to-cross-cutting.md
@@ -43,8 +43,7 @@ Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLA
 Invoke the bridge for the EPIC (not the cc work unit — the epic continues its pipeline):
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: specification
+work_unit={work_unit} completed_phase=specification
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -212,8 +212,7 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: specification
+work_unit={work_unit} completed_phase=specification
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -230,8 +229,7 @@ Completed phase: specification
 Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
-Pipeline bridge for: {work_unit}
-Completed phase: specification
+work_unit={work_unit} completed_phase=specification
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -209,11 +209,7 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 > for a cross-cutting concern — the pipeline completes here.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=specification
-```
+Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -226,10 +222,6 @@ work_unit={work_unit} completed_phase=specification
 > implementable tasks with dependencies and acceptance criteria.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
-
-```
-work_unit={work_unit} completed_phase=specification
-```
+Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -209,7 +209,7 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 > for a cross-cutting concern — the pipeline completes here.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
+Invoke `/workflow-bridge {work_unit} specification`.
 
 #### Otherwise
 
@@ -220,4 +220,4 @@ Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} s
 > implementable tasks with dependencies and acceptance criteria.
 ```
 
-Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
+Invoke `/workflow-bridge {work_unit} specification`.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -209,13 +209,11 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 > for a cross-cutting concern — the pipeline completes here.
 ```
 
-Invoke the bridge:
+Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: specification
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.
@@ -229,13 +227,11 @@ Invoke the workflow-bridge skill to enter plan mode with continuation instructio
 > implementable tasks with dependencies and acceptance criteria.
 ```
 
-Invoke the bridge:
+Invoke the **workflow-bridge** skill (Skill tool) — the next fenced block is its arguments:
 
 ```
 Pipeline bridge for: {work_unit}
 Completed phase: specification
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -211,8 +211,6 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 
 Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
 
-**STOP.** Do not proceed — terminal condition.
-
 #### Otherwise
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -223,5 +221,3 @@ Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} s
 ```
 
 Invoke the **workflow-bridge** skill (Skill tool) with arguments: `{work_unit} specification`.
-
-**STOP.** Do not proceed — terminal condition.

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -701,6 +701,29 @@ function checkTemplatedRatchet(files, pins = RATCHET_PINS) {
 }
 
 // ---------------------------------------------------------------------------
+// Check 14 — No buried invocation imperatives. A skill-invocation instruction
+// lives BEFORE its payload fence (Loading/Invoking/Bridge conventions); a
+// line inside a fence starting "Invoke the workflow-" is payload text the
+// model prints instead of executing — the Portal stall class.
+// ---------------------------------------------------------------------------
+
+function checkBuriedInvoke(files) {
+  const out = [];
+  for (const file of files) {
+    const lines = readLines(file);
+    const { blocks } = parseFences(lines);
+    for (const b of blocks) {
+      for (const { n, text } of b.lines) {
+        if (/^\s*Invoke the workflow-/.test(text)) {
+          out.push({ file, line: n + 1, message: 'invocation imperative inside a fence — payload is never instruction; put the imperative before the fence' });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // Registry + reporting
 // ---------------------------------------------------------------------------
 
@@ -718,6 +741,7 @@ const CHECKS = [
   ['11: load-directive footers (On return)', checkLoadFooters],
   ['12: earned chrome (inert load-only steps)', checkInertLoadChrome],
   ['13: templated-fence ratchet (render-surfaces D4)', checkTemplatedRatchet],
+  ['14: buried invocation imperatives', checkBuriedInvoke],
 ];
 
 function report(violations) {
@@ -1056,5 +1080,15 @@ test('check 13 (templated-fence ratchet) — catches drift both ways, skips stat
       '> *Output the next fenced block as a ` ```diff ` code block:*\n\n```diff\n {context}\n-{removed lines}\n+{new lines}\n```\n'
     );
     assert.strictEqual(checkTemplatedRatchet([diffForm], {}).length, 1, 'the diff-form instruction is inside the ratchet');
+  });
+});
+
+test('check 14 (buried invoke) — catches in-fence imperatives, permits pre-fence ones', () => {
+  withTemp((dir) => {
+    const bad = write(dir, 'skills/x/a.md', '```\nPipeline bridge for: pay\n\nInvoke the workflow-bridge skill.\n```\n');
+    const v = checkBuriedInvoke([bad]);
+    assert.strictEqual(v.length, 1, 'in-fence imperative must be caught');
+    const good = write(dir, 'skills/x/b.md', 'Invoke the **workflow-bridge** skill (Skill tool) with the next fenced block as its arguments.\n\n```\nPipeline bridge for: pay\n```\n');
+    assert.strictEqual(checkBuriedInvoke([good]).length, 0, 'pre-fence imperative is the canonical form');
   });
 });


### PR DESCRIPTION
Standalone PR off main (independent of the batching stack). Fixes the Portal stall (`conclude-discovery` printing its bridge payload and stopping) as one instance of a family, per the plan agreed with Lee.

## The mechanisms, made explicit (CONVENTIONS: "Loading, Invoking, and the Bridge")

- **Loading a reference** reads into context; variables resolve because prose stated them first.
- **Invoking a skill** is a Skill tool call at a boundary, enriching the running context — **nothing is cleared**. Canonical form: imperative *before* the payload fence ("Invoke the **workflow-x** skill (Skill tool) with the next fenced block as its arguments…"), fence as pure payload, terminal after — no STOP, no after-fence instruction (too late), no in-fence instruction (gets printed, not executed).
- **The bridge** owns the only context-clear, phase→phase via plan mode.

## The sweep (34 sites, 24 files)

- In-fence `Invoke the workflow-X skill.` payload tails removed everywhere (conclude-* ×9 incl. review-actions ×5, entry invoke-skill ×8 skills, spec-entry handoffs ×6).
- `conclude-discovery` gains the missing imperative and loses the terminal STOP that licensed the stall.
- Entry files' imperatives move from after the fence to before it; payload-construction notes move above too (command-prelude).

## Bridge plan integrity (the ~10% contamination)

All 8 plan-template sites: **"verbatim — this is the complete plan"**, plan mode's investigate/verify/design job explicitly disclaimed, nothing learned this session added (the next context is designed to start empty), `## User instructions` as the sole sanctioned addition — and `## How to proceed` now addresses the human plainly: approve with **"Clear context and continue"** (the option migration 034 keeps enabled).

## Test plan

- Lint check 14 (buried invocation imperative) + fixtures; corpus clean.
- `npm test` 1560/1560 · conventions lint 29/29 · typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)