### PR TITLE
feat(scoping): promotion routes through first-phase choice + bridge

### DIFF
--- a/skills/workflow-scoping-process/references/complexity-check.md
+++ b/skills/workflow-scoping-process/references/complexity-check.md
@@ -129,12 +129,4 @@ The promoted work unit re-enters the pipeline the way discovery hands off single
 > phase in a clean context.
 ```
 
-```
-Pipeline bridge for: {work_unit}
-Completed phase: discovery
-Next phase: {next_phase}
-
-Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
-```
-
-**STOP.** Do not proceed — terminal condition.
+Invoke `/workflow-bridge {work_unit} discovery {next_phase}` via the Skill tool.

--- a/skills/workflow-scoping-process/references/complexity-check.md
+++ b/skills/workflow-scoping-process/references/complexity-check.md
@@ -70,9 +70,7 @@ Commit both manifests:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "workflow({work_unit}): promote quick-fix to feature"
 ```
 
-Invoke `/workflow-discussion-entry feature {work_unit}`.
-
-**STOP.** Do not proceed — terminal condition.
+→ Proceed to **C. First Phase**.
 
 #### If `bugfix`
 
@@ -89,6 +87,54 @@ Commit both manifests:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "workflow({work_unit}): promote quick-fix to bugfix"
 ```
 
-Invoke `/workflow-investigation-entry bugfix {work_unit}`.
+Set `next_phase` = `investigation`.
+
+→ Proceed to **D. Bridge**.
+
+## C. First Phase
+
+Propose research-vs-discussion — the concerns that triggered promotion are the strongest cue:
+
+- **research** — open feasibility / "how does X work" / "what's possible" unknowns the work hasn't resolved.
+- **discussion** — the shape is clear and the open questions are trade-offs and decisions, not unknowns.
+
+Lead with your read and one reason, then render the choice:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+{One-line read + reason, e.g. "The concern is an open unknown —
+I'd start with research."}
+
+- **`r`/`research`** — Explore feasibility and options first, no decisions yet
+- **`d`/`discussion`** — Ready to discuss and make decisions
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+Set `next_phase` to the choice (`research` or `discussion`).
+
+→ Proceed to **D. Bridge**.
+
+## D. Bridge
+
+The promoted work unit re-enters the pipeline the way discovery hands off single-phase work — the destination is supplied, not derived from state.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Work type updated — entering plan mode to hand off the first
+> phase in a clean context.
+```
+
+```
+Pipeline bridge for: {work_unit}
+Completed phase: discovery
+Next phase: {next_phase}
+
+Invoke the workflow-bridge skill to enter plan mode with continuation instructions.
+```
 
 **STOP.** Do not proceed — terminal condition.


### PR DESCRIPTION
## Summary
- The quick-fix promote paths predate discovery by two months and never picked up its routing: promoted features were forced straight into discussion (no research option), and both promotions invoked the phase entry skill directly inside the still-loaded scoping session.
- Feature promotion now presents the same research-vs-discussion choice discovery's `first-phase-routing.md` gives a fresh feature; bugfix promotion sets `next_phase = investigation`.
- Both hand off via the workflow-bridge context block (`Completed phase: discovery` — the supplied-destination arm, no state derivation), mirroring `conclude-discovery.md`'s B. Bridge shape, so the first phase starts in a clean context.

## Test plan
- Conventions lint green (27 checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. #507
4. #508
5. #509
6. #510
7. #512
8. #513
9. #514
10. **#515** 👈 current
11. #516
12. #517
13. #518
14. #519
15. #520
16. #521
17. #522
18. #523
<!-- stack:links:end -->