### PR TITLE
fix(spec): pin the bugfix source name to the topic

### DIFF
--- a/skills/workflow-specification-process/references/initialize-specification.md
+++ b/skills/workflow-specification-process/references/initialize-specification.md
@@ -28,7 +28,7 @@ Branch on the response's `created` flag:
 
 #### If `created` is `true`
 
-The item is genuinely new (feature/bugfix, or a fresh single-discussion create). Add every source with `status: pending`:
+The item is genuinely new (feature/bugfix, or a fresh single-discussion create). Add every source with `status: pending`. For a bugfix the single source is the investigation and its `{source-name}` is `{topic}` — the same name must be used when marking it incorporated:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} sources.{source-name}.status pending

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -194,7 +194,7 @@ If you are uncertain whether the user approved, **ASK**: "Ready to log it, or do
 ## E. Log and Commit
 
 1. Write to the specification — **verbatim** as presented and approved. No silent modifications. Before extracting a `pending` source, re-read the specification for content already logged from it (a crash can leave content written with the status still `pending`) — never double-log.
-2. After completing exhaustive extraction from a source (all relevant content presented and logged), update that source's status to `incorporated` via `engine manifest` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} sources.{source-name}.status incorporated`). See **[specification-format.md](specification-format.md)** for source status details.
+2. After completing exhaustive extraction from a source (all relevant content presented and logged), update that source's status to `incorporated` via `engine manifest` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} sources.{source-name}.status incorporated`). `{source-name}` is the registered key — read the existing `sources` map and flip that row, never invent a new name (for a bugfix it is `{topic}`). See **[specification-format.md](specification-format.md)** for source status details.
 3. Commit at natural breaks — after significant exchanges, after each major topic, and before any context refresh:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): {what changed}"


### PR DESCRIPTION
## Summary
- For a bugfix, nothing pinned the canonical `{source-name}` for the investigation source — the model invented one at register-time and again at incorporate-time. Same-session both match; a cross-session resume can diverge, writing a second `sources` row and stranding the original `pending` row that `spec-completion.md` then blocks sign-off on.
- Pinned to `{topic}` at registration (`initialize-specification.md`), and incorporation (`spec-construction.md` E.2) now flips the registered key read from the manifest instead of deriving a name.

## Test plan
- Conventions lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. #507
4. #508
5. #509
6. #510
7. #512
8. #513
9. #514
10. #515
11. **#516** 👈 current
12. #517
13. #518
14. #519
15. #520
16. #521
17. #522
18. #523
<!-- stack:links:end -->