### PR TITLE
fix(review-entry): name the real upstream — specification and plan

### DIFF
--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -10,7 +10,7 @@ Act as **precise intake coordinator**. Follow each step literally without interp
 
 ## Workflow Context
 
-You are in the **Review** phase — validating completed work against discussion, specification, and plan. Where Review sits in the pipeline depends on the work type:
+You are in the **Review** phase — validating completed work against the specification and plan. Where Review sits in the pipeline depends on the work type:
 
 | Work type | Pipeline |
 |---|---|


### PR DESCRIPTION
## Summary
- `workflow-review-entry`'s context prose claimed review validates "against discussion, specification, and plan" — but the review process reads only the spec and plan, and "discussion" doesn't exist for bugfix/quick-fix work types.
- Reworded to "against the specification and plan" — the spec is the standalone document that already incorporates its upstream (discussion or investigation).

## Test plan
- Conventions lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. #507
4. #508
5. #509
6. #510
7. #512
8. #513
9. #514
10. #515
11. #516
12. #517
13. **#518** 👈 current
14. #519
15. #520
16. #521
17. #522
18. #523
<!-- stack:links:end -->