### PR TITLE
fix(shared): strip triage-landing's unreachable superseded-research arm

### DIFF
--- a/skills/workflow-shared/references/triage-landing.md
+++ b/skills/workflow-shared/references/triage-landing.md
@@ -82,12 +82,6 @@ Set `landing_phase = research` and `landing_status` to that status.
 
 → Proceed to **D. Existing Target**.
 
-**If the research status is `superseded`:**
-
-The research lineage is closed — an entry written there would never drain.
-
-→ Proceed to **F. Superseded Research**.
-
 **If neither item is live:**
 
 No live artefact. Set `landing_phase` to the row's `routing=` value — unless that phase's item exists as `cancelled` (`topic start` refuses it), in which case set `landing_phase` to the other phase.
@@ -158,13 +152,13 @@ Surface the engine's error verbatim. Nothing has been written; set `result = can
 
 **Otherwise:**
 
-→ Proceed to **G. Append the Entry**.
+→ Proceed to **F. Append the Entry**.
 
 #### If `landing_status` is `in-progress`
 
 The item is already live — no reopen needed.
 
-→ Proceed to **G. Append the Entry**.
+→ Proceed to **F. Append the Entry**.
 
 ## E. Closed Target
 
@@ -214,47 +208,7 @@ Nothing written. Set `result = cancelled`.
 
 → Return to caller.
 
-## F. Superseded Research
-
-Read where the research lineage went:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{target} superseded_by
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-"{target}"'s research was superseded by "{superseded_by}" — an entry there would never drain.
-
-- **`s`/`superseding`** — Land the concern in "{superseded_by}" instead
-- **`d`/`discussion`** — Start "{target}"'s discussion and land it there
-- **`e`/`elsewhere`** — Pick a different target
-· · · · · · · · · · · ·
-```
-
-**STOP.** Wait for user response.
-
-**If `superseding`:**
-
-Set `target = {superseded_by}` and re-classify:
-
-→ Return to **A. Classify the Target**.
-
-**If `discussion`:**
-
-Set `landing_phase = discussion`.
-
-→ Proceed to **C. Fresh Target**.
-
-**If `elsewhere`:**
-
-Ask the user which topic the concern should land in, set `target` to their answer, and re-classify:
-
-→ Return to **A. Classify the Target**.
-
-## G. Append the Entry
+## F. Append the Entry
 
 Append the concern as a `### {short title}` subsection under `.workflows/{work_unit}/{landing_phase}/{target}.md`'s `## Triage` heading, using the entry shape above. If the section holds the `(none)` placeholder, replace it; otherwise add the entry below the existing ones. If the file has no `## Triage` heading at all — an artefact created outside the template — add the heading at end of file with the entry beneath it.
 

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -616,7 +616,7 @@ const RATCHET_PINS = {
   'skills/workflow-shared/references/drain-triage.md': 1,
   'skills/workflow-shared/references/final-review-menu.md': 1,
   'skills/workflow-shared/references/topic-name-validation.md': 1,
-  'skills/workflow-shared/references/triage-landing.md': 2,
+  'skills/workflow-shared/references/triage-landing.md': 1,
   'skills/workflow-specification-entry/references/confirm-continue.md': 4,
   'skills/workflow-specification-entry/references/confirm-create.md': 3,
   'skills/workflow-specification-entry/references/confirm-refine.md': 2,


### PR DESCRIPTION
## Summary
- Chesterton check first: section F was added deliberately in #451's honest-classification pass, not legacy — but it models spec-style supersession (single absorber, `superseded_by`) that research supersession doesn't have.
- The only producer of superseded research is `workflow-legacy-research-split`'s `apply.cjs`, which renames the item to `{source}-superseded-{datetime}` (never matching a map item, so triage can never target it) and supersedes via raw `set status` — `superseded_by` is never written. F was unreachable, and would interpolate an empty absorber name if it ever fired.
- Stripped the classification branch and section F; renamed G→F. A superseded item now falls to the neither-live branch → Fresh Target, whose existing `ok: false` handling surfaces the engine's `topic start` refusal verbatim — the code guard is the handler.

## Test plan
- Conventions lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. #507
4. #508
5. #509
6. #510
7. #512
8. #513
9. #514
10. #515
11. #516
12. #517
13. #518
14. **#519** 👈 current
15. #520
16. #521
17. #522
18. #523
<!-- stack:links:end -->