### PR TITLE
feat(engine): refuse work-unit-level fields that shadow the phases tree

### DIFF
--- a/skills/workflow-engine/scripts/domain/fields.cjs
+++ b/skills/workflow-engine/scripts/domain/fields.cjs
@@ -255,6 +255,20 @@ function validateSet(segments, value) {
   }
 }
 
+// A work-unit-level field whose first segment names a phase builds a shadow
+// tree beside `phases.*` that no read ever joins — a typo'd dot-path
+// (`set wu specification.x` for `set wu.specification.topic x`) must fail
+// loudly, not land silently. Mutation-only: reads and delete stay free so a
+// stray tree can still be inspected and repaired.
+/** @param {string|null} phase @param {string[]} fieldSegments */
+function refuseShadowField(phase, fieldSegments) {
+  if (phase !== null) return;
+  const head = fieldSegments[0];
+  if (VALID_PHASES.includes(head)) {
+    fail(`Invalid field "${fieldSegments.join('.')}" at work-unit level: "${head}" is a phase — use the dot-path (<work-unit>.${head}[.<topic>] <field>) so the write lands under phases with validation`);
+  }
+}
+
 /** @param {*} value */
 function validateStoragePaths(value) {
   if (!Array.isArray(value) || value.some((p) => typeof p !== 'string')) {
@@ -747,7 +761,9 @@ function cmdSet(cwd, args) {
   // checked whatever type that parse produced (a bare number/boolean/~ would
   // otherwise slip past a string-only guard and corrupt a typed field).
   const planned = writes.map((write) => {
-    const segments = resolveSegments(phase, topic, write.field.split('.'));
+    const fieldSegments = write.field.split('.');
+    refuseShadowField(phase, fieldSegments);
+    const segments = resolveSegments(phase, topic, fieldSegments);
     validateSet(segments, write.value);
     return { segments, value: write.value };
   });
@@ -801,6 +817,7 @@ function cmdPush(cwd, args) {
 
   requireWorkUnit(cwd, workUnit);
 
+  refuseShadowField(phase, fieldSegments);
   const segments = resolveSegments(phase, topic, fieldSegments);
 
   const length = manifestTarget(cwd, false, workUnit).transact((manifest, save) => {
@@ -959,7 +976,9 @@ function cmdApply(cwd, args) {
         fail(`apply: ${at} — "fields" must be a non-empty object of {"<field.path>": value}`);
       }
       const writes = entries.map(([field, value]) => {
-        const segments = resolveSegments(phase, topic, field.split('.'));
+        const fieldSegments = field.split('.');
+        refuseShadowField(phase, fieldSegments);
+        const segments = resolveSegments(phase, topic, fieldSegments);
         validateSet(segments, value);
         return { segments, value };
       });

--- a/tests/scripts/test-engine-manifest-fields.cjs
+++ b/tests/scripts/test-engine-manifest-fields.cjs
@@ -470,6 +470,51 @@ describe('engine manifest set — two grammars, never mixed', () => {
   });
 });
 
+describe('work-unit-level fields never shadow the phases tree', () => {
+  let dir;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'shadow-guard-'));
+    writeWorkUnit(dir, 'pay', 'feature');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('set refuses a phase-name-headed field in both grammars', () => {
+    const err = runFails(dir, ['set', 'pay', 'specification.foo', 'bar']);
+    assert.match(err.error, /"specification" is a phase/);
+    const batch = runFails(dir, ['set', 'pay', 'description=ok', 'discussion.x=1']);
+    assert.match(batch.error, /"discussion" is a phase/);
+    const m = readWorkUnit(dir, 'pay');
+    assert.strictEqual(m.specification, undefined);
+    assert.strictEqual(m.discussion, undefined);
+    assert.strictEqual(m.description, 'Fixture', 'refused batch persisted nothing');
+  });
+
+  it('push refuses a phase-name-headed field; apply routes set ops through the same guard', () => {
+    assert.match(runFails(dir, ['push', 'pay', 'review.list', 'x']).error, /"review" is a phase/);
+    const f = path.join(dir, 'ops.json');
+    fs.writeFileSync(f, JSON.stringify([{ op: 'set', path: 'pay', fields: { 'research.foo': 1 } }]));
+    assert.match(runFails(dir, ['apply', 'pay', '--file', f]).error, /"research" is a phase/);
+    assert.strictEqual(readWorkUnit(dir, 'pay').research, undefined, 'nothing persisted');
+  });
+
+  it('reads and delete stay free so a stray tree can be inspected and repaired', () => {
+    const m = readWorkUnit(dir, 'pay');
+    m.specification = { foo: 'bar' };
+    fs.writeFileSync(path.join(dir, '.workflows', 'pay', 'manifest.json'), JSON.stringify(m, null, 2) + '\n');
+    assert.strictEqual(runOk(dir, ['get', 'pay', 'specification.foo']).trim(), 'bar');
+    runJson(dir, ['delete', 'pay', 'specification']);
+    assert.strictEqual(readWorkUnit(dir, 'pay').specification, undefined);
+  });
+
+  it('phase- and topic-level writes are untouched, as are legitimate root fields', () => {
+    runJson(dir, ['set', 'pay.specification.pay', 'status', 'in-progress']);
+    runJson(dir, ['set', 'pay', 'description', 'updated']);
+    const m = readWorkUnit(dir, 'pay');
+    assert.strictEqual(m.phases.specification.items.pay.status, 'in-progress');
+    assert.strictEqual(m.description, 'updated');
+  });
+});
+
 describe('storage_paths is guarded at write time — set and apply', () => {
   let dir;
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Verified live: `manifest set pay specification.foo bar` succeeded and created a root `specification: {foo: "bar"}` object *beside* `phases` — an unvalidated shadow tree invisible to every phase-level read. The typo class (`{wu} specification.x` for `{wu}.specification.{topic} x`) landed garbage silently.
- `set` (both grammars), `push`, and `apply` set-ops now refuse work-unit-level fields whose first segment is a phase name, with a pointer to the canonical dot-path. Reads and `delete` stay free so a stray tree can be inspected and repaired.
- `phases.*`-headed fields stay permitted — they resolve into the real tree through full validation (and the contract suite pins that for fixture setup).

## Test plan
- New suite in `test-engine-manifest-fields.cjs`: refusal in both set grammars + push + apply (nothing persisted), repair paths free, phase/topic-level and legit root fields untouched.
- `npm test` 1575 pass; `test:cli`, typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. #507
4. #508
5. #509
6. #510
7. #512
8. #513
9. #514
10. #515
11. #516
12. #517
13. #518
14. #519
15. **#520** 👈 current
16. #521
17. #522
18. #523
<!-- stack:links:end -->