### PR TITLE
fix(discovery): first-written briefs join the full brief lifecycle

### DIFF
--- a/skills/workflow-discovery/references/brief-synthesis.md
+++ b/skills/workflow-discovery/references/brief-synthesis.md
@@ -4,13 +4,13 @@
 
 ---
 
-Loaded by [topic-synthesis.md](topic-synthesis.md) E on the confirmed harvest, while the whole exploration is still in context. A **brief** is a per-topic *view* — one topic's slice of the discovery record (soft decisions, reasoning, rejected paths, open questions), projected out of the source-of-truth logs. It is regenerated at every harvest that touches its topic — overwrite freely; it is never a record. Writes the briefs for the confirmed set, reconciles brief files against any topics the harvest restructured, and flags downstream work that a regenerated brief now post-dates.
+Loaded by [topic-synthesis.md](topic-synthesis.md) E on the confirmed harvest, while the whole exploration is still in context. A **brief** is a per-topic *view* — one topic's slice of the discovery record (soft decisions, reasoning, rejected paths, open questions), projected out of the source-of-truth logs. It is regenerated at every harvest that touches its topic — overwrite freely; it is never a record. Writes the briefs for the confirmed set, reconciles brief files and pointers against the harvest, and flags in-flight downstream work the fresh briefs post-date.
 
 ## A. Write the Briefs
 
 For each topic in the confirmed set — the working-list new topics **plus** any existing map topic this session's exploration materially deepened — extract that topic's slice from the whole exploration (all sessions in context) and (over)write `.workflows/{work_unit}/discovery/briefs/{topic}.md`.
 
-Note which briefs already existed on disk before this write (**regenerations**) versus which are **first writes** — **C** needs the distinction.
+Note which written topics are existing committed map topics that had no brief before this write — **B**'s pointer backfill needs them.
 
 The brief is a written artifact, not user output — write the file, do not render it. Word every decision plainly and naturally: softness is conferred by where the brief lives on the gradient, not by hedged wording. Empty sections get `(none)`.
 
@@ -36,7 +36,7 @@ Drawn from discovery session(s) {coarse session range}.
 
 ## B. Lifecycle
 
-This section applies only to restructures **within the session's working list** — the set the harvest shaped and the user confirmed. Committed map items outside the working list are never restructured by a harvest (map edits go through map-operations, which owns its own log entries); their briefs are untouched here. When the confirmed working list restructured a topic that already carried a brief, keep brief files and `brief_path` pointers in step with the confirmed set. Apply whichever operations occurred — split, merge, and drop are independent, and more than one may apply in a single harvest. This section removes only what the restructuring orphaned.
+Keep brief files and `brief_path` pointers in step with the confirmed set. The restructure cleanup below applies only to restructures **within the session's working list** — the set the harvest shaped and the user confirmed. Committed map items outside the working list are never restructured by a harvest (map edits go through map-operations, which owns its own log entries); their briefs are untouched here. Apply whichever operations occurred — split, merge, and drop are independent, and more than one may apply in a single harvest. This section removes only what the restructuring orphaned.
 
 Collect the orphaned topics across every operation that occurred — **split** orphans the parent (children's briefs are written in **A**), **merge** orphans each absorbed topic (the merged topic's brief is written in **A**), **drop** orphans the removed topic — then clean them all up in two calls: one `rm -f` naming every orphaned brief file, and one `apply` deleting every `brief_path` pointer (write the ops file with the Write tool first):
 
@@ -52,7 +52,15 @@ rm -f .workflows/{work_unit}/discovery/briefs/{parent}.md .workflows/{work_unit}
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest apply {work_unit} --file .workflows/.cache/{work_unit}/discovery/brief-cleanup-ops.json
 ```
 
-New topics with no prior brief need no cleanup. A `delete` op fails the whole batch when the field is absent — include only topics that actually carried a `brief_path` (committed map topics with a prior brief), and skip the `apply` entirely when no orphan carried one; the `rm -f` paths are safe to include unconditionally.
+New topics with no prior brief need no cleanup. A `delete` op fails the whole batch when the field is absent — include only topics that actually carried a `brief_path` (committed map topics with a prior brief); the `rm -f` paths are safe to include unconditionally.
+
+**Pointer backfill** — the write direction of the same bookkeeping: a brief first-written in **A** for an existing committed topic has a file but no pointer (new working-list topics get `brief_path` from the persist batch; regenerated briefs already point). Add one set op per such topic to the same ops file:
+
+```json
+[{"op": "set", "path": "{work_unit}.discovery.{topic}", "fields": {"brief_path": "discovery/briefs/{topic}.md"}}]
+```
+
+Skip the `apply` when the ops file would hold no ops at all.
 
 → Proceed to **C. Propagation**.
 
@@ -60,22 +68,20 @@ New topics with no prior brief need no cleanup. A `delete` op fails the whole ba
 
 Flag downstream work, never overwrite it.
 
-#### If no briefs were regenerated
-
-Every write in **A** was a first brief — there is no prior downstream work to flag.
+#### If **A** wrote no briefs
 
 → Return to caller.
 
 #### Otherwise
 
-Read both downstream phases once — every topic's items in two calls, however many briefs regenerated:
+Read both downstream phases once — every topic's items in two calls, however many briefs were written:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion
 ```
 
-For each brief **regenerated** in **A** (the topic already had a brief before this harvest), check the subtrees for that topic's item — a topic routes to one of the two. Collect a flag op for every hit, then persist them in one call (skip when none; write the ops file with the Write tool):
+For each brief written in **A**, check the subtrees for that topic's item — a topic routes to one of the two. A hit is in-flight downstream work the fresh brief post-dates: a regenerated brief changed content the phase may have read; a first-written brief covers work that started brief-less and has never been read at all. Collect a flag op for every hit, then persist them in one call (skip when none; write the ops file with the Write tool):
 
 ```json
 [{"op": "set", "path": "{work_unit}.{research|discussion}.{topic}", "fields": {"reconcile_needed": true}}]
@@ -85,6 +91,6 @@ For each brief **regenerated** in **A** (the topic already had a brief before th
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest apply {work_unit} --file .workflows/.cache/{work_unit}/discovery/reconcile-ops.json
 ```
 
-This is a signal, not a rewrite — it never touches the downstream artifact's content. Soft can prompt re-examination; it can never overwrite hard. The downstream phase surfaces the flag when it next runs. First-write briefs have no prior downstream work — skip them.
+This is a signal, not a rewrite — it never touches the downstream artifact's content. Soft can prompt re-examination; it can never overwrite hard. The downstream phase surfaces the flag when it next runs.
 
 → Return to caller.

--- a/skills/workflow-shared/references/reconcile-advisory.md
+++ b/skills/workflow-shared/references/reconcile-advisory.md
@@ -22,13 +22,13 @@ The common case. No output.
 
 #### If output is non-empty (reconcile flagged)
 
-The discovery brief was regenerated after this work started. Surface a non-blocking advisory (never a STOP gate), re-read the regenerated brief into context, and clear the flag.
+A discovery brief was written or regenerated after this work started. Surface a non-blocking advisory (never a STOP gate), re-read the regenerated brief into context, and clear the flag.
 
 > *Output the next fenced block as a code block:*
 
 ```
   ⚑ Discovery context changed since this work started.
-    Reconciling against the regenerated discovery brief —
+    Reconciling against the latest discovery brief —
     review and update as needed. Nothing has been overwritten.
 ```
 


### PR DESCRIPTION
## Summary
- Pre-existing gap found while reviewing #513's propagation skip: a brief **first-written** for an existing committed topic (materially deepened this session; topic originally added by research-analysis/gap-analysis/migration, before briefs existed) produced a file with **no `brief_path` pointer** — `confirm-and-persist` only sets pointers for new working-list topics. The brief was invisible to `read-brief-context` (silent fallback to the `description` seed) and exempt from reconcile flagging.
- `brief-synthesis` B gains a **pointer backfill**: one set op per first-written existing topic, riding the same ops file as the restructure cleanup.
- C widens from regenerated-only to **every brief written in A**: in-flight downstream work is flagged whether the brief changed under it or appeared after it started brief-less. The zero-briefs gate keeps the H4 conditional shape from #513's review.
- `reconcile-advisory` wording follows ("written or regenerated", "latest discovery brief").

## Test plan
- Conventions lint green (29 checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #505
2. #506
3. #507
4. #508
5. #509
6. #510
7. #512
8. #513
9. #514
10. #515
11. #516
12. #517
13. #518
14. #519
15. #520
16. **#521** 👈 current
17. #522
18. #523
<!-- stack:links:end -->