### PR TITLE
refactor(planning): approvals leave the plan's prose (stage 5)

### DIFF
--- a/agents/workflow-planning-task-author.md
+++ b/agents/workflow-planning-task-author.md
@@ -22,7 +22,7 @@ You receive file paths via the orchestrator's prompt:
 7. **Task detail file path** — Where to write authored tasks
 
 On **amendment**, you also receive:
-- **Task detail file path** — Contains previously authored tasks with status markers
+- **Task detail file path** — Contains previously authored tasks (an amendment run's prompt names the rejected ids)
 - The task detail file contains `rejected` tasks with feedback blockquotes — rewrite only those
 
 ## Your Process
@@ -34,7 +34,7 @@ On **amendment**, you also receive:
 5. Read the approved phases and task list — understand context and scope
 6. Author all tasks in the phase, writing each to the task detail file incrementally — each task written to disk before starting the next
 
-If this is an **amendment**: read the task detail file, find tasks marked `rejected` (they have a feedback blockquote below the status line). Rewrite the entire task detail file — copy `approved` tasks verbatim, rewrite `rejected` tasks addressing the feedback. Reset rewritten tasks to `pending` status.
+If this is an **amendment**: the prompt names the rejected ids, and each carries a feedback blockquote below its heading in the file. Rewrite the entire task detail file — copy the other tasks verbatim, rewrite the rejected ones addressing the feedback and dropping the spent blockquote. The file carries no status markers — the orchestrator tracks decisions in its own store.
 
 ## Task Detail File Format
 
@@ -47,7 +47,7 @@ phase_name: {Phase Name}
 total: {count}
 ---
 
-## {internal_id} | pending
+## {internal_id}
 
 ### Task {task_id}: {Task Name}
 
@@ -61,7 +61,7 @@ total: {count}
 **Context**: ...
 **Spec Reference**: ...
 
-## {internal_id} | pending
+## {internal_id}
 
 ### Task {task_id}: {Task Name}
 ...

--- a/skills/workflow-engine/scripts/domain/fields.cjs
+++ b/skills/workflow-engine/scripts/domain/fields.cjs
@@ -247,8 +247,8 @@ function validateSet(segments, value) {
     // Staging task decisions (phases.<phase>.items.<item>.staging.c<N>.tasks.<n>)
     if (segments.length >= 2 && segments[segments.length - 2] === 'tasks'
         && segments.includes('staging')) {
-      if (typeof value !== 'string' || !['pending', 'approved', 'skipped'].includes(value)) {
-        fail(`Invalid staging task status ${JSON.stringify(value)}. Must be one of: pending, approved, skipped`);
+      if (typeof value !== 'string' || !['pending', 'approved', 'skipped', 'rejected'].includes(value)) {
+        fail(`Invalid staging task status ${JSON.stringify(value)}. Must be one of: pending, approved, skipped, rejected`);
       }
       return;
     }

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -90,6 +90,12 @@ Apply the user's correction.
 
 ## D. Check Gate Mode
 
+Register the phase's authoring state — one batched write, one row per task in the detail file, keyed by internal id (skip rows that already exist from a prior pass — a resume never resets decisions):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id}=pending …
+```
+
 Check `author_gate_mode` via `engine manifest`:
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} author_gate_mode
@@ -97,7 +103,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 #### If `author_gate_mode` is `auto`
 
-Set every `pending` task in the task detail file to `approved`.
+Approve every `pending` row in one batched write: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id}=approved …`.
 
 > *Output the next fenced block as a code block:*
 
@@ -115,15 +121,15 @@ Phase {N}: {count} tasks authored. Auto-approved. Writing to plan.
 
 ## E. Approval Loop
 
-For each task in the task detail file, in order:
+For each task in the task detail file, in order, branching on its row in the manifest's `staging.author-p{N}.tasks`:
 
-#### If task status is `approved`
+#### If the row is `approved`
 
 Skip — already approved from a previous pass.
 
 → Return to **E. Approval Loop**.
 
-#### If task status is `pending`
+#### If the row is `pending`
 
 Present the full task content:
 
@@ -143,25 +149,25 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render author-task-gate {
 
 **If `yes`:**
 
-Mark the task `approved` in the task detail file.
+Record the approval: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id} approved`.
 
 → Return to **E. Approval Loop**.
 
 **If `auto`:**
 
-Mark the task `approved` in the task detail file. Set all remaining `pending` tasks to `approved`. Update `author_gate_mode` in the manifest:
+Record this task and every remaining `pending` row `approved`, and the gate mode, in one batched write:
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} author_gate_mode auto
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} author_gate_mode=auto staging.author-p{N}.tasks.{internal_id}=approved …
 ```
 
 → Proceed to **F. Revision Check** (earlier `rejected` tasks still need revision before writing).
 
 **If the user provides feedback:**
 
-Mark the task `rejected` in the task detail file and add the feedback as a blockquote:
+Record the rejection (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id} rejected`) and add the feedback as a blockquote under the task's heading in the detail file:
 
 ```markdown
-## {internal_id} | rejected
+## {internal_id}
 
 > **Feedback**: {user's feedback here}
 
@@ -185,7 +191,7 @@ When all tasks are processed:
 
 ## F. Revision Check
 
-Check for rejected tasks in the task detail file.
+Read the manifest's `staging.author-p{N}.tasks` for `rejected` rows.
 
 #### If no rejected tasks
 
@@ -199,13 +205,15 @@ Check for rejected tasks in the task detail file.
 {N} tasks need revision. Re-invoking author agent...
 ```
 
+After the agent's rewrite lands, reset each rewritten task's row: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id} pending` per rejected id.
+
 → Return to **B. Invoke the Agent**.
 
 ---
 
 ## G. Write to Plan
 
-> **CHECKPOINT**: Verify all tasks in the task detail file are marked `approved` before writing — both gate modes approve every task before reaching this section.
+> **CHECKPOINT**: Verify the manifest marks every `staging.author-p{N}` row `approved` before writing — both gate modes approve every task before reaching this section.
 
 For each approved task in the task detail file, in order (crash-resume guard: a task whose internal id is already in `task_map` was written before an interruption — skip its format write and continue with the next; re-creating it would duplicate the task in external backends):
 
@@ -232,6 +240,10 @@ Task {M} of {total}: {Task Name} — authored.
 
 Repeat for each task.
 
-Authoring for this phase is **complete** — report that to the caller.
+Authoring for this phase is **complete** — the plan's tasks are the record, so clear the spent authoring state and report completion to the caller:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.planning.{topic} staging.author-p{N}
+```
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -104,12 +104,12 @@ Resolve the destination per the caller's **Navigation** section — the user's p
 
 **If the phase structure is new or was amended:**
 
-1. Update each phase in the planning file: set `status: approved` and `approved_at: YYYY-MM-DD` (use today's actual date)
+1. Record the approval — `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} approvals.structure $(date +%Y-%m-%d)`
 2. Commit:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): approve phase structure"
    ```
 
-If the phase structure was already approved and unchanged, no updates are needed.
+If the manifest already carries `approvals.structure` and the structure is unchanged, no updates are needed.
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/define-tasks.md
+++ b/skills/workflow-planning-process/references/define-tasks.md
@@ -113,7 +113,7 @@ Resolve the destination per the caller's **Navigation** section — the user's p
 
 **If the task list is new or was amended:**
 
-1. Update the task table in the planning file: set `status: approved` and `approved_at: YYYY-MM-DD` (use today's actual date)
+1. Record the approval — `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} approvals.tasks.p{N} $(date +%Y-%m-%d)`
 2. Advance the planning position in the manifest to the first task in this phase:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} task {first_task_id}
@@ -123,6 +123,6 @@ Resolve the destination per the caller's **Navigation** section — the user's p
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): approve Phase {N} task list"
    ```
 
-If the task list was already approved and unchanged, no updates are needed.
+If the manifest already carries `approvals.tasks.p{N}` and the list is unchanged, no updates are needed.
 
 → Return to caller.

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -298,6 +298,16 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
     'format=local-markdown', 'task_list_gate_mode=gated', 'author_gate_mode=gated',
     'finding_gate_mode=gated', 'review_cycle=0', 'phase=1', 'task=~',
     `task_map.${topic}-1-1=${topic}-1-1`, 'storage_paths=[]']);
+
+  // Approvals and authoring decisions are manifest state, vocabulary-guarded.
+  sim.run(['manifest', 'set', `${wu}.planning.${topic}`, 'approvals.structure', '2026-07-23']);
+  sim.run(['manifest', 'set', `${wu}.planning.${topic}`, 'approvals.tasks.p1', '2026-07-23']);
+  sim.run(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'pending']);
+  sim.run(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'rejected']);
+  sim.run(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'approved']);
+  sim.refuses(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'maybe'], /Invalid staging task status/);
+  sim.run(['manifest', 'delete', `${wu}.planning.${topic}`, 'staging.author-p1']);
+
   sim.run(['commit', wu, '-m', `plan(${wu}): author`, '--plan', topic]);
   sim.run(['topic', 'complete', wu, 'planning', topic]);
 


### PR DESCRIPTION
## Summary
- Stage 5 of the analysis-state programme (design log #526) — the adjacent find from the census: state written in *natural language* rather than frontmatter, same disease without the YAML.
- **Plan approvals**: `status: approved` + `approved_at` lines edited into `planning.md` become manifest dates — `approvals.structure` and `approvals.tasks.p{N}` — written by `define-phases`/`define-tasks` on the `yes` arms; the already-approved-and-unchanged checks read the manifest.
- **Authoring decisions**: the per-task `| pending`/`| rejected` heading suffixes in `phase-{N}-tasks.md` become `staging.author-p{N}.tasks.{internal_id}` rows (`rejected` joins the guarded staging vocabulary): registered at gate entry, resume-safe (existing rows never reset), auto-arm approves in one batched write, amendments reset only the rewritten ids, and completion clears the subtree — the plan's authored tasks are the record.
- **Task-author agent** writes bare `## {internal_id}` headings; an amendment identifies rejected tasks from the prompt's id list and the feedback blockquotes (content), never status markers.

## Test plan
- Staging vocabulary guard extended + pinned; simulation walks approvals and the authoring decision lifecycle with a refusal asserted.
- `npm test` 1613 pass; conventions lint, typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #527
2. #528
3. #529
4. #530
5. **#531** 👈 current
6. #532
7. #533
8. #534
9. #535
10. #536
11. #537
<!-- stack:links:end -->