### PR TITLE
fix(stack-review): round 4 — the enumeration pass

### DIFF
--- a/agents/workflow-planning-task-author.md
+++ b/agents/workflow-planning-task-author.md
@@ -32,7 +32,7 @@ On **amendment**, the task detail file already contains previously authored task
 5. Read the approved phases and task list — understand context and scope
 6. Author all tasks in the phase, writing each to the task detail file incrementally — each task written to disk before starting the next
 
-If this is an **amendment**: the prompt names the rejected ids, and each carries a feedback blockquote below its heading in the file. Rewrite the entire task detail file — copy the other tasks verbatim, rewrite the rejected ones addressing the feedback and dropping the spent blockquote. The file carries no status markers — the orchestrator tracks decisions in its own store.
+If this is an **amendment**: the prompt names the rejected ids, and each carries a feedback blockquote below its heading in the file. Rewrite the entire task detail file — copy the other tasks verbatim, rewrite the rejected ones addressing the feedback and dropping the spent blockquote. A named id with **no** feedback blockquote was already rewritten by an interrupted run — copy it verbatim like the others. The file carries no status markers — the orchestrator tracks decisions in its own store.
 
 ## Task Detail File Format
 

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -20,9 +20,31 @@ node .claude/skills/workflow-engine/scripts/engine.cjs agent scan {work_unit} di
 
 Synthesis findings drain first — perspective-council tensions that never finished surfacing during the session would otherwise be dropped at conclusion.
 
+#### If a complete `perspective` set has no `synthesis` row
+
+Every member of the set is `pending` — a landed council awaiting synthesis (the scan just promoted lenses that finished after the session's last check). Promote it via the **Perspective completion check** in **D. Check and Surface** in **[perspective-agents.md](perspective-agents.md)**, then bounce back to the session — the in-flight gate owns the new synthesis on the next conclusion attempt. An incomplete set (a lens still in flight) is not caught here — the session's in-flight gate already owns that wait-or-proceed decision.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 5**.
+
 #### If any `synthesis` row is `pending` or `acknowledged`
 
-Surface one tension via **D. Check and Surface** in **[perspective-agents.md](perspective-agents.md)**, then bounce back to the session so the user can engage.
+Surface one tension via **D. Check and Surface** in **[perspective-agents.md](perspective-agents.md)**.
+
+**If a tension was raised:**
+
+Bounce back to the session so the user can engage.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 5**.
+
+**If the row incorporated without findings** (a clean report):
+
+Nothing awaited engagement — drain any further rows before proceeding.
+
+→ Return to **A. Check Review State**.
+
+**If the row still holds unraised findings** (the user deferred at the announce menu):
+
+The session owns the deferral — the next done-signal re-enters this gate.
 
 → Return to **[the skill](../SKILL.md)** for **Step 5**.
 

--- a/skills/workflow-engine/scripts/domain/fields.cjs
+++ b/skills/workflow-engine/scripts/domain/fields.cjs
@@ -890,6 +890,11 @@ function cmdPush(cwd, args) {
     fail(`"${fieldSegments[0]}" is a guarded state container — its fields take vocabulary values via set, never array pushes`);
   }
   const segments = resolveSegments(phase, topic, fieldSegments);
+  // storage_paths is guarded at write time on every route — set validates the
+  // whole array; push validates the one entry it appends.
+  if (segments.length === 5 && segments[2] === 'items' && segments[4] === 'storage_paths') {
+    validateStoragePaths([value]);
+  }
 
   const length = manifestTarget(cwd, false, workUnit).transact((manifest, save) => {
     const current = getByPath(manifest, segments);

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -272,8 +272,8 @@ function taskList(cwd, { dotpath, file, variant: variantArg }) {
 // proposed-task / tasks-overview — the analysis and review synthesis loops'
 // shared task presentation (their prose templates were byte-identical twins).
 // Gate mode rides as a flag, not an address read: one consumer carries it in
-// the cycle response, the other in staging-file frontmatter — the surface
-// guarantees the form of both outputs, the flow owns the mode.
+// the cycle response, the other in the manifest's staging.c{N} subtree — the
+// surface guarantees the form of both outputs, the flow owns the mode.
 // ---------------------------------------------------------------------------
 
 /**

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -287,6 +287,12 @@ impl({work_unit}): analysis cycle {N} — tasks skipped
 
 > **CHECKPOINT**: Do not proceed until the task writer has returned.
 
+**If the planning item carries no `storage_paths`** (a plan initialised before the field existed): record it now — read the format's authoring.md → Storage Pathspecs and copy the fenced array:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} storage_paths '{format storage pathspecs}'
+```
+
 Commit all analysis and plan changes with raw git — stage the analysis outputs, the plan's `storage_paths` (recorded on the planning item), and the work unit, then commit:
 
 ```

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -32,7 +32,7 @@ Mid-authoring resume — the text and its decisions already stand; re-invoking w
 
 ## B. Invoke the Agent
 
-**Amendment runs** — when `staging.author-p{N}` carries `rejected` rows (arrival from **F. Revision Check**), the invocation is an amendment: name those ids via input item 8. All other arrivals are full runs — omit item 8.
+**Amendment runs** — when `staging.author-p{N}` carries `rejected` rows (arrival from **F. Revision Check**, or a mismatch retry from **C** during an amendment), the invocation is an amendment: name those ids via input item 8. All other arrivals are full runs — omit item 8.
 
 > *Output the next fenced block as a code block:*
 
@@ -49,11 +49,9 @@ Invoke `workflow-planning-task-author` with these file paths:
 5. **All approved phases**: the complete phase structure from the planning file body
 6. **Task list for current phase**: the task table for this specific phase from the planning file
 7. **Task detail file path**: `.workflows/{work_unit}/planning/{topic}/phase-{N}-tasks.md`
-8. **Amendment context** (amendment runs only): the rejected internal ids being rewritten — their feedback blockquotes sit under their headings in the detail file
+8. **Amendment context** (amendment runs only): the rejected internal ids being rewritten — any surviving feedback blockquotes sit under their headings in the detail file
 
 The agent writes all tasks to the task detail file and returns.
-
-**On an amendment run**, reset each rewritten row to `pending` now that the rewrite is on disk (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id} pending` per id) — the rows return to the loop, and in auto mode they approve automatically like any pending row. Rows stay `rejected` until this point so an interrupted amendment resumes as an amendment, never as a silent skip.
 
 → Proceed to **C. Validate Task Detail File**.
 
@@ -64,6 +62,8 @@ The agent writes all tasks to the task detail file and returns.
 Read the task detail file and count tasks. Verify task count matches the task table in the planning file for this phase. Track the number of agent invocations for this phase in-conversation.
 
 #### If `valid`
+
+**On an amendment run** (the manifest still carries `rejected` rows): the rewrite is validated — reset each rejected row to `pending` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id} pending` per id); in auto mode they approve automatically, like any pending row. Rows stay `rejected` until validation passes so a mismatch retry re-enters **B** as an amendment — never as a full run over approved text — and an interrupted amendment resumes as one.
 
 → Proceed to **D. Check Gate Mode**.
 

--- a/skills/workflow-planning-process/references/author-tasks.md
+++ b/skills/workflow-planning-process/references/author-tasks.md
@@ -122,7 +122,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 #### If `author_gate_mode` is `auto`
 
-Approve every `pending` row in one batched write: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id}=approved …`.
+Approve every `pending` row in one batched write — skip the call entirely when none are `pending` (an all-approved crash resume): `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} staging.author-p{N}.tasks.{internal_id}=approved …`.
 
 > *Output the next fenced block as a code block:*
 

--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -93,6 +93,11 @@ All tasks already authored. Check via manifest:
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map
 ```
 
+If the manifest still carries a `staging.author-p{N}` subtree for this phase (check with `manifest exists {work_unit}.planning.{topic} staging.author-p{N}` — a crash landed the last task but not the clear), delete it — the plan's tasks are the record:
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.planning.{topic} staging.author-p{N}
+```
+
 > *Output the next fenced block as a code block:*
 
 ```

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -22,7 +22,23 @@ Deep-dive findings drain first — thread findings that never finished surfacing
 
 #### If any `deep-dive` row is `pending` or `acknowledged`
 
-Surface one finding via **C. Check and Surface** in **[deep-dive-agent.md](deep-dive-agent.md)**, then bounce back to the session so the user can engage.
+Surface one finding via **C. Check and Surface** in **[deep-dive-agent.md](deep-dive-agent.md)**.
+
+**If a finding was raised:**
+
+Bounce back to the session so the user can engage.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 6**.
+
+**If the row incorporated without findings** (a clean report):
+
+Nothing awaited engagement — drain any further rows before proceeding.
+
+→ Return to **A. Check Review State**.
+
+**If the row still holds unraised findings** (the user deferred at the announce menu):
+
+The session owns the deferral — the next done-signal re-enters this gate.
 
 → Return to **[the skill](../SKILL.md)** for **Step 6**.
 

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -124,15 +124,15 @@ Set `unreviewed_tasks` = `[{list of unreviewed internal IDs}]`.
 #### If `restart`
 
 1. Delete the review file and all report files (`report-*.md`) in the review directory (`.workflows/{work_unit}/review/{topic}/`)
-2. Clear review tracking (if it exists):
-   ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {work_unit}.review.{topic} reviewed_tasks
-   ```
-   If `true`:
+2. Delete any synthesis staging files (`review-tasks-c*.md`) in `.workflows/{work_unit}/implementation/{topic}/` — stale proposals from the abandoned run; a surviving one would resume the old cycle's approvals over the fresh review's findings. The synthesis reports (`review-report-c*.md`) stay — history, and the cycle counter reads them
+3. Clear review tracking (each subtree only if it exists — check with `manifest exists {work_unit}.review.{topic} reviewed_tasks` and `… staging` first):
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.review.{topic} reviewed_tasks
    ```
-3. Commit:
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.review.{topic} staging
+   ```
+4. Commit:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): restart review"
    ```

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -24,6 +24,12 @@ G. Re-open implementation + plan mode handoff
 
 Check the verdict(s) from the review(s) being analyzed.
 
+#### If a prior session's staging cycle is still mid-flight
+
+Read `manifest get {work_unit}.review.{topic} staging`. Mid-flight means any of: a cycle's `tasks` still hold a `pending` row; the latest cycle has approvals but the planning file carries no `Review Remediation (Cycle {N})` phase; or that phase exists and none of its task ids appear in `{work_unit}.implementation.{topic}` `completed_tasks` (the re-open never ran). The synthesis decision for that cycle was already made — do not re-ask; **B**'s guards resume it precisely.
+
+→ Proceed to **B. Dispatch Review Synthesizer**.
+
 #### If all verdicts are `Approve` with no required changes
 
 > *Output the next fenced block as a code block:*
@@ -163,6 +169,12 @@ The session died between the last gate decision and the plan write — the appro
 A crash between the synthesizer's write and the init — initialise the cycle now from the file's task count (the batched `pending` set from **[invoke-review-synthesizer.md](invoke-review-synthesizer.md)**).
 
 → Proceed to **C. Approval Overview**.
+
+#### If the latest cycle's remediation phase is in the plan and none of its tasks are in `completed_tasks`
+
+The session died between **F**'s plan write and **G**'s re-open — the remediation exists but implementation never resumed. (A fully-landed cycle's task ids appear in `{work_unit}.implementation.{topic}` `completed_tasks` once the re-opened implementation runs them, so this arm never fires on history.)
+
+→ Proceed to **G. Re-open Implementation**.
 
 #### Otherwise
 

--- a/skills/workflow-scoping-process/references/write-tasks.md
+++ b/skills/workflow-scoping-process/references/write-tasks.md
@@ -61,7 +61,13 @@ Load the chosen format's **[authoring.md](../../workflow-planning-process/refere
 
 ## C. Register Plan in Manifest
 
-Capture the current git commit hash: `git rev-parse HEAD`
+Commit the specification first — the baseline hash must name a commit that contains it:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "scoping({work_unit}): specification"
+```
+
+Capture the resulting commit hash: `git rev-parse HEAD`
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} planning {topic}

--- a/skills/workflow-shared/references/convergence-analysis.md
+++ b/skills/workflow-shared/references/convergence-analysis.md
@@ -17,7 +17,7 @@ The caller provides these via context before loading:
 
 ## Threshold Check
 
-Cross-cycle analysis requires at least 2 data points. Determine the number of available cycles from how the loop type stores them: the `fix` loop appends every cycle as an `## Attempt {N}` section inside its single tracking file — count those sections; the other three loop types write one numbered `-c{N}` file per cycle — count the files.
+Cross-cycle analysis requires at least 2 data points. Determine the number of available cycles from how the loop type stores them: the `fix` loop appends every cycle as an `## Attempt {N}` section inside its single tracking file — count those sections; the other three loop types write numbered `-c{N}` files, up to two per cycle — count the **distinct `{N}` suffixes**, never the files.
 
 #### If fewer than 2 cycles of data exist
 

--- a/tests/scripts/test-engine-agent-state.cjs
+++ b/tests/scripts/test-engine-agent-state.cjs
@@ -333,6 +333,10 @@ describe('engine agent — lifecycle store', () => {
       // '' is refused one layer up, at the CLI's usage check — still a refusal.
       assert.match(runFails(dir, ['dispatch', 'pay', 'research', topic, '--kind', 'review']).error, /Invalid topic|Usage:/);
       assert.match(runFails(dir, ['ack', 'pay', 'research', topic, 'review-001', '--clean']).error, /Invalid topic|Usage:/);
+      assert.match(runFails(dir, ['scan', 'pay', 'research', topic]).error, /Invalid topic|Usage:/);
+      assert.match(runFails(dir, ['announce', 'pay', 'research', topic, 'review-001']).error, /Invalid topic|Usage:/);
+      assert.match(runFails(dir, ['surface', 'pay', 'research', topic, 'review-001', 'F1']).error, /Invalid topic|Usage:/);
+      assert.match(runFails(dir, ['incorporate', 'pay', 'research', topic, 'review-001']).error, /Invalid topic|Usage:/);
     }
     assert.strictEqual(fs.existsSync(path.join(dir, '.workflows', 'escape')), false);
     assert.strictEqual(fs.existsSync(path.join(dir, '.workflows', '.cache', 'pay', 'research', 'a')), false);

--- a/tests/scripts/test-engine-manifest-fields.cjs
+++ b/tests/scripts/test-engine-manifest-fields.cjs
@@ -601,6 +601,15 @@ describe('storage_paths is guarded at write time — set and apply', () => {
     assert.strictEqual(readWorkUnit(dir, 'pay').phases.planning.items.pay.storage_paths, undefined, 'nothing persisted');
   });
 
+  it('push validates the one entry it appends — the write-time guard covers every route', () => {
+    for (const bad of ['../evil', '/abs', '.', '']) {
+      const err = runFails(dir, ['push', 'pay.planning.pay', 'storage_paths', bad]);
+      assert.match(err.error, /Invalid storage_paths/);
+    }
+    runJson(dir, ['push', 'pay.planning.pay', 'storage_paths', '.tick/']);
+    assert.deepStrictEqual(readWorkUnit(dir, 'pay').phases.planning.items.pay.storage_paths, ['.tick/']);
+  });
+
   it('apply handles set-then-delete on the same item in array order (reconcile shape)', () => {
     const p = path.join(dir, 'ops.json');
     fs.writeFileSync(p, JSON.stringify([

--- a/tests/scripts/test-engine-manifest.sh
+++ b/tests/scripts/test-engine-manifest.sh
@@ -1069,7 +1069,16 @@ echo ""
 echo -e "${YELLOW}Test: get with wildcard topic on empty phase returns empty${NC}"
 setup_fixture
 create_wu wc-empty epic "Empty"
-run_cli set wc-empty phases.implementation '{}' >/dev/null 2>&1
+# The field surface refuses phases.-prefixed writes (shadow guard), so the
+# empty-phase fixture is written directly.
+node -e "
+const fs = require('fs');
+const p = process.argv[1];
+const m = JSON.parse(fs.readFileSync(p, 'utf8'));
+m.phases = m.phases || {};
+m.phases.implementation = {};
+fs.writeFileSync(p, JSON.stringify(m, null, 2) + '\n');
+" "$TEST_DIR/.workflows/wc-empty/manifest.json"
 output=$(run_cli_stdout get wc-empty.implementation.* status)
 assert_equals "$output" "" "Wildcard on empty phase returns empty stdout"
 run_cli_stdout get wc-empty.implementation.* status >/dev/null

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -304,7 +304,7 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
   sim.run(['manifest', 'set', `${wu}.planning.${topic}`, 'approvals.tasks.p1', '2026-07-23']);
   sim.run(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'pending']);
   sim.run(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'rejected']);
-  // The amendment resets a rejected row to pending only after the rewrite lands (author-tasks B).
+  // The amendment resets a rejected row to pending only after the rewrite validates (author-tasks C).
   sim.run(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'pending']);
   sim.run(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'approved']);
   sim.refuses(['manifest', 'set', `${wu}.planning.${topic}`, `staging.author-p1.tasks.${topic}-1-1`, 'maybe'], /Invalid staging task status/);

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -536,6 +536,12 @@ describe('pipeline simulation', () => {
     sim.run(['manifest', 'set', `${wu}.review.unified`, 'staging.c1.gate_mode=gated', 'staging.c1.tasks.1=pending', 'staging.c1.tasks.2=pending']);
     sim.run(['manifest', 'set', `${wu}.review.unified`, 'staging.c1.tasks.1', 'approved']);
     sim.refuses(['manifest', 'set', `${wu}.review.unified`, 'staging.c1.tasks.2', 'later'], /Invalid staging task status/);
+    // The review restart clears its staging subtree (exists-guarded delete) so a
+    // stale cycle can never hijack the post-restart loop's crash-resume guards.
+    assert.strictEqual(sim.read(['manifest', 'exists', `${wu}.review.unified`, 'staging']).trim(), 'true');
+    sim.run(['manifest', 'delete', `${wu}.review.unified`, 'staging']);
+    assert.strictEqual(sim.read(['manifest', 'exists', `${wu}.review.unified`, 'staging']).trim(), 'false');
+    sim.refuses(['manifest', 'delete', `${wu}.review.unified`, 'staging'], /not found/);
     sim.run(['manifest', 'set', `${wu}.discovery`,
       'analysis_staging.research-analysis.gate_mode=gated',
       'analysis_staging.research-analysis.candidates.gamma-prime.status=pending',


### PR DESCRIPTION
## Summary
The coverage-grade pass Lee called after three sampling rounds: five slices producing **tables, not samples** — a 22-family state-contract audit (writers/readers/deleters/migration arms all paired), full edge maps for every section in the 26 substantive flow files (every inbound route grepped and walked), four engine guard matrices (every verb × every guard, each cell proven by execution), the round-3 diff's cold review with mandatory edge maps, and every universal claim in three rounds of commit messages re-enumerated member-by-member.

**Every fix here landed under the strict process**: inbound/outbound edges enumerated before the edit, adversarial verify agent per fix *before* commit. It caught one of my own fixes mid-flight — the two-branch drain arm was non-exhaustive over the surfacing protocol's exit states and got rebuilt as three branches with a full exit-state map and termination proofs before it ever reached a commit.

**Fixed (verified SOUND, most-severe first):**
- Round 3 broke the shipped `test:cli` gate — the shell suite's empty-phase fixture was the one caller of the newly-refused `phases.`-prefixed write, and my gate sweep read the truncated output through a pipe that swallowed the exit code. Fixture writes the manifest directly; every gate in this PR ran with real exit codes.
- The amendment reset rides validation, not the agent's return — a mismatch retry stayed classified as a full run and rewrote approved text; now rows stay `rejected` until C validates, and the agent contract makes re-amendment idempotent.
- Review restart clears the staging cycle it abandons (files + subtree, exists-guarded) — a stale pending cycle could hijack the post-restart loop and bulk-approve old synthesis under a stale `auto`.
- Discussion conclusion drains landed councils — a perspective pair finishing after the session's last check was invisible to every conclusion gate and silently dropped; the final review now promotes complete synthesis-less sets, and both final reviews' drain arms are exhaustive over all six protocol exit states.
- The review loop resumes crashed sessions at the verdict gate without re-asking — mid-flight staging routes to B; B's fourth arm catches the post-plan-write/pre-re-open window via the `completed_tasks` discriminator (provably silent on fully-landed history).
- Engine: `push` joins the `storage_paths` write-time guard; the traversal pin covers all six agent verbs (was 2 of 6).
- Smalls: analysis-loop's missing backfill guard, the auto arm's zero-pair call, quick-fix's spec baseline captured before the spec's commit, the stranded author-staging subtree, the convergence diagnostic double-counting cycles (a first cycle read as "diverging"), a stale render comment.

**Accepted, on record**: the state-contract table documents the deliberate asymmetries (implementation's topic-level gate mode, provenance-only approval dates, quick-fix's schema-uniformity writes) so they stop resurfacing as findings.

## Test plan
- `npm test` 1630, `test:cli` (355-assertion manifest suite runs to completion again), `test:migrations`, typecheck — all exit 0, verified unpiped.
- New pins: six-verb traversal, push × storage_paths, the review-restart staging cleanse, the amendment lifecycle's corrected order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #527
2. #528
3. #529
4. #530
5. #531
6. #532
7. #533
8. #534
9. #535
10. **#536** 👈 current
11. #537
<!-- stack:links:end -->