### PR TITLE
feat(conclusion): codified closing recap at research, discussion, and investigation conclude

### DIFF
--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -48,7 +48,11 @@ Conclude this discussion and mark as completed?
 
 Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
 
-4. Hand off to the pipeline bridge:
+4. Closing recap:
+
+   → Load **[closing-recap.md](../../workflow-shared/references/closing-recap.md)** with phase = `discussion`, work_unit = `{work_unit}`, topic = `{topic}`.
+
+5. Hand off to the pipeline bridge:
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -36,18 +36,9 @@ Investigation complete. Ready to conclude?
 
 Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
 
-3. Display conclusion:
+3. Closing recap:
 
-> *Output the next fenced block as a code block:*
-
-```
-Investigation completed: {work_unit}
-
-Root cause: {brief summary — the behaviour and its cause in product terms}
-Fix direction: {chosen approach}
-
-The investigation is completed. Root cause and fix direction are documented.
-```
+   → Load **[closing-recap.md](../../workflow-shared/references/closing-recap.md)** with phase = `investigation`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 4. Closure signpost:
 

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -32,7 +32,11 @@ A concern was rerouted into this topic after drain ran this session. It must be 
 
 Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
 
-3. Closure signpost:
+3. Closing recap:
+
+   → Load **[closing-recap.md](../../workflow-shared/references/closing-recap.md)** with phase = `research`, work_unit = `{work_unit}`, topic = `{topic}`.
+
+4. Closure signpost:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -41,4 +45,4 @@ Emit the `complete` response's `DISPLAY: kb warning` section when present, verba
 > to make decisions about architecture and approach.
 ```
 
-4. Invoke `/workflow-bridge {work_unit} research`.
+5. Invoke `/workflow-bridge {work_unit} research`.

--- a/skills/workflow-shared/references/closing-recap.md
+++ b/skills/workflow-shared/references/closing-recap.md
@@ -1,0 +1,27 @@
+# Closing Recap
+
+*Shared reference. Loaded by the conclude flows of research, discussion, and investigation.*
+
+---
+
+**Parameters** (provided by caller via Load directive):
+
+- `phase`, `work_unit`, `topic` — the concluding topic
+
+The topic is complete and committed. Before the closure signpost, send the session off with a recap — a short markdown narrative (not a code block, no structured template) telling the story of the session just finished. One paragraph, scaled to the session's substance: a long multi-review session earns a fuller recap than a quick one.
+
+Three beats:
+
+1. **Where it started → where it landed** — the seed question or framing the session opened with, and the shape of what it resolved into.
+2. **Concrete tallies** — pulled from the artifact and map, never invented: subtopics decided, threads explored, gaps reconciled, review cycles survived.
+3. **What transformed along the way** — a problem that dissolved, scope that grew or shrank, a direction nobody expected at the start.
+
+**If phase is `research`:** frame the arc as questions in → findings out — what was unknown at the start and what is known now.
+
+**If phase is `discussion`:** frame the arc around the decisions — what was settled and how the hard ones resolved.
+
+**If phase is `investigation`:** root cause and fix direction are required beats — the recap is the conclusion's only retelling of them.
+
+Tone: warm and energising, grounded in the specifics above — no generic praise, never condescending.
+
+→ Return to caller.

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -575,7 +575,6 @@ const RATCHET_PINS = {
   'skills/workflow-implementation-process/references/task-loop.md': 7,
   'skills/workflow-investigation-entry/references/gather-context.md': 1,
   'skills/workflow-investigation-process/references/analysis-checkpoints.md': 3,
-  'skills/workflow-investigation-process/references/conclude-investigation.md': 1,
   'skills/workflow-investigation-process/references/fix-exploration.md': 1,
   'skills/workflow-investigation-process/references/fix-validation.md': 2,
   'skills/workflow-investigation-process/references/investigation-plan.md': 2,


### PR DESCRIPTION
## Summary

Locks in a behaviour a discussion session recently improvised: a warm narrative recap at topic conclusion — where the session started, where it landed, concrete tallies, what transformed along the way — rendered between the final commit and the closure signpost.

- New shared reference `skills/workflow-shared/references/closing-recap.md` (pure prose instruction, modeled on findings-signoff's narrative-retelling pattern; no templated fence, so no ratchet pin needed)
- Loaded from the conclude flows of **research**, **discussion**, and **investigation** with `phase`/`work_unit`/`topic` params
- **Investigation**: replaces the templated "Investigation completed" code-block display — root cause and fix direction carry into the recap as required beats. Its templated-fence ratchet pin is removed accordingly (1 → 0; the conclude gate fence is static)
- **Scoping** deliberately skipped: single-pass phase with little journey to narrate, and its completion display already lists the artifacts

## Testing

- `npm test` green (1678 tests — includes conventions lint ratchet + pipeline simulation; no engine call sequences changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)