### PR TITLE
feat(discussion): honest conclusion gates — say the final review is next, not that we're concluding

### DIFF
--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -158,19 +158,6 @@ Load **[discussion-session.md](references/discussion-session.md)** and follow it
 
 ## Step 6: Final Gap Review
 
-> *Output the next fenced block as a code block:*
-
-```
-── Final Gap Review ─────────────────────────────
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Before concluding, checking whether a fresh review is needed
-> to catch any gaps that may have emerged since the last review.
-```
-
 Load **[final-review.md](references/final-review.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 7**.

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -59,7 +59,7 @@ Subtopics move through states as the conversation progresses. The judgment call 
 
 **decided** → Decision reached with rationale. The subtopic section gets written up with the full Context → Options → Journey → Decision structure. This is the terminal state.
 
-**deferred** → Deliberately set aside. Applied at conclude-anyway time (see **H**) to subtopics still unresolved — each is also noted in Summary → Open Threads.
+**deferred** → Deliberately set aside. Applied when concluding with unresolved subtopics (see **H**) — each is also noted in Summary → Open Threads.
 
 **State transitions are judgement calls.** Move a subtopic to `converging` when the viable options are narrowed and the discussion is heading toward resolution. Move to `decided` when there's a clear outcome with rationale — even if provisional. Don't wait for absolute certainty. Any state can move to any other — judgment may revisit.
 
@@ -240,7 +240,6 @@ Convergence is the natural end state — not a forced conclusion. The discussion
 
 - All subtopics on the Discussion Map are `decided` (or `deferred`)
 - Neither you nor the user can identify new subtopics without breaking scope
-- At least one review cycle has completed (see safety net below)
 
 **Before rendering the convergence menu**, run the map call:
 
@@ -248,23 +247,9 @@ Convergence is the natural end state — not a forced conclusion. The discussion
 node .claude/skills/workflow-discussion-process/scripts/gateway.cjs map {work_unit} {topic}
 ```
 
-Its DATA section carries the convergence facts: `all_decided` and `review_cycles`. The DISPLAY section isn't emitted here — this flow reads DATA only.
+Its DATA section carries `all_decided`. The DISPLAY section isn't emitted here — this flow reads DATA only.
 
-#### If `review_cycles` is 0
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ No review agent has been dispatched during this discussion.
-  At least one review cycle is required before concluding.
-  Dispatching now.
-```
-
-Dispatch a review agent as a foreground task (not background — results are needed before concluding). Follow **A. Dispatch** in review-agent.md but omit `run_in_background`. When results return, delegate to **B. Check and Surface** in review-agent.md — the shared surfacing protocol applies the never-dump rules and presents findings one at a time.
-
-→ Return to **B. Session Loop**.
-
-#### If `review_cycles` is at least 1
+Classify the pending closing work by following **J. Closing Probe**, then announce:
 
 > *Output the next fenced block as a code block:*
 
@@ -272,13 +257,16 @@ Dispatch a review agent as a foreground task (not background — results are nee
 All subtopics on the Discussion Map are decided.
 ```
 
+#### If the probe classified `due`
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 · · · · · · · · · · · ·
-Discussion complete. Ready to conclude?
+Next: a final gap review before concluding — {reason}.
+Proceed?
 
-- **`y`/`yes`** — Conclude discussion
+- **`y`/`yes`** — Run the final review
 - **Keep going** — Tell me what else to explore
 · · · · · · · · · · · ·
 ```
@@ -295,6 +283,33 @@ Continue the discussion. The user may want to revisit a decision, explore an edg
 
 → Return to **B. Session Loop**.
 
+#### If the probe classified `satisfied`
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+The final review is up to date. Begin wrap-up? I'll reconcile the
+document against our conversation, then confirm before marking
+complete.
+
+- **`y`/`yes`** — Begin wrap-up
+- **Keep going** — Tell me what else to explore
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `yes`:**
+
+→ Proceed to **I. In-Flight Agent Check**.
+
+**If keep going:**
+
+Continue the discussion — revisit decisions, explore edge cases, probe for gaps. If new subtopics emerge, add them to the map and continue.
+
+→ Return to **B. Session Loop**.
+
 ---
 
 ## H. When the User Signals Conclusion
@@ -307,25 +322,11 @@ When the user indicates they want to conclude the discussion (e.g., "that covers
 node .claude/skills/workflow-discussion-process/scripts/gateway.cjs map {work_unit} {topic}
 ```
 
-Its DATA section carries everything this flow needs: `all_decided`, `unresolved`, `review_cycles`.
-
-#### If `review_cycles` is 0
-
-> *Output the next fenced block as a code block:*
-
-```
-⚑ No review agent has been dispatched during this discussion.
-  At least one review cycle is required before concluding.
-  Dispatching now.
-```
-
-Dispatch a review agent as a foreground task (not background — results are needed before concluding). Follow **A. Dispatch** in review-agent.md but omit `run_in_background`. When results return, delegate to **B. Check and Surface** in review-agent.md — the shared surfacing protocol applies the never-dump rules and presents findings one at a time. Then continue with the conclusion flow below.
-
-#### If `review_cycles` is at least 1
-
-Continue with the conclusion flow below.
+Its DATA section carries everything this flow needs: `all_decided` and `unresolved`.
 
 #### If `all_decided` is false
+
+Classify the pending closing work by following **J. Closing Probe**.
 
 Emit the map call's DISPLAY section verbatim as a code block, then ({N} = the length of `unresolved`):
 
@@ -339,7 +340,11 @@ There are still {N} subtopics not yet decided:
 - {name:(titlecase)}
 @endforeach
 
-- **`y`/`yes`** — Conclude anyway (unresolved items deferred and noted in Summary)
+@if(review_due)
+Next: a final gap review before concluding — {reason}.
+@endif
+
+- **`y`/`yes`** — Defer them and @if(review_due) run the final review @else begin wrap-up @endif
 - **`n`/`no`** — Continue discussing
 · · · · · · · · · · · ·
 ```
@@ -400,3 +405,23 @@ Watch for `agent scan` to promote each in-flight row to `pending`. When none rem
 **If `proceed`:**
 
 → Return to caller.
+
+---
+
+## J. Closing Probe
+
+A read-only classification for the conclusion gates — is final-review work still owed (`due`, with a reason) or is the gate `satisfied`? Step 6 (Final Gap Review) is the executor and re-derives state itself — a probe mismatch is cosmetic, never state-corrupting. In-flight rows keep their wait-or-proceed decision at **I. In-Flight Agent Check**.
+
+Read the store:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs agent scan {work_unit} discussion {topic}
+```
+
+Classify — first match wins:
+
+1. Any `review`, `synthesis`, or `perspective` row is `pending` or `acknowledged` → `due`: "background findings are still to be walked through"
+2. Any `review` row is `in-flight` → `due`: "a dispatched review is still running"
+3. No `review` row exists → `due`: "no review has run yet"
+4. The highest-numbered `review` row is `incorporated` and a meaningful discussion commit landed after its dispatch (`git log --oneline -- .workflows/{work_unit}/discussion/{topic}.md` — a decision documented, a subtopic explored, not typo fixes) → `due`: "the discussion has moved since the last review"
+5. Otherwise → `satisfied`

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -565,7 +565,7 @@ const RATCHET_PINS = {
   'skills/workflow-discussion-entry/references/gather-context-fresh.md': 1,
   'skills/workflow-discussion-entry/references/gather-context.md': 1,
   'skills/workflow-discussion-process/references/conclude-discussion.md': 1,
-  'skills/workflow-discussion-process/references/discussion-session.md': 5,
+  'skills/workflow-discussion-process/references/discussion-session.md': 6,
   'skills/workflow-discussion-process/references/perspective-agents.md': 2,
   'skills/workflow-implementation-entry/references/check-dependencies.md': 4,
   'skills/workflow-implementation-process/SKILL.md': 1,

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -808,6 +808,35 @@ describe('pipeline simulation', () => {
     scan = sim.run(['agent', 'scan', wu, 'discussion', 'alpha']);
     assert.deepStrictEqual(scan.next, { action: 'acknowledge', id: syn.id },
       'consumed perspectives never mask the synthesis');
+
+    // The discussion closing sequence: the synthesis drains, the closing
+    // probe classifies off the scan lists, the final review dispatches and
+    // drains, and a satisfied probe precedes completion.
+    sim.run(['agent', 'ack', wu, 'discussion', 'alpha', syn.id, '--findings', 'T1']);
+    sim.run(['agent', 'announce', wu, 'discussion', 'alpha', syn.id]);
+    const synDone = sim.run(['agent', 'surface', wu, 'discussion', 'alpha', syn.id, 'T1']);
+    assert.strictEqual(synDone.status, 'incorporated');
+
+    const reviewRows = (s) => [...s.in_flight, ...s.pending, ...s.acknowledged, ...s.incorporated]
+      .filter((r) => r.kind === 'review');
+    let probe = sim.run(['agent', 'scan', wu, 'discussion', 'alpha']);
+    assert.strictEqual(reviewRows(probe).length, 0, 'probe: no review row — the due classification');
+    assert.strictEqual(probe.next, null, 'nothing else awaits surfacing');
+
+    const fin = sim.run(['agent', 'dispatch', wu, 'discussion', 'alpha', '--kind', 'review']);
+    sim.write(fin.file, '# Final review\n\n## G1\n');
+    sim.run(['agent', 'scan', wu, 'discussion', 'alpha']);
+    sim.run(['agent', 'ack', wu, 'discussion', 'alpha', fin.id, '--findings', 'G1']);
+    sim.run(['agent', 'announce', wu, 'discussion', 'alpha', fin.id]);
+    const finDone = sim.run(['agent', 'surface', wu, 'discussion', 'alpha', fin.id, 'G1']);
+    assert.strictEqual(finDone.status, 'incorporated');
+
+    probe = sim.run(['agent', 'scan', wu, 'discussion', 'alpha']);
+    assert.strictEqual(probe.in_flight.length + probe.pending.length + probe.acknowledged.length, 0,
+      'probe: nothing owed — the satisfied classification');
+    assert.strictEqual(reviewRows(probe)[0].status, 'incorporated');
+    sim.write(`.workflows/${wu}/discussion/alpha.md`, '# Discussion — Alpha\n');
+    sim.run(['topic', 'complete', wu, 'discussion', 'alpha']);
   });
 
   it('guards hold mid-pipeline: shadow fields, empty segments, cross-type reuse, bad statuses', () => {


### PR DESCRIPTION
## Summary

Discussion's session-level conclude gates said "Discussion complete. Ready to conclude?" — but `yes` actually entered Step 6 Final Gap Review (possibly dispatching a fresh review agent), Step 7 Document Review, and Step 8 Compliance before Step 9's real conclude confirm. Discussion was the only phase with this mismatch (research runs its reviews *before* its conclude ask; investigation/spec/planning gates conclude immediately).

- **New section J. Closing Probe** in `discussion-session.md`: a read-only classification (`agent scan` + the same commit-currency test `final-review.md` §B uses) of whether final-review work is still owed, with a reason. Deliberately coarse — Step 6 stays the executor and re-derives state itself; a probe mismatch is cosmetic, never state-corrupting.
- **G. Convergence** now renders one of two honest gates: review due → "Next: a final gap review before concluding — {reason}. Proceed?"; satisfied → "Begin wrap-up? I'll reconcile the document against our conversation, then confirm before marking complete." Step 9 remains the single real "mark completed?" confirm, so the two asks are semantically distinct.
- **H (user signals done)** folds the probe reason and the honest next-step into the unresolved-subtopics gate (`Defer them and run the final review` / `begin wrap-up`).
- **Zero-review-cycles auto-dispatch branches removed** from G and H: the "no review has run yet" case now flows through the honest gate into Step 6, whose no-review-row path already dispatches — the at-least-one-review guarantee moves wholly into the executor instead of a pre-gate special case.
- **Step 6 chrome dropped** (silent step per the conditional-chrome rule): the gate now announces the review, and `final-review.md` renders its own `·· Dispatch Final Review ··` chrome when it acts — the satisfied path no longer prints a header for a non-event.

## Ratchet pin

`discussion-session.md` 5 → 6: the review-due gate carries the probe-derived `{reason}` — a judgment-classified value with no engine render surface; the satisfied-path gate is static. Pinned deliberately per the ratchet's sanctioned-judgment rule.

## Simulation

The changed prose call sequence is pinned: the background-agents scenario now finishes the discussion arc through the new closing sequence — synthesis drains, a probe scan shows the no-review-row facts (`due`), the final review dispatches and drains, a satisfied scan (nothing in-flight/pending/acknowledged) precedes `topic complete`. The probe classifies purely off the `agent scan` response lists (`in_flight`/`pending`/`acknowledged`/`incorporated`), which the scenario asserts directly.

## Testing

- `npm test` green (1678 tests — conventions lint + extended pipeline simulation)
- Walked all five probe classifications against `final-review.md` §A/§B: each gate promise matches executor behaviour; the two tolerated cosmetic divergences (declined-wait in-flight rows, incomplete perspective sets) are documented in J's prelude

🤖 Generated with [Claude Code](https://claude.com/claude-code)