### PR TITLE
fix(entry-skills): every handoff arm says to invoke the skill

### DIFF
--- a/skills/workflow-investigation-entry/references/invoke-skill.md
+++ b/skills/workflow-investigation-entry/references/invoke-skill.md
@@ -35,6 +35,8 @@ Bug context:
 
 #### If source is `continue`
 
+Invoke the **workflow-investigation-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Investigation session for: {work_unit}
 

--- a/skills/workflow-planning-entry/references/invoke-skill.md
+++ b/skills/workflow-planning-entry/references/invoke-skill.md
@@ -25,6 +25,8 @@ Cross-cutting references: {list of applicable cross-cutting specs with brief sum
 
 #### If continuing or reviewing existing plan
 
+Invoke the **workflow-planning-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Planning session for: {topic}
 Work unit: {work_unit}

--- a/skills/workflow-specification-entry/references/invoke-skill.md
+++ b/skills/workflow-specification-entry/references/invoke-skill.md
@@ -26,6 +26,8 @@ Action: {verb} specification
 
 #### If `work_type` is `bugfix`
 
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
 ```
 Specification session for: {work_unit}
 
@@ -58,6 +60,8 @@ Action: {verb} specification
 #### If `work_type` is `cross-cutting`
 
 Check for completed research: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{topic} status`. Include the `Research:` line only when the status is `completed`; omit it otherwise.
+
+Invoke the **workflow-specification-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Specification session for: {work_unit}


### PR DESCRIPTION
## Summary
- A prose-test walker on the bugfix path recorded a `DEVIATION`: the arm hands over a fenced block of arguments and **never says what to do with it** — no invocation directive, and no directive to emit it either. Reproduced identically on both independent walks, against the already-fixed fences, so it isn't a rendering artefact.
- **Enumerating before fixing turned one arm into four**, across three files:

| file | arm |
| --- | --- |
| `workflow-specification-entry` | `#### If work_type is bugfix` |
| `workflow-specification-entry` | `#### If work_type is cross-cutting` |
| `workflow-investigation-entry` | `#### If source is continue` |
| `workflow-planning-entry` | `#### If continuing or reviewing existing plan` |

- In every case a sibling arm *in the same file* carries the sentence and these don't. `discussion-entry` and `research-entry` carry it on **every** arm — the same proof structure that settled the fence bug: two files doing it correctly means the others are omissions, not house style.

## Test plan
- Re-enumerated after the change: 13 arms across 8 files, **0 missing**.
- Re-verified fence pairing afterwards, since these files were the subject of #550: **0 files broken**.
- `npm test` green: 1699 tests, 0 fail.
- Diff is additions only — 8 lines, no wording altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. **#552** 👈 current
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->