### PR TITLE
test(prose): claims assert consequences, not what was displayed

### DIFF
--- a/tests/prose/cases/investigation-entry-seeds-from-carrier/assert.md
+++ b/tests/prose/cases/investigation-entry-seeds-from-carrier/assert.md
@@ -6,8 +6,8 @@ The prose should have taken this path:
 3. finds a discovery session log, so seeds the bug context from the
    manifest description and that log — the context-gathering questions
    are not asked
-4. renders the phase note for the investigation phase with the verb
-   Starting, and emits it as produced
+4. renders the phase note for the investigation phase through the engine,
+   with the verb Starting — the wording is the engine's, not the skill's
 5. hands off to the investigation processing skill for crash-fix
 
 Further claims:

--- a/tests/prose/cases/root-cause-validation-clean-verdict/assert.md
+++ b/tests/prose/cases/root-cause-validation-clean-verdict/assert.md
@@ -1,19 +1,20 @@
 The prose should have taken this path:
 
-1. offers the independent validation, presents the run-or-skip choice,
-   and waits
-2. on yes, records the dispatch through the engine and creates no report
-   file of its own — the response carries the id and the path to use
-3. announces that validation is running, then dispatches exactly one
-   agent, synchronously
-4. once the report has landed, promotes the row with a scan and closes
-   it with an incorporate — the verdict is consumed whole, never
-   surfaced finding by finding
-5. reads the report and, the verdict being validated, states the
-   confidence and returns to its caller — the gap-handling choice is
-   never reached
+1. the scripted `yes` is consumed at the run-or-skip choice, so the walk
+   takes the run arm — a `skip` would have returned to the caller with no
+   dispatch at all
+2. the dispatch is recorded through the engine, and the report lands at
+   the path that response returned — the prose does not invent a path or
+   pre-create the file
+3. exactly one validation agent stands behind that dispatch: one dispatch
+   recorded, one report written, no second of either
+4. once the report has landed, the row is promoted by a scan and closed
+   by an incorporate — the verdict is consumed whole, never surfaced
+   finding by finding
+5. the report is read and, the verdict being validated, the reference
+   returns to its caller — the gap-handling choice is never reached, so
+   no gaps are recorded and the investigation file is never edited
 
 Further claims:
 
-- the investigation file is untouched and nothing is committed: the
-  validated path has no gaps to record
+- nothing is committed: the validated path has no gaps to record


### PR DESCRIPTION
## Summary
- **P4c was written and not applied.** The runs then showed why it matters. `root-cause-validation-clean-verdict` failed *only* on *"offers the choice and waits"* and *"announces that validation is running"*. `implementation-picks-first-task` came back **FLAKY** on *"asks the question, gathering the answer"* — evidenced in one run's narrative, absent from the other, with an **identical world both times**. Display claims don't merely fail, they fail *intermittently*, which is worse than failing.
- Every display-only claim in the corpus is rewritten as something the record can prove:

| was | now |
| --- | --- |
| "offers the choice and waits" | the scripted `yes` was consumed, so the run arm was taken — a `skip` would have returned with no dispatch |
| "announces running, then dispatches exactly one agent" | one dispatch recorded, one report written, no second of either |
| "asks the question, gathering without acting on it" | the answer was consumed there, and the entry wrote and committed no setup document |
| "renders the phase note **and emits it as produced**" | renders it through the engine with the verb Starting — the render *is* an engine call; the emission isn't |

- Swept the whole corpus rather than only the two failing cases, so the rule is applied uniformly.

**No prose touched** — test authoring only.

## Test plan
- `npm test` green: 1699 tests, 0 fail. Corpus valid.
- Both previously-failing cases should now be judged on evidence that exists — worth re-running to confirm, though a PASS then means the claims are provable rather than that anything in the prose changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. **#556** 👈 current
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->