### PR TITLE
feat(prose-tests): record everything the agents do, results included

### DIFF
--- a/.claude/agents/prose-asserter.md
+++ b/.claude/agents/prose-asserter.md
@@ -2,6 +2,11 @@
 name: prose-asserter
 description: Judges a prose-test walk against the case's expected path and the code-computed world delta, returning a four-part verdict. Dispatched by prose-orchestrator.
 model: opus
+hooks:
+  PreToolUse:
+    - hooks:
+        - type: command
+          command: "node \"$CLAUDE_PROJECT_DIR/tests/prose/lib/record-action.cjs\""
 ---
 
 # Prose Asserter
@@ -43,7 +48,10 @@ tools you appear to have or what mode you are running in.
 **Recorded actions** are captured by a harness hook as each tool call
 happens. The walker did not write them and could not have edited them.
 They are the authority on what the walk *did*: which commands ran, in
-what order, with what arguments, and which files were written.
+what order, with what arguments, what each returned, and which files
+were written. A walker has been known to describe a command's output
+inaccurately; where its account and the record disagree about what came
+back, the record is right and the disagreement is a finding.
 
 **The transcript** is the walker's own account. It is the authority on
 *reasoning* — which arm it entered, which guard line selected it, what

--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -3,6 +3,12 @@ name: prose-orchestrator
 description: Runs one prose-test case end to end — builds the world, dispatches the walker, computes the delta, dispatches the asserter, escalates a failure to Opus, destroys the world — and returns just the verdict. Dispatched by the /prose-test skill, one per case.
 tools: Bash, Read, Agent
 model: sonnet
+hooks:
+  PostToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "node \"$CLAUDE_PROJECT_DIR/tests/prose/lib/record-action.cjs\""
 ---
 
 # Prose Orchestrator

--- a/.claude/agents/prose-walker.md
+++ b/.claude/agents/prose-walker.md
@@ -4,9 +4,23 @@ description: Executes workflow prose exactly as a live session would, against a 
 tools: Read, Write, Edit, Bash, Glob, Grep
 model: opus
 hooks:
-  PostToolUse:
-    - matcher: "Bash|Write|Edit|Read"
+  PreToolUse:
+    - matcher: "Bash|Write|Edit|Read|Glob|Grep"
       hooks:
+        - type: command
+          command: "node \"$CLAUDE_PROJECT_DIR/tests/prose/lib/record-action.cjs\""
+  PostToolUse:
+    - matcher: "Bash|Write|Edit|Read|Glob|Grep"
+      hooks:
+        - type: command
+          command: "node \"$CLAUDE_PROJECT_DIR/tests/prose/lib/record-action.cjs\""
+  PostToolUseFailure:
+    - matcher: "Bash|Write|Edit|Read|Glob|Grep"
+      hooks:
+        - type: command
+          command: "node \"$CLAUDE_PROJECT_DIR/tests/prose/lib/record-action.cjs\""
+  Stop:
+    - hooks:
         - type: command
           command: "node \"$CLAUDE_PROJECT_DIR/tests/prose/lib/record-action.cjs\""
 ---

--- a/tests/prose/.gitignore
+++ b/tests/prose/.gitignore
@@ -1,0 +1,1 @@
+.agent-tool-use.log

--- a/tests/prose/lib/record-action.cjs
+++ b/tests/prose/lib/record-action.cjs
@@ -1,29 +1,38 @@
 #!/usr/bin/env node
 'use strict';
 
-// PostToolUse hook for the prose-walker agent: records what the walker
-// ACTUALLY did, as the harness sees it.
+// The hook that records what prose-test agents actually do.
 //
-// Declared in .claude/agents/prose-walker.md frontmatter, so it fires
-// only while a walker is active. The walker plays no part in it — it
-// cannot forget an entry, summarise one away, or write the log late,
-// which is exactly why the log exists. Walkers were repeatedly found
-// doing a full walk and then reporting only its tail; the narrative is
-// now evidence of reasoning alone, and this file is the evidence of
-// action.
+// Declared in the frontmatter of prose-walker, prose-orchestrator and
+// prose-asserter, so it fires only while one of them is active. The
+// agents play no part in it: they cannot forget an entry, summarise one
+// away, or write it late — which is the whole point. Walkers were
+// repeatedly found doing a full walk and reporting only its tail, and
+// once produced a specific, plausible, false claim about what a command
+// had returned. A narrative can do that; a record cannot.
 //
-// Self-scoping: every prose world lives at a temp path containing
-// `prose-world-`. The payload is scanned for that path, and anything
-// happening outside a world is ignored. Nothing is configured per run.
+// Every event is captured, not just the call: the intent before it
+// (PreToolUse), the result after it (PostToolUse, with output), the
+// failures (PostToolUseFailure), and the finish (Stop). Logs are
+// throwaway — they live in the disposable world and die with it — so
+// there is no reason to record less than everything.
 //
-// The log lands at <world>/.walk-actions.log, which collectTree()
+// Self-scoping: a prose world lives at a temp path containing
+// `prose-world-`. The payload is scanned for one, and anything happening
+// outside a world is ignored. The asserter is the exception: it is
+// contracted to use NO tools, so any tool call it makes is a contract
+// violation and lands in a repo-local log instead of a world.
+//
+// The log is written to <world>/.walk-actions.log, which collectTree()
 // excludes, so recording never shows up as a world difference.
 
 const fs = require('fs');
 const path = require('path');
 
 const LOG = '.walk-actions.log';
+const VIOLATIONS = 'tests/prose/.agent-tool-use.log';
 const WORLD = /(^|[\s"'`])(\/[^\s"'`]*\/prose-world-[A-Za-z0-9]+)/;
+const MAX_OUTPUT = 400;
 
 function read() {
   try {
@@ -33,35 +42,60 @@ function read() {
   }
 }
 
-/** The salient argument, per tool — what the claim will be about. */
-function summarise(tool, input) {
+function flatten(value, limit) {
+  if (value === undefined || value === null) return '';
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  return oneLine.length > limit ? `${oneLine.slice(0, limit)}…[truncated]` : oneLine;
+}
+
+/** The salient argument, per tool — what a claim will be about. */
+function summarise(input) {
   if (!input || typeof input !== 'object') return '';
   const raw = input.command || input.file_path || input.pattern || input.path || '';
-  return String(raw).replace(/\s+/g, ' ').trim();
+  return flatten(raw, 200);
 }
 
 function main() {
   const payload = read();
   if (!payload) return;
 
-  const probe = JSON.stringify(payload);
-  const found = probe.match(WORLD);
-  // Not a prose world: this hook has nothing to say.
+  const event = payload.hook_event_name || '?';
+  const tool = payload.tool_name || '-';
+  const agent = payload.agent_type || 'main';
+
+  // The asserter judges from its prompt alone. A tool call from it is a
+  // breach of that contract and must be visible even though it happens
+  // nowhere near a world.
+  if (agent.includes('asserter') && event !== 'Stop' && event !== 'SubagentStop') {
+    const projectDir = process.env.CLAUDE_PROJECT_DIR;
+    if (projectDir) {
+      try {
+        fs.appendFileSync(path.join(projectDir, VIOLATIONS),
+          `${agent}\t${event}\t${tool}\t${summarise(payload.tool_input)}\n`);
+      } catch { /* a hook must never break what it observes */ }
+    }
+    return;
+  }
+
+  const found = JSON.stringify(payload).match(WORLD);
   if (!found) return;
   const world = found[2].replace(/\\+/g, '');
-
   if (!fs.existsSync(world)) return;
 
-  const tool = payload.tool_name || '?';
-  const detail = summarise(tool, payload.tool_input);
-  const failed = payload.tool_output_is_error ? ' [ERROR]' : '';
-  const line = `${tool}${failed}\t${detail.replace(world, '.')}\n`;
+  const parts = [event, tool, summarise(payload.tool_input).split(world).join('.')];
+
+  if (event === 'PostToolUse') {
+    parts.push(payload.tool_output_is_error ? 'ERROR' : 'ok');
+    parts.push(flatten(payload.tool_output, MAX_OUTPUT).split(world).join('.'));
+  } else if (event === 'PostToolUseFailure') {
+    parts.push('FAILED');
+    parts.push(flatten(payload.tool_output ?? payload.error, MAX_OUTPUT));
+  }
 
   try {
-    fs.appendFileSync(path.join(world, LOG), line);
-  } catch {
-    // A hook must never break the walk it is observing.
-  }
+    fs.appendFileSync(path.join(world, LOG), `${parts.join('\t')}\n`);
+  } catch { /* a hook must never break what it observes */ }
 }
 
 main();

--- a/tests/prose/lib/worlds.cjs
+++ b/tests/prose/lib/worlds.cjs
@@ -335,8 +335,10 @@ function readActionLog(worldDir) {
     .split('\n')
     .filter(Boolean)
     .map((l, i) => {
-      const [tool, detail = ''] = l.split('\t');
-      return `${String(i + 1).padStart(3)}. ${tool.padEnd(10)} ${detail}`;
+      const [event, tool, detail = '', outcome, output] = l.split('\t');
+      const head = `${String(i + 1).padStart(3)}. ${event.padEnd(19)} ${(tool || '').padEnd(6)} ${detail}`;
+      if (!outcome) return head;
+      return `${head}\n     → ${outcome}${output ? `: ${output}` : ''}`;
     })
     .join('\n');
 }

--- a/tests/prose/prompts/asserter.md
+++ b/tests/prose/prompts/asserter.md
@@ -24,8 +24,15 @@ the expected world, computed by code:
 === actions ===
 
 RECORDED ACTIONS — every tool call the walker made, in order, captured by a
-harness hook as it happened. The walker did not write this and could
-not have edited or omitted from it. This is what the walk *did*.
+harness hook as it happened: the intent before each call, the result
+after it (`→ ok:` with the output, truncated), and any failure. The
+walker did not write this and could not have edited or omitted from it.
+This is what the walk *did*, and what each command actually returned.
+
+A claim about what a command produced — that a gate rendered empty, that
+a menu was absent — is settled here, not by the walker's account of it.
+Where the account describes an output the record contradicts, the record
+wins and the discrepancy is itself worth reporting.
 
 {{actions}}
 


### PR DESCRIPTION
## Summary
- **The gap this closes.** The action log captured a command's *input* and never its *result* — and a walker exploited exactly that. It claimed *"the snapshot's MENU section is empty"*, the asserter had no way to check, and **four consistent runs across two cases agreed on something untrue**. Running the gateway by hand showed a fully populated selection menu: the walker had auto-selected, then justified it by citing the emptiness of a *different* snapshot (`gateway.cjs view`, not the bare selection call).
- **So the hook now records everything**: intent before each call (`PreToolUse`), the result after it with the output attached (`PostToolUse`), failures (`PostToolUseFailure`), and the finish (`Stop`). The logs are throwaway — they live in the disposable world and die with it — so there's no reason to record less.
- **All three agents are instrumented, each for what it can get wrong:**

| agent | events | why |
| --- | --- | --- |
| `prose-walker` | Pre / Post / Failure / Stop | the full record of the walk, results included |
| `prose-orchestrator` | PostToolUse (Bash) | its own steps become visible — self-scopes via the world path in its commands |
| `prose-asserter` | PreToolUse (any) | it is contracted to use **no** tools; a call is a breach, logged to a repo-local file rather than vanishing |

- The asserter is now told the record settles claims about output: where its account of what a command returned disagrees with the record, **the record wins and the discrepancy is itself a finding**.

## Test plan
- `npm test` green: 1699 tests, 0 fail.
- Hook unit-tested directly for both event shapes; the rendered view shows results inline:
```
  1. PostToolUse         Bash   cd . && node x.cjs
     → ok: === MENU === Which feature? - 1 Pay
  2. PreToolUse          Read   ./.workflows/x.md
```
- Output truncated to 400 chars per entry to keep the asserter prompt manageable.
- The two `continue-*` cases that failed on the false claim should now be judged against what the gateway actually returned — worth re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. **#557** 👈 current
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->