### PR TITLE
fix(discussion-entry): the handoff reports the source it actually had

### DIFF
--- a/skills/workflow-discussion-entry/references/invoke-skill.md
+++ b/skills/workflow-discussion-entry/references/invoke-skill.md
@@ -72,7 +72,7 @@ Invoke the **workflow-discussion-process** skill (Skill tool) with the next fenc
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
-Source: fresh
+Source: {source}
 Output: {output_path}
 
 Description:


### PR DESCRIPTION
## Summary
- `skills/workflow-discussion-entry/references/invoke-skill.md` line 68 opens `#### If source is \`fresh\` **or** \`topic-provided\`` — and line 75 then states `Source: fresh`. A discussion arriving with a topic already chosen (from the epic map, or a continue menu) told the processing skill it was a direct entry.
- Now renders `Source: {source}`, the variable the entry skill already set.
- **Found by a prose-test walker**, recorded as a `DEVIATION` on a case that otherwise passed 5/5 — a marker is a finding in its own right, which is why they're reported even on green cases.

**Scope checked before changing anything:** the sibling entry skills (`research`, `investigation`) carry a `Source:` line only inside single-source arms, where the fixed wording is accurate. This was the one multi-source arm stating a constant.

**Impact, honestly:** nothing in `workflow-discussion-process` reads `Source:` — grep finds no consumer. So this is context handed downstream being wrong, not a branch being taken wrongly. Worth correcting; not worth overstating.

## Test plan
- `npm test` green: 1699 tests, 0 fail.
- `discussion-entry-seeds-from-carrier` passed 5/5 *with* this DEVIATION recorded; re-running it should now produce the same pass with no marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. **#558** 👈 current
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->