### PR TITLE
fix(prose-tests): command output was never actually recorded

### DIFF
--- a/tests/prose/lib/record-action.cjs
+++ b/tests/prose/lib/record-action.cjs
@@ -42,6 +42,11 @@ const LOG = '.walk-actions.log';
 const VIOLATIONS = 'tests/prose/.agent-tool-use.log';
 const WORLD = /(^|[\s"'`])(\/[^\s"'`]*\/prose-world-[A-Za-z0-9]+)/;
 const MAX_OUTPUT = 400;
+// A command's output is the evidence that settles what the prose was
+// shown — whether a gate rendered empty, whether a menu had entries. It
+// gets the room a whole rendered section needs; a file read does not,
+// since no claim turns on the bytes a walker read back.
+const MAX_COMMAND_OUTPUT = 2000;
 
 function read() {
   try {
@@ -63,6 +68,24 @@ function summarise(input) {
   if (!input || typeof input !== 'object') return '';
   const raw = input.command || input.file_path || input.pattern || input.path || '';
   return flatten(raw, 200);
+}
+
+/**
+ * What a tool actually gave back. The payload field is `tool_response`,
+ * and its shape is the tool's own: a shell reports `{stdout, stderr}`,
+ * everything else answers in whatever form suits it. Reading a shell's
+ * streams directly keeps a command's output legible as output rather
+ * than as a JSON envelope around it.
+ */
+function responseText(response, limit) {
+  if (response === null || response === undefined) return '';
+  if (typeof response === 'object') {
+    const { stdout, stderr } = response;
+    if (typeof stdout === 'string' || typeof stderr === 'string') {
+      return flatten([stdout, stderr].filter(Boolean).join('\n'), limit);
+    }
+  }
+  return flatten(response, limit);
 }
 
 /**
@@ -134,11 +157,19 @@ function main() {
   ];
 
   if (event === 'PostToolUse') {
-    parts.push(payload.tool_output_is_error ? 'ERROR' : 'ok');
-    parts.push(flatten(payload.tool_output, MAX_OUTPUT).split(world).join('.'));
+    // A call that failed never arrives here — it raises PostToolUseFailure
+    // instead — so reaching this point is itself the success signal.
+    parts.push('ok');
+    parts.push(
+      responseText(payload.tool_response, tool === 'Bash' ? MAX_COMMAND_OUTPUT : MAX_OUTPUT)
+        .split(world).join('.'),
+    );
   } else if (event === 'PostToolUseFailure') {
     parts.push('FAILED');
-    parts.push(flatten(payload.tool_output ?? payload.error, MAX_OUTPUT));
+    parts.push(
+      responseText(payload.tool_response ?? payload.tool_output ?? payload.error,
+        MAX_COMMAND_OUTPUT).split(world).join('.'),
+    );
   } else if (stop) {
     parts.push(flatten(payload.last_assistant_message, MAX_OUTPUT).split(world).join('.'));
   }

--- a/tests/scripts/test-prose-record-action.cjs
+++ b/tests/scripts/test-prose-record-action.cjs
@@ -63,29 +63,76 @@ describe('prose recorder — tool events', () => {
     assert.match(row, /^PreToolUse\tBash\t/);
   });
 
-  it('records the output of a call, so a claim about it can be checked', () => {
+  it('records a command output, so a claim about it can be checked', () => {
     fire({
       hook_event_name: 'PostToolUse',
       tool_name: 'Bash',
       agent_type: 'prose-walker',
       tool_input: { command: `cd ${world} && engine view` },
-      tool_output: 'MENU: 1. Continue "Pay"',
+      tool_response: { stdout: 'MENU: 1. Continue "Pay"', stderr: '' },
     });
     const [row] = logLines();
     assert.ok(row.includes('\tok\t'), 'a successful call is marked ok');
-    assert.ok(row.includes('MENU: 1. Continue "Pay"'), 'output is recorded verbatim');
+    assert.ok(row.includes('MENU: 1. Continue "Pay"'), 'output is recorded, not just its status');
   });
 
-  it('marks a failing call so a walk cannot look cleaner than it was', () => {
+  it('keeps stderr, where a command often says what went wrong', () => {
     fire({
       hook_event_name: 'PostToolUse',
       tool_name: 'Bash',
       agent_type: 'prose-walker',
-      tool_input: { command: `cd ${world} && engine nope` },
-      tool_output: 'unknown command',
-      tool_output_is_error: true,
+      tool_input: { command: `cd ${world} && engine view` },
+      tool_response: { stdout: 'partial output', stderr: 'warning: store is stale' },
     });
-    assert.ok(logLines()[0].includes('\tERROR\t'));
+    const [row] = logLines();
+    assert.ok(row.includes('partial output'));
+    assert.ok(row.includes('warning: store is stale'));
+  });
+
+  it('gives a command far more room than a file read', () => {
+    const long = 'x'.repeat(1800);
+    fire({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      agent_type: 'prose-walker',
+      tool_input: { command: `cd ${world} && engine view` },
+      tool_response: { stdout: long },
+    });
+    assert.ok(!logLines()[0].includes('[truncated]'), 'a rendered section survives whole');
+
+    fs.rmSync(path.join(world, LOG));
+    fire({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Read',
+      agent_type: 'prose-walker',
+      tool_input: { file_path: `${world}/big.md` },
+      tool_response: { file: { content: long } },
+    });
+    assert.ok(logLines()[0].includes('[truncated]'), 'a file read is trimmed — no claim rests on it');
+  });
+
+  it('records a tool that answers in its own shape, not a shell’s', () => {
+    fire({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Read',
+      agent_type: 'prose-walker',
+      tool_input: { file_path: `${world}/notes.md` },
+      tool_response: { file: { filePath: 'notes.md', numLines: 3 } },
+    });
+    assert.ok(logLines()[0].includes('numLines'));
+  });
+
+  it('marks a failing call so a walk cannot look cleaner than it was', () => {
+    fire({
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'Bash',
+      agent_type: 'prose-walker',
+      tool_input: { command: `cd ${world} && engine nope` },
+      tool_response: { stdout: 'Exit code 1\nUsage: engine <command>', stderr: '' },
+    });
+    const [row] = logLines();
+    assert.ok(row.includes('\tFAILED\t'));
+    assert.ok(row.includes('Usage: engine <command>'), 'and says what came back');
   });
 
   it('ignores anything happening outside a world', () => {


### PR DESCRIPTION
## Summary

- **The recorder read the wrong field.** It took `tool_output` off a post-tool payload; the field is `tool_response`, and for a shell it's an object of `stdout`/`stderr`, not a string. Every successful call therefore recorded its status and nothing else — rows read `→ ok` with an empty output column.
- **That silence undercut the record's whole purpose.** The asserter is told that a claim about what a command produced — a gate rendering empty, a menu having no entries — is settled by the record, not the walker's account. It couldn't be. Claims about output had only the narrative to rest on, which is the exact evidence the record was introduced to replace.
- **A command now gets far more room than a file read** (2000 vs 400 chars). A claim turns on a rendered section surviving whole; none turns on the bytes a walker read back.
- **Drops the `tool_output_is_error` check** — it never fired and never could. A failing call doesn't reach `PostToolUse`; it raises `PostToolUseFailure`, which was already recording correctly. Reaching the success branch is itself the signal.

## Test plan

- `node --test tests/scripts/test-prose-record-action.cjs` — 17/17, with five new cases: stdout capture, stderr merging, the command-vs-read budget split, a non-shell response shape, and the failure path
- Prose gate green: 38/38 across recorder, corpus and snapshot suites
- **Verified against a live walk** — the gateway's DATA, DISPLAY and MENU sections now all appear in the record, menu entries included. Before this change the same walk recorded `→ ok` and nothing more.

## Why it matters beyond the bug

Steps about display and menus could previously only be evidenced from the walker's narrative. In a Sonnet-walker trial, one case passed cleanly and another failed purely because its narrative was thin — the recorded actions proved the work was done. With output in the record, that evidence moves off the narrative, which is the precondition for revisiting the walker model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. **#560** 👈 current
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->