### PR TITLE
feat(prose-tests): walk on Sonnet, judge on Opus, escalate a failure

### DIFF
--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -63,17 +63,28 @@ a walk.
    `VERDICT: HARNESS ERROR` with the message it printed. Never fall back
    to judging a walk with no record of what it did.
 
-Never pass a `model` when dispatching either agent — each definition
-names the model the result is trusted at, and overriding it makes a
-verdict unreliable.
+Never pass a `model` on a first walk or on any assertion — each
+definition names the model the result is trusted at. The single
+exception is the confirmation rerun in step 4, below.
 
 4. **Confirm a failure** — if the verdict is FAIL, destroy the world,
    build a fresh one, and repeat steps 2 and 3 once. A defect in the
-   prose reproduces; a one-off does not. Two outcomes:
+   prose reproduces; a one-off does not.
+
+   Dispatch this second walk with `model: opus`. Walks run on the model
+   the definition names; a failure is where it is worth spending more,
+   and a defect a stronger walker also hits is a defect. The model each
+   walk ran on is recorded and reported, so an escalated rerun is never
+   mistaken for a like-for-like one. Escalate here and nowhere else —
+   never on a first walk, and never for the asserter.
+
+   Three outcomes:
    - The second run also FAILs → a confirmed finding. Report the
      evidence from the second run.
-   - The second run PASSes → a non-reproducing failure. Report it as
-     `FLAKY`, quoting both, and resolve nothing yourself.
+   - The second run PASSes → report `FLAKY`, quoting both, and resolve
+     nothing yourself. Name both models: the same case passing on the
+     stronger walker is a fact about the walk, not about the prose.
+   - The second run returns `INVALID WALK` → follow step 5.
 
 5. **Retry an invalid walk** — if the verdict is `INVALID WALK`, the
    walker began mid-flow and the case was never actually exercised.
@@ -90,7 +101,8 @@ Return exactly this and nothing else:
 
 ```
 CASE: <case-id>
-MODEL: <the model the asserter reported, or `unrecorded`>
+MODEL: <the model the asserter reported, or `unrecorded`. On a confirmed or
+       flaky failure, both — the first walk's and the escalated rerun's>
 VERDICT: PASS | FAIL | FLAKY | INVALID | HARNESS ERROR
 PATH: <n>/<total> steps passed
 WORLD: PASS | FAIL

--- a/.claude/agents/prose-walker.md
+++ b/.claude/agents/prose-walker.md
@@ -2,7 +2,7 @@
 name: prose-walker
 description: Executes workflow prose exactly as a live session would, against a disposable test world, and returns a transcript of what it did. Dispatched by prose-orchestrator during a prose-test run.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: opus
+model: sonnet
 hooks:
   PreToolUse:
     - matcher: "Bash|Write|Edit|Read|Glob|Grep"

--- a/design/prose-tests.md
+++ b/design/prose-tests.md
@@ -119,15 +119,19 @@ testing.
   computation powers the PR-end suggestion — "these N cases intersect
   this PR's prose changes"), by hand-picked ids, or `--all`. An
   engine-only PR intersects nothing and suggests nothing.
-- **P6 — one model, chosen for trust.** Walker and asserter both run on
-  **Opus**. Measured, not assumed: across three runs a Sonnet walker
-  performed the walk correctly every time but narrated it in summary,
-  omitting the quoted evidence the asserter requires — even with a
-  worked transcript example in front of it. A tiered arrangement then
-  produces a disagreement on every case, which is noise, not a signal.
-  A result you cannot rely on is worth nothing, so the cheaper tier is
-  a false economy. The orchestrator never overrides the model: each
-  definition names the model its result is trusted at.
+- **P6 — the walker walks on Sonnet, the asserter judges on Opus, and a
+  failure escalates.** Both ran on Opus while the harness was reading only
+  an agent's closing message and mistaking a compressed summary for a
+  skipped step; with the walk captured turn by turn (P6e) that gap closed,
+  and a Sonnet walk of implementation-picks-first-task passed every step
+  with quoted evidence, matching an Opus walk of the same case action for
+  action. Judging stays on Opus — it is the cheap half and the half a
+  verdict rests on. A FAIL is reran once on Opus by the orchestrator,
+  because a failure is where spending more is worth it and a defect a
+  stronger walker also hits is a defect; the model of every walk is
+  recorded and reported, so an escalated rerun is never mistaken for a
+  like-for-like one. Escalation happens in the moment, never by editing
+  the definition.
 - **P6a — a FAIL is confirmed by repetition, not by promotion.** A
   failing case re-runs once from a fresh world at the same models. A
   defect in the prose reproduces; a one-off does not, and is reported


### PR DESCRIPTION
## Summary

- **Walker moves to Sonnet.** Both agents went to Opus back when a walk was judged by the single message an agent returns — a compressed closing summary read as a skipped step, the walker looked unreliable, and the answer was to spend more. With the walk captured turn by turn (#561), that reason is gone.
- **Measured, not assumed.** A Sonnet walk of `implementation-picks-first-task` passes every path step with quoted evidence, identical world, no markers. An Opus walk of the same case made the same calls in the same order. Across both cases and both models the code-checked layer came out identical.
- **Sonnet was better on one axis**: it declined a system-reminder pushing auto-mode bias against stopping, citing the prose line naming harness auto mode as exactly the thing to ignore. That's the STOP-gate discipline the pipeline depends on.
- **Asserter stays on Opus** — the cheaper half (one prompt in, a verdict out) and the half the result rests on.
- **A FAIL is rerun once on Opus** by the orchestrator. A failure is where spending more is worth it, and a defect a stronger walker also hits is a defect. Escalation happens in the moment, never by editing the definition, so a routine run is always the model the definition names.
- **Both models are reported** on a confirmed or flaky failure, so an escalated rerun is never read as like-for-like.

## Test plan

- Prose suites green (39/39 on corpus + invariants; full prose gate unchanged)
- The Sonnet verdict this rests on: 5/5 path steps, further claim PASS, world `identical: true`, all three deterministic checks PASS, zero markers
- `design/prose-tests.md` P6 rewritten to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. **#564** 👈 current
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->