### PR TITLE
fix(prose-tests): the verdict names only the model the record names

### DIFF
--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -100,8 +100,11 @@ Return exactly this and nothing else:
 
 ```
 CASE: <case-id>
-MODEL: <the model the asserter reported, or `unrecorded`. On a confirmed or
-       flaky failure, both — the first walk's and the escalated rerun's>
+MODEL: <the walking model, exactly as the asserter read it off the recorded
+       `SubagentStop` line, or `unrecorded`. On a confirmed or flaky failure,
+       both walks'. Never any other agent's — nothing in the record names the
+       model you or the asserter ran on, so stating one is a guess in a slot
+       reserved for facts.>
 VERDICT: PASS | FAIL | FLAKY | INVALID | HARNESS ERROR
 CHECKS: <every deterministic check the asserter reported, verdict and name,
         one per line — or `none declared`. Never summarised, never inferred


### PR DESCRIPTION
## Summary

Found by deliberately breaking a skill to prove the harness catches it. It did — and turned up something else on the way.

The orchestrator returned:

```
MODEL: first walk claude-sonnet-5, escalated rerun claude-opus-5
       (asserter: claude-sonnet-5 both times)
```

**The asserter was not on Sonnet.** Every asserter transcript from that run is `claude-opus-5` with zero tool calls, exactly as contracted; the Sonnet agents were the orchestrators, which are Sonnet by design.

**And it had no way to know either way.** The only model anywhere in the record comes off the walker's `SubagentStop` line. No agent's own model appears anywhere it can read.

So a slot that exists to carry a fact carried a guess — in the one field whose whole purpose is catching a run that silently used the wrong model. `MODEL:` now states the walking model and nothing else.

## The break test itself (reverted, never committed)

Moved `render phase-note` above the status read in `workflow-investigation-entry` — a plausible "announce the phase first" reordering. Result:

```
VERDICT: FAIL
FAIL  calls_in_order — "render phase-note" never ran after
                       "manifest get crash-fix.investigation.crash-fix status"
PASS  calls_include  — ran all of: … status, render phase-note
N/A   engine_before_write — no workflow state was written
PATH: 4/5 — step 4 fails on both runs
```

Every layer behaved:
- `calls_in_order` caught it while `calls_include` passed — both calls ran, just out of order. Precisely the gap ordering was added for, now proven on real prose rather than a unit test.
- `engine_before_write` reported `N/A`, not a misleading green tick.
- **Escalation fired for the first time**: Sonnet walked and failed, the orchestrator rebuilt the world and reran on Opus, Opus failed identically → confirmed defect rather than flake.
- The `CHECKS` line surfaced the computed facts instead of leaving them to be inferred from a green overall verdict.

## Test plan

- Prose gate unchanged and green
- Working tree verified clean after revert; the broken prose was never committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. **#567** 👈 current
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->