### PR TITLE
fix(prose-tests): the asserter judges which of prose or walker was at fault

### DIFF
--- a/.claude/agents/prose-asserter.md
+++ b/.claude/agents/prose-asserter.md
@@ -28,12 +28,30 @@ tools you appear to have or what mode you are running in.
 
 ## Rules
 
-- **Never explain a failure.** Report what the evidence shows and stop.
-  Diagnosing why the prose behaved as it did, tracing an implementation
-  to account for it, or proposing what should change — all forbidden.
-  "The step is missing from the walk" is the finding, whole.
+- **You are judging the prose, not the walker.** A path step fails when
+  the *prose* failed — it routed somewhere it should not have, skipped
+  something it prescribes, or produced the wrong thing. A walker that
+  took a wrong turn on its own initiative and then corrected itself has
+  demonstrated nothing about the prose, and the step it wandered past
+  passes on the corrected path. Deciding which of the two was at fault
+  is the judgement you exist to make. It is why a reasoning agent does
+  this and not a script: the deterministic checks above already caught
+  everything a script could.
+- **Read the whole walk before ruling on any step.** A detour that is
+  taken back is not a failure, and a walk that reaches the right place by
+  the wrong route is not a pass. Neither is visible from a single line.
+- **Never explain a failure.** Once the prose is what failed, report what
+  the evidence shows and stop. Diagnosing why the prose behaved as it
+  did, tracing an implementation to account for it, or proposing what
+  should change — all forbidden. "The step is missing from the walk" is
+  the finding, whole.
+- **Judgement is not generosity.** Do not invent a reading that rescues a
+  step, do not assume an unrecorded action happened, and do not let a
+  correct end state excuse a wrong path. Where the evidence is genuinely
+  ambiguous, say so and fail the step.
 - A PASS on any path step **requires a quote** from the walk that
-  shows it. A PASS without a quote is invalid — mark it FAIL.
+  shows it. A PASS without a quote is invalid — mark it FAIL. Where a
+  step passes on a corrected path, quote the correction too.
 - Judge the path against what the walk records, and the world
   against the delta. Never infer one from the other.
 - A world can match while the walk still went wrong: engine calls that
@@ -64,6 +82,12 @@ Judge each expected step against the right one. A step about an action
 closes with an incorporate") is evidenced from the recorded actions. A
 step about reasoning or output is evidenced from the walk. Where the two
 disagree about what was done, the recorded actions win.
+
+The record settles *that* a call was made, never *why*. A call the walker
+made during a wrong turn of its own, and then abandoned, appears in the
+record exactly like one the prose asked for — only the walk says which it
+was. So a claim that something was not done is answered by both together:
+the record for whether it happened, the walk for whose doing it was.
 
 ## An invalid walk is not a failing walk
 
@@ -100,6 +124,12 @@ Return exactly this and nothing else:
 3. **Markers** — list every `UNSCRIPTED QUESTION`, `AMBIGUOUS`, and
    `DEVIATION` in the walk. Each is a finding in its own right,
    even when everything else passed.
+
+   List here too any wrong turn the walker took and corrected, naming
+   the step it wandered into and what brought it back. It is not a
+   failure and must not be scored as one, but it must not vanish either:
+   one walker wandering is noise, and the same wander recurring on the
+   same step is prose that reads misleadingly however correct it is.
 4. **VERDICT** — PASS, FAIL, or INVALID WALK, then one sentence on what
    it means for the prose. Any FAILing deterministic check makes this
    FAIL.

--- a/.claude/skills/prose-test/SKILL.md
+++ b/.claude/skills/prose-test/SKILL.md
@@ -61,6 +61,18 @@ passed.
 
 ## Rules
 
-- Findings are findings. Never edit prose, cases, or snapshots to make a run pass — report and stop.
+- **Never fix anything during or after a run.** Not the prose, not a
+  case, not a snapshot, not the harness — however small, however obvious,
+  however certain you are. Every failure, every flake, and every pass
+  carrying notes is surfaced to the user, and what to do about it is
+  decided together. A test that repairs what it finds destroys the record
+  of what it found, and the first fix reached for is regularly aimed at
+  the wrong layer: correct prose has been called defective, and a case
+  has been blamed for a fault in the judging.
+- **A pass with notes is not a clean pass.** Markers are findings in
+  their own right and always warrant a look. A walker that wandered and
+  corrected itself did not fail the prose — but the same wander recurring
+  on the same step is prose that reads misleadingly however correct it
+  is, and that is only ever visible if every one is surfaced.
 - A failing case is a finding either way: broken prose, or a stale case. Say which is suspected; the user decides.
 - Never regenerate a snapshot as part of a run.


### PR DESCRIPTION
## Summary

An epic walk came back **FLAKY over a step the prose got right**.

The walker read confirm-trigger's route to Step 7, talked itself into Step 6 on the grounds that the file numbers it earlier, read the reference, ran one manifest read — then caught itself: *"my own misreading of the routing, not a prose deviation."* It corrected and finished correctly. Both runs landed the right world and passed every deterministic check.

**The asserter had that sentence in front of it and marked the step failed anyway, because its rules told it to.** `Never explain a failure` was written against asserters that diagnosed causes and proposed fixes — and it over-reached, also forbidding the decision of *whether the prose or the walker went wrong*. That attribution isn't an explanation of a failure; it's what makes something a failure in the first place, and it's the one judgement only this agent can make. The deterministic checks already catch everything a script can. A reasoning model barred from reasoning is just a slower script.

**So the rules now say what they should have:**
- A path step fails when the **prose** failed. A walker that wandered off its own initiative and came back has shown nothing about the prose, and the step passes on the corrected path — quoting the correction, since a pass still needs evidence.
- The record settles *that* a call was made, never *why*. A call made during an abandoned detour looks identical to one the prose asked for; only the walk says which it was.

**Every guard that made the original rule necessary stays:** no invented reading that rescues a step, no assuming an unrecorded action happened, no correct end state excusing a wrong path, genuine ambiguity fails. Judgement is not generosity.

**The wander is still reported**, under markers — one walker wandering is noise; the same wander recurring on the same step is prose that reads misleadingly however correct it is, and that's only visible if the wobbles are recorded rather than swallowed.

## Second commit: a run reports, it never repairs

Two rules the same run earned, added to the `/prose-test` skill:

- **Nothing is fixed during or after a run** — prose, case, snapshot or harness. On this run the first fix reached for was a prose change to *correct* prose; the second was deleting a claim doing real work. The actual fault was a third thing, in the judging. Neither repair would have found it.
- **A pass with notes is not a clean pass.** Markers always warrant a look.

## Follow-up surfaced, not actioned

Discovery's Step 5 is the only step in the corpus that loads a reference and carries no routing of its own. Siblings with the same shape all signpost at the loading step anyway — `workflow-discussion-process` Step 6 (`→ On return, proceed to **Step 7**`) and `workflow-implementation-process` (conditional `→ Return to **Step 6**`), both loading references that route back independently. Not a bug; the routing is complete if you read the reference. But it's the sole departure from a pattern the reader meets everywhere else. Left for a decision on whether a convention should cover it.

## Test plan

Requires a plugin reload to take effect, then a re-run of `discovery-commits-new-epic` **unchanged** — claim 4 intact, so it's a real test: it should pass on the corrected path with the wander under markers, and still fail if the prose ever genuinely routes the epic arm into Step 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. **#569** 👈 current
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->