### PR TITLE
docs(conventions): a step whose reference routes every exit still signposts

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -692,6 +692,7 @@ Rules:
 - `→ On return, proceed to` is the footer after a Load directive, separated by a blank line — the loaded reference runs to completion (its STOP gates and loops included) before the proceed applies. A bare `→ Proceed to` here reads as the immediate next action and overshoots the reference
 - When a `**STOP.**` gate or a bold conditional sits between the Load directive and the routing line, the routing is keyed to the user's response or the branch, not the return — those use the bare `→ Proceed to`
 - The final step has no routing footer (it's terminal)
+- A footer governs only the reference's bare `→ Return to caller.` exits — never the branches the reference routes itself (see Navigation & Return Patterns → backbone escape). Where every exit routes to a named step, no branch is left for a footer to serve and naming one would name a step that never runs: the footer instead defers, `→ On return, proceed as the reference directed.` A step is never left with no footer at all — silence reads as the end of the step, and the next heading gets treated as the fall-through
 - Within reference files routing to other reference files, use `→` before Load (it IS a routing instruction in that context)
 
 **Parameter passing**: When a shared reference needs context from the caller, append `with` followed by named assignments. String literals and variable values are both backtick-wrapped; variables use curly brace placeholders:

--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -150,6 +150,8 @@ Load **[shape-and-confirm.md](references/shape-and-confirm.md)** and follow its 
 
 Load **[confirm-trigger.md](references/confirm-trigger.md)** and follow its instructions as written.
 
+→ On return, proceed as the reference directed.
+
 ---
 
 ## Step 6: Resume Detection


### PR DESCRIPTION
## Summary

Discovery's Step 5 loads `confirm-trigger.md` and ends there. Every other step in that skill says where it goes next — so a reader reaching the blank line has one signal left, the next heading, and takes it. A walk did exactly that: read confirm-trigger's route to Step 7, talked itself into Step 6 because the file numbers it earlier, then caught itself and corrected.

**The convention already anticipates most of this.** A reference whose paths need different backbone steps overrides its caller, because *"the caller's single `→ Proceed to` line can only go one place, so the file overrides it."* That wording assumes a line exists to be overridden — and for `final-review.md` it does: three of its eight exits return bare, and the caller's footer is what serves them.

`confirm-trigger.md` has no such exit. **Every path routes**, so any footer would name a step that never runs, and the step was left with nothing at all. That's the one shape with no documented form.

**Two rules added** under `### Load Directive Format`:
- Where every exit routes, the footer **defers** rather than naming a step: `→ On return, proceed as the reference directed.`
- A footer governs only the reference's bare `→ Return to caller.` exits — never branches the reference routed itself. True already, unwritten, and what lets a reader over-apply a footer to all eight of `final-review`'s exits when it serves three.
- And: a step is never left with no footer. Silence reads as the end of the step, making the heading below the fall-through by default.

Applied to `workflow-discovery` Step 5. **Behaviour is unchanged** — the routing was always complete for anyone who read the reference; this makes it complete for someone who has just finished reading it.

## Swept for other instances

Only two other footerless load-steps exist:
- `workflow-specification-entry` Step 4 — terminal (invokes the processing skill), correct as-is.
- `workflow-bridge` Step 2 — a different shape: six conditional branches, each a bare Load, none carrying routing. Reads against the every-branch-routes rule, though each continuation ends by invoking a skill, which is terminal and may be legitimately exempt. **Surfaced, not touched.**

## Test plan

- Conventions lint 29/29; prose gate 47/47
- No simulation change: this adds a routing signpost, not an engine verb or a changed call sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. **#570** 👈 current
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->