### PR TITLE
fix(investigation): the symptom interview never ran for work shaped in discovery

### DIFF
--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -85,6 +85,8 @@ Check if the investigation file exists at `.workflows/{work_unit}/investigation/
 
 #### If no file exists
 
+Set `resumed` = `false`.
+
 → Proceed to **Step 1**.
 
 #### If file exists
@@ -103,6 +105,10 @@ Check if the investigation file exists at `.workflows/{work_unit}/investigation/
 ```
 
 Load **[resume-detection.md](../workflow-shared/references/resume-detection.md)** with artifact = `investigation`, file = `.workflows/{work_unit}/investigation/{topic}.md`, continue_step = `Step 2`, restart_targets = `the investigation file and the phase cache directory (rm -rf .workflows/.cache/{work_unit}/investigation/{topic}/ — content and agent state together)`, commit = `investigation({work_unit}): restart investigation`.
+
+Set `resumed` from where the reference returns: `true` for **Step 2**, the earlier session's symptoms still standing; `false` for **Step 1**, its file deleted and rebuilt.
+
+→ On return, proceed as the reference directed.
 
 ---
 
@@ -124,9 +130,9 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 
 ## Step 3: Symptom Gathering
 
-#### If the Symptoms section is already populated
+#### If `resumed` is `true`
 
-Resuming — don't re-interview. Fold in anything new the user has mentioned this session (commit if the file changed).
+An earlier session already interviewed the user — don't re-interview. Fold in anything new they have mentioned this session (commit if the file changed).
 
 → Proceed to **Step 4**.
 


### PR DESCRIPTION
## The defect

Step 3 asks whether the Symptoms section is **already populated**, treating that as *"a previous session gathered these — don't re-interview"*.

But **Step 1 populates Symptoms itself**, from the discovery carrier and the seed, precisely so the user isn't asked to repeat what they already said. So every path into Step 3 arrives with the section populated:

| Path | Symptoms at Step 3 |
|---|---|
| fresh (no file) | populated by Step 1 from the carrier |
| restart | file deleted, Step 1 rebuilds and populates again |
| continue | earlier session's content stands |

The guard is true in all three, so **the interview is skipped in all three**. For a bugfix shaped in discovery — which is how bugfixes reach investigation — symptom gathering never runs. It only works when there was no carrier and the section was left as template placeholders.

## The fix

The guard was asking about the *file* when the question is about the *session*.

Step 0 already knows which it is: no file means fresh; a continue returns for Step 2 with the earlier session's symptoms standing; a restart deletes the file and returns for Step 1 to rebuild it. That distinction is now held as `resumed`, and Step 3 branches on it.

**An engine fact couldn't serve here.** After Step 1 the topic status is `in-progress` on both paths, so `manifest get` can't discriminate. Which arm Step 0 took is the only thing that can.

## Scope — checked, not assumed

**Contained to this skill.** Discussion and research load the same shared resume reference, but their equivalent steps are unconditional guidance loads rather than an interview, so they have nothing to distinguish.

**The other four "already populated" guards are sound.** `discovery_map` non-empty, a key in `items`, `review_cycle` set — all engine state, none of it writable by the step immediately before. Only this one keyed on content.

**Nothing downstream reads it.** `Symptoms` appears only at this guard and in initialisation.

## Also

Step 0's file-exists arm gains the routing footer it lacked. `resume-detection.md` routes every exit itself, which is exactly the shape that takes `→ On return, proceed as the reference directed.` (#570) — its second instance, found incidentally.

## Test plan and its limit

- Conventions lint 29/29; prose gate 19/19
- `investigation-initialises-the-phase` re-run to confirm the fresh arm and new footer walk cleanly

**Not proven by test:** the case stops before Step 3, so the *resumed* arm is unexercised. Catching this defect requires a case that starts with an existing investigation file and takes the continue path — a different fixture, and the one that would actually fail on the old prose. Worth adding; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. **#575** 👈 current
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->