### PR TITLE
fix(investigation): the interview starts from the carrier, not over it

### DIFF
--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -151,6 +151,8 @@ An earlier session already interviewed the user — don't re-interview. Fold in 
 > messages, affected areas, and environmental context.
 ```
 
+Read what the Symptoms section already holds — initialisation seeded it from the carrier, and that is the user's own account. Ask what it does not answer, and confirm rather than re-ask where it is thin. Putting a question they have already answered back to them reads as not having listened.
+
 Load **[symptom-gathering.md](references/symptom-gathering.md)** and use its questions to gather symptoms from the user.
 
 Document symptoms in the investigation file as you gather them. Commit after each significant addition.


### PR DESCRIPTION
## Summary

#575 made the symptom interview run for work shaped in discovery. The first walk through the arm showed what it does when it finally executes: **three of six questions re-asked things the carrier had already answered** and initialisation had already written into the file — asking what the user sees when it crashes, against a Symptoms section already reading *"No error surfaces to the user — the page just fails."*

**That is what the prose literally said to do.** The `Otherwise` arm loaded the question bank with no instruction to read the file it had just seeded, and the question bank carries no such instruction either. The don't-re-ask rule lives in the entry skill (*"Do not re-ask; live conversation context, when present, supplements the carrier"*); the process skill lost it at the handoff.

**Pre-existing, newly reachable.** The arm was effectively unreachable for carrier-shaped work until #575 fixed the guard, so the gap has existed as long as the arm has — it simply never ran on the path that matters.

**Fix — three sentences ahead of the Load:** read what the Symptoms section already holds (the seed is the user's own account), ask what it does not answer, confirm rather than re-ask where it is thin.

## Provenance

Found by `investigation-gathers-symptoms` (#576) on its first run — the walker put Q1 to a user whose file already contained the answer. One walk did this, the confirmation walk did not, which is exactly the model-dependent behaviour an unstated intent produces.

## Test plan

- Conventions lint 29/29; prose gate 90/90
- Verified by the case re-run once the stack is reloaded — its further claim *"nothing the user already said in discovery is put back to them as a question"* is the direct probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. **#578** 👈 current
35. #579
36. #580
37. #581
38. #582
39. #583
<!-- stack:links:end -->