### PR TITLE
fix(prose-tests): the world log is the walker's record

### DIFF
--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -3,12 +3,6 @@ name: prose-orchestrator
 description: Runs one prose-test case end to end — builds the world, dispatches the walker, computes the delta, dispatches the asserter, reruns a failure from a fresh world to confirm it, destroys the world — and returns just the verdict. Dispatched by the /prose-test skill, one per case.
 tools: Bash, Read, Agent
 model: sonnet
-hooks:
-  PostToolUse:
-    - matcher: "Bash"
-      hooks:
-        - type: command
-          command: "node \"$CLAUDE_PROJECT_DIR/tests/prose/lib/record-action.cjs\""
 ---
 
 # Prose Orchestrator

--- a/tests/prose/lib/record-action.cjs
+++ b/tests/prose/lib/record-action.cjs
@@ -3,8 +3,8 @@
 
 // The hook that records what prose-test agents actually do.
 //
-// Declared in the frontmatter of prose-walker, prose-orchestrator and
-// prose-asserter, so it fires only while one of them is active. The
+// Declared in the frontmatter of prose-walker and prose-asserter, so it
+// fires only while one of them is active. The
 // agents play no part in it: they cannot forget an entry, summarise one
 // away, or write it late — which is the whole point. Walkers were
 // repeatedly found doing a full walk and reporting only its tail, and
@@ -201,6 +201,13 @@ function main() {
   // every other event is absent from it — resolve it from the transcript.
   const stop = event === 'Stop' || event === 'SubagentStop';
   const traced = stop ? fromTranscript(payload.agent_transcript_path) : null;
+  // The world log is the walker's record. The orchestrator shares this
+  // hook, and its own commands carry world paths in their payloads — the
+  // world it just built, the prompt it just emitted — so without this
+  // gate its rows land in the walker's log ahead of the walk itself,
+  // padding the record and handing the checks substrings no walk ran.
+  if (!agent.includes('walker')) return;
+
   const found = JSON.stringify(payload).match(WORLD);
   const world = found ? found[2].replace(/\\+/g, '') : traced && traced.world;
   if (!world || !fs.existsSync(world)) return;

--- a/tests/scripts/test-prose-record-action.cjs
+++ b/tests/scripts/test-prose-record-action.cjs
@@ -164,6 +164,21 @@ describe('prose recorder — tool events', () => {
     assert.ok(row.includes('Usage: engine <command>'), 'and says what came back');
   });
 
+  it('keeps the orchestrator out of the walker\'s record', () => {
+    // The orchestrator's own commands carry world paths — the world it
+    // just built, the prompt it just emitted — and its rows were landing
+    // in the walker's log ahead of the walk itself, padding the record
+    // and handing the checks substrings no walk ran.
+    fire({
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Bash',
+      agent_type: 'prose-orchestrator',
+      tool_input: { command: 'node tests/prose/run.cjs world some-case' },
+      tool_response: { stdout: `{"world":"${world}","case":"some-case"}` },
+    });
+    assert.deepEqual(logLines(), [], 'no orchestrator row reaches the world log');
+  });
+
   it('ignores anything happening outside a world', () => {
     fire({
       hook_event_name: 'PreToolUse',


### PR DESCRIPTION
## Summary

The first two rows of the quick-fix walk's action log weren't the walk's — they were the **orchestrator's own commands** (the world it had just built, the prompt it had just emitted), landing in the walker's log because their payloads carry the world path and the recorder scopes by finding one.

Noise today, a hazard tomorrow: the checks match substrings against those rows, so an orchestrator command could satisfy a `calls_include` or trip a `calls_exclude` on a walk that did neither.

- The recorder now **gates world-scoped writes on the walker** — nothing else writes into a world's action log or walk transcript.
- The asserter's violation path is untouched: its tool calls still land in the repo-local log, since a breach of the no-tools contract must be visible wherever it happens.
- The orchestrator's own recording hook is removed — everything it recorded in a world was someone else's record.

## Test plan

- `test-prose-record-action.cjs` 26/26, with a new case: an orchestrator `run.cjs world` call whose payload names the world leaves no row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. **#580** 👈 current
37. #581
38. #582
39. #583
<!-- stack:links:end -->