### PR TITLE
fix(prose-tests): a confirmed failure reports both runs' checks

### DIFF
--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -79,6 +79,12 @@ exception is the confirmation rerun in step 4, below.
      stronger walker is a fact about the walk, not about the prose.
    - The second run returns `INVALID WALK` → follow step 5.
 
+   When two runs happened, report both runs' deterministic checks,
+   labelled per run — never one run's block standing for both. Checks
+   that pass on one walk and fail on the other are not a property of the
+   prose; they are the two walks behaving differently, and that variance
+   is a finding in its own right. Name it as one.
+
 5. **Retry an invalid walk** — if the verdict is `INVALID WALK`, the
    walker began mid-flow and the case was never actually exercised.
    Destroy the world, build a fresh one, and repeat steps 2 and 3 once.
@@ -103,7 +109,9 @@ VERDICT: PASS | FAIL | FLAKY | INVALID | HARNESS ERROR
 CHECKS: <every deterministic check the asserter reported, verdict and name,
         one per line — or `none declared`. Never summarised, never inferred
         from the overall verdict: these were decided in code, and dropping
-        them turns a fact back into an assumption.>
+        them turns a fact back into an assumption. When two runs happened,
+        both runs' blocks, labelled — `first walk:` / `confirmation:` —
+        and a line naming any divergence between them as walk variance.>
 PATH: <n>/<total> steps passed
 WORLD: PASS | FAIL
 MARKERS: <none, or one line each>


### PR DESCRIPTION
## Summary

The quick-fix verdict showed one CHECKS block with two FAILs. What actually happened: **the first walk's checks all passed** and it failed only on a path step; the confirmation walk then skipped two prescribed calls and its checks caught that. The single block was the second run's, standing silently for both — reading as though the case's checks failed, when the failures were one walk's behaviour.

The orchestrator was obeying its own instruction — *report the evidence from the second run* — which is right for path evidence and wrong for checks: **checks that pass on one walk and fail on the other are not a property of the prose.** They're the two walks behaving differently, and that variance is itself a finding — the exact signal separating a defect from an unreliable walk.

A confirmed or flaky verdict now carries **both runs' check blocks, labelled** (`first walk:` / `confirmation:`), with any divergence named as walk variance. Untangling this took transcript archaeology the report should have made unnecessary.

## Test plan

- Agent-prose change; takes effect on reload, proven by the case re-run above the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. **#581** 👈 current
38. #582
39. #583
<!-- stack:links:end -->