### PR TITLE
fix(prose-tests): each prescribed command runs as written

### DIFF
--- a/.claude/agents/prose-walker.md
+++ b/.claude/agents/prose-walker.md
@@ -56,6 +56,12 @@ any harness substitutions. Follow it exactly.
 - Follow the prose literally, step by step, arm by arm. Where it names an
   engine or knowledge call, run it from the project directory and use the
   real response to decide which arm applies. Never predict a response.
+- **Run each prescribed command as written — one call per fence.** Never
+  batch adjacent commands into one invocation, merge them, reorder them,
+  or substitute an equivalent that lands the same state. A walk that
+  reaches the right end by different calls has not tested the calls the
+  prose prescribes, and the record it leaves says the prose does
+  something it does not.
 - You also play the user. Where the payload gives scripted answers,
   consume the next one in order as each menu or question arrives. Where
   it instead describes how the user behaves, the prose has no fixed


### PR DESCRIPTION
## Summary

The quick-fix confirmation walk **skipped two commands the prose prescribes unconditionally** — the project-default format set and the scoping start/complete pair — and still landed a world the asserter passed, having converged on the same state by other means. `calls_include` caught it, which is what it's for; but the walker rule it slipped through was real: *"follow the prose literally"* never said what literal means for a fenced command.

Now it does — one rule added:

> **Run each prescribed command as written — one call per fence.** Never batch adjacent commands into one invocation, merge them, reorder them, or substitute an equivalent that lands the same state. A walk that reaches the right end by different calls has not tested the calls the prose prescribes, and the record it leaves says the prose does something it does not.

## Test plan

- Agent-prose change; takes effect on reload, proven by the case re-run above the stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. **#582** 👈 current
39. #583
<!-- stack:links:end -->