### PR TITLE
fix(scoping): context gathering reads the whole carrier, asks only the gaps

### DIFF
--- a/skills/workflow-scoping-process/references/gather-context.md
+++ b/skills/workflow-scoping-process/references/gather-context.md
@@ -14,7 +14,9 @@ Gather targeted context about the mechanical change. Read the work's seed and th
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} description
 ```
 
-#### If the seed and description already capture what, where, and why
+Read the latest discovery session log's **Exploration** when one exists (`.workflows/{work_unit}/discovery/sessions/session-NNN.md`, highest-numbered) — discovery's shaped context is the carrier's second half. A logless quick-fix has none.
+
+#### If the carrier — seed, description, and exploration — already captures what, where, and why
 
 → Return to caller.
 
@@ -23,6 +25,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} 
 → Proceed to **B. Targeted Questions**.
 
 ## B. Targeted Questions
+
+The carrier has already answered some of these. Emit only the questions it leaves open, dropping any bullet it already covers — a question the user has already answered reads as not having listened.
 
 > *Output the next fenced block as a code block:*
 


### PR DESCRIPTION
## The defect

The quick-fix walk **re-asked the what and the why the user gave in discovery** — both walks, independently. It asked "what exactly is being changed?" against a carrier that says the support mailbox is retiring and everything should point at the new address.

Two causes, both in `gather-context.md`:

1. **Its guard weighed only the seed and description** — blind to the session log's Exploration, the half of the carrier the entry skill reads by name and the half holding the shaped context.
2. **Its question block is a static fence** — all four questions prescribed verbatim, whatever the carrier holds.

## The fix

- Section A reads the **Exploration alongside the description**, mirroring the entry's own wording for where it lives and for the logless quick-fix that has none.
- The guard weighs **the whole carrier** — seed, description, and exploration.
- Section B emits **only the bullets the carrier leaves open**: *a question the user has already answered reads as not having listened.*

Same family as the investigation fix (#578) — the entry reads the carrier, the process skill dropped half of it — and the same repair.

## Provenance and proof

Found by `scoping-defines-the-quickfix` (#579) on its first run; its step-3 claim — *questions go to what the carrier does not answer* — is the test for this. Re-run pending reload.

## Test plan

- Conventions lint 29/29
- The case re-run is the direct probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #544
2. #545
3. #546
4. #548
5. #549
6. #550
7. #551
8. #552
9. #553
10. #554
11. #555
12. #556
13. #557
14. #558
15. #559
16. #560
17. #561
18. #562
19. #563
20. #564
21. #565
22. #566
23. #567
24. #568
25. #569
26. #570
27. #571
28. #572
29. #573
30. #574
31. #575
32. #576
33. #577
34. #578
35. #579
36. #580
37. #581
38. #582
39. **#583** 👈 current
<!-- stack:links:end -->