### PR TITLE
docs: idea-index discipline — tick on completion, never edit closed ideas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,14 @@ Agentic Engineering Workflows for Claude Code. Installed via `npx agntc add leeo
 
 Always create a feature branch **before** the first commit. Never commit to main and move commits after. The only exception is when explicitly told to commit to main.
 
+## Ideas
+
+Improvement ideas live in `ideas/`, indexed by `ideas/INDEX.md`.
+
+**When you complete an idea from the index, mark it done in the same PR as the work** — strike the title (`~~[Title](file.md)~~`) and append a `✅ Done` cell. Shipping the fix and leaving the row open is how the index stops being trustworthy; an entry that reads open when the work landed sends the next reader to re-do it.
+
+**A done idea's own file is a historical record — never edit it.** It captures what was true when the work shipped. Later corrections, caveats, or status nuance belong in the index row or a new idea, never in the closed one.
+
 ## Workflow Phases
 
 The phases group into three stages (the **three D's**), used as the top-level grouping in the epic dashboard (`workflow-continue-epic/references/epic-display-and-menu.md`): **Discovery** (Discovery, Research, Discussion, Investigation) — explore and decide; **Definition** (Scoping, Specification, Planning) — specify and plan; **Delivery** (Implementation, Review) — build and verify. The dashboard renders each stage as a `── STAGE ──` divider with the phases beneath it.


### PR DESCRIPTION
Adds an **Ideas** section to `CLAUDE.md` covering two rules that were convention at best — and that both got broken in a single session.

## The rules

1. **Complete an idea → mark it done in the same PR as the work.** Strike the title, append `✅ Done`. A row that still reads open after the work landed sends the next reader off to re-do it.
2. **A done idea's own file is a historical record — never edit it.** It captures what was true when the work shipped. Corrections, caveats, and status nuance belong in the index row or a new idea, never in the closed one.

## Why now

Both were broken this session, which is the evidence they need writing down:

- An audit found **four** entries fully delivered and never ticked (#30, #31, #32, #33) — #32 had grown into the entire workflow engine across ~29 PRs and its row still read open.
- Then I shipped the fix for #39 and left *its* row open too — recreating the exact drift the audit had just cleaned up.
- And I edited a closed idea's file (#32's) to scrub a stale path, rather than leaving the record as written.

Rule 1 is the one that keeps the index worth reading. Rule 2 is what stops the archive being rewritten after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)