### PR TITLE
docs(knowledge): the prose that reaches topic amend

### DIFF
--- a/skills/workflow-knowledge/references/knowledge-usage.md
+++ b/skills/workflow-knowledge/references/knowledge-usage.md
@@ -77,7 +77,80 @@ Note in the current phase's working file that the knowledge query was skipped. E
 
 → Return to caller.
 
-## E. Phase-specific notes
+## E. Correcting a wrong claim in a specification
+
+A completed specification is the one artifact the knowledge base never decays — it stays indexed at `high` confidence for the life of the project, so a wrong claim in one is served authoritatively to every future query until somebody corrects it.
+
+This applies **only** to a retrieved `specification` chunk whose claim you can *demonstrate* is wrong — the code, the test, or a later decision is in front of you and shows it. A claim you merely doubt is not this. Research, discussion, and investigation chunks are never corrected: they record what was said and found at the time, they stay true as records however wrong the thinking was, and they decay out of the store on their own.
+
+The target is another work unit's completed spec — the knowledge base is how you meet one. This is not for your own live work: a wrong claim in the artefact you are currently writing gets fixed in the writing.
+
+**Never autonomous.** Editing another work unit's artefact is proposed and confirmed before anything is written.
+
+Tell the user which work unit and topic the spec belongs to (the chunk header's second field is `{work-unit}/{topic}`), the claim as the spec states it, what demonstrates it is wrong, and the correction you would write. Then:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Amend that specification?
+
+- **`y`/`yes`** — Write the corrigendum and reindex
+- **`n`/`no`** — Leave it as it stands
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+#### If `no`
+
+Nothing is written. Carry the correct understanding into the current work yourself.
+
+→ Return to caller.
+
+#### If `yes`
+
+`{spec_wu}` and `{spec_topic}` come from the chunk header; `{current_wu}` is the work unit you are working in. Resolve the file:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest resolve {spec_wu}.specification.{spec_topic}
+```
+
+Read it in full, then make both edits in one pass:
+
+1. **Correct the affected lines in place** — the spec must read correctly to someone who never reaches the corrigendum.
+2. **Add the corrigendum** directly beneath the H1, above any earlier corrigendum so the newest reads first. Pin this exact shape:
+
+```
+## Corrigendum — {YYYY-MM-DD}
+*From: {current_wu}*
+
+Original: "{the claim as the spec stated it}"
+
+Correction: {what is true, and what demonstrates it}
+```
+
+Then record it:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs topic amend {spec_wu} specification {spec_topic} --from {current_wu}
+```
+
+The verb records the amendment, flags the plan built on the old text, re-indexes, and commits. It touches no status — the target's pipeline stays finished.
+
+**If the response is `ok: false`:**
+
+Surface the engine's error verbatim — it names the reason and the recovery path. Your edits are still on disk, uncommitted; leave them for the user to decide on.
+
+→ Return to caller.
+
+**Otherwise:**
+
+The correction is committed and the knowledge base now serves it. Carry on with the current work.
+
+→ Return to caller.
+
+## F. Phase-specific notes
 
 - **Research** — query at the start of the phase (via the contextual query step) and throughout. Early phases have the highest chance of overlapping with prior work — research is often where the same ground gets explored twice if we don't check.
 - **Discussion** — query at the start and throughout. Decisions being made now often echo or contradict decisions made elsewhere. Check before committing to a direction.


### PR DESCRIPTION
Idea #22, PR 2 of 3. Stacked on #590 — inert without it.

## Why here

`skills/workflow-knowledge/references/knowledge-usage.md` is loaded by all seven processing skills, and it is already where retrieved content is interpreted. All seven declare `Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)` in `allowed-tools` — verified, no frontmatter changes needed.

## What

New **section E — Correcting a wrong claim in a specification**.

The scope is stated narrowly *with its reason*, so it does not get helpfully generalised later:

- only a retrieved `specification` chunk, and only a claim you can **demonstrate** is wrong — the code, the test, or a later decision is in front of you. A claim you merely doubt is not this.
- research / discussion / investigation are **never** corrected: they record what was said and found, they stay true as records however wrong the thinking was, and they decay out of the store on their own.
- cross-work-unit only — the KB is how you meet another unit's completed spec. Your own live work fixes its claims in the writing.

**Never autonomous.** Editing another work unit's artefact is proposed and confirmed at a STOP gate. On `yes`: `manifest resolve` for the path → read the file → correct the affected lines *in place* (the spec must read correctly to someone who never reaches the corrigendum) → add a dated corrigendum beneath the H1, newest first → `engine topic amend`. The model authors the prose; the engine transacts — the same division `discovery-session close` follows.

The corrigendum shape mirrors the triage entry's (heading, italic provenance line, body):

```
## Corrigendum — {YYYY-MM-DD}
*From: {current_wu}*

Original: "{the claim as the spec stated it}"

Correction: {what is true, and what demonstrates it}
```

Phase-specific notes move E → F. No inbound reference names either letter — `contextual-query.md` and `planning-entry/references/cross-cutting-context.md` both point at **D. Query failure handling**, which is untouched.

## Prose test case — not practical, and why

The plan asked for one if a KB-bearing fixture were practical. It is not, and the blocker is structural rather than effort:

`tests/prose/lib/worlds.cjs` **excludes `.workflows/.knowledge/` from every snapshot** and re-derives the store with `knowledge setup --keyword-only` when it materialises a live world — so a world always starts with an **empty** store. A recipe can call `h.knowledge(...)`, but whatever it indexes is dropped at snapshot time. Populating the store in `materialiseWorld` would change the store every existing case runs against, which is a corpus-wide harness change, not this PR.

Second, independent blocker: section E's trigger is the walker *noticing and demonstrating* a wrong claim. `act.md` must stay coarse (P1b), so a case could not point at the amendment without scripting the derivation under test.

Conventions lint passes with the file's templated-fence pin unchanged at 1 — the confirm menu is static, and the corrigendum shape is a model-instruction template, not a rendered display.

## Verification

`npm test` · `npm run test:cli` · `npm run typecheck` green.

`node tests/prose/run.cjs select --diff main` selects three intersecting cases (they scope `knowledge-usage.md`): `investigation-gathers-symptoms`, `investigation-initialises-the-phase`, `scoping-defines-the-quickfix`. Worth a `/prose-test` run before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)