### PR TITLE
fix(prose-harness): recorded commands survive whole and match through quotes

### DIFF
--- a/tests/prose/lib/invariants.cjs
+++ b/tests/prose/lib/invariants.cjs
@@ -86,6 +86,23 @@ function commands(rows) {
 }
 
 /**
+ * Quotes are shell syntax, not command identity. The repo's own
+ * conventions tell a walker to quote dotpath arguments, so
+ * `manifest get 'wu.phase.topic' field` and the unquoted form are the
+ * same call — but a needle written from the prose's literal text spans
+ * the spot where the quote lands, and a whole case failed on exactly
+ * that. Both sides of every match drop quote characters first, so
+ * quoting style can never decide a verdict.
+ */
+function bare(s) {
+  return s.replace(/['"]/g, '');
+}
+
+function ranMatch(command, needle) {
+  return bare(command).includes(bare(needle));
+}
+
+/**
  * A write the prose could only have reached by consulting state first.
  * Reading a file is not enough — the engine is how a workflow skill
  * learns anything, so a walk that writes workflow state having never
@@ -117,7 +134,7 @@ function engineBeforeWrite(rows) {
 
 function callsInclude(rows, wanted) {
   const ran = commands(rows);
-  const missing = wanted.filter((w) => !ran.some((c) => c.includes(w)));
+  const missing = wanted.filter((w) => !ran.some((c) => ranMatch(c, w)));
   return missing.length
     ? { ok: false, detail: `never ran: ${missing.join(', ')}` }
     : { ok: true, detail: `ran all of: ${wanted.join(', ')}` };
@@ -125,7 +142,7 @@ function callsInclude(rows, wanted) {
 
 function callsExclude(rows, forbidden) {
   const ran = commands(rows);
-  const found = forbidden.filter((f) => ran.some((c) => c.includes(f)));
+  const found = forbidden.filter((f) => ran.some((c) => ranMatch(c, f)));
   return found.length
     ? { ok: false, detail: `ran what it should not have: ${found.join(', ')}` }
     : { ok: true, detail: `ran none of: ${forbidden.join(', ')}` };
@@ -141,7 +158,7 @@ function callsInOrder(rows, sequence) {
   const ran = commands(rows);
   let at = 0;
   for (const wanted of sequence) {
-    const found = ran.findIndex((c, i) => i >= at && c.includes(wanted));
+    const found = ran.findIndex((c, i) => i >= at && ranMatch(c, wanted));
     if (found === -1) {
       const seen = sequence.slice(0, sequence.indexOf(wanted));
       return {

--- a/tests/prose/lib/record-action.cjs
+++ b/tests/prose/lib/record-action.cjs
@@ -56,6 +56,13 @@ const WORLD = /(^|[\s"'`])(\/[^\s"'`]*\/prose-world-[A-Za-z0-9]+)/;
 // of that content lived in the response being cut.
 const MAX_OUTPUT = 400;
 const MAX_PRODUCED_OUTPUT = 10000;
+// The detail column is the substrate the deterministic checks match
+// against — a call that ran must be findable in it. It is truncated only
+// after the world path collapses to `.`, and generously: a cap that bit
+// into real commands made four includes report never-ran on calls the
+// walk performed (the world prefix ate the budget and the field name
+// fell off the end).
+const MAX_DETAIL = 600;
 const WRITE_RESPONSE_TOOLS = new Set(['Bash', 'Write', 'Edit', 'NotebookEdit']);
 
 function read() {
@@ -73,11 +80,10 @@ function flatten(value, limit) {
   return oneLine.length > limit ? `${oneLine.slice(0, limit)}…[truncated]` : oneLine;
 }
 
-/** The salient argument, per tool — what a claim will be about. */
+/** The salient argument, per tool, untruncated — callers flatten it. */
 function summarise(input) {
   if (!input || typeof input !== 'object') return '';
-  const raw = input.command || input.file_path || input.pattern || input.path || '';
-  return flatten(raw, 200);
+  return input.command || input.file_path || input.pattern || input.path || '';
 }
 
 /**
@@ -191,7 +197,7 @@ function main() {
         const file = path.join(projectDir, VIOLATIONS);
         fs.mkdirSync(path.dirname(file), { recursive: true });
         fs.appendFileSync(file,
-          `${agent}\t${event}\t${tool}\t${summarise(payload.tool_input)}\n`);
+          `${agent}\t${event}\t${tool}\t${flatten(summarise(payload.tool_input), MAX_DETAIL)}\n`);
       } catch { /* a hook must never break what it observes */ }
     }
     return;
@@ -217,7 +223,7 @@ function main() {
     tool,
     stop
       ? traced.model || 'model-unknown'
-      : summarise(payload.tool_input).split(world).join('.'),
+      : flatten(summarise(payload.tool_input).split(world).join('.'), MAX_DETAIL),
   ];
 
   if (event === 'PostToolUse') {

--- a/tests/scripts/test-prose-invariants.cjs
+++ b/tests/scripts/test-prose-invariants.cjs
@@ -139,6 +139,31 @@ describe('calls_include / calls_exclude', () => {
     assert.equal(invariants.check(rows, { calls_exclude: ['task start'] })[0].ok, true);
     assert.equal(invariants.check(rows, { calls_include: ['task start'] })[0].ok, false);
   });
+
+  it('matches through quotes — quoting a dotpath is style, not a different call', () => {
+    const rows = [
+      bash(`${ENGINE} manifest get 'wu.discovery.topic' brief_path`),
+      bash(`${ENGINE} manifest set "wu.discovery.topic" brief_incorporated true`),
+    ];
+    const declared = {
+      calls_include: [
+        'manifest get wu.discovery.topic brief_path',
+        'manifest set wu.discovery.topic brief_incorporated true',
+      ],
+    };
+    assert.equal(invariants.check(rows, declared)[0].ok, true);
+  });
+
+  it('a quoted needle matches an unquoted command the same way', () => {
+    const rows = [bash(`${ENGINE} manifest get wu.research.* status`)];
+    assert.equal(invariants.check(rows, { calls_include: ["manifest get 'wu.research.*' status"] })[0].ok, true);
+  });
+
+  it('quoting cannot hide a forbidden command from exclude', () => {
+    const rows = [bash(`${ENGINE} topic start 'wu' research 'topic'`)];
+    const [result] = invariants.check(rows, { calls_exclude: ['topic start wu research topic'] });
+    assert.equal(result.ok, false);
+  });
 });
 
 describe('calls_in_order — presence is not sequence', () => {
@@ -164,6 +189,15 @@ describe('calls_in_order — presence is not sequence', () => {
     });
     assert.equal(result.ok, false);
     assert.match(result.detail, /"knowledge.cjs query" never ran after "render entry-gate/);
+  });
+
+  it('matches the sequence through quoting differences', () => {
+    const rows = [
+      bash(`${ENGINE} manifest get 'wu.research.topic' status`),
+      bash(`${ENGINE} topic start wu research topic`),
+    ];
+    const declared = { calls_in_order: ['manifest get wu.research.topic status', 'topic start wu research topic'] };
+    assert.equal(invariants.check(rows, declared)[0].ok, true);
   });
 
   it('tolerates other calls falling between them', () => {

--- a/tests/scripts/test-prose-record-action.cjs
+++ b/tests/scripts/test-prose-record-action.cjs
@@ -63,6 +63,24 @@ describe('prose recorder — tool events', () => {
     assert.match(row, /^PreToolUse\tBash\t/);
   });
 
+  it('keeps a long command whole once the world path collapses — the checks match against it', () => {
+    // Measured failure mode: the world prefix ate the truncation budget
+    // and the trailing field name fell off, so calls_include reported
+    // never-ran on a call the walk performed.
+    const command = `cd ${world} && node .claude/skills/workflow-engine/scripts/engine.cjs `
+      + 'manifest set search-relevance.discovery.relevance-measurement brief_incorporated true';
+    fire({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Bash',
+      agent_type: 'prose-walker',
+      tool_input: { command },
+    });
+    const [row] = logLines();
+    const detail = row.split('\t')[2];
+    assert.ok(detail.includes('brief_incorporated true'), 'the field and value survive');
+    assert.ok(!detail.includes('…[truncated]'), 'nothing was cut');
+  });
+
   it('records a command output, so a claim about it can be checked', () => {
     fire({
       hook_event_name: 'PostToolUse',


### PR DESCRIPTION
Two harness-layer fixes from case 4's confirmed FAIL, in causal order of discovery:

**The root cause (second commit — the real fix)**: the recorder truncated the raw command at 200 chars *before* collapsing the world path to `.`, so the ~75-char world prefix ate the budget and the trailing words — `brief_path`, `brief_incorporated true`, `description`, the commit-message tail — fell off the record. `calls_include` then reported never-ran on calls the walk performed, **identically on both walker models** (deterministic truncation, not walk behaviour), while the world — built by the real calls — passed. Found by a diagnostic walker whose action log preserved the failure in the raw: 148-char lines ending in a literal `…[truncated]`. Every earlier case passed only because `pay`-sized names stayed under the cap. The detail column now truncates after the world path collapses, at 600, with the failure mode pinned in the recorder suite.

**Hardening (first commit)**: quote-normalised matching in `calls_include`/`calls_exclude`/`calls_in_order`. The first commit's message blames quoting for the FAIL — written before the diagnostic; the diagnostic refuted it (the walk used no quotes). The change stays on its own merits: the repo's conventions do tell walkers to quote dotpaths, needles are written from the prose's literal text, and quoting style should never decide a verdict. Four unit tests.

Base of a three-PR stack: this → the research/discussion handoff fix → the case-4 update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#599** 👈 current
2. #600
3. #601
4. #602
<!-- stack:links:end -->