### PR TITLE
fix(research,discussion): the handoff says what fed it and what type it serves

### DIFF
--- a/skills/workflow-discussion-entry/references/invoke-skill.md
+++ b/skills/workflow-discussion-entry/references/invoke-skill.md
@@ -41,6 +41,7 @@ Invoke the **workflow-discussion-process** skill (Skill tool) with the next fenc
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
+Work type: {work_type}
 Output: {output_path}
 
 Research files:
@@ -61,6 +62,7 @@ Invoke the **workflow-discussion-process** skill (Skill tool) with the next fenc
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
+Work type: {work_type}
 Source: existing discussion
 Output: {output_path}
 ```
@@ -72,6 +74,7 @@ Invoke the **workflow-discussion-process** skill (Skill tool) with the next fenc
 ```
 Discussion session for: {topic}
 Work unit: {work_unit}
+Work type: {work_type}
 Source: {source}
 Output: {output_path}
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -15,6 +15,7 @@ The decision phase, entered from discovery — or from research when it ran. Deb
 ### What This Skill Needs
 
 - **Topic** (required) - What technical area to discuss/document
+- **Work type** (required) - `epic`, `feature`, or `cross-cutting`. Determines session behaviour — off-topic concerns reroute between an epic's topics but log or pivot on single-topic work
 - **Context** (optional) - Prior research, constraints, existing decisions
 - **Seed concerns** (optional) - Initial subtopics or architectural questions to explore
 

--- a/skills/workflow-research-entry/references/invoke-skill.md
+++ b/skills/workflow-research-entry/references/invoke-skill.md
@@ -34,25 +34,27 @@ When the read returns non-empty, append the Description block shown in each sour
 
 No description load for `continue` — resuming an existing session, no need to re-prime.
 
-The `Description:` block is omitted when `description` is null or empty.
-
 Invoke the **workflow-research-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Research session for: {topic}
 Work unit: {work_unit}
+Work type: {work_type}
 
 Source: existing research
 Output: .workflows/{work_unit}/research/{resolved_filename}
 ```
 
-#### Otherwise
+#### If the context was gathered by interview
+
+gather-context ran at Step 4 — its answers fill the Context block. The `Description:` block is omitted when `description` is null or empty.
 
 Invoke the **workflow-research-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Research session for: {topic}
 Work unit: {work_unit}
+Work type: {work_type}
 
 Output: .workflows/{work_unit}/research/{resolved_filename}
 
@@ -61,6 +63,23 @@ Context:
 - Already knows: {any initial thoughts or research, or "starting fresh"}
 - Starting point: {technical feasibility, market, business model, or general direction}
 - Constraints: {any constraints mentioned, or "none"}
+
+Description:
+{description text — paragraph or two, preserved as-is}
+```
+
+#### Otherwise
+
+The carrier seeded the context — a feature's discovery record, or an epic topic's brief. No interview ran, so there are no gathered answers to relay: the process re-reads the carrier itself at initialisation, and the description carries the record. The `Description:` block is omitted when `description` is null or empty.
+
+Invoke the **workflow-research-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
+
+```
+Research session for: {topic}
+Work unit: {work_unit}
+Work type: {work_type}
+
+Output: .workflows/{work_unit}/research/{resolved_filename}
 
 Description:
 {description text — paragraph or two, preserved as-is}


### PR DESCRIPTION
Two template gaps surfaced independently by three walkers (both orchestrated models, then the diagnostic walk, all recording the same DEVIATION):

1. **Research's handoff carried an interview-shaped Context block on every non-continue path** — but its four fields are `gather-context.md`'s answers, and the carrier-seeded arms (a feature's discovery record, an epic topic's brief) never run the interview, so walkers improvised the fields from the brief. The handoff now branches: the interview-fed variant keeps the Context block; the carrier-seeded variant carries just the description — the process re-reads the carrier itself at initialisation, so nothing is lost.

2. **Neither research's nor discussion's handoff carried the work type**, though research's process declares it required (it routes epic vs feature sessions) and discussion's references branch on it (the off-topic reroute). It worked only because the invocation shares the entry's conversation context. Every handoff variant now carries a `Work type:` line, and discussion's needs-list declares it.

Conventions lint green. Diff-intersection: the four discussion/start cases plus case 4 — none pins handoff line content, so no case-claim change beyond the stacked case-4 PR.

Stacked on the harness fix; the case-4 PR sits on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #599
2. **#600** 👈 current
3. #601
4. #602
<!-- stack:links:end -->