### PR TITLE
fix(research): Starting Point fills from whatever seeded the phase

### DIFF
--- a/skills/workflow-research-process/references/initialize-research.md
+++ b/skills/workflow-research-process/references/initialize-research.md
@@ -9,7 +9,7 @@
 → Load **[read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
 
 1. Load **[template.md](template.md)** — use it to create the research file at the Output path from the handoff (e.g., `.workflows/{work_unit}/research/{resolved_filename}`). Include the terminal `## Triage` section seeded as `(none)`. When the file already exists as a `triaged` stub (rerouted concerns parked before any session), write the template's working sections around it and preserve the existing `## Triage` entries verbatim — never reset them to `(none)`; they drain during the session.
-2. Populate the Starting Point section with context from the handoff's `Context:` section and the seed. If restarting (no `Context:` in handoff), leave the Starting Point section empty — the session will gather context naturally.
+2. Populate the Starting Point section from whatever seeded this phase: the handoff's `Context:` fields when the interview ran, otherwise the carrier just read — the brief or the seed — and the handoff's `Description:`. When restarting (the handoff carries `Source: existing research`), leave the section empty — the session gathers context naturally.
 3. Register in manifest:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} research {topic}


### PR DESCRIPTION
PR D on the stack (#599 ← #600 ← #601 ← this), from the post-approval verification runs: both walker models identically left the research file's Starting Point empty on the carrier-seeded path, because `initialize-research.md` item 2 tested "no `Context:` in handoff" as its restart proxy — and #600's brief-fed fresh handoff legitimately carries only a `Description:`. The pre-#600 improvised Context block had been masking the bad proxy.

The fix: Starting Point fills from **whatever seeded the phase** — the interview's `Context:` fields when it ran, otherwise the just-read carrier (brief or seed) plus the `Description:` — and the restart arm keys on the handoff's explicit `Source: existing research` line, a stated fact instead of an absence-of-field. Same trap-ledger lens as investigation's symptom guard and scoping's gather-context: a guard keyed on content an upstream step's shape determines is suspect.

`research-initialises-from-the-brief` is the catching case and needs no change — its assert already states the correct behaviour, which is how this was found. Re-run on the final stack shape to follow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #599
2. #600
3. #601
4. **#602** 👈 current
<!-- stack:links:end -->