### PR TITLE
fix(spec): input review never reviews the spec against itself

### DIFF
--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -98,7 +98,7 @@ Dispatch the `workflow-specification-review-input` agent via the Task tool:
   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
   ```
   Sources returns an object keyed by source name (e.g., `{"auth-design": {"status": "incorporated"}}`). Resolve each source name to its artifact — sources can be incorporated specifications or research files, not only discussions:
-  - If a specification item named `{source-name}` exists in the manifest (an incorporated source spec): `.workflows/{work_unit}/specification/{source-name}/specification.md`
+  - If `{source-name}` is not `{topic}` and a specification item named `{source-name}` exists in the manifest (an incorporated source spec): `.workflows/{work_unit}/specification/{source-name}/specification.md` — the item sharing this topic's name is the spec under construction, never a source
   - Else if `.workflows/{work_unit}/research/{source-name}.md` exists: that research file
   - Else, when work type is `bugfix`: `.workflows/{work_unit}/investigation/{source-name}.md`
   - Else: `.workflows/{work_unit}/discussion/{source-name}.md`

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -98,7 +98,7 @@ Dispatch the `workflow-specification-review-input` agent via the Task tool:
   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
   ```
   Sources returns an object keyed by source name (e.g., `{"auth-design": {"status": "incorporated"}}`). Resolve each source name to its artifact — sources can be incorporated specifications or research files, not only discussions:
-  - If `{source-name}` is not `{topic}` and a specification item named `{source-name}` exists in the manifest (an incorporated source spec): `.workflows/{work_unit}/specification/{source-name}/specification.md` — the item sharing this topic's name is the spec under construction, never a source
+  - If `{source-name}` is not `{topic}` and a specification item named `{source-name}` exists in the manifest (an incorporated source spec): `.workflows/{work_unit}/specification/{source-name}/specification.md`
   - Else if `.workflows/{work_unit}/research/{source-name}.md` exists: that research file
   - Else, when work type is `bugfix`: `.workflows/{work_unit}/investigation/{source-name}.md`
   - Else: `.workflows/{work_unit}/discussion/{source-name}.md`

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -97,11 +97,12 @@ Dispatch the `workflow-specification-review-input` agent via the Task tool:
   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic} sources
   node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type
   ```
-  Sources returns an object keyed by source name (e.g., `{"auth-design": {"status": "incorporated"}}`). Resolve each source name to its artifact — sources can be incorporated specifications or research files, not only discussions:
-  - If `{source-name}` is not `{topic}` and a specification item named `{source-name}` exists in the manifest (an incorporated source spec): `.workflows/{work_unit}/specification/{source-name}/specification.md`
-  - Else if `.workflows/{work_unit}/research/{source-name}.md` exists: that research file
-  - Else, when work type is `bugfix`: `.workflows/{work_unit}/investigation/{source-name}.md`
-  - Else: `.workflows/{work_unit}/discussion/{source-name}.md`
+  Sources returns an object keyed by source name (e.g., `{"auth-design": {"status": "incorporated"}}`). Resolve each source name to its artifact — sources can be incorporated specifications or research files, not only discussions. First match wins:
+
+  1. `{source-name}` is not `{topic}` and a specification item named `{source-name}` exists in the manifest (an incorporated source spec) → `.workflows/{work_unit}/specification/{source-name}/specification.md`
+  2. `.workflows/{work_unit}/research/{source-name}.md` exists → that research file
+  3. Work type is `bugfix` → `.workflows/{work_unit}/investigation/{source-name}.md`
+  4. Otherwise → `.workflows/{work_unit}/discussion/{source-name}.md`
 
   Pass all resolved paths to the agent.
 - **Topic name**: the current topic

--- a/tests/prose/cases/spec-extracts-the-discussion/assert.md
+++ b/tests/prose/cases/spec-extracts-the-discussion/assert.md
@@ -22,10 +22,12 @@ The prose should have taken this path:
 6. when the discussion's relevant content is exhausted, its source row
    flips to incorporated
 7. review cycle 1 initialises through the engine; the input-review
-   agent is dispatched first and returns clean through the harness stub
-   — no tracking file exists, so the no-findings result is announced —
-   and only then is gap analysis dispatched, with the same clean
-   return; the two are never dispatched in parallel
+   agent is dispatched first — against the discussion file as its
+   source material, never against the specification itself — and
+   returns clean through the harness stub, with no tracking file, so
+   the no-findings result is announced; only then is gap analysis
+   dispatched, with the same clean return; the two are never dispatched
+   in parallel
 8. with both phases clean the review completes — no findings menus, no
    second cycle — and the review state commits
 9. the compliance self-check re-reads the session's instructions;


### PR DESCRIPTION
The DEVIATION from #604's walk, fixed. `spec-review.md` §C's first source-resolution arm ("a specification item named `{source-name}` exists") was written for epic consolidation sources — but on every single-topic work type the source name equals the topic name, so the arm matched **the spec under construction** and Phase 1's input-review agent was handed the specification as its own source material: a self-comparison structurally unable to find divergence from the discussion. Feature, bugfix, and cross-cutting were all affected; epic's differently-named discussion sources fell through correctly.

One-guard fix: the arm applies only when `{source-name}` is not `{topic}` — the item sharing this topic's name is the spec under construction, never a source. Enumerated: this resolution list exists in exactly one place; the other `{source-name}` uses are manifest status writes.

Lands twice: the case's assert step 7 now pins the dispatch target (the discussion, never the spec itself). Verification re-run of the case on this stack follows once review settles, per the run-timing rule.

Stacked on #604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #604
2. **#605** 👈 current
<!-- stack:links:end -->