### PR TITLE
fix(planning): spec-change detection says so when there is no baseline

### DIFF
--- a/skills/workflow-planning-process/references/spec-change-detection.md
+++ b/skills/workflow-planning-process/references/spec-change-detection.md
@@ -10,6 +10,19 @@ The manifest stores `spec_commit` — the git commit hash of the spec baseline t
 
 ## Detection
 
+#### If the planning item carries no `spec_commit`
+
+> *Output the next fenced block as a code block:*
+
+```
+No specification baseline is recorded on this plan — changes since
+planning began cannot be detected.
+```
+
+→ Return to caller.
+
+#### Otherwise
+
 Run a git diff against the stored commit for all input files:
 
 ```bash
@@ -17,6 +30,8 @@ git diff {spec_commit} -- {specification-path} {cross-cutting-spec-paths...}
 ```
 
 Also check for new cross-cutting specification files that didn't exist at that commit.
+
+→ Proceed to **Reporting**.
 
 ## Reporting
 


### PR DESCRIPTION
A plan initialised before the `spec_commit` field existed has nothing to diff against, and `spec-change-detection.md` ran its diff unconditionally — both prose-test walker models improvised at the gap, one announcing "Specification unchanged" on a baseline-less diff: invented assurance where an honest cannot-check belongs. Detection now branches: no baseline recorded → a code-block message that changes since planning began cannot be detected, and return; otherwise diff as before.

Caught by `planning-graphs-the-tasks` (stacked below), whose assert pins the honest message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)