### PR TITLE
fix(planning): construction re-entry on a finished plan completes the loop

### DIFF
--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -40,6 +40,10 @@ every stage.
 
 Work through each phase in order. Check the current phase's state.
 
+#### If the manifest position is past the last phase
+
+→ Proceed to **E. Loop Complete**.
+
 #### If the phase has no task table in the planning file
 
 → Load **[define-tasks.md](define-tasks.md)** and follow its instructions as written.


### PR DESCRIPTION
`plan-construction.md` D. Advance sets `phase={N+1}` even on the last phase, so every fully constructed plan rests one past the end — and §B had no arm for that position: neither per-phase condition can match a phase that does not exist, leaving re-entry (a resume heading for the graph or review) with no defined path. Both walker models improvised the escape; the arm now states it: position past the last phase → E. Loop Complete.

Caught by `planning-graphs-the-tasks`, whose assert pins the fast path. Verification rerun on this stack top is in flight; verdict to follow in the PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)