### PR TITLE
fix(planning): construction re-entry on a finished plan completes the loop

### DIFF
--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -40,6 +40,10 @@ every stage.
 
 Work through each phase in order. Check the current phase's state.
 
+#### If the manifest position is past the last phase
+
+→ Proceed to **E. Loop Complete**.
+
 #### If the phase has no task table in the planning file
 
 → Load **[define-tasks.md](define-tasks.md)** and follow its instructions as written.


### PR DESCRIPTION
Supersedes #610, which GitHub auto-closed when the withdrawn #609's branch beneath it was deleted; the branch is rebased directly onto #608 with the withdrawn commit dropped from its history.

`plan-construction.md` D. Advance sets `phase={N+1}` even on the last phase, then branches — so every plan that completes construction durably rests one past the end. §B had no arm for that position (neither per-phase condition can match a phase that does not exist), while the file's own Navigation section already defines it: "If all phases and tasks are complete, the leading edge is the end of plan construction." Any resume of a construction-complete-but-unconcluded plan — and any reopened concluded plan, since conclusion never normalises the pointer — re-enters §B in exactly this state. Both walker models hit it and improvised the escape; the arm states it: position past the last phase → E. Loop Complete.

Caught by `planning-graphs-the-tasks` (#608), whose assert pins the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #606
2. #607
3. #608
4. **#611** 👈 current
<!-- stack:links:end -->