### PR TITLE
feat(prose-harness): failed worlds leave their evidence behind

### DIFF
--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -32,8 +32,11 @@ a walk.
 - **Never investigate a failure.** Do not read the skill or engine source
   to explain a verdict, and do not add your own analysis to what the
   asserter returned. Pass the verdict through as given.
-- Destroy every world you build. On a failure, destroy it too but report
-  the case id so it can be rebuilt for inspection.
+- Destroy every world you build. On a FAIL, FLAKY, or INVALID, first
+  archive its evidence — `node tests/prose/run.cjs archive <case-id>
+  --world <dir>` — and carry the printed path into the verdict's
+  ARCHIVE line; then destroy as normal. A failed world's logs are the
+  only copy of what happened.
 
 ## Steps
 
@@ -117,6 +120,9 @@ WORLD: PASS | FAIL
 MARKERS: <none, or one line each>
 EVIDENCE: <for FAIL/FLAKY — the failing step and the quoted line that shows it;
           for INVALID — where the transcript opened and where it should have>
+ARCHIVE: <for FAIL/FLAKY/INVALID — the archived-evidence path each such run's
+         `archive` command printed, labelled per run when there were two;
+         omit the line entirely on PASS>
 ```
 
 No transcripts, no prompts, no commentary, no recommendations.

--- a/tests/prose/lib/worlds.cjs
+++ b/tests/prose/lib/worlds.cjs
@@ -347,6 +347,27 @@ function destroyWorld(dir) {
   fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 }
 
+// Worlds die with their logs — and a failed run's logs are exactly the
+// evidence a human wants afterwards. Archiving copies the record (both
+// logs) and the workflow state out of a world before it is destroyed,
+// to a directory that outlives the run. Never the skills layer — that
+// is the repo's copy, not the walk's.
+const ARCHIVE_PREFIX = 'prose-failed-';
+
+function archiveWorld(dir, caseId) {
+  if (!path.basename(dir).startsWith(WORLD_PREFIX)) {
+    throw new Error(`refusing to archive non-world directory: ${dir}`);
+  }
+  const dest = fs.mkdtempSync(path.join(os.tmpdir(), `${ARCHIVE_PREFIX}${caseId}-`));
+  for (const name of [ACTION_LOG, WALK_LOG]) {
+    const src = path.join(dir, name);
+    if (fs.existsSync(src)) fs.copyFileSync(src, path.join(dest, name));
+  }
+  const state = path.join(dir, '.workflows');
+  if (fs.existsSync(state)) fs.cpSync(state, path.join(dest, '.workflows'), { recursive: true });
+  return dest;
+}
+
 /** The recorded actions as rows, for checks that run in code. */
 function readActionRows(worldDir) {
   const file = path.join(worldDir, ACTION_LOG);
@@ -387,5 +408,5 @@ module.exports = {
   ROOT, ENGINE, KNOWLEDGE, MAINLINES_DIR, WORLD_PREFIX,
   ACTION_LOG, readActionLog, readActionRows, WALK_LOG, readWalkLog,
   runRecipe, collectTree, readSnapshot, snapshotDir, recipeHash, storedHash,
-  writeSnapshot, verifySnapshot, diffWorld, buildWorld, destroyWorld,
+  writeSnapshot, verifySnapshot, diffWorld, buildWorld, destroyWorld, archiveWorld,
 };

--- a/tests/prose/run.cjs
+++ b/tests/prose/run.cjs
@@ -13,6 +13,7 @@
 //   assert <case-id> --world <d>  the asserting agent's prompt
 //   snap <case-id>                (re)generate a case's snapshots
 //   verify [case-id]              rebuild-compare snapshot(s)
+//   archive <case-id> --world <d> lift a failed world's evidence out before destroy
 //   destroy --world <dir>         remove a world
 
 const fs = require('fs');
@@ -103,6 +104,15 @@ function cmdDestroy(argv) {
   const dir = flag(argv, '--world') || die('usage: destroy --world <dir>');
   worlds.destroyWorld(dir);
   process.stdout.write(`destroyed ${dir}\n`);
+}
+
+// A failed run's world holds the only copy of its evidence. Archiving
+// lifts the recorded logs and the workflow state to a directory that
+// outlives the run, so a failure can be inspected without re-walking.
+function cmdArchive(argv) {
+  const c = getCase(argv[0]);
+  const dir = requireWorld(argv, c);
+  process.stdout.write(`${JSON.stringify({ archived: worlds.archiveWorld(dir, c.id) })}\n`);
 }
 
 // --- prompt (the walker) --------------------------------------------------
@@ -250,9 +260,10 @@ function cmdList() {
 const [, , command, ...rest] = process.argv;
 const commands = {
   list: cmdList, select: cmdSelect, world: cmdWorld, prompt: cmdPrompt,
-  diff: cmdDiff, assert: cmdAssert, snap: cmdSnap, verify: cmdVerify, destroy: cmdDestroy,
+  diff: cmdDiff, assert: cmdAssert, snap: cmdSnap, verify: cmdVerify,
+  destroy: cmdDestroy, archive: cmdArchive,
 };
 if (!commands[command]) {
-  die('usage: run.cjs <list|select|world|prompt|diff|assert|snap|verify|destroy> …');
+  die('usage: run.cjs <list|select|world|prompt|diff|assert|snap|verify|archive|destroy> …');
 }
 commands[command](rest);


### PR DESCRIPTION
Improvement B of the hardening stack. Diagnosing case 4's FAIL required dispatching a whole fresh diagnostic walker because the failed worlds — and their action/walk logs, the only copy of the evidence — were destroyed with the verdict. `run.cjs archive <case-id> --world <dir>` now lifts both logs plus the `.workflows/` state to an outliving temp directory (never the skills layer, which is the repo's copy); the orchestrator is instructed to archive on FAIL/FLAKY/INVALID before destroy, and the verdict format gains an `ARCHIVE:` line (omitted on PASS).

Verified end to end against a live world. Note: the orchestrator-definition half is inert until `/reload-plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #612
2. **#613** 👈 current
3. #614
4. #615
5. #616
<!-- stack:links:end -->