### PR TITLE
feat(prose-harness): mid-walk deaths are INVALID, and the boundary rule is written down

### DIFF
--- a/.claude/agents/prose-asserter.md
+++ b/.claude/agents/prose-asserter.md
@@ -106,7 +106,7 @@ record exactly like one the prose asked for — only the walk says which it
 was. So a claim that something was not done is answered by both together:
 the record for whether it happened, the walk for whose doing it was.
 
-## One known difference between here and a live session
+## Two known differences between here and a live session
 
 An inline `` !`command` `` directive is substituted when a skill loads
 live. A walk reads the prose as a file, so the substitution never happens
@@ -119,7 +119,15 @@ real session almost always takes, and here it is never exercised. A claim
 that depends on the substituted value cannot be answered by a walk, and
 should be judged unprovable rather than passed or failed.
 
-This is the only such difference. Anything else that looks like an
+The second: a live session crosses a skill boundary through the Skill
+tool, which the walker does not have. Where the prose invokes another
+skill and the task sanctions continuing, the walker reads the named
+skill's file and follows it with the stated arguments — the same
+instructions a live invocation loads. That is correct behaviour, not a
+`DEVIATION` and not a missing step; do not fail a handoff for having
+been read rather than invoked.
+
+These are the only such differences. Anything else that looks like an
 environment quirk is a finding, not an exemption.
 
 ## An invalid walk is not a failing walk
@@ -135,6 +143,17 @@ on and the step it should have opened on, and judge nothing further.
 This is a fault in the walk, not in the prose. A walk that *did* the
 work and merely described it poorly is **not** invalid — judge it from
 the actions.
+
+The same holds at the other end. A walk that simply stops — its
+recorded actions ending before the task's stop condition, with no
+hard error, no `UNSCRIPTED QUESTION`, and no terminal arm of the
+prose reached — died mid-walk. The prose beyond that point was never
+exercised, so its steps are not failures and the expected world was
+never something this walk could have produced. Return
+`VERDICT: INVALID WALK`, name the last action taken and the stop
+condition it never reached, and judge nothing further. A walk the
+prose itself halted — a terminal STOP, a blocker arm — is **not**
+invalid: reaching that halt is the behaviour under judgment.
 
 ## Verdict
 

--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -89,7 +89,8 @@ exception is the confirmation rerun in step 4, below.
    is a finding in its own right. Name it as one.
 
 5. **Retry an invalid walk** — if the verdict is `INVALID WALK`, the
-   walker began mid-flow and the case was never actually exercised.
+   walker began mid-flow or died before the task's stop condition, and
+   the case was never actually exercised.
    Destroy the world, build a fresh one, and repeat steps 2 and 3 once.
    If the second walk is also invalid, report `INVALID` — never `FAIL`.
    A case that was not walked properly has said nothing about the prose,
@@ -119,7 +120,7 @@ PATH: <n>/<total> steps passed
 WORLD: PASS | FAIL
 MARKERS: <none, or one line each>
 EVIDENCE: <for FAIL/FLAKY — the failing step and the quoted line that shows it;
-          for INVALID — where the transcript opened and where it should have>
+          for INVALID — where the walk opened or died, and where it should have>
 ARCHIVE: <for FAIL/FLAKY/INVALID — the archived-evidence path each such run's
          `archive` command printed, labelled per run when there were two;
          omit the line entirely on PASS>

--- a/.claude/agents/prose-walker.md
+++ b/.claude/agents/prose-walker.md
@@ -86,6 +86,14 @@ any harness substitutions. Follow it exactly.
   errored. Use only the tools the walk itself requires.
 - Do not read the case directory (`tests/prose/cases/…`). It holds the
   expected result, and seeing it invalidates the run.
+- **Crossing a skill boundary is done by reading.** Where the prose
+  invokes another skill — "Invoke the X skill", a stored route like
+  `/workflow-y …` — there is no Skill tool here: when the task
+  sanctions continuing, read the named skill's file under
+  `.claude/skills/` and follow it with the stated arguments, exactly
+  as a live invocation would have loaded it. Expected, not a
+  `DEVIATION`, no marker. Where the task says to stop at the handoff,
+  stop there.
 - **An inline `` !`command` `` directive will not have run.** That
   substitution happens when a skill is loaded live; here the prose is read
   as a file, so the literal backtick line is what you see. The prose gives


### PR DESCRIPTION
Improvement C of the hardening stack, both halves definition-layer (inert until `/reload-plugins`):

1. **Early termination = INVALID.** The protocol treated mid-flow *starts* as invalid but mid-walk *deaths* as FAIL — the planning-graphs Opus confirmation stopped three steps short and its truncation polluted the verdict, leaving the decomposition to prose argument. The asserter now returns `INVALID WALK` when the record ends before the task's stop condition with no hard error, no `UNSCRIPTED QUESTION`, and no terminal arm reached — with the carve-out stated: a walk the *prose* halted is the behaviour under judgment, not invalid. The orchestrator's retry step covers both shapes.

2. **The skill-boundary rule graduates from act-wording to the definitions**, closing the proposal open since cycle 1: the walker reads the named skill and continues when the task sanctions it (mirroring the `!`-directive rule's placement), and the asserter's known-differences section grows from one entry to two — still closed with "anything else is a finding".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #612
2. #613
3. **#614** 👈 current
4. #615
5. #616
<!-- stack:links:end -->