### PR TITLE
feat(prose-harness): the verdict is a schema — scope always stated, markers typed

### DIFF
--- a/.claude/agents/prose-asserter.md
+++ b/.claude/agents/prose-asserter.md
@@ -173,15 +173,26 @@ Return exactly this and nothing else:
 2. **World** — PASS or FAIL. Enumerate EVERY difference in the delta and
    classify each volatile or material. Any material difference fails. An
    empty delta passes.
-3. **Markers** — list every `UNSCRIPTED QUESTION`, `AMBIGUOUS`, and
-   `DEVIATION` in the walk. Each is a finding in its own right,
-   even when everything else passed.
-
-   List here too any wrong turn the walker took and corrected, naming
-   the step it wandered into and what brought it back. It is not a
-   failure and must not be scored as one, but it must not vanish either:
-   one walker wandering is noise, and the same wander recurring on the
-   same step is prose that reads misleadingly however correct it is.
+2b. **Scope** — always present. When the prompt carried an UNDECLARED
+   PROSE section, repeat its file list; when it carried none, write
+   `SCOPE: none undeclared`. Silence is not a statement, and this line
+   is how the case's file ratchet learns what a walk actually opened.
+3. **Markers** — always present; `MARKERS: none` when there are none.
+   Type every entry with one of these prefixes so nothing rests on
+   phrasing:
+   - `WALK:` — the walker's own markers (`UNSCRIPTED QUESTION`,
+     `AMBIGUOUS`, `DEVIATION`), each a finding in its own right even
+     when everything else passed.
+   - `WANDER:` — a wrong turn the walker took and corrected, naming
+     the step it wandered into and what brought it back. Not a failure
+     and never scored as one, but never vanished either: one walker
+     wandering is noise; the same wander recurring on the same step is
+     prose that reads misleadingly however correct it is.
+   - `INERT:` — recorded-but-unnarrated activity that touched no
+     workflow state (orientation reads, `ls`, `mkdir`, re-reads).
+     Group these into one line; they are hygiene, not findings.
+   - `NOTE:` — anything else worth a human's eye that fits none of
+     the above (record-internal discrepancies, fixture observations).
 4. **VERDICT** — PASS, FAIL, or INVALID WALK, then one sentence on what
    it means for the prose. Any FAILing deterministic check makes this
    FAIL.

--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -118,7 +118,12 @@ CHECKS: <every deterministic check the asserter reported, verdict and name,
         and a line naming any divergence between them as walk variance.>
 PATH: <n>/<total> steps passed
 WORLD: PASS | FAIL
-MARKERS: <none, or one line each>
+SCOPE: <the asserter's scope line, verbatim — `none undeclared`, or the
+       undeclared file list. Never omitted: an absent line is silence
+       where the file ratchet needs a statement>
+MARKERS: <none, or the asserter's typed entries (`WALK:`/`WANDER:`/
+         `INERT:`/`NOTE:`) one per line, verbatim — never retyped or
+         summarised>
 EVIDENCE: <for FAIL/FLAKY — the failing step and the quoted line that shows it;
           for INVALID — where the walk opened or died, and where it should have>
 ARCHIVE: <for FAIL/FLAKY/INVALID — the archived-evidence path each such run's

--- a/.claude/skills/prose-test/SKILL.md
+++ b/.claude/skills/prose-test/SKILL.md
@@ -38,8 +38,12 @@ about an expected result can leak into a later dispatch.
 ## Step 3: Collate
 
 Report a verdict table from what the orchestrators returned: case id,
-model, verdict, deterministic checks, path steps passed, world, markers.
-Quote the evidence line for every failure.
+model, verdict, deterministic checks, path steps passed, world, scope,
+markers. Quote the evidence line for every failure, and the archive
+path for every FAIL, FLAKY, or INVALID. Carry the scope line even when
+it is `none undeclared` — it feeds the case's file ratchet — and carry
+markers with their type prefixes intact (`WALK:`/`WANDER:`/`INERT:`/
+`NOTE:`); `INERT:` entries may be collapsed to a count in the table.
 
 Carry the checks through as reported. They were decided in code before
 any agent saw the case, so they are the one part of a verdict that rests


### PR DESCRIPTION
Improvements D and E of the hardening stack, folded — the marker typing IS the inert-class fix, so a separate E would be empty. All definition-layer (inert until `/reload-plugins`).

Two silences the campaign paid for: the verdict format had no SCOPE field (a clean scope-lint and a dropped one were indistinguishable — cycle 1's file-ratchet judgment rested on inferring from absence), and markers were freeform (the recurring recorded-but-unnarrated orientation class arrived phrased differently every run, training the reader to skim). Now: the asserter always states scope (`none undeclared` or the list) and types every marker — `WALK:` (the walker's own), `WANDER:` (corrected wrong turns, never scored, never vanished), `INERT:` (stateless unnarrated activity, grouped), `NOTE:` (the rest). The orchestrator schema carries both verbatim, and `/prose-test`'s collation reports them plus archive paths for failures.

Closes the hardening stack: #612 (recorder adversarial tests) ← #613 (failed-world archiving) ← #614 (early-death INVALID + boundary rule) ← this. After landing + `/reload-plugins`, the next coverage case (plan-review) exercises the new schema live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #612
2. #613
3. #614
4. **#615** 👈 current
5. #616
<!-- stack:links:end -->