### PR TITLE
docs(prose): world claims state their shape — never defer to a file

### DIFF
--- a/tests/prose/README.md
+++ b/tests/prose/README.md
@@ -76,6 +76,16 @@ reason. Write "casing conventions load before the boot pipeline", not
 "Step 0.1 before Step 0.2". Anchors in `case.json` are substring
 fragments matched against heading text (`#Boot` matches "Step 0.2: Boot").
 
+**Claims state the expected shape — they never defer to a file.** "The
+file is shaped by the template" outsources the expectation to a document
+the asserter cannot fully see: file *reads* are truncated in the record
+(writes are kept whole), so template-equivalence is unanswerable from
+the evidence. Enumerate the shape instead — "holding Symptoms, Analysis,
+and Fix Direction sections, with a terminal `## Triage` holding
+`(none)`" — which the write record answers completely. Naming which
+reference *fed* a step ("created from the template") is fine in the
+path; it is the world claims that must carry their own expectations.
+
 **Assert what actions and state can prove.** A claim about something
 *displayed* — "offers the choice and waits", "emits the summary block" —
 can never be evidenced by the action log, because emitting text is not a

--- a/tests/prose/cases/epic-resumes-and-harvests-topics/assert.md
+++ b/tests/prose/cases/epic-resumes-and-harvests-topics/assert.md
@@ -61,8 +61,8 @@ sketch:
   rationale; a Conclusion that is no longer `(none)` and states the
   topics added and the map size
 - the active-session marker cleared
-- one brief per topic under `discovery/briefs/`, shaped by the brief
-  template — soft decisions, rejected paths, open questions
+- one brief per topic under `discovery/briefs/`, each holding its
+  soft-decisions, rejected-paths, and open-questions sections
 - no research, discussion, specification, planning, implementation, or
   review artifacts anywhere; the work-unit description unchanged; no
   second work unit

--- a/tests/prose/cases/investigation-gathers-symptoms/assert.md
+++ b/tests/prose/cases/investigation-gathers-symptoms/assert.md
@@ -21,14 +21,14 @@ Further claims:
   question — the carrier is read, not re-asked
 - the user's ignorance is recorded as such: where they had no error
   tracking, no logs, and no better date than last week, the file says so
-  rather than leaving those parts of the template as placeholders
+  rather than leaving those sections as placeholders
 - the analysis is untouched: no hypothesis, no code trace, no root cause.
   Nothing has been investigated yet, only described
 
 EXPECTED WORLD — from a work unit whose investigation had not begun:
 
 - an investigation file at `.workflows/crash-fix/investigation/crash-fix.md`
-  carrying the template's structure
+  holding Symptoms, Analysis, and Fix Direction sections
 - its Symptoms section holding both what discovery captured and what the
   interview added — the digital-only basket, the staging reproduction,
   the absence of logs or a tracking link

--- a/tests/prose/cases/investigation-initialises-the-phase/assert.md
+++ b/tests/prose/cases/investigation-initialises-the-phase/assert.md
@@ -21,8 +21,7 @@ Further claims:
 EXPECTED WORLD — from a work unit whose investigation had not begun:
 
 - an investigation file at `.workflows/crash-fix/investigation/crash-fix.md`,
-  carrying the template's section structure — Symptoms, Analysis, Fix
-  Direction, Notes
+  holding Symptoms, Analysis, Fix Direction, and Notes sections
 - its Symptoms section seeded from what discovery already captured about
   the checkout crash, not left as template placeholders
 - its Analysis and Fix Direction sections still unwritten: nothing has

--- a/tests/prose/cases/research-initialises-from-the-brief/assert.md
+++ b/tests/prose/cases/research-initialises-from-the-brief/assert.md
@@ -38,7 +38,7 @@ EXPECTED WORLD — from a harvested epic with no per-topic work:
 
 - a research file at
   `.workflows/search-relevance/research/relevance-measurement.md`
-  shaped by the template, its Starting Point reflecting the brief — the
+  holding a Starting Point that reflects the brief — the
   measurement problem, no evaluation set, the user never having built a
   harness — with a terminal `## Triage` holding `(none)` and no
   findings recorded yet

--- a/tests/prose/cases/start-continues-a-feature-into-discussion/assert.md
+++ b/tests/prose/cases/start-continues-a-feature-into-discussion/assert.md
@@ -41,8 +41,8 @@ Further claims:
 
 EXPECTED WORLD — from a feature holding only its discovery carrier:
 
-- a discussion file at `.workflows/pay/discussion/pay.md` shaped by the
-  template: a Context section reflecting card payments at checkout via
+- a discussion file at `.workflows/pay/discussion/pay.md` holding a
+  Context section reflecting card payments at checkout via
   the existing gateway account, and a terminal `## Triage` section
   holding `(none)`
 - no decisions recorded in it — nothing has been discussed yet


### PR DESCRIPTION
Top of the hardening stack, from the shakedown's own findings: the asserter noted that `template.md`'s content truncates in its evidence (file reads cap at 400 chars; writes are kept whole), making "shaped by the template" claims partly unanswerable. The fault is claim style, not the harness — deferring an expectation to a file the judge can't read is the sibling of the "name behaviour, never coordinates" rule.

Six world claims across five cases now enumerate their expected sections directly (answerable entirely from the write record); path-step mentions of which reference fed a creation are untouched — those name behaviour. One paragraph in the README codifies the rule for future authoring.

Corpus valid; no fixture, invariant, or snapshot changes — claims only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #612
2. #613
3. #614
4. #615
5. **#616** 👈 current
<!-- stack:links:end -->