### PR TITLE
fix(shared): the compliance refresh works with the tool, not against it

### DIFF
--- a/skills/workflow-shared/references/compliance-check.md
+++ b/skills/workflow-shared/references/compliance-check.md
@@ -4,14 +4,14 @@
 
 ---
 
-Before concluding this phase, verify that the skill instructions were followed correctly throughout this session. This check exists because context drift is real — after a long session, the original instructions may be buried under pages of conversation. Re-reading pulls them fresh into attention so the audit is actually effective.
+Before concluding this phase, verify that the skill instructions were followed correctly throughout this session. This check exists because context drift is real — after a long session, the original instructions may be buried under pages of conversation. The audit runs against the instructions as written, never a recollection of them.
 
 ## A. Re-Read Skill Instructions
 
-1. **Re-read the processing skill's SKILL.md** — the top-level file of the current processing skill (the backbone that loaded this reference, or its parent backbone if loaded from within a reference file). Read it completely.
-2. **Re-read every reference file that was loaded during this session.** The SKILL.md's step directives list them. Re-read each one.
+1. **Re-read the processing skill's SKILL.md** — the top-level file of the current processing skill (the backbone that loaded this reference, or its parent backbone if loaded from within a reference file).
+2. **Re-read every reference file that was loaded during this session.** The SKILL.md's step directives list them.
 
-This is non-negotiable. Do not skip this step or rely on your memory of what the instructions said. The re-read IS the mechanism.
+Attempt each read. Where the tool answers that a file is unchanged since your last read, that earlier read is current and still in context — audit from it, not from a memory of it; the refusal is confirmation, not an obstacle, and never a reason to claim a read that was not attempted. Where a read is served fresh, the content had left your context — take it in fully before auditing.
 
 → Proceed to **B. Audit the Session**.
 


### PR DESCRIPTION
The substantive finding from case 8: `compliance-check.md`'s "re-read everything; the re-read IS the mechanism" is unachievable under the Read tool's unchanged-file dedupe. Measured on both walker models: a compliant Opus walk attempted all 17 re-reads and was refused each with `file_unchanged`; a Sonnet walk took the worse path the impossible instruction invites — narrating re-reads it never made (caught by the record, evidence archived).

The reword keeps the essence — the audit runs against the instructions as written, never a recollection — and treats the tool's answer as arbitration: an unchanged-file refusal confirms the earlier read is current and in context (audit from it; never claim a read not attempted), a served read replaced content that had left context. One shared file; every processing skill's compliance step inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #617
2. **#618** 👈 current
3. #619
<!-- stack:links:end -->