### PR TITLE
fix(planning,spec): the review re-loop arms require findings; clean reviews write no file

### DIFF
--- a/agents/workflow-planning-review-integrity.md
+++ b/agents/workflow-planning-review-integrity.md
@@ -54,7 +54,8 @@ For `remove-task` or `remove-phase`, include **Current** for reference and omit 
 5. **Full fix content** — every finding must include complete Current/Proposed content in plan format. No summaries.
 6. **Proportional** — prioritize by impact. Don't nitpick style when architecture is wrong.
 7. **Task scope only** — check the plan as built; don't redesign it
-8. **Never lose your work** — the findings you generate must survive the run, and the tracking file is how they survive. Produce the tracking file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the findings in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
+8. **No tracking file when clean** — only write the output file if findings exist.
+9. **Never lose your work** — the findings you generate must survive the run, and the tracking file is how they survive. Produce the tracking file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the findings in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
 
 ## Your Output
 
@@ -63,7 +64,7 @@ Return a brief status:
 ```
 STATUS: findings | clean
 CYCLE: {N}
-TRACKING_FILE: {path to tracking file}
+TRACKING_FILE: {path to tracking file — omit when clean}
 FINDINGS_COUNT: {N}
 ```
 

--- a/agents/workflow-planning-review-traceability.md
+++ b/agents/workflow-planning-review-traceability.md
@@ -57,7 +57,8 @@ For `remove-task` or `remove-phase`, include **Current** for reference and omit 
 5. **Full fix content** — every finding must include complete Current/Proposed content in plan format. No summaries.
 6. **Trace, don't invent** — if content can't be traced to the spec, flag it. Don't justify it.
 7. **Spec-grounded fixes** — proposed content must come from the specification. Do not hallucinate plan content.
-8. **Never lose your work** — the findings you generate must survive the run, and the tracking file is how they survive. Produce the tracking file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the findings in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
+8. **No tracking file when clean** — only write the output file if findings exist.
+9. **Never lose your work** — the findings you generate must survive the run, and the tracking file is how they survive. Produce the tracking file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the findings in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
 
 ## Your Output
 
@@ -66,7 +67,7 @@ Return a brief status:
 ```
 STATUS: findings | clean
 CYCLE: {N}
-TRACKING_FILE: {path to tracking file}
+TRACKING_FILE: {path to tracking file — omit when clean}
 FINDINGS_COUNT: {N}
 ```
 

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -131,7 +131,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 → Proceed to **F. Completion**.
 
-#### If `finding_gate_mode` is `auto` and `review_cycle` < 5
+#### If findings were surfaced and `finding_gate_mode` is `auto` and `review_cycle` < 5
 
 > *Output the next fenced block as a code block:*
 
@@ -141,7 +141,7 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 → Return to **A. Cycle Initialization**.
 
-#### If `finding_gate_mode` is `auto` and `review_cycle` >= 5
+#### If findings were surfaced and `finding_gate_mode` is `auto` and `review_cycle` >= 5
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `planning-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
@@ -174,7 +174,7 @@ Run another review round?
 
 → Proceed to **F. Completion**.
 
-#### If `finding_gate_mode` is `gated`
+#### If findings were surfaced and `finding_gate_mode` is `gated`
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `planning-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -164,7 +164,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 → Proceed to **F. Completion**.
 
-#### If `finding_gate_mode` is `auto` and `review_cycle` < 5
+#### If findings were surfaced and `finding_gate_mode` is `auto` and `review_cycle` < 5
 
 > *Output the next fenced block as a code block:*
 
@@ -174,7 +174,7 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 → Return to **A. Cycle Initialization**.
 
-#### If `finding_gate_mode` is `auto` and `review_cycle` >= 5
+#### If findings were surfaced and `finding_gate_mode` is `auto` and `review_cycle` >= 5
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `spec-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
@@ -199,7 +199,7 @@ Run another review cycle?
 
 → Proceed to **F. Completion**.
 
-#### If `finding_gate_mode` is `gated`
+#### If findings were surfaced and `finding_gate_mode` is `gated`
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `spec-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 


### PR DESCRIPTION
Two consistency findings from case 8's walks. The review loops' §E gate-mode arms matched on a clean cycle alongside the no-findings arm — non-exclusive conditions only prose ordering resolved, flagged AMBIGUOUS by the Opus walker. Each arm gains the missing "findings were surfaced and" conjunct — enumerated to both siblings, since `plan-review.md` and `spec-review.md` share the structure.

And the planning review agents gain the rule their spec siblings already state explicitly: **no tracking file when clean**, with the return schema marking `TRACKING_FILE` omitted on clean — the caller already branches on whether a file was created.

Top of the case-8 stack; the stack-top re-run follows once review settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #617
2. #618
3. **#619** 👈 current
<!-- stack:links:end -->