### PR TITLE
feat(prose-harness): the report-write refusal is the third known difference

### DIFF
--- a/.claude/agents/prose-asserter.md
+++ b/.claude/agents/prose-asserter.md
@@ -106,7 +106,7 @@ record exactly like one the prose asked for — only the walk says which it
 was. So a claim that something was not done is answered by both together:
 the record for whether it happened, the walk for whose doing it was.
 
-## Two known differences between here and a live session
+## Three known differences between here and a live session
 
 An inline `` !`command` `` directive is substituted when a skill loads
 live. A walk reads the prose as a file, so the substitution never happens
@@ -126,6 +126,12 @@ skill's file and follows it with the stated arguments — the same
 instructions a live invocation loads. That is correct behaviour, not a
 `DEVIATION` and not a missing step; do not fail a handoff for having
 been read rather than invoked.
+
+The third: the harness refuses report-shaped `.md` writes from
+subagents, so a walker producing one writes the `.txt` path and renames
+it — the same mechanism the product's own agents are instructed to use.
+A write-then-rename where a report file was called for is correct
+behaviour: not a deviation, not a missing write.
 
 These are the only such differences. Anything else that looks like an
 environment quirk is a finding, not an exemption.

--- a/.claude/agents/prose-walker.md
+++ b/.claude/agents/prose-walker.md
@@ -94,6 +94,11 @@ any harness substitutions. Follow it exactly.
   as a live invocation would have loaded it. Expected, not a
   `DEVIATION`, no marker. Where the task says to stop at the handoff,
   stop there.
+- **A report-shaped `.md` write may be refused.** The harness blocks
+  subagents writing report-looking `.md` files. Where the prose or an
+  armed substitution calls for one, write the same path with a `.txt`
+  extension and `mv` it to `.md` — the mechanism the product's own
+  agents use. Expected, not a `DEVIATION`, no marker.
 - **An inline `` !`command` `` directive will not have run.** That
   substitution happens when a skill is loaded live; here the prose is read
   as a file, so the literal backtick line is what you see. The prose gives


### PR DESCRIPTION
Stacked on #620, from its walk's two DEVIATIONs: the harness refuses report-shaped `.md` writes from subagents, and each walker improvised the `.txt`-then-`mv` fallback the product's own agents are instructed to use. The walker definition now prescribes exactly that (no marker), and the asserter's known-differences section grows from two entries to three — still closed with "anything else is a finding".

Definition-layer: inert until `/reload-plugins`. The next review-family case exercises it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #620
2. **#621** 👈 current
<!-- stack:links:end -->