### PR TITLE
fix(implementation): commit discipline — scoped staging, exact subjects

### DIFF
--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -75,7 +75,11 @@ The response's `MENU: blocked tasks` section serves the task loop's blocked-task
 
 #### If the response's `mode` is `created`
 
-Commit: `impl({work_unit}): start implementation`
+Commit the tracking (the scoped commit covers the manifest):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): start implementation"
+```
 
 → Proceed to **Step 1**.
 

--- a/skills/workflow-implementation-process/references/environment-setup.md
+++ b/skills/workflow-implementation-process/references/environment-setup.md
@@ -46,12 +46,24 @@ I should follow before implementing?
 
 **If they provide instructions:**
 
-Save them to `.workflows/.state/environment-setup.md` and follow them.
+Save them to `.workflows/.state/environment-setup.md` and commit the document (the scoped commit covers it):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "chore(workflows): record environment setup"
+```
+
+Then follow the saved instructions.
 
 → Return to caller.
 
 **If they say no setup is needed:**
 
-Create `.workflows/.state/environment-setup.md` with "No special setup required." and commit. This prevents asking the same question in future sessions.
+Create `.workflows/.state/environment-setup.md` with "No special setup required." and commit it (the scoped commit covers the document):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "chore(workflows): record environment setup"
+```
+
+This prevents asking the same question in future sessions.
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -346,13 +346,13 @@ The response also carries the `MENU: blocked tasks` section that **A. Retrieve N
 
 **If the planning item carries no `storage_paths`** (a plan initialised before the field existed): record it now — read the format's authoring.md → Storage Pathspecs and copy the fenced array (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} storage_paths '{format storage pathspecs}'`).
 
-**Commit all changes** with raw git — stage the task's code and tests, the plan's `storage_paths` (recorded on the planning item), the work unit's manifest, and the task's fix-tracking file when one exists (`.workflows/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md`), then commit:
+**Commit all changes** with raw git — stage the task's code and tests, the plan's task state (the files the format's **updating.md** touched, plus the `storage_paths` pathspecs recorded on the planning item for storage outside the work unit), the work unit's manifest, and the task's fix-tracking file when one exists (`.workflows/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md`), then commit:
 
 ```
 impl({work_unit}): T{internal_id} — {brief description}
 ```
 
-One commit per approved task. Never `engine commit` here — its scopes cover `.workflows` only, never code or the plan format's storage.
+One commit per approved task, staging the listed paths explicitly — never `git add -A` or `git add .`. The subject is exactly as fenced — `T` immediately followed by the internal id; review's scope-grep finds task commits by this token. Never `engine commit` here — its scopes cover `.workflows` only, never code or the plan format's storage.
 
 → Return to **A. Retrieve Next Task**.
 

--- a/tests/prose/cases/implementation-executes-the-loop/assert.md
+++ b/tests/prose/cases/implementation-executes-the-loop/assert.md
@@ -6,8 +6,8 @@ The prose should have taken this path:
 2. the entry hands off into the processing skill carrying the
    local-markdown format read from the planning item
 3. resume detection initialises tracking and reports the created mode,
-   which commits the start of implementation — never the
-   resuming-from-a-previous-session note
+   which commits the start of implementation through the engine's
+   scoped commit — never the resuming-from-a-previous-session note
 4. environment setup finds the existing document stating no setup is
    required and returns without asking anything and without writing it
    again

--- a/tests/prose/cases/implementation-executes-the-loop/case.json
+++ b/tests/prose/cases/implementation-executes-the-loop/case.json
@@ -40,7 +40,7 @@
       "manifest get pay.implementation.pay status",
       "manifest exists pay.implementation.pay",
       "task init pay pay",
-      "impl(pay): start implementation",
+      "engine.cjs commit pay -m impl(pay): start implementation",
       "manifest get pay.planning.pay format",
       "manifest get pay.implementation.pay project_skills",
       "manifest exists project.defaults.project_skills",
@@ -73,7 +73,9 @@
       "topic reopen",
       "task_gate_mode auto",
       "fix_gate_mode auto",
-      "engine.cjs commit pay -m impl(pay): T"
+      "engine.cjs commit pay -m impl(pay): T",
+      "git add -A",
+      "git add --all"
     ]
   }
 }

--- a/tests/prose/cases/implementation-picks-first-task/case.json
+++ b/tests/prose/cases/implementation-picks-first-task/case.json
@@ -15,7 +15,9 @@
   "invariants": {
     "engine_before_write": true,
     "calls_include": [
-      "task init"
+      "task init",
+      "engine.cjs commit pay -m impl(pay): start implementation",
+      "engine.cjs commit --workflows -m chore(workflows): record environment setup"
     ],
     "calls_exclude": [
       "task start",

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -274,6 +274,7 @@ function walkDeliveryPhasesToImplementation(sim, wu, topic) {
   // task init owns creation (implementation-process Step 0, created arm).
   const init = sim.run(['task', 'init', wu, topic]);
   assert.strictEqual(init.mode, 'created', 'fresh implementation takes the created arm');
+  sim.run(['commit', wu, '-m', `impl(${wu}): start implementation`]);
   sim.run(['task', 'start', wu, topic, `${topic}-1-1`]);
   sim.run(['task', 'complete', wu, topic, `${topic}-1-1`, '--next-task', '~', '--phase-complete']);
   sim.run(['topic', 'complete', wu, 'implementation', topic]);
@@ -324,6 +325,7 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
   sim.render(['entry-gate', `${wu}.implementation.${topic}`], { expect: 'empty' });
   const implInit = sim.run(['task', 'init', wu, topic]);
   assert.strictEqual(implInit.mode, 'created', 'fresh implementation takes the created arm');
+  sim.run(['commit', wu, '-m', `impl(${wu}): start implementation`]);
   sim.run(['task', 'start', wu, topic, `${topic}-1-1`]);
   sim.run(['task', 'complete', wu, topic, `${topic}-1-1`, '--next-task', '~', '--phase-complete']);
   sim.run(['topic', 'complete', wu, 'implementation', topic]);
@@ -432,6 +434,7 @@ describe('pipeline simulation', () => {
     // Implementation (verification workflow) + review — task init creates.
     const init = sim.run(['task', 'init', wu, wu]);
     assert.strictEqual(init.mode, 'created', 'fresh implementation takes the created arm');
+    sim.run(['commit', wu, '-m', `impl(${wu}): start implementation`]);
     sim.run(['task', 'start', wu, wu, `${wu}-1-1`]);
     sim.run(['task', 'complete', wu, wu, `${wu}-1-1`, '--next-task', '~', '--phase-complete']);
     sim.run(['topic', 'complete', wu, 'implementation', wu]);
@@ -713,6 +716,7 @@ describe('pipeline simulation', () => {
     const init = sim.run(['task', 'init', wu, wu]);
     assert.strictEqual(init.mode, 'created', 'fresh implementation takes the created arm');
     assert.strictEqual(init.gates.task_gate_mode, 'gated');
+    sim.run(['commit', wu, '-m', `impl(${wu}): start implementation`]);
     sim.run(['task', 'start', wu, wu, `${wu}-1-1`]);
     const findings = sim.write(`.workflows/.cache/${wu}/implementation/${wu}/findings.json`,
       { findings: [{ title: 'Loose end', severity: 'minor' }] });


### PR DESCRIPTION
Stacked on #622. Fixes findings 1–3 from the implementation-loop walk, where both walkers resolved under-specified commit instructions with `git add -A` — which swept unrelated files into an impl commit — and the Sonnet walk drifted the commit subject (`T pay-1-1`) off the token review's scope-grep depends on (`invoke-task-verifiers.md` greps `impl({wu}): T{topic}-`).

## Prose

- **task-loop.md stage H** — the staging enumeration now covers the plan's task state (the files the format's updating.md touched — previously local-markdown's in-work-unit task files fell through the gap, forcing the `add -A` improvisation), explicitly forbids `git add -A`/`git add .`, and pins the subject as exactly fenced (`T` immediately followed by the internal id) with the review scope-grep named as the consumer.
- **SKILL.md Step 0** — the bare `Commit:` becomes the engine's scoped commit (`engine commit {wu}`), matching conclude-implementation and analysis-loop; the change is manifest-only, so the scoped commit is the mechanised staging.
- **environment-setup.md** — two same-class siblings found by route enumeration, flagged here: the no-setup arm's bare "commit" is now `engine commit --workflows` (precedent: workflow-start, complexity-check), and the instructions-provided arm previously never committed the document at all — it now uses the same scoped commit.

## Simulation

The four `task init` created-arm sites now run the Step 0 scoped commit, mirroring the new prose sequence.

## Cases (each finding lands twice)

- `implementation-executes-the-loop`: excludes `git add -A`/`git add --all`; the start-commit include is pinned to the engine form.
- `implementation-picks-first-task`: includes pin the Step 0 scoped commit and the environment-doc `--workflows` commit.

## Verification

- `npm test` — 1807 pass (simulation + prose corpus/goldens included)
- conventions lint clean

Reruns of both implementation cases to follow once the stack is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)