### PR TITLE
fix(prose-harness): worlds exclude the walk logs from git

### DIFF
--- a/tests/prose/lib/worlds.cjs
+++ b/tests/prose/lib/worlds.cjs
@@ -322,6 +322,10 @@ function buildWorld(caseId) {
   git('config', 'user.email', 'prose@example.com');
   git('config', 'user.name', 'Prose World');
   git('config', 'commit.gpgsign', 'false');
+  // The harness's logs live inside the world but are not world state — a
+  // walker staging broadly must never commit them. info/exclude keeps the
+  // rule out of the working tree, so snapshots and deltas never see it.
+  fs.writeFileSync(path.join(dir, '.git', 'info', 'exclude'), '.walk-actions.log\n.walk-transcript.log\n');
   git('add', '-A');
   git('commit', '-q', '-m', `world: ${caseId}`);
 


### PR DESCRIPTION
Stacked on #624. The implementation-loop walk's first run committed `.walk-actions.log` into the world's history via a broad `git add -A` — harness state riding a workflow commit. `buildWorld` now writes the two log names to the world's `.git/info/exclude`, which lives outside the working tree: snapshots, `collectTree`, and the delta never see the rule, and no staging command can sweep the logs regardless of how a walker stages.

Smoke-verified against a real world build: a written log leaves `git status --porcelain` empty. `npm test` — 1809 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)