### PR TITLE
feat(prose-harness): plan-mode capture — the fourth known difference

### DIFF
--- a/.claude/agents/prose-asserter.md
+++ b/.claude/agents/prose-asserter.md
@@ -106,7 +106,7 @@ record exactly like one the prose asked for — only the walk says which it
 was. So a claim that something was not done is answered by both together:
 the record for whether it happened, the walk for whose doing it was.
 
-## Three known differences between here and a live session
+## Four known differences between here and a live session
 
 An inline `` !`command` `` directive is substituted when a skill loads
 live. A walk reads the prose as a file, so the substitution never happens
@@ -132,6 +132,16 @@ subagents, so a walker producing one writes the `.txt` path and renames
 it — the same mechanism the product's own agents are instructed to use.
 A write-then-rename where a report file was called for is correct
 behaviour: not a deviation, not a missing write.
+
+The fourth: plan mode does not exist in a walk. Where the prose calls
+`EnterPlanMode` and writes plan content, the walker resolves the
+content as the prose directs and writes it to `.plan-handoff.md` at
+the project root — the world's stand-in for the plan file, which lands
+in the delta where its content is judged like any other artifact — and
+where the prose calls `ExitPlanMode` to present the plan, the walk
+stops at that presentation as its terminal handoff. The capture write
+and the stop are correct behaviour: not a deviation, not a missing
+tool call, and not a walk that died early.
 
 These are the only such differences. Anything else that looks like an
 environment quirk is a finding, not an exemption.

--- a/.claude/agents/prose-walker.md
+++ b/.claude/agents/prose-walker.md
@@ -99,6 +99,14 @@ any harness substitutions. Follow it exactly.
   armed substitution calls for one, write the same path with a `.txt`
   extension and `mv` it to `.md` — the mechanism the product's own
   agents use. Expected, not a `DEVIATION`, no marker.
+- **Plan mode does not exist here.** Where the prose calls the
+  `EnterPlanMode` tool and writes plan content: resolve the content
+  exactly as the prose directs — conditionals and placeholders, then
+  verbatim — and write it to `.plan-handoff.md` at the project root,
+  the world's stand-in for the plan file. Where the prose then calls
+  `ExitPlanMode` to present the plan for approval, that presentation
+  is the flow's terminal handoff: STOP there. Expected, not a
+  `DEVIATION`, no marker.
 - **An inline `` !`command` `` directive will not have run.** That
   substitution happens when a skill is loaded live; here the prose is read
   as a file, so the literal backtick line is what you see. The prose gives


### PR DESCRIPTION
The bridge continuations' plan-mode arms (revisit + EnterPlanMode/ExitPlanMode) have been unreachable by walks: the walker has no plan-mode tools, so every continuation case so far stopped at (or before) the terminal `done` arm.

This adds plan-mode capture as the **fourth known environment difference**, mirroring the shape of the existing three:

- **Walker def**: where the prose calls `EnterPlanMode` and writes plan content, resolve the content exactly as directed and write it to `.plan-handoff.md` at the project root — the world's stand-in for the plan file. `ExitPlanMode`'s presentation is the flow's terminal handoff: STOP there. Expected, no marker.
- **Asserter def**: the capture write and the stop are correct behaviour — not a deviation, not a missing tool call, not an early death. The plan file lands in the world delta, where its content is judged like any other artifact — which is the point: the resolved template becomes evidence instead of unprovable display.

No case or lib changes here; the proving case (feature-continuation's revisit + plan-mode arms) stacks on top.

**Agent-definition change — needs `/reload-plugins` before any run trusts it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)