### PR TITLE
fix(surfacing): never use bare finding/tension ids as labels in prose

### DIFF
--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -166,7 +166,7 @@ This section runs once per invocation and then exits. It never waits in-protocol
    node .claude/skills/workflow-engine/scripts/engine.cjs agent surface {work_unit} {phase} {topic} {id} {finding}
    ```
 3. Digest the finding from the content file — never read it out — and compose the raise as conversational prose in three beats:
-   - **Present** — orientation before any assessment. Say where it came from (the background {agent_type}) and what it observed — for a synthesis, the two positions in tension — in plain, self-contained terms a user returning after hours can follow. Restate any term borrowed from another subtopic or an earlier decision; never reference it bare. Depth follows the conversation: a clause when the finding set was visible moments ago, full orientation when the conversation has moved on since it was last visible. When earlier findings from this set have been raised, open with a one-line bridge: what the previous one settled — or simply that it was raised, when that engagement predates this session — and how many follow this one (the surface response's `remaining`; `findings` is the full set).
+   - **Present** — orientation before any assessment. Say where it came from (the background {agent_type}) and what it observed — for a synthesis, the two positions in tension — in plain, self-contained terms a user returning after hours can follow. Restate any term borrowed from another subtopic or an earlier decision; never reference it bare. Never use a bare id (`F5`, `T2`) as a label in conversational prose — name the finding by its report title on first mention, or describe it by what it is; ids belong in commit messages and in-document markers (`(resolves review-003 F5)`), not in the conversation. Depth follows the conversation: a clause when the finding set was visible moments ago, full orientation when the conversation has moved on since it was last visible. When earlier findings from this set have been raised, open with a one-line bridge: what the previous one settled — or simply that it was raised, when that engagement predates this session — and how many follow this one (the surface response's `remaining`; `findings` is the full set).
    - **Position** — your read, only where you genuinely have one: verified it holds, narrower than framed, already covered by a decision made since the report. Skip the beat rather than manufacture a verdict.
    - **Move** — sized to how settled the finding is: a clear resolution — propose it; genuinely open — sketch the option space in a sentence or two; needs investigation — suggest research or a deep-dive.
 4. Raise it in the current turn, ending in a single question. One finding, one question, no bundled follow-ups, no menu.
@@ -184,6 +184,7 @@ Before producing any surfacing output, verify:
 - □ Raising AT MOST one finding this turn — the rest of the set appears as a count, never as content
 - □ Asking AT MOST one question this turn
 - □ The finding itself is stated, self-contained, before any position or proposal
+- □ No bare id (`F5`, `T2`) as a label in prose — named by report title or described
 - □ Not reading the content file verbatim
 
 If any box is unchecked, stop and reframe.


### PR DESCRIPTION
Background-agent findings were being raised to the user with their report identifiers (F1, F7, …) as bare labels in conversational prose — unexplained jargon placed in front of the explanation. Nothing in `background-agent-surfacing.md` governed those identifiers.

This adds one line to the **Present** beat of D. Raise One Finding: a bare id (`F5`, `T2`) is never a label in prose — name the finding by its report title on first mention or describe it by what it is; ids belong in commit messages and in-document markers (`(resolves review-003 F5)`). Synthesis tensions (T1, T2, …) have the identical shape and are covered by the same line.

A matching item lands in the Never-Dump Checklist alongside the existing self-containment check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)