### PR TITLE
feat(coherence): anchor findings to the decision layer

### DIFF
--- a/skills/workflow-shared/references/coherence-analysis.md
+++ b/skills/workflow-shared/references/coherence-analysis.md
@@ -38,11 +38,13 @@ Cross-reference across all documents — pairs of decisions that interact, prose
 
 ## B. Identify Findings
 
+Discussions document the journey to a decision — false paths, reversals, positions later abandoned. That record is supposed to disagree, with itself and with other documents; coherence is a property of the **settled decisions**, never the prose around them. Findings target the decision layer only.
+
 Analyse the artifacts from A to identify findings across three categories:
 
-1. **Unacknowledged conflict** — two documents decide incompatibly and neither cites the other. Distinguish this from deliberate supersession: when the newer document acknowledges it is changing an earlier decision, the conflict is acknowledged — any prose still citing the old decision is a stale reference (category 2), not a conflict.
+1. **Unacknowledged conflict** — two documents decide incompatibly and neither cites the other. Decisions only: a position explored and walked back in journey or options prose is not a side of a conflict, however flatly it contradicts the other document. Distinguish deliberate supersession: when the newer document acknowledges it is changing an earlier decision, the conflict is acknowledged — any prose still citing the old decision is a stale reference (category 2), not a conflict.
 
-2. **Stale reference** — prose (cross-document, or within one document) citing a decision that has since changed, where the newer document acknowledges the change. The decision record is coherent; the citing prose is out of date.
+2. **Stale reference** — prose (cross-document, or within one document) that relies, as current, on a decision that has since changed, where the newer document acknowledges the change. The decision record is coherent; the citing prose is out of date. Narration of what was believed at the time is history, not staleness.
 
 3. **Owned ambiguity** — a term or assumption used inconsistently across documents, with a clear home document that owns the definition. The inconsistency would propagate into specification if left unresolved.
 


### PR DESCRIPTION
PR 5 of the coherence-analysis stack, on top of #640.

Design correction from review discussion: discussion documents record the journey — false paths, reversals, abandoned positions — and that record is *supposed* to disagree, with itself and with other documents. Coherence is a property of the **settled decisions**, never the prose around them. This was implicit in the category definitions ("two documents *decide* incompatibly"); a full-document read could still quote journey prose against a decision and stage noise — the failure mode where a large epic never gets past discussion because the analysis sands every document into agreement.

Three sentences make the charter explicit in `coherence-analysis.md` B:
- Framing: findings target the decision layer only.
- Category 1: a position explored and walked back in journey/options prose is not a side of a conflict, however flatly it contradicts the other document.
- Category 2: stale reference means prose that *relies on* a superseded decision as current — narration of what was believed at the time is history, not staleness.

The findings gate needs no matching change — it presents whatever was staged, so the framing is inherited from the staging side.

Conventions lint zero-violation; prose-only change, corpus valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)