### PR TITLE
fix(drain-triage): fold-into-existing re-arms the conclusion gate

### DIFF
--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -51,7 +51,7 @@ Walk the conversation against the document and check four dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user pushback, competing options understated to make the chosen one look cleaner, or a subtopic marked `decided` on the Discussion Map when it was really `converging`. Check the Discussion Map itself for drift — child subtopics absorbed into a parent decision when they weren't fully resolved, Open Threads in the Summary that don't match what was actually left unresolved in the conversation.
 
-4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the working content — a `pending` subtopic on the Discussion Map (engine `discussion-map add`) plus a seeded `## {title}` section — and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
+4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the working content — a `pending` subtopic on the Discussion Map (engine `discussion-map add`) plus a seeded `## {title}` section; when the subtopic already exists, fold the entry body into its section and set the subtopic back to `exploring` (engine `discussion-map set`) so the conclusion gate re-arms — and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
 
 **Apply the reconciliation.** For each finding:
 

--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -51,7 +51,7 @@ Walk the conversation against the document and check four dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user pushback, competing options understated to make the chosen one look cleaner, or a subtopic marked `decided` on the Discussion Map when it was really `converging`. Check the Discussion Map itself for drift — child subtopics absorbed into a parent decision when they weren't fully resolved, Open Threads in the Summary that don't match what was actually left unresolved in the conversation.
 
-4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the working content — a `pending` subtopic on the Discussion Map (engine `discussion-map add`) plus a seeded `## {title}` section; when the subtopic already exists, fold the entry body into its section and set the subtopic back to `exploring` (engine `discussion-map set`) so the conclusion gate re-arms — and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
+4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the working content — a `pending` subtopic on the Discussion Map (engine `discussion-map add`) plus a seeded `## {title}` section — and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
 
 **Apply the reconciliation.** For each finding:
 

--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -37,7 +37,7 @@ Don't rely on your memory of what you wrote earlier. Pay particular attention to
 - The **Discussion Map** — every subtopic's state from the call's DATA section
 - Each subtopic section (Context → Options → Journey → Decision)
 - The **Summary** section (Key Insights, Open Threads, Current State)
-- The **Triage** section — it must read `(none)` by conclusion
+- The **Triage** section — the `(none)` placeholder intact, or real entries (the conclude gate's to route)
 
 → Proceed to **B. Compare and Reconcile**.
 
@@ -51,14 +51,14 @@ Walk the conversation against the document and check four dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user pushback, competing options understated to make the chosen one look cleaner, or a subtopic marked `decided` on the Discussion Map when it was really `converging`. Check the Discussion Map itself for drift — child subtopics absorbed into a parent decision when they weren't fully resolved, Open Threads in the Summary that don't match what was actually left unresolved in the conversation.
 
-4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the working content — a `pending` subtopic on the Discussion Map (engine `discussion-map add`) plus a seeded `## {title}` section — and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
+4. **Triage consistency** — `## Triage` must hold either `(none)` or real `### {title}` entries. A real entry is not yours to fold — leave it in place: the conclude gate checks the section and routes back through the session drain, which folds it and opens it for exploration. Clearing it here would let the discussion conclude without the concern ever being explored. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
 
 **Apply the reconciliation.** For each finding:
 
 - Gap → add the missing substance to the discussion file at the appropriate place (subtopic section, Journey, or Summary)
 - Hallucination → remove or correct to match what was discussed
 - Drift → rewrite to faithfully reflect the conversation; correct Discussion Map states where needed (`node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map set {work_unit} {topic} {subtopic} {state}`)
-- Undrained Triage entry → fold into the Discussion Map and a subtopic section, then reset `## Triage` to `(none)`; restore the placeholder if it drifted
+- Triage placeholder drift → restore `(none)`; real entries stay untouched for the conclude gate
 
 Commit the changes with a descriptive message (e.g., `docs(discussion): capture undocumented trade-off thread`, `docs(discussion): correct drift on caching decision`, `docs(discussion): soften Map state to converging`).
 

--- a/skills/workflow-research-process/references/document-review.md
+++ b/skills/workflow-research-process/references/document-review.md
@@ -27,7 +27,7 @@ Read the research document(s) in full:
 - Feature: `.workflows/{work_unit}/research/{topic}.md`
 - Epic: all files in `.workflows/{work_unit}/research/` relevant to the current topic
 
-Pull the current state fresh into context — don't rely on your memory of what you wrote earlier. Include the `## Triage` section — it must read `(none)` by conclusion.
+Pull the current state fresh into context — don't rely on your memory of what you wrote earlier. Include the `## Triage` section — the `(none)` placeholder intact, or real entries (the conclude gate's to route).
 
 → Proceed to **B. Compare and Reconcile**.
 
@@ -41,14 +41,14 @@ Walk the conversation against the document and check four dimensions:
 
 3. **Accuracy drift** — positions documented as firmer than they were, tentative leans written as decisions, softened user views, tradeoffs reframed beyond what the conversation supported, or context omitted that changes how a position should read.
 
-4. **Triage consistency** — `## Triage` must read `(none)` by conclusion. The drain at session start normally clears it, but a concern can land mid-session after drain ran. If any `### {title}` entry remains, fold it into the research body as a seed thread and clear the section. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
+4. **Triage consistency** — `## Triage` must hold either `(none)` or real `### {title}` entries. A real entry is not yours to fold — leave it in place: the conclude gate checks the section and routes back through the session drain, which folds it and opens it for exploration. Clearing it here would let the research conclude without the concern ever being explored. If the `(none)` placeholder drifted (missing, or replaced by stray text with no real entry), restore it.
 
 **Apply the reconciliation.** For each finding:
 
 - Gap → add the missing substance to the research file at the appropriate place
 - Hallucination → remove or correct to match what was discussed
 - Drift → rewrite to faithfully reflect the conversation
-- Undrained Triage entry → fold into the research body as a seed thread, then reset `## Triage` to `(none)`; restore the placeholder if it drifted
+- Triage placeholder drift → restore `(none)`; real entries stay untouched for the conclude gate
 
 Commit the changes with a descriptive message (e.g., `docs(research): capture undocumented tradeoff thread`, `docs(research): correct drift on storage preference`).
 

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -38,14 +38,19 @@ For each `### {title}` subsection under `## Triage`, carry its **full body** (ev
 
 **If `phase` is `discussion`:**
 
-- Add `{title}` to the Discussion Map as a `pending` subtopic:
+Attempt to add `{title}` to the Discussion Map:
 
-  ```bash
-  node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map add {work_unit} {topic} {title:(kebabcase)}
-  ```
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map add {work_unit} {topic} {title:(kebabcase)}
+```
 
-  If the add refuses because the subtopic already exists, the concern names ground this discussion already covers — skip the map write and fold the entry body into that existing subtopic's section instead of creating a new one.
-- Create a `## {title}` subtopic section with the entry body written in as its `### Context`, so the session explores it from there.
+**If the add succeeds** — the concern is new ground: create a `## {title}` subtopic section with the entry body written in as its `### Context`, so the session explores it from there.
+
+**If the add refuses because the subtopic already exists** — the concern names ground this discussion already covers: fold the entry body into that existing subtopic's section, and flip the subtopic back to open so the conclusion gate re-arms and the session must re-decide with the concern in hand:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map set {work_unit} {topic} {title:(kebabcase)} exploring
+```
 
 **If `phase` is `research`:**
 

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -506,8 +506,11 @@ describe('pipeline simulation', () => {
     sim.write(`.workflows/${wu}/discussion/alpha.md`, '# Discussion — Alpha\n');
     sim.run(['topic', 'complete', wu, 'discussion', 'alpha']);
 
-    // Beta discussed; gamma-prime cancelled mid-flight and reactivated later.
+    // Beta discussed to a decided map; gamma-prime cancelled mid-flight and
+    // reactivated later.
     sim.run(['topic', 'start', wu, 'discussion', 'beta']);
+    sim.run(['discussion-map', 'add', wu, 'beta', 'retry-policy']);
+    sim.run(['discussion-map', 'set', wu, 'beta', 'retry-policy', 'decided']);
     sim.write(`.workflows/${wu}/discussion/beta.md`, '# Discussion — Beta\n');
     sim.run(['topic', 'complete', wu, 'discussion', 'beta']);
     sim.run(['topic', 'start', wu, 'research', 'gamma-prime']);
@@ -537,10 +540,18 @@ describe('pipeline simulation', () => {
     sim.refuses(['topic', 'complete', wu, 'research', 'delta'], /triaged/);
     sim.refuses(['topic', 'supersede', wu, 'research', 'delta', '--by', 'alpha'], /triaged/);
     sim.refuses(['topic', 'supersede', wu, 'research', 'alpha', '--by', 'delta'], /cannot absorb/);
-    // Landing on a completed discussion reopens it to receive the entry.
+    // Landing on a completed discussion reopens it to receive the entry. The
+    // drain's fold-into-existing branch: the concern collides with a decided
+    // subtopic, so the fold flips it back to exploring — re-arming the
+    // conclusion gate — and the session re-decides before re-completing.
     const reopened = sim.run(['topic', 'triage', wu, 'discussion', 'beta']);
     assert.strictEqual(reopened.reopened, true);
     assert.strictEqual(reopened.status, 'in-progress');
+    sim.refuses(['discussion-map', 'add', wu, 'beta', 'retry-policy'], /already exists/);
+    const rearmed = sim.run(['discussion-map', 'set', wu, 'beta', 'retry-policy', 'exploring']);
+    assert.strictEqual(rearmed.all_decided, false, 'the fold re-arms the conclusion gate');
+    const redecided = sim.run(['discussion-map', 'set', wu, 'beta', 'retry-policy', 'decided']);
+    assert.strictEqual(redecided.all_decided, true);
     sim.run(['topic', 'complete', wu, 'discussion', 'beta']);
 
     // Coherence: two completed discussions arm the analysis. The stamp


### PR DESCRIPTION
## Summary

PR 1 of 2 for the discussion decision timeline (idea #41): the triage fold paths had two ways to let a topic conclude without exploring a drained concern.

**Drain-triage fold-into-existing never re-armed the gate.** When `discussion-map add` refuses (subtopic exists), the prose said "skip the map write" — a `decided` subtopic stayed `decided`, `all_decided` stayed true, and a lazy session could conclude without re-deciding the drained concern. Both freshness filters class the drain commit as bookkeeping, so no re-review triggered either. The create-section bullet was also unconditional, contradicting the fold-into-existing path.

**Document review's inline fold short-circuited the conclude gate** (found during review of this PR). Document review runs after the `all_decided` check has passed but before the conclude gate's `## Triage` check. Its dimension 4 folded a mid-session entry inline and cleared the section — so the conclude gate saw `(none)` and the discussion could complete with a never-explored `pending` subtopic; nothing re-checks the map after closing gates. Research had the same short-circuit: a seed thread folded at review time was never picked up by the session.

## Changes

- **`skills/workflow-shared/references/drain-triage.md`** — the discussion branch is now a clean new-vs-existing branch: add succeeds → create the `## {title}` section as today; add refuses → fold the entry body into the existing subtopic's section **and** flip it back to `exploring` (`discussion-map set`, any-state→any-state legal — no new engine surface) so the conclusion gate re-arms deterministically.
- **`skills/workflow-{discussion,research}-process/references/document-review.md`** — dimension 4 no longer folds real triage entries; they stay in place for the conclude gate, which bounces back through the session drain (the canonical fold path — folded, opened for exploration, re-concluded). Document review keeps the placeholder-drift restoration only.
- **`tests/scripts/test-pipeline-simulation.cjs`** — the epic scenario now discusses beta to a decided map, and the triage-reopen sequence exercises the fold path: add refuses on the colliding subtopic, `set … exploring` flips `all_decided` false (gate re-armed), re-decide flips it back true, re-complete.

## Verification

- `node --test tests/scripts/test-pipeline-simulation.cjs` — 14/14 pass.
- `node --test tests/scripts/test-conventions-lint.cjs` — 29/29 pass.
- Edge enumeration: both drain-triage loaders (discussion Step 5, research Step 6) pass parameters only — no routing change; conclude-discussion/conclude-research already own the bounce (`drain-triage.md` prelude names it); closing-gates' freshness filter still classes drain and document-review commits as bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)