### PR TITLE
fix(template): trigger-line examples must model the substance rule

### DIFF
--- a/skills/workflow-discussion-process/references/template.md
+++ b/skills/workflow-discussion-process/references/template.md
@@ -108,7 +108,7 @@ What we chose, why, the deciding factor, trade-offs accepted, confidence level.
 
 ```markdown
 #### {YYYY-MM-DD} — revised
-*Trigger: {substance — e.g. triage from {origin}: "{concern title}" / review finding: {one-line substance} / user reversal}*
+*Trigger: {substance — e.g. triage from {origin}: "{concern title}" — {one-line substance} / review finding: {one-line substance} / user reversal: {what changed}}*
 
 {the current decision — what we now choose, why, what changed from the entry below}
 

--- a/tests/prose/cases/discussion-redecision-lands-timeline/case.json
+++ b/tests/prose/cases/discussion-redecision-lands-timeline/case.json
@@ -10,6 +10,7 @@
     "skills/workflow-discussion-entry/references/invoke-skill.md",
     "skills/workflow-discussion-process/SKILL.md",
     "skills/workflow-shared/references/resume-detection.md",
+    "skills/workflow-shared/references/read-brief-context.md",
     "skills/workflow-discussion-process/references/discussion-guidelines.md",
     "skills/workflow-discussion-process/references/meeting-assistant.md",
     "skills/workflow-discussion-process/references/guidelines.md",

--- a/tests/prose/cases/discussion-runs-to-convergence/case.json
+++ b/tests/prose/cases/discussion-runs-to-convergence/case.json
@@ -19,6 +19,7 @@
     "skills/workflow-shared/references/drain-triage.md",
     "skills/workflow-discussion-process/references/discussion-session.md",
     "skills/workflow-discussion-process/references/closing-gates.md",
+    "skills/workflow-discussion-process/references/final-review.md",
     "skills/workflow-discussion-process/references/review-agent.md",
     "skills/workflow-discussion-process/references/perspective-agents.md",
     "skills/workflow-shared/references/background-agent-surfacing.md",


### PR DESCRIPTION
## Summary

Follow-up from the post-merge prose run of stack #648 (11 cases: 9 PASS, 2 FLAKY, 0 confirmed FAIL).

`discussion-redecision-lands-timeline` flaked on the revision trigger line — and the template was the actual defect: its example modelled the exact substance-free shape the rule below it forbids (`triage from {origin}: "{concern title}"`). The first walk followed the example and the asserter failed it against the case's substance claim; the confirmation only passed on a higher-tier walker. Examples are behaviour models — both offending examples now carry substance:

```
*Trigger: {substance — e.g. triage from {origin}: "{concern title}" — {one-line substance} / review finding: {one-line substance} / user reversal: {what changed}}*
```

## Also in this PR (scope ratchet from the same run)

- `discussion-redecision-lands-timeline/case.json` — declares `read-brief-context.md` (walked in both runs, undeclared)
- `discussion-runs-to-convergence/case.json` — declares `final-review.md` (walked, undeclared)

## Not in this PR (open findings from the run, awaiting a call)

- `discussion-drained-close-skips-rereview` flake: session-loop step 1's "Skip on the first iteration (no agents have been dispatched yet)" read literally in a resumed session — candidate rewording keys the skip on the condition, not the iteration
- `spec-completes-the-cross-cutting`: one vacuously-satisfiable claim (deferred-section phrasing)

## Verification

- `npm test` — 1833/1833 (fixture snapshot untouched: template.md doesn't feed the recipe)
- Re-run of the case at the declared walker tier to follow once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)