### PR TITLE
fix(session-loop): key the findings-check skip on the store, not the iteration

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -22,7 +22,7 @@ The discussion is an organic conversation. The Discussion Map is your tracking b
    - **Review agent**: follow **B. Check and Surface** in **[review-agent.md](review-agent.md)** — delegates to the shared surfacing protocol for review findings.
    - **Perspective agents**: follow **D. Check and Surface** in **[perspective-agents.md](perspective-agents.md)** — promotes completed perspective sets to synthesis, then delegates to the shared surfacing protocol for synthesis findings.
    
-   Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip on the first iteration (no agents have been dispatched yet).
+   Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.
 2. **Discuss** — Engage with the user on the current subtopic or wherever the conversation leads. Challenge thinking, push back, explore edge cases. Participate as an expert architect. Follow interesting threads — tangents that surface new concerns are valuable. New subtopics may emerge; record each on the map as it's identified (kebab-case name; new subtopics start `pending`; `--parent` nests under an existing top-level subtopic):
 
    ```bash

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -12,7 +12,7 @@ Not a rigid checklist — a natural cadence for productive research conversation
    - **Review agent**: follow **B. Check and Surface** in **[review-agent.md](review-agent.md)** — delegates to the shared surfacing protocol for review findings.
    - **Deep-dive agent**: follow **C. Check and Surface** in **[deep-dive-agent.md](deep-dive-agent.md)** — delegates to the shared surfacing protocol for deep-dive findings.
    
-   Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip on the first iteration (no agents have been dispatched yet).
+   Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.
 
 2. **Explore** — Probe the topic from a relevant angle. Use the funnel technique: broad first, specific later. Choose your probe type deliberately. One question at a time — wait for the answer before asking the next.
 

--- a/tests/prose/cases/spec-completes-the-cross-cutting/assert.md
+++ b/tests/prose/cases/spec-completes-the-cross-cutting/assert.md
@@ -35,8 +35,8 @@ Further claims:
   .workflows/error-handling/specification/error-handling/specification.md
   is faithful to the discussion: the envelope fields, the code-range
   retry classification, and boundary-only logging all present; the
-  SDK helper library appears only as deferred/out of scope, never as
-  a requirement
+  SDK helper library never appears as a requirement — it is either
+  absent entirely or expressly recorded as deferred/out of scope
 - the manifest ends with the specification item completed, the source
   incorporated, work_type cross-cutting, status completed, and a
   completed_at stamp


### PR DESCRIPTION
## Summary

The two remaining findings from the post-merge prose run of stack #648 (follow-up to #649).

**1. "First iteration" read as the trigger.** `discussion-drained-close-skips-rereview` flaked because the session loop's check-for-results step said *"Skip on the first iteration (no agents have been dispatched yet)"* — a walker resuming a session keyed on "first iteration" and skipped the scan even though a review from an earlier sitting sat in the store. The condition in the parenthetical is now the rule:

> Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.

Applied to both sites (edge enumeration: exactly two): `workflow-discussion-process/references/discussion-session.md` and `workflow-research-process/references/session-loop.md`.

**2. Vacuously-satisfiable assert claim.** `spec-completes-the-cross-cutting`'s claim *"the SDK helper library appears only as deferred/out of scope"* passed on a spec with no deferred section at all (the library appeared nowhere). The claim now states the intent affirmatively — never a requirement; absence legitimate (exhaustive-extraction's exclude-rejected rule permits it); any appearance must be an express deferral.

## Verification

- `npm test` — green (conventions lint, prose corpus validation, snapshot goldens untouched — neither change feeds a fixture recipe).
- Post-merge, a re-run of `discussion-drained-close-skips-rereview` will verify the rewording against the walk that tripped on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)