### PR TITLE
fix(prose-orchestrator): steps 4 and 5 archive before destroying

### DIFF
--- a/.claude/agents/prose-orchestrator.md
+++ b/.claude/agents/prose-orchestrator.md
@@ -63,9 +63,9 @@ Never pass a `model` on a first walk or on any assertion — each
 definition names the model the result is trusted at. The single
 exception is the confirmation rerun in step 4, below.
 
-4. **Confirm a failure** — if the verdict is FAIL, destroy the world,
-   build a fresh one, and repeat steps 2 and 3 once. A defect in the
-   prose reproduces; a one-off does not.
+4. **Confirm a failure** — if the verdict is FAIL, archive the world's
+   evidence and then destroy it, build a fresh one, and repeat steps 2
+   and 3 once. A defect in the prose reproduces; a one-off does not.
 
    Dispatch this second walk with `model: opus`. Walks run on the model
    the definition names; a failure is where it is worth spending more,
@@ -91,7 +91,8 @@ exception is the confirmation rerun in step 4, below.
 5. **Retry an invalid walk** — if the verdict is `INVALID WALK`, the
    walker began mid-flow or died before the task's stop condition, and
    the case was never actually exercised.
-   Destroy the world, build a fresh one, and repeat steps 2 and 3 once.
+   Archive the world's evidence, destroy it, build a fresh one, and
+   repeat steps 2 and 3 once.
    If the second walk is also invalid, report `INVALID` — never `FAIL`.
    A case that was not walked properly has said nothing about the prose,
    and reporting it as a prose failure would be a false finding.


### PR DESCRIPTION
## Summary

The only fix to come out of the 24-case baseline run (23 PASS, 1 FLAKY). During an earlier run, an orchestrator destroyed a failing world before archiving it — the only copy of that walk's logs — and self-reported the process error. Root cause is a rule/step contradiction in the agent definition: the Rules section says archive-then-destroy on FAIL/FLAKY/INVALID, but step 4's FAIL branch opens with "destroy the world, build a fresh one" and step 5 (INVALID retry) likewise. A step-executing reader hits "destroy" with no archive mention. Both step sites now state the ordering inline.

Findings examined and **not** fixed, with why:

- `compliance-check.md` hardening (the `planning-reviews-and-concludes` flake) — the prose already demands attempted re-reads and forbids claiming an unattempted read (§A); the flake was walk variance against correct prose, correctly caught by the asserter.
- Discovery staging filename — the walk followed `confirm-trigger.md:21`'s prescribed `session-001.md` staging path; `template.md`'s `session-draft.md` belongs to the subsequent-session `discovery-session open` flow. Orchestrator note misattributed the governing prose.
- Exploration incremental capture — `session-loop.md:144` already anchors writes to natural pauses.
- Sibling case for `spec-entry-from-investigation`'s non-bugfix arm — already covered by `spec-entry-from-discussion` walking the same entry skill as a feature.

## Verification

`npm test` — 1833/1833. Harness-only change — affects future prose runs; no case or snapshot feeds from agent definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)