### PR TITLE
feat(spec): one-home rule for facts at authoring and construction

### DIFF
--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -106,6 +106,8 @@ Already-`addressed` references are skipped on later topic cycles.
 
 ## B. Synthesize and Present
 
+Check the draft against the one-home rule (**[specification-format.md](specification-format.md)**): a fact already stated in the specification is referenced at its home, never restated. If the new topic should own the fact, move it — edits to already-logged content go through **Context Resurfacing**.
+
 Present your understanding to the user **in the format it would appear in the specification** (shown in both modes):
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-specification-process/references/specification-format.md
+++ b/skills/workflow-specification-process/references/specification-format.md
@@ -8,6 +8,8 @@ This file defines the canonical structure for specification files (`.workflows/{
 
 The specification is a single file per topic. Structure is **flexible** — organize around phases and subject matter, not rigid sections. This is a working document.
 
+Structure is flexible; facts are not. Every value, rule, threshold, and enumeration has exactly one section that states it — its **home**. Every other mention references the home and never restates it. Reference only to avoid restating — never to justify, compare, or note consistency: if deleting the sentence containing a reference loses no information, delete the sentence. Never state a derived fact (a count or summary of a list sitting beside it) — it drifts when the list changes.
+
 > **CHECKPOINT**: You should NOT be creating or writing to this file unless you have explicit user approval for specific content. If you're about to create this file with content you haven't presented and had approved, **STOP**. That violates the workflow.
 
 ---


### PR DESCRIPTION
Part 1 of 3 implementing [idea #42](../blob/main/ideas/spec-review-non-convergence-cross-reference-web.md) (spec review non-convergence on cross-reference-web specs).

A spec authored as a densely cross-referenced web defeats review convergence: facts restated in multiple sections drift under later edits, and every drift surfaces as a fresh contradiction finding — the portal `theming-system` run plateaued at 7–10 gap findings for nine consecutive cycles this way, while a comparable self-contained spec converged in 3.

This PR adds the prevention: a **one-home rule** for facts.

- `specification-format.md` — beside "structure is flexible": every value, rule, threshold, and enumeration has exactly one home section; every other mention references the home and never restates. Reference only to avoid restating (deletion test included); never state derived facts (counts/summaries of an adjacent list).
- `spec-construction.md` §B — check each draft against the rule before presenting. Construction's per-topic exhaustive extraction is where restatements are born: a fact relevant to two topics gets extracted and logged twice unless checked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)