### PR TITLE
feat(spec-review): hunt duplication, let findings shrink the spec

### DIFF
--- a/agents/workflow-specification-review-gap-analysis.md
+++ b/agents/workflow-specification-review-gap-analysis.md
@@ -27,6 +27,7 @@ No source material — this phase looks inward only.
 - Insufficient detail that would force implementers to guess
 - Ambiguity that could be interpreted multiple ways
 - Contradictions between sections
+- Duplication — the same fact stated in more than one section
 - Edge cases within scope boundaries
 - Planning readiness — could this be broken into clear tasks?
 
@@ -64,6 +65,13 @@ No source material — this phase looks inward only.
    - Requirements that conflict with each other
    - Behaviors defined differently in different sections
    - Constraints that make other requirements impossible
+
+   **Duplication**
+   - The same fact, value, rule, or enumeration stated in more than one section
+   - A count or summary restating a list or table that sits beside it
+   - A cross-reference that justifies, compares, or notes consistency instead of pointing at a fact's home
+
+   Flag duplication even when the copies still agree — copies drift apart under later edits and return as contradictions. One finding per restated site: name the fact's home in Details, put the site's current content in Current, and propose replacing the restatement with a reference to the home (or deleting it, where a reference adds nothing).
 
    **Edge Cases Within Scope**
    - For the behaviors specified, what happens at boundaries?
@@ -107,7 +115,7 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-gap-analysis-track
 ### 1. {Brief Title}
 
 **Source**: Specification analysis
-**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity
+**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Duplication
 **Priority**: Critical | Important | Minor
 **Affects**: {which section(s) of the specification}
 
@@ -115,10 +123,10 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-gap-analysis-track
 {Explanation of what was found and why it matters}
 
 **Current**:
-{For Enhancement findings only — copy the existing specification content in the affected section that will be modified. This enables diff presentation to the user. Omit for New topic and Gap/Ambiguity findings.}
+{For findings that modify existing content (Enhancement, Duplication) — copy the existing specification content that will be modified. This enables diff presentation to the user. Omit for New topic and Gap/Ambiguity findings.}
 
-**Proposed Addition**:
-{What you would add to the specification — leave blank until discussed}
+**Proposed Change**:
+{What you would add or change in the specification — leave blank until discussed}
 
 **Resolution**: Pending
 **Notes**:

--- a/agents/workflow-specification-review-input.md
+++ b/agents/workflow-specification-review-input.md
@@ -90,8 +90,8 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-input-tracking-c{c
 **Current**:
 {For Enhancement findings only — copy the existing specification content in the affected section that will be modified. This enables diff presentation to the user. Omit for New topic and Gap/Ambiguity findings.}
 
-**Proposed Addition**:
-{What you would add to the specification — leave blank until discussed}
+**Proposed Change**:
+{What you would add or change in the specification — leave blank until discussed}
 
 **Resolution**: Pending
 **Notes**:

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -52,14 +52,16 @@ Work through each finding **sequentially**. For each finding: present it, show t
 
 ### Present Finding
 
+Before presenting, check the finding's proposed content against the one-home rule (**[specification-format.md](specification-format.md)**): where it restates a fact that already has a home in the specification, revise it to reference the home and update the tracking file.
+
 Write the finding payload to `.workflows/.cache/{work_unit}/specification/{topic}/finding-current.json` with the Write tool, from the tracking file:
 
 - `n`, `total`, `title` — the finding's position and titlecased brief title.
 - `meta` — `[label, value]` pairs: Source / Category / Affects, plus Priority for Gap Analysis findings.
 - `details` — the Details field.
-- If Category is `Enhancement to existing topic` and a Current field is present: `diff` — `{"context_above": […], "current": […], "proposed": […], "context_below": […]}` with only the changed lines and 2 context lines each side (Proposed Addition as the proposed lines).
-- Otherwise: `content` — `{"label": "Proposed Addition", "lines": […]}` with the content to add.
-- `apply_label`: `"Add to the specification verbatim"` · `applied_label`: `"approved. Added to specification."` · `feedback_hint`: `"Adjust before approving"`
+- If a Current field is present: `diff` — `{"context_above": […], "current": […], "proposed": […], "context_below": […]}` with only the changed lines and 2 context lines each side (Proposed Change as the proposed lines).
+- Otherwise: `content` — `{"label": "Proposed Change", "lines": […]}` with the proposed content.
+- `apply_label`: `"Apply to the specification verbatim"` · `applied_label`: `"approved. Applied to specification."` · `feedback_hint`: `"Adjust before approving"`
 
 Render, then emit each returned section verbatim at its marked instruction — the diff body as a ` ```diff ` fence:
 
@@ -73,7 +75,7 @@ The response carries the finding presentation plus the surface for the current g
 
 #### If the response carried `DISPLAY: finding auto-approved`
 
-1. Log the proposed content to the specification verbatim
+1. Log the proposed content to the specification verbatim — a finding with a Current field replaces that content, never appends
 2. Update the tracking file: set resolution to "Approved"
 3. Commit
 4. Emit the `DISPLAY: finding auto-approved` section now, per its marker.
@@ -92,7 +94,7 @@ The response carries the finding presentation plus the surface for the current g
 
 #### If `view full`
 
-Re-present the finding's **Current** and **Proposed Addition** content in full from the tracking file. Then re-emit the `MENU: finding gate` section.
+Re-present the finding's **Current** and **Proposed Change** content in full from the tracking file. Then re-emit the `MENU: finding gate` section.
 
 **STOP.** Wait for user response.
 
@@ -104,14 +106,14 @@ Incorporate feedback and update the tracking file with the revised content. Rewr
 
 #### If `yes`
 
-1. Log the content to the specification verbatim
+1. Log the content to the specification verbatim — a finding with a Current field replaces that content, never appends
 2. Update the tracking file: set resolution to "Approved", add any discussion notes
 3. Commit — ensures progress survives context refresh
 
 > *Output the next fenced block as a code block:*
 
 ```
-Finding {N} of {total}: {brief_title:(titlecase)} — added.
+Finding {N} of {total}: {brief_title:(titlecase)} — applied.
 ```
 
 **If pending findings remain:**

--- a/skills/workflow-specification-process/references/review-tracking-format.md
+++ b/skills/workflow-specification-process/references/review-tracking-format.md
@@ -24,7 +24,7 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 ### 1. [Brief Title]
 
 **Source**: [Where this came from — file/section reference, or "Specification analysis" for Gap Analysis]
-**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity
+**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Duplication
 **Priority**: [Gap Analysis only — Critical | Important | Minor. Omit for Input Review.]
 **Affects**: [Which section(s) of the specification]
 
@@ -32,10 +32,10 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 [Explanation of what was found and why it matters]
 
 **Current**:
-[For Enhancement findings only — the existing specification content in the affected section that will be modified. Omit for New topic and Gap/Ambiguity findings.]
+[For findings that modify existing content (Enhancement, Duplication) — the existing specification content that will be modified. Omit for New topic and Gap/Ambiguity findings.]
 
-**Proposed Addition**:
-[What you would add to the specification — leave blank until discussed]
+**Proposed Change**:
+[What you would add or change in the specification — leave blank until discussed]
 
 **Resolution**: Pending | Approved | Adjusted | Skipped
 **Notes**: [Any discussion notes or adjustments made]
@@ -45,6 +45,8 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 ### 2. [Next Finding]
 ...
 ```
+
+Some tracking files name the **Proposed Change** field **Proposed Addition** — read both as the same field.
 
 ## Workflow with Tracking Files
 


### PR DESCRIPTION
Part 2 of 3 implementing idea #42 (stacked on #656).

Gap analysis hunted contradictions but not the duplication that breeds them, and every finding wore an add-only frame (`Proposed Addition`, "Add to the specification verbatim") — nothing in review could make a spec smaller, so restatement drift compounded cycle over cycle. Notably the mechanics already supported shrinking (the finding renderer diffs `current` → `proposed`, and the engine's default labels are neutral); the additive frame was pure prose.

- `agents/workflow-specification-review-gap-analysis.md` — **Duplication** hunt bucket (same fact in two sections; count/summary restating an adjacent list; cross-references that justify/compare instead of pointing at a home) with one-finding-per-restated-site guidance; flag copies even while they still agree.
- `review-tracking-format.md` — `Duplication` category; `Proposed Addition` → `Proposed Change`; Current-field guidance covers both modifying categories; one compat line so old tracking files with the previous field name still read.
- `process-review-findings.md` — neutral labels ("Apply to the specification verbatim"); diff presentation keyed on Current-field presence rather than category; one-home check on proposed content before presenting; apply steps state that a Current-field finding replaces, never appends.
- `agents/workflow-specification-review-input.md` — field rename only (its category set is unchanged; duplication hunting stays gap analysis's concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)