### PR TITLE
fix(spec): body template placeholders are guidance, topics nest as H3

### DIFF
--- a/skills/workflow-specification-process/references/specification-format.md
+++ b/skills/workflow-specification-process/references/specification-format.md
@@ -59,6 +59,8 @@ Lifecycle `status` transitions go through the engine, not `set` — `engine topi
 [Optional - capture in-progress discussion if needed]
 ```
 
+Bracketed lines are placeholders, not content — create the file with the headings and leave the sections empty; never copy placeholder text into the file. Topic content nests beneath `## Specification` as `###` sections — never as sibling `##` headings.
+
 ---
 
 ## Sources and Incorporation Status


### PR DESCRIPTION
Part 4 of the idea #42 stack (stacked on #658) — a fix surfaced by the pre-release prose walks.

The `spec-extracts-the-discussion` walk left two template artifacts in the written specification: the literal `[Optional - capture in-progress discussion if needed]` placeholder copied into `## Working Notes`, and the topic's content heading written as a sibling of `## Specification` instead of beneath it. The body template in `specification-format.md` never said bracketed lines are placeholders or where topic headings nest — now it does: sections are created empty, and topic content nests as `###` under `## Specification`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)