### PR TITLE
fix(discussion-session): deferred belongs to the defer gate, not session judgement

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-guidelines.md
+++ b/skills/workflow-discussion-process/references/discussion-guidelines.md
@@ -26,7 +26,7 @@ The conversation follows the thinking, not a checklist. Subtopics emerge, get ex
 
 **Don't force transitions**: If the user is deep in a subtopic, don't interrupt to check off progress. Let the conversation breathe. Transition when there's a natural pause or a decision lands.
 
-**Circle back**: Track what's been partially explored. When a related subtopic resolves, suggest returning to the deferred one — new context may change the thinking.
+**Circle back**: Track what's been partially explored. When a related subtopic resolves, suggest returning to the one left open — new context may change the thinking.
 
 ## Do / Don't
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -61,9 +61,9 @@ Subtopics move through states as the conversation progresses. The judgment call 
 
 **decided** → Decision reached with rationale. The subtopic section gets written up with the full Context → Options → Journey → Decision structure. Terminal for the map, though a later sitting may re-decide — the re-decision lands as a dated entry on the block's timeline (template revision convention).
 
-**deferred** → Deliberately set aside. Applied when concluding with unresolved subtopics (see **G. Concluding**) — each is also noted in Summary → Open Threads.
+**deferred** → Deliberately set aside. Written by the defer gate in **G. Concluding** and nowhere else — never set it during the session loop, however plainly the user parks something. When they say a subtopic stays open, leave it in the state the conversation reached and carry on; the defer gate sweeps it at conclusion. Setting it early makes `all_decided` true, so the gate never renders — the user is never shown what is being set aside, and the Open Threads entry the gate writes never lands.
 
-**State transitions are judgement calls.** Move a subtopic to `converging` when the viable options are narrowed and the discussion is heading toward resolution. Move to `decided` when there's a clear outcome with rationale — even if provisional. Don't wait for absolute certainty. Any state can move to any other — judgment may revisit.
+**State transitions are judgement calls.** Move a subtopic to `converging` when the viable options are narrowed and the discussion is heading toward resolution. Move to `decided` when there's a clear outcome with rationale — even if provisional. Don't wait for absolute certainty. Any state can move to any other — judgment may revisit. The one exception is `deferred`: it belongs to the defer gate, not to session judgement.
 
 Child subtopics can exist under parents. A parent might be `exploring` while one of its children is already `decided`. The parent reaches `decided` when all its meaningful children are resolved and the overall concern is addressed.
 


### PR DESCRIPTION
Found by the prose walk on `discussion-runs-to-convergence`.

## The contradiction

Two lines, four apart in `discussion-session.md`:

- **:64** — `deferred` → *"Deliberately set aside. **Applied when concluding** with unresolved subtopics."*
- **:68** — *"**State transitions are judgement calls.** … **Any state can move to any other** — judgment may revisit."*

One restricts, the other licenses. The permission is a bolded rule; the restriction is a parenthetical inside a vocabulary list — so the permission wins. The walk set `unpaid-order-expiration` to `deferred` the moment the user said it stays open.

There is also no state that fits what the user meant. The map has `pending`, `exploring`, `converging`, `decided`, `deferred`. A subtopic raised, discussed, and deliberately parked mid-session — *"I need to check retention rules with ops first"* — has nowhere to sit but `deferred`, whose first sentence describes precisely that.

## Why it matters

Deferring mid-session makes `all_decided` true. The conclusion routes straight to the closing gates and **the defer gate never renders**: the user is never shown what is being set aside, and the Summary → Open Threads entry that only the gate writes never lands. The discussion file ends up missing a thread the user explicitly asked to keep on the record.

## The fix

The engine already agrees with the restriction — `deferred` feeds `all_decided`, and the only prose that writes it is the defer gate's batch call at `discussion-session.md:179`. So both places now say so, and :64 names what to do instead: leave the subtopic where the conversation left it and let the gate sweep it at conclusion.

`discussion-guidelines.md:29` said *"returning to the deferred one"* of a partially explored subtopic. Lowercase English rather than the map state, but it reinforces the exact misreading — now *"the one left open"*.

## Tests

Conventions lint and prose corpus validation green. The behavioural walk runs once this review settles — running it against a diff that may still move would certify bytes that never land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)