### PR TITLE
fix(review-agent): the deferral commit does not arm a review dispatch

### DIFF
--- a/skills/workflow-discussion-process/references/review-agent.md
+++ b/skills/workflow-discussion-process/references/review-agent.md
@@ -8,7 +8,7 @@ These instructions are loaded into context at the start of the discussion sessio
 
 **Trigger checklist** — evaluate after every commit as part of the session loop's dispatch check:
 
-- □ Meaningful content committed? (a decision documented, a question explored, options analysed — not a typo fix or reformatting; a commit whose subject carries a `review-` or `synthesis-` drain marker — e.g. `(review-003 F2)` — doesn't tick this box)
+- □ Meaningful content committed? (a decision documented, a question explored, options analysed — not a typo fix or reformatting; a commit whose subject carries a `review-` or `synthesis-` drain marker — e.g. `(review-003 F2)` — doesn't tick this box, nor does one carrying a `(deferral)` marker: the concluding flow's deferral write is bookkeeping, and a review dispatched on it would be in flight before the closing gates it delays)
 - □ All prior reviews drained? (`agent scan` shows no `review` row in flight, pending, or acknowledged — or no review row exists yet; an in-flight row an earlier session dispatched is dead, not running — incorporate it and count it drained)
 - □ Not the first commit? (the discussion needs enough content to review)
 - □ At least 2-3 conversational exchanges since the last review dispatch?


### PR DESCRIPTION
Stacked on #661. Completes an enumeration #654 got wrong — mine.

## What #654 missed

#654 taught the movement classifier to drop the conclusion's own `(deferral)` write, landing it in `closing-gates.md` and both `final-review.md` copies. It missed the **dispatch trigger**, which asks the same question in different words:

`review-agent.md:11` — *"Meaningful content committed?"* — excludes `review-`/`synthesis-` drain markers, and knew nothing about `(deferral)`.

So the deferral commit ticked the box, a review dispatched on it, and the closing gates then found that review `pending`. Rule 1 fires (`any review row is pending or acknowledged → findings-owed`), and rule 4 — where the whole marker fix lives — is never reached.

The walk hit exactly this: `review-003` pending at the gates, a mandatory review gate rendered with no arm matching a user who had just wrapped up, and the conclude ask never reached. **The fix shipped in #654 was unreachable in the one flow it was written for.**

## How the enumeration failed

I grepped for `deferral` and `closing-gates`. That finds classifiers by name and cannot find a trigger that never uses the word. The concept is *"does this commit count as movement"*, and it is written in five places:

| Site | Needs the marker |
|---|---|
| `discussion/closing-gates.md:24` | yes — landed in #654 |
| `discussion/final-review.md:87` | yes — landed in #654 |
| `discussion/review-agent.md:11` | yes — **this PR** |
| `research/final-review.md:71` | no — research authors no deferral commit |
| `research/review-agent.md:11` | no — same |

Enumerate by concept, not by keyword.

## Consequence for the case

With #661 and this in place, the path `discussion-runs-to-convergence` asserts becomes reachable and deterministic: nothing dispatches on the deferral commit, every clean review is `incorporated` rather than `acknowledged` (`agent-state.cjs:355` — a clean report skips that state), rule 1 falls through, rule 4 drops the marker, no commits remain, classification is `satisfied`.

That is the expectation, not a result. The walk runs once this stack's review settles, before merge.

## Tests

Conventions lint and prose corpus validation green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)