### PR TITLE
test(prose): the closing-gate classification is not a property this case pins

### DIFF
--- a/tests/prose/cases/discussion-runs-to-convergence/assert.md
+++ b/tests/prose/cases/discussion-runs-to-convergence/assert.md
@@ -34,14 +34,20 @@ The prose should have taken this path:
    the undecided count, and on their confirmation defers the unresolved
    subtopic(s) in one engine write — the batch form, not a per-subtopic
    loop — noted under the Summary's open threads
-10. the closing gates then hold: the pending closing work is classified
-    from the agent store, and with every review row incorporated the
-    movement read drops the `(deferral)` commit it just authored and
-    finds nothing left — `satisfied`, so no fresh-review offer is
-    rendered at all and the conclude ask comes straight up; it is
-    answered yes; the in-flight agent check runs, and the walk stops
-    there — the final review step never executes, document review and
-    the compliance check never load, and the discussion is not completed
+10. the closing gates then hold: with every review row incorporated, the
+    movement read drops the `(deferral)` commit the conclusion just
+    authored and classifies whatever remains. Both outcomes are correct
+    and either is a pass — `satisfied` when every subtopic write-up
+    landed before the last review dispatched, so the window comes back
+    empty; `re-review` when one landed after it, since a subtopic
+    explored since the last review is real movement, and the optional
+    fresh-review offer then renders and is declined. Nothing in the prose
+    fixes which side of the review dispatch a write-up falls on, so the
+    classification is not a property this case pins. What must hold on
+    both routes: the conclude ask is reached and answered yes, the
+    in-flight agent check runs, and the walk stops there — the final
+    review step never executes, document review and the compliance check
+    never load, and the discussion is not completed
 
 Further claims:
 


### PR DESCRIPTION
Stacked on #664 → #662 → #661. Removes the coin-flip the last walk exposed.

## The flake

Two walks of the same fixture reached different classifications at the closing gates, and **both were correct**:

| Walk | Movement window held | Classification |
|---|---|---|
| sonnet | `(deferral)` + a committed Unpaid Order Expiry subtopic section | `re-review` |
| opus | `(deferral)` only — the write-up landed before the last review dispatched | `satisfied` |

A subtopic explored since the last review *is* real movement, so `re-review` is the gate working, not failing.

Nothing in the prose fixes which side of the review dispatch a write-up falls on. Discussion writes at natural pauses; reviews dispatch after meaningful commits. Both are judgement calls. The classification is downstream of timing the case cannot control — and a test pinning an uncontrolled value is a coin-flip, not a check.

## The fix

Step 10 names both routes and the discriminator between them, then asserts what is actually invariant: the conclude ask is reached and answered yes, the in-flight agent check runs, the walk stops there, the final review step never executes, and the discussion is not completed.

This is not the vague hedge that was there before #654 (*"a fresh review, where offered, is declined"*), which permitted both branches without saying why either was legitimate. Both are now named, with the condition that produces each.

## What is deliberately not softened

The perspective-agent claim stays exactly as written, though the sonnet walk failed it too.

That one is not timing-dependent. `perspective-agents.md:17` says outright: *"Do not fire when the decision is straightforward, the tradeoffs are already well understood, or the user has already made a confident decision."* This case's user decides confidently throughout — that is the whole of their `conduct`. A walk that offers a perspective agent here has gone against clear prose, and the claim catching it is the case doing its job.

The line: soften what the prose does not guarantee, keep what it does.

## Tests

Prose corpus validation and invariants green. The behavioural walk runs once this review settles — and this is the layer that walk most needs to exercise, since it changes what counts as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)