### PR TITLE
fix(prose): resume-detection openers state the instruction, not triage rationale

### DIFF
--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -43,7 +43,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
-Read the phase status — a `triaged` topic's parked concerns live in its triage queue and it may have no file at all, so file existence alone cannot distinguish the cases:
+Read the phase status:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} status

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -43,7 +43,7 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 ## Step 0: Resume Detection
 
-Read the phase status — file existence alone cannot distinguish a resumable session from a `triaged` stub of parked concerns:
+Read the phase status:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.research.{topic} status


### PR DESCRIPTION
Review follow-up to #673: both resume-detection Step 0 openers (discussion + research) led with triage rationale — a justification clause for a stub-file ambiguity the sidecar removed. Trimmed to the bare instruction; the `triaged` branch body keeps the queue mention at proportionate weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)