### PR TITLE
feat(engine): topic queue — gates and drains ask for the triage queue instead of globbing

### DIFF
--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -4,22 +4,26 @@
 
 ---
 
-When the discussion session returns here (either through natural convergence or user-initiated conclusion), first check the topic's triage queue: `.workflows/{work_unit}/discussion/.triage/{topic}/*.md`.
+When the discussion session returns here (either through natural convergence or user-initiated conclusion), first check the topic's triage queue:
 
-**If the queue holds entries:**
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs topic queue {work_unit} discussion {topic}
+```
+
+**If `count` is non-zero:**
 
 A concern was rerouted into this topic after drain ran this session. It must be folded before concluding.
 
 > *Output the next fenced block as a code block:*
 
 ```
-  ⚑ Triage queue not empty — {N} rerouted concern(s) awaiting fold.
+  ⚑ Triage queue not empty — {count} rerouted concern(s) awaiting fold.
     Returning to the session to drain and explore them before concluding.
 ```
 
 → Return to **[the skill](../SKILL.md)** for **Step 5**.
 
-**If the queue is missing or empty:**
+**If `count` is `0`:**
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -126,6 +126,7 @@ Across the family, the knowledge base is a derived index — its failures land i
 ```bash
 engine topic start <work-unit> <phase> <topic>
 engine topic triage <work-unit> <phase> <topic> [--concern <file> --slug <kebab> -m <message>]   # research|discussion only; parks a concern (bare) or delivers it into the triage queue, self-committing (delivery form)
+engine topic queue <work-unit> <phase> <topic>     # read the topic's triage queue — {"count": N, "files": [paths…]}; the engine owns the queue layout, so gates, drains, and resume detection ask instead of globbing
 engine topic complete <work-unit> <phase> <topic>
 engine topic reopen <work-unit> <phase> <topic>
 engine topic supersede <work-unit> <phase> <topic> --by <topic>

--- a/skills/workflow-engine/scripts/domain/transitions.cjs
+++ b/skills/workflow-engine/scripts/domain/transitions.cjs
@@ -287,6 +287,40 @@ function triageTopic(cwd, workUnit, phase, topic, opts = {}) {
 }
 
 /**
+ * @typedef {object} TopicQueueResult
+ * @property {string} work_unit
+ * @property {string} phase
+ * @property {string} topic
+ * @property {number} count
+ * @property {string[]} files  project-relative queue file paths, sorted
+ */
+
+/**
+ * Read a topic's triage queue: the engine owns the queue layout, so gates
+ * and drains ask instead of globbing. Legal only in triage-legal phases;
+ * a missing directory is an empty queue.
+ * @param {string} cwd project root
+ * @param {string} workUnit
+ * @param {string} phase
+ * @param {string} topic
+ * @returns {TopicQueueResult}
+ */
+function queueStatus(cwd, workUnit, phase, topic) {
+  assertLegalWrite(phase, 'triaged');
+  if (!fs.existsSync(path.join(cwd, '.workflows', workUnit))) {
+    throw new Error(`no work unit directory: .workflows/${workUnit}`);
+  }
+  const dirRel = `.workflows/${workUnit}/${phase}/.triage/${topic}`;
+  /** @type {string[]} */
+  let names = [];
+  try {
+    names = fs.readdirSync(path.join(cwd, dirRel));
+  } catch { /* no queue yet — empty */ }
+  const files = names.filter((f) => f.endsWith('.md')).sort().map((f) => `${dirRel}/${f}`);
+  return { work_unit: workUnit, phase, topic, count: files.length, files };
+}
+
+/**
  * Complete a phase item: set `status: completed` and, when the phase's
  * artifact is knowledge-base indexed, index it (warn-don't-block). The item
  * must exist; a cancelled item must go through reactivate first. No git
@@ -532,4 +566,4 @@ function reactivateTopic(cwd, workUnit, phase, topic) {
   return result;
 }
 
-module.exports = { startTopic, triageTopic, completeTopic, reopenTopic, supersedeTopic, cancelTopic, reactivateTopic };
+module.exports = { startTopic, triageTopic, queueStatus, completeTopic, reopenTopic, supersedeTopic, cancelTopic, reactivateTopic };

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -23,7 +23,7 @@ const { commitScopedWithKb, commitPathspecScoped, KB_DIR } = require('./domain/c
 const { recordSubtopicAdd, recordSubtopicState, recordSubtopicStates, SUBTOPIC_STATES } = require('./domain/discussion-map.cjs');
 const { VALID_ROUTINGS } = require('./kernel/manifest-schema.cjs');
 const { sequenceMap, addItem, addItemsBatch, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem } = require('./domain/discovery-map.cjs');
-const { startTopic, triageTopic, completeTopic, reopenTopic, supersedeTopic, cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
+const { startTopic, triageTopic, queueStatus, completeTopic, reopenTopic, supersedeTopic, cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
 const { initTasks, startTask, fixAttempt, completeTask, analysisCycle } = require('./domain/tasks.cjs');
 const taskSections = require('./domain/projections/tasks.cjs');
 const txSections = require('./domain/projections/transactions.cjs');
@@ -141,6 +141,7 @@ Commands:
   discovery-session close <work-unit> -m <message>
   topic start <work-unit> <phase> <topic>
   topic triage <work-unit> <phase> <topic> [--concern <file> --slug <kebab> -m <message>]
+  topic queue <work-unit> <phase> <topic>
   topic complete <work-unit> <phase> <topic>
   topic reopen <work-unit> <phase> <topic>
   topic supersede <work-unit> <phase> <topic> --by <topic>
@@ -524,6 +525,14 @@ function runTopic(argv) {
         throw new Error('Usage: engine topic supersede <work-unit> <phase> <topic> --by <topic>');
       }
       respond(supersedeTopic(process.cwd(), workUnit, phase, topic, { by: opts.by }));
+      return;
+    }
+    if (command === 'queue') {
+      const [workUnit, phase, topic] = rest;
+      if (!workUnit || !phase || !topic || rest.length !== 3) {
+        throw new Error('Usage: engine topic queue <work-unit> <phase> <topic>');
+      }
+      respond(queueStatus(process.cwd(), workUnit, phase, topic));
       return;
     }
     if (command === 'triage') {

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -4,22 +4,26 @@
 
 ---
 
-First check the topic's triage queue: `.workflows/{work_unit}/research/.triage/{topic}/*.md`.
+First check the topic's triage queue:
 
-**If the queue holds entries:**
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs topic queue {work_unit} research {topic}
+```
+
+**If `count` is non-zero:**
 
 A concern was rerouted into this topic after drain ran this session. It must be folded before concluding.
 
 > *Output the next fenced block as a code block:*
 
 ```
-  ⚑ Triage queue not empty — {N} rerouted concern(s) awaiting fold.
+  ⚑ Triage queue not empty — {count} rerouted concern(s) awaiting fold.
     Returning to the session to drain and explore them before concluding.
 ```
 
 → Return to **[the skill](../SKILL.md)** for **Step 6**.
 
-**If the queue is missing or empty:**
+**If `count` is `0`:**
 
 1. Mark the research completed — the engine sets the status and indexes the artifact into the knowledge base:
    ```bash

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -4,7 +4,7 @@
 
 ---
 
-Folds the current topic's triage queue — concerns rerouted here from other topics, one file each under `.workflows/{work_unit}/{phase}/.triage/{topic}/` — into its working content, then deletes the drained files. Runs at every entry to the session step — the first pass of a session, and again when the conclusion gate bounces back because a concern landed mid-session. An empty queue is a no-op; a resume or reopen folds whatever landed since the topic last ran.
+Folds the current topic's triage queue — concerns rerouted here from other topics, one file each — into its working content, then deletes the drained files. Runs at every entry to the session step — the first pass of a session, and again when the conclusion gate bounces back because a concern landed mid-session. An empty queue is a no-op; a resume or reopen folds whatever landed since the topic last ran.
 
 The fold preserves the **full** rerouted context — each entry becomes real working material the session explores, not a bare map row. The conclusion gate backstops this: a topic cannot conclude while its queue holds entries.
 
@@ -18,9 +18,13 @@ The caller provides these via context before loading:
 
 ## A. Read
 
-List the topic's triage queue: `.workflows/{work_unit}/{phase}/.triage/{topic}/*.md`.
+List the topic's triage queue:
 
-#### If the directory is missing or empty
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs topic queue {work_unit} {phase} {topic}
+```
+
+#### If `count` is `0`
 
 Nothing landed. No-op — do not commit, surface nothing.
 
@@ -28,7 +32,7 @@ Nothing landed. No-op — do not commit, surface nothing.
 
 #### Otherwise
 
-Each file holds one `### {title}` entry (shape pinned in [triage-landing.md](triage-landing.md)). Read every file.
+Each path in `files` holds one `### {title}` entry (shape pinned in [triage-landing.md](triage-landing.md)). Read every file.
 
 → Proceed to **B. Fold Each Entry**.
 

--- a/skills/workflow-shared/references/resume-detection.md
+++ b/skills/workflow-shared/references/resume-detection.md
@@ -6,7 +6,7 @@
 
 Read `{file}`.
 
-**If the topic's triage queue holds entries** (`.triage/{topic}/*.md` beside the artifact — research and discussion only): they are concerns rerouted here from other topics — their origin sessions recorded them as landed. Restart preserves the queue (it is not a restart target), but the count belongs in the gate. Set `{N}` = the count of queue files and pass `--triage {N}` below; omit the flag otherwise.
+**If the topic has a triage queue with entries** (research and discussion artifacts only — `node .claude/skills/workflow-engine/scripts/engine.cjs topic queue {work_unit} {phase} {topic}`, `count` non-zero): they are concerns rerouted here from other topics — their origin sessions recorded them as landed. Restart preserves the queue (it is not a restart target), but the count belongs in the gate. Set `{N}` = `count` and pass `--triage {N}` below; omit the flag otherwise.
 
 Render the gate:
 

--- a/skills/workflow-shared/references/triage-landing.md
+++ b/skills/workflow-shared/references/triage-landing.md
@@ -4,7 +4,7 @@
 
 ---
 
-Lands a rerouted concern in a target topic's **triage queue** — `.workflows/{work_unit}/{landing_phase}/.triage/{target}/`, one engine-numbered file per concern — so the target drains it when its phase next runs. Epic-only — single-topic work types (feature, bugfix, quick-fix) have no second topic to route to; their callers ignore the concern, surface it to the inbox, or pivot to an epic, and never load this reference.
+Lands a rerouted concern in a target topic's **triage queue** — one engine-numbered file per concern, installed and committed by the engine — so the target drains it when its phase next runs. Epic-only — single-topic work types (feature, bugfix, quick-fix) have no second topic to route to; their callers ignore the concern, surface it to the inbox, or pivot to an epic, and never load this reference.
 
 The caller has already resolved and confirmed the target, and confirmed it is a **different** topic from the current one (a concern that belongs to the current topic is normal subtopic or thread work, not a reroute). The delivery is a self-committing engine transaction — the concern file and manifest land action-scoped under the reroute message; the caller commits nothing for the landing itself. (`topic reactivate` in **D** likewise commits itself.)
 

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -351,6 +351,27 @@ describe('engine topic triage', () => {
     assert.ok(fs.existsSync(path.join(dir, 'c.md')), 'scratch concern preserved on refusal');
   });
 
+  it('queue read: empty for a missing directory, lists delivered concerns sorted, refuses illegal phases', () => {
+    const empty = engine(dir, ['topic', 'queue', 'payments', 'discussion', 'edge-cases']);
+    assert.deepStrictEqual(empty, { ok: true, work_unit: 'payments', phase: 'discussion', topic: 'edge-cases', count: 0, files: [] });
+
+    for (const slug of ['first', 'second']) {
+      fs.writeFileSync(path.join(dir, 'c.md'), `### ${slug}\n*From: x · discussion · d*\n\nBody.\n`);
+      engine(dir, ['topic', 'triage', 'payments', 'discussion', 'edge-cases',
+        '--concern', 'c.md', '--slug', slug, '-m', 'discussion(payments/x): reroute concern to edge-cases']);
+    }
+    const two = engine(dir, ['topic', 'queue', 'payments', 'discussion', 'edge-cases']);
+    assert.strictEqual(two.count, 2);
+    assert.deepStrictEqual(two.files, [
+      '.workflows/payments/discussion/.triage/edge-cases/001-first.md',
+      '.workflows/payments/discussion/.triage/edge-cases/002-second.md',
+    ]);
+
+    assert.match(engineFails(dir, ['topic', 'queue', 'payments', 'planning', 'edge-cases']).error, /non-lifecycle phase|Invalid status/);
+    assert.match(engineFails(dir, ['topic', 'queue', 'ghost', 'discussion', 'edge-cases']).error, /no work unit directory/);
+    assert.match(engineFails(dir, ['topic', 'queue', 'payments', 'discussion']).error, /Usage/);
+  });
+
   it('is idempotent — a second call on a triaged stub is a no-op', () => {
     engine(dir, ['topic', 'triage', 'payments', 'research', 'edge-cases']);
     const res = engine(dir, ['topic', 'triage', 'payments', 'research', 'edge-cases']);
@@ -1336,6 +1357,7 @@ describe('engine usage banner', () => {
     for (const line of [
       'topic start <work-unit> <phase> <topic>',
       'topic triage <work-unit> <phase> <topic> [--concern <file> --slug <kebab> -m <message>]',
+      'topic queue <work-unit> <phase> <topic>',
       'topic complete <work-unit> <phase> <topic>',
       'topic reopen <work-unit> <phase> <topic>',
       'topic supersede <work-unit> <phase> <topic> --by <topic>',

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -539,6 +539,9 @@ describe('pipeline simulation', () => {
     assert.strictEqual(parked.concern_path, `.workflows/${wu}/research/.triage/delta/001-parked-concern.md`);
     assert.ok(parked.committed, 'delivery self-commits');
     assert.ok(!fs.existsSync(path.join(sim.dir, 'concern-scratch.md')), 'scratch consumed');
+    const queue = sim.run(['topic', 'queue', wu, 'research', 'delta']);
+    assert.strictEqual(queue.count, 1);
+    assert.deepStrictEqual(queue.files, [parked.concern_path], 'the read verb lists the delivered concern');
     // Concurrent-session shape: a --topic commit slices out only its own
     // topic's paths — a peer topic's dirty file survives unstaged and
     // uncommitted, and the commit contains no path outside the topic + manifest.


### PR DESCRIPTION
Next layer of the concurrent-discussions stack (design: #668), from the #673 review discussion: concern bodies stay as files (content in files, state in manifest, readable recovery commits), and the layout-knowledge gap closes with an engine read instead — `engine topic queue <wu> <phase> <topic>` answers `{count, files}`, with a missing directory reading as empty and non-triage phases refused. Both conclude gates, drain-triage's read step, and resume-detection's `--triage N` count now consume the verb; no skill prose spells `.triage/` any more (the API reference documents the layout, as it should). Transactions suite covers the verb; the simulation pins the read after a delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)