### PR TITLE
feat(triage): mid-session queue check — landings surface during the conversation

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -24,7 +24,7 @@ The discussion is an organic conversation. The Discussion Map is your tracking b
    
    Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.
 
-   Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break; deferred concerns fold before conclusion.
+   Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break, and re-offered at later breaks until drained; the conclusion gate is the backstop.
 2. **Discuss** — Engage with the user on the current subtopic or wherever the conversation leads. Challenge thinking, push back, explore edge cases. Participate as an expert architect. Follow interesting threads — tangents that surface new concerns are valuable. New subtopics may emerge; record each on the map as it's identified (kebab-case name; new subtopics start `pending`; `--parent` nests under an existing top-level subtopic):
 
    ```bash

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -23,6 +23,8 @@ The discussion is an organic conversation. The Discussion Map is your tracking b
    - **Perspective agents**: follow **D. Check and Surface** in **[perspective-agents.md](perspective-agents.md)** — promotes completed perspective sets to synthesis, then delegates to the shared surfacing protocol for synthesis findings.
    
    Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.
+
+   Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break; deferred concerns fold before conclusion.
 2. **Discuss** — Engage with the user on the current subtopic or wherever the conversation leads. Challenge thinking, push back, explore edge cases. Participate as an expert architect. Follow interesting threads — tangents that surface new concerns are valuable. New subtopics may emerge; record each on the map as it's identified (kebab-case name; new subtopics start `pending`; `--parent` nests under an existing top-level subtopic):
 
    ```bash

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -14,6 +14,8 @@ Not a rigid checklist — a natural cadence for productive research conversation
    
    Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.
 
+   Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break; deferred concerns fold before conclusion.
+
 2. **Explore** — Probe the topic from a relevant angle. Use the funnel technique: broad first, specific later. Choose your probe type deliberately. One question at a time — wait for the answer before asking the next.
 
 3. **Engage** — Don't just collect the answer. React to it. Challenge assumptions. Explore implications. Follow promising tangents. Connect what the user just said to something from earlier. This is where your value as a research partner lives — you're thinking alongside, not just recording.

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -14,7 +14,7 @@ Not a rigid checklist — a natural cadence for productive research conversation
    
    Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.
 
-   Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break; deferred concerns fold before conclusion.
+   Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break, and re-offered at later breaks until drained; the conclusion gate is the backstop.
 
 2. **Explore** — Probe the topic from a relevant angle. Use the funnel technique: broad first, specific later. Choose your probe type deliberately. One question at a time — wait for the answer before asking the next.
 

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -81,7 +81,7 @@ Commit the drained artefact: `engine commit {work_unit} --topic {phase}/{topic} 
 
 ## D. Mid-Session Check
 
-Entered from the session loop's findings check — notices concerns that landed after the session-entry drain. Run **A. Read**'s queue command. When `count` is `0`, or every listed file has already been offered this session (a deferred offer is not re-raised), there is nothing to do — return silently.
+Entered from the session loop's findings check — notices concerns that landed after the session-entry drain. Run **A. Read**'s queue command. When `count` is `0`, there is nothing to do — return silently.
 
 Otherwise, surface at the next natural break — the same mid-thread protection agent findings get, never interrupting a live thread:
 
@@ -104,6 +104,6 @@ Otherwise, surface at the next natural break — the same mid-thread protection 
 
 **If `later`:**
 
-Note the offered files and do not re-offer them this session. Nothing is lost either way — the conclusion gate routes back through the drain before the topic can conclude.
+Continue the current thread. `later` means *not now*, never *not this session* — the loop's check re-enters here and re-offers at the next natural break, the same cadence review findings keep. The conclusion gate remains the backstop: nothing concludes over an undrained queue.
 
 → Return to caller.

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -1,6 +1,6 @@
 # Drain Triage
 
-*Shared reference. Loaded by `workflow-discussion-process` (Step 5) and `workflow-research-process` (Step 6) at the session step, before the session loop runs.*
+*Shared reference. Loaded by `workflow-discussion-process` (Step 5) and `workflow-research-process` (Step 6) at the session step, before the session loop runs. The session loops re-enter **D. Mid-Session Check** from their findings check.*
 
 ---
 
@@ -76,5 +76,34 @@ Surface that concerns arrived from elsewhere:
 ## C. Commit
 
 Commit the drained artefact: `engine commit {work_unit} --topic {phase}/{topic} -m "{phase}({work_unit}/{topic}): drain triage"`.
+
+→ Return to caller.
+
+## D. Mid-Session Check
+
+Entered from the session loop's findings check — notices concerns that landed after the session-entry drain. Run **A. Read**'s queue command. When `count` is `0`, or every listed file has already been offered this session (a deferred offer is not re-raised), there is nothing to do — return silently.
+
+Otherwise, surface at the next natural break — the same mid-thread protection agent findings get, never interrupting a live thread:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+{count} concern(s) landed in this topic's triage queue mid-session:
+
+- **`d`/`drain`** — Fold them into the session now
+- **`l`/`later`** — Keep the current thread; they fold before conclusion
+· · · · · · · · · · · ·
+```
+
+**STOP.** Wait for user response.
+
+**If `drain`:**
+
+→ Return to **A. Read**.
+
+**If `later`:**
+
+Note the offered files and do not re-offer them this session. Nothing is lost either way — the conclusion gate routes back through the drain before the topic can conclude.
 
 → Return to caller.

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -616,7 +616,7 @@ const RATCHET_PINS = {
   'skills/workflow-shared/references/compliance-check.md': 1,
   'skills/workflow-shared/references/convergence-analysis.md': 1,
   'skills/workflow-shared/references/correcting-historical-artifacts.md': 1,
-  'skills/workflow-shared/references/drain-triage.md': 1,
+  'skills/workflow-shared/references/drain-triage.md': 2,
   'skills/workflow-shared/references/final-review-menu.md': 1,
   'skills/workflow-shared/references/topic-name-validation.md': 1,
   'skills/workflow-shared/references/triage-landing.md': 1,


### PR DESCRIPTION
Next layer of the concurrent-discussions stack (design: #668).

Both session loops (discussion, research shared loop) extend their per-turn findings check with a triage-queue check via `topic queue`: a concern rerouted in mid-session surfaces at the next natural break — same mid-thread protection as agent findings — with a drain-now / later offer. `later` never loses anything: deferred offers aren't re-raised, and the conclusion gate already routes back through the drain before the topic can conclude. The check lives as a new section of the shared `drain-triage.md` (single source, already in context during loops). Conventions-lint fence pin raised 1→2 for drain-triage deliberately: the offer menu's placement is judgment-timed (natural-break), which is what the ratchet's pin escape is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)