### PR TITLE
feat(research): adopt action-scoped --topic commits across the flow

### DIFF
--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -31,7 +31,7 @@ A concern was rerouted into this topic after drain ran this session. It must be 
    ```
 2. Final commit:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}): complete {topic} research"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic research/{topic} --kb -m "research({work_unit}): complete {topic} research"
    ```
 
 Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.

--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -125,7 +125,7 @@ Delegate all check-for-results and presentation behaviour to the shared surfacin
 
 3. **If `result` is `cancelled`:** the promotion was dropped — the findings stay in the cache file. Otherwise create the research file at `.workflows/{work_unit}/research/{created_topic}.md` and synthesise the deep-dive findings into it (don't copy the cache file verbatim — organise for the research document context), then commit:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}): add {created_topic} research from deep dive"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic research/{created_topic} -m "research({work_unit}): add {created_topic} research from deep dive"
    ```
 
 For feature work types, deep-dive findings fold into the existing research file — there is only one research topic per feature.

--- a/skills/workflow-research-process/references/initialize-research.md
+++ b/skills/workflow-research-process/references/initialize-research.md
@@ -18,7 +18,7 @@ Whatever those loads returned — a seed, a brief, the handoff's carrier descrip
    ```
 4. Commit:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}): initialize {topic} research"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic research/{topic} -m "research({work_unit}): initialize {topic} research"
    ```
 
 → Return to caller.

--- a/skills/workflow-research-process/references/research-guidelines.md
+++ b/skills/workflow-research-process/references/research-guidelines.md
@@ -96,7 +96,7 @@ The research file is your memory. Context compaction is lossy — what's not on 
 
 These are natural pauses, not every exchange. Capture the substance — not a verbatim transcript.
 
-**After writing, commit** (`engine commit {work_unit} -m "research({work_unit}/{topic}): {what changed}"`; an agent-finding engagement's subject carries `({id} {finding})`, e.g. `(review-003 F2)`). Commits let you track, backtrack, and recover after compaction. Don't batch — commit each time you write.
+**After writing, commit** (`engine commit {work_unit} --topic research/{topic} -m "research({work_unit}/{topic}): {what changed}"`; an agent-finding engagement's subject carries `({id} {finding})`, e.g. `(review-003 F2)`). Commits let you track, backtrack, and recover after compaction. Don't batch — commit each time you write.
 
 **Create the file early.** After understanding the starting point, create the research file with initial context. Don't wait for findings.
 

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -29,7 +29,7 @@ Not a rigid checklist — a natural cadence for productive research conversation
 6. **Commit & dispatch check** — Commit after each write. Don't batch — the commit history is your safety net across context compaction. When the write documents an agent finding's engagement, the subject carries `({id} {finding})` — e.g. `research({work_unit}/{topic}): pinned retry bound (review-003 F2)` — and the commit carries only the engagement's write; unrelated substance commits separately:
 
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}/{topic}): {what changed}"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic research/{topic} -m "research({work_unit}/{topic}): {what changed}"
    ```
 
    Then immediately evaluate agent dispatch — **CHECKPOINT**: Do not respond to the user until this check is complete. Evaluate the trigger conditions defined in the review agent and deep-dive agent instructions loaded by the session wrapper. If conditions are met, dispatch before continuing. If not, proceed.

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -496,7 +496,7 @@ describe('pipeline simulation', () => {
     // Alpha: research then discussion; regenerated-brief reconcile flag rides.
     sim.run(['topic', 'start', wu, 'research', 'alpha']);
     sim.write(`.workflows/${wu}/research/alpha.md`, '# Research — Alpha\n');
-    sim.run(['commit', wu, '-m', `research(${wu}): alpha`]);
+    sim.run(['commit', wu, '-m', `research(${wu}): alpha`, '--topic', 'research/alpha']);
     sim.run(['topic', 'complete', wu, 'research', 'alpha']);
     const ops = sim.write(`.workflows/.cache/${wu}/discovery/reconcile-ops.json`,
       [{ op: 'set', path: `${wu}.research.alpha`, fields: { reconcile_needed: true } }]);


### PR DESCRIPTION
Final layer of the concurrent-discussions stack (design: #668).

The judged-landing work makes concurrent research sessions designed-for (a landing reopens research beneath live discussions), and research's cadence still committed whole-WU — the peer-sweep hazard PR 4 fixed for discussions. Session-loop cadence, guidelines, initialize, and the deep-dive topic creation switch to `--topic research/{topic}`; the conclusion commits `--topic … --kb`. The topic-split commit deliberately stays work-unit scoped (a split writes the superseded parent plus N new files — genuinely cross-topic). Simulation pins the new call shape. Prose-test intersection: `research-initialises-from-the-brief`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)