### PR TITLE
test(prose): refresh case expectations for the presence and judged-landing layers

### DIFF
--- a/tests/prose/cases/discussion-drained-close-skips-rereview/assert.md
+++ b/tests/prose/cases/discussion-drained-close-skips-rereview/assert.md
@@ -45,6 +45,7 @@ Further claims:
   surface, no incorporate — the store already held the row
   incorporated and it stays untouched
 - nothing is written: no discussion-file edit, no map change, no
-  commit — the walk reads, classifies, and stops
+  commit — the walk reads, classifies, and stops (per-turn cache
+  heartbeats under `.workflows/.cache/` are expected, not writes)
 
 EXPECTED WORLD — the fixture, unchanged.

--- a/tests/prose/cases/discussion-redecision-lands-timeline/assert.md
+++ b/tests/prose/cases/discussion-redecision-lands-timeline/assert.md
@@ -36,7 +36,8 @@ The prose should have taken this path:
    final gap review and document review steps run without unwinding
    the timeline — the revision landing survives reconciliation intact
 8. the conclusion marks the discussion complete (`topic complete`),
-   commits, and the walk stops at the bridge invocation
+   commits, clears the session's presence heartbeat, finds no
+   leavings to sweep, and the walk stops at the bridge invocation
 
 Further claims:
 

--- a/tests/prose/cases/start-coherence-finding-reopens-discussion/assert.md
+++ b/tests/prose/cases/start-coherence-finding-reopens-discussion/assert.md
@@ -24,11 +24,12 @@ The prose should have taken this path:
 6. the findings gate leads in with a count of 1; the second scripted
    answer reviews; the finding renders with its category, both quotes,
    and the proposed target; the third scripted answer approves
-7. triage landing classifies the live target — a completed discussion
-   — and delivers through the self-committing `topic triage`: the item
-   reopens to in-progress and the finding lands as one file in
-   synonym-handling's triage queue carrying the conflict's full
-   context, committed by the delivery itself
+7. triage landing resolves the target on the live map and delivers at
+   the gate's landing phase (discussion) through the self-committing
+   `topic triage`: the completed discussion reopens to in-progress and
+   the finding lands as one file in synonym-handling's triage queue
+   carrying the conflict's full context, committed by the delivery
+   itself
 8. the gate completes: the candidate recorded approved, the tracker
    carries synonym-handling, the spent `analysis_staging` subtree
    deleted, and the gate's commit — "discovery(search-relevance):


### PR DESCRIPTION
Eyeball pass over the intersecting prose cases before walking them: the redecision conclusion claim gains the presence-clear + sweep steps, drained-close's 'nothing is written' claim carves out per-turn cache heartbeats, and the coherence case drops the stale 'classifies the live target' wording for the judged-landing shape. The other intersecting cases needed nothing: wraps stops pre-conclusion and already tolerates cache artifacts, research-initialises pins no commit form, and no case's invariants name the new presence/queue calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)