### PR TITLE
fix(engine): an emptied triage queue no longer poisons --topic commits

### DIFF
--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -803,15 +803,47 @@ const TOPIC_COMMIT_ARTIFACTS = /** @type {Record<string, (wu: string, topic: str
 });
 
 /**
- * Keep pathspecs `git add` will accept: on disk, or holding index entries
- * (a deleted-but-tracked path still stages its deletions).
+ * Whether the directory holds any file, at any depth. An existing-but-empty
+ * directory is a git no-man's-land: `git add` tolerates its pathspec
+ * silently while `git commit -- <paths>` refuses it — the state every
+ * triage queue reaches once its last concern's deletion is committed.
+ * @param {string} dirAbs
+ * @returns {boolean}
+ */
+function dirHasFiles(dirAbs) {
+  /** @type {fs.Dirent[]} */
+  let entries;
+  try {
+    entries = fs.readdirSync(dirAbs, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (dirHasFiles(path.join(dirAbs, e.name))) return true;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Keep pathspecs the whole add+commit sequence will accept: a file on disk,
+ * a directory with content, or a path holding index entries (a
+ * deleted-but-tracked path still stages its deletions). An empty directory
+ * with no index entries is dropped — see dirHasFiles.
  * @param {string} cwd @param {string[]} specs
  * @returns {string[]}
  */
 function stageableSpecs(cwd, specs) {
   const { execFileSync } = require('child_process');
   return specs.filter((p) => {
-    if (fs.existsSync(path.join(cwd, p))) return true;
+    const abs = path.join(cwd, p);
+    if (fs.existsSync(abs)) {
+      if (!fs.statSync(abs).isDirectory()) return true;
+      if (dirHasFiles(abs)) return true;
+    }
     try {
       return execFileSync('git', ['ls-files', '--', p], { cwd, encoding: 'utf8' }).trim() !== '';
     } catch {

--- a/tests/scripts/test-engine-commit-door.cjs
+++ b/tests/scripts/test-engine-commit-door.cjs
@@ -151,6 +151,23 @@ describe('engine commit --topic: pathspec isolation', () => {
     assert.strictEqual(missing.note, 'nothing to commit');
   });
 
+  it('regression: --topic commits survive an emptied triage queue (the post-drain state)', () => {
+    // Deliver a concern (creates + commits the sidecar file), drain it (rm +
+    // commit stages the deletion), then keep working: the emptied-but-present
+    // directory must not poison later --topic commits.
+    fs.writeFileSync(path.join(dir, 'c.md'), '### Q\n*From: x · discussion · d*\n\nBody.\n');
+    engine(dir, ['topic', 'triage', 'payments', 'discussion', 'topic-a',
+      '--concern', 'c.md', '--slug', 'q', '-m', 'discussion(payments/x): reroute concern to topic-a']);
+    fs.unlinkSync(path.join(dir, '.workflows/payments/discussion/.triage/topic-a/001-q.md'));
+    const drain = engine(dir, ['commit', 'payments', '-m', 'discussion(payments/topic-a): drain triage', '--topic', 'discussion/topic-a']);
+    assert.match(drain.committed, /^[0-9a-f]+$/, 'the drain commit stages the deletion');
+
+    writeFile(dir, '.workflows/payments/discussion/topic-a.md', '# Topic A\nprogress after the drain\n');
+    const after = engine(dir, ['commit', 'payments', '-m', 'discussion(payments/topic-a): progress', '--topic', 'discussion/topic-a']);
+    assert.match(after.committed, /^[0-9a-f]+$/, 'the emptied queue directory no longer breaks the pathspec');
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/payments/discussion/.triage/topic-a')), 'the empty dir is still on disk — excluded, not deleted');
+  });
+
   it('does not stage the knowledge store — the KB dir never rides a --topic commit', () => {
     writeFile(dir, '.workflows/.knowledge/metadata.json', '{}\n');
     writeFile(dir, '.workflows/payments/discussion/topic-a.md', '# Topic A\nprogress\n');


### PR DESCRIPTION
From the prose-test run (design: #668): `discussion-redecision-lands-timeline` failed with `git commit failed: error: pathspec '….triage/synonym-handling' did not match any file(s) known to git` — three identical failures per walk, both walkers. Root cause: once a drain's deletion commits, the queue directory is empty-but-present; `stageableSpecs`' bare exists-check kept it, `git add` tolerated it silently, and the pathspec'd commit refused it — the state every topic reaches after its first complete drain. The guard now drops an existing directory holding no files (recursively) and no index entries. Regression test pins deliver → drain-commit → keep-working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)