### PR TITLE
test(prose): refresh stale worlds — the sidecar and presence layers moved them

### DIFF
--- a/tests/prose/cases/discussion-resumes-review-walkthrough/assert.md
+++ b/tests/prose/cases/discussion-resumes-review-walkthrough/assert.md
@@ -43,7 +43,9 @@ Further claims:
   lifecycle carries the walk, and surfacing the last finding is what
   closes the row
 - nothing is written: no discussion-file edit, no map change, no
-  commit — the only state change is the surface call's
+  commit — the only state change is the surface call's (per-turn
+  presence heartbeats under `.workflows/.cache/` are expected, not
+  writes)
 - the walk stops with the question pending; the user never answers it
 
 EXPECTED WORLD — the fixture plus exactly one change: the agent store

--- a/tests/prose/cases/discussion-runs-to-convergence/assert.md
+++ b/tests/prose/cases/discussion-runs-to-convergence/assert.md
@@ -8,12 +8,11 @@ The prose should have taken this path:
 2. the process reads the status again, finds no discussion file, and
    starts fresh — no resume choice is put to the user
 3. initialisation registers the discussion through the engine before
-   the file exists, creates the file from the template with its
-   terminal Triage section, seeds initial subtopics on the map as
-   pending, and commits once
+   the file exists, creates the file from the template, seeds initial
+   subtopics on the map as pending, and commits once
 4. the guidelines load, and the knowledge base is addressed once as a
    contextual query; with an empty store the session proceeds silently
-5. the triage drain no-ops on a `(none)` section — no commit, nothing
+5. the triage drain no-ops on an empty queue — no commit, nothing
    surfaced
 6. the session runs as an organic conversation: subtopics move through
    their lifecycle by engine calls as the discussion progresses, and
@@ -71,8 +70,8 @@ EXPECTED WORLD — from a feature holding only its discovery carrier:
   sections whose decisions match what the user actually said — webhook
   capture over polling, orders left open for bounded retries, hosted
   fields keeping card data out of scope — a Summary noting the unpaid
-  order expiry window as an open thread, and a terminal `## Triage`
-  holding `(none)`
+  order expiry window as an open thread; the topic's triage queue is
+  empty
 - the manifest holding the discussion in progress with every subtopic
   settled — `decided` or `deferred`, none left pending or exploring —
   the subtopics the user drove to decisions all `decided`, and an

--- a/tests/prose/cases/discussion-wraps-when-all-decided/assert.md
+++ b/tests/prose/cases/discussion-wraps-when-all-decided/assert.md
@@ -11,7 +11,7 @@ The prose should have taken this path:
    subtopics as pending, and commits once
 4. the guidelines load and the knowledge base is addressed once as a
    contextual query; with an empty store the session proceeds silently;
-   the triage drain no-ops on `(none)`
+   the triage drain no-ops on an empty queue
 5. the session runs as an organic conversation: every thread the user
    engages is driven to a decision, the transitions recorded through
    the engine, the file written and committed at natural pauses
@@ -48,8 +48,8 @@ EXPECTED WORLD — from a feature holding only its discovery carrier:
 
 - a discussion file at `.workflows/pay/discussion/pay.md` whose
   decisions match what the user said — webhook capture over polling,
-  hosted fields keeping card data off their servers — with a terminal
-  `## Triage` holding `(none)`
+  hosted fields keeping card data off their servers; the topic's
+  triage queue is empty
 - the manifest holding the discussion in progress with every subtopic
   `decided` — none pending, exploring, or deferred; the discussion is
   NOT completed

--- a/tests/prose/cases/research-initialises-from-the-brief/assert.md
+++ b/tests/prose/cases/research-initialises-from-the-brief/assert.md
@@ -19,9 +19,8 @@ The prose should have taken this path:
 7. initialisation reads the work's seed and no-ops — an epic's seed
    surfaces per topic through the knowledge base, not here; the brief
    read repeats idempotently; the research file is created from the
-   template with its terminal Triage section, its Starting Point
-   populated from the brief-fed context; the topic is registered
-   through the engine and one commit lands
+   template, its Starting Point populated from the brief-fed context;
+   the topic is registered through the engine and one commit lands
 8. the walk stops there — no knowledge query runs, and the research
    session never starts
 
@@ -40,8 +39,8 @@ EXPECTED WORLD — from a harvested epic with no per-topic work:
   `.workflows/search-relevance/research/relevance-measurement.md`
   holding a Starting Point that reflects the brief — the
   measurement problem, no evaluation set, the user never having built a
-  harness — with a terminal `## Triage` holding `(none)` and no
-  findings recorded yet
+  harness — with no findings recorded yet; the topic's triage queue
+  is empty
 - the manifest holding one research item, relevance-measurement, in
   progress — the epic's only per-phase item — and the topic's discovery
   map item now carrying `brief_incorporated: true`

--- a/tests/prose/lib/worlds.cjs
+++ b/tests/prose/lib/worlds.cjs
@@ -120,6 +120,10 @@ function excluded(rel) {
   if (rel.startsWith(path.join('.workflows', '.knowledge') + path.sep)) return true;
   if (rel.startsWith(path.join('.claude', 'skills') + path.sep)) return true;
   if (rel.startsWith(path.join('.claude', 'agents') + path.sep)) return true;
+  // Presence heartbeats are timing noise: every session loop beats one per
+  // turn, and no case claim can meaningfully pin an mtime artifact. Other
+  // cache content (the agent store) stays visible — cases pin its rows.
+  if (parts[0] === '.workflows' && parts[1] === '.cache' && parts[parts.length - 1] === 'presence') return true;
   return false;
 }
 


### PR DESCRIPTION
From the prose-test run: four of the five FAILs were stale worlds, two flavours. Three cases (convergence, wraps, research-initialises) pinned the terminal `## Triage`/`(none)` section that PR 5 removed from the templates — their claims now assert an empty triage queue instead. One (resumes-review) failed on the world delta counting the per-turn presence heartbeat as an undeclared change — the harness's `excluded()` now drops `.workflows/.cache/**/presence` from snapshots and deltas (timing noise no claim can meaningfully pin), while the rest of the cache — the agent store cases legitimately pin — stays visible; the case's only-state-change claim gains the matching carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)