### PR TITLE
chore(prose): run hygiene — template placeholder, beat-once wording, case scope

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -26,7 +26,7 @@ The discussion is an organic conversation. The Discussion Map is your tracking b
 
    Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break, and re-offered at later breaks until drained; the conclusion gate is the backstop.
 
-   Beat presence — `node .claude/skills/workflow-engine/scripts/engine.cjs presence beat {work_unit} discussion {topic}` — the freshness signal peer sessions, the bridge, and the conclude sweep read.
+   Beat presence, once per check — `node .claude/skills/workflow-engine/scripts/engine.cjs presence beat {work_unit} discussion {topic}` — the freshness signal peer sessions, the bridge, and the conclude sweep read.
 2. **Discuss** — Engage with the user on the current subtopic or wherever the conversation leads. Challenge thinking, push back, explore edge cases. Participate as an expert architect. Follow interesting threads — tangents that surface new concerns are valuable. New subtopics may emerge; record each on the map as it's identified (kebab-case name; new subtopics start `pending`; `--parent` nests under an existing top-level subtopic):
 
    ```bash

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -16,7 +16,7 @@ Not a rigid checklist — a natural cadence for productive research conversation
 
    Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break, and re-offered at later breaks until drained; the conclusion gate is the backstop.
 
-   Beat presence — `node .claude/skills/workflow-engine/scripts/engine.cjs presence beat {work_unit} research {topic}` — the freshness signal peer sessions, the bridge, and the conclude sweep read.
+   Beat presence, once per check — `node .claude/skills/workflow-engine/scripts/engine.cjs presence beat {work_unit} research {topic}` — the freshness signal peer sessions, the bridge, and the conclude sweep read.
 
 2. **Explore** — Probe the topic from a relevant angle. Use the funnel technique: broad first, specific later. Choose your probe type deliberately. One question at a time — wait for the answer before asking the next.
 

--- a/skills/workflow-research-process/references/template.md
+++ b/skills/workflow-research-process/references/template.md
@@ -21,8 +21,6 @@ What we know so far:
 - {Where we're starting: technical, market, business, etc.}
 
 ---
-
-{Content follows - freeform, managed by the skill}
 ```
 
 ## Notes

--- a/tests/prose/cases/discussion-resumes-review-walkthrough/case.json
+++ b/tests/prose/cases/discussion-resumes-review-walkthrough/case.json
@@ -9,6 +9,7 @@
     "skills/workflow-shared/references/voice.md",
     "skills/workflow-shared/references/ensure-discovery-item.md",
     "skills/workflow-discussion-entry/references/validate-phase.md",
+    "skills/workflow-discussion-entry/references/gather-context.md",
     "skills/workflow-shared/references/reconcile-advisory.md",
     "skills/workflow-discussion-entry/references/invoke-skill.md",
     "skills/workflow-discussion-process/SKILL.md",


### PR DESCRIPTION
The prose run's secondary findings: the research template's `{Content follows…}` placeholder line is removed from inside the fence — both confirmed walks copied it verbatim into real files (pre-existing weakness, surfaced by the run); the session loops' beat instruction gains 'once per check' after a walk double-fired consecutive heartbeats; the resumes-review case declares `gather-context.md` in its files list (its first walk read it undeclared — scope ratchet). The walker's 'already worked through last time' note has no repo line behind it — it was walk-composed narration, carried as a finding only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)