### PR TITLE
feat(triage): drain is a surfacing loop — one concern at a time, through conversation

### DIFF
--- a/skills/workflow-discussion-process/references/closing-gates.md
+++ b/skills/workflow-discussion-process/references/closing-gates.md
@@ -21,7 +21,7 @@ Classify what the final-review step still owes — first match wins:
 3. No `review` row exists → **never-reviewed**: "no review has run yet"
 4. Otherwise the highest-numbered `review` row is `incorporated` — classify by movement. Run `git log --since='{created}' --format='%h %s' -- .workflows/{work_unit}/discussion/{topic}.md` (`{created}` = the row's `created` timestamp; git does the time comparison), then drop commits whose subject carries a `review-` or `synthesis-` drain marker (e.g. `(review-003 F2)`) or a `(deferral)` marker — engagement writes and the conclusion's own deferral write are not new work. Classify the residue:
    1. No commits remain → **satisfied**: the final review is up to date — no judgment
-   2. A remaining commit is meaningful — a decision documented, a subtopic explored; not typo fixes, not bookkeeping (document-review reconciliation, drain triage, summary maintenance) → **re-review**: the discussion has moved since the last review
+   2. A remaining commit is meaningful — a decision documented, a subtopic explored; not typo fixes, not bookkeeping (document-review reconciliation, summary maintenance) → **re-review**: the discussion has moved since the last review
    3. Otherwise → **satisfied** — doubt resolves here; declining forfeits nothing, a later attempt reclassifies
 
    A commit carrying both — a decision documented alongside bookkeeping in one write — is meaningful; the bookkeeping it travels with does not neutralise it. Genuine doubt about whether the substance is a decision at all still resolves at 4.3.

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -24,7 +24,7 @@ The discussion is an organic conversation. The Discussion Map is your tracking b
    
    Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.
 
-   Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break, and re-offered at later breaks until drained; the conclusion gate is the backstop.
+   Then check the triage queue: follow **E. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break, and re-offered at later breaks until drained; the conclusion gate is the backstop.
 
    Beat presence, once per check — `node .claude/skills/workflow-engine/scripts/engine.cjs presence beat {work_unit} discussion {topic}` — the freshness signal peer sessions, the bridge, and the conclude sweep read.
 2. **Discuss** — Engage with the user on the current subtopic or wherever the conversation leads. Challenge thinking, push back, explore edge cases. Participate as an expert architect. Follow interesting threads — tangents that surface new concerns are valuable. New subtopics may emerge; record each on the map as it's identified (kebab-case name; new subtopics start `pending`; `--parent` nests under an existing top-level subtopic):

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -84,7 +84,7 @@ Nothing new for a fresh review to see — the final-review gate is satisfied. De
 
 → Return to caller.
 
-**If a remaining commit is meaningful** (a decision documented, a subtopic explored — not typo fixes, not bookkeeping: document-review reconciliation, drain triage, summary maintenance). A commit carrying both — a decision documented alongside bookkeeping in one write — is meaningful; the bookkeeping it travels with does not neutralise it:
+**If a remaining commit is meaningful** (a decision documented, a subtopic explored — not typo fixes, not bookkeeping: document-review reconciliation, summary maintenance). A commit carrying both — a decision documented alongside bookkeeping in one write — is meaningful; the bookkeeping it travels with does not neutralise it:
 
 → Proceed to **C. Dispatch Final Review**.
 

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -68,7 +68,7 @@ Nothing new for a fresh review to see — the final-review gate is satisfied. De
 
 → Return to caller.
 
-**If a remaining commit is meaningful** (new findings, folded threads — not typo fixes, not bookkeeping: document-review reconciliation, drain triage). A commit carrying both — a finding recorded alongside bookkeeping in one write — is meaningful; the bookkeeping it travels with does not neutralise it:
+**If a remaining commit is meaningful** (new findings, folded threads — not typo fixes, not bookkeeping: document-review reconciliation). A commit carrying both — a finding recorded alongside bookkeeping in one write — is meaningful; the bookkeeping it travels with does not neutralise it:
 
 → Proceed to **C. Dispatch Final Review**.
 

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -14,7 +14,7 @@ Not a rigid checklist — a natural cadence for productive research conversation
    
    Both enforce the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection. **Do not surface findings directly — always go through the agent files, which route to the shared protocol.** Skip only when no agents have been dispatched yet — the store decides, not the iteration count: a resumed session may hold agents from an earlier sitting.
 
-   Then check the triage queue: follow **D. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break, and re-offered at later breaks until drained; the conclusion gate is the backstop.
+   Then check the triage queue: follow **E. Mid-Session Check** in **[drain-triage.md](../../workflow-shared/references/drain-triage.md)** — a concern rerouted here mid-session is offered at the next natural break, and re-offered at later breaks until drained; the conclusion gate is the backstop.
 
    Beat presence, once per check — `node .claude/skills/workflow-engine/scripts/engine.cjs presence beat {work_unit} research {topic}` — the freshness signal peer sessions, the bridge, and the conclude sweep read.
 

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -1,20 +1,18 @@
 # Drain Triage
 
-*Shared reference. Loaded by `workflow-discussion-process` (Step 5) and `workflow-research-process` (Step 6) at the session step, before the session loop runs. The session loops re-enter **D. Mid-Session Check** from their findings check.*
+*Shared reference. Loaded by `workflow-discussion-process` (Step 5) and `workflow-research-process` (Step 6) at the session step, before the session loop runs. The session loops re-enter **E. Mid-Session Check** from their findings check.*
 
 ---
 
-Folds the current topic's triage queue — concerns rerouted here from other topics, one file each — into its working content, then deletes the drained files. Runs at every entry to the session step — the first pass of a session, and again when the conclusion gate bounces back because a concern landed mid-session. An empty queue is a no-op; a resume or reopen folds whatever landed since the topic last ran.
-
-The fold preserves the **full** rerouted context — each entry becomes real working material the session explores, not a bare map row. The conclusion gate backstops this: a topic cannot conclude while its queue holds entries.
+Surfaces the current topic's triage queue — concerns rerouted here from other topics, one file each — **one at a time, through conversation**. A concern leaves the queue only after it has been discussed: surfaced with its full context, worked with the user, folded into the topic's content as the record of that discussion, and absorbed under its own commit. Runs at every entry to the session step and re-offers at every natural break; an empty queue is a no-op. The conclusion gate backstops the whole loop: a topic cannot conclude while its queue holds entries, so nothing is lost however freely the user moves.
 
 ## Parameters
 
 The caller provides these via context before loading:
 
 - `work_unit` — the work unit. Always present.
-- `topic` — the current topic, whose artefact is drained.
-- `phase` — `discussion` or `research`. Selects the artefact path and the fold shape.
+- `topic` — the current topic, whose queue is drained.
+- `phase` — `discussion` or `research`. Selects the artefact and the fold shape.
 
 ## A. Read
 
@@ -32,13 +30,44 @@ Nothing landed. No-op — do not commit, surface nothing.
 
 #### Otherwise
 
-Each path in `files` holds one `### {title}` entry (shape pinned in [triage-landing.md](triage-landing.md)). Read every file.
+Each path in `files` holds one `### {title}` entry (shape pinned in [triage-landing.md](triage-landing.md)). Read every file — the titles and `*From:*` lines feed the agenda; the bodies feed the surfacing.
 
-→ Proceed to **B. Fold Each Entry**.
+→ Proceed to **B. Agenda**.
 
-## B. Fold Each Entry
+## B. Agenda
 
-For each queue file, carry its **full body** (everything below the `*From: ...*` line) into the topic's working content:
+Show the user what is waiting before surfacing anything — scope first, one concern at a time after:
+
+> *Output the next fenced block as a code block:*
+
+```
+  ⚑ {count} rerouted concern(s) waiting in this topic's triage queue:
+
+  1. {title} — from {origin} ({phase}, {date})
+  2. ...
+```
+
+→ Proceed to **C. Surface One Concern**.
+
+## C. Surface One Concern
+
+Take the lowest-numbered concern still queued — or whichever the user asks for. Present it whole: name its origin in a sentence, then emit the file's full content verbatim as a code block (with a rendering instruction) — the origin session carried everything it worked out, and the user decides from the substance, never from the title.
+
+Then discuss it as real session material: engage, challenge, connect it to what this topic has already decided. Control belongs to the conversation — this may take one exchange or many.
+
+**If the discussion reaches an outcome** — a decision, a direction, or the user explicitly parking it as a deferred thread:
+
+→ Proceed to **D. Fold and Absorb**.
+
+**If the user moves on without engaging it** — they bounce to another subtopic, another concern, or the main thread:
+
+The concern stays queued, untouched. Follow them — **E. Mid-Session Check** re-offers at the next natural break, and the conclusion gate holds until the queue is empty.
+
+→ Return to caller.
+
+## D. Fold and Absorb
+
+Record the discussion in the topic's content, then absorb the concern:
 
 **If `phase` is `discussion`:**
 
@@ -48,40 +77,37 @@ Attempt to add `{title}` to the Discussion Map:
 node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map add {work_unit} {topic} {title:(kebabcase)}
 ```
 
-**If the add succeeds** — the concern is new ground: create a `## {title}` subtopic section with the entry body written in as its `### Context`, so the session explores it from there.
+**If the add succeeds** — new ground: create a `## {title}` subtopic section whose `### Context` opens with a provenance line (`*From: {origin} · {phase} · {date}*`) followed by the concern's body, then document what the discussion just concluded in the section's usual shape. Set the subtopic's map state to wherever the conversation actually got it.
 
-**If the add refuses because the subtopic already exists** — the concern names ground this discussion already covers: fold the entry body into that existing subtopic's section, and flip the subtopic back to open so the conclusion gate re-arms and the session must re-decide with the concern in hand:
+**If the add refuses because the subtopic already exists** — ground this discussion already covers: append the provenance line and the concern's body to that subtopic's existing `### Context` — never a new heading of your own — and set the map so the recorded state reflects the re-decision that just happened:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map set {work_unit} {topic} {title:(kebabcase)} exploring
+node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map set {work_unit} {topic} {title:(kebabcase)} {state}
 ```
 
 **If `phase` is `research`:**
 
-- Fold the entry body into the freeform research body as a seed thread under a `### {title}` heading, so the session picks it up from there.
+Fold the concern into the freeform body as a `### {title}` thread opening with the provenance line, followed by the body and what the discussion made of it.
 
-Delete each drained queue file (`rm`) — the commit below stages the deletions.
+Then delete the concern's queue file (`rm`) and commit it by name — one commit per absorbed concern, bracketing its life in history with the delivery commit that landed it:
 
-Surface that concerns arrived from elsewhere:
-
-> *Output the next fenced block as a code block:*
-
-```
-  ⚑ Drained {N} rerouted concern(s) into this topic:
-    {title}, {title}
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{topic} -m "{phase}({work_unit}/{topic}): absorb {NNN-slug} (from {origin})"
 ```
 
-→ Proceed to **C. Commit**.
+**If concerns remain queued:**
 
-## C. Commit
+→ Return to **C. Surface One Concern**.
 
-Commit the drained artefact: `engine commit {work_unit} --topic {phase}/{topic} -m "{phase}({work_unit}/{topic}): drain triage"`.
+**Otherwise:**
+
+The queue is clear.
 
 → Return to caller.
 
-## D. Mid-Session Check
+## E. Mid-Session Check
 
-Entered from the session loop's findings check — notices concerns that landed after the session-entry drain. Run **A. Read**'s queue command. When `count` is `0`, there is nothing to do — return silently.
+Entered from the session loop's findings check — notices concerns that landed after the session-entry pass, and re-offers anything the user set aside. Run **A. Read**'s queue command. When `count` is `0`, there is nothing to do — return silently.
 
 Otherwise, surface at the next natural break — the same mid-thread protection agent findings get, never interrupting a live thread:
 
@@ -89,10 +115,10 @@ Otherwise, surface at the next natural break — the same mid-thread protection 
 
 ```
 · · · · · · · · · · · ·
-{count} concern(s) landed in this topic's triage queue mid-session:
+{count} concern(s) waiting in this topic's triage queue:
 
-- **`d`/`drain`** — Fold them into the session now
-- **`l`/`later`** — Keep the current thread; they fold before conclusion
+- **`d`/`drain`** — Surface the next one now
+- **`l`/`later`** — Keep the current thread
 · · · · · · · · · · · ·
 ```
 

--- a/tests/prose/cases/discussion-redecision-lands-timeline/assert.md
+++ b/tests/prose/cases/discussion-redecision-lands-timeline/assert.md
@@ -12,13 +12,15 @@ The prose should have taken this path:
    addresses the knowledge base once as a contextual query
    (keyword-only store — the session proceeds), and enters the session
    step
-4. the drain reads the triage queue and finds the Expansion Source
-   entry. The map add refuses — the subtopic already exists — so the
-   fold lands the entry body into the existing `## Expansion Source`
-   section and flips the subtopic back to `exploring`: the map is no
-   longer all-decided, the conclusion gate is re-armed. The drained
-   queue file is deleted, the drained-concern callout is surfaced, and
-   the drain commits with its drain-triage message
+4. the drain reads the triage queue, shows the one-entry agenda, and
+   surfaces the Expansion Source concern whole — its provenance and
+   full body presented to the user, not a title. The session discusses
+   it; the map add refuses — the subtopic already exists — so the fold
+   lands the provenance line and body into the existing
+   `## Expansion Source` section's Context and the subtopic re-arms to
+   `exploring`: the map is no longer all-decided. The queue file is
+   deleted and absorbed under its own commit naming the concern and
+   its origin
 5. the session explores the challenge; the user lands the changed
    decision (batch aggregates, daily refresh). Because the decision
    being re-decided was recorded in an earlier sitting, it lands as a

--- a/tests/prose/cases/discussion-redecision-lands-timeline/case.json
+++ b/tests/prose/cases/discussion-redecision-lands-timeline/case.json
@@ -49,7 +49,7 @@
       "manifest get search-relevance.discussion.synonym-handling status",
       "discussion-map add search-relevance synonym-handling expansion-source",
       "discussion-map set search-relevance synonym-handling expansion-source exploring",
-      "discussion(search-relevance/synonym-handling): drain triage",
+      "absorb 001-expansion-source (from behavioural-ranking)",
       "discussion-map set search-relevance synonym-handling expansion-source decided",
       "workflow-discussion-process/scripts/gateway.cjs map search-relevance synonym-handling",
       "topic complete search-relevance discussion synonym-handling"
@@ -58,7 +58,7 @@
       "manifest get search-relevance.discussion.synonym-handling status",
       "discussion-map add search-relevance synonym-handling expansion-source",
       "discussion-map set search-relevance synonym-handling expansion-source exploring",
-      "discussion(search-relevance/synonym-handling): drain triage",
+      "absorb 001-expansion-source (from behavioural-ranking)",
       "discussion-map set search-relevance synonym-handling expansion-source decided",
       "topic complete search-relevance discussion synonym-handling"
     ],


### PR DESCRIPTION
From the post-run design discussion (design: #668). The batch fold had two structural problems: it wrote detailed substance into the document that the session's conversation never produced (the exact shape document-review's drift dimension polices), and the never-lost guarantee handed off mid-flight from the queue gate to the map gate. The drain is now a surfacing loop: an agenda view first (titles, origins, count — the findings-summary precedent), then each concern surfaced whole — provenance and full body, never just a title — discussed as real session material, folded as the *record* of that discussion (into a new subtopic's Context, or appended to an existing one's under a provenance line, never an invented heading — retiring the `### Reopened` recurrence signal), and absorbed under its own commit: `{phase}({wu}/{topic}): absorb {NNN-slug} (from {origin})`. Delivery and absorption commits bracket each concern's life in git history, which is the provenance ledger — queue files stay deleted on absorption, per the design discussion. The user moves freely: unengaged concerns stay queued, the mid-session check re-offers at every natural break, and the unchanged queue-empty conclude gate is now the single guarantee covering the whole journey. Ripples: absorb commits are meaningful movement, so 'drain triage' leaves the three review classifiers' bookkeeping lists; both session-loop callers track the section shift; the redecision prose case pins the surfacing shape and the absorb commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)