### PR TITLE
fix(prose): per-action triage vocabulary — discuss, surface, absorb; drain stays aggregate

### DIFF
--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -17,8 +17,8 @@ A concern was rerouted into this topic after drain ran this session. It must be 
 > *Output the next fenced block as a code block:*
 
 ```
-  ⚑ Triage queue not empty — {count} rerouted concern(s) awaiting fold.
-    Returning to the session to drain and explore them before concluding.
+  ⚑ Triage queue not empty — {count} rerouted concern(s) awaiting discussion.
+    Returning to the session to surface them before concluding.
 ```
 
 → Return to **[the skill](../SKILL.md)** for **Step 5**.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -17,8 +17,8 @@ A concern was rerouted into this topic after drain ran this session. It must be 
 > *Output the next fenced block as a code block:*
 
 ```
-  ⚑ Triage queue not empty — {count} rerouted concern(s) awaiting fold.
-    Returning to the session to drain and explore them before concluding.
+  ⚑ Triage queue not empty — {count} rerouted concern(s) awaiting discussion.
+    Returning to the session to surface them before concluding.
 ```
 
 → Return to **[the skill](../SKILL.md)** for **Step 6**.

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -117,14 +117,14 @@ Otherwise, surface at the next natural break — the same mid-thread protection 
 · · · · · · · · · · · ·
 {count} concern(s) waiting in this topic's triage queue:
 
-- **`d`/`drain`** — Surface the next one now
+- **`d`/`discuss`** — Surface and discuss the next concern
 - **`l`/`later`** — Keep the current thread
 · · · · · · · · · · · ·
 ```
 
 **STOP.** Wait for user response.
 
-**If `drain`:**
+**If `discuss`:**
 
 → Return to **A. Read**.
 


### PR DESCRIPTION
Review follow-up to #686, split out for review: the loop rewrite left the vocabulary half-migrated. The three-word split is now consistent — **drain** is the aggregate invariant (the queue empties over the session; filename, loaders, gate language unchanged), **surface** is presenting one concern, **absorb** is one concern's completion. Fixes the residue: the mid-session menu offered `d`/`drain` while describing surfacing (now `d`/`discuss` — 'Surface and discuss the next concern', keeping the key), and both conclude-gate bounces said 'awaiting fold… drain and explore' (now 'awaiting discussion… surface them').

🤖 Generated with [Claude Code](https://claude.com/claude-code)