### PR TITLE
fix(migrations): addenda survive aborted runs; 054 parser hardening

### DIFF
--- a/skills/workflow-migrate/scripts/migrate.cjs
+++ b/skills/workflow-migrate/scripts/migrate.cjs
@@ -50,8 +50,28 @@ const MIGRATIONS_DIR = path.join(SCRIPT_DIR, 'migrations');
 const STOP_GATE_MARKER = '---STOP_GATE: FILES_UPDATED---';
 
 // Marker preceding the one-line JSON array of verification addenda from
-// migrations executed this run. Boot extracts and strips it.
+// migrations executed this run. Boot extracts and strips it. Addenda are
+// journaled to a pending file beside the tracking log as each migration
+// records, and emitted (then cleared) only by a fully successful run — a
+// later migration aborting the run must never cost an earlier migration's
+// checks, whose ID is already recorded and will never re-run.
 const VERIFY_MARKER = '---VERIFY_ADDENDA---';
+const PENDING_VERIFY = 'pending-verify.json';
+
+/** @param {string} cwd @param {string} trackingRel */
+function pendingVerifyPath(cwd, trackingRel) {
+  return path.join(path.dirname(path.resolve(cwd, trackingRel)), PENDING_VERIFY);
+}
+
+/** @param {string} file @returns {{id: string, description: string, info: string|null, verify: string}[]} */
+function readPendingVerify(file) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
 
 // Bash used to source `*.sh` migrations. Default `bash` (PATH); the override
 // lets the orchestrator test pin stock /bin/bash 3.2 explicitly.
@@ -254,8 +274,6 @@ function main() {
 
   let filesUpdated = 0;
   let migrationsRun = 0;
-  /** @type {{id: string, description: string, info: string|null, verify: string}[]} */
-  const addenda = [];
 
   for (const script of scripts) {
     const id = migrationId(script);
@@ -273,15 +291,21 @@ function main() {
 
     if (result.stdout) process.stdout.write(result.stdout);
     filesUpdated += result.updated;
-    if ('verify' in result && result.verify) {
-      addenda.push({ id, description: require(script).description || '', info: result.info, verify: result.verify });
-    }
 
     // Re-find the tracking file (migration 011 moves it), then record the ID.
     trackingRel = findTrackingFile(cwd);
     fs.mkdirSync(path.dirname(trackingAbs()), { recursive: true });
     fs.appendFileSync(trackingAbs(), id + '\n');
     migrationsRun += 1;
+
+    // Journal the addendum durably the moment its migration is recorded —
+    // an abort further down the fleet must not lose it.
+    if ('verify' in result && result.verify) {
+      const pendingFile = pendingVerifyPath(cwd, trackingRel);
+      const pending = readPendingVerify(pendingFile);
+      pending.push({ id, description: require(script).description || '', info: result.info, verify: result.verify });
+      fs.writeFileSync(pendingFile, JSON.stringify(pending) + '\n');
+    }
   }
 
   if (filesUpdated > 0) {
@@ -295,9 +319,14 @@ function main() {
     process.stdout.write('[SKIP] No changes needed\n');
   }
 
+  // A fully successful run emits everything journaled — this run's addenda
+  // plus any stranded by an earlier aborted run — and clears the journal.
+  const pendingFile = pendingVerifyPath(cwd, trackingRel);
+  const addenda = readPendingVerify(pendingFile);
   if (addenda.length > 0) {
     process.stdout.write(VERIFY_MARKER + '\n');
     process.stdout.write(JSON.stringify(addenda) + '\n');
+    try { fs.unlinkSync(pendingFile); } catch { /* already gone */ }
   }
 }
 

--- a/skills/workflow-migrate/scripts/migrations/053-ignore-lock-and-temp-files.cjs
+++ b/skills/workflow-migrate/scripts/migrations/053-ignore-lock-and-temp-files.cjs
@@ -5,10 +5,11 @@
 //
 // The engine's transient artifacts — manifest lock files
 // (.workflows/{wu}/.lock, plus the .breaking stale-break guard), the
-// project lock (.workflows/.project-lock), the commit lock
-// (.workflows/.commit-lock), and the knowledge store's atomic-write temp
-// files (.workflows/.knowledge/*.tmp) — are stageable today: a scoped
-// `git add` racing a live holder commits them. Migration 049 created
+// project lock (.workflows/.project-lock), and the knowledge store's
+// atomic-write temp files (.workflows/.knowledge/*.tmp) — are stageable
+// today: a scoped `git add` racing a live holder commits them. (The
+// .commit-lock rules cover a lock that ultimately shipped in the .git
+// dir instead — harmless, kept for the frozen rule set.) Migration 049 created
 // .workflows/.gitignore with only the .cache/ and manifest-temp rules;
 // this extends it to cover every transient the engine creates.
 //

--- a/skills/workflow-migrate/scripts/migrations/054-triage-sections-to-queue.cjs
+++ b/skills/workflow-migrate/scripts/migrations/054-triage-sections-to-queue.cjs
@@ -27,18 +27,26 @@ function slugify(title) {
 }
 
 /**
- * Split `content` around its `## Triage` section. Returns null when the
- * section is absent.
+ * Split `content` around its `## Triage` section, fence-aware — a heading
+ * quoted inside a fenced code block is content, not the section. Returns
+ * null when the section is absent.
  * @param {string} content
  * @returns {{before: string, body: string, after: string}|null}
  */
 function splitTriageSection(content) {
   const lines = content.split('\n');
-  const start = lines.findIndex((l) => l.trim() === '## Triage');
+  let inFence = false;
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^\s*```/.test(lines[i])) { inFence = !inFence; continue; }
+    if (!inFence && lines[i].trim() === '## Triage') { start = i; break; }
+  }
   if (start === -1) return null;
   let end = lines.length;
+  inFence = false;
   for (let i = start + 1; i < lines.length; i++) {
-    if (/^## /.test(lines[i])) { end = i; break; }
+    if (/^\s*```/.test(lines[i])) { inFence = !inFence; continue; }
+    if (!inFence && /^## /.test(lines[i])) { end = i; break; }
   }
   return {
     before: lines.slice(0, start + 1).join('\n'),
@@ -103,16 +111,32 @@ module.exports = {
         } catch {
           continue;
         }
+        // A completed topic's artifact is knowledge-indexed — its edits go
+        // through the corrigendum protocol, never a migration; the verify
+        // pass owns spotting anything parked there. Read the manifest
+        // directly (never `engine manifest` — migrations are point-in-time).
+        /** @type {Record<string, any>} */
+        let items = {};
+        try {
+          const manifest = JSON.parse(fs.readFileSync(path.join(workflowsDir, wu, 'manifest.json'), 'utf8'));
+          const ph = manifest && manifest.phases && manifest.phases[phase];
+          if (ph && typeof ph.items === 'object' && ph.items !== null) items = ph.items;
+        } catch { /* unreadable manifest — convert everything, verify pass reviews */ }
+
         for (const file of files) {
           sawArtifacts = true;
+          const topic = file.replace(/\.md$/, '');
+          const item = items[topic];
+          if (item && typeof item === 'object' && item.status === 'completed') continue;
           const artifact = path.join(phaseDir, file);
-          const content = fs.readFileSync(artifact, 'utf8');
+          // Normalise CRLF for parsing — the exact-match patterns are
+          // LF-anchored, and a CRLF artifact must convert, not silently skip.
+          const content = fs.readFileSync(artifact, 'utf8').replace(/\r\n/g, '\n');
           const split = splitTriageSection(content);
           if (!split) continue;
           const entries = parseEntries(split.body);
           if (entries.length === 0) continue;
 
-          const topic = file.replace(/\.md$/, '');
           const queueDir = path.join(phaseDir, '.triage', topic);
           fs.mkdirSync(queueDir, { recursive: true });
           let n = 0;
@@ -127,11 +151,12 @@ module.exports = {
           }
           fs.writeFileSync(artifact, `${split.before}\n\n(none)\n${split.after === '' ? '' : '\n' + split.after}`);
           converted.push(`${wu}/${phase}/${file}`);
+          reportUpdate();
         }
       }
     }
 
-    if (converted.length > 0) reportUpdate(); else reportSkip();
+    if (converted.length === 0) reportSkip();
 
     // The parser is exact-match; artifacts were written by judgment and may
     // hold shapes it cannot recognise — hand those to the verification pass.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -92,7 +92,7 @@ All documents up to date.
    **Do not stop here.** → Proceed to **Step 0.2**.
 
 3. Write a brief natural language summary of what the migrations did — verification fixes included (e.g., "Restructured workflow directories, created manifest files, recovered a rerouted concern the converter missed"). Focus on the nature of the changes, not individual file paths — these are internal workflow state files.
-4. Display the summary (`{N}`/`{M}` come from `migrations.output`):
+4. Display the summary (`{N}`/`{M}` come from `migrations.output`; when it reports no changes — verification fixes only — omit the counts line):
 
 > *Output the next fenced block as a code block:*
 

--- a/tests/scripts/test-migration-054.cjs
+++ b/tests/scripts/test-migration-054.cjs
@@ -162,6 +162,58 @@ describe('migration 054: triage sections to queue', () => {
     assert.match(MIGRATION.info, /triage queue/);
   });
 
+  it('CRLF artifacts convert instead of silently skipping', () => {
+    const dir = setup();
+    write(dir, '.workflows/pay/discussion/alpha.md',
+      '# D\r\n\r\n## Triage\r\n\r\n### Windows Concern\r\n*From: x · discussion · d*\r\n\r\nBody.\r\n');
+
+    const c = runMigration(dir);
+
+    assert.strictEqual(c.updates, 1);
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/pay/discussion/.triage/alpha/001-windows-concern.md')));
+    assert.match(read(dir, '.workflows/pay/discussion/alpha.md'), /## Triage\n\n\(none\)/);
+    teardown(dir);
+  });
+
+  it('a "## Triage" quoted inside a fence is content, not the section', () => {
+    const dir = setup();
+    const doc = '# D\n\n```\n## Triage\n### fake\nbody\n```\n\n## Summary\n\nReal content.\n';
+    write(dir, '.workflows/pay/discussion/alpha.md', doc);
+
+    const c = runMigration(dir);
+
+    assert.strictEqual(c.updates, 0);
+    assert.strictEqual(read(dir, '.workflows/pay/discussion/alpha.md'), doc, 'fenced example untouched');
+    teardown(dir);
+  });
+
+  it('completed topics are skipped — knowledge-indexed artifacts are the verify pass\'s to review', () => {
+    const dir = setup();
+    write(dir, '.workflows/pay/manifest.json', JSON.stringify({
+      name: 'pay', phases: { discussion: { items: { alpha: { status: 'completed' }, beta: { status: 'in-progress' } } } },
+    }));
+    write(dir, '.workflows/pay/discussion/alpha.md', DOC);
+    write(dir, '.workflows/pay/discussion/beta.md', '# D\n\n## Triage\n\n### Live One\n*From: x · discussion · d*\n\nBody.\n');
+
+    const c = runMigration(dir);
+
+    assert.strictEqual(c.updates, 1, 'only the in-progress topic converts');
+    assert.ok(read(dir, '.workflows/pay/discussion/alpha.md').includes('### Rate limits'), 'completed artifact untouched');
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/pay/discussion/.triage/beta/001-live-one.md')));
+    teardown(dir);
+  });
+
+  it('reports one update per converted file', () => {
+    const dir = setup();
+    write(dir, '.workflows/pay/discussion/alpha.md', DOC);
+    write(dir, '.workflows/pay/research/topic.md', '# R\n\n## Triage\n\n### Q\n*From: x · discussion · d*\n\nBody.\n');
+
+    const c = runMigration(dir);
+
+    assert.strictEqual(c.updates, 2);
+    teardown(dir);
+  });
+
   it('research phase converts too', () => {
     const dir = setup();
     write(dir, '.workflows/pay/research/topic.md', '# R\n\n## Triage\n\n### Feasibility flag\n*From: x · discussion · d*\n\nBody.\n');

--- a/tests/scripts/test-migration-orchestrator.cjs
+++ b/tests/scripts/test-migration-orchestrator.cjs
@@ -187,6 +187,38 @@ describe('migrate.cjs — synthetic fleet', () => {
     assert.ok(!second.stdout.includes('---VERIFY_ADDENDA---'), 'recorded migrations never re-emit');
   });
 
+  it('an aborted run journals earlier addenda — the next successful run emits them', () => {
+    const throwing =
+      `'use strict';\nmodule.exports = { id: '002', description: 'boom', run() { throw new Error('boom'); } };\n`;
+    const { migrate, root } = synthFleet({
+      '001-a.cjs':
+        `'use strict';\nmodule.exports = { id: '001', description: 'synthetic 001', info: 'What 001 does.',\n` +
+        `  run({ reportUpdate }) { reportUpdate(); return { verify: 'Check 001 by hand.' }; } };\n`,
+      '002-b.cjs': throwing,
+    });
+    const project = freshProject();
+
+    const first = run(migrate, project, { WORKFLOWS_MIGRATE_BASH: SYSTEM_BASH });
+    assert.notStrictEqual(first.status, 0, 'the fleet aborts on 002');
+    assert.ok(!first.stdout.includes('---VERIFY_ADDENDA---'), 'an aborted run emits nothing');
+    assert.deepStrictEqual(trackingLog(project).trim().split('\n'), ['001'], '001 recorded, 002 not');
+
+    // Fix 002 and re-run: 001 never re-runs, but its journaled addendum rides.
+    fs.writeFileSync(path.join(root, 'scripts/migrations/002-b.cjs'),
+      `'use strict';\nmodule.exports = { id: '002', description: 'fixed', run({ reportSkip }) { reportSkip(); } };\n`);
+    const second = run(migrate, project, { WORKFLOWS_MIGRATE_BASH: SYSTEM_BASH });
+    assert.strictEqual(second.status, 0, second.stderr);
+    const lines = second.stdout.split('\n');
+    const mi = lines.findIndex((l) => l.trim() === '---VERIFY_ADDENDA---');
+    assert.notStrictEqual(mi, -1, 'the recovered run emits the journal');
+    const addenda = JSON.parse(lines[mi + 1]);
+    assert.deepStrictEqual(addenda.map((a) => a.id), ['001'], "001's addendum survived the abort");
+    assert.ok(!fs.existsSync(path.join(project, '.workflows/.state/pending-verify.json')), 'journal cleared after emission');
+
+    const third = run(migrate, project, { WORKFLOWS_MIGRATE_BASH: SYSTEM_BASH });
+    assert.ok(!third.stdout.includes('---VERIFY_ADDENDA---'), 'emitted once, never again');
+  });
+
   it('emits no addenda when no executed migration declares verify', () => {
     const { migrate } = synthFleet({ '001-a.cjs': cjsMig('001'), '002-b.sh': shMig('002') });
     const project = freshProject();


### PR DESCRIPTION
Second audit fix layer (design: #668). The high-severity find: verification addenda were lost forever when a later migration aborted the run — the earlier migration's ID is recorded (never re-runs) but its addendum only flushed at the end of a successful main(). Addenda now journal durably to `.workflows/.state/pending-verify.json` as each migration records; a fully successful run emits the journal under the marker and clears it (orchestrator test pins abort → recover → emit-once). 054 parser hardening, each reproduced by the auditor: CRLF artifacts converted nothing silently (LF-anchored patterns) — now normalised; a `## Triage` inside a fenced example was treated as the section — now fence-aware; completed topics' knowledge-indexed artifacts were rewritten against the addendum's own 'leave them untouched' — now skipped via a direct manifest read (never `engine manifest`, per the migration rules); `reportUpdate` fires per converted file per the authoring contract. Plus the 053 header comment correction and Step 0.1 omitting the counts line when only verification changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)