### PR TITLE
fix(prose): correct runtime-misleading text found by the audit

### DIFF
--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -127,6 +127,11 @@ Across the family, the knowledge base is a derived index — its failures land i
 engine topic start <work-unit> <phase> <topic>
 engine topic triage <work-unit> <phase> <topic> [--concern <file> --slug <kebab> -m <message>]   # research|discussion only; parks a concern (bare) or delivers it into the triage queue, self-committing (delivery form)
 engine topic queue <work-unit> <phase> <topic>     # read the topic's triage queue — {"count": N, "files": [paths…]}; the engine owns the queue layout, so gates, drains, and resume detection ask instead of globbing
+engine topic complete <work-unit> <phase> <topic>
+engine topic reopen <work-unit> <phase> <topic>
+engine topic supersede <work-unit> <phase> <topic> --by <topic>
+engine topic cancel <work-unit> <phase> <topic>
+engine topic reactivate <work-unit> <phase> <topic>
 ```
 
 **`presence`** — the per-topic session heartbeat, cache-resident (`.workflows/.cache/{wu}/{phase}/{topic}/presence`, gitignored; mtime is the signal). Awareness, never mutual exclusion. `beat` refreshes it — session loops beat at their per-turn check; `clear` drops it — the concludes' orderly exit (a crashed session's heartbeat ages out instead). `scan` reads every heartbeat in the work unit with liveness applied (`live` when younger than `stale_after_seconds`, 900): response `{"live": N, "stale_after_seconds": 900, "sessions": [{phase, topic, age_seconds, live}…]}`, plus a `DISPLAY: presence deferral` section after the JSON line when anything is live — emitted verbatim only at the analysis-dispatch deferral its marker names. Consumers: the topic-discovery dispatch defers stale-cache analyses while a peer session is live; the conclude sweep leaves a live row's dirt alone and commits a dead session's leavings action-scoped.
@@ -135,11 +140,6 @@ engine topic queue <work-unit> <phase> <topic>     # read the topic's triage que
 engine presence beat <work-unit> <phase> <topic>    # research|discussion only
 engine presence clear <work-unit> <phase> <topic>
 engine presence scan <work-unit>
-engine topic complete <work-unit> <phase> <topic>
-engine topic reopen <work-unit> <phase> <topic>
-engine topic supersede <work-unit> <phase> <topic> --by <topic>
-engine topic cancel <work-unit> <phase> <topic>
-engine topic reactivate <work-unit> <phase> <topic>
 ```
 
 **`task`** — implementation-task bookkeeping: format-blind, manifest-side only. The engine never reads or writes a task backend and knows no plan-format names — the session does the plan surgery, these commands record it against `phases.implementation.items.{topic}`. Each command is load → apply → save plus one decision-ready JSON line followed by rendered gate sections; no git commit (the session's per-task commit cadence picks the manifest change up).

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -35,9 +35,8 @@ function resolveAddress(cwd, dotpath, surface) {
 // ---------------------------------------------------------------------------
 // resume-gate — the shared continue/restart gate over an in-progress phase
 // artifact. Address-backed; the artifact name is the phase segment. The
-// optional triage count is model-counted (the Triage section lives in the
-// artifact markdown, which the model has already read and the engine never
-// parses) and rides as a scalar flag.
+// optional triage count comes from the caller's `topic queue` read and
+// rides as a scalar flag.
 // ---------------------------------------------------------------------------
 
 const RESUME_MENU_INSTRUCTION = "emit verbatim as markdown, then STOP for the user's response";
@@ -137,8 +136,8 @@ function resumeGate(cwd, args) {
       'DISPLAY: triage warning',
       'emit verbatim as a code block, directly above the menu',
       callout([
-        `${n} rerouted concern(s) from other topics sit undrained in this`,
-        "file's Triage section. Restarting deletes them permanently.",
+        `${n} rerouted concern(s) from other topics wait in this topic's`,
+        'triage queue. Restart leaves them queued — they surface next session.',
       ]),
     ));
   }

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -17,7 +17,7 @@ A concern was rerouted into this topic after drain ran this session. It must be 
 > *Output the next fenced block as a code block:*
 
 ```
-  ⚑ Triage queue not empty — {count} rerouted concern(s) awaiting discussion.
+  ⚑ Triage queue not empty — {count} rerouted concern(s) awaiting exploration.
     Returning to the session to surface them before concluding.
 ```
 

--- a/skills/workflow-research-process/references/document-review.md
+++ b/skills/workflow-research-process/references/document-review.md
@@ -47,7 +47,7 @@ Walk the conversation against the document and check three dimensions:
 - Hallucination → remove or correct to match what was discussed
 - Drift → rewrite to faithfully reflect the conversation
 
-Commit the changes with a descriptive message (e.g., `docs(research): capture undocumented tradeoff thread`, `docs(research): correct drift on storage preference`).
+Commit the changes (`engine commit {work_unit} --topic research/{topic} -m "..."`) with a descriptive message (e.g., `docs(research): capture undocumented tradeoff thread`, `docs(research): correct drift on storage preference`).
 
 → Proceed to **C. Brief the User**.
 

--- a/skills/workflow-research-process/references/topic-splitting.md
+++ b/skills/workflow-research-process/references/topic-splitting.md
@@ -57,6 +57,8 @@ Once all accepted threads have been processed, single commit covering the manife
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "research({work_unit}/{parent_topic}): split into {N} topic(s)"
 ```
 
+The work-unit scope is deliberate: a split writes the superseded parent and every new topic's file — no single `--topic` covers it.
+
 Then offer the user a choice of which topic to continue with:
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-shared/references/resume-detection.md
+++ b/skills/workflow-shared/references/resume-detection.md
@@ -6,7 +6,7 @@
 
 Read `{file}`.
 
-**If the topic has a triage queue with entries** (research and discussion artifacts only — `node .claude/skills/workflow-engine/scripts/engine.cjs topic queue {work_unit} {phase} {topic}`, `count` non-zero): they are concerns rerouted here from other topics — their origin sessions recorded them as landed. Restart preserves the queue (it is not a restart target), but the count belongs in the gate. Set `{N}` = `count` and pass `--triage {N}` below; omit the flag otherwise.
+**If `artifact` is `research` or `discussion`**, read the topic's triage queue — `node .claude/skills/workflow-engine/scripts/engine.cjs topic queue {work_unit} {artifact} {topic}`. When `count` is non-zero, the entries are concerns rerouted here from other topics — their origin sessions recorded them as landed. Restart preserves the queue (it is not a restart target), but the count belongs in the gate: set `{N}` = `count` and pass `--triage {N}` below. Omit the flag when the count is zero or the artifact has no queue.
 
 Render the gate:
 

--- a/skills/workflow-shared/references/triage-landing.md
+++ b/skills/workflow-shared/references/triage-landing.md
@@ -22,7 +22,7 @@ The caller provides these via context before loading:
 
 After return, the caller reads these from conversation memory:
 
-- `result` — `landed` (entry written; manifest/artefact ready for the caller's commit) or `cancelled` (the reroute was dropped or blocked; nothing written).
+- `result` — `landed` (concern delivered and committed by the engine) or `cancelled` (the reroute was dropped or blocked; nothing written).
 - `landed_topic` — the final target name (a new target may have been renamed during validation).
 
 ## Triage Entry Shape

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -107,8 +107,8 @@ describe('render resume-gate', () => {
     const out = renderSurface(dir, 'resume-gate', { dotpath: 'pay.discussion.auth-flow', triage: '3' });
     assert.ok(out.startsWith([
       '=== DISPLAY: triage warning (emit verbatim as a code block, directly above the menu) ===',
-      '  ⚑ 3 rerouted concern(s) from other topics sit undrained in this',
-      "    file's Triage section. Restarting deletes them permanently.",
+      "  ⚑ 3 rerouted concern(s) from other topics wait in this topic's",
+      '    triage queue. Restart leaves them queued — they surface next session.',
       '',
     ].join('\n')));
     assert.ok(out.includes('=== MENU: resume gate'));


### PR DESCRIPTION
Third audit fix layer (design: #668) — the findings where prose or engine-rendered text actively misleads at runtime: (1) the API reference's `presence` fence had swallowed five `topic` commands (my earlier insert landed inside the open fence) — restored to their family; (2) resume-detection's queue read used `{phase}`, a parameter no caller passes — every caller passes `artifact` — making the command unrunnable as written; now `{artifact}` with the research/discussion guard hoisted so investigation/specification callers skip the call; (3) the engine's resume-gate warning still said queued concerns 'sit undrained in this file's Triage section. Restarting deletes them permanently' — false on both counts since the sidecar; retexted with the render-surface test pin updated; (4) research's document review now commits `--topic research/{topic}` like its discussion twin (the unscoped form swept peer dirt — the exact hazard this stack removes); (5) topic-splitting's work-unit-scoped commit gains its stated justification (a split is genuinely multi-topic); (6) triage-landing's `result` contract stops promising 'ready for the caller's commit' — the engine already committed; (7) research's conclude callout says 'awaiting exploration' — 'discussion' read as the phase name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)