### PR TITLE
fix(prose): reroute, landing, and conclude polish from the audit

### DIFF
--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -50,22 +50,24 @@ Conclude this discussion and mark as completed?
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic discussion/{topic} --kb -m "discussion({work_unit}): complete {topic} discussion"
    ```
 
-Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
+   Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
 
-Then clear this session's presence and sweep for leavings:
+4. Clear this session's presence and sweep for leavings:
 
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs presence clear {work_unit} discussion {topic}
-git status --porcelain -- .workflows
-```
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs presence clear {work_unit} discussion {topic}
+   git status --porcelain -- .workflows
+   ```
 
-**If dirt remains under another topic's paths:** run `node .claude/skills/workflow-engine/scripts/engine.cjs presence scan {work_unit}`. Dirt under a `live` row's topic belongs to that session — leave it. For each dirty topic with no live presence — a crashed session's leavings — commit it action-scoped: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{dirty_topic} -m "chore({work_unit}/{dirty_topic}): sweep session leavings"`.
+   **If dirt remains under another topic's paths:** run `node .claude/skills/workflow-engine/scripts/engine.cjs presence scan {work_unit}`. Dirt under a `live` row's topic belongs to that session — leave it. For each dirty topic with no live presence — a crashed session's leavings — commit it action-scoped: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{dirty_topic} -m "chore({work_unit}/{dirty_topic}): sweep session leavings"`.
 
-4. Closing recap:
+   **Otherwise:** nothing to sweep — continue.
+
+5. Closing recap:
 
    → Load **[closing-recap.md](../../workflow-shared/references/closing-recap.md)** with phase = `discussion`, work_unit = `{work_unit}`, topic = `{topic}`.
 
-5. Hand off to the pipeline bridge:
+6. Hand off to the pipeline bridge:
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-discussion-process/references/off-topic-epic.md
+++ b/skills/workflow-discussion-process/references/off-topic-epic.md
@@ -53,6 +53,8 @@ Name it in passing as the landing happens — the user corrects you if you've mi
 
 **If genuinely ambiguous** — two or more plausible homes and the conversation doesn't settle it:
 
+Judge `landing_phase` from the concern's nature — an open question needing exploration → `research`; a decision needing making → `discussion` — and state the recommendation in the menu:
+
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
@@ -63,11 +65,9 @@ Where should "{concern}" land?
 - **`2`** — {candidate} [{lifecycle}]
 - **`n`/`new`** — Create a new topic for it
 
-It reads as {an open question — I'd land it research-side|a decision to make — I'd land it discussion-side}. Append a phase to override (e.g. `1 discussion`).
+It reads as {concern_nature:[an open question — I'd land it research-side|a decision to make — I'd land it discussion-side]}. Reply with an option, appending a phase to override (e.g. `1 discussion`).
 · · · · · · · · · · · ·
 ```
-
-Before rendering, judge `landing_phase` from the concern's nature: an open question needing exploration → `research`; a decision needing making → `discussion`. The menu states the recommendation.
 
 **STOP.** Wait for user response.
 
@@ -87,6 +87,8 @@ Nothing landed.
 
 **Otherwise:**
 
-The concern landed in `{landed_topic}`'s {landing_phase} triage queue — the delivery committed itself@if(reconcile_flagged), and `{landed_topic}`'s completed discussion is flagged to reconcile against the reopened research@endif. The current Discussion Map is unchanged — rerouting sends the concern away from this topic, it doesn't mark it.
+The concern landed in `{landed_topic}`'s `{landing_phase}` triage queue — the delivery committed itself. The current Discussion Map is unchanged — rerouting sends the concern away from this topic, it doesn't mark it.
+
+**If the response carried `reconcile_flagged`:** also tell the user `{landed_topic}`'s completed discussion is flagged to reconcile against the reopened research.
 
 → Return to caller for **B. Session Loop**.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -34,22 +34,24 @@ A concern was rerouted into this topic after drain ran this session. It must be 
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic research/{topic} --kb -m "research({work_unit}): complete {topic} research"
    ```
 
-Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
+   Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
 
-Then clear this session's presence and sweep for leavings:
+3. Clear this session's presence and sweep for leavings:
 
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs presence clear {work_unit} research {topic}
-git status --porcelain -- .workflows
-```
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs presence clear {work_unit} research {topic}
+   git status --porcelain -- .workflows
+   ```
 
-**If dirt remains under another topic's paths:** run `node .claude/skills/workflow-engine/scripts/engine.cjs presence scan {work_unit}`. Dirt under a `live` row's topic belongs to that session — leave it. For each dirty topic with no live presence — a crashed session's leavings — commit it action-scoped: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{dirty_topic} -m "chore({work_unit}/{dirty_topic}): sweep session leavings"`.
+   **If dirt remains under another topic's paths:** run `node .claude/skills/workflow-engine/scripts/engine.cjs presence scan {work_unit}`. Dirt under a `live` row's topic belongs to that session — leave it. For each dirty topic with no live presence — a crashed session's leavings — commit it action-scoped: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{dirty_topic} -m "chore({work_unit}/{dirty_topic}): sweep session leavings"`.
 
-3. Closing recap:
+   **Otherwise:** nothing to sweep — continue.
+
+4. Closing recap:
 
    → Load **[closing-recap.md](../../workflow-shared/references/closing-recap.md)** with phase = `research`, work_unit = `{work_unit}`, topic = `{topic}`.
 
-4. Closure signpost:
+5. Closure signpost:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -58,4 +60,4 @@ git status --porcelain -- .workflows
 > to make decisions about architecture and approach.
 ```
 
-5. Invoke `/workflow-bridge {work_unit} research`.
+6. Invoke `/workflow-bridge {work_unit} research`.

--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -58,16 +58,20 @@ When a concern surfaces that belongs to a *different* topic — raised in conver
    - **`1`** — {candidate} [{state}]
    - **`2`** — {candidate} [{state}]
    - **`n`/`new`** — Create a new topic for it
+
+   It reads as {concern_nature:[an open question — I'd land it research-side|a decision to make — I'd land it discussion-side]}. Reply with an option, appending a phase to override (e.g. `1 discussion`).
    · · · · · · · · · · · ·
    ```
 
    **STOP.** Wait for user response.
 
-   A chosen candidate is the target; `new` means propose a kebab-case name and confirm it. If the resolved target is the current topic, it's not a reroute — fold it into this research file as a thread and → Return to **B. Session Loop**.
+   A chosen candidate is the target; `new` means propose a kebab-case name and confirm it. A phase appended to the selection overrides `landing_phase`. If the resolved target is the current topic, it's not a reroute — fold it into this research file as a thread and → Return to **B. Session Loop**.
 
 2. Record the concern with the full context discussed about it as `concern` — the target topic picks it up cold.
 
-3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{concern}`, origin = `{topic}`, phase = `research`, landing_phase = `{landing_phase}`, date = `{today}`. If `result` is `cancelled`, nothing landed — → Return to **B. Session Loop**. Otherwise the concern landed in `{landed_topic}`'s {landing_phase} triage queue — the delivery committed itself@if(reconcile_flagged), and `{landed_topic}`'s completed discussion is flagged to reconcile against the reopened research@endif.
+3. Load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{concern}`, origin = `{topic}`, phase = `research`, landing_phase = `{landing_phase}`, date = `{today}`. If `result` is `cancelled`, nothing landed — → Return to **B. Session Loop**. Otherwise the concern landed in `{landed_topic}`'s `{landing_phase}` triage queue — the delivery committed itself.
+
+   **If the response carried `reconcile_flagged`:** also tell the user `{landed_topic}`'s completed discussion is flagged to reconcile against the reopened research.
 
 → Return to **B. Session Loop**.
 

--- a/skills/workflow-shared/references/create-discovery-topic.md
+++ b/skills/workflow-shared/references/create-discovery-topic.md
@@ -78,15 +78,25 @@ Assemble the call as follows:
 
 Single-quote any value containing characters zsh would interpret — backticks, `$`, `[]`, `{}`, `~` — so the shell passes it through literally.
 
-**If the response is `ok: false` naming an active duplicate:** the map moved since validation — a concurrent session landed the same name. Surface the engine's error verbatim, set `proposed_name` to the clashing name, and re-validate against the fresh map:
+#### If the response is `ok: false` naming an active duplicate
+
+The map moved since validation — a concurrent session landed the same name. Surface the engine's error verbatim, set `proposed_name` to the clashing name, and re-validate against the fresh map:
 
 → Return to **A. Validate the Name**.
 
-**If `phase` is set**, create the phase item:
+#### If `phase` is set
+
+Create the phase item:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} {phase} {created_topic}
 ```
+
+Set `result = created`. No commit here — the caller folds these writes into its own commit.
+
+→ Return to caller.
+
+#### Otherwise
 
 Set `result = created`. No commit here — the caller folds these writes into its own commit.
 

--- a/skills/workflow-shared/references/reconcile-advisory.md
+++ b/skills/workflow-shared/references/reconcile-advisory.md
@@ -40,7 +40,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_uni
 
 → Return to caller.
 
-#### If output is any other non-empty value (brief reconcile flagged)
+#### Otherwise (brief reconcile flagged)
 
 A discovery brief was written or regenerated after this work started. Surface a non-blocking advisory (never a STOP gate), re-read the regenerated brief into context, and clear the flag.
 

--- a/skills/workflow-shared/references/triage-landing.md
+++ b/skills/workflow-shared/references/triage-landing.md
@@ -92,9 +92,9 @@ One engine transaction owns the whole delivery: `topic triage` handles the item 
 2. Write the full entry (shape above) to `.workflows/.cache/{work_unit}/{phase}/{origin}/concern-{slug}.md` with the Write tool.
 3. Deliver:
 
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs topic triage {work_unit} {landing_phase} {target} --concern .workflows/.cache/{work_unit}/{phase}/{origin}/concern-{slug}.md --slug {slug} -m "{phase}({work_unit}/{origin}): reroute concern to {target}"
-```
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs topic triage {work_unit} {landing_phase} {target} --concern .workflows/.cache/{work_unit}/{phase}/{origin}/concern-{slug}.md --slug {slug} -m "{phase}({work_unit}/{origin}): reroute concern to {target}"
+   ```
 
 **If the response is `ok: false`:**
 
@@ -140,13 +140,13 @@ For `cancelled` (an engine transaction — it commits itself) — reactivate the
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reactivate {work_unit} {cancelled_phase} {target}
 ```
 
-If the response is `ok: false`, surface the engine's error verbatim and re-render this menu — the concern is still unlanded. Otherwise re-classify against the fresh state:
+If the response is `ok: false`, surface the engine's error verbatim and re-render this menu — the concern is still unlanded. Otherwise re-resolve against the fresh state:
 
 → Return to **A. Resolve the Target**.
 
 **If `elsewhere`:**
 
-Ask the user which topic the concern should land in, set `target` to their answer, and re-classify:
+Ask the user which topic the concern should land in, set `target` to their answer, and re-resolve:
 
 → Return to **A. Resolve the Target**.
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -83,13 +83,15 @@ Files were updated, or a migration handed over checks its code could not perform
 
    **If nothing changed** (the migrations skipped everything and verification found nothing to fix):
 
-> *Output the next fenced block as a code block:*
+   > *Output the next fenced block as a code block:*
 
-```
-All documents up to date.
-```
+   ```
+   All documents up to date.
+   ```
 
-   **Do not stop here.** → Proceed to **Step 0.2**.
+   **Do not stop here.** Nothing needs review.
+
+   → Proceed to **Step 0.2**.
 
 3. Write a brief natural language summary of what the migrations did — verification fixes included (e.g., "Restructured workflow directories, created manifest files, recovered a rerouted concern the converter missed"). Focus on the nature of the changes, not individual file paths — these are internal workflow state files.
 4. Display the summary (`{N}`/`{M}` come from `migrations.output`; when it reports no changes — verification fixes only — omit the counts line):


### PR DESCRIPTION
Fifth and final audit fix layer (design: #668) — the remaining conventions findings: reroute menus name the recommendation placeholder (`{concern_nature:[…|…]}`) with the phase-override grammar as the trailing prompt line and the judging prelude above the render it feeds; the research reroute menu gains the recommendation + override parity the discussion twin had; the `@if(reconcile_flagged)` directives in running prose become bold conditionals; the reconcile advisory's catch-all arm is `#### Otherwise`; triage-landing indents its delivery fence into its numbered item and routes with 're-resolve' matching the renamed section; create-discovery-topic's top-level bold conditionals become H4 with an explicit Otherwise tail; both concludes promote the presence-clear/sweep to a numbered step with an Otherwise arm (fixing the duplicate numbering the wedged prose caused); workflow-start's nothing-changed branch keeps its fence indented within its item and splits the do-not-stop line from its routing, mirroring its sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)