### PR TITLE
fix(prose): re-arm a settled subtopic to exploring at surface time

### DIFF
--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -63,6 +63,12 @@ Take the lowest-numbered concern still queued — or whichever the user asks for
 
 **STOP.** Wait for user response.
 
+**If `phase` is `discussion` and the concern's title names an existing subtopic in a settled state** (`decided` or `deferred`): the ground is reopening — re-arm it before the discussion starts, so the map tells the truth while the re-decision is live:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map set {work_unit} {topic} {title:(kebabcase)} exploring
+```
+
 Then discuss it as real session material: engage, challenge, connect it to what this topic has already decided. Control belongs to the conversation — this may take one exchange or many.
 
 **If the discussion reaches an outcome** — a decision, a direction, or the user explicitly parking it as a deferred thread:


### PR DESCRIPTION
Post-release fix from the prose runs against landed main: `discussion-redecision-lands-timeline` failed on both walkers because the surfacing loop lost the batch-era flip-to-`exploring` — the fold now happens after the discussion, so the only map write went `decided → decided` and every mid-session map read reported `all_decided: true` while settled ground was actively being re-decided (end state identical, which is why only the call-sequence invariants caught it; archives in the run report). The re-arm moves to where the ground actually reopens: drain-triage §C flips a surfaced concern's settled subtopic to `exploring` as its discussion opens (discussion phase only — research has no map, and new-ground concerns need nothing since the map never claims anything false about them); §D's fold still records the state the conversation reached. The redecision case passes unchanged — its invariants pin exactly the restored write. Built and gated entirely in a worktree; 1885/1885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)