### PR TITLE
test(prose): refresh the two continues cases and declare a wandered scope

### DIFF
--- a/tests/prose/cases/discussion-entry-seeds-from-carrier/case.json
+++ b/tests/prose/cases/discussion-entry-seeds-from-carrier/case.json
@@ -3,6 +3,7 @@
   "entry": "workflow-discussion-entry",
   "files": [
     "skills/workflow-discussion-entry/SKILL.md",
+    "skills/workflow-discussion-entry/references/gather-context.md",
     "skills/workflow-shared/references/framework.md",
     "skills/workflow-shared/references/instructions.md",
     "skills/workflow-shared/references/casing-conventions.md",

--- a/tests/prose/cases/start-continues-a-feature-into-discussion/assert.md
+++ b/tests/prose/cases/start-continues-a-feature-into-discussion/assert.md
@@ -43,8 +43,7 @@ EXPECTED WORLD — from a feature holding only its discovery carrier:
 
 - a discussion file at `.workflows/pay/discussion/pay.md` holding a
   Context section reflecting card payments at checkout via
-  the existing gateway account, and a terminal `## Triage` section
-  holding `(none)`
+  the existing gateway account; the topic's triage queue is empty
 - no decisions recorded in it — nothing has been discussed yet
 - the manifest holding an in-progress discussion for pay with its
   subtopics all pending; no discovery map item — a feature never gains

--- a/tests/prose/cases/start-continues-an-epic-into-discussion/assert.md
+++ b/tests/prose/cases/start-continues-an-epic-into-discussion/assert.md
@@ -30,9 +30,8 @@ The prose should have taken this path:
    for an epic
 9. the discussion is registered through the engine, the discussion
    file is created from the template with a Context drawn from the
-   brief and a terminal Triage section seeded as (none), initial
-   subtopics land on the discussion map, and the initialisation
-   commit closes the walk — the session is never opened with the user
+   brief, initial subtopics land on the discussion map, and the
+   initialisation commit closes the walk — the session is never opened with the user
 
 Further claims:
 


### PR DESCRIPTION
From the post-release prose runs: `start-continues-an-epic-into-discussion` and `start-continues-a-feature-into-discussion` failed as stale cases — both pinned the terminal `## Triage`/`(none)` section the sidecar removed from the templates. They were never walked before this sweep, so their pins outlived the #684 refresh that fixed their four siblings; both now assert the empty triage queue. Also declares `gather-context.md` in entry-seeds' file list — two cases' walkers read it on the entry path (resumes-review already declares it). No prose changes; 1885/1885.

🤖 Generated with [Claude Code](https://claude.com/claude-code)