### PR TITLE
fix(discovery): analyses end with a sweep commit — no dirty tree at the dashboard

### DIFF
--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -182,6 +182,20 @@ If a name appears in both `new_arrivals.research_analysis` and `new_arrivals.gap
 
 ## F. Return
 
+Analyses and their gates write state nothing self-commits — staging files and gate registrations (a deferred gate's pending candidates included), spent-state clears, cache files, manifest stamps, knowledge-store dirt. When at least one analysis dispatched this pass, sweep it:
+
+```bash
+git status --porcelain -- .workflows/{work_unit} .workflows/.knowledge
+```
+
+**If the tree is dirty:**
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): analysis run bookkeeping"
+```
+
+**Otherwise:** every write was already carried by a self-committing delivery — nothing to sweep.
+
 The caller reads `new_arrivals` from conversation memory:
 
 - **`workflow-continue-epic`** — passes `new_arrivals` to `epic-display-and-menu.md` for the callouts above the Discovery Map: `⚑ N new topics added to the map from {analysis}` for the topic analyses, and a reopened-topics callout for `coherence_analysis` (the tracker holds topics reopened by landed findings). Callouts are rendered once at this boot-up; subsequent boots without changes don't repeat them.

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -643,6 +643,12 @@ describe('pipeline simulation', () => {
     assert.strictEqual(specAdvisory.coherence_status, 'absent');
     assert.strictEqual(specAdvisory.coherence_pending, 0);
 
+    // The analysis pass ends with the host's sweep commit — stamp dirt
+    // (cache files, manifest) never survives to the dashboard render.
+    sim.run(['commit', wu, '-m', `discovery(${wu}): analysis run bookkeeping`]);
+    const postSweep = git(sim.dir, ['status', '--porcelain', '--', `.workflows/${wu}`, '.workflows/.knowledge']);
+    assert.strictEqual(postSweep.trim(), '', 'analysis sweep leaves a clean tree');
+
     // The drain re-concludes the reopened discussion; the corpus is back
     // above the floor and the 1-file stamp reads stale.
     sim.write(`.workflows/${wu}/discussion/alpha.md`,


### PR DESCRIPTION
The analysis fleet (research, gap, coherence) writes durable state nothing self-commits: staging files and gate registrations (a deferred gate's pending candidates included), spent-state clears from the K=0 arms, cache files, manifest stamps, knowledge-store dirt. The coherence gate's own commit runs before the stamp, so a processed pass still reached the epic menu with a dirty work tree (observed in the field on the fumi epic).

`topic-discovery.md` F. Return now sweeps whatever the pass left behind under one `discovery({wu}): analysis run bookkeeping` commit, guarded on at least one analysis having dispatched. The pipeline simulation pins the new sequence: after the boot-time stamp, the sweep commit leaves a clean tree.

Layer 1 of 4 of the cross-topic decision propagation work (idea #41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)