### PR TITLE
fix(discussion): initialization never seeds subtopics from the triage queue

### DIFF
--- a/skills/workflow-discussion-process/references/initialize-discussion.md
+++ b/skills/workflow-discussion-process/references/initialize-discussion.md
@@ -26,6 +26,8 @@ Whatever those loads returned — a seed, a brief, the handoff's carrier descrip
 
    Populate from the seed, handoff context, and user input. Derive initial subtopics from whatever context is available — the seed, the user's description, the topic itself, obvious architectural concerns. These are seeds, not a complete list — the map grows during discussion.
 
+   Either way, the triage queue is never a seeding source: parked concerns enter through the session drain — surfaced whole and discussed — and pre-adding their titles to the map forces every fold into the wrong branch.
+
 5. Seed the Discussion Map — record each initial subtopic (kebab-case name; new subtopics start `pending`):
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map add {work_unit} {topic} {subtopic}


### PR DESCRIPTION
Found by the drains-a-full-agenda first walk: the walker pre-added the parked concerns' titles to the map at initialization, forcing both folds into the add-refuses branch. The SKILL's triaged arm already says parked concerns are untouched by initialization; the seeding step now says it where the seeding happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)