### PR TITLE
fix(surfacing): quoted markdown renders as markdown, not a code block

### DIFF
--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -90,12 +90,12 @@ Take the next unhandled note. Handled-ness lives in the walk and is recoverable 
 
 Judge the target topic from the note's own addressing, and judge `landing_phase` from its nature — an open question needing exploration → `research`; a correction or decision owed → `discussion`. Present it:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 {the note, quoted}
 
-  Addressed to: {target} — lands in its {landing_phase} triage queue
+*Addressed to: {target} — lands in its {landing_phase} triage queue*
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-research-process/references/document-review.md
+++ b/skills/workflow-research-process/references/document-review.md
@@ -78,12 +78,12 @@ Take the next unhandled note. Handled-ness lives in the walk and is recoverable 
 
 Judge the target topic from the note's own addressing, and judge `landing_phase` from its nature — an open question needing exploration → `research`; a correction or decision owed → `discussion`. Present it:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 {the note, quoted}
 
-  Addressed to: {target} — lands in its {landing_phase} triage queue
+*Addressed to: {target} — lands in its {landing_phase} triage queue*
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-shared/references/drain-triage.md
+++ b/skills/workflow-shared/references/drain-triage.md
@@ -59,7 +59,7 @@ The agenda is the whole entry pass — the session loop's check (**F. Mid-Sessio
 
 ## C. Surface One Concern
 
-Take the lowest-numbered concern still queued — or whichever the user asks for. Present it whole: name its origin in a sentence, then emit the file's full content verbatim as a code block (with a rendering instruction) — the origin session carried everything it worked out, and the user decides from the substance, never from the title.
+Take the lowest-numbered concern still queued — or whichever the user asks for. Present it whole: name its origin in a sentence, then emit the file's full content verbatim as markdown (not a code block) — the entry is markdown and renders as such; the origin session carried everything it worked out, and the user decides from the substance, never from the title.
 
 **STOP.** Wait for user response.
 


### PR DESCRIPTION
A triage concern entry and a carry-note are markdown — H3 title, italic provenance, body paragraphs, often blockquotes — and the code-block emission showed all of it as raw syntax (observed live). The drain's surface and both document-review note gates now use the established `verbatim as markdown (not a code block)` emission form. Composed status displays (agendas, the coherence finding render) stay code blocks — indented alignment is what fences are for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)