### PR TITLE
fix(triage): the arming step names its state read

### DIFF
--- a/skills/workflow-shared/references/rerouted-concerns.md
+++ b/skills/workflow-shared/references/rerouted-concerns.md
@@ -96,7 +96,13 @@ No opt-in. The check re-offers at a later break; the conclusion gate holds regar
 
 Take the lowest-numbered concern still queued — or whichever the user asks for.
 
-**If `phase` is `discussion`, arm the Discussion Map first** — the map tells the truth while the concern is live. Route on the subtopic the concern's title names (`{title:(kebabcase)}`), noting its prior state for the fold:
+**If `phase` is `discussion`, arm the Discussion Map first** — the map tells the truth while the concern is live. Read the subtopic states:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} subtopics
+```
+
+Route on the subtopic the concern's title names (`{title:(kebabcase)}`), noting its prior state for the fold:
 
 - Not on the map — new ground. Add it, then arm it:
 


### PR DESCRIPTION
First of two walk-finding fixes from the triage prose-test run.

The raise's map arming routed on "the subtopic the concern's title names, noting its prior state" without naming a read — a walker improvised and reached for a `discussion-map get` verb that doesn't exist before self-correcting to the manifest read. The arming block now states the read (`engine manifest get {wu}.discussion.{topic} subtopics`) ahead of the routing bullets, per the command-prelude convention.

`npm test` — 1896 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)