### PR TITLE
fix(entry): the brief is read once, at Gather Context

### DIFF
--- a/skills/workflow-discussion-process/references/initialize-discussion.md
+++ b/skills/workflow-discussion-process/references/initialize-discussion.md
@@ -6,9 +6,7 @@
 
 → Load **[seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
 
-→ Load **[read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
-
-Whatever those loads returned — a seed, a brief, the handoff's carrier description — is this discussion's **inherited position**, not a list of questions to re-ask. Decisions discovery already reached with the user carry forward as working ground: record them, build on them, let this discussion's own findings test them. Softness means such a decision *can* move when something surfaced here contradicts it, or when the user reopens it — never that it gets re-elicited on entry. Re-running settled scope as a fresh options weigh-up spends the user's time on ground they covered and puts alternatives they already rejected back into the document as live material.
+The seed just read, the brief or carrier the entry skill read at Gather Context, and the handoff's description are this discussion's **inherited position**, not a list of questions to re-ask. Decisions discovery already reached with the user carry forward as working ground: record them, build on them, let this discussion's own findings test them. Softness means such a decision *can* move when something surfaced here contradicts it, or when the user reopens it — never that it gets re-elicited on entry. Re-running settled scope as a fresh options weigh-up spends the user's time on ground they covered and puts alternatives they already rejected back into the document as live material.
 
 1. Ensure the discussion directory exists: `.workflows/{work_unit}/discussion/`
 2. Register the discussion in the manifest (the map commands below require the item to exist):

--- a/skills/workflow-research-process/references/initialize-research.md
+++ b/skills/workflow-research-process/references/initialize-research.md
@@ -6,12 +6,10 @@
 
 → Load **[seed-context.md](../../workflow-shared/references/seed-context.md)** and follow its instructions as written.
 
-→ Load **[read-brief-context.md](../../workflow-shared/references/read-brief-context.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`.
-
-Whatever those loads returned — a seed, a brief, the handoff's carrier description — is inherited ground, not a list of questions to re-ask. Exploring adjacent territory is this phase's job; putting a decision discovery already reached back to the user as an open question is not. Where exploration turns up something that genuinely undercuts one, surface that as a finding rather than reopening the decision.
+The seed just read, the brief or carrier the entry skill read at Gather Context, and the handoff's description are inherited ground, not a list of questions to re-ask. Exploring adjacent territory is this phase's job; putting a decision discovery already reached back to the user as an open question is not. Where exploration turns up something that genuinely undercuts one, surface that as a finding rather than reopening the decision.
 
 1. Load **[template.md](template.md)** — use it to create the research file at the Output path from the handoff (e.g., `.workflows/{work_unit}/research/{resolved_filename}`). When the file already exists, keep its content and write the template's working sections around it.
-2. Populate the Starting Point section from whatever seeded this phase: the handoff's `Context:` fields when the interview ran, otherwise the carrier just read — the brief or the seed — and the handoff's `Description:`. When restarting (the handoff carries `Source: existing research`), leave the section empty — the session gathers context naturally.
+2. Populate the Starting Point section from whatever seeded this phase: the handoff's `Context:` fields when the interview ran, otherwise the carrier in context — the brief the entry read, or the seed — and the handoff's `Description:`. When restarting (the handoff carries `Source: existing research`), leave the section empty — the session gathers context naturally.
 3. Register in manifest:
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} research {topic}

--- a/skills/workflow-shared/references/read-brief-context.md
+++ b/skills/workflow-shared/references/read-brief-context.md
@@ -1,6 +1,6 @@
 # Read the Topic's Discovery Brief
 
-*Shared reference for the research and discussion entry and processing skills.*
+*Shared reference. Loaded by the research and discussion entry skills at Gather Context, and by the reconcile advisory over a regenerated brief.*
 
 ---
 

--- a/tests/prose/cases/research-initialises-from-the-brief/assert.md
+++ b/tests/prose/cases/research-initialises-from-the-brief/assert.md
@@ -18,9 +18,10 @@ The prose should have taken this path:
    — a fresh start, no resume choice
 7. initialisation reads the work's seed and no-ops — an epic's seed
    surfaces per topic through the knowledge base, not here; the brief
-   read repeats idempotently; the research file is created from the
-   template, its Starting Point populated from the brief-fed context;
-   the topic is registered through the engine and one commit lands
+   is already in context from the entry's read and is not re-read; the
+   research file is created from the template, its Starting Point
+   populated from the brief-fed context; the topic is registered
+   through the engine and one commit lands
 8. the walk stops there — no knowledge query runs, and the research
    session never starts
 

--- a/tests/prose/cases/start-continues-an-epic-into-discussion/assert.md
+++ b/tests/prose/cases/start-continues-an-epic-into-discussion/assert.md
@@ -24,10 +24,11 @@ The prose should have taken this path:
    unit, and the topic
 7. discussion entry validates a fresh phase — status reads empty — and
    the discovery item already exists, so nothing is added to the map;
-   the handoff carries the work into the processing skill
-8. initialisation reads the topic's brief pointer and the brief file
-   in full, then records brief_incorporated; the seed reference no-ops
-   for an epic
+   its Gather Context reads the topic's brief pointer and the brief
+   file in full and records brief_incorporated; the handoff carries
+   the work into the processing skill
+8. initialisation inherits the brief already in context — the read is
+   not repeated — and the seed reference no-ops for an epic
 9. the discussion is registered through the engine, the discussion
    file is created from the template with a Context drawn from the
    brief, initial subtopics land on the discussion map, and the


### PR DESCRIPTION
Second walk-finding fix, stacked on the arming-read PR.

Both process inits re-loaded `read-brief-context.md` after the entry skill had already read the brief and set `brief_incorporated` at Gather Context — a full duplicate brief read plus an idempotent duplicate manifest write in every discussion/research session (surfaced as walk noise in two of the four triage walks). 

- `initialize-discussion.md` / `initialize-research.md` drop the load and inherit the entry's read; their inherited-position prose names the entry's Gather Context as the source.
- `read-brief-context.md`'s attribution now names its real callers: the two entry skills and the reconcile advisory (which legitimately re-reads a regenerated brief).
- The two case asserts that narrated the repeat (`start-continues-an-epic-into-discussion`, `research-initialises-from-the-brief`) are re-pinned; their invariant pins were always the entry-side sequence and are untouched.
- `brief_incorporated` has no readers anywhere in the codebase — the entry-side write fully preserves the tracking.

`npm test` — 1896 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)