### PR TITLE
fix(instructions): artifacts stay in-world — the pipeline is not the topic

### DIFF
--- a/skills/workflow-shared/references/instructions.md
+++ b/skills/workflow-shared/references/instructions.md
@@ -16,6 +16,7 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 - Failure mode — "the user already set this, confirmation is redundant" (e.g. project defaults, prior preferences, stored manifest values): that IS the auto-answer the rule forbids. Stored values are suggestions, not consent for this run.
 - Don't invent stops. Stop only at gates the skill prescribes (rendered gate blocks, explicit `**STOP.**` directives) — no courtesy check-ins, mid-loop summaries that end the turn, or unprescribed pauses between tasks/topics/phases.
 - Don't invent approvals. A gate's consent covers only material already surfaced at that gate — never solicit approval that spans gates not yet reached ("shall I do all N?"), and never treat an answer to such a question as consent for unseen items. A question broad enough to pre-answer a later STOP is the same violation as skipping it.
+- Work artifacts record their topic's substance — never the workflow around them. Beyond the markers a flow prescribes (provenance lines, `Sibling check:`, finding ids, revision timestamps), no process observations, documentation conventions, or lessons about how a session ran land in an artifact: the pipeline is not the topic.
 - After rendering a gate block, the turn MUST end. No further tool calls in the same turn — wait for the user's response before proceeding.
 - Complete each step fully before moving to the next
 

--- a/skills/workflow-shared/references/rerouted-concerns.md
+++ b/skills/workflow-shared/references/rerouted-concerns.md
@@ -147,7 +147,7 @@ The concern stays queued, untouched, and the opt-in is cleared. Follow them; the
 
 Record the discussion in the topic's content. An outcome that re-decides ground this topic didn't introduce — it names an entity, field, rule, or classification this topic's artifact didn't define — requires the sibling consult before it is recorded: follow **G. Sibling consult at cross-topic decision points** in **[knowledge-usage.md](../../workflow-knowledge/references/knowledge-usage.md)** — query or cite, and carry the `Sibling check:` line in the recorded decision.
 
-A cross-topic correction tempts meta — rules about how to cite, edit, or point between documents, lessons about how the topics drifted. None of it lands: the fold records what changed and why in the topic's own terms; the pipeline is not the topic.
+A cross-topic correction tempts you to write guidance about the documents themselves. Do not: never write rules for how documents cite, edit, or point at each other, and never write lessons about how the topics drifted apart. The fold records only what changed and why, in the topic's own terms.
 
 #### If `phase` is `discussion`
 

--- a/skills/workflow-shared/references/rerouted-concerns.md
+++ b/skills/workflow-shared/references/rerouted-concerns.md
@@ -147,6 +147,8 @@ The concern stays queued, untouched, and the opt-in is cleared. Follow them; the
 
 Record the discussion in the topic's content. An outcome that re-decides ground this topic didn't introduce — it names an entity, field, rule, or classification this topic's artifact didn't define — requires the sibling consult before it is recorded: follow **G. Sibling consult at cross-topic decision points** in **[knowledge-usage.md](../../workflow-knowledge/references/knowledge-usage.md)** — query or cite, and carry the `Sibling check:` line in the recorded decision.
 
+A cross-topic correction tempts meta — rules about how to cite, edit, or point between documents, lessons about how the topics drifted. None of it lands: the fold records what changed and why in the topic's own terms; the pipeline is not the topic.
+
 #### If `phase` is `discussion`
 
 Write the concern into its armed subtopic:


### PR DESCRIPTION
From the third live triage session (Fumi, note-model): while folding a cross-topic correction, the model proposed — and briefly wrote — a documentation-methodology rule and a process Key Insight into the product discussion document. Artifacts feed the spec, so pipeline meta becomes spec noise. No existing rule forbade it: `voice.md` explicitly governs turns and leaves artifact prose alone, State Ownership bans state (not meta), and the templates define shape, not content scope.

## Changes

- **`instructions.md`** (framework-loaded into every flow skill) gains the universal rule: work artifacts record their topic's substance, never the workflow around them — the flow's own prescribed markers (provenance lines, `Sibling check:`, finding ids, revision timestamps) excepted; no process observations, documentation conventions, or lessons about how a session ran.
- **`rerouted-concerns.md` D. Fold** gains the scoped application at the point it bit: a cross-topic correction tempts exactly this meta ("how to cite, how to point between documents"), and the fold records what changed in the topic's own terms.

## Tests

`npm test` — 1897 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)