### PR TITLE
refactor(engine): one home for the pipeline tables

### DIFF
--- a/skills/workflow-bridge/scripts/gateway.cjs
+++ b/skills/workflow-bridge/scripts/gateway.cjs
@@ -5,7 +5,7 @@ const engine = require('../../workflow-engine/scripts/lib.cjs');
 const { loadManifest, fileExists, listFiles, listDirs } = engine.reads;
 const { phaseStatus, computeNextPhase } = engine.derivations;
 
-const ALL_PHASES = ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
+const ALL_PHASES = engine.schema.VALID_PHASES.filter((p) => p !== 'discovery');
 
 function phaseFileExists(cwd, workUnit, phase, manifest) {
   const dir = path.join(cwd, '.workflows', workUnit, phase);

--- a/skills/workflow-engine/scripts/domain/epic-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/epic-detail.cjs
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------------
 
 const path = require('path');
+const { WORK_TYPE_PIPELINES } = require('../kernel/manifest-schema.cjs');
 const {
   phaseItems,
   computeAnalysisCacheStatus,
@@ -19,11 +20,9 @@ const {
 } = require('./derivations.cjs');
 
 // Every phase the epic detail iterates and the epic dashboard / thin dump
-// surface — discovery (the map) first, then the pipeline. The pipeline-only
-// view (research → review, for completion / next-phase and the start
-// dashboard) is domain/start.cjs's EPIC_PIPELINE_PHASES, derived from this
-// minus discovery — discovery is the map, not a pipeline phase.
-const EPIC_DETAIL_PHASES = ['discovery', 'research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
+// surface — discovery (the map, not a pipeline phase) first, then the epic
+// pipeline from the schema's one home for pipeline order.
+const EPIC_DETAIL_PHASES = ['discovery', ...WORK_TYPE_PIPELINES.epic];
 
 /**
  * @typedef {object} SpecSource

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -11,6 +11,7 @@
 // ---------------------------------------------------------------------------
 
 const { signpost, box, renderTree, wrap } = require('../../kernel/render.cjs');
+const { WORK_TYPE_PIPELINES } = require('../../kernel/manifest-schema.cjs');
 const { TREE_WIDTH, treeHeader, titlecase, title, derivedFrom, discoveryGlyph, discoveryLifecycleLabel } = require('../conventions.cjs');
 const { section, dotFrame, cmdOption, callout } = require('./surfaces.cjs');
 const { fmtAge } = require('../presence.cjs');
@@ -46,13 +47,27 @@ const { fmtAge } = require('../presence.cjs');
 
 /** @typedef {import('../presence.cjs').PresenceRow} PresenceRow */
 
-const BUILD_PHASES = ['specification', 'planning', 'implementation', 'review'];
+const EPIC_PIPELINE = WORK_TYPE_PIPELINES.epic;
 
-const STAGES = [
-  { name: 'DISCOVERY', phases: ['research', 'discussion'] },
-  { name: 'DEFINITION', phases: ['specification', 'planning'] },
-  { name: 'DELIVERY', phases: ['implementation', 'review'] },
-];
+const BUILD_PHASES = EPIC_PIPELINE.slice(EPIC_PIPELINE.indexOf('specification'));
+
+// The three-D stage each pipeline phase renders under. STAGES groups the epic
+// pipeline in order by this labelling, so the dividers can never hold a phase
+// the pipeline lacks.
+const STAGE_OF = {
+  research: 'DISCOVERY', discussion: 'DISCOVERY',
+  specification: 'DEFINITION', planning: 'DEFINITION',
+  implementation: 'DELIVERY', review: 'DELIVERY',
+};
+
+/** @type {{name: string, phases: string[]}[]} */
+const STAGES = EPIC_PIPELINE.reduce((/** @type {{name: string, phases: string[]}[]} */ stages, phase) => {
+  const name = STAGE_OF[/** @type {keyof typeof STAGE_OF} */ (phase)];
+  const last = stages[stages.length - 1];
+  if (last && last.name === name) last.phases.push(phase);
+  else stages.push({ name, phases: [phase] });
+  return stages;
+}, []);
 
 const STATUS_ORDER = ['proposed', 'triaged', 'in-progress', 'completed', 'cancelled', 'promoted'];
 
@@ -653,7 +668,7 @@ function epicMenu(workUnit, detail, opts = {}) {
     }
   } else {
     // Continue items — any in-progress item in any phase, pipeline order.
-    for (const phase of ['research', 'discussion', ...BUILD_PHASES]) {
+    for (const phase of EPIC_PIPELINE) {
       numbered.push(...continueEntries(workUnit, detail, phase));
     }
     // Next-phase-ready items — specification first, then planning,

--- a/skills/workflow-engine/scripts/domain/start.cjs
+++ b/skills/workflow-engine/scripts/domain/start.cjs
@@ -19,29 +19,23 @@ const {
   computeUnitPhaseState,
   lastCompletedPhase,
 } = require('./derivations.cjs');
-const { WORK_UNIT_TYPES } = require('./workunit-detail.cjs');
-const { EPIC_DETAIL_PHASES } = require('./epic-detail.cjs');
+const { WORK_TYPE_PIPELINES, VALID_PHASES } = require('../kernel/manifest-schema.cjs');
 
 // The epic pipeline — research → review, the completion / next-phase pipeline
-// and the start dashboard's active-phase row. Derived from epic-detail's full
-// EPIC_DETAIL_PHASES minus discovery (the map, not a pipeline phase) so the two
-// lists can never drift.
-const EPIC_PIPELINE_PHASES = EPIC_DETAIL_PHASES.filter((p) => p !== 'discovery');
+// and the start dashboard's active-phase row.
+const EPIC_PIPELINE_PHASES = WORK_TYPE_PIPELINES.epic;
 
-const ALL_PHASES = ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
+// Every pipeline phase across all work types — the closed-unit last-phase scan.
+const ALL_PHASES = VALID_PHASES.filter((p) => p !== 'discovery');
 
 /**
- * The type's pipeline phases — the same per-type list the work-unit detail
- * builders derive from, so the two surfaces can never disagree. Epic uses its
- * own phase list; an unknown type (grouped with features) falls back to every
- * phase.
+ * The type's pipeline phases, from the schema's one home for pipeline order.
+ * An unknown type (grouped with features) falls back to every phase.
  * @param {string} workType
  * @returns {string[]}
  */
 function pipelineOf(workType) {
-  if (workType === 'epic') return EPIC_PIPELINE_PHASES;
-  const cfg = WORK_UNIT_TYPES[workType];
-  return cfg ? cfg.pipeline : ALL_PHASES;
+  return WORK_TYPE_PIPELINES[/** @type {keyof typeof WORK_TYPE_PIPELINES} */ (workType)] || ALL_PHASES;
 }
 
 /**

--- a/skills/workflow-engine/scripts/domain/workunit-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-detail.cjs
@@ -13,6 +13,7 @@
 // ---------------------------------------------------------------------------
 
 const { loadActiveManifests, loadAllManifests } = require('./reads.cjs');
+const { WORK_TYPE_PIPELINES } = require('../kernel/manifest-schema.cjs');
 const {
   phaseStatus,
   computeUnitPhaseState,
@@ -38,7 +39,7 @@ const WORK_UNIT_TYPES = {
     header: 'FEATURES',
     nounPlural: 'features',
     nounCounted: 'feature(s)',
-    pipeline: ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'],
+    pipeline: WORK_TYPE_PIPELINES.feature,
     surfacesSeeds: true,
   },
   bugfix: {
@@ -47,7 +48,7 @@ const WORK_UNIT_TYPES = {
     header: 'BUGFIXES',
     nounPlural: 'bugfixes',
     nounCounted: 'bugfix(es)',
-    pipeline: ['investigation', 'specification', 'planning', 'implementation', 'review'],
+    pipeline: WORK_TYPE_PIPELINES.bugfix,
     surfacesSeeds: false,
   },
   'quick-fix': {
@@ -56,7 +57,7 @@ const WORK_UNIT_TYPES = {
     header: 'QUICK-FIXES',
     nounPlural: 'quick-fixes',
     nounCounted: 'quick-fix(es)',
-    pipeline: ['scoping', 'implementation', 'review'],
+    pipeline: WORK_TYPE_PIPELINES['quick-fix'],
     surfacesSeeds: false,
   },
   'cross-cutting': {
@@ -65,7 +66,7 @@ const WORK_UNIT_TYPES = {
     header: 'CROSS-CUTTING',
     nounPlural: 'cross-cutting concerns',
     nounCounted: 'cross-cutting concern(s)',
-    pipeline: ['research', 'discussion', 'specification'],
+    pipeline: WORK_TYPE_PIPELINES['cross-cutting'],
     surfacesSeeds: false,
   },
 };

--- a/skills/workflow-engine/scripts/kernel/manifest-schema.cjs
+++ b/skills/workflow-engine/scripts/kernel/manifest-schema.cjs
@@ -18,6 +18,19 @@ const VALID_PHASES = [
   'review'
 ];
 
+// Per-work-type pipeline order — the phases a unit of that type moves through
+// after discovery (the universal first phase; a map, not a pipeline phase, so
+// it never appears here). The one home for pipeline order: detail builders,
+// dashboards, gateways, and the simulation all read these arrays, never a
+// local copy.
+const WORK_TYPE_PIPELINES = {
+  epic:            ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'],
+  feature:         ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'],
+  bugfix:          ['investigation', 'specification', 'planning', 'implementation', 'review'],
+  'quick-fix':     ['scoping', 'implementation', 'review'],
+  'cross-cutting': ['research', 'discussion', 'specification'],
+};
+
 const VALID_PHASE_STATUSES = {
   // Empty on purpose, never removed: discovery items are map items with NO
   // status field (lifecycle is computed at render time), and an empty
@@ -51,6 +64,7 @@ const RESERVED_WORK_UNIT_NAMES = ['project'];
 module.exports = {
   VALID_WORK_TYPES,
   VALID_PHASES,
+  WORK_TYPE_PIPELINES,
   VALID_PHASE_STATUSES,
   VALID_ROUTINGS,
   VALID_GATE_MODES,

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -8,6 +8,7 @@
 // Rings:
 //   engine.render         kernel — pure layout (no workflow vocabulary)
 //   engine.manifest       kernel — work-unit manifest IO (load / atomic save)
+//   engine.schema         kernel — manifest vocabulary (phases, per-type pipelines)
 //   engine.conventions    domain — workflow glyphs, tags, title composition
 //   engine.reads          domain — generic manifest/file reads (no phase semantics)
 //   engine.derivations    domain — shared derivations (phase joins, lifecycle, cache status)
@@ -22,6 +23,7 @@
 
 const render = require('./kernel/render.cjs');
 const manifest = require('./kernel/manifest.cjs');
+const schema = require('./kernel/manifest-schema.cjs');
 const conventions = require('./domain/conventions.cjs');
 const reads = require('./domain/reads.cjs');
 const derivations = require('./domain/derivations.cjs');
@@ -48,6 +50,10 @@ module.exports = {
   manifest,
   conventions,
   gateway,
+  schema: {
+    VALID_PHASES: schema.VALID_PHASES,
+    WORK_TYPE_PIPELINES: schema.WORK_TYPE_PIPELINES,
+  },
   reads: {
     listFiles: reads.listFiles,
     listDirs: reads.listDirs,

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -33,16 +33,11 @@ const ENGINE = path.join(ROOT, 'skills/workflow-engine/scripts/engine.cjs');
 
 const schema = require(path.join(ROOT, 'skills/workflow-engine/scripts/kernel/manifest-schema.cjs'));
 const derivations = require(path.join(ROOT, 'skills/workflow-engine/scripts/domain/derivations.cjs'));
-const { WORK_UNIT_TYPES } = require(path.join(ROOT, 'skills/workflow-engine/scripts/domain/workunit-detail.cjs'));
 
 // The same per-type pipeline the start dashboard derives from (start.cjs
-// pipelineOf): epics use the epic phase list minus discovery.
+// pipelineOf): the schema's one home for pipeline order.
 function pipelineOf(workType) {
-  if (workType === 'epic') {
-    return ['research', 'discussion', 'specification', 'planning', 'implementation', 'review'];
-  }
-  const cfg = WORK_UNIT_TYPES[workType];
-  return cfg ? cfg.pipeline : schema.VALID_PHASES.filter((p) => p !== 'discovery');
+  return schema.WORK_TYPE_PIPELINES[workType] || schema.VALID_PHASES.filter((p) => p !== 'discovery');
 }
 
 const GATEWAYS = {


### PR DESCRIPTION
Pure refactor, zero behavioural change — PR 1 of the staleness-hops stack (ideas #40 + #26).

Per-work-type pipeline order moves to `kernel/manifest-schema.cjs` as `WORK_TYPE_PIPELINES` (epic included) — the schema was already the stated single source of legal phases/statuses; now it owns pipeline order too. Consumers import it instead of holding copies:

- `workunit-detail.cjs` — the four `WORK_UNIT_TYPES` pipelines
- `start.cjs` — `EPIC_PIPELINE_PHASES`, `ALL_PHASES` (derived from `VALID_PHASES`), `pipelineOf`
- `epic-detail.cjs` — `EPIC_DETAIL_PHASES` = discovery + the epic pipeline
- `workflow-bridge/scripts/gateway.cjs` — phase scan via a new `engine.schema` lib ring
- `projections/epic.cjs` — `BUILD_PHASES` sliced from the pipeline; `STAGES` grouped from it by stage labelling
- simulation's test-local `pipelineOf`

Gate: full `npm test` (1920), `npm run test:cli`, `npm run typecheck` — all green with zero diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)