### PR TITLE
feat(engine): read side — reconcile routing override and render cues

### DIFF
--- a/skills/workflow-bridge/scripts/gateway.cjs
+++ b/skills/workflow-bridge/scripts/gateway.cjs
@@ -3,7 +3,7 @@
 const path = require('path');
 const engine = require('../../workflow-engine/scripts/lib.cjs');
 const { loadManifest, fileExists, listFiles, listDirs } = engine.reads;
-const { phaseStatus, computeNextPhase } = engine.derivations;
+const { phaseStatus, phaseItems, computeNextPhase } = engine.derivations;
 
 const ALL_PHASES = engine.schema.VALID_PHASES.filter((p) => p !== 'discovery');
 
@@ -36,12 +36,24 @@ function discover(cwd, workUnit) {
   const workType = manifest.work_type;
   const next_phase = computeNextPhase(manifest).next_phase;
 
+  // Completed items carrying a live reconcile flag — observability for the
+  // continuation prose (routing itself rides next_phase).
+  const reconcile_pending = [];
+  for (const phase of ALL_PHASES) {
+    for (const item of phaseItems(manifest, phase)) {
+      if (item.status === 'completed' && item.reconcile_needed !== undefined) {
+        reconcile_pending.push(`${phase}/${item.name} (${item.reconcile_needed})`);
+      }
+    }
+  }
+
   return {
     work_unit: workUnit,
     work_type: workType,
     status: manifest.status,
     phases,
     next_phase,
+    reconcile_pending,
   };
 }
 
@@ -61,6 +73,7 @@ function format(result) {
   lines.push(`=== ${result.work_unit} (${result.work_type}) ===`);
   lines.push(`next_phase: ${result.next_phase}`);
   lines.push(`completed_phases: ${completed.join(', ') || '(none)'}`);
+  lines.push(`reconcile_pending: ${(result.reconcile_pending || []).join(', ') || '(none)'}`);
 
   let section = '';
   if (engine.detail.WORK_UNIT_TYPES[result.work_type]) {

--- a/skills/workflow-engine/scripts/domain/derivations.cjs
+++ b/skills/workflow-engine/scripts/domain/derivations.cjs
@@ -9,6 +9,7 @@
 
 const path = require('path');
 const { fileExists, filesChecksum } = require('./reads.cjs');
+const { WORK_TYPE_PIPELINES } = require('../kernel/manifest-schema.cjs');
 
 function phaseStatus(manifest, phase) {
   const p = (manifest.phases || {})[phase] || {};
@@ -49,6 +50,25 @@ function computeNextPhase(manifest) {
   const wt = manifest.work_type;
 
   const ps = (phase) => phaseStatus(manifest, phase);
+
+  // A completed phase whose item carries a reconcile flag routes BACK to that
+  // phase for the linear types — routing forward past known-stale input is
+  // the bug this override closes, and it keeps the bridge off its terminal
+  // `done` branch while a flag is live. The walk stops at the first in-flight
+  // phase: an upstream mid-revision owns the next action, and its conclusion
+  // re-runs this. Epics are excluded — their next_phase is phase-coarse;
+  // flagged epic items get per-item cues instead.
+  if (wt !== 'epic') {
+    const pipeline = WORK_TYPE_PIPELINES[/** @type {keyof typeof WORK_TYPE_PIPELINES} */ (wt)] || [];
+    for (const phase of pipeline) {
+      if (ps(phase) === 'in-progress') break;
+      const flagged = phaseItems(manifest, phase)
+        .some((i) => i.status === 'completed' && i.reconcile_needed !== undefined);
+      if (flagged) {
+        return { next_phase: phase, phase_label: `${phase} (input moved — reconcile)` };
+      }
+    }
+  }
 
   // Quick-fix has its own short pipeline: scoping → implementation → review
   if (wt === 'quick-fix') {

--- a/skills/workflow-engine/scripts/domain/epic-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/epic-detail.cjs
@@ -42,6 +42,8 @@ const EPIC_DETAIL_PHASES = ['discovery', ...WORK_TYPE_PIPELINES.epic];
  * @typedef {object} PhaseEntry
  * @property {string} name
  * @property {string} status
+ * @property {string|boolean} [reconcile_needed]  a live reconcile flag — the upstream phase that
+ *                                             moved, or `true` for a brief flag
  * @property {SpecSource[]} [sources]          specification items
  * @property {string} [format]                 planning items
  * @property {boolean} [deps_satisfied]        planning items
@@ -205,6 +207,7 @@ function epicDetail(cwd, manifest) {
     for (const item of items) {
       /** @type {PhaseEntry} */
       const entry = { name: item.name, status: item.status || 'unknown' };
+      if (item.reconcile_needed !== undefined) entry.reconcile_needed = item.reconcile_needed;
 
       if (phase === 'specification' && item.sources) {
         const sourcesArr = Array.isArray(item.sources)

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -140,10 +140,13 @@ function displayOrder(phase, items) {
   return [...items.filter((i) => i.status === 'proposed'), ...items.filter((i) => i.status !== 'proposed')];
 }
 
-/** Build the tree nodes for one build/flat phase. @param {string} phase @param {PhaseEntry[]} items */
+/** Build the tree nodes for one build/flat phase — a completed item with a live reconcile flag carries the `· input moved` cue. @param {string} phase @param {PhaseEntry[]} items */
 function phaseNodes(phase, items) {
   return displayOrder(phase, items).map((item) => {
-    let head = title({ label: titlecase(item.name), tag: item.status });
+    const tagText = item.status === 'completed' && item.reconcile_needed !== undefined
+      ? 'completed · input moved'
+      : item.status;
+    let head = title({ label: titlecase(item.name), tag: tagText });
     if (phase === 'planning' && item.format) head += ` · ${item.format}`;
     /** @type {{title: string}[]} */
     const children = [];
@@ -375,6 +378,11 @@ const KEY_SESSION =
   '    Session:\n'
   + '      in session — a live session elsewhere holds this topic';
 
+const KEY_RECONCILE =
+  '    Cue:\n'
+  + '      input moved — an upstream artifact was revised since this item\n'
+  + '                    completed; the item\'s entry flow reconciles it';
+
 /**
  * Section B — the Key block, showing only categories present in the display.
  * Empty string for a brand-new epic (the key is skipped on that branch).
@@ -389,6 +397,11 @@ function epicKey(detail, opts = {}) {
 
   const anyBlocked = (detail.phases.planning || [])
     .some((p) => Array.isArray(p.deps_blocking) && p.deps_blocking.length > 0);
+  // The cue legend mirrors the display: with a map only build phases render
+  // item rows; without one every phase does.
+  const cuePhases = hasMap ? BUILD_PHASES : Object.keys(detail.phases);
+  const anyFlagged = cuePhases.some((p) => (detail.phases[p] || [])
+    .some((i) => i.status === 'completed' && i.reconcile_needed !== undefined));
   const blocks = [];
   if (hasMap) {
     blocks.push(KEY_TIER);
@@ -396,6 +409,7 @@ function epicKey(detail, opts = {}) {
   } else {
     blocks.push(KEY_STATUS);
   }
+  if (anyFlagged) blocks.push(KEY_RECONCILE);
   if (hasMap && heldSessions(opts.presence).length > 0) blocks.push(KEY_SESSION);
   if (anyBlocked) blocks.push(KEY_BLOCKING);
   return '  Key:\n' + blocks.join('\n\n');
@@ -429,27 +443,32 @@ function discoveryEntryLabel(action, name, researchState, triageParked) {
 /** @param {string} phase @param {PhaseEntry} item */
 function continueLabel(phase, item) {
   const t = titlecase(item.name);
+  let label;
   if (phase === 'implementation' && item.current_phase != null) {
     if (item.current_task) {
-      return `Continue "${t}" — implementation (Phase ${item.current_phase}, Task ${item.current_task})`;
+      label = `Continue "${t}" — implementation (Phase ${item.current_phase}, Task ${item.current_task})`;
+    } else {
+      const tasks = Array.isArray(item.completed_tasks) ? item.completed_tasks.length : 0;
+      label = `Continue "${t}" — implementation (Phase ${item.current_phase}, ${tasks} task(s) completed)`;
     }
-    const tasks = Array.isArray(item.completed_tasks) ? item.completed_tasks.length : 0;
-    return `Continue "${t}" — implementation (Phase ${item.current_phase}, ${tasks} task(s) completed)`;
+  } else {
+    label = `Continue "${t}" — ${phase} [in-progress]`;
   }
-  return `Continue "${t}" — ${phase} [in-progress]`;
+  return item.reconcile_needed !== undefined ? `${label} · input moved` : label;
 }
 
-/** @param {NextPhaseEntry} n */
-function startVerbLabel(n) {
+/** @param {NextPhaseEntry} n @param {boolean} [srcFlagged]  the entry's source item carries a live reconcile flag */
+function startVerbLabel(n, srcFlagged) {
   const t = titlecase(n.name);
+  const cue = srcFlagged ? ' · input moved' : '';
   if (n.action === 'start_implementation') {
     if (n.blocked) {
-      return `Start implementation of "${t}" — blocked by ${(n.deps_blocking || []).map(depRef).join(', ')}`;
+      return `Start implementation of "${t}" — blocked by ${(n.deps_blocking || []).map(depRef).join(', ')}${cue}`;
     }
-    return `Start implementation of "${t}" — ${n.label}`;
+    return `Start implementation of "${t}" — ${n.label}${cue}`;
   }
   const phase = ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (n.action)];
-  return `Start ${phase} for "${t}" — ${n.label}`;
+  return `Start ${phase} for "${t}" — ${n.label}${cue}`;
 }
 
 /** Continue entries for one phase's in-progress items. @param {string} workUnit @param {EpicDetail} detail @param {string} phase @returns {MenuKey[]} */
@@ -473,13 +492,18 @@ function startEntries(workUnit, detail, phase) {
     if (ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (n.action)] !== phase) continue;
     const gate = START_GATE[/** @type {keyof typeof START_GATE} */ (n.action)];
     if (gate && !detail.gating[/** @type {keyof EpicDetail['gating']} */ (gate)]) continue;
+    // The entry's source item is the previous pipeline phase's same-named
+    // item — a live reconcile flag there means starting forward propagates
+    // known-stale input, so the label carries the cue.
+    const srcPhase = EPIC_PIPELINE[EPIC_PIPELINE.indexOf(phase) - 1];
+    const srcItem = srcPhase ? (detail.phases[srcPhase] || []).find((i) => i.name === n.name) : undefined;
     /** @type {MenuKey} */
     const entry = {
       key: '',
       action: n.action,
       topic: n.name,
       route: topicRoute(n.action, workUnit, n.name),
-      label: startVerbLabel(n),
+      label: startVerbLabel(n, srcItem !== undefined && srcItem.reconcile_needed !== undefined),
     };
     if (n.blocked) {
       entry.blocked = true;

--- a/skills/workflow-engine/scripts/domain/projections/workunit.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/workunit.cjs
@@ -54,12 +54,14 @@ function nextPhaseStarted(unit) {
   return unit.phase_label.endsWith('(in-progress)');
 }
 
-/** Pipeline rows: completed phases, the next phase (in flight or ready), and any other phase in flight (a reopened phase mid-revisit is never dropped). @param {WorkUnitTypeConfig} cfg @param {WorkUnitEntry} unit */
+/** Pipeline rows: completed phases (an `· input moved` cue on flagged ones), the next phase (in flight or ready), and any other phase in flight (a reopened phase mid-revisit is never dropped). @param {WorkUnitTypeConfig} cfg @param {WorkUnitEntry} unit */
 function pipelineNodes(cfg, unit) {
+  const flaggedPhases = new Set((unit.reconcile_phases || []).map((r) => r.phase));
   const nodes = [];
   for (const phase of cfg.pipeline) {
     if (unit.completed_phases.includes(phase)) {
-      nodes.push({ title: title({ glyph: '✓', label: titlecase(phase), tag: 'completed' }) });
+      const tag = flaggedPhases.has(phase) ? 'completed · input moved' : 'completed';
+      nodes.push({ title: title({ glyph: '✓', label: titlecase(phase), tag }) });
     } else if (phase === unit.next_phase) {
       const started = nextPhaseStarted(unit);
       nodes.push({
@@ -94,6 +96,11 @@ function workUnitStatus(type, unit) {
   if (callouts.length > 0) out += callouts.join('\n') + '\n\n';
   out += `  PIPELINE (${cfg.workType})\n`;
   out += renderTree(pipelineNodes(cfg, unit), { width: TREE_WIDTH });
+  for (const r of unit.reconcile_phases || []) {
+    out += typeof r.from === 'string'
+      ? `\n  ⚑ ${titlecase(r.phase)} input moved — ${r.from} revised since it completed.\n`
+      : `\n  ⚑ ${titlecase(r.phase)} input moved — reconcile at next entry.\n`;
+  }
   if (unit.finalising) out += '\n  ⚑ All phases complete — ready to finalise.\n';
   return out.replace(/\n+$/, '\n');
 }
@@ -168,6 +175,7 @@ function workUnitData(type, unit, menu) {
   lines.push(`phase_label: ${unit.phase_label}`);
   lines.push(`finalising: ${unit.finalising === true}`);
   lines.push(`completed_phases: ${unit.completed_phases.join(', ') || '(none)'}`);
+  lines.push(`reconcile_pending: ${(unit.reconcile_phases || []).map((r) => `${r.phase} (${r.from})`).join(', ') || '(none)'}`);
   lines.push(`revisit_available: ${menu.keys.some((k) => k.action === 'revisit')}`);
   if (cfg.surfacesSeeds) {
     lines.push(`seeds_count: ${unit.seeds_count || 0}`);

--- a/skills/workflow-engine/scripts/domain/workunit-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/workunit-detail.cjs
@@ -16,6 +16,7 @@ const { loadActiveManifests, loadAllManifests } = require('./reads.cjs');
 const { WORK_TYPE_PIPELINES } = require('../kernel/manifest-schema.cjs');
 const {
   phaseStatus,
+  phaseItems,
   computeUnitPhaseState,
   lastCompletedPhase,
 } = require('./derivations.cjs');
@@ -81,6 +82,9 @@ const WORK_UNIT_TYPES = {
  *                                     complete` never ran
  * @property {string[]} completed_phases
  * @property {string[]} in_progress_phases  pipeline phases in flight (a reopened phase mid-revisit)
+ * @property {{phase: string, from: string|boolean}[]} [reconcile_phases]  completed phases whose item carries
+ *                                     a reconcile flag — `from` is the flag value (the upstream
+ *                                     phase that moved, or `true` for a brief flag)
  * @property {number} [imports_count]  types with surfacesSeeds only
  * @property {number} [seeds_count]    types with surfacesSeeds only
  */
@@ -127,6 +131,18 @@ function completedPhases(cfg, manifest) {
   return cfg.pipeline.filter((phase) => phaseStatus(manifest, phase) === 'completed');
 }
 
+/** Completed pipeline phases whose item carries a reconcile flag, in pipeline order. @param {WorkUnitTypeConfig} cfg @param {object} manifest @returns {{phase: string, from: string|boolean}[]} */
+function reconcilePhases(cfg, manifest) {
+  /** @type {{phase: string, from: string|boolean}[]} */
+  const out = [];
+  for (const phase of cfg.pipeline) {
+    const flagged = phaseItems(manifest, phase)
+      .find((i) => i.status === 'completed' && i.reconcile_needed !== undefined);
+    if (flagged) out.push({ phase, from: flagged.reconcile_needed });
+  }
+  return out;
+}
+
 /**
  * Build the work-unit detail for one single-topic type: active units with
  * next-phase state, plus the completed/cancelled sets.
@@ -151,6 +167,8 @@ function workUnitDetail(cwd, type) {
       completed_phases: completedPhases(cfg, m),
       in_progress_phases: state.in_progress_phases,
     };
+    const flagged = reconcilePhases(cfg, m);
+    if (flagged.length > 0) unit.reconcile_phases = flagged;
     if (cfg.surfacesSeeds) {
       unit.imports_count = Array.isArray(m.imports) ? m.imports.length : 0;
       unit.seeds_count = Array.isArray(m.seeds) ? m.seeds.length : 0;

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -145,6 +145,29 @@ describe('epic projections: dashboard (map branch)', () => {
     );
   });
 
+  it('a flagged completed item carries the input-moved cue on the dashboard, key, and menu', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discovery: { items: { 'menu-admin': { routing: 'discussion', source: 'discovery', order: 1 } } },
+        discussion: { items: { 'menu-admin': { status: 'completed' } } },
+        specification: { items: { 'menu-admin': { status: 'completed', reconcile_needed: 'discussion', sources: { 'menu-admin': { status: 'stale' } } } } },
+        planning: { items: { 'other-topic': { status: 'in-progress', reconcile_needed: 'specification' } } },
+      },
+    });
+    const out = epicDashboard('v1', d);
+    assert.ok(out.includes('Menu Admin [completed · input moved]'), out);
+    const key = epicKey(d);
+    assert.ok(key.includes('input moved — an upstream artifact was revised'), key);
+    const { keys } = epicMenu('v1', d);
+    const start = keys.find((k) => k.action === 'start_planning');
+    assert.ok(start, 'start_planning entry present');
+    assert.strictEqual(start.label, 'Start planning for "Menu Admin" — spec completed · input moved');
+    const cont = keys.find((k) => k.action === 'continue_planning');
+    assert.ok(cont, 'continue_planning entry present');
+    assert.strictEqual(cont.label, 'Continue "Other Topic" — planning [in-progress] · input moved');
+  });
+
   it('a triaged stub renders fresh with the triage waiting cue and counts as fresh', () => {
     const d = detailFor(dir, 'v1', {
       work_type: 'epic',

--- a/tests/scripts/test-engine-workunit-projections.cjs
+++ b/tests/scripts/test-engine-workunit-projections.cjs
@@ -70,6 +70,32 @@ describe('workunit projections: status display', () => {
     assert.ok(!out.includes('seeded from the inbox'));
   });
 
+  it('feature: a flagged completed phase carries the cue, the ⚑ line, and takes next_phase', () => {
+    createManifest(dir, 'auth-flow', {
+      phases: {
+        discussion: { items: { 'auth-flow': { status: 'completed' } } },
+        specification: { items: { 'auth-flow': { status: 'completed', reconcile_needed: 'discussion' } } },
+        planning: { items: { 'auth-flow': { status: 'completed' } } },
+      },
+    });
+    const unit = unitOf(dir, 'feature', 'auth-flow');
+    assert.strictEqual(workUnitStatus('feature', unit), [
+      ...boxOf('Auth Flow'),
+      '  PIPELINE (feature)',
+      '  ├─ ✓ Discussion [completed]',
+      '  ├─ ✓ Specification [completed · input moved]',
+      '  └─ ✓ Planning [completed]',
+      '',
+      '  ⚑ Specification input moved — discussion revised since it completed.',
+      '',
+    ].join('\n'));
+    assert.strictEqual(unit.next_phase, 'specification');
+    assert.strictEqual(unit.phase_label, 'specification (input moved — reconcile)');
+    const menu = workUnitMenu('feature', unit);
+    assert.strictEqual(menu.keys[0].route, '/workflow-specification-entry feature auth-flow');
+    assert.match(workUnitData('feature', unit, menu), /^reconcile_pending: specification \(discussion\)$/m);
+  });
+
   it('bugfix: completed investigation and a ready next phase', () => {
     createManifest(dir, 'login-crash', {
       work_type: 'bugfix',
@@ -395,6 +421,7 @@ describe('workunit projections: data body', () => {
       'phase_label: specification (in-progress)',
       'finalising: false',
       'completed_phases: discussion',
+      'reconcile_pending: (none)',
       'revisit_available: true',
       'seeds_count: 1',
       'imports_count: 0',
@@ -416,6 +443,7 @@ describe('workunit projections: data body', () => {
       'phase_label: ready for investigation',
       'finalising: false',
       'completed_phases: (none)',
+      'reconcile_pending: (none)',
       'revisit_available: false',
       'ACTIONS (key  action  topic  → route):',
       '  y  continue  login-crash  → /workflow-investigation-entry bugfix login-crash',
@@ -440,6 +468,7 @@ describe('workunit projections: data body', () => {
       'phase_label: pipeline complete',
       'finalising: true',
       'completed_phases: scoping, implementation, review',
+      'reconcile_pending: (none)',
       'revisit_available: true',
       'ACTIONS (key  action  topic  → route):',
       '  y  finalise  hotfix-logs  → (internal)',

--- a/tests/scripts/test-gateway-for-bridge.cjs
+++ b/tests/scripts/test-gateway-for-bridge.cjs
@@ -53,6 +53,22 @@ describe('workflow-bridge discovery', () => {
     assert.strictEqual(r.next_phase, 'done');
   });
 
+  it('a live reconcile flag keeps the pipeline off done — the flagged phase is next', () => {
+    createManifest(dir, 'moved', {
+      work_type: 'feature',
+      phases: {
+        discussion: { items: { moved: { status: 'completed' } } },
+        specification: { items: { moved: { status: 'completed' } } },
+        planning: { items: { moved: { status: 'completed' } } },
+        implementation: { items: { moved: { status: 'completed' } } },
+        review: { items: { moved: { status: 'completed', reconcile_needed: 'implementation' } } },
+      },
+    });
+    const r = discover(dir, 'moved');
+    assert.strictEqual(r.next_phase, 'review');
+    assert.deepStrictEqual(r.reconcile_pending, ['review/moved (implementation)']);
+  });
+
   it('computes next_phase for epic same as other types', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
@@ -218,6 +234,7 @@ describe('workflow-bridge format', () => {
       '=== auth (feature) ===',
       'next_phase: discussion',
       'completed_phases: (none)',
+      'reconcile_pending: (none)',
       'revisitable_phases: (none)',
       '',
     ].join('\n'));
@@ -238,6 +255,7 @@ describe('workflow-bridge format', () => {
       '=== auth (feature) ===',
       'next_phase: planning',
       'completed_phases: research, discussion, specification',
+      'reconcile_pending: (none)',
       'revisitable_phases: research, discussion, specification',
       '=== MENU: revisit phases (emit verbatim as markdown only at the revisit phase gate — never at the call) ===',
       '· · · · · · · · · · · ·',
@@ -268,6 +286,7 @@ describe('workflow-bridge format', () => {
       '=== rename-api (quick-fix) ===',
       'next_phase: done',
       'completed_phases: scoping, implementation, review',
+      'reconcile_pending: (none)',
       'revisitable_phases: (none)',
       '',
     ].join('\n'));
@@ -288,6 +307,7 @@ describe('workflow-bridge format', () => {
       '=== rename-api (quick-fix) ===',
       'next_phase: review',
       'completed_phases: scoping, specification, planning, implementation',
+      'reconcile_pending: (none)',
       'revisitable_phases: scoping, implementation',
       '=== MENU: revisit phases (emit verbatim as markdown only at the revisit phase gate — never at the call) ===',
       '· · · · · · · · · · · ·',
@@ -301,6 +321,22 @@ describe('workflow-bridge format', () => {
       '· · · · · · · · · · · ·',
       '',
     ].join('\n'));
+  });
+
+  it('a flagged phase surfaces in the dump and takes next_phase', () => {
+    createManifest(dir, 'moved', {
+      work_type: 'feature',
+      phases: {
+        discussion: { items: { moved: { status: 'completed' } } },
+        specification: { items: { moved: { status: 'completed', reconcile_needed: 'discussion' } } },
+        planning: { items: { moved: { status: 'completed' } } },
+        implementation: { items: { moved: { status: 'completed' } } },
+        review: { items: { moved: { status: 'completed' } } },
+      },
+    });
+    const out = format(discover(dir, 'moved'));
+    assert.match(out, /^next_phase: specification$/m);
+    assert.match(out, /^reconcile_pending: specification\/moved \(discussion\)$/m);
   });
 
   it('epic dump carries no revisitable line and no section', () => {

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -820,6 +820,11 @@ describe('pipeline simulation', () => {
     let spec = sim.manifest(wu).phases.specification.items[wu];
     assert.strictEqual(spec.reconcile_needed, 'discussion');
     assert.strictEqual(spec.sources[wu].status, 'stale');
+    // The read side never routes forward past the flag: the bridge's next
+    // phase is the flagged spec, not done — the terminal branch stays untaken.
+    const bridged = BRIDGE.discover(sim.dir, wu);
+    assert.strictEqual(bridged.next_phase, 'specification');
+    assert.deepStrictEqual(bridged.reconcile_pending, [`specification/${wu} (discussion)`]);
     sim.run(['manifest', 'delete', `${wu}.specification.${wu}`, 'reconcile_needed']);
     sim.run(['manifest', 'set', `${wu}.specification.${wu}`, `sources.${wu}.status`, 'incorporated']);
 
@@ -852,6 +857,8 @@ describe('pipeline simulation', () => {
     ro = sim.run(['topic', 'reopen', wu, 'review', wu]);
     assert.strictEqual(ro.reconcile_flagged, undefined);
     sim.run(['topic', 'complete', wu, 'review', wu]);
+    // Every flag cleared, every phase re-completed: the pipeline reads done.
+    assert.strictEqual(BRIDGE.discover(sim.dir, wu).next_phase, 'done');
   });
 
   it('work-unit lifecycle: complete → reactivate → cancel → reactivate', () => {

--- a/tests/scripts/test-reads-derivations.cjs
+++ b/tests/scripts/test-reads-derivations.cjs
@@ -437,6 +437,69 @@ describe('reads + derivations', () => {
       assert.ok(r.phase_label.includes('in-progress'));
     });
 
+    it('a flagged completed phase overrides forward routing — the pipeline never reads done past it', () => {
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: {
+        discussion: { items: { test: { status: 'completed' } } },
+        specification: { items: { test: { status: 'completed' } } },
+        planning: { items: { test: { status: 'completed' } } },
+        implementation: { items: { test: { status: 'completed' } } },
+        review: { items: { test: { status: 'completed', reconcile_needed: 'implementation' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'review');
+      assert.strictEqual(r.phase_label, 'review (input moved — reconcile)');
+    });
+
+    it('the earliest flagged phase wins over later flags and forward routing', () => {
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: {
+        discussion: { items: { test: { status: 'completed' } } },
+        specification: { items: { test: { status: 'completed', reconcile_needed: 'discussion' } } },
+        planning: { items: { test: { status: 'completed' } } },
+        implementation: { items: { test: { status: 'completed', reconcile_needed: 'planning' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'specification');
+      assert.strictEqual(r.phase_label, 'specification (input moved — reconcile)');
+    });
+
+    it('an upstream phase in flight preempts the flag walk — the cascade answers as before', () => {
+      // Mid-revision upstream: the flag must NOT route into the spec while its
+      // input is still moving. The walk defers to the cascade (which keeps the
+      // pre-flag mid-revisit answer); the upstream's conclusion re-runs this
+      // and the flag wins then.
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: {
+        discussion: { items: { test: { status: 'in-progress' } } },
+        specification: { items: { test: { status: 'completed', reconcile_needed: 'discussion' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'planning');
+      assert.strictEqual(r.phase_label, 'ready for planning');
+    });
+
+    it('a flagged in-progress item never triggers the override — completed only', () => {
+      const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: {
+        discussion: { items: { test: { status: 'completed' } } },
+        specification: { items: { test: { status: 'in-progress', reconcile_needed: 'discussion' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'specification');
+      assert.strictEqual(r.phase_label, 'specification (in-progress)');
+    });
+
+    it('quick-fix flags route back the same way', () => {
+      const r = computeNextPhase({ name: 'test', work_type: 'quick-fix', phases: {
+        scoping: { items: { test: { status: 'completed' } } },
+        implementation: { items: { test: { status: 'completed', reconcile_needed: 'scoping' } } },
+        review: { items: { test: { status: 'completed' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'implementation');
+      assert.strictEqual(r.phase_label, 'implementation (input moved — reconcile)');
+    });
+
+    it('epics are excluded from the flag override — next_phase stays phase-coarse', () => {
+      const r = computeNextPhase({ name: 'test', work_type: 'epic', phases: {
+        discussion: { items: { alpha: { status: 'completed' } } },
+        specification: { items: { alpha: { status: 'completed', reconcile_needed: 'discussion' } } },
+      } });
+      assert.strictEqual(r.next_phase, 'planning');
+    });
+
     it('returns in-progress review', () => {
       const r = computeNextPhase({ name: 'test', work_type: 'feature', phases: { review: { items: { test: { status: 'in-progress' } } } } });
       assert.strictEqual(r.next_phase, 'review');


### PR DESCRIPTION
PR 3 of the staleness-hops stack (ideas #40 + #26) — the read side; closes #26's remainder.

**Routing** — `computeNextPhase` for the linear types: the earliest pipeline phase whose live item is completed + flagged wins as `next_phase` with the `{phase} (input moved — reconcile)` label. Routing never walks forward past known-stale input, and the bridge's terminal `done` branch is simply never taken while a flag is live — no bridge prose change needed. An upstream phase in flight defers to the cascade (its conclusion re-runs the walk); `finalising` stays false automatically. Epics stay phase-coarse and get per-item cues instead.

**Cues** (the `triage_parked` rider pattern):
- Single-topic view: pipeline node `[completed · input moved]` tag, a `⚑ {Phase} input moved — {upstream} revised since it completed.` status line, and a `reconcile_pending:` DATA line for skills to branch on.
- Epic view: dashboard item tag, `· input moved` suffix on continue entries (flagged in-progress item) and start entries (flagged source item — starting forward propagates stale input), and a Key legend entry.
- Bridge dump: a `reconcile_pending:` line (observability; routing rides `next_phase`).

Tests: 6 new `computeNextPhase` cases (override, earliest-wins, in-flight deferral, completed-only, quick-fix, epic exclusion), bridge dump pins re-pointed + 2 flag-aware cases, feature/epic projection cue goldens, simulation asserts the bridge reads the flagged spec — never `done` — until every flag clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)