### PR TITLE
fix(surfacing): the apply lane says how its corrections land

### DIFF
--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -66,6 +66,8 @@ Read each finding's **lane** from its report section. Three lanes carry across e
 
 Re-classify before anything renders, in the one permitted direction (core rule 5): an `apply` finding whose fix turns out to rest on a choice nobody has made moves to the walked lane. Never move a finding the other way.
 
+This is the first of two catches, not the only one. Re-classify here whatever the document itself shows — a subtopic the report read as settled that the artifact records as open, a fix resting on a decision no section carries. What survives is what looked settled from the document alone, and the user's own knowledge is the second catch: **E** promotes anything they say isn't settled. Neither replaces the other, and a finding caught here never reaches the batch screen at all.
+
 #### If the report has no findings (zero-gap case)
 
 ```bash
@@ -215,13 +217,17 @@ Emit the call's DISPLAY and MENU sections, each verbatim per its marker.
 
 **If `yes`:**
 
-Apply each finding to the phase's artifact, then record the whole batch in one call and commit each finding's write under its own subject marker:
+Take the findings one at a time: apply, then commit, before moving to the next. Applying them all and committing afterwards collapses the batch into a single commit — the first commit sweeps every edit and the rest report nothing to commit — and the per-finding subject markers the closing gates read are lost.
+
+An `apply` finding is a **pure correction**: nothing new was decided, so its fix lands as the amendment shape in **D. Fold** in **[rerouted-concerns.md](rerouted-concerns.md)** — the affected sites amended in place, each amendment a dated note naming the decision that determines it, striking or rewriting the stale text as each site needs. Never the template's revision shape: that belongs to a decision this session re-took, and there is none here.
+
+Each finding's write commits under its own subject marker (`({id} {finding})`). When the last one has landed, record the batch in one call:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs agent surface {work_unit} {phase} {topic} {id} {F1,F2,…}
 ```
 
-Confirm in one line per finding — what changed, no restatement of the reasoning the screen already carried.
+Confirm in one line per finding — what changed, no restatement of the reasoning the screen already carried. Say what the record says: an amended site is amended, not removed.
 
 → Return to caller.
 
@@ -310,7 +316,7 @@ Emit the call's DISPLAY and MENU sections, each verbatim per its marker.
 
 **If `yes`:**
 
-Deliver each finding in turn, with the context built here so its target resolves it from cold.
+Deliver each finding in turn, with the context built here so its target resolves it from cold. Rerouting sends a concern away from this topic; it does not mark it. No reroute record is written here and the Discussion Map is untouched — the delivery commits itself, and the target's queue is the record.
 
 → Load **[triage-landing.md](triage-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{the finding with the context built here}`, origin = `{topic}`, phase = `{phase}`, landing_phase = `{landing_phase}`, date = `{today}`.
 


### PR DESCRIPTION
Four prose defects, all found by walking the three new lane cases
through the real skills. Three read-throughs before the merge found
none of them.

**1. The apply lane never said what shape a correction takes on disk.**
A walker improvised the template's *re-decision* convention — dated
block, original preserved under `#### Initial` — then told the user the
text had been "struck". The record and the narration disagreed. An
`apply` finding is a **pure correction** by definition (nothing new was
decided), so it now lands as the amendment shape `rerouted-concerns.md`
§ D already prescribes, and the confirmation says *amended*, not
*removed*.

**2. The apply/commit ordering could not work.** *"Apply each finding…
then commit each write under its own subject marker"* — applying all
first means the first commit sweeps every edit and the rest return
`nothing to commit`. A walk proved it: two edits, one commit, the
`(review-001 F3)` marker never created. That silently breaks the
closing-gates classifier, which reads those markers to decide whether
the discussion moved. Each finding now applies **and commits** before
the next begins; the batch is recorded in one call at the end.

**3. A real ambiguity between `B` and `E`.** Two walkers read the
re-classification rule in opposite directions — one rendered all three
findings and reclassified on user pushback, the other caught the
misfile before rendering and showed two. Both readings were available
in what I wrote, and they produce different screens. They are two
catches at the same error, not rivals: `B` catches what the document
itself shows, `E` catches what only the user knows. Now stated.

**4. The route lane's silence about a reroute record** was correct —
`off-topic-epic.md` is explicit that rerouting sends a concern away
without marking this topic — but silence invites the opposite
assumption. I made that assumption myself while writing the case. Now
stated.

Prose only; no engine change. The three cases are re-pinned to this
behaviour in the PR stacked above this one.

Gates green: `npm test` 1920/1920, `test:cli`, `typecheck`, conventions
lint 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)