### PR TITLE
fix(surfacing): apply lane commits per finding and amends in place

### DIFF
--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -215,13 +215,17 @@ Emit the call's DISPLAY and MENU sections, each verbatim per its marker.
 
 **If `yes`:**
 
-Apply each finding to the phase's artifact, then record the whole batch in one call and commit each finding's write under its own subject marker:
+Take the findings one at a time — apply, then commit under that finding's own subject marker (`({id} {finding})`) — before starting the next.
+
+Each fix is a pure correction: amend the affected sites in place, each amendment a dated note naming the decision that determines it, striking or rewriting the stale text as each site needs — the shape in **D. Fold** in **[rerouted-concerns.md](rerouted-concerns.md)**. Never the template's revision shape.
+
+When every finding has landed, record the batch in one call:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs agent surface {work_unit} {phase} {topic} {id} {F1,F2,…}
 ```
 
-Confirm in one line per finding — what changed, no restatement of the reasoning the screen already carried.
+Confirm in one line per finding — what changed, no restatement of the reasoning the screen already carried. An amended site is amended, not removed.
 
 → Return to caller.
 

--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -318,7 +318,7 @@ Deliver each finding in turn, with the context built here so its target resolves
 
 → Load **[triage-landing.md](triage-landing.md)** with work_unit = `{work_unit}`, target = `{target}`, concern = `{the finding with the context built here}`, origin = `{topic}`, phase = `{phase}`, landing_phase = `{landing_phase}`, date = `{today}`.
 
-On return, a `result` of `cancelled` means nothing was written for that finding — leave it unsurfaced and re-present it on the next visit. When a landing response carried `reconcile_flagged` or `sources_staled`, also tell the user what it flagged — the target's completed discussion (research landing) or the specification(s) named in `sources_staled` (discussion landing, their extraction now stale). Record the landed ids in one call:
+On return, a `result` of `cancelled` means nothing was written for that finding — leave it unsurfaced and re-present it on the next visit. When a landing response carried `reconcile_flagged` or `sources_staled`, also tell the user what it flagged — the target's completed discussion (research landing) or the specification(s) named in `sources_staled` (discussion landing, their extraction now stale). When every delivery has returned, record the landed ids in one call:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs agent surface {work_unit} {phase} {topic} {id} {F1,F2,…}


### PR DESCRIPTION
Two defects in `background-agent-surfacing.md` § E, both found by
walking `discussion-promotes-a-batch-item` through the real skills.

**1. The commit ordering cannot work.** § E said *"apply each finding…
then commit each write under its own subject marker"*. Applying all
findings before committing means the first commit sweeps every edit and
the rest return `nothing to commit`, so the per-finding
`({id} {finding})` markers are never created.

Those markers are what `closing-gates.md` § A.4 and `final-review.md`
§ B drop when deciding whether the discussion moved since the last
review. Without them a drained review reads as fresh movement and
re-fires — the treadmill this feature exists to stop.

Walk evidence: two edits landed, one commit (`93e42f6`) succeeded, the
second returned `{"ok":true,"committed":null,"note":"nothing to
commit"}`.

**2. The lane never said what shape a correction takes on disk.** With
no shape given, a walker reached for the template's *re-decision*
convention — a dated block preserving the original under `#### Initial`
— then reported the text as struck. An apply finding is a pure
correction by definition, so it now lands as the amendment shape
`rerouted-concerns.md` § D. Fold already prescribes.

Prose only, one file, six lines. Conventions lint 31/31.

Behaviour is asserted by the case corrections in the PR stacked above
this one; the full prose-test run covers the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)