### PR TITLE
fix(surfacing): guard the announce record, and read the session log every time

### DIFF
--- a/skills/workflow-discovery/references/topic-synthesis.md
+++ b/skills/workflow-discovery/references/topic-synthesis.md
@@ -10,7 +10,7 @@ The harvest ceremony. Analyse the session's exploration as a whole, produce a to
 
 You have three sources of truth:
 
-1. **The Exploration section** of the active session log at `.workflows/{work_unit}/discovery/sessions/session-{session_number:03d}.md`. Read it now if you haven't recently — your in-context memory might be stale.
+1. **The Exploration section** of the active session log at `.workflows/{work_unit}/discovery/sessions/session-{session_number:03d}.md`. Read it now, every time, whatever is already in context.
 2. **In-context memory of the conversation.** When not compacted, this carries detail the Exploration summary may have skipped.
 3. **The existing discovery map** from Step 7's discovery output. Continuing sessions add to it; first sessions seed it.
 

--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -141,7 +141,7 @@ Background {agent_type} returned — {N} finding(s): {shape}.
 · · · · · · · · · · · ·
 ```
 
-After rendering the menu, record the announce:
+After rendering the menu, record the announce — skip the call when the row already reads `announced: true`:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs agent announce {work_unit} {phase} {topic} {id}


### PR DESCRIPTION
Stacked on #749. Two one-line changes, each closing something the walk
sweep surfaced repeatedly.

**1. `agent announce` re-fired on already-announced rows.** § C records
the announce after rendering the menu, unconditionally — so every
resumed session re-issues a write verb against a row that already
carries it. Idempotent and byte-identical, but it appeared in the
markers of essentially every walk that passes through § C, which is
noise on every future verdict of every resuming case. Now guarded.

**2. `topic-synthesis` § A's session-log re-read.** It read *"Read it
now if you haven't recently — your in-context memory might be stale."*
That conditional, plus the hedge, is what makes
`epic-resumes-and-harvests-topics` **FLAKY**: a walker holding the
Exploration content in context judged the read already satisfied, and
the asserter scored the same absence FAIL on one run and NOTE on the
next.

Resolved toward unconditional rather than the other direction, because
a prescribed re-read is compaction insurance — and *"it's already in
context"* is precisely the belief a compaction summary manufactures.
The read is cheap; what it guards against is silent.

Conventions lint 31/31. Prose walks deferred until after review, per
the agreed sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)