### PR TITLE
refactor(triage): the landing-phase rule lives with its consumer

### DIFF
--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -88,7 +88,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topi
 
 Every unhandled note goes on one screen — the same batch the surfacing protocol sends rerouted findings on, over the same kind of item. Handled-ness lives in the document itself: a landed note reads as a reroute record, a kept note stays as prose — so a re-run after a context refresh re-presents kept notes, which costs a repeat ask, never a silent loss. A note addressed to *this* topic is not a reroute — treat it as undocumented substance: fold it into the document, no gate.
 
-Judge each note's target topic from its own addressing, and its `landing_phase` from its nature — an open question needing exploration → `research`; a correction or decision owed → `discussion`. Write the payload with the Write tool (`{"lane": "route", "items": [{"target": "…", "detail": "…"}]}`, one entry per note: `target` is the topic, `detail` is what the note says, why it is theirs, and which queue it lands in), then render it:
+Judge each note's target topic from its own addressing, and its `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](../../workflow-shared/references/triage-landing.md)**. Write the payload with the Write tool (`{"lane": "route", "items": [{"target": "…", "detail": "…"}]}`, one entry per note: `target` is the topic, `detail` is what the note says, why it is theirs, and which queue it lands in), then render it:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render finding-batch {work_unit}.discussion.{topic} --file .workflows/.cache/{work_unit}/discussion/{topic}/carry-notes.json

--- a/skills/workflow-discussion-process/references/off-topic-epic.md
+++ b/skills/workflow-discussion-process/references/off-topic-epic.md
@@ -53,7 +53,7 @@ Name it in passing as the landing happens — the user corrects you if you've mi
 
 **If genuinely ambiguous** — two or more plausible homes and the conversation doesn't settle it:
 
-Judge `landing_phase` from the concern's nature — an open question needing exploration → `research`; a decision needing making → `discussion` — and state the recommendation in the menu:
+Judge `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** and state the recommendation in the menu:
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-discussion-process/references/off-topic-non-epic.md
+++ b/skills/workflow-discussion-process/references/off-topic-non-epic.md
@@ -49,7 +49,7 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 
 2. Derive `proposed_name` — a kebab-case topic name for the concern.
 
-3. Judge `landing_phase` from the concern's nature (an open question needing exploration → `research`; a decision needing making → `discussion`), then load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern}`, origin = `{topic}`, phase = `discussion`, landing_phase = `{landing_phase}`, date = `{today}`. It validates the name against the map and, on a clash, prompts to pick another or cancel. If `result` is `cancelled`, the topic wasn't created — note the concern in the Summary so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic and the delivery committed itself.
+3. Judge `landing_phase` per **Judging the Landing Phase**, then load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern}`, origin = `{topic}`, phase = `discussion`, landing_phase = `{landing_phase}`, date = `{today}`. It validates the name against the map and, on a clash, prompts to pick another or cancel. If `result` is `cancelled`, the topic wasn't created — note the concern in the Summary so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic and the delivery committed itself.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-research-process/references/document-review.md
+++ b/skills/workflow-research-process/references/document-review.md
@@ -76,7 +76,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topi
 
 Take the next unhandled note. Handled-ness lives in the walk and is recoverable from the document itself: a landed note reads as a reroute record, a kept note stays as prose — so a re-run after a context refresh re-presents kept notes, which costs a repeat ask, never a silent loss. A note addressed to *this* topic is not a reroute — treat it as undocumented substance: fold it into the document, no gate.
 
-Judge the target topic from the note's own addressing, and judge `landing_phase` from its nature — an open question needing exploration → `research`; a correction or decision owed → `discussion`. Present it:
+Judge the target topic from the note's own addressing, and `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](../../workflow-shared/references/triage-landing.md)**. Present it:
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -49,7 +49,7 @@ When a concern surfaces that belongs to a *different* topic — raised in conver
    node .claude/skills/workflow-discovery/scripts/gateway.cjs {work_unit}
    ```
 
-   Resolve the target, and judge `landing_phase` from the concern's nature: an open question needing exploration → `research`; a decision needing making → `discussion`. If one topic clearly matches, propose it — with the recommended phase — and confirm with the user (their reply may override the phase). If nothing fits, propose a new kebab-case name and confirm. If several plausible candidates exist — or a near-match you're unsure of — present them and let the user choose:
+   Resolve the target, and judge `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](../../workflow-shared/references/triage-landing.md)**. If one topic clearly matches, propose it — with the recommended phase — and confirm with the user (their reply may override the phase). If nothing fits, propose a new kebab-case name and confirm. If several plausible candidates exist — or a near-match you're unsure of — present them and let the user choose:
 
    > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-research-process/references/feature-session.md
+++ b/skills/workflow-research-process/references/feature-session.md
@@ -103,7 +103,7 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 
 2. From the context you already have, derive two values: `proposed_name` — a kebab-case topic name for the concern; and `concern` — the concern with the full context discussed about it.
 
-3. Judge `landing_phase` from the concern's nature (an open question needing exploration → `research`; a decision needing making → `discussion`), then load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern}`, origin = `{topic}`, phase = `research`, landing_phase = `{landing_phase}`, date = `{today}`. It validates the name against the map and, on a clash, prompts to pick another or cancel. If `result` is `cancelled`, the topic wasn't created — note the concern in the research file so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic and the delivery committed itself.
+3. Judge `landing_phase` per **Judging the Landing Phase**, then load **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** with work_unit = `{work_unit}`, target = `{proposed_name}`, concern = `{concern}`, origin = `{topic}`, phase = `research`, landing_phase = `{landing_phase}`, date = `{today}`. It validates the name against the map and, on a clash, prompts to pick another or cancel. If `result` is `cancelled`, the topic wasn't created — note the concern in the research file so it isn't lost; otherwise the concern landed as the `{landed_topic}` topic and the delivery committed itself.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -302,7 +302,7 @@ Emit the lane marker once per visit to this section — on a re-render after a q
 ·· Belongs Elsewhere ····························
 ```
 
-Judge each finding's `landing_phase` from its nature — an open question needing exploration → `research`; a correction or decision owed → `discussion`. The target's own `routing` does not decide it: a question landing on a discussion-routed topic still lands research-side. Write the payload with the Write tool (`{"lane": "route", "items": [{"target": "…", "detail": "…"}]}`, one entry per finding: `target` is the owning topic, `detail` is what it says, why it is theirs, and which queue it lands in), then render it:
+Judge each finding's `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](triage-landing.md)**. Write the payload with the Write tool (`{"lane": "route", "items": [{"target": "…", "detail": "…"}]}`, one entry per finding: `target` is the owning topic, `detail` is what it says, why it is theirs, and which queue it lands in), then render it:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render finding-batch {work_unit}.{phase}.{topic} --file .workflows/.cache/{work_unit}/{phase}/{topic}/batch-route.json

--- a/skills/workflow-shared/references/triage-landing.md
+++ b/skills/workflow-shared/references/triage-landing.md
@@ -17,13 +17,17 @@ The caller provides these via context before loading:
 - `concern` — the concern as a short title, plus the full context discussed about it.
 - `origin` — the topic the concern surfaced in (the current session's topic).
 - `phase` — the current session's phase, `research` or `discussion`. Recorded in the entry.
-- `landing_phase` — where the concern lands on the target, `research` or `discussion`: judged by the origin session from the concern's nature (an open question needing exploration → research; a decision needing making → discussion), recommended and confirmed at the caller's gate. The coherence findings gate always passes `discussion`. Any target state is legal — the delivery parks, leaves live work untouched, or reopens completed work as needed.
+- `landing_phase` — where the concern lands on the target, `research` or `discussion`: judged by the origin session per **Judging the Landing Phase** below, recommended and confirmed at the caller's gate. The coherence findings gate always passes `discussion`. Any target state is legal — the delivery parks, leaves live work untouched, or reopens completed work as needed.
 - `date` — today's date.
 
 After return, the caller reads these from conversation memory:
 
 - `result` — `landed` (concern delivered and committed by the engine) or `cancelled` (the reroute was dropped or blocked; nothing written).
 - `landed_topic` — the final target name (a new target may have been renamed during validation).
+
+## Judging the Landing Phase
+
+The concern's nature decides, never the target: an open question needing exploration → `research`; a correction or decision owed → `discussion`. The target's map `routing` and live state have no vote — a question landing on a discussion-routed topic still lands research-side.
 
 ## Triage Entry Shape
 


### PR DESCRIPTION
Stack layer 1 of the review-maturity programme (design log: #756, M6).

The landing-phase judgement — open question needing exploration →
`research`; a correction or decision owed → `discussion` — was stated
independently at **seven call sites** plus triage-landing's own
parameter bullet. The design note said three; the enumeration found:

- `background-agent-surfacing.md` § G
- `off-topic-epic.md`, `off-topic-non-epic.md` (discussion)
- `document-review.md` × 2 (discussion and research)
- `feature-session.md`, `epic-session.md` (research)

The wording had already drifted ("a decision needing making" vs "a
correction or decision owed"), and the clause guarding against the
misread that produced a live prose-test flake — resolving the phase
from the target's `routing` field — existed at exactly one of the
eight sites.

The rule now lives once, as **Judging the Landing Phase** in
`triage-landing.md` — the reference that consumes the parameter — with
the no-vote clause included. All seven call sites defer by name;
behaviour is unchanged.

Conventions lint 31/31, corpus 46 cases valid. Walks run once the
stack settles, per the agreed sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)