### PR TITLE
refactor(surfacing): three owners — the shared file returns to its name

### DIFF
--- a/skills/workflow-discussion-process/references/review-agent.md
+++ b/skills/workflow-discussion-process/references/review-agent.md
@@ -29,6 +29,14 @@ At natural conversational breaks, check for completed results.
 
 ---
 
+## Lanes
+
+The shared surfacing protocol reads this declaration when presenting this phase's findings.
+
+- `decide` — the walked lane. Raises render under the heading `Needs A Decision`.
+- `apply` — approving lands each fix as a pure correction: amend the affected sites in place, each amendment a dated note naming the decision that determines it, striking or rewriting the stale text as each site needs — the shape in **D. Fold** in **[rerouted-concerns.md](../../workflow-shared/references/rerouted-concerns.md)**; never the template's revision shape. The confirmation says amended, never removed.
+- `route` — approving delivers each finding to its owning topic through the shared triage landing.
+
 ## A. Dispatch
 
 Record the dispatch — the engine allocates the id and answers with the content-file path; no file is created (the file's later existence is the completion signal):

--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -111,11 +111,15 @@ The research session continues — do not wait for the agent to return.
 
 ---
 
+## Lanes
+
+Deep-dive findings are all walked — no batch lanes. Raises render under the heading `Needs Investigation`.
+
 ## C. Check and Surface
 
 Delegate all check-for-results and presentation behaviour to the shared surfacing protocol. Deep-dive reports are substantive and prone to wall-of-text dumps — the protocol's never-dump rules are especially important here.
 
-→ Load **[background-agent-surfacing.md](../../workflow-shared/references/background-agent-surfacing.md)** with agent_type = `deep-dive`, work_unit = `{work_unit}`, phase = `research`, topic = `{topic}`, walk_heading = `Needs Investigation`.
+→ Load **[background-agent-surfacing.md](../../workflow-shared/references/background-agent-surfacing.md)** with agent_type = `deep-dive`, work_unit = `{work_unit}`, phase = `research`, topic = `{topic}`.
 
 **Promoting to a research file** (epic work type only): If during presentation the user engages with findings substantial enough to warrant their own research file — and agrees or requests it — promote them through the shared topic-creation core, so the new topic lands on the discovery map with validated naming and provenance:
 

--- a/skills/workflow-research-process/references/review-agent.md
+++ b/skills/workflow-research-process/references/review-agent.md
@@ -29,6 +29,14 @@ At natural conversational breaks, check for completed results.
 
 ---
 
+## Lanes
+
+The shared surfacing protocol reads this declaration when presenting this phase's findings.
+
+- `explore` — the walked lane. Raises render under the heading `Needs Investigation`.
+- `apply` — approving lands each fix as a pure correction: amend the affected sites in place, each amendment a dated note naming the source or finding that determines it. The confirmation says amended, never removed.
+- `route` — approving delivers each finding to its owning topic through the shared triage landing.
+
 ## A. Dispatch
 
 Record the dispatch — the engine allocates the id and answers with the content-file path; no file is created (the file's later existence is the completion signal):
@@ -70,7 +78,7 @@ The research session continues — do not wait for the agent to return.
 
 Delegate all check-for-results and presentation behaviour to the shared surfacing protocol. This enforces the never-dump rules: two-phase surfacing, one finding at a time, mid-thread protection.
 
-→ Load **[background-agent-surfacing.md](../../workflow-shared/references/background-agent-surfacing.md)** with agent_type = `review`, work_unit = `{work_unit}`, phase = `research`, topic = `{topic}`, walk_heading = `Needs Investigation`.
+→ Load **[background-agent-surfacing.md](../../workflow-shared/references/background-agent-surfacing.md)** with agent_type = `review`, work_unit = `{work_unit}`, phase = `research`, topic = `{topic}`.
 
 **Offering deep dives during presentation**: If the user engages with a raised finding and it's substantial enough for independent investigation, offer to dispatch a deep-dive agent for it. Follow the deep-dive agent instructions for the offer and dispatch.
 

--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -10,7 +10,8 @@ This reference defines how to surface findings from background agents. Findings 
 
 - `agent_type` — `review` | `synthesis` | `deep-dive` — human-readable name used in user-facing messages, and the row kind this invocation surfaces
 - `work_unit`, `phase`, `topic` — the agent store address
-- `walk_heading` — optional; the heading the walked lane renders under. Defaults to `Needs A Decision`
+
+**Lane declaration** — the calling reference's **Lanes** section, already in context, owns this phase's lane semantics: the walked lane's name and heading, and what approving each batch lane does. A caller with no **Lanes** section is all-walk; its raises render under `Needs A Decision`.
 
 ## The Core Rules
 
@@ -62,7 +63,7 @@ The report was first-read on an earlier iteration; the row carries `announced`, 
 
 Read the row's content file completely — `.workflows/.cache/{work_unit}/{phase}/{topic}/{id}.md`. The finding ids come from the agent's returned status block (its `FINDINGS:`/`TENSIONS:` line — the author's own declaration); when that message is no longer in context, fall back to the file's `### {ID}:` section headings. Cross-check the count either way.
 
-Read each finding's **lane** from its report section. Three lanes carry across every caller — the batched `apply`, the batched `route`, and the walked one, which a report names for its own phase (`decide` in discussion, `explore` in research). A report that declares no lanes is all-walk, as is any single finding whose section names none — an unlabelled finding is never assumed settled. Synthesis tensions are always walked, whatever the report says.
+Read each finding's **lane** from its report section. Three lanes carry across every caller — the batched `apply`, the batched `route`, and the walked one, named by the caller's **Lanes** declaration. A report that declares no lanes is all-walk, as is any single finding whose section names none — an unlabelled finding is never assumed settled. Synthesis tensions are always walked, whatever the report says.
 
 Re-classify before anything renders, in the one permitted direction (core rule 5): an `apply` finding the artifact itself contradicts — a subtopic the map records as open, a fix resting on a decision no section carries — moves to the walked lane and never reaches the batch screen. Never move a finding the other way.
 
@@ -217,7 +218,7 @@ Emit the call's DISPLAY and MENU sections, each verbatim per its marker.
 
 Take the findings one at a time — apply, then commit under that finding's own subject marker (`({id} {finding})`) — before starting the next.
 
-Each fix is a pure correction: amend the affected sites in place, each amendment a dated note naming the decision that determines it, striking or rewriting the stale text as each site needs — the shape in **D. Fold** in **[rerouted-concerns.md](rerouted-concerns.md)**. Never the template's revision shape.
+Each fix lands as the **Lanes** declaration's `apply` resolution prescribes.
 
 When every finding has landed, record the batch in one call:
 
@@ -225,7 +226,7 @@ When every finding has landed, record the batch in one call:
 node .claude/skills/workflow-engine/scripts/engine.cjs agent surface {work_unit} {phase} {topic} {id} {F1,F2,…}
 ```
 
-Confirm in one line per finding — what changed, no restatement of the reasoning the screen already carried. An amended site is amended, not removed.
+Confirm in one line per finding — what changed, no restatement of the reasoning the screen already carried.
 
 → Return to caller.
 
@@ -260,12 +261,12 @@ This section runs once per invocation and then exits. It never waits in-protocol
    - **Move** — sized to how open the decision is as much as how cold the context: a clear resolution — propose it and name what it costs ("this creates X and Y; I don't see another approach"), never an option survey; genuinely open — sketch the option space in a sentence or two; needs investigation — suggest research or a deep-dive.
 4. Raise it in the current turn, ending in a single question — or, for a finding with one defensible resolution, a stated proposal awaiting the user's response. Either way the turn ends and control returns: one finding per invocation, and the user's agreement is never licence to roll into the next. No bundled follow-ups, no menu.
 
-When this row's `surfaced` list holds no walked finding yet, the raise opens with the lane heading, padded with middle dots to 49 characters total, so the shift out of the batches is visible. A walk already under way — including one resumed from an earlier session — opens with its bridge instead, never a repeated heading:
+When this row's `surfaced` list holds no walked finding yet, the raise opens with the walked lane's declared heading, padded with middle dots to 49 characters total, so the shift out of the batches is visible. A walk already under way — including one resumed from an earlier session — opens with its bridge instead, never a repeated heading:
 
 > *Output the next fenced block as a code block:*
 
 ```
-·· {walk_heading} ·······························
+·· {lane_heading} ·······························
 ```
 
 **Setting the scene** — an example over a description, every time. A reader who can picture the failure can judge the fix; a reader parsing a mechanism description is still building the picture when the ask arrives.


### PR DESCRIPTION
Stack layer 2 (design log: #756, M4–M5).

`background-agent-surfacing.md` promises surfacing mechanics and was
carrying phase content: lane vocabulary, the apply lane's correction
shape, and `walk_heading` — a phase's own word passed into a shared
file as a synonym, which was the smell all along.

**The three-owner contract:**

- the **agent brief** owns *what earns a lane* (unchanged here)
- the **phase's caller reference** owns *what approving a lane does* —
  a `## Lanes` declaration in each of discussion's and research's
  `review-agent.md` (walked-lane name + heading; apply resolution;
  route resolution), plus a walk-only declaration in
  `deep-dive-agent.md`
- the **shared file** owns *how findings reach the user* — lifecycle,
  screens, ordering, promotion, never-dump — and defers to the
  declaration at every resolution point

`walk_heading` is deleted repo-wide. A caller with no declaration is
all-walk under `Needs A Decision`, which is exactly what synthesis
needs, so `perspective-agents.md` is untouched.

**Inbound-route enumeration** (every path into the shared protocol has
a declaration in context): discussion session loop and research's
three session shapes (epic, feature, session-loop) all load their
phase's `review-agent.md` at session start; deep-dive declares in the
same file that loads the protocol; `final-review-menu.md` only ever
runs inside one of those sessions; synthesis is the deliberate
default.

The apply resolution's substance is unchanged — discussion still lands
the amendment shape per `rerouted-concerns.md` § D. Fold, committed
per finding — it has moved home, not changed meaning. Research's apply
now cites *the source or finding* that determines a fix rather than
discussion's "decision", which was always the right word there.

Conventions lint 31/31, corpus 46 valid. Walks after the stack
settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)