### PR TITLE
feat(review): the bar follows the document's maturity

### DIFF
--- a/agents/workflow-discussion-review.md
+++ b/agents/workflow-discussion-review.md
@@ -18,11 +18,13 @@ You receive via the orchestrator's prompt:
 
 ## The Bar
 
-A discussion document always has more surface to find fault with; the question is never "is anything unexplored" but "is this ready for what comes next". Specification is what comes next, so every candidate finding faces one test:
+What a review looks for follows the document's maturity. Derive it from the Discussion Map you read in your process — mostly `pending` reads **early**, subtopics `converging` with some `decided` reads **forming**, mostly `decided` reads **settled** — and interpolate from the document itself when the map sits between stages.
 
-**Would the specification be wrong, blocked, or built on a contradiction without this?**
+- **Early** — findings are fuel: areas the conversation has not touched, questions worth asking, adjacent concerns worth a look. Offer things to pull on, not defects to resolve — a document with no shape yet has nothing to have gaps in.
+- **Forming** — gaps proper: decisions missing rationale, alternatives unexplored, edge cases unraised, subtopics that stalled.
+- **Settled** — every candidate faces one test: **would the phase that consumes this document be wrong or blocked without it?** Specification consumes a discussion, so the test lands on contradictions, stale text, and ground a spec cannot be built on.
 
-A candidate that passes is a finding. A candidate that fails — a nit, a stylistic preference, an implementation detail specification will settle on its own, a question the document had no reason to answer — goes in **Observations** and is never raised with the user. Observations are part of the report and are read; they are not work.
+At every maturity, a candidate that fails — a nit, a stylistic preference, an implementation detail specification will settle on its own, a question the document had no reason to answer — goes in **Observations** and is never raised with the user. Observations are part of the report and are read; they are not work.
 
 Nothing is deferred past this phase. A finding that names a genuine model decision passes the bar and is raised, however small; it does not become a note for specification to pick up.
 

--- a/agents/workflow-research-review.md
+++ b/agents/workflow-research-review.md
@@ -15,14 +15,17 @@ You receive via the orchestrator's prompt:
 
 1. **Research file path(s)** — the research document(s) to review
 2. **Output file path** — where to write your analysis. Nothing exists there yet — your write creates it, pure markdown with no frontmatter (the orchestrator tracks lifecycle in its own store; your file's existence is the completion signal)
+3. **Maturity indication** — one line on where the session stands. An input to weigh against your own read of the document, never a verdict.
 
 ## The Bar
 
-A research document always has another angle nobody took; the question is never "is anything unexplored" but "is this enough for what comes next". Discussion is what comes next — it decides on what this file found — so every candidate faces one test:
+What a review looks for follows the research's maturity. The orchestrator passes a one-line indication of where the session stands; weigh it against your own read of the document — open questions against concluded threads. The indication is an input, never a verdict.
 
-**Would the discussion that consumes this be wrong or blocked without it?**
+- **Early** — findings are breadth: angles nobody has taken, threads worth pulling, assumptions worth checking before they harden. Frame each as an investigable thread — the session offers deep-dives, and a well-framed early finding becomes one.
+- **Forming** — depth: coverage that stayed shallow, claims without evidence, threads bookmarked and forgotten, assumptions still unvalidated.
+- **Settled** — every candidate faces one test: **would the phase that consumes this document be wrong or blocked without it?** Discussion consumes research — it decides on what this file found — so the test lands on missing ground a decision would rest on.
 
-A candidate that passes is a finding. A candidate that fails — an interesting adjacency nobody needs, depth beyond what a decision turns on, a dimension the work was never scoped to cover — goes in **Observations** and is never raised with the user. Observations are part of the report and are read; they are not work.
+At every maturity, a candidate that fails — an interesting adjacency nobody needs, depth beyond what a decision turns on, a dimension the work was never scoped to cover — goes in **Observations** and is never raised with the user. Observations are part of the report and are read; they are not work.
 
 ## Lanes
 

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -147,6 +147,7 @@ The review agent receives:
 
 1. **Research file path(s)** — `.workflows/{work_unit}/research/{topic}.md` (for epic, include all research files in `.workflows/{work_unit}/research/` relevant to the current topic)
 2. **Output file path** — the `file` from the dispatch response. The agent writes its completed report there — pure markdown with one `### {ID}: {label}` section per finding (`F1`, `F2`, …), never frontmatter.
+3. **Maturity indication** — one line judging where the session stands. At conclusion this is `largely concluded` unless the session genuinely stopped early.
 
 When the agent returns:
 

--- a/skills/workflow-research-process/references/review-agent.md
+++ b/skills/workflow-research-process/references/review-agent.md
@@ -53,6 +53,7 @@ The review agent receives:
 
 1. **Research file path(s)** — `.workflows/{work_unit}/research/{topic}.md` (for epic, include all research files in `.workflows/{work_unit}/research/` relevant to the current topic)
 2. **Output file path** — the `file` from the dispatch response. The agent writes its completed report there — pure markdown with one `### {ID}: {label}` section per finding (`F1`, `F2`, …), never frontmatter.
+3. **Maturity indication** — one line judging where the session stands, from the session itself: early exploration, threads deepening, or largely concluded.
 
 > *Output the next fenced block as a code block:*
 


### PR DESCRIPTION
Stack layer 3 (design log: #756, M1–M3). The decisions taken at the
gate: early/forming/settled vocabulary, one canonical settled-end
wording, and the explicit deep-dive tie.

**One bar became three emphases.** The shipped bar asked every review
the settled question — right for a decided document, wrong for one two
decisions old, where it suppresses exactly the seeding findings an
early review is valued for. Each brief now grades:

- **early** — findings are fuel: untouched areas, questions worth
  asking. Things to pull on, not defects — no shape yet means nothing
  to have gaps in.
- **forming** — gaps proper: missing rationale, unexplored
  alternatives, unraised edge cases, stalled subtopics.
- **settled** — the canonical test, word-identical in both briefs:
  *would the phase that consumes this document be wrong or blocked
  without it?* — each brief naming its consumer in the clause after.

The final review needs no special case: at conclusion the map is
decided, so the settled emphasis applies by construction (M1).

**Maturity signals (M3).** Discussion self-derives from the Discussion
Map the brief already reads — tracked state beats impression. Research
has nothing tracked, so all three of its dispatch sites (session
review, deep-dive untouched, final review) pass a one-line indication
the agent weighs against its own read — an input, never a verdict. The
final review's indication is `largely concluded` unless the session
genuinely stopped early.

**The deep-dive tie.** Research's early emphasis frames findings as
investigable threads; the caller's existing "offering deep dives
during presentation" behaviour is what picks them up. One sentence
each side — the machinery existed, the connection was luck.

The Observations rule and nothing-defers-past-the-phase are unchanged
at every maturity.

Conventions lint 31/31, corpus 46 valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)