### PR TITLE
fix(review): polish the maturity stack — one axis wording, one statement, prelude placement

### DIFF
--- a/agents/workflow-discussion-review.md
+++ b/agents/workflow-discussion-review.md
@@ -18,7 +18,7 @@ You receive via the orchestrator's prompt:
 
 ## The Bar
 
-What a review looks for follows the document's maturity. Derive it from the Discussion Map you read in your process — mostly `pending` reads **early**, subtopics `converging` with some `decided` reads **forming**, mostly `decided` reads **settled** — and interpolate from the document itself when the map sits between stages.
+What a review looks for follows the document's maturity. Derive it from the Discussion Map — mostly `pending` reads **early**, subtopics `converging` with some `decided` reads **forming**, mostly `decided` reads **settled** — and interpolate from the document itself when the map sits between stages.
 
 - **Early** — findings are fuel: areas the conversation has not touched, questions worth asking, adjacent concerns worth a look. Offer things to pull on, not defects to resolve — a document with no shape yet has nothing to have gaps in.
 - **Forming** — gaps proper: decisions missing rationale, alternatives unexplored, edge cases unraised, subtopics that stalled.

--- a/agents/workflow-research-review.md
+++ b/agents/workflow-research-review.md
@@ -15,11 +15,11 @@ You receive via the orchestrator's prompt:
 
 1. **Research file path(s)** — the research document(s) to review
 2. **Output file path** — where to write your analysis. Nothing exists there yet — your write creates it, pure markdown with no frontmatter (the orchestrator tracks lifecycle in its own store; your file's existence is the completion signal)
-3. **Maturity indication** — one line on where the session stands. An input to weigh against your own read of the document, never a verdict.
+3. **Maturity indication** — one line on where the session stands.
 
 ## The Bar
 
-What a review looks for follows the research's maturity. The orchestrator passes a one-line indication of where the session stands; weigh it against your own read of the document — open questions against concluded threads. The indication is an input, never a verdict.
+What a review looks for follows the document's maturity. The orchestrator passes a one-line indication of where the session stands; weigh it against your own read of the document — open questions against concluded threads. The indication is an input, never a verdict.
 
 - **Early** — findings are breadth: angles nobody has taken, threads worth pulling, assumptions worth checking before they harden. Frame each as an investigable thread — the session offers deep-dives, and a well-framed early finding becomes one.
 - **Forming** — depth: coverage that stayed shallow, claims without evidence, threads bookmarked and forgotten, assumptions still unvalidated.

--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -28,6 +28,10 @@ Do not fire for quick lookups, single searches, or questions that inform the nex
 
 ---
 
+## Lanes
+
+Deep-dive findings are all walked — no batch lanes. Raises render under the heading `Needs Investigation`.
+
 ## A. Offer Deep Dive
 
 #### If user-initiated
@@ -110,10 +114,6 @@ The research session continues — do not wait for the agent to return.
 **Concurrency**: Before dispatching, count the `deep-dive` ids in `agent scan`'s `in_flight` list — excluding rows an earlier session dispatched (those agents are dead; incorporate them instead of counting them). Limit to 3-4 in flight at once. If the limit is reached, note the thread for later dispatch.
 
 ---
-
-## Lanes
-
-Deep-dive findings are all walked — no batch lanes. Raises render under the heading `Needs Investigation`.
 
 ## C. Check and Surface
 


### PR DESCRIPTION
Stack layer 5 — the self-review pass over layers 1–4, requested before
prose coverage. Full re-read of CONVENTIONS.md, then every changed
line of the stack against it.

**Three findings, all fixed here:**

1. **Self-referential scaffolding** (discussion brief). *"Derive it
   from the Discussion Map you read in your process"* pointed at the
   brief's own section structure — the kind of meta-reference the
   prose-economy rule exists to cut. Now just "Derive it from the
   Discussion Map"; the process step already says how to read it.
2. **Axis wording and duplication** (research brief). The axis was
   "the research's maturity" where discussion's brief says "the
   document's maturity" — one axis, one name. And
   input-never-a-verdict was stated in both the Input list and The
   Bar; it now lives only in The Bar, where it's applied.
3. **Structural placement** (deep-dive). Its `Lanes` declaration sat
   between flow sections B and C; both review callers put theirs in
   the prelude. Moved to match.

**Checked and clean:** the amendment-shape guidance lives exactly once
(discussion's Lanes block); the synthesis-always-walked rule survived
the §B rewrite; every deferring site reaches the canonical
landing-phase section as the immediate prelude to loading the same
file; no historical references, no authoring meta, no discussion
residue anywhere in the stack's added prose; all branch routing intact;
link paths verified by lint check 7.

Conventions lint 31/31, corpus 46 valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)