### PR TITLE
fix(review): an explore raise's move is investigation

### DIFF
--- a/skills/workflow-research-process/references/review-agent.md
+++ b/skills/workflow-research-process/references/review-agent.md
@@ -33,7 +33,7 @@ At natural conversational breaks, check for completed results.
 
 The shared surfacing protocol reads this declaration when presenting this phase's findings.
 
-- `explore` — the walked lane. Raises render under the heading `Needs Investigation`.
+- `explore` — the walked lane. Raises render under the heading `Needs Investigation`, and the raise's move is investigation: offer a deep-dive on the thread, never dispatched without the user's say.
 - `apply` — approving lands each fix as a pure correction: amend the affected sites in place, each amendment a dated note naming the source or finding that determines it. The confirmation says amended, never removed.
 - `route` — approving delivers each finding to its owning topic through the shared triage landing.
 


### PR DESCRIPTION
Stack layer 7 — a one-sentence prose gap the research walk found,
confirmed on two models.

The deep-dive tie was implemented brief-side only: the reviewer is told
to frame explore findings as investigable threads, but nothing
orchestrator-side said an explore *raise's* move is investigation.
Both walkers rendered the heading and framing correctly, then closed
on a plain conversational question — the shared move beat offers
"suggest a deep-dive" as one option among three, and with nothing
selecting it, neither walker did.

Per the three-owner contract the fix has exactly one home: research's
Lanes declaration, which owns what its lanes do. The explore bullet
now names the move — offer a deep-dive on the thread, never dispatched
without the user's say.

Only the red research case loads this file, so no green walk is
invalidated. Conventions lint 31/31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)