### PR TITLE
fix(research): the reroute selection renders from the engine

### DIFF
--- a/skills/workflow-research-process/references/epic-session.md
+++ b/skills/workflow-research-process/references/epic-session.md
@@ -51,19 +51,13 @@ When a concern surfaces that belongs to a *different* topic — raised in conver
 
    Resolve the target, and judge `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](../../workflow-shared/references/triage-landing.md)**. If one topic clearly matches, propose it — with the recommended phase — and confirm with the user (their reply may override the phase). If nothing fits, propose a new kebab-case name and confirm. If several plausible candidates exist — or a near-match you're unsure of — present them and let the user choose:
 
-   > *Output the next fenced block as markdown (not a code block):*
+   Write the candidates payload to `.workflows/.cache/{work_unit}/research/{topic}/reroute-candidates.json` with the Write tool (`{"concern": "…", "landing_phase": "…", "candidates": [{"name": "…", "lifecycle": "…"}]}` — every plausible home, lifecycle from the map read), then render it:
 
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs render reroute-candidates {work_unit}.research.{topic} --file .workflows/.cache/{work_unit}/research/{topic}/reroute-candidates.json
    ```
-   · · · · · · · · · · · ·
-   Where should "{concern}" land?
 
-   - **`1`** — {candidate} [{state}]
-   - **`2`** — {candidate} [{state}]
-   - **`n`/`new`** — Create a new topic for it
-
-   It reads as {concern_nature:[an open question — I'd land it research-side|a decision to make — I'd land it discussion-side]}. Reply with an option, appending a phase to override (e.g. `1 discussion`).
-   · · · · · · · · · · · ·
-   ```
+   Emit the call's MENU section verbatim per its marker.
 
    **STOP.** Wait for user response.
 

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -662,7 +662,7 @@ const RATCHET_PINS = {
   'skills/workflow-planning-process/references/resolve-dependencies.md': 1,
   'skills/workflow-research-process/references/deep-dive-agent.md': 2,
   'skills/workflow-research-process/references/document-review.md': 2,
-  'skills/workflow-research-process/references/epic-session.md': 3,
+  'skills/workflow-research-process/references/epic-session.md': 2,
   'skills/workflow-research-process/references/feature-session.md': 2,
   'skills/workflow-research-process/references/topic-splitting.md': 2,
   'skills/workflow-review-process/references/present-review.md': 7,


### PR DESCRIPTION
Stack layer 10 — the enumeration follow-through from #766, kept
separate because it is not that PR's scope.

The research session's off-topic path carried its own copy of the
ambiguous-reroute candidates menu as a templated fence — the same
fence family #766 converts on the discussion side. It now renders from
the same `reroute-candidates` surface (research-phase address and
cache path), and `epic-session.md`'s templated-fence pin tightens
3 → 2.

No new engine code — the surface landed in #766 with its tests.
Conventions lint 31/31, corpus 48 valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)