### PR TITLE
feat(engine): trees connect, hang, and column their tags

### DIFF
--- a/skills/workflow-engine/scripts/domain/conventions.cjs
+++ b/skills/workflow-engine/scripts/domain/conventions.cjs
@@ -66,10 +66,16 @@ function tag(term) {
   return `[${term}]`;
 }
 
-// `↳ Derived-from` line — provenance, capitalised. Feeds a tree node's body[].
-/** @param {string} text */
+// `↳ Derived-from` line — provenance, capitalised. Feeds a tree node's body[]
+// as a hanging paragraph: the marker is two columns wide, so continuation
+// lines indent past it and the provenance reads as one block rather than
+// wrapping back under the arrow. The domain owns the marker, so it owns its
+// width; the renderer only applies the hang it is given.
+const PROVENANCE_HANG = '↳ '.length;
+
+/** @param {string} text @returns {{text: string, hang: number}} */
 function derivedFrom(text) {
-  return '↳ ' + capitalise(String(text).trim());
+  return { text: '↳ ' + capitalise(String(text).trim()), hang: PROVENANCE_HANG };
 }
 
 // Compose a tree node's title from its parts: `glyph label [tag]`. Any part may

--- a/skills/workflow-engine/scripts/domain/projections/discovery-map.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/discovery-map.cjs
@@ -63,21 +63,19 @@ function breakdown(summary) {
   return ' — ' + present.map(([key, label]) => `${summary[key]} ${label}`).join(' · ');
 }
 
-/** Map rows as kernel tree nodes: glyph + name + [lifecycle label]. @param {DiscoveryMapRow[]} rows */
+/** Map rows as kernel tree nodes: glyph + name, lifecycle label in the tag column. @param {DiscoveryMapRow[]} rows */
 function mapNodes(rows) {
   return rows.map((row) => ({
-    title: title({
-      glyph: discoveryGlyph(row.lifecycle),
-      label: titlecase(row.name),
-      tag: discoveryLifecycleLabel(row.lifecycle, row.routing ?? null, row.research_state ?? null, row.triage_parked ?? false, row.reconcile_pending ?? false),
-    }),
+    title: title({ glyph: discoveryGlyph(row.lifecycle), label: titlecase(row.name) }),
+    tag: discoveryLifecycleLabel(row.lifecycle, row.routing ?? null, row.research_state ?? null, row.triage_parked ?? false, row.reconcile_pending ?? false),
   }));
 }
 
-/** Proposed rows: ○ (fresh-to-be) + name + [routing], summary wrapping beneath. @param {ProposedTopic[] } proposed */
+/** Proposed rows: ○ (fresh-to-be) + name, routing in the tag column, summary beneath. @param {ProposedTopic[] } proposed */
 function proposedNodes(proposed) {
   return proposed.map((t) => ({
-    title: title({ glyph: '○', label: titlecase(t.name), tag: t.routing }),
+    title: title({ glyph: '○', label: titlecase(t.name) }),
+    tag: t.routing,
     body: [t.summary],
   }));
 }

--- a/skills/workflow-engine/scripts/domain/projections/discussion-map.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/discussion-map.cjs
@@ -62,7 +62,7 @@ function discussionMap(topic, manifest) {
   const byName = new Map();
   for (const [name, sub] of Object.entries(subtopics)) {
     /** @type {TreeNode} */
-    const node = { title: title({ glyph: discussionGlyph(sub.status), label: titlecase(name), tag: sub.status }) };
+    const node = { title: title({ glyph: discussionGlyph(sub.status), label: titlecase(name) }), tag: sub.status };
     byName.set(name, { node, rank: rank(sub.status), kids: [] });
   }
 

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -147,13 +147,15 @@ function phaseNodes(phase, items) {
     const tagText = item.status === 'completed' && item.reconcile_needed !== undefined
       ? 'completed · input moved'
       : item.status;
-    let head = title({ label: titlecase(item.name), tag: tagText });
-    if (phase === 'planning' && item.format) head += ` · ${item.format}`;
-    /** @type {{title: string}[]} */
+    const head = title({ label: titlecase(item.name) });
+    // The plan format rides inside the tag rather than after it: anything
+    // appended past the tag column would break the alignment for every row.
+    const tag = phase === 'planning' && item.format ? `${tagText} · ${item.format}` : tagText;
+    /** @type {{title: string, tag?: string}[]} */
     const children = [];
     if (phase === 'specification' && Array.isArray(item.sources)) {
       for (const src of item.sources) {
-        children.push({ title: title({ label: titlecase(sourceName(src)), tag: src.status || 'pending' }) });
+        children.push({ title: title({ label: titlecase(sourceName(src)) }), tag: src.status || 'pending' });
       }
     }
     if (phase === 'implementation') {
@@ -164,7 +166,7 @@ function phaseNodes(phase, items) {
         children.push({ title: `${tasks} task(s) completed` });
       }
     }
-    return children.length ? { title: head, children } : { title: head };
+    return children.length ? { title: head, tag, children } : { title: head, tag };
   });
 }
 
@@ -225,7 +227,8 @@ function mapNodes(detail, heldTopics) {
     if (row.source_provenance) body.push(derivedFrom(row.source_provenance));
     const tag = heldTopics.has(row.name) ? `${lifecycleLabel(row)} · in session` : lifecycleLabel(row);
     const node = {
-      title: title({ glyph: discoveryGlyph(row.lifecycle), label: titlecase(row.name), tag }),
+      title: title({ glyph: discoveryGlyph(row.lifecycle), label: titlecase(row.name) }),
+      tag,
     };
     return body.length ? { ...node, body } : node;
   });
@@ -319,7 +322,11 @@ function epicDashboard(workUnit, detail, opts = {}) {
   const stages = [];
 
   if (hasMap) {
-    let block = signpost('DISCOVERY') + '\n\n';
+    // Stage dividers are drawn inside the fence, where markdown chrome cannot
+    // reach — so they size to the content they divide rather than to the
+    // kernel's fixed chrome width, and the dashboard stays internally
+    // consistent at any terminal width.
+    let block = signpost('DISCOVERY', { width: TREE_WIDTH }) + '\n\n';
     const callouts = stageMetaCallouts(detail, newArrivals);
     if (callouts.length > 0) block += callouts.join('\n') + '\n\n';
     const total = detail.map_summary ? detail.map_summary.total : detail.discovery_map.length;
@@ -333,7 +340,7 @@ function epicDashboard(workUnit, detail, opts = {}) {
     const populated = stage.phases.filter((p) => (detail.phases[p] || []).length > 0);
     if (populated.length === 0) continue;
     stages.push(
-      signpost(stage.name) + '\n\n'
+      signpost(stage.name, { width: TREE_WIDTH }) + '\n\n'
       + populated.map((p) => phaseBlock(p, detail.phases[p])).join('\n')
     );
   }

--- a/skills/workflow-engine/scripts/domain/projections/specification.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/specification.cjs
@@ -103,10 +103,10 @@ function itemBlock(number, row) {
   /** @type {TreeNode[]} */
   const nodes = [{ title: specLine(row) }];
   if (row.sources.length > 0) {
-    nodes.push({ title: 'Discussions:', children: row.sources.map((s) => ({ title: `${s.name} [${s.tag}]` })) });
+    nodes.push({ title: 'Discussions:', children: row.sources.map((s) => ({ title: s.name, tag: s.tag })) });
   }
   if (row.consult.length > 0) {
-    nodes.push({ title: 'Consult:', children: row.consult.map((c) => ({ title: `${c.name} [${c.status}]` })) });
+    nodes.push({ title: 'Consult:', children: row.consult.map((c) => ({ title: c.name, tag: c.status })) });
   }
   const tree = renderTree(nodes, { width: TREE_WIDTH })
     .replace(/\n+$/, '')
@@ -407,7 +407,7 @@ function specificationCompletedMenu(detail) {
   const rendered = dotFrame(lines);
 
   const display = 'Completed Specifications\n'
-    + renderTree(detail.concluded.map((row) => ({ title: title({ label: titlecase(row.name), tag: 'completed' }) })), { width: TREE_WIDTH });
+    + renderTree(detail.concluded.map((row) => ({ title: title({ label: titlecase(row.name) }), tag: 'completed' })), { width: TREE_WIDTH });
 
   return { keys, display, rendered };
 }

--- a/skills/workflow-engine/scripts/domain/projections/workunit.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/workunit.cjs
@@ -61,18 +61,15 @@ function pipelineNodes(cfg, unit) {
   for (const phase of cfg.pipeline) {
     if (unit.completed_phases.includes(phase)) {
       const tag = flaggedPhases.has(phase) ? 'completed · input moved' : 'completed';
-      nodes.push({ title: title({ glyph: '✓', label: titlecase(phase), tag }) });
+      nodes.push({ title: title({ glyph: '✓', label: titlecase(phase) }), tag });
     } else if (phase === unit.next_phase) {
       const started = nextPhaseStarted(unit);
       nodes.push({
-        title: title({
-          glyph: started ? '◐' : '→',
-          label: titlecase(phase),
-          tag: started ? 'in-progress' : 'ready',
-        }),
+        title: title({ glyph: started ? '◐' : '→', label: titlecase(phase) }),
+        tag: started ? 'in-progress' : 'ready',
       });
     } else if ((unit.in_progress_phases || []).includes(phase)) {
-      nodes.push({ title: title({ glyph: '◐', label: titlecase(phase), tag: 'in-progress' }) });
+      nodes.push({ title: title({ glyph: '◐', label: titlecase(phase) }), tag: 'in-progress' });
     }
   }
   return nodes;

--- a/skills/workflow-engine/scripts/gateway.cjs
+++ b/skills/workflow-engine/scripts/gateway.cjs
@@ -26,7 +26,11 @@
 
 const SECTION = {
   data:    '=== DATA (reason from this — never display or parse the sections below) ===',
-  display: '=== DISPLAY (emit verbatim as a code block) ===',
+  // The makefile fence is what tints a tree's `# tag` column apart from its
+  // rows. It is safe for arbitrary content — makefile highlighting leaves
+  // ordinary prose alone, unlike every language that treats English words as
+  // keywords — so a display carrying no tree renders exactly as it used to.
+  display: '=== DISPLAY (emit verbatim as a makefile code block — ```makefile fence) ===',
   menu:    '=== MENU (emit verbatim as markdown) ===',
 };
 

--- a/skills/workflow-engine/scripts/kernel/render.cjs
+++ b/skills/workflow-engine/scripts/kernel/render.cjs
@@ -13,9 +13,17 @@
 // ---------------------------------------------------------------------------
 
 /**
+ * @typedef {{text: string, hang?: number}} TreeBody
+ *   A body paragraph. `hang` indents its continuation lines, so a paragraph
+ *   opening with a marker wraps under its text rather than under the marker.
+ *   A bare string is the same thing with no hang.
+ */
+
+/**
  * @typedef {object} TreeNode
- * @property {string} title          one-line header row (glyph/label/tag already composed)
- * @property {string[]} [body]       paragraphs beneath the row; each wraps independently
+ * @property {string} title          one-line header row (glyph/label already composed)
+ * @property {string} [tag]          trailing annotation, aligned into a column across the tree
+ * @property {(string|TreeBody)[]} [body] paragraphs beneath the row; each wraps independently
  * @property {TreeNode[]} [children] nested nodes, same shape, recursively
  */
 
@@ -71,15 +79,22 @@ function wrap(text, budget) {
 // rendered width (prefix + text) within `width`. THE budget bug lives here and
 // only here: the wrap budget is `width - prefix.length`, never the bare width.
 // `prefix` is the gutter/indent string applied to every line uniformly.
-/** @param {string} text @param {{width?: number, prefix?: string}} [opts] @returns {string[]} */
-function wrapWithPrefix(text, { width = WIDTH, prefix = '' } = {}) {
-  const budget = width - prefix.length;
+//
+// `hang` indents continuation lines by that many columns, so a paragraph
+// opening with a marker (`↳ `) wraps under its text rather than under the
+// marker. The budget subtracts the hang from every line, not just the
+// continuations — one unused column on the first line buys arithmetic that
+// cannot overflow.
+/** @param {string} text @param {{width?: number, prefix?: string, hang?: number}} [opts] @returns {string[]} */
+function wrapWithPrefix(text, { width = WIDTH, prefix = '', hang = 0 } = {}) {
+  const budget = width - prefix.length - hang;
   if (budget < 1) {
     throw new Error(
       `wrapWithPrefix: prefix (${prefix.length}) leaves no room within width ${width}`
     );
   }
-  return wrap(text, budget).map((seg) => prefix + seg);
+  const continuation = prefix + ' '.repeat(hang);
+  return wrap(text, budget).map((seg, i) => (i === 0 ? prefix : continuation) + seg);
 }
 
 // ---------------------------------------------------------------------------
@@ -121,20 +136,29 @@ function box(title, { width = WIDTH } = {}) {
 // Shapes: tree (continuous-gutter, recursive)
 // ---------------------------------------------------------------------------
 
+// Marker introducing a row's trailing annotation. It is a comment opener in
+// the fence the tree is emitted into, which is what tints the annotation
+// apart from the row — the kernel only knows it as the string that precedes
+// a tag, never what the tag means.
+const TAG_MARKER = '# ';
+
+// Blank columns between the longest row and the tag column.
+const TAG_GAP = 4;
+
 // Render nodes as a continuous-gutter tree. PURE LAYOUT: branch glyphs (├─/└─,
 // never ┌─ — the list hangs off whatever header precedes it), a continuous │
-// gutter at every depth, body word-wrap with the gutter subtracted from the
-// budget, and recursion for children. It knows nothing about glyphs, tags, or
-// provenance — the caller composes those into the strings (see the domain
-// ring's conventions.cjs).
+// gutter at every depth, a connector from a parent down to its children, body
+// word-wrap with the gutter subtracted from the budget, and tags aligned into
+// one column. It knows nothing about glyphs, statuses, or provenance — the
+// caller composes those (see the domain ring's conventions.cjs).
 //
-//   ├─ ◐ Ai Content Engine [researching]      ← title (caller-composed line)
-//   │      summary text wrapped to the budget…  ← body[0]
-//   │      ↳ From exploration                   ← body[1]
-//   ├─ → Decision-Point INFO Line Shape
-//   │  ├─ ✓ Field Order                         ← child
-//   │  └─ ◐ Truncation Rules
-//   └─ ◐ Menu And Admin [researching]           ← last sibling drops the │
+//   ├─ ◐ Ai Content Engine        # researching   ← title + columnised tag
+//   │  │  Summary text wrapped to the budget…      ← body[0], hanging off
+//   │  │  ↳ From exploration                       ← body[1], marker hangs
+//   │  ├─ ✓ Field Order           # decided        ← child
+//   │  └─ ◐ Truncation Rules      # exploring
+//   └─ ◐ Menu And Admin           # researching    ← last sibling drops the │
+//         Summary with no children sits unconnected
 //
 // Every sub-line carries the accumulated gutter, so the │ runs unbroken at any
 // depth; the body wrap budget is width − gutter, so body can never orphan.
@@ -143,27 +167,34 @@ function renderTree(nodes, { width = displayWidth() } = {}) {
   if (!Array.isArray(nodes) || nodes.length === 0) {
     throw new Error('renderTree: nodes must be a non-empty array');
   }
-  /** @type {string[]} */
-  const out = [];
-  renderSiblings(nodes, '  ', width, out);
-  return out.join('\n') + '\n';
+  /** @type {{text: string, tag: string|null}[]} */
+  const rows = [];
+  renderSiblings(nodes, '  ', width, rows);
+  return columniseTags(rows, width).join('\n') + '\n';
 }
 
 // `prefix` is the accumulated gutter that precedes this level's branch glyphs.
-/** @param {TreeNode[]} nodes @param {string} prefix @param {number} width @param {string[]} out */
+/** @param {TreeNode[]} nodes @param {string} prefix @param {number} width @param {{text: string, tag: string|null}[]} out */
 function renderSiblings(nodes, prefix, width, out) {
   nodes.forEach((node, i) => {
     if (!node || !node.title) throw new Error(`renderTree: node ${i} needs a title`);
     const isLast = i === nodes.length - 1;
-    out.push(prefix + (isLast ? '└─ ' : '├─ ') + node.title);
+    out.push({ text: prefix + (isLast ? '└─ ' : '├─ ') + node.title, tag: node.tag || null });
     // Sub-content lives one level in. The last sibling drops the │ (blank) so
-    // nothing dangles below └─. Children branch at `childPrefix`; body has no
-    // branch, so it indents by the branch width (3) to land at the same content
-    // column — body text and child rows align.
+    // nothing dangles below └─.
     const childPrefix = prefix + (isLast ? '   ' : '│  ');
-    const bodyPrefix = childPrefix + '   ';
+    const hasChildren = !!(node.children && node.children.length);
+    // With children, the connector runs from this node's glyph through its
+    // body down to the last child, so the subtree visibly descends from its
+    // parent rather than appearing at an indent. With none there is nothing
+    // to connect to, so body indents to the content column instead.
+    const bodyPrefix = childPrefix + (hasChildren ? '│  ' : '   ');
     for (const para of node.body || []) {
-      for (const wl of wrapWithPrefix(para, { width, prefix: bodyPrefix })) out.push(wl);
+      const text = typeof para === 'string' ? para : para.text;
+      const hang = typeof para === 'string' ? 0 : (para.hang || 0);
+      for (const wl of wrapWithPrefix(text, { width, prefix: bodyPrefix, hang })) {
+        out.push({ text: wl, tag: null });
+      }
     }
     if (node.children && node.children.length) {
       renderSiblings(node.children, childPrefix, width, out);
@@ -171,4 +202,18 @@ function renderSiblings(nodes, prefix, width, out) {
   });
 }
 
-module.exports = { WIDTH, fillTo, wrap, wrapWithPrefix, signpost, box, renderTree };
+// Pad every tagged row out to one shared column so tags line up regardless of
+// label length or depth. When the column would push the longest tag past the
+// width, it tightens to a single space — an aligned column is worth less than
+// a row that fits.
+/** @param {{text: string, tag: string|null}[]} rows @param {number} width @returns {string[]} */
+function columniseTags(rows, width) {
+  const tagged = rows.filter((r) => r.tag);
+  if (!tagged.length) return rows.map((r) => r.text);
+  const longestRow = Math.max(...tagged.map((r) => r.text.length));
+  const longestTag = Math.max(...tagged.map((r) => TAG_MARKER.length + String(r.tag).length));
+  const column = longestRow + TAG_GAP + longestTag <= width ? longestRow + TAG_GAP : longestRow + 1;
+  return rows.map((r) => (r.tag ? r.text.padEnd(column) + TAG_MARKER + r.tag : r.text));
+}
+
+module.exports = { WIDTH, TAG_MARKER, TAG_GAP, fillTo, wrap, wrapWithPrefix, signpost, box, renderTree };

--- a/tests/scripts/test-engine-discovery-projections.cjs
+++ b/tests/scripts/test-engine-discovery-projections.cjs
@@ -72,13 +72,13 @@ describe('discoveryMapView', () => {
       '',
       '  Discovery Map (7 topics — 1 decided · 1 in flight · 1 ready · 2',
       '  fresh · 1 handled · 1 cancelled)',
-      '  ├─ ✓ Ordering Flow [decided]',
-      '  ├─ → Kitchen Hardware [research complete · ready for discussion]',
-      '  ├─ ◐ Menu Management [researching]',
-      '  ├─ ○ Loyalty [fresh]',
-      '  ├─ ○ Operator Analytics [fresh · routed to research]',
-      '  ├─ ⊙ Umbrella [handled]',
-      '  └─ ⊘ Legacy Import [cancelled]',
+      '  ├─ ✓ Ordering Flow      # decided',
+      '  ├─ → Kitchen Hardware   # research complete · ready for discussion',
+      '  ├─ ◐ Menu Management    # researching',
+      '  ├─ ○ Loyalty            # fresh',
+      '  ├─ ○ Operator Analytics # fresh · routed to research',
+      '  ├─ ⊙ Umbrella           # handled',
+      '  └─ ⊘ Legacy Import      # cancelled',
       '',
     ].join('\n'));
   });
@@ -101,8 +101,8 @@ describe('discoveryMapView', () => {
       '●───────────────────────────────────────────────●',
       '',
       '  Discovery Map (2 topics)',
-      '  ├─ ○ Alpha [fresh · routed to research]',
-      '  └─ ○ Beta [fresh · routed to discussion]',
+      '  ├─ ○ Alpha    # fresh · routed to research',
+      '  └─ ○ Beta     # fresh · routed to discussion',
       '',
     ].join('\n'));
   });
@@ -145,9 +145,9 @@ describe('discoveryMapView', () => {
       '●───────────────────────────────────────────────●',
       '',
       '  Discovery Map (3 topics — 1 ready · 2 handled)',
-      '  ├─ → Split Parent [research superseded · ready for discussion]',
-      '  ├─ ⊙ No Research [handled]',
-      '  └─ ⊙ Umbrella [handled · research fanned out]',
+      '  ├─ → Split Parent # research superseded · ready for discussion',
+      '  ├─ ⊙ No Research  # handled',
+      '  └─ ⊙ Umbrella     # handled · research fanned out',
       '',
     ].join('\n'));
   });
@@ -190,20 +190,20 @@ describe('discoverySynthesisView', () => {
       '  Synthesised Discovery Map — Payments',
       '',
       '  New this session (3):',
-      '  ├─ ○ Kitchen Printers [discussion]',
+      '  ├─ ○ Kitchen Printers      # discussion',
       '  │     Print routing by station, failure handling, and offline',
       '  │     queueing for kitchen ticket printers across multiple',
       '  │     sites',
-      '  ├─ ○ Operator Analytics [research]',
+      '  ├─ ○ Operator Analytics    # research',
       '  │     Daily service dashboards for shift leads — covers order',
       '  │     throughput, voids, and prep-time drift with per-branch',
       '  │     comparison',
-      '  └─ ○ Loyalty [discussion]',
+      '  └─ ○ Loyalty               # discussion',
       '        Points and rewards',
       '',
       '  Already on the map (2):',
-      '  ├─ ✓ Onboarding Flow [decided]',
-      '  └─ ◐ Payments Core [researching]',
+      '  ├─ ✓ Onboarding Flow    # decided',
+      '  └─ ◐ Payments Core      # researching',
       '',
       '  3 topic(s). Summaries come from the exploration; routing is my',
       '  read of where each one goes next.',
@@ -217,7 +217,7 @@ describe('discoverySynthesisView', () => {
       '  Synthesised Discovery Map — Payments',
       '',
       '  Proposed topics (1):',
-      '  └─ ○ Loyalty [discussion]',
+      '  └─ ○ Loyalty    # discussion',
       '        Points and rewards',
       '',
       '  1 topic(s). Summaries come from the exploration; routing is my',
@@ -251,11 +251,11 @@ describe('gateway.cjs adapter: map-view', () => {
     const res = run(['map-view', 'payments']);
     assert.strictEqual(res.status, 0);
     assert.ok(res.stdout.includes('=== DATA (reason from this — never display or parse the sections below) ==='));
-    assert.ok(res.stdout.includes('=== DISPLAY (emit verbatim as a code block) ==='));
+    assert.ok(res.stdout.includes('=== DISPLAY (emit verbatim as a makefile code block — ```makefile fence) ==='));
     assert.ok(!res.stdout.includes('=== MENU'));
     assert.match(res.stdout, /mode: map\n/);
     assert.match(res.stdout, /map: 7 topics — 1 decided, 1 in-flight, 1 ready, 2 fresh, 1 handled, 1 cancelled/);
-    assert.ok(res.stdout.includes('  ├─ → Kitchen Hardware [research complete · ready for discussion]'));
+    assert.ok(res.stdout.includes('  ├─ → Kitchen Hardware   # research complete · ready for discussion'));
   });
 
   it('--proposed-file renders the synthesis view and flags each proposed name in DATA', () => {

--- a/tests/scripts/test-engine-discussion-map.cjs
+++ b/tests/scripts/test-engine-discussion-map.cjs
@@ -143,12 +143,12 @@ describe('discussion-map projection: golden renders', () => {
     assert.strictEqual(discussionMap('auth-flow', m), [
       '  Discussion Map — Auth Flow (6 subtopics — 2 decided · 1',
       '  converging · 1 exploring · 1 pending · 1 deferred)',
-      '  ├─ ✓ Subsystem Prefix Taxonomy [decided]',
-      '  ├─ → Info Line Shape [converging]',
-      '  │  ├─ ✓ Field Order [decided]',
-      '  │  └─ ◐ Truncation Rules [exploring]',
-      '  ├─ ○ Rollout Sequencing [pending]',
-      '  └─ ⊙ Context Preservation [deferred]',
+      '  ├─ ✓ Subsystem Prefix Taxonomy    # decided',
+      '  ├─ → Info Line Shape              # converging',
+      '  │  ├─ ✓ Field Order               # decided',
+      '  │  └─ ◐ Truncation Rules          # exploring',
+      '  ├─ ○ Rollout Sequencing           # pending',
+      '  └─ ⊙ Context Preservation         # deferred',
       '',
     ].join('\n'));
   });
@@ -162,11 +162,11 @@ describe('discussion-map projection: golden renders', () => {
       'info-line-shape': { status: 'converging', parent: null },
     });
     assert.deepStrictEqual(discussionMap('auth-flow', m).split('\n').slice(2), [
-      '  ├─ ✓ Subsystem Prefix Taxonomy [decided]',
-      '  ├─ → Info Line Shape [converging]',
-      '  ├─ ◐ Truncation Rules [exploring]',
-      '  ├─ ○ Rollout Sequencing [pending]',
-      '  └─ ⊙ Context Preservation [deferred]',
+      '  ├─ ✓ Subsystem Prefix Taxonomy    # decided',
+      '  ├─ → Info Line Shape              # converging',
+      '  ├─ ◐ Truncation Rules             # exploring',
+      '  ├─ ○ Rollout Sequencing           # pending',
+      '  └─ ⊙ Context Preservation         # deferred',
       '',
     ]);
   });
@@ -180,11 +180,11 @@ describe('discussion-map projection: golden renders', () => {
       charlie: { status: 'pending', parent: null },
     });
     assert.deepStrictEqual(discussionMap('auth-flow', m).split('\n').slice(2, -1), [
-      '  ├─ ✓ Zulu [decided]',
-      '  ├─ ✓ Alpha [decided]',
-      '  ├─ ✓ Bravo [decided]',
-      '  ├─ ○ Mike [pending]',
-      '  └─ ○ Charlie [pending]',
+      '  ├─ ✓ Zulu       # decided',
+      '  ├─ ✓ Alpha      # decided',
+      '  ├─ ✓ Bravo      # decided',
+      '  ├─ ○ Mike       # pending',
+      '  └─ ○ Charlie    # pending',
     ]);
   });
 
@@ -196,10 +196,10 @@ describe('discussion-map projection: golden renders', () => {
       'field-order': { status: 'decided', parent: 'info-line-shape' },
     });
     assert.deepStrictEqual(discussionMap('auth-flow', m).split('\n').slice(2, -1), [
-      '  └─ ◐ Info Line Shape [exploring]',
-      '     ├─ ✓ Field Order [decided]',
-      '     ├─ ○ Truncation Rules [pending]',
-      '     └─ ⊙ Context Preservation [deferred]',
+      '  └─ ◐ Info Line Shape            # exploring',
+      '     ├─ ✓ Field Order             # decided',
+      '     ├─ ○ Truncation Rules        # pending',
+      '     └─ ⊙ Context Preservation    # deferred',
     ]);
   });
 
@@ -210,9 +210,9 @@ describe('discussion-map projection: golden renders', () => {
       'field-order': { status: 'pending', parent: 'info-line-shape' },
     });
     assert.deepStrictEqual(discussionMap('auth-flow', m).split('\n').slice(2, -1), [
-      '  ├─ ✓ Info Line Shape [decided]',
-      '  │  └─ ○ Field Order [pending]',
-      '  └─ ○ Rollout Sequencing [pending]',
+      '  ├─ ✓ Info Line Shape       # decided',
+      '  │  └─ ○ Field Order        # pending',
+      '  └─ ○ Rollout Sequencing    # pending',
     ]);
   });
 
@@ -222,8 +222,8 @@ describe('discussion-map projection: golden renders', () => {
       'info-line-shape': { status: 'exploring', parent: null },
     });
     assert.deepStrictEqual(discussionMap('auth-flow', m).split('\n').slice(2, -1), [
-      '  └─ ◐ Info Line Shape [exploring]',
-      '     └─ ✓ Field Order [decided]',
+      '  └─ ◐ Info Line Shape    # exploring',
+      '     └─ ✓ Field Order     # decided',
     ]);
   });
 
@@ -239,8 +239,8 @@ describe('discussion-map projection: golden renders', () => {
     });
     assert.strictEqual(discussionMap('auth-flow', m), [
       '  Discussion Map — Auth Flow (2 subtopics)',
-      '  ├─ ○ One [pending]',
-      '  └─ ○ Two [pending]',
+      '  ├─ ○ One    # pending',
+      '  └─ ○ Two    # pending',
       '',
     ].join('\n'));
   });
@@ -249,7 +249,7 @@ describe('discussion-map projection: golden renders', () => {
     const m = manifestWith({ 'prefix-taxonomy': { status: 'pending', parent: null } });
     assert.strictEqual(discussionMap('auth-flow', m), [
       '  Discussion Map — Auth Flow (1 subtopic)',
-      '  └─ ○ Prefix Taxonomy [pending]',
+      '  └─ ○ Prefix Taxonomy    # pending',
       '',
     ].join('\n'));
   });
@@ -420,11 +420,11 @@ describe('discussion adapter: map verb', () => {
       'unresolved: ["token-refresh"]',
       'review_cycles: 1',
       '',
-      '=== DISPLAY (emit verbatim as a code block) ===',
+      '=== DISPLAY (emit verbatim as a makefile code block — ```makefile fence) ===',
       '  Discussion Map — Auth Flow (2 subtopics — 1 decided · 1',
       '  exploring)',
-      '  ├─ ✓ Session Storage [decided]',
-      '  └─ ◐ Token Refresh [exploring]',
+      '  ├─ ✓ Session Storage    # decided',
+      '  └─ ◐ Token Refresh      # exploring',
       '',
       "=== MENU: defer gate (emit verbatim as markdown only at the concluding step, then STOP for the user's response) ===",
       '· · · · · · · · · · · ·',

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -60,7 +60,7 @@ describe('epic projections: dashboard (map branch)', () => {
     '  Quiz Competition V1',
     '●───────────────────────────────────────────────●',
     '',
-    '── DISCOVERY ────────────────────────────────────',
+    '── DISCOVERY ────────────────────────────────────────────────────',
     '',
     '  · seeded from the inbox',
     '  · 1 import',
@@ -68,29 +68,29 @@ describe('epic projections: dashboard (map branch)', () => {
     '  ⚑ 1 discussion(s) reopened by coherence review.',
     '',
     '  RESEARCH & DISCUSSION (2 topics · 1 ready · 1 fresh)',
-    '  ├─ → Kitchen Hardware [research complete · ready for discussion]',
+    '  ├─ → Kitchen Hardware # research complete · ready for discussion',
     '  │     Receipt printing, KDS handoff, and the',
     '  │     fastest-cumulative-time-tiebreak-resolution-policy-and-of',
     '  │     fline-sync token that cannot break',
-    '  └─ ○ Menu Admin [fresh · routed to discussion]',
+    '  └─ ○ Menu Admin       # fresh · routed to discussion',
     '        Business-side menu modelling, admin shell (Filament vs',
     '        custom Vue/Nuxt), JustEat import, staff/roles',
     '        ↳ From exploration',
     '',
-    '── DEFINITION ───────────────────────────────────',
+    '── DEFINITION ───────────────────────────────────────────────────',
     '',
     '  SPECIFICATION (1 completed)',
-    '  └─ Roles And Permissions [completed]',
-    '     ├─ Menu Admin [incorporated]',
-    '     └─ Auth Flow [pending]',
+    '  └─ Roles And Permissions    # completed',
+    '     ├─ Menu Admin            # incorporated',
+    '     └─ Auth Flow             # pending',
     '',
     '  PLANNING (1 completed)',
-    '  └─ Roles And Permissions [completed] · tick',
+    '  └─ Roles And Permissions    # completed · tick',
     '',
-    '── DELIVERY ─────────────────────────────────────',
+    '── DELIVERY ─────────────────────────────────────────────────────',
     '',
     '  IMPLEMENTATION (1 in-progress)',
-    '  └─ Roles And Permissions [in-progress]',
+    '  └─ Roles And Permissions    # in-progress',
     '     └─ Phase 2, 3 task(s) completed',
     '',
   ].join('\n');
@@ -107,7 +107,7 @@ describe('epic projections: dashboard (map branch)', () => {
       newArrivals: { research_analysis: ['menu-admin'], gap_analysis: [] },
     });
     const lines = out.split('\n');
-    const start = lines.indexOf('  ├─ → Kitchen Hardware [research complete · ready for discussion]');
+    const start = lines.findIndex((l) => l.startsWith('  ├─ → Kitchen Hardware'));
     const end = lines.indexOf('        ↳ From exploration');
     assert.ok(start > 0 && end > start, 'map tree rows present');
     let underLast = false;
@@ -136,10 +136,10 @@ describe('epic projections: dashboard (map branch)', () => {
         '  V1',
         '●───────────────────────────────────────────────●',
         '',
-        '── DISCOVERY ────────────────────────────────────',
+        '── DISCOVERY ────────────────────────────────────────────────────',
         '',
         '  RESEARCH & DISCUSSION (1 topics · 1 fresh)',
-        '  └─ ○ Topic [fresh · routed to research]',
+        '  └─ ○ Topic    # fresh · routed to research',
         '',
       ].join('\n')
     );
@@ -156,7 +156,7 @@ describe('epic projections: dashboard (map branch)', () => {
       },
     });
     const out = epicDashboard('v1', d);
-    assert.ok(out.includes('Menu Admin [completed · input moved]'), out);
+    assert.match(out, /Menu Admin\s+# completed · input moved/, out);
     const key = epicKey(d);
     assert.ok(key.includes('input moved — an upstream artifact was revised'), key);
     const { keys } = epicMenu('v1', d);
@@ -177,7 +177,7 @@ describe('epic projections: dashboard (map branch)', () => {
       },
     });
     const out = epicDashboard('v1', d);
-    assert.ok(out.includes('✓ Fees [decided · input moved]'), out);
+    assert.match(out, /✓ Fees\s+# decided · input moved/, out);
     const key = epicKey(d);
     assert.ok(key.includes('input moved — an upstream artifact was revised'), key);
   });
@@ -244,7 +244,7 @@ describe('epic projections: dashboard (map branch)', () => {
     });
     const out = epicDashboard('v1', d);
     assert.ok(out.includes('  RESEARCH & DISCUSSION (1 topics · 1 fresh)'), out);
-    assert.ok(out.includes('  └─ ○ Parked [fresh · routed to research · triage waiting]'), out);
+    assert.match(out, /  └─ ○ Parked\s+# fresh · routed to research · triage waiting/, out);
   });
 });
 
@@ -268,14 +268,14 @@ describe('epic projections: dashboard (no-map and brand-new branches)', () => {
         '  Auth Overhaul',
         '●───────────────────────────────────────────────●',
         '',
-        '── DISCOVERY ────────────────────────────────────',
+        '── DISCOVERY ────────────────────────────────────────────────────',
         '',
         '  RESEARCH (1 in-progress, 1 completed)',
-        '  ├─ Market Analysis [in-progress]',
-        '  └─ Competitor Scan [completed]',
+        '  ├─ Market Analysis    # in-progress',
+        '  └─ Competitor Scan    # completed',
         '',
         '  DISCUSSION (1 completed)',
-        '  └─ Auth Flow [completed]',
+        '  └─ Auth Flow    # completed',
         '',
         '  ⚑ Consider completing remaining research before starting',
         '    discussion. Topic analysis works best with all research',
@@ -737,8 +737,8 @@ describe('epic projections: presence join', () => {
   it('the dashboard cues held map rows and the key explains the cue', () => {
     const d = twoTopicDetail();
     const out = epicDashboard('v1', d, { presence: [heldRow] });
-    assert.ok(out.includes('Topic A [discussing · in session]'), out);
-    assert.ok(!out.includes('Topic B [fresh · routed to discussion · in session]'), out);
+    assert.match(out, /Topic A\s+# discussing · in session/, out);
+    assert.doesNotMatch(out, /Topic B\s+# fresh · routed to discussion · in session/, out);
     const key = epicKey(d, { presence: [heldRow] });
     assert.ok(key.includes('    Session:\n      in session — a live session elsewhere holds this topic'), key);
     assert.ok(!epicKey(d).includes('Session:'), 'no presence, no session key block');
@@ -944,7 +944,7 @@ describe('epic projections: selection sub-views', () => {
       '  2  resume  auth-flow  discussion  → /workflow-discussion-entry epic quiz-competition-v1 auth-flow',
       '  b  back  —  —  → (internal)',
       '',
-      '=== DISPLAY (emit verbatim as a code block) ===',
+      '=== DISPLAY (emit verbatim as a makefile code block — ```makefile fence) ===',
       'Completed Topics',
       '',
       '  Research',

--- a/tests/scripts/test-engine-specification-projections.cjs
+++ b/tests/scripts/test-engine-specification-projections.cjs
@@ -206,16 +206,16 @@ describe('specification projections: display goldens', () => {
       '1. Auth Flow',
       '   ├─ Spec: [no spec]',
       '   └─ Discussions:',
-      '      ├─ auth-design [ready]',
-      '      └─ session-model [ready]',
+      '      ├─ auth-design      # ready',
+      '      └─ session-model    # ready',
       '',
       '2. Data Spec',
       '   ├─ Spec: in-progress (1 of 2 sources extracted)',
       '   ├─ Discussions:',
-      '   │  ├─ data-model [pending]',
-      '   │  └─ session-model [extracted]',
+      '   │  ├─ data-model       # pending',
+      '   │  └─ session-model    # extracted',
       '   └─ Consult:',
-      '      └─ billing [pending]',
+      '      └─ billing          # pending',
       '',
       '⚑ Discussions not ready for specification:',
       '  These discussions are still in progress and must be completed',
@@ -281,13 +281,13 @@ describe('specification projections: display goldens', () => {
       '1. Auth Spec',
       '   ├─ Spec: in-progress (1 of 1 sources extracted)',
       '   └─ Discussions:',
-      '      └─ auth-design [extracted, reopened]',
+      '      └─ auth-design    # extracted, reopened',
       '',
       '2. Data Spec',
       '   ├─ Spec: completed (1 of 2 sources extracted)',
       '   └─ Discussions:',
-      '      ├─ data-model [extracted]',
-      '      └─ billing [pending]',
+      '      ├─ data-model    # extracted',
+      '      └─ billing       # pending',
       '',
       'Completed discussions not in a specification:',
       '  • reports',
@@ -373,7 +373,7 @@ describe('specification projections: display goldens', () => {
       '1. V1',
       '   ├─ Spec: [no spec]',
       '   └─ Discussions:',
-      '      └─ solo [ready]',
+      '      └─ solo    # ready',
       '',
       '⚑ Discussions not ready for specification:',
       '  These discussions are still in progress and must be completed',
@@ -411,7 +411,7 @@ describe('specification projections: display goldens', () => {
       '1. V1',
       '   ├─ Spec: in-progress (1 of 1 sources extracted)',
       '   └─ Discussions:',
-      '      └─ solo [extracted]',
+      '      └─ solo    # extracted',
       '',
       'Key:',
       '',
@@ -453,8 +453,8 @@ describe('specification projections: display goldens', () => {
       '1. Combined Spec',
       '   ├─ Spec: completed (2 of 2 sources extracted)',
       '   └─ Discussions:',
-      '      ├─ solo [extracted]',
-      '      └─ other [extracted, reopened]',
+      '      ├─ solo     # extracted',
+      '      └─ other    # extracted, reopened',
       '',
       '⚑ Discussions not ready for specification:',
       '  These discussions are still in progress and must be completed',
@@ -700,8 +700,8 @@ describe('specification projections: menu goldens', () => {
     const sub = specificationCompletedMenu(detailOf(dir, 'v1'));
     assert.strictEqual(sub.display, [
       'Completed Specifications',
-      '  ├─ Auth Flow [completed]',
-      '  └─ Data Model [completed]',
+      '  ├─ Auth Flow     # completed',
+      '  └─ Data Model    # completed',
       '',
     ].join('\n'));
     assert.strictEqual(sub.rendered, [
@@ -773,7 +773,7 @@ describe('specification adapter: gateway verbs', () => {
     ].join('\n'));
     const out = run(['view', 'v1']);
     assert.ok(out.includes('=== DATA (reason from this — never display or parse the sections below) ==='));
-    assert.ok(out.includes('=== DISPLAY (emit verbatim as a code block) ==='));
+    assert.ok(out.includes('=== DISPLAY (emit verbatim as a makefile code block — ```makefile fence) ==='));
     assert.ok(out.includes('=== MENU (emit verbatim as markdown) ==='));
     assert.ok(out.includes('scenario: groupings\n'));
     assert.ok(out.includes('discussions_checksum: (none)'));
@@ -787,7 +787,7 @@ describe('specification adapter: gateway verbs', () => {
     createManifest(dir, 'v1', { work_type: 'epic' });
     const out = run(['view', 'v1']);
     assert.ok(out.includes('scenario: blocked-no-discussions'));
-    assert.ok(out.includes('=== DISPLAY (emit verbatim as a code block) ==='));
+    assert.ok(out.includes('=== DISPLAY (emit verbatim as a makefile code block — ```makefile fence) ==='));
     assert.ok(!out.includes('=== MENU'));
     assert.ok(!out.includes('ACTIONS'));
   });

--- a/tests/scripts/test-engine-workunit-projections.cjs
+++ b/tests/scripts/test-engine-workunit-projections.cjs
@@ -47,8 +47,8 @@ describe('workunit projections: status display', () => {
       '  · 2 imports',
       '',
       '  PIPELINE (feature)',
-      '  ├─ ✓ Discussion [completed]',
-      '  └─ ◐ Specification [in-progress]',
+      '  ├─ ✓ Discussion       # completed',
+      '  └─ ◐ Specification    # in-progress',
       '',
     ].join('\n'));
   });
@@ -58,7 +58,7 @@ describe('workunit projections: status display', () => {
     assert.strictEqual(workUnitStatus('feature', unitOf(dir, 'feature', 'dark-mode')), [
       ...boxOf('Dark Mode'),
       '  PIPELINE (feature)',
-      '  └─ → Discussion [ready]',
+      '  └─ → Discussion    # ready',
       '',
     ].join('\n'));
   });
@@ -82,9 +82,9 @@ describe('workunit projections: status display', () => {
     assert.strictEqual(workUnitStatus('feature', unit), [
       ...boxOf('Auth Flow'),
       '  PIPELINE (feature)',
-      '  ├─ ✓ Discussion [completed]',
-      '  ├─ ✓ Specification [completed · input moved]',
-      '  └─ ✓ Planning [completed]',
+      '  ├─ ✓ Discussion       # completed',
+      '  ├─ ✓ Specification    # completed · input moved',
+      '  └─ ✓ Planning         # completed',
       '',
       '  ⚑ Specification input moved — discussion revised since it completed.',
       '',
@@ -104,8 +104,8 @@ describe('workunit projections: status display', () => {
     assert.strictEqual(workUnitStatus('bugfix', unitOf(dir, 'bugfix', 'login-crash')), [
       ...boxOf('Login Crash'),
       '  PIPELINE (bugfix)',
-      '  ├─ ✓ Investigation [completed]',
-      '  └─ → Specification [ready]',
+      '  ├─ ✓ Investigation    # completed',
+      '  └─ → Specification    # ready',
       '',
     ].join('\n'));
   });
@@ -118,7 +118,7 @@ describe('workunit projections: status display', () => {
     assert.strictEqual(workUnitStatus('quick-fix', unitOf(dir, 'quick-fix', 'rename-api')), [
       ...boxOf('Rename Api'),
       '  PIPELINE (quick-fix)',
-      '  └─ ◐ Scoping [in-progress]',
+      '  └─ ◐ Scoping    # in-progress',
       '',
     ].join('\n'));
   });
@@ -134,9 +134,9 @@ describe('workunit projections: status display', () => {
     assert.strictEqual(workUnitStatus('cross-cutting', unitOf(dir, 'cross-cutting', 'caching')), [
       ...boxOf('Caching'),
       '  PIPELINE (cross-cutting)',
-      '  ├─ ✓ Research [completed]',
-      '  ├─ ✓ Discussion [completed]',
-      '  └─ → Specification [ready]',
+      '  ├─ ✓ Research         # completed',
+      '  ├─ ✓ Discussion       # completed',
+      '  └─ → Specification    # ready',
       '',
     ].join('\n'));
   });
@@ -152,8 +152,8 @@ describe('workunit projections: status display', () => {
     assert.strictEqual(workUnitStatus('cross-cutting', unitOf(dir, 'cross-cutting', 'caching')), [
       ...boxOf('Caching'),
       '  PIPELINE (cross-cutting)',
-      '  ├─ ✓ Discussion [completed]',
-      '  └─ ✓ Specification [completed]',
+      '  ├─ ✓ Discussion       # completed',
+      '  └─ ✓ Specification    # completed',
       '',
       '  ⚑ All phases complete — ready to finalise.',
       '',
@@ -179,11 +179,11 @@ describe('workunit projections: status display', () => {
     assert.strictEqual(workUnitStatus('feature', unit), [
       ...boxOf('Auth Flow'),
       '  PIPELINE (feature)',
-      '  ├─ ◐ Discussion [in-progress]',
-      '  ├─ ✓ Specification [completed]',
-      '  ├─ ✓ Planning [completed]',
-      '  ├─ ✓ Implementation [completed]',
-      '  └─ ✓ Review [completed]',
+      '  ├─ ◐ Discussion        # in-progress',
+      '  ├─ ✓ Specification     # completed',
+      '  ├─ ✓ Planning          # completed',
+      '  ├─ ✓ Implementation    # completed',
+      '  └─ ✓ Review            # completed',
       '',
     ].join('\n'));
   });
@@ -201,11 +201,11 @@ describe('workunit projections: status display', () => {
     assert.strictEqual(workUnitStatus('feature', unitOf(dir, 'feature', 'auth-flow')), [
       ...boxOf('Auth Flow'),
       '  PIPELINE (feature)',
-      '  ├─ ◐ Discussion [in-progress]',
-      '  ├─ ✓ Specification [completed]',
-      '  ├─ ◐ Planning [in-progress]',
-      '  ├─ ✓ Implementation [completed]',
-      '  └─ ✓ Review [completed]',
+      '  ├─ ◐ Discussion        # in-progress',
+      '  ├─ ✓ Specification     # completed',
+      '  ├─ ◐ Planning          # in-progress',
+      '  ├─ ✓ Implementation    # completed',
+      '  └─ ✓ Review            # completed',
       '',
     ].join('\n'));
   });

--- a/tests/scripts/test-render.cjs
+++ b/tests/scripts/test-render.cjs
@@ -26,18 +26,21 @@ const {
 // the split: conventions builds the strings, the renderer lays them out).
 const MAP = [
   {
-    title: title({ glyph: discoveryGlyph('researching'), label: 'Ai Content Engine', tag: 'researching' }),
+    title: title({ glyph: discoveryGlyph('researching'), label: 'Ai Content Engine' }),
+    tag: 'researching',
     body: [
       'AI imagery (enhancement-only v1), description generation, per-tenant tone / base-knowledge primitive, allowance + overage cost shape',
       derivedFrom('from exploration'),
     ],
   },
   {
-    title: title({ glyph: discoveryGlyph('ready_for_discussion'), label: 'Legal And Regulatory', tag: 'research complete · ready for discussion' }),
+    title: title({ glyph: discoveryGlyph('ready_for_discussion'), label: 'Legal And Regulatory' }),
+    tag: 'research complete · ready for discussion',
     body: ['Data residency, GDPR, age-gating for the competition flows', derivedFrom('from research-analysis')],
   },
   {
-    title: title({ glyph: discoveryGlyph('researching'), label: 'Menu And Admin', tag: 'researching' }),
+    title: title({ glyph: discoveryGlyph('researching'), label: 'Menu And Admin' }),
+    tag: 'researching',
     body: ['Business-side menu modelling, admin shell (Filament vs custom Vue/Nuxt), JustEat import, staff/roles', derivedFrom('from exploration')],
   },
 ];
@@ -178,14 +181,17 @@ describe('render shape: box (phase title)', () => {
 describe('render shape: renderTree (discovery map)', () => {
   it('reproduces the documented row lines byte-for-byte', () => {
     const lines = renderTree(MAP, { width: 65 }).split('\n');
-    assert.strictEqual(lines[0], '  ├─ ◐ Ai Content Engine [researching]');
+    // One shared tag column across the whole tree. The longest row sets it;
+    // here the 40-char tag will not fit at width 65, so the column tightens
+    // to a single space rather than pushing the tag past the edge.
+    assert.strictEqual(lines[0], '  ├─ ◐ Ai Content Engine    # researching');
     assert.strictEqual(
       lines.find((l) => l.includes('Legal And Regulatory')),
-      '  ├─ → Legal And Regulatory [research complete · ready for discussion]'
+      '  ├─ → Legal And Regulatory # research complete · ready for discussion'
     );
     assert.strictEqual(
       lines.find((l) => l.includes('Menu And Admin')),
-      '  └─ ◐ Menu And Admin [researching]'
+      '  └─ ◐ Menu And Admin       # researching'
     );
   });
 
@@ -269,8 +275,8 @@ describe('conventions (domain composition layer)', () => {
     assert.strictEqual(capitalise(''), '');
   });
 
-  it('derivedFrom builds a capitalised ↳ line', () => {
-    assert.strictEqual(derivedFrom('from research-analysis'), '↳ From research-analysis');
+  it('derivedFrom builds a capitalised ↳ line that hangs past its marker', () => {
+    assert.deepStrictEqual(derivedFrom('from research-analysis'), { text: '↳ From research-analysis', hang: 2 });
   });
 
   it('title composes glyph + label + [tag], omitting absent parts', () => {


### PR DESCRIPTION
Slice 2 of the adaptive-display stack, on top of #771.

Connector from parent to children, hanging indents on wrapped body lines, `[tag]` → a shared right-aligned `# tag` column, and the makefile fence that tints it. Stage dividers size to the content they divide.

Gates: 1978 node tests, 40 + 357 + 5 CLI, 46 migration suites, typecheck — all green. Prose snapshots unmoved (trees never land on disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)