### PR TITLE
feat(display): blocked states render red — advisories stay plain

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -262,6 +262,8 @@ Advisory and gating messages inside code blocks use a `⚑` prefix to visually s
   before they can be included in a specification.
 ```
 
+**Blocked states render red — advisory callouts stay plain.** A message meaning *you cannot proceed* (a terminal entry blocker, a conclusion blocked on an unmet condition) emits in its own `properties` fence: the `⚑` first token renders turquoise, everything after it red, and `properties` is the one highlighter that never tokenises English, so the message stays uniform whatever words it contains. One logical line, flag at column zero, no hard wrapping — a wrapped continuation would restart the per-line colouring mid-sentence, while the renderer's own soft-wrap keeps it intact. Guidance (what to do about it) travels separately as a markdown signpost beneath the fence, where it reflows. A warning or suggestion the user may act on or ignore is not a blocked state — it keeps the plain form above, so red stays rare enough to mean something. Engine blockers build through `blocker()` in `domain/render.cjs`; prose-authored blockers mirror the same shape.
+
 ### Content Dividers & Frames
 
 Inside a single DISPLAY/code block, centered `── {Title} ──` dividers separate grouped content (the epic dashboard's stage dividers, per-item boundaries in inbox views). They are content dividers, not step markers — no width rule, no signpost pairing.

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -12,7 +12,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic queue {work_unit} d
 
 **If `count` is non-zero:**
 
-A rerouted concern is still queued — it must be discussed and folded before concluding. Render the blocker and emit its `DISPLAY: triage block` section verbatim as a code block:
+A rerouted concern is still queued — it must be discussed and folded before concluding. Render the blocker and emit both its sections verbatim per their markers — the red blocker line, then its guidance:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render triage-block {work_unit}.discussion.{topic}

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -834,10 +834,16 @@ function triageBlock(cwd, { dotpath }) {
   const { files } = triageQueue(cwd, workUnit, phase, topic);
   if (!files.length) throw new Error(`render triage-block: the ${topic} ${phase} triage queue is empty — nothing blocks conclusion`);
   const doing = phase === 'research' ? 'exploration' : 'discussion';
-  return section('DISPLAY: triage block', 'emit verbatim as a code block', callout([
-    `Triage queue not empty — ${files.length} rerouted concern${files.length === 1 ? '' : 's'} awaiting ${doing}.`,
-    'Returning to the session to surface them before concluding.',
-  ]));
+  // A true blocker — the red register (see blocker()), guidance as markdown.
+  return section(
+    'DISPLAY: triage block',
+    'emit verbatim as a properties code block — ```properties fence',
+    `⚑ Triage queue not empty — ${files.length} rerouted concern${files.length === 1 ? '' : 's'} awaiting ${doing}`,
+  ) + section(
+    'DISPLAY: triage block guidance',
+    'emit verbatim as markdown',
+    '> Returning to the session to surface them before concluding.',
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -987,12 +993,23 @@ function itemOf(manifest, phase, topic) {
   return (((manifest.phases || {})[phase] || {}).items || {})[topic];
 }
 
-/** @param {string} title @param {string[]} bodyLines */
-function blocker(title, bodyLines) {
+// Blocked states render red: a `properties` fence colours the first token
+// (the ⚑) turquoise and everything after it red, and is the one highlighter
+// that never tokenises English — so the message stays uniform whatever words
+// it contains. One logical line only; a hard-wrapped continuation would
+// restart the per-line colouring mid-sentence, while soft-wrap keeps it
+// intact. Red means "you cannot proceed" — guidance travels in its own
+// markdown section as a signpost, so it reflows and stays calm.
+/** @param {string} fact @param {string} guidance */
+function blocker(fact, guidance) {
   return section(
     'DISPLAY: entry blocker',
-    'emit verbatim as a code block, then STOP — terminal condition',
-    [title, '', ...bodyLines].join('\n'),
+    'emit verbatim as a properties code block — ```properties fence',
+    `⚑ ${fact}`,
+  ) + section(
+    'DISPLAY: blocker guidance',
+    'emit verbatim as markdown, then STOP — terminal condition',
+    `> ${guidance}`,
   );
 }
 
@@ -1013,16 +1030,16 @@ function entryGate(cwd, { dotpath, own }) {
     }
     const spec = itemOf(manifest, 'specification', topic) || {};
     if (spec.status === 'superseded') {
-      return blocker('Specification Superseded', [
-        `The specification for "${t}" was consolidated into`,
-        `"${titlecase(String(spec.superseded_by || ''))}". Work on that specification instead.`,
-      ]);
+      return blocker(
+        `The specification for "${t}" was consolidated into "${titlecase(String(spec.superseded_by || ''))}"`,
+        'Work on that specification instead.',
+      );
     }
     if (spec.status === 'promoted') {
-      return blocker('Specification Promoted', [
-        `"${t}" was promoted to the cross-cutting work unit`,
-        `"${String(spec.promoted_to || '')}". Continue it from that work unit.`,
-      ]);
+      return blocker(
+        `"${t}" was promoted to the cross-cutting work unit "${String(spec.promoted_to || '')}"`,
+        'Continue it from that work unit.',
+      );
     }
     return '';
   }
@@ -1031,42 +1048,34 @@ function entryGate(cwd, { dotpath, own }) {
     const spec = itemOf(manifest, 'specification', topic);
     const status = spec && spec.status;
     if (!status) {
-      return blocker('Specification Missing', [
-        `No specification found for "${t}".`,
-        '',
+      return blocker(
+        `No specification found for "${t}"`,
         'The specification must be completed before planning can begin.',
-      ]);
+      );
     }
     if (status === 'in-progress') {
-      return blocker('Specification In Progress', [
-        `The specification for "${t}" is not yet completed.`,
-        '',
+      return blocker(
+        `The specification for "${t}" is not yet completed`,
         'The specification must be completed before planning can begin.',
-      ]);
+      );
     }
     if (status === 'proposed') {
-      return blocker('Specification Not Started', [
-        `"${t}" is a proposed grouping — the specification`,
-        "hasn't been started yet.",
-        '',
-        'Start the specification first, then return to planning once it',
-        'completes.',
-      ]);
+      return blocker(
+        `"${t}" is a proposed grouping — the specification hasn't been started yet`,
+        'Start the specification first, then return to planning once it completes.',
+      );
     }
     if (status === 'superseded') {
-      return blocker('Specification Superseded', [
-        `The specification for "${t}" was consolidated into`,
-        `"${titlecase(String(spec.superseded_by || ''))}".`,
-        '',
+      return blocker(
+        `The specification for "${t}" was consolidated into "${titlecase(String(spec.superseded_by || ''))}"`,
         'Plan the superseding specification instead.',
-      ]);
+      );
     }
     if (status === 'promoted') {
-      return blocker('Specification Promoted', [
-        `"${t}" was promoted to the cross-cutting work unit`,
-        `"${String(spec.promoted_to || '')}". Cross-cutting specifications inform other plans —`,
-        'they are not planned directly.',
-      ]);
+      return blocker(
+        `"${t}" was promoted to the cross-cutting work unit "${String(spec.promoted_to || '')}"`,
+        'Cross-cutting specifications inform other plans — they are not planned directly.',
+      );
     }
     return '';
   }
@@ -1074,36 +1083,39 @@ function entryGate(cwd, { dotpath, own }) {
   if (phase === 'implementation') {
     const plan = itemOf(manifest, 'planning', topic);
     if (!plan || !plan.status) {
-      return blocker('Plan Missing', [
-        `No plan found for "${t}".`,
-        '',
+      return blocker(
+        `No plan found for "${t}"`,
         'A completed plan is required for implementation.',
-      ]);
+      );
     }
     if (plan.status !== 'completed') {
-      return blocker('Plan Not Completed', [`The plan for "${t}" is not yet completed.`]);
+      return blocker(
+        `The plan for "${t}" is not yet completed`,
+        'A completed plan is required for implementation.',
+      );
     }
     return '';
   }
 
   if (phase === 'review') {
     if (!itemOf(manifest, 'planning', topic)) {
-      return blocker('Plan Missing', [
-        `No plan found for "${t}".`,
-        '',
+      return blocker(
+        `No plan found for "${t}"`,
         'A completed plan and completed implementation are required for review.',
-      ]);
+      );
     }
     const impl = itemOf(manifest, 'implementation', topic);
     if (!impl) {
-      return blocker('Implementation Missing', [
-        `No implementation found for "${t}".`,
-        '',
+      return blocker(
+        `No implementation found for "${t}"`,
         'A completed implementation is required for review.',
-      ]);
+      );
     }
     if (impl.status !== 'completed') {
-      return blocker('Implementation Not Complete', [`The implementation for "${t}" is not yet completed.`]);
+      return blocker(
+        `The implementation for "${t}" is not yet completed`,
+        'A completed implementation is required for review.',
+      );
     }
     return '';
   }
@@ -1114,18 +1126,16 @@ function entryGate(cwd, { dotpath, own }) {
     if (workType === 'bugfix') {
       const inv = itemOf(manifest, 'investigation', topic);
       if (!inv) {
-        return blocker('Source Material Missing', [
-          `No investigation found for "${wu}".`,
-          '',
+        return blocker(
+          `No investigation found for "${wu}"`,
           'A completed investigation is required before specification can begin.',
-        ]);
+        );
       }
       if (inv.status !== 'completed') {
-        return blocker('Investigation In Progress', [
-          `The investigation for "${wu}" is not yet completed.`,
-          '',
+        return blocker(
+          `The investigation for "${wu}" is not yet completed`,
           'The investigation must be completed before specification can begin.',
-        ]);
+        );
       }
       return '';
     }
@@ -1133,37 +1143,32 @@ function entryGate(cwd, { dotpath, own }) {
       const items = ((manifest.phases || {}).discussion || {}).items || {};
       const names = Object.keys(items);
       if (names.length === 0) {
-        return blocker('Source Material Missing', [
-          `No discussions found for "${wu}".`,
-          '',
+        return blocker(
+          `No discussions found for "${wu}"`,
           'At least one completed discussion is required before specification can begin.',
-        ]);
+        );
       }
       if (!names.some((n) => items[n] && items[n].status === 'completed')) {
-        return blocker('No Completed Discussions', [
-          `No completed discussions found for "${wu}".`,
-          '',
-          'At least one completed discussion is required before specification can begin.',
-          'Run /workflow-start to continue an in-progress discussion.',
-        ]);
+        return blocker(
+          `No completed discussions found for "${wu}"`,
+          'At least one completed discussion is required before specification can begin. Run /workflow-start to continue an in-progress discussion.',
+        );
       }
       return '';
     }
     // feature / cross-cutting: the topic's own discussion.
     const disc = itemOf(manifest, 'discussion', topic);
     if (!disc) {
-      return blocker('Source Material Missing', [
-        `No discussion found for "${wu}".`,
-        '',
+      return blocker(
+        `No discussion found for "${wu}"`,
         'A completed discussion is required before specification can begin.',
-      ]);
+      );
     }
     if (disc.status !== 'completed') {
-      return blocker('Discussion In Progress', [
-        `The discussion for "${wu}" is not yet completed.`,
-        '',
+      return blocker(
+        `The discussion for "${wu}" is not yet completed`,
         'The discussion must be completed before specification can begin.',
-      ]);
+      );
     }
     return '';
   }

--- a/skills/workflow-implementation-entry/references/validate-phase.md
+++ b/skills/workflow-implementation-entry/references/validate-phase.md
@@ -16,7 +16,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render entry-gate {work_u
 
 #### If the response carried `DISPLAY: entry blocker`
 
-Emit the section verbatim per its marker.
+Emit both sections verbatim per their markers — the red blocker line, then its guidance.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-planning-entry/references/validate-spec.md
+++ b/skills/workflow-planning-entry/references/validate-spec.md
@@ -18,6 +18,6 @@ The specification is completed — clear to plan.
 
 #### If the response carried `DISPLAY: entry blocker`
 
-Emit the section verbatim per its marker.
+Emit both sections verbatim per their markers — the red blocker line, then its guidance.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -12,7 +12,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic queue {work_unit} r
 
 **If `count` is non-zero:**
 
-A rerouted concern is still queued — it must be discussed and folded before concluding. Render the blocker and emit its `DISPLAY: triage block` section verbatim as a code block:
+A rerouted concern is still queued — it must be discussed and folded before concluding. Render the blocker and emit both its sections verbatim per their markers — the red blocker line, then its guidance:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render triage-block {work_unit}.research.{topic}

--- a/skills/workflow-review-entry/references/validate-phase.md
+++ b/skills/workflow-review-entry/references/validate-phase.md
@@ -16,7 +16,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render entry-gate {work_u
 
 #### If the response carried `DISPLAY: entry blocker`
 
-Emit the section verbatim per its marker.
+Emit both sections verbatim per their markers — the red blocker line, then its guidance.
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-specification-entry/references/validate-source.md
+++ b/skills/workflow-specification-entry/references/validate-source.md
@@ -18,6 +18,6 @@ Source material is ready.
 
 #### If the response carried `DISPLAY: entry blocker`
 
-Emit the section verbatim per its marker.
+Emit both sections verbatim per their markers — the red blocker line, then its guidance.
 
 **STOP.** Do not proceed — terminal condition.

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -610,16 +610,17 @@ describe('render concern', () => {
     writeQueue('measurement', { '001-a.md': 'x' });
     const out = renderSurface(dir, 'triage-block', { dotpath: 'wu.discussion.measurement' });
     assert.ok(out.startsWith([
-      '=== DISPLAY: triage block (emit verbatim as a code block) ===',
-      '  ⚑ Triage queue not empty — 1 rerouted concern awaiting discussion.',
-      '    Returning to the session to surface them before concluding.',
+      '=== DISPLAY: triage block (emit verbatim as a properties code block — ```properties fence) ===',
+      '⚑ Triage queue not empty — 1 rerouted concern awaiting discussion',
+      '=== DISPLAY: triage block guidance (emit verbatim as markdown) ===',
+      '> Returning to the session to surface them before concluding.',
     ].join('\n')), out);
     const rdir = path.join(dir, '.workflows', 'wu', 'research', '.triage', 'measurement');
     fs.mkdirSync(rdir, { recursive: true });
     fs.writeFileSync(path.join(rdir, '001-a.md'), 'x');
     fs.writeFileSync(path.join(rdir, '002-b.md'), 'y');
     const rout = renderSurface(dir, 'triage-block', { dotpath: 'wu.research.measurement' });
-    assert.ok(rout.includes('2 rerouted concerns awaiting exploration.'), rout);
+    assert.ok(rout.includes('2 rerouted concerns awaiting exploration'), rout);
   });
 });
 
@@ -1084,7 +1085,7 @@ describe('CLI boundary — engine render via subprocess', () => {
     assert.ok(run(['phase-completed', 'pay', '--phase', 'discussion']).includes('Discussion completed for "Pay".'));
     assert.ok(run(['early-completion-gate', 'pay']).includes('Complete without review'));
     assert.ok(run(['epic-all-done-gate', 'pay']).includes('Mark this epic as completed'));
-    assert.ok(run(['entry-gate', 'pay.specification.pay', '--own']).includes('Specification Superseded'),
+    assert.ok(run(['entry-gate', 'pay.specification.pay', '--own']).includes('was consolidated into'),
       '--own must survive boolean-flag registration through argv');
     assert.ok(run(['phase-completed', 'pay', '--phase', 'scoping', '--paths']).includes('  Spec: .workflows/pay/specification/pay/specification.md'),
       '--paths must survive boolean-flag registration through argv');
@@ -1125,54 +1126,54 @@ describe('render entry-gate', () => {
 
   it('planning: every specification state maps to its blocker; completed is clear', () => {
     manifestWith({});
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification Missing\n\nNo specification found for "Auth"\./);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /⚑ No specification found for "Auth"/);
     manifestWith({ specification: { items: { auth: { status: 'in-progress' } } } });
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification In Progress/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /⚑ The specification for "Auth" is not yet completed/);
     manifestWith({ specification: { items: { auth: { status: 'proposed' } } } });
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification Not Started[\s\S]*proposed grouping/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /proposed grouping[\s\S]*Start the specification first/);
     manifestWith({ specification: { items: { auth: { status: 'superseded', superseded_by: 'core-auth' } } } });
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification Superseded[\s\S]*"Core Auth"/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /consolidated into "Core Auth"[\s\S]*Plan the superseding specification/);
     manifestWith({ specification: { items: { auth: { status: 'promoted', promoted_to: 'cc-auth' } } } });
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /Specification Promoted[\s\S]*"cc-auth"/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), /promoted to the cross-cutting work unit "cc-auth"/);
     manifestWith({ specification: { items: { auth: { status: 'completed' } } } });
     assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.planning.auth' }), '');
   });
 
   it('implementation and review derive their plan/implementation blockers', () => {
     manifestWith({});
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.implementation.auth' }), /Plan Missing[\s\S]*A completed plan is required for implementation\./);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.implementation.auth' }), /⚑ No plan found for "Auth"[\s\S]*A completed plan is required for implementation\./);
     manifestWith({ planning: { items: { auth: { status: 'in-progress' } } } });
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.implementation.auth' }), /Plan Not Completed/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.implementation.auth' }), /⚑ The plan for "Auth" is not yet completed/);
     manifestWith({ planning: { items: { auth: { status: 'completed' } } } });
     assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.implementation.auth' }), '');
 
     manifestWith({});
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /Plan Missing[\s\S]*plan and completed implementation are required for review\./);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /⚑ No plan found for "Auth"[\s\S]*plan and completed implementation are required for review\./);
     manifestWith({ planning: { items: { auth: { status: 'completed' } } } });
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /Implementation Missing/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /⚑ No implementation found for "Auth"/);
     manifestWith({ planning: { items: { auth: { status: 'completed' } } }, implementation: { items: { auth: { status: 'in-progress' } } } });
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /Implementation Not Complete/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), /⚑ The implementation for "Auth" is not yet completed/);
     manifestWith({ planning: { items: { auth: { status: 'completed' } } }, implementation: { items: { auth: { status: 'completed' } } } });
     assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.review.auth' }), '');
   });
 
   it('specification is work-type-aware: feature discussion, bugfix investigation, epic any-completed', () => {
     manifestWith({}, 'feature');
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /Source Material Missing\n\nNo discussion found for "Pay"\./);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /⚑ No discussion found for "Pay"/);
     manifestWith({ discussion: { items: { auth: { status: 'in-progress' } } } }, 'feature');
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /Discussion In Progress/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /⚑ The discussion for "Pay" is not yet completed/);
     manifestWith({ discussion: { items: { auth: { status: 'completed' } } } }, 'feature');
     assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), '');
 
     manifestWith({}, 'bugfix');
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /No investigation found/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /⚑ No investigation found/);
     manifestWith({ investigation: { items: { auth: { status: 'in-progress' } } } }, 'bugfix');
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /Investigation In Progress/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /⚑ The investigation for "Pay" is not yet completed/);
 
     manifestWith({}, 'epic');
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /No discussions found/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /⚑ No discussions found/);
     manifestWith({ discussion: { items: { a: { status: 'in-progress' }, b: { status: 'in-progress' } } } }, 'epic');
-    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /No Completed Discussions[\s\S]*continue an in-progress discussion/);
+    assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), /⚑ No completed discussions found[\s\S]*continue an in-progress discussion/);
     manifestWith({ discussion: { items: { a: { status: 'completed' } } } }, 'epic');
     assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth' }), '');
   });
@@ -1195,16 +1196,15 @@ describe('render entry-gate --own', () => {
   it('renders the superseded and promoted terminals byte-exactly', () => {
     specWith({ status: 'superseded', superseded_by: 'core-auth' });
     assert.strictEqual(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth', own: '1' }), [
-      '=== DISPLAY: entry blocker (emit verbatim as a code block, then STOP — terminal condition) ===',
-      'Specification Superseded',
-      '',
-      'The specification for "Auth" was consolidated into',
-      '"Core Auth". Work on that specification instead.',
+      '=== DISPLAY: entry blocker (emit verbatim as a properties code block — ```properties fence) ===',
+      '⚑ The specification for "Auth" was consolidated into "Core Auth"',
+      '=== DISPLAY: blocker guidance (emit verbatim as markdown, then STOP — terminal condition) ===',
+      '> Work on that specification instead.',
       '',
     ].join('\n'));
     specWith({ status: 'promoted', promoted_to: 'auth-platform' });
     assert.match(renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth', own: '1' }),
-      /Specification Promoted\n\n"Auth" was promoted to the cross-cutting work unit\n"auth-platform"\. Continue it from that work unit\./);
+      /⚑ "Auth" was promoted to the cross-cutting work unit "auth-platform"[\s\S]*> Continue it from that work unit\./);
   });
 
   it('is clear for live statuses and a missing item', () => {
@@ -1224,7 +1224,8 @@ describe('render entry-gate --own', () => {
   it('a promoted item missing its target degrades to an empty quoted name, never "undefined"', () => {
     specWith({ status: 'promoted' });
     const out = renderSurface(dir, 'entry-gate', { dotpath: 'pay.specification.auth', own: '1' });
-    assert.ok(out.includes('"". Continue it from that work unit.'));
+    assert.ok(out.includes('cross-cutting work unit ""'));
+    assert.ok(out.includes('> Continue it from that work unit.'));
     assert.ok(!out.includes('undefined'));
   });
 });


### PR DESCRIPTION
Slice 4 of the adaptive-display stack, on top of #773.

Terminal blockers (entry gates, triage-block) emit a `properties`-fenced ⚑ line — turquoise flag, red message — with guidance as a markdown signpost in its own section. Advisory callouts keep the plain form, so red means exactly "you cannot proceed".

Gates: 1981 node tests, typecheck — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)