### PR TITLE
feat(display): drawn chrome becomes markdown — squares at falling weight

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -20,11 +20,13 @@ All user-facing output uses five distinct visual tiers, each with a specific pur
 
 | Tier | Element | Purpose | Rendering |
 |------|---------|---------|-----------|
-| 1 | Phase title | "Where am I" — top-level anchor | Code block |
+| 1 | Phase title | "Where am I" — top-level anchor | Markdown — `# **`■ Title`**` |
 | 2 | Signpost blockquote | "What's happening" — guidance, context, closure | Markdown |
-| 3 | Step marker | Progress through the phase | Code block |
-| 4 | Sub-step marker | Progress within a step | Code block |
+| 3 | Step marker | Progress through the phase | Markdown — `**`□ Name`**` |
+| 4 | Sub-step marker | Progress within a step | Markdown — `**`▪ Name`**` |
 | 5 | Status / menu | Data displays and interactive choices | Code block / markdown |
+
+The chrome family is the square glyphs at falling weight — `■` filled, `□` hollow, `▪` small — all in bold inline code so they render blue, the H1 adding its underline to the title alone. Squares are structure; circles (`○ ◐ ✓ ⊙ ⊘`) are item state, `◆` is a decision, `⚑` is an alert, and `⏺` belongs to the host UI's gutter.
 
 Every skill invocation should produce at most one phase title. Signpost blockquotes appear at phase entry, before steps where context helps, and at phase completion.
 
@@ -42,7 +44,7 @@ or:
 > *Output the next fenced block as markdown (not a code block):*
 ```
 
-Code blocks are used for informational displays (overviews, status, keys, phase titles, step markers) — they preserve indentation for tree structures and aligned lists. Markdown is used for interactive elements (menus, prompts) and signpost blockquotes where bold formatting is needed. When content benefits from rendered formatting (headings, checkboxes, bold) and indentation control isn't needed, prefer markdown rendering even for informational displays.
+Code blocks are used for informational displays (overviews, status, keys) — they preserve indentation for tree structures and aligned lists. Markdown is used for chrome (phase titles, step and sub-step markers), interactive elements (menus, prompts), and signpost blockquotes, where the renderer's own styling does the work. When content benefits from rendered formatting (headings, checkboxes, bold) and indentation control isn't needed, prefer markdown rendering even for informational displays.
 
 ### Presentation Register
 
@@ -62,27 +64,23 @@ Engine calls may append labelled DISPLAY/MENU sections — transaction verbs (e.
 
 ### Phase Titles
 
-Bullet-bordered box. One per skill invocation. Serves as the top-level anchor telling the user where they are. Always followed by a blank line before any subsequent content.
+A markdown H1 carrying the chrome family's heaviest register — bold inline code with the filled square, so it renders blue, underlined, and italic. One per skill invocation. Serves as the top-level anchor telling the user where they are.
 
 ```
-●───────────────────────────────────────────────●
-  Specification Overview
-●───────────────────────────────────────────────●
-
+# **`■ Specification Overview`**
 ```
 
 Rules:
-- Fixed width: 49 characters total (● + 47 em-dashes + ●)
-- 2-space left padding on the title text
+- Exactly this shape: `# ` + `**` + backtick + `■ ` + title + backtick + `**`
 - Title text is the phase or context name (e.g., "Workflow Overview", "Planning Overview")
-- Include a trailing blank line after the closing border inside the code block — this creates visual breathing room in the rendered output
-- **Must be inside a code block** — never markdown. Code blocks preserve the indentation and whitespace that the border layout depends on. Markdown rendering would collapse the spacing and break the layout
+- **Emitted as markdown** (use the markdown rendering instruction) — the styling comes from the renderer, so the title is correct at any terminal width
+- The glyph is always `■`. Squares are structure (`■` phase, `□` step, `▪` sub-step); circles are item state (`○ ◐ ✓ ⊙ ⊘`), `◆` is a decision, and `⏺` is the host UI's own gutter — chrome never borrows another family's shape
 
-Status displays use the phase title at the top of the same code block, followed by a blank line before the content.
+Engine-rendered displays that carry a title inside their fenced DISPLAY section still draw the legacy bullet-bordered box — markdown cannot reach inside a fence. The workflow-start banner likewise keeps its bordered art (see Workflow Banner).
 
 ### Step Markers
 
-Em-dash framed progress indicators. Embedded at the step boundaries that earn them — never instructed once at the top of a file. Short left side, long right side to fill width.
+Progress indicators in the chrome family's middle register — bold inline code with the hollow square, rendering as a blue label. Embedded at the step boundaries that earn them — never instructed once at the top of a file.
 
 **Markers are earned, not automatic.** A step carries a marker only when the user gets something between it and the next visible output: an interaction (menu, `**STOP.**` gate), substantive watchable activity (analysis, agent dispatch, engine transactions, multi-file work), or rendered content. Consecutive markers with nothing between them read as step-by-step progress that isn't happening — noise, not orientation.
 
@@ -92,39 +90,39 @@ Em-dash framed progress indicators. Embedded at the step boundaries that earn th
 Every step marker must be followed by a signpost blockquote explaining what the step does and why — the marker names the step, the signpost explains it.
 
 ```
-── Construct Specification ─────────────────────
+**`□ Construct Specification`**
 ```
 
 Variations for loops and routing:
 
 ```
-── Task Execution (3 of 12) ────────────────────
-── Review (cycle 2) ────────────────────────────
-── Returning to Discussion Session ─────────────
+**`□ Task Execution (3 of 12)`**
+**`□ Review (cycle 2)`**
+**`□ Returning to Discussion Session`**
 ```
 
 Rules:
-- Always `── ` (two em-dashes + space) on the left
-- Right side padded with em-dashes to 49 characters total — aligned with phase title width
+- Exactly this shape: `**` + backtick + `□ ` + name + backtick + `**` — no fill, no padding; the styling comes from the renderer, so the marker is correct at any terminal width
 - **No step numbers** — steps may be skipped based on conditionals and routing is non-linear. Names alone are sufficient
 - Loop iterations shown in parentheses: `(cycle N)`, `(N of M)`
 - Route-back uses `Returning to {Name}`
-- Rendered as a code block with its own rendering instruction. No trailing blank line — natural block separation provides enough spacing
+- Emitted as markdown with its own rendering instruction. No trailing blank line — natural block separation provides enough spacing
+
+Engine-drawn dividers inside a fenced DISPLAY block (the epic dashboard's `── STAGE ──` lines) are a different object: markdown cannot reach inside a fence, so they stay drawn, sized to the content they divide.
 
 ### Sub-step Markers
 
-Dot-framed markers for stages within a step. Visually lighter than step markers to indicate nesting.
+Markers for stages within a step, in the chrome family's lightest register — the small square marks the nesting.
 
 ```
-·· Extract Sources ·································
+**`▪ Extract Sources`**
 ```
 
 Rules:
-- Always `·· ` (two middle dots + space) on the left
-- Right side padded with middle dots to 49 characters total — aligned with phase title and step marker width
+- Exactly this shape: `**` + backtick + `▪ ` + name + backtick + `**`
 - Named only — no numbering or lettered suffixes
 - Same loop/iteration conventions as step markers
-- Rendered as a single-line code block with its own rendering instruction
+- Emitted as markdown with its own rendering instruction
 
 ### Signpost Blockquotes
 
@@ -380,17 +378,19 @@ Automatically proceeding with "{topic:(titlecase)}".
 
 ### Block / Terminal Messages
 
-When a phase can't proceed — use the phase title at the top, then explain:
+When a phase can't proceed — the phase title, the blocking fact in the red register (see Callout Flag → blocked states), then guidance as a signpost:
 
 ```
-●───────────────────────────────────────────────●
-  Planning Overview
-●───────────────────────────────────────────────●
-
-No specification found in .workflows/{work_unit}/specification/{topic}/
-
-The planning phase requires a completed specification.
+# **`■ Planning Overview`**
 ```
+
+```properties
+⚑ No specification found for this topic
+```
+
+> The planning phase requires a completed specification.
+
+Engine entry gates emit this shape as two sections (`DISPLAY: entry blocker` + `DISPLAY: blocker guidance`); prose-authored terminal messages mirror it by hand.
 
 ### Bullet Characters
 
@@ -400,7 +400,7 @@ Within a numbered item, `·` marks quiet sub-detail: a wrapped summary paragraph
 
 ### Spacing Rules
 
-**Between blocks**: One blank line after the phase title closing border before any content (code block, blockquote, or step marker). No `---` separators between code blocks (overview → not-ready → key → menu) — just natural block separation.
+**Between blocks**: One blank line after the phase title before any content (code block, blockquote, or step marker). No `---` separators between code blocks (overview → not-ready → key → menu) — just natural block separation.
 
 **Inside code blocks**: One blank line between:
 - Each numbered tree item

--- a/skills/workflow-bridge/SKILL.md
+++ b/skills/workflow-bridge/SKILL.md
@@ -23,10 +23,10 @@ This skill receives positional arguments:
 
 ## Step 1: Read Work Type and Run Discovery
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Read Work Type and Run Discovery ─────────────
+**`□ Read Work Type and Run Discovery`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -68,10 +68,10 @@ The output contains `next_phase`, `completed_phases` (in pipeline order), and `r
 
 ## Step 2: Route to Continuation Reference
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Route to Continuation Reference ──────────────
+**`□ Route to Continuation Reference`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-continue-bugfix/SKILL.md
+++ b/skills/workflow-continue-bugfix/SKILL.md
@@ -16,13 +16,10 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 
 ## Step 0: Initialisation
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-●───────────────────────────────────────────────●
-  Continue Bugfix
-●───────────────────────────────────────────────●
-
+# **`■ Continue Bugfix`**
 ```
 
 → Proceed to **Step 1**.
@@ -87,10 +84,10 @@ Store the work_unit.
 
 ## Step 3: Select Bugfix
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Select Bugfix ────────────────────────────────
+**`□ Select Bugfix`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -115,10 +112,10 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Display State and Menu
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Bugfix State ─────────────────────────────────
+**`□ Bugfix State`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-continue-cross-cutting/SKILL.md
+++ b/skills/workflow-continue-cross-cutting/SKILL.md
@@ -16,13 +16,10 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 
 ## Step 0: Initialisation
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-●───────────────────────────────────────────────●
-  Continue Cross-Cutting
-●───────────────────────────────────────────────●
-
+# **`■ Continue Cross-Cutting`**
 ```
 
 → Proceed to **Step 1**.
@@ -87,10 +84,10 @@ Store the work_unit.
 
 ## Step 3: Select Cross-Cutting Concern
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Select Concern ───────────────────────────────
+**`□ Select Concern`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -115,10 +112,10 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Display State and Menu
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Cross-Cutting State ──────────────────────────
+**`□ Cross-Cutting State`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -16,13 +16,10 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 
 ## Step 0: Initialisation
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-●───────────────────────────────────────────────●
-  Continue Epic
-●───────────────────────────────────────────────●
-
+# **`■ Continue Epic`**
 ```
 
 → Proceed to **Step 1**.
@@ -87,10 +84,10 @@ Store the work_unit.
 
 ## Step 3: Select Epic
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Select Epic ──────────────────────────────────
+**`□ Select Epic`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -129,10 +126,10 @@ Then read `discovery_map` from the most recent discovery output and filter for r
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Backfill ─────────────────────────────────────
+**`□ Backfill`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -164,10 +161,10 @@ Read `needs_sequencing` from the most recent discovery output.
 
 #### If `needs_sequencing` is true
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Sequence Map ─────────────────────────────────
+**`□ Sequence Map`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -194,10 +191,10 @@ node .claude/skills/workflow-continue-epic/scripts/gateway.cjs {work_unit}
 
 ## Step 8: Display State and Menu
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Epic State ───────────────────────────────────
+**`□ Epic State`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-continue-epic/references/backfill-checks.md
+++ b/skills/workflow-continue-epic/references/backfill-checks.md
@@ -48,10 +48,10 @@ Load **[summary-backfill.md](summary-backfill.md)** with work_unit = `{work_unit
 
 Mutations from A and B are already committed. Returning to the caller would continue Step 6 onward inside the same conversation, but the backfill pass — particularly legacy decomposition — is context-heavy by design. Hand the user a fresh window before the rest of `/workflow-continue-epic` runs.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Backfill Complete ────────────────────────────
+**`□ Backfill Complete`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-continue-epic/references/summary-backfill.md
+++ b/skills/workflow-continue-epic/references/summary-backfill.md
@@ -11,10 +11,10 @@ The caller passes:
 
 ## A. Read Source Files
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Summary Backfill ─────────────────────────────
+**`□ Summary Backfill`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-continue-feature/SKILL.md
+++ b/skills/workflow-continue-feature/SKILL.md
@@ -16,13 +16,10 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 
 ## Step 0: Initialisation
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-●───────────────────────────────────────────────●
-  Continue Feature
-●───────────────────────────────────────────────●
-
+# **`■ Continue Feature`**
 ```
 
 → Proceed to **Step 1**.
@@ -87,10 +84,10 @@ Store the work_unit.
 
 ## Step 3: Select Feature
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Select Feature ───────────────────────────────
+**`□ Select Feature`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -115,10 +112,10 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Display State and Menu
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Feature State ────────────────────────────────
+**`□ Feature State`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-continue-quickfix/SKILL.md
+++ b/skills/workflow-continue-quickfix/SKILL.md
@@ -16,13 +16,10 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 
 ## Step 0: Initialisation
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-●───────────────────────────────────────────────●
-  Continue Quick-Fix
-●───────────────────────────────────────────────●
-
+# **`■ Continue Quick-Fix`**
 ```
 
 → Proceed to **Step 1**.
@@ -87,10 +84,10 @@ Store the work_unit.
 
 ## Step 3: Select Quick-Fix
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Select Quick-Fix ─────────────────────────────
+**`□ Select Quick-Fix`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -115,10 +112,10 @@ Load **[validate-selection.md](references/validate-selection.md)** and follow it
 
 ## Step 5: Display State and Menu
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Quick-Fix State ──────────────────────────────
+**`□ Quick-Fix State`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -82,10 +82,10 @@ Load **[detection-core.md](references/detection-core.md)** and follow its instru
 
 ## Step 3: Open
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Open Discovery ───────────────────────────────
+**`□ Open Discovery`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -103,10 +103,10 @@ Load **[opener-pattern.md](references/opener-pattern.md)** and follow its instru
 
 ## Step 4: Shape and Confirm the Work Type
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Shape and Confirm ────────────────────────────
+**`□ Shape and Confirm`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -124,10 +124,10 @@ Load **[shape-and-confirm.md](references/shape-and-confirm.md)** and follow its 
 
 ## Step 5: Confirm Trigger — Create the Work Unit
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Confirm Trigger ──────────────────────────────
+**`□ Confirm Trigger`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -197,10 +197,10 @@ Load **[discovery-guidelines.md](references/discovery-guidelines.md)** and follo
 
 ## Step 10: Session Loop
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Discovery Session ────────────────────────────
+**`□ Discovery Session`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -219,10 +219,10 @@ Load **[session-loop.md](references/session-loop.md)** and follow its instructio
 
 ## Step 11: Document Review
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Document Review ──────────────────────────────
+**`□ Document Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -241,10 +241,10 @@ Load **[document-review.md](references/document-review.md)** and follow its inst
 
 ## Step 12: Confirm and Persist Topics
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Confirm and Persist ──────────────────────────
+**`□ Confirm and Persist`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -264,10 +264,10 @@ Load **[confirm-and-persist.md](references/confirm-and-persist.md)** and follow 
 
 Reached only for single-phase work — feature, cross-cutting, bugfix, quick-fix — routed here by the confirm-trigger (Step 5). The epic topic path does not pass through here.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── First-Phase Routing ──────────────────────────
+**`□ First-Phase Routing`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -298,10 +298,10 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 The single exit for every work type — both paths arrive from the Step 14 compliance check.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Conclude Discovery ───────────────────────────
+**`□ Conclude Discovery`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discovery/references/document-review.md
+++ b/skills/workflow-discovery/references/document-review.md
@@ -4,10 +4,10 @@
 
 ---
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Document Review ······························
+**`▪ Document Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discovery/references/resume-detection.md
+++ b/skills/workflow-discovery/references/resume-detection.md
@@ -22,10 +22,10 @@ No prior session is in progress. `session_number` will be set at Step 7 from dis
 
 The output is the in-progress session number string (e.g. `002`) — the prior session was interrupted before finalisation.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resume Detection ─────────────────────────────
+**`□ Resume Detection`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -95,10 +95,10 @@ Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `
 
 ## Step 3: Gather Context
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Gather Context ───────────────────────────────
+**`□ Gather Context`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -68,10 +68,10 @@ A first start, not a resume — no session has ever run and no subtopics exist, 
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resume Detection ─────────────────────────────
+**`□ Resume Detection`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -127,10 +127,10 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 
 ## Step 5: Discussion Session
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Discussion Session ───────────────────────────
+**`□ Discussion Session`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -159,10 +159,10 @@ Load **[final-review.md](references/final-review.md)** and follow its instructio
 
 ## Step 7: Document Review
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Document Review ──────────────────────────────
+**`□ Document Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -188,10 +188,10 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ## Step 9: Conclude Discussion
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Conclude Discussion ──────────────────────────
+**`□ Conclude Discussion`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -8,10 +8,10 @@ The review agent catches *topical* gaps — areas that should have been explored
 
 Discussion is higher-stakes than research for this check. The Context → Options → Journey → Decision structure creates pressure to polish rationale beyond what was actually said, Journey sections are usually written after-the-fact and easy to clean up post-hoc, and tentative leans can harden into documented decisions. The specification phase builds directly from this file — drift here compounds downstream.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Document Review ······························
+**`▪ Document Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -136,10 +136,10 @@ Findings from the current review are still being drained.
 
 ## C. Dispatch Final Review
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Dispatch Final Review ························
+**`▪ Dispatch Final Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -126,10 +126,10 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 
 ## Step 6: Task Loop
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Task Loop ────────────────────────────────────
+**`□ Task Loop`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -160,10 +160,10 @@ After the loop completes:
 
 ## Step 7: Analysis Loop
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Analysis Loop ────────────────────────────────
+**`□ Analysis Loop`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -196,10 +196,10 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ## Step 9: Mark Implementation Complete
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Conclude Implementation ──────────────────────
+**`□ Conclude Implementation`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-investigation-entry/SKILL.md
+++ b/skills/workflow-investigation-entry/SKILL.md
@@ -69,10 +69,10 @@ Load **[validate-phase.md](references/validate-phase.md)** with phase_status = `
 
 ## Step 3: Gather Bug Context
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Gather Bug Context ───────────────────────────
+**`□ Gather Bug Context`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-investigation-process/SKILL.md
+++ b/skills/workflow-investigation-process/SKILL.md
@@ -80,10 +80,10 @@ Set `resumed` = `false`.
 
 #### If file exists
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resume Detection ─────────────────────────────
+**`□ Resume Detection`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -127,10 +127,10 @@ An earlier session already interviewed the user — don't re-interview. Fold in 
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Symptom Gathering ────────────────────────────
+**`□ Symptom Gathering`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -162,10 +162,10 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 
 ## Step 5: Investigation Plan
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Investigation Plan ───────────────────────────
+**`□ Investigation Plan`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -184,10 +184,10 @@ Load **[investigation-plan.md](references/investigation-plan.md)** and follow it
 
 ## Step 6: Code Analysis
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Code Analysis ────────────────────────────────
+**`□ Code Analysis`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -209,10 +209,10 @@ When the root cause is identified and every hypothesis is resolved:
 
 ## Step 7: Root Cause Synthesis
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Root Cause Synthesis ─────────────────────────
+**`□ Root Cause Synthesis`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -241,10 +241,10 @@ Document in the investigation file and commit.
 
 ## Step 8: Root Cause Validation
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Root Cause Validation ────────────────────────
+**`□ Root Cause Validation`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -262,10 +262,10 @@ Load **[root-cause-validation.md](references/root-cause-validation.md)** and fol
 
 ## Step 9: Findings Sign-off
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Findings Sign-off ────────────────────────────
+**`□ Findings Sign-off`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -283,10 +283,10 @@ Load **[findings-signoff.md](references/findings-signoff.md)** and follow its in
 
 ## Step 10: Fix Exploration & Discussion
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Fix Exploration ──────────────────────────────
+**`□ Fix Exploration`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -303,10 +303,10 @@ Load **[fix-exploration.md](references/fix-exploration.md)** and follow its inst
 
 ## Step 11: Fix Validation
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Fix Validation ───────────────────────────────
+**`□ Fix Validation`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -332,10 +332,10 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ## Step 13: Conclude Investigation
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Conclude Investigation ───────────────────────
+**`□ Conclude Investigation`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-legacy-research-split/SKILL.md
+++ b/skills/workflow-legacy-research-split/SKILL.md
@@ -20,13 +20,10 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 
 ## Step 1: List Qualifying Sources
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-●───────────────────────────────────────────────●
-  Legacy Research Split
-●───────────────────────────────────────────────●
-
+# **`■ Legacy Research Split`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -37,10 +34,10 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 > user-guided per source.
 ```
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── List Qualifying Sources ──────────────────────
+**`□ List Qualifying Sources`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -113,10 +110,10 @@ Qualifying source files (in-progress, migration-seeded):
 
 ## Step 2: Per-Source Session Loop
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Session Loop ─────────────────────────────────
+**`□ Session Loop`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -134,10 +131,10 @@ Load **[dialog.md](references/dialog.md)** and follow its instructions as writte
 
 ## Step 3: Conclude
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Legacy Split Complete ────────────────────────
+**`□ Legacy Split Complete`**
 ```
 
 Evaluate the branches below in order — error reporting takes precedence over clean outcomes.

--- a/skills/workflow-legacy-research-split/references/dialog.md
+++ b/skills/workflow-legacy-research-split/references/dialog.md
@@ -16,10 +16,10 @@ Drive the per-source iteration: read source, identify themes, early sanity gate,
 
 Pop the next name from `remaining`. Set `current_source = name`.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Processing {current_source} ··················
+**`▪ Processing {current_source}`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-planning-process/SKILL.md
+++ b/skills/workflow-planning-process/SKILL.md
@@ -84,10 +84,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 #### Otherwise (planning entry exists)
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resume Detection ─────────────────────────────
+**`□ Resume Detection`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -185,10 +185,10 @@ Load **[verify-source-material.md](references/verify-source-material.md)** and f
 
 ## Step 6: Plan Construction
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Plan Construction ────────────────────────────
+**`□ Plan Construction`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -207,10 +207,10 @@ Load **[plan-construction.md](references/plan-construction.md)** and follow its 
 
 ## Step 7: Analyze Task Graph
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Analyze Task Graph ───────────────────────────
+**`□ Analyze Task Graph`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -234,10 +234,10 @@ Load **[analyze-task-graph.md](references/analyze-task-graph.md)** and follow it
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resolve External Dependencies ────────────────
+**`□ Resolve External Dependencies`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -255,10 +255,10 @@ Load **[resolve-dependencies.md](references/resolve-dependencies.md)** and follo
 
 ## Step 9: Plan Review
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Plan Review ──────────────────────────────────
+**`□ Plan Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -285,10 +285,10 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ## Step 11: Conclude the Plan
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Conclude the Plan ────────────────────────────
+**`□ Conclude the Plan`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -101,10 +101,10 @@ A first start — the session's triage check surfaces the parked concerns; seed 
 
 ## Step 4: Gather Context
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Gather Context ───────────────────────────────
+**`□ Gather Context`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-research-process/SKILL.md
+++ b/skills/workflow-research-process/SKILL.md
@@ -68,10 +68,10 @@ A first start, not a resume — no session has ever run. Parked concerns wait in
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resume Detection ─────────────────────────────
+**`□ Resume Detection`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -127,10 +127,10 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 
 ## Step 6: Research Session
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Research Session ─────────────────────────────
+**`□ Research Session`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-research-process/references/document-review.md
+++ b/skills/workflow-research-process/references/document-review.md
@@ -6,10 +6,10 @@
 
 The review agent catches *topical* gaps — areas that should have been explored. This check catches *conversational* gaps — substance that was discussed in the session but never made it into the research file. Only the main orchestrator can do this: you were in the conversation, a sub-agent wasn't.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Document Review ······························
+**`▪ Document Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-research-process/references/final-review.md
+++ b/skills/workflow-research-process/references/final-review.md
@@ -120,10 +120,10 @@ Findings from the current review are still being drained.
 
 ## C. Dispatch Final Review
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Dispatch Final Review ························
+**`▪ Dispatch Final Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -61,10 +61,10 @@ Check if a review file exists at `.workflows/{work_unit}/review/{topic}/report.m
 
 #### If review file exists
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resume Detection ─────────────────────────────
+**`□ Resume Detection`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -184,10 +184,10 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 
 ## Step 5: QA Verification
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── QA Verification ──────────────────────────────
+**`□ QA Verification`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -208,10 +208,10 @@ Load **[invoke-task-verifiers.md](references/invoke-task-verifiers.md)** and fol
 
 ## Step 6: Produce Review
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Produce Review ───────────────────────────────
+**`□ Produce Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -229,10 +229,10 @@ Load **[produce-review.md](references/produce-review.md)** and follow its instru
 
 ## Step 7: Present Review
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Present Review ───────────────────────────────
+**`□ Present Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -258,10 +258,10 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ## Step 9: Review Actions
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Review Actions ───────────────────────────────
+**`□ Review Actions`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -61,10 +61,10 @@ ls .workflows/{work_unit}/specification/{topic}/specification.md 2>/dev/null && 
 
 #### If specification exists
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resume Detection ─────────────────────────────
+**`□ Resume Detection`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -211,10 +211,10 @@ Load **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)
 
 ## Step 2: Gather Context
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Gather Context ───────────────────────────────
+**`□ Gather Context`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -250,10 +250,10 @@ Load **[complexity-check.md](references/complexity-check.md)** and follow its in
 
 ## Step 5: Write Specification
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Write Specification ──────────────────────────
+**`□ Write Specification`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -271,10 +271,10 @@ Load **[write-specification.md](references/write-specification.md)** and follow 
 
 ## Step 6: Select Output Format
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Select Output Format ─────────────────────────
+**`□ Select Output Format`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -291,10 +291,10 @@ Load **[select-format.md](references/select-format.md)** and follow its instruct
 
 ## Step 7: Write Tasks
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Write Tasks ──────────────────────────────────
+**`□ Write Tasks`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -312,10 +312,10 @@ Load **[write-tasks.md](references/write-tasks.md)** and follow its instructions
 
 ## Step 8: Conclude Scoping
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Conclude Scoping ─────────────────────────────
+**`□ Conclude Scoping`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -197,10 +197,10 @@ The lane emptied — every one applied, or every one promoted out.
 
 Emit the lane marker once per visit to this section — on a re-render after a question, skip it:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· No Decision Needed ···························
+**`▪ No Decision Needed`**
 ```
 
 Digest the report — never read it out. Write the payload to the topic's cache directory with the Write tool (`{"lane": "apply", "items": [{"title": "…", "detail": "…"}]}`, one entry per remaining `apply` finding in the order they should read: `title` is the report's own claim, `detail` is one or two sentences saying what the fix is and which decision determines it), then render it:
@@ -260,12 +260,12 @@ This section runs once per invocation and then exits. It never waits in-protocol
    - **Move** — sized to how open the decision is as much as how cold the context: a clear resolution — propose it and name what it costs ("this creates X and Y; I don't see another approach"), never an option survey; genuinely open — sketch the option space in a sentence or two; needs investigation — suggest research or a deep-dive. Where the caller's **Lanes** declaration names the walked lane's move, that move closes the raise.
 4. Raise it in the current turn, ending in a single question — or, for a finding with one defensible resolution, a stated proposal awaiting the user's response. Either way the turn ends and control returns: one finding per invocation, and the user's agreement is never licence to roll into the next. No bundled follow-ups, no menu.
 
-When this row's `surfaced` list holds no walked finding yet, the raise opens with the walked lane's declared heading, padded with middle dots to 49 characters total, so the shift out of the batches is visible. A walk already under way — including one resumed from an earlier session — opens with its bridge instead, never a repeated heading:
+When this row's `surfaced` list holds no walked finding yet, the raise opens with the walked lane's declared heading as sub-step chrome, so the shift out of the batches is visible. A walk already under way — including one resumed from an earlier session — opens with its bridge instead, never a repeated heading:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· {lane_heading} ·······························
+**`▪ {lane_heading}`**
 ```
 
 **Setting the scene** — an example over a description, every time. A reader who can picture the failure can judge the fix; a reader parsing a mechanism description is still building the picture when the ask arrives.
@@ -296,10 +296,10 @@ The lane emptied — every one sent, or every one kept here.
 
 Emit the lane marker once per visit to this section — on a re-render after a question, skip it:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Belongs Elsewhere ····························
+**`▪ Belongs Elsewhere`**
 ```
 
 Judge each finding's `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](triage-landing.md)**. Write the payload with the Write tool (`{"lane": "route", "items": [{"target": "…", "detail": "…"}]}`, one entry per finding: `target` is the owning topic, `detail` is what it says, why it is theirs, and which queue it lands in), then render it:

--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -22,10 +22,10 @@ The caller provides these via context before loading:
 
 ## A. Read Cache State
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Cache Check ··································
+**`▪ Cache Check`**
 ```
 
 Run discovery for the work unit:
@@ -56,10 +56,10 @@ Research-analysis runs first so that a theme both analyses surface is already on
 
 #### If `analysis_caches.research_analysis.status` is `stale`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Research Analysis ····························
+**`▪ Research Analysis`**
 ```
 
 **Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.research-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:
@@ -96,10 +96,10 @@ No dispatch.
 
 #### If `analysis_caches.gap_analysis.status` is `stale`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Gap Analysis ·································
+**`▪ Gap Analysis`**
 ```
 
 **Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.discovery-gap-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:
@@ -136,10 +136,10 @@ No dispatch.
 
 #### If `analysis_caches.coherence_analysis.status` is `stale`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-·· Coherence Check ······························
+**`▪ Coherence Check`**
 ```
 
 **Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.coherence-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -94,10 +94,10 @@ Load **[check-prerequisites.md](references/check-prerequisites.md)** and follow 
 
 ## Step 6: Route Based on State
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Route Based on State ─────────────────────────
+**`□ Route Based on State`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -75,10 +75,10 @@ Check if `.workflows/{work_unit}/specification/{topic}/specification.md` exists.
 
 #### If file exists
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Resume Detection ─────────────────────────────
+**`□ Resume Detection`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -126,10 +126,10 @@ Load **[specification-principles.md](references/specification-principles.md)** a
 
 ## Step 5: Spec Construction
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Spec Construction ────────────────────────────
+**`□ Spec Construction`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -154,10 +154,10 @@ Load **[spec-construction.md](references/spec-construction.md)** and follow its 
 
 #### Otherwise
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Document Dependencies ────────────────────────
+**`□ Document Dependencies`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -175,10 +175,10 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 
 ## Step 7: Specification Review
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Specification Review ─────────────────────────
+**`□ Specification Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -205,10 +205,10 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 
 ## Step 9: Assess Cross-Cutting & Conclude
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Conclude ─────────────────────────────────────
+**`□ Conclude`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -36,10 +36,10 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 ●─────────────────────────────────────────────────────────────────●
 ```
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Initialisation ───────────────────────────────
+**`□ Initialisation`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -164,10 +164,10 @@ The response's `system_config` object carries what the gate needs to branch. Loa
 
 ## Step 1: Run Discovery
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Run Discovery ────────────────────────────────
+**`□ Run Discovery`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -209,10 +209,10 @@ Display and routing derive from the `view` snapshot at Step 3 — this dump is t
 
 ## Step 2: Check State
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Check State ──────────────────────────────────
+**`□ Check State`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -234,10 +234,10 @@ Load **[empty-state.md](references/empty-state.md)** and follow its instructions
 
 ## Step 3: Display and Route
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-── Display and Route ────────────────────────────
+**`□ Display and Route`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-start/references/knowledge-gate.md
+++ b/skills/workflow-start/references/knowledge-gate.md
@@ -245,13 +245,10 @@ Knowledge base ready — @if(provider) {provider} · {model} @else keyword-only 
 
 ## F. Terminal Wizard
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-●───────────────────────────────────────────────●
-  Knowledge Base Setup
-●───────────────────────────────────────────────●
-
+# **`■ Knowledge Base Setup`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -131,15 +131,21 @@ function checkBorders(files) {
     }
     lines.forEach((line, i) => {
       const t = line.trim();
-      if (!/^●─+●$/.test(t)) return; // ● … ─ … ●
-      if (bannerLines.has(i)) return; // documented banner exception
-      const w = charLen(t);
-      if (w !== 49) {
+      // Drawn borders are retired from prose — the phase title is markdown
+      // chrome (`# **`■ Title`**`). Only the workflow-start banner keeps its
+      // bordered art (documented exception).
+      if (/^●─+●$/.test(t) && !bannerLines.has(i)) {
         out.push({
           file,
           line: i + 1,
-          message: `phase-title border must be 49 characters (● + 47 ─ + ●), found ${w}`,
+          message: 'drawn phase-title borders are retired — use `# **`■ Title`**` markdown chrome (banner excepted)',
         });
+        return;
+      }
+      // The markdown phase title must pair H1 with the filled square.
+      const h1 = /^# \*\*`(.)/.exec(t);
+      if (h1 && '■□▪○◐✓⊙⊘◆'.includes(h1[1]) && h1[1] !== '■') {
+        out.push({ file, line: i + 1, message: `phase-title chrome uses ■ — found ${h1[1]}` });
       }
     });
   }
@@ -159,17 +165,25 @@ function checkMarkers(files) {
     const lines = readLines(file);
     const { blocks } = parseFences(lines);
     for (const b of blocks) {
-      if (b.lines.length !== 1) continue; // sole-line fence only
+      if (b.lines.length !== 1) continue; // sole-line fence only — engine
+      // stage dividers live inside multi-line DISPLAY templates and are
+      // a different object (drawn, sized to their content).
       const { n, text } = b.lines[0];
-      if (!/^(── |·· )/.test(text)) continue;
-      const w = charLen(text);
-      if (w !== 49) {
+      // Drawn markers are retired — the chrome family is markdown.
+      if (/^── .+ ─+$/.test(text) || /^·· .+ ·+$/.test(text)) {
         const kind = text.startsWith('── ') ? 'step marker' : 'sub-step marker';
         out.push({
           file,
           line: n + 1,
-          message: `${kind} must be 49 characters, found ${w}`,
+          message: `drawn ${kind}s are retired — use **\`□ Name\`** / **\`▪ Name\`** markdown chrome`,
         });
+        continue;
+      }
+      // New-chrome shape: a sole-line marker fence must be exact, and the
+      // glyph must match its register (□ step, ▪ sub-step; ■ is the H1's).
+      const m = /^\*\*`(.) (.+)`\*\*$/.exec(text);
+      if (m && '■□▪'.includes(m[1]) && !'□▪'.includes(m[1])) {
+        out.push({ file, line: n + 1, message: `marker chrome uses □ or ▪ — ■ belongs to the phase title` });
       }
     }
   }
@@ -735,7 +749,8 @@ function countTemplatedSites(file) {
     while (k < lines.length && !/^\s*```/.test(lines[k])) k++;
     const content = lines.slice(start, k);
     const text = content.join('\n');
-    const isMarker = content.length === 1 && /^(── |·· )/.test(content[0]);
+    const isMarker = content.length === 1
+      && (/^(── |·· )/.test(content[0]) || /^(# )?\*\*`[■□▪] /.test(content[0]));
     const isSignpost = content.every((l) => l.trim() === '' || l.startsWith('>'));
     // Templated = any single-line braced token or directive. Deliberately
     // wider than the template-placeholder grammar: `{2 context lines}` and
@@ -871,12 +886,13 @@ for (const [label, fn] of CHECKS) {
 // must NOT flag the sanctioned edge cases it is designed to permit.
 // ---------------------------------------------------------------------------
 
-test('check 1 (borders) — catches wrong widths, skips the banner', () => {
+test('check 1 (borders) — bans drawn borders, skips the banner, pins the H1 glyph', () => {
   withTemp((dir) => {
+    // any drawn border in prose is retired — width no longer matters
     const bad = write(
       dir,
       'skills/x/SKILL.md',
-      '```\n●' + '─'.repeat(46) + '●\n  Too Short\n●' + '─'.repeat(46) + '●\n```\n'
+      '```\n●' + '─'.repeat(47) + '●\n  Overview\n●' + '─'.repeat(47) + '●\n```\n'
     );
     const v1 = checkBorders([bad]);
     assert.strictEqual(v1.length, 2, `expected 2 border violations, got ${v1.length}`);
@@ -889,19 +905,21 @@ test('check 1 (borders) — catches wrong widths, skips the banner', () => {
     );
     assert.strictEqual(checkBorders([banner]).length, 0, 'banner border must be exempt');
 
-    // a correct 49-char border → clean
-    const good = write(dir, 'skills/y/SKILL.md', '```\n●' + '─'.repeat(47) + '●\n  Overview\n●' + '─'.repeat(47) + '●\n```\n');
-    assert.strictEqual(checkBorders([good]).length, 0, 'valid 49-char border must pass');
+    // markdown phase title: ■ passes, any other family glyph is caught
+    const good = write(dir, 'skills/y/SKILL.md', '```\n# **`■ Overview`**\n```\n');
+    assert.strictEqual(checkBorders([good]).length, 0, 'markdown phase title must pass');
+    const wrongGlyph = write(dir, 'skills/z/SKILL.md', '```\n# **`□ Overview`**\n```\n');
+    assert.strictEqual(checkBorders([wrongGlyph]).length, 1, 'an H1 with a non-■ chrome glyph must be caught');
   });
 });
 
-test('check 2 (markers) — catches wrong widths, skips embedded dividers', () => {
+test('check 2 (markers) — bans drawn markers, skips embedded dividers, pins marker glyphs', () => {
   withTemp((dir) => {
-    const badStep = write(dir, 'skills/x/a.md', '```\n── Too Short ────\n```\n');
-    assert.strictEqual(checkMarkers([badStep]).length, 1, 'short step marker must be caught');
+    const drawnStep = write(dir, 'skills/x/a.md', '```\n── Construct Specification ────────\n```\n');
+    assert.strictEqual(checkMarkers([drawnStep]).length, 1, 'drawn step marker must be caught');
 
-    const badSub = write(dir, 'skills/x/b.md', '```\n·· Sub ' + '·'.repeat(60) + '\n```\n');
-    assert.strictEqual(checkMarkers([badSub]).length, 1, 'over-long sub-step marker must be caught');
+    const drawnSub = write(dir, 'skills/x/b.md', '```\n·· Sub ' + '·'.repeat(60) + '\n```\n');
+    assert.strictEqual(checkMarkers([drawnSub]).length, 1, 'drawn sub-step marker must be caught');
 
     // centered content divider embedded in a multi-line display fence → not a marker
     const divider = write(
@@ -911,12 +929,13 @@ test('check 2 (markers) — catches wrong widths, skips embedded dividers', () =
     );
     assert.strictEqual(checkMarkers([divider]).length, 0, 'embedded content divider must not be flagged');
 
-    // valid 49-char step marker → clean
-    const label = '── Construct Specification ';
-    const marker = label + '─'.repeat(49 - charLen(label));
-    assert.strictEqual(charLen(marker), 49);
-    const good = write(dir, 'skills/x/d.md', '```\n' + marker + '\n```\n');
-    assert.strictEqual(checkMarkers([good]).length, 0, 'valid marker must pass');
+    // markdown chrome: □ and ▪ pass; ■ in a marker fence belongs to the H1
+    const good = write(dir, 'skills/x/d.md', '```\n**`□ Construct Specification`**\n```\n');
+    assert.strictEqual(checkMarkers([good]).length, 0, 'markdown step marker must pass');
+    const goodSub = write(dir, 'skills/x/e.md', '```\n**`▪ Extract Sources`**\n```\n');
+    assert.strictEqual(checkMarkers([goodSub]).length, 0, 'markdown sub-step marker must pass');
+    const wrongGlyph = write(dir, 'skills/x/f.md', '```\n**`■ Construct Specification`**\n```\n');
+    assert.strictEqual(checkMarkers([wrongGlyph]).length, 1, 'a marker carrying the phase-title glyph must be caught');
   });
 });
 


### PR DESCRIPTION
Slice 5 of the adaptive-display stack, on top of #774.

7 phase-title boxes, 77 step markers, 13 sub-step markers → the markdown chrome family (`# **`■ Title`**` / `**`□ Name`**` / `**`▪ Name`**`). CONVENTIONS rewritten (hierarchy table, three chrome sections, rendering split, block/terminal shape); lint now bans drawn chrome and pins per-register glyphs. Banner and in-fence engine chrome stay drawn, as designed.

Gates: 1981 node tests, 40 + 357 + 5 CLI, typecheck — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)