### PR TITLE
fix(prose): six walk findings from the 48-case run

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -51,7 +51,7 @@ Set `source = "topic-provided"`.
 
 Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery-item.md)** with work_type = `{work_type}`, work_unit = `{work_unit}`, topic = `{topic}`, routing = `discussion`.
 
-→ On return, proceed to **Step 3** (Gather Context).
+→ On return, proceed to **Step 3**.
 
 **Otherwise (an entry exists):**
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -138,6 +138,8 @@ Load **[contextual-query.md](../workflow-knowledge/references/contextual-query.m
 > Discussion starting. I'll track our conversation on a Discussion Map. You can lead wherever you want — I'll challenge thinking, explore edge cases, and capture decisions as we go.
 ```
 
+Both blocks above are emitted before the reference loads.
+
 Load **[discussion-session.md](references/discussion-session.md)** and follow its instructions as written.
 
 *Knowledge-base nudge — before committing to a direction on a new subtopic, or when a decision might echo one made elsewhere, run a quick query. See **[knowledge-usage.md](../workflow-knowledge/references/knowledge-usage.md)**.*

--- a/skills/workflow-review-process/references/invoke-task-verifiers.md
+++ b/skills/workflow-review-process/references/invoke-task-verifiers.md
@@ -127,7 +127,7 @@ This enables incremental review detection on subsequent review sessions.
 
 ## G. Aggregate Findings
 
-1. Read all `.workflows/{work_unit}/review/{topic}/report-*.md` files
+1. Read every `.workflows/{work_unit}/review/{topic}/report-*.md` file from disk — the aggregation draws from the files as they stand, never from memory of the dispatches that produced them
 2. Synthesize findings from file contents:
    - Collect all tasks with `STATUS: incomplete` or `STATUS: issues_found` as blocking issues
    - Collect all test issues (under/over-tested)

--- a/skills/workflow-shared/references/framework.md
+++ b/skills/workflow-shared/references/framework.md
@@ -4,7 +4,7 @@
 
 ---
 
-Read each file below every time this reference is loaded. Never skip one on the belief it is already in context — these are short, re-reading costs almost nothing, and a summary that kept their conclusions and dropped their text reads exactly like having them.
+Read each file below every time this reference is loaded. Never skip one on the belief it is already in context — these are short, re-reading costs almost nothing, and a summary that kept their conclusions and dropped their text reads exactly like having them. Attempt each read; where the tool answers that a file is unchanged since your last read, that earlier read is current and still in context — follow it from there. The refusal is confirmation, not a skipped read.
 
 → Load **[instructions.md](instructions.md)** and follow its instructions as written.
 

--- a/skills/workflow-shared/references/natural-breaks.md
+++ b/skills/workflow-shared/references/natural-breaks.md
@@ -18,6 +18,7 @@ Any of these qualifies:
 - A commit just landed AND the exchange prior to that commit resolved your outstanding question
 - The phase is about to conclude (convergence menu, final review, wrap-up)
 - The user explicitly asked about background-agent state ("anything come back yet?", "any review results?")
+- The session just opened or resumed and no conversation thread is underway yet — a pending announcement lands here, before momentum builds, rather than falling to **C**'s default
 
 ## B. Signals That It Is NOT a Natural Break
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -208,7 +208,7 @@ Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)*
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Wrapping up. Final assessment, sign-off, and handover to the planning phase.
+> Wrapping up. Final assessment, sign-off, and @if(work_type is cross-cutting) closure — the pipeline completes here @else handover to the planning phase @endif.
 ```
 
 Load **[spec-completion.md](references/spec-completion.md)** and follow its instructions as written.

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -12,7 +12,7 @@ Unified workflow entry point. Discovers state, shows all active work, and routes
 
 ## Instructions
 
-Load **[framework.md](../workflow-shared/references/framework.md)** and follow its instructions as written.
+Load **[framework.md](../workflow-shared/references/framework.md)** and follow its instructions as written — after Step 0's four display blocks: the BANNER FIRST rule above governs the ordering, and this load comes second.
 
 ---
 


### PR DESCRIPTION
Prose fixes for the recurring findings from the full 48-case prose-walk run (45 PASS / 3 FLAKY / 0 FAIL), stacked on #778. Each fix's sighting count is in the commit message; every finding was surfaced and decided before any edit, per the prose-test skill's no-mid-run-fixes rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)