### PR TITLE
fix(prose-tests): walk-run case repairs — answers and file ratchets

### DIFF
--- a/tests/prose/cases/discussion-applies-a-settled-batch/case.json
+++ b/tests/prose/cases/discussion-applies-a-settled-batch/case.json
@@ -25,11 +25,12 @@
     "skills/workflow-discussion-process/references/perspective-agents.md",
     "skills/workflow-shared/references/background-agent-surfacing.md",
     "skills/workflow-shared/references/natural-breaks.md",
-    "skills/workflow-discussion-process/references/template.md"
+    "skills/workflow-discussion-process/references/template.md",
+    "skills/workflow-discussion-entry/references/gather-context.md"
   ],
   "answers": [
     "c — continue",
-    "n — now",
+    "y — yes, work through them now",
     "y — yes"
   ],
   "conduct": "The user is picking a card-payments discussion back up after most of a day away. They are brisk and want to spend their attention on decisions, not on bookkeeping. Asked whether to look at what the background review returned, they say yes. Shown a screen of corrections that the document's own decisions already determine, they read it, find nothing that surprises them, and approve the lot in one go without asking for any of them to be expanded. They offer no new material of their own and do not ask to move on to anything else.",

--- a/tests/prose/cases/discussion-promotes-a-batch-item/case.json
+++ b/tests/prose/cases/discussion-promotes-a-batch-item/case.json
@@ -29,7 +29,7 @@
   ],
   "answers": [
     "c — continue",
-    "n — now",
+    "y — yes, work through them now",
     "the retry ceiling is not three for us — we are on a negotiated plan",
     "y — yes"
   ],

--- a/tests/prose/cases/discussion-sends-a-route-batch/case.json
+++ b/tests/prose/cases/discussion-sends-a-route-batch/case.json
@@ -41,7 +41,7 @@
   ],
   "answers": [
     "c — continue",
-    "n — now",
+    "y — yes, work through them now",
     "y — yes",
     "y — yes"
   ],

--- a/tests/prose/cases/discussion-walks-an-early-review/case.json
+++ b/tests/prose/cases/discussion-walks-an-early-review/case.json
@@ -25,11 +25,12 @@
     "skills/workflow-discussion-process/references/perspective-agents.md",
     "skills/workflow-shared/references/background-agent-surfacing.md",
     "skills/workflow-shared/references/natural-breaks.md",
-    "skills/workflow-discussion-process/references/template.md"
+    "skills/workflow-discussion-process/references/template.md",
+    "skills/workflow-shared/references/final-review-menu.md"
   ],
   "answers": [
     "c — continue",
-    "n — now"
+    "y — yes, work through them now"
   ],
   "conduct": "The user is at the start of a card-payments discussion, back after most of a day away. They remember a background review returned while they were wrapping up and want to hear it before picking the threads back up. They opt in when offered, and they read the first raised area with interest — but the walk stops before they answer. They volunteer nothing new and do not steer the conversation anywhere else.",
   "invariants": {

--- a/tests/prose/cases/epic-resumes-and-harvests-topics/case.json
+++ b/tests/prose/cases/epic-resumes-and-harvests-topics/case.json
@@ -26,7 +26,8 @@
     "skills/workflow-discovery/references/brief-synthesis.md",
     "skills/workflow-discovery/references/template.md",
     "skills/workflow-discovery/references/document-review.md",
-    "skills/workflow-discovery/references/confirm-and-persist.md"
+    "skills/workflow-discovery/references/confirm-and-persist.md",
+    "skills/workflow-continue-epic/references/select-epic.md"
   ],
   "answers": [
     "1 — continue the search relevance epic",

--- a/tests/prose/cases/planning-graphs-the-tasks/case.json
+++ b/tests/prose/cases/planning-graphs-the-tasks/case.json
@@ -23,7 +23,8 @@
     "skills/workflow-planning-process/references/verify-source-material.md",
     "skills/workflow-planning-process/references/plan-construction.md",
     "skills/workflow-planning-process/references/define-phases.md",
-    "skills/workflow-planning-process/references/analyze-task-graph.md"
+    "skills/workflow-planning-process/references/analyze-task-graph.md",
+    "skills/workflow-shared/references/reconcile-advisory.md"
   ],
   "answers": [
     "c — pick the plan up where it left off",

--- a/tests/prose/cases/planning-reviews-and-concludes/case.json
+++ b/tests/prose/cases/planning-reviews-and-concludes/case.json
@@ -29,7 +29,8 @@
     "skills/workflow-planning-process/references/invoke-review-integrity.md",
     "skills/workflow-planning-process/references/process-review-findings.md",
     "skills/workflow-shared/references/compliance-check.md",
-    "skills/workflow-planning-process/references/conclude-plan.md"
+    "skills/workflow-planning-process/references/conclude-plan.md",
+    "skills/workflow-shared/references/reconcile-advisory.md"
   ],
   "answers": [
     "c — pick the plan up where it left off",

--- a/tests/prose/cases/research-review-walks-the-lanes/case.json
+++ b/tests/prose/cases/research-review-walks-the-lanes/case.json
@@ -35,7 +35,7 @@
   ],
   "answers": [
     "c — continue",
-    "n — now",
+    "y — yes, work through them now",
     "y — yes"
   ],
   "conduct": "The user returns to the relevance-measurement research after a day away. They have one thing to contribute: they checked, and the events pipeline retains ninety days of click logs — enough history to derive labels from. They share it, agree with how it is captured, and carry on. When the background review is offered they say yes to hearing it. Shown a one-item correction their own benchmark note determines, they approve it without asking for expansion. When the investigable thread is raised they read it with interest but the walk stops before they answer. They never ask for a deep-dive and never move to conclude.",


### PR DESCRIPTION
Case-fixture repairs from the 48-case walk run, stacked on #779. The answers fix removes a five-times-sighted mismatch between the script and the menus it meets; the file-list additions close selection-ratchet gaps the scope lines surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)