### PR TITLE
fix(surfacing): a drain runs to the next ask — approved batches roll forward, the drained row closes out loud

### DIFF
--- a/skills/workflow-shared/references/background-agent-surfacing.md
+++ b/skills/workflow-shared/references/background-agent-surfacing.md
@@ -18,7 +18,7 @@ This reference defines how to surface findings from background agents. Findings 
 **The ceremony matches the move owed, never the finding's importance.** Five hard rules govern every surfacing interaction:
 
 1. **Two-phase surfacing.** First acknowledge the report exists (micro-menu, no content). Only after the user opts in, start on the lanes.
-2. **One lane per turn, and inside the walked lane one finding per turn.** Each invocation of this protocol does at most one thing and hands control back. Never expect the protocol to "resume" after the user has engaged — the next session-loop check picks up where the store says it left off.
+2. **One open ask per turn.** A surfacing turn ends only on a pending ask — a batch screen awaiting approval, one raised finding awaiting its answer — never after a completed action: an approved batch confirms in a line and rolls into the next lane in the same turn, and a documented walk engagement re-enters the check (**F**). Inside the walked lane, one finding per turn, always.
 3. **Mid-thread protection.** If you are mid-Q/A with the user, defer the announce menu until the next natural break. A one-line parenthetical is acceptable, but only the first time.
 4. **Nothing is applied unseen.** A batch is rendered in full — every item, numbered, with its two-line reading — before a single edit lands. "There was no choice anyway" is not licence to write first.
 5. **Findings move toward the user, never away.** A finding the report placed in a batch moves into the walked lane the moment you find a real choice hiding in it, or the user says it isn't settled. Never the reverse: a walked finding is never demoted into a batch to save a turn.
@@ -29,7 +29,7 @@ Natural-break detection is guidance, not hard-enforced.
 
 ## LLM Turn Semantics (IMPORTANT)
 
-This protocol runs as a turn-level check, not a long-running state machine. Each invocation runs one `agent scan`, does at most one thing with its answer (a parenthetical, a menu, one batch, or one raised finding), and exits back to the session loop. Once a batch lands or a finding is raised, control belongs to the conversation. Do NOT wait "inside the protocol" for the user to finish engaging. The next iteration of the session loop's check will re-enter here and scan again; the row lists say exactly where things stand.
+This protocol runs as a turn-level check, not a long-running state machine. Each invocation runs one `agent scan` and acts on its answer. Turns end at asks, never after actions: once a finding is raised or a batch screen awaits approval, control belongs to the conversation — do NOT wait "inside the protocol" for the user to finish engaging. A completed action is no exit: an approved batch confirms in one line and continues to the next lane in the same turn, and a documented walk engagement re-enters the check in the same turn (**F**). A drain the user deflects out of resumes at the next natural break — every session-loop iteration re-enters here, and the row lists say exactly where things stand.
 
 **The engine store is the only state.** Never track surfacing progress in conversation memory, and never write it anywhere else. Lanes live in the report file, which is durable — re-read it rather than recalling it.
 
@@ -185,6 +185,12 @@ Intersect the row's `remaining` with each finding's lane, and take the first lan
 
 → Proceed to **G. Belongs Elsewhere**.
 
+#### If no lane holds findings
+
+The row is drained — the final surface call incorporated it. Close it out loud in this same turn, never silently: one line that the {agent_type}'s findings are worked through, then hand the conversation back where the announce interrupted it — resume the open thread, or when the session was already winding down, say so and name the next move. A caller with its own continuation (the final-review drain at phase conclusion) resumes it on return instead.
+
+→ Return to caller.
+
 ## E. No Decision Needed
 
 Every remaining `apply` finding lands in one screen. The set only ever shrinks — a finding the user promotes leaves this lane for the walk; nothing is ever added.
@@ -227,9 +233,9 @@ When every finding has landed, record the batch in one call:
 node .claude/skills/workflow-engine/scripts/engine.cjs agent surface {work_unit} {phase} {topic} {id} {F1,F2,…}
 ```
 
-Confirm in one line per finding — what changed, no restatement of the reasoning the screen already carried.
+Confirm in one line total — `All {N} landed.` — never a per-finding recap: the screen the user approved already said what each fix is. Nothing is pending, so the turn continues.
 
-→ Return to caller.
+→ Return to **D. Route by Lane**.
 
 **If the user asks about a number:**
 
@@ -260,7 +266,7 @@ This section runs once per invocation and then exits. It never waits in-protocol
    - **Present** — scene reconstruction before any assessment: say where it came from (the background {agent_type}) and what it observed — for a synthesis, the two positions in tension — then rebuild the scene as **Setting the scene** below prescribes. Restate any term borrowed from another subtopic or an earlier decision; never reference it bare. Never use a bare id (`F5`, `T2`) as a label in conversational prose — name the finding by its report title on first mention, or describe it by what it is; ids belong in commit subjects (`(review-003 F5)`) and in-document markers (`(resolves review-003 F5)`), not in the conversation. When earlier findings from this set have been raised, open with a one-line bridge: what the previous one settled — or simply that it was raised, when that engagement predates this session — and how many follow this one (the surface response's `remaining`, counted within this lane).
    - **Position** — your read, only where you genuinely have one: verified it holds, narrower than framed, already covered by a decision made since the report. Skip the beat rather than manufacture a verdict.
    - **Move** — sized to how open the decision is as much as how cold the context: a clear resolution — propose it and name what it costs ("this creates X and Y; I don't see another approach"), never an option survey; genuinely open — sketch the option space in a sentence or two; needs investigation — suggest research or a deep-dive. Where the caller's **Lanes** declaration names the walked lane's move, that move closes the raise.
-4. Raise it in the current turn, ending in a single question — or, for a finding with one defensible resolution, a stated proposal awaiting the user's response. Either way the turn ends and control returns: one finding per invocation, and the user's agreement is never licence to roll into the next. No bundled follow-ups, no menu.
+4. Raise it in the current turn, ending in a single question — or, for a finding with one defensible resolution, a stated proposal awaiting the user's response. Either way the turn ends and control returns: one raise per turn, and the next finding waits until this one's outcome is documented — the write-up turn picks it up (below). No bundled follow-ups, no menu.
 
 When this row's `surfaced` list holds no walked finding yet, the raise opens with the walked lane's declared heading as sub-step chrome, so the shift out of the batches is visible. A walk already under way — including one resumed from an earlier session — opens with its bridge instead, never a repeated heading:
 
@@ -278,7 +284,7 @@ When this row's `surfaced` list holds no walked finding yet, the raise opens wit
 - **The cheap path**: within a scene already rebuilt this session, or when the finding set was visible moments ago, a bridge clause replaces the reconstruction.
 - **The test**: the user can picture the problem before the ask arrives.
 
-After this, control belongs to the conversation. The user will engage (or deflect, or redirect) naturally. Handle their response as normal discussion — not as protocol-driven routing. An outcome that re-decides ground this topic didn't introduce — it names an entity, field, rule, or classification this topic's artifact didn't define — requires the sibling consult before it is documented: follow **G. Sibling consult at cross-topic decision points** in **[knowledge-usage.md](../../workflow-knowledge/references/knowledge-usage.md)** — query or cite, and carry the `Sibling check:` line in the documented decision. When the engagement's outcome is documented and committed — resolved or deflected — the commit subject carries `({id} {finding})`, e.g. `(review-003 F2)`.
+After this, control belongs to the conversation. The user will engage (or deflect, or redirect) naturally. Handle their response as normal discussion — not as protocol-driven routing. An outcome that re-decides ground this topic didn't introduce — it names an entity, field, rule, or classification this topic's artifact didn't define — requires the sibling consult before it is documented: follow **G. Sibling consult at cross-topic decision points** in **[knowledge-usage.md](../../workflow-knowledge/references/knowledge-usage.md)** — query or cite, and carry the `Sibling check:` line in the documented decision. When the engagement's outcome is documented and committed — resolved or deflected — the commit subject carries `({id} {finding})`, e.g. `(review-003 F2)`. That commit is a natural break (the landed-commit signal): re-enter **A. Check for Results** in the same turn, so the next raise follows the write-up while the context is warm. When the raise was the row's last — its surface response said nothing remains — there is no re-entry to make: the write-up turn closes the drain as **D**'s drained exit prescribes.
 
 An engagement that concludes the concern belongs to a sibling topic moves the finding to the `route` lane rather than rerouting it now — **G** sends the batch, and one send beats two.
 
@@ -293,6 +299,12 @@ Every remaining `route` finding lands in one screen, together with any the walk 
 The lane emptied — every one sent, or every one kept here.
 
 → Return to **D. Route by Lane**.
+
+#### If a delivery was cancelled this turn
+
+The user just declined it — re-rendering now would re-ask. The next natural break re-presents the lane.
+
+→ Return to caller.
 
 #### Otherwise
 
@@ -326,7 +338,9 @@ On return, a `result` of `cancelled` means nothing was written for that finding 
 node .claude/skills/workflow-engine/scripts/engine.cjs agent surface {work_unit} {phase} {topic} {id} {F1,F2,…}
 ```
 
-→ Return to caller.
+Confirm in one line total — `All {N} sent.`, or what actually landed when a delivery was cancelled — never a per-delivery recap.
+
+→ Return to **D. Route by Lane**.
 
 **If the user asks about a number:**
 
@@ -346,7 +360,7 @@ Nothing is sent and nothing is recorded. Follow them; the next natural break re-
 
 Before producing any surfacing output, verify:
 
-- □ Working ONE lane this turn — never two screens, never a batch and a raise together
+- □ At most one OPEN ask this turn — one batch screen awaiting approval or one raised finding awaiting its answer; a confirmed batch rolls into the next lane, but nothing ever stacks unanswered
 - □ In the walked lane: AT MOST one finding, AT MOST one question, and the finding stated self-contained before any position or proposal
 - □ In a batch: every item shown before anything is applied or sent, two lines each, numbered continuously
 - □ No finding demoted out of the walked lane — promotion only

--- a/tests/prose/cases/discussion-applies-a-settled-batch/assert.md
+++ b/tests/prose/cases/discussion-applies-a-settled-batch/assert.md
@@ -38,6 +38,10 @@ the behaviour under test:
   no worked example, no per-finding question, and no per-finding stop
 - exactly one stop gate stands between the announce and the applied
   batch: the batch menu itself
+- after the commits the confirmation is one line total, not a
+  per-finding recap, and the turn does not end silently on it: the row
+  is drained, so the same turn closes the review out loud — a line that
+  the findings are worked through — and hands the conversation back
 
 Further claims:
 
@@ -52,8 +56,8 @@ Further claims:
   amendment rather than a revision block preserving the original under
   an `#### Initial` heading. No subtopic is added, no map state changes,
   and the Options blocks are untouched
-- the walk stops after the commits; no new subtopic is opened and no
-  conclusion gate is entered
+- the walk stops after the drained close; no new subtopic is opened and
+  no conclusion gate is entered
 
 EXPECTED WORLD — the fixture plus: the agent store row `review-001`
 holds all three findings surfaced and stands `incorporated`; the

--- a/tests/prose/cases/discussion-sends-a-route-batch/assert.md
+++ b/tests/prose/cases/discussion-sends-a-route-batch/assert.md
@@ -32,7 +32,9 @@ Presentation claims:
 
 - the two batch screens are separate turns with a stop each; the apply
   screen never shows route items and the route screen never shows the
-  applied one
+  applied one. The route screen follows the apply lane's one-line
+  confirmation in the same turn — approving the apply batch is not a
+  dead stop
 - neither batch raises an item individually: no scene, no worked
   example, no per-finding question
 - the route screen names each target topic against its item, so the
@@ -49,7 +51,11 @@ Further claims:
   section still reads `(none)`, its Discussion Map is unchanged, and no
   reroute record is written
 - no fresh review dispatch, no ack, no incorporate call
-- the walk stops after the sends; the conclusion gate is never entered
+- the sends confirm in one line total, and the drained row closes out
+  loud in the same turn — a line that the findings are worked through,
+  handing the conversation back
+- the walk stops after the drained close; the conclusion gate is never
+  entered
 
 EXPECTED WORLD — the fixture plus: the Decision clause amended in place
 and committed; a triage entry in each of synonym-handling's and


### PR DESCRIPTION
## What

Fixes the dead stop after an approved finding batch (observed in a live fumi session: "Apply all 3, then move on" → three fixes landed → silence).

The one-lane-per-turn rule dates from the all-walk protocol, where every exit carried a pending question — momentum came free with each ask. Lanes (#737) made the ask-less exit reachable: an approved batch returned to caller with nothing pending, ending the turn silently right after the menu promised to move on.

## How

All in `background-agent-surfacing.md`, feeder architecture unchanged:

- **Core rule 2 + turn semantics**: "one lane per turn" → "one open ask per turn". Turns end at asks (a batch screen awaiting approval, a raise awaiting its answer), never after completed actions.
- **E/G `yes` exits**: confirm in one line total — no per-finding recap — then return to **D** so the next lane opens in the same turn.
- **D drained exit**: when no lane holds findings, the review closes out loud and hands the conversation back; callers with their own continuation (final-review) resume on return.
- **F write-up turn**: the landed commit is the natural break — re-enter the check in the same turn, so the next raise follows the write-up while the context is warm (previously emergent, now prescribed).
- **G cancelled-delivery guard**: a same-turn revisit after a cancel returns to caller instead of instantly re-asking; the next break re-presents the lane.
- The never-dump checklist line rebinds to the ask ("nothing ever stacks unanswered").

The two batch-exit prose cases (`discussion-applies-a-settled-batch`, `discussion-sends-a-route-batch`) now assert the roll-forward and the drained close — the inverse of the observed bug.

## Verification

- `npm test` — 1981 pass (includes prose corpus validation + snapshot goldens)
- `node tests/prose/run.cjs select --diff main` — 16 intersecting cases, worth a walk on the batch/walk ones before release

🤖 Generated with [Claude Code](https://claude.com/claude-code)