### PR TITLE
feat(presentation): report summaries become glanceable — depth joins the register

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -50,7 +50,7 @@ Code blocks are used for informational displays (overviews, status, keys) — th
 
 ### Presentation Register
 
-Report-class content — findings, review summaries, validation gaps and risks, diagnostics, item summaries — renders as markdown narrative in the register defined by `skills/workflow-shared/references/product-lens.md`: manifestation first in product terms, `file:line` refs as anchors, full fidelity to the underlying record. A `t/technical` option retells the same report from the code's perspective per `skills/workflow-shared/references/technical-lens.md` — a lens shift driven by Claude, never a file dump; where a raw view earns a place, it is a separate `v/view` option rendering the record file as markdown. Artifact content the user approves as the thing itself (spec prose, plan phases, diffs) stays verbatim in its fence — see Content Dividers & Frames.
+Report-class content — findings, review summaries, validation gaps and risks, diagnostics, item summaries — renders as markdown narrative in the register defined by `skills/workflow-shared/references/product-lens.md`: manifestation first in product terms, `file:line` refs as anchors, glanceable depth with the record file authoritative. A `t/technical` option retells the same report from the code's perspective per `skills/workflow-shared/references/technical-lens.md` — a lens shift driven by Claude, never a file dump; where a raw view earns a place, it is a separate `v/view` option rendering the record file as markdown. Artifact content the user approves as the thing itself (spec prose, plan phases, diffs) stays verbatim in its fence — see Content Dividers & Frames.
 
 ### Engine Output Sections
 

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -22,7 +22,7 @@ H. Update progress + phase check + commit
 
 **Engine gate sections**: `engine task` responses carry rendered `=== DISPLAY … ===` / `=== MENU … ===` sections after their JSON line — the loop's state-derived gates, parameterised from manifest state. Emit a section only where a stage below prescribes it: DISPLAY verbatim as a code block, MENU verbatim as markdown (not a code block). A section is everything beneath its `===` marker up to the next marker or the end of the response — the marker lines themselves are never emitted. Section content is emitted byte-for-byte — never redrawn, reflowed, or re-derived.
 
-→ Load **[product-lens.md](../../workflow-shared/references/product-lens.md)** and follow its instructions as written — the register for the review and task-result retellings in **E** and **G**. Findings cache files and records stay fully technical.
+→ Load **[product-lens.md](../../workflow-shared/references/product-lens.md)** and follow its instructions as written — the register and depth for the review and task-result summaries in **E** and **G**. Findings cache files and records stay fully technical.
 
 Read `work_type` once here at loop entry — it selects the executor's workflow reference (TDD vs verification) for every task and never changes mid-loop, so **[invoke-executor.md](invoke-executor.md)** consumes it from session context rather than re-reading it per invocation:
 
@@ -198,7 +198,7 @@ Emit the response's `DISPLAY: fix threshold` section.
 Review for Task {internal_id}: {Task Name} — needs changes (attempt {N})
 ```
 
-Retell the reviewer's findings as a product-lens markdown narrative (not a code block): each issue as what is wrong or at risk in what was built, with the proposed fix, any alternative, and the reviewer's confidence; non-blocking notes last.
+Present the reviewer's findings as a product-lens summary (markdown, not a code block): each issue in a sentence or two — what is wrong or at risk in what was built and the proposed fix, with the alternative or the reviewer's confidence only where it changes the call; non-blocking notes in one line.
 
 → On return, proceed to **F. Fix Approval Gate**.
 
@@ -210,7 +210,7 @@ Retell the reviewer's findings as a product-lens markdown narrative (not a code 
 Review for Task {internal_id}: {Task Name} — needs changes (attempt {N})
 ```
 
-Retell the reviewer's findings as a product-lens markdown narrative (not a code block): each issue as what is wrong or at risk in what was built, with the proposed fix, any alternative, and the reviewer's confidence; non-blocking notes last.
+Present the reviewer's findings as a product-lens summary (markdown, not a code block): each issue in a sentence or two — what is wrong or at risk in what was built and the proposed fix, with the alternative or the reviewer's confidence only where it changes the call; non-blocking notes in one line.
 
 Branch on the response's `fix_gate_mode`.
 
@@ -280,7 +280,7 @@ Task {internal_id}: {Task Name} — approved
 Phase: {phase number} — {phase name}
 ```
 
-Retell the executor's SUMMARY as a product-lens markdown narrative (not a code block): what the product now does that it didn't before, the decisions worth knowing, and how it was verified. After a fix round, include what changed since the last gate.
+Present the executor's SUMMARY as a product-lens summary (markdown, not a code block) in four beats: what this part of the product did before, what it does now, any issues hit on the way, and anything to watch. After a fix round, include what changed since the last gate.
 
 Branch on the `task_gate_mode` carried by this task's `start` response.
 

--- a/skills/workflow-investigation-process/references/findings-signoff.md
+++ b/skills/workflow-investigation-process/references/findings-signoff.md
@@ -25,7 +25,7 @@ Retell the investigation file's findings as a markdown narrative (not a code blo
 3. **What else it touches** — the Blast Radius: which parts of the product share the broken path.
 4. **Why nobody caught it** — the testing gap, edge case, or recent change, plainly.
 
-Every substantive point in those sections appears in the retelling — nothing softened, nothing dropped. The code-perspective retelling is one `t` away; the record file itself one `v` away.
+Each beat lands in a paragraph the user takes in at a glance — complete in coverage, compact in telling. The code-perspective retelling is one `t` away; the record file itself one `v` away.
 
 → On return, proceed to **B. Sign-off Gate**.
 

--- a/skills/workflow-shared/references/product-lens.md
+++ b/skills/workflow-shared/references/product-lens.md
@@ -18,6 +18,6 @@ An engineer who knows the product but not this codebase. Full engineering fluenc
 - **`file:line` refs as anchors.** Keep them — subordinate to the story, never its spine.
 - **Translate codebase-internal names.** Helpers, flags, and jargon are introduced on first use or replaced with what they do.
 
-## Fidelity
+## Depth
 
-A retelling, not a summary. Every substantive point in the underlying record appears; nothing softened, nothing dropped. The record file on disk stays fully technical and remains authoritative — the retelling presents it, never replaces it.
+A summary the user takes in at a glance — two or three short paragraphs, never a wall of text. Complete in coverage, compact in telling: every substantive point in the record is represented, in a sentence or two each, never at its full depth. Detail is deferred, not lost — the technical retelling and the record itself sit one option away at the site's gate. The record file on disk stays fully technical and remains authoritative — the summary presents it, never replaces it.

--- a/skills/workflow-shared/references/technical-lens.md
+++ b/skills/workflow-shared/references/technical-lens.md
@@ -19,4 +19,4 @@ The same engineer — knows the product, and is now asking how the code produces
 
 ## Fidelity
 
-Same rule as product-lens: a retelling, not a summary — every substantive point in the underlying record appears; nothing softened, nothing dropped. The record file stays authoritative.
+A retelling, not a summary — every substantive point in the underlying record appears; nothing softened, nothing dropped. This is the detail path the product-lens summary defers to. The record file stays authoritative.


### PR DESCRIPTION
## The problem

The product-lens register demanded a retelling with nothing dropped, and the task loop's gate summaries grew into 3,000-character walls. A wall of text at a gate drains the reader — and at the auto gates it reads as a sign-off, which is where the task loop has been stalling (see the next PR in this stack).

## The change

- **product-lens.md** — the Fidelity section becomes **Depth**: a summary the user takes in at a glance, two or three short paragraphs. Complete in coverage, compact in telling — every substantive point represented in a sentence or two, never at full depth. The record file stays authoritative.
- **technical-lens.md** — explicitly the detail path the summary defers to: full retelling, nothing dropped, unchanged in substance. `t/technical` is how the user asks for more.
- **task-loop.md stage G** — the executor result lands in four beats: what this part of the product did before, what it does now, any issues hit on the way, anything to watch.
- **task-loop.md stage E** — each review finding in a sentence or two: what's wrong or at risk and the proposed fix; alternative/confidence only where it changes the call.
- **findings-signoff.md** (investigation) — keeps its four beats at the same glanceable depth; the record is one `v` away.
- **CONVENTIONS.md** — the Presentation Register line follows ("glanceable depth with the record file authoritative").

`present-review.md` already prescribes a single summary paragraph and needed nothing.

Part 1 of a 3-PR stack repairing the task-loop stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
