### PR TITLE
fix(prose-test): walks never run from a worktree-isolated session

### DIFF
--- a/.claude/skills/prose-test/SKILL.md
+++ b/.claude/skills/prose-test/SKILL.md
@@ -65,6 +65,13 @@ passed.
 
 ## Rules
 
+- **Never run cases from a worktree-isolated session.** The harness's
+  worktree-isolation guard refuses the engine's `complete`-family
+  subcommands (`task complete`, `topic complete`, `workunit complete`)
+  inside the walkers' temp-dir worlds, failing every case on environment
+  rather than prose — and pushing walkers toward guard-bypass workarounds
+  the record then contradicts. Run from the primary checkout; exit any
+  worktree first.
 - **Never run cases against prose that is still under review.** While a
   PR's diff is moving — the author iterating, the reviewer commenting — a
   walk certifies bytes that may not survive the review, and each further


### PR DESCRIPTION
One new rule in the /prose-test skill. Eight walks across four cases failed on a single environment defect: the harness's worktree-isolation guard refuses the engine's `complete`-family subcommands (`task complete`, `topic complete`, `workunit complete`) inside the walkers' temp-dir worlds — every case fails on environment rather than prose, and the obstruction pushed two walkers into guard-bypass wrapper scripts whose success their own records contradicted. The rule: run walks from the primary checkout, never a worktree-isolated session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)