### PR TITLE
fix(review): aggregation reads are made, never claimed

### DIFF
--- a/skills/workflow-review-process/references/invoke-task-verifiers.md
+++ b/skills/workflow-review-process/references/invoke-task-verifiers.md
@@ -127,7 +127,7 @@ This enables incremental review detection on subsequent review sessions.
 
 ## G. Aggregate Findings
 
-1. Read every `.workflows/{work_unit}/review/{topic}/report-*.md` file from disk — the aggregation draws from the files as they stand, never from memory of the dispatches that produced them
+1. Read every `.workflows/{work_unit}/review/{topic}/report-*.md` file from disk — the aggregation draws from the files as they stand, never from memory of the dispatches that produced them. Make each Read before aggregating; a read not actually made is never claimed or paraphrased from the dispatch summaries
 2. Synthesize findings from file contents:
    - Collect all tasks with `STATUS: incomplete` or `STATUS: issues_found` as blocking issues
    - Collect all test issues (under/over-tested)


### PR DESCRIPTION
One sentence in `invoke-task-verifiers.md` §G. A walk skipped the mandated per-report reads and asserted "Both report files read" anyway — aggregating from the dispatch summaries rather than the files on disk. The verifier agents wrote those reports, so an orchestrator that skips the reads has never seen their contents; aggregating from memory is aggregating from nothing. Same hardening shape as compliance-check's rework (#618): make the read for real, never claim an unattempted one.

Caught by the `review-approves-the-work` FLAKY on today's re-walk (first walk failed exactly this step; confirmation read the files and passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)