### PR TITLE
feat(presentation): banner recut as two-tone block art

### DIFF
--- a/.claude/agents/prose-walker.md
+++ b/.claude/agents/prose-walker.md
@@ -148,7 +148,10 @@ Narrate these, each as its own entry, the moment it happens:
 
 1. Every prose section or arm entered: `file.md § Heading`, plus the
    quoted guard line that selected it.
-2. Every block the prose directed you to emit, quoted in full.
+2. Every block the prose directed you to emit, quoted in full. The one
+   exception is static branding — the `workflow-start` banner art —
+   recorded as `EMITTED: [banner]`: no assertion can rest on it, and the
+   art is heavy to reproduce.
 3. Every menu or question encountered, verbatim, and the scripted answer
    used.
 4. Every marker above.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -149,7 +149,7 @@ Rules:
 
 ### Workflow Banner
 
-The `workflow-start` skill opens with an ASCII art banner (see skill file for exact art) emitted as a yaml code block — the fence is what colours the art — followed by a markdown title line carrying the product name and version (`# **`■ Agentic Engineering Workflows`** · *vN.N.N*`). No borders; the version rides the title line, where the release tooling pattern-matches it.
+The `workflow-start` skill opens with an ASCII art banner (see skill file for exact art) emitted as a properties code block — the fence is what colours the art: each line's first token renders turquoise and everything after the first space red, so the single space between the two words is load-bearing — followed by a markdown title line carrying the product name and version (`# **`■ Agentic Engineering Workflows`** · *vN.N.N*`). No borders; the version rides the title line, where the release tooling pattern-matches it.
 
 ### Template Placeholders
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -18,19 +18,12 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 
 ## Step 0: Initialisation
 
-> *Output the next fenced block as a yaml code block (```yaml fence — it colours the art):*
+> *Output the next fenced block as a properties code block (```properties fence — it colours the art; the space between the two words is the token break that splits the colours, so emit every line byte-for-byte):*
 
 ```
-    ___   _____________   __________________
-   /   | / ____/ ____/ | / /_  __/  _/ ____/
-  / /| |/ / __/ __/ /  |/ / / /  / // /
- / ___ / /_/ / /___/ /|  / / / _/ // /___
-/_/  |_\____/_____/_/ |_/ /_/ /___/\____/
- _       ______  ____  __ __ ________    ____ _       _______
-| |     / / __ \/ __ \/ //_// ____/ /   / __ \ |     / / ___/
-| | /| / / / / / /_/ / ,<  / /_  / /   / / / / | /| / /\__ \
-| |/ |/ / /_/ / _, _/ /| |/ __/ / /___/ /_/ /| |/ |/ /___/ /
-|__/|__/\____/_/ |_/_/ |_/_/   /_____/\____/ |__/|__//____/
+█▀█░█▀▀░█▀▀░█▀█░▀█▀░▀█▀░█▀▀ █░█░█▀█░█▀▄░█░█░█▀▀░█░░░█▀█░█░█░█▀▀
+█▀█░█░█░█▀▀░█░█░░█░░░█░░█░░ █▄█░█░█░█▀▄░█▀▄░█▀▀░█░░░█░█░█▄█░▀▀█
+▀░▀░▀▀▀░▀▀▀░▀░▀░░▀░░▀▀▀░▀▀▀ ▀░▀░▀▀▀░▀░▀░▀░▀░▀░░░▀▀▀░▀▀▀░▀░▀░▀▀▀
 ```
 
 > *Output the next fenced block as markdown (not a code block):*


### PR DESCRIPTION
The `/workflow-start` splash drops the slash-outline figlet for a compact half-block cut (toilet `pagga`), rendered through a `properties` fence: each line's first token colours turquoise and everything after the first space red, so AGENTIC and WORKFLOWS split colours on the single load-bearing space between them. One line group, 63 columns — inside the 65-column fallback floor.

```
█▀█░█▀▀░█▀▀░█▀█░▀█▀░▀█▀░█▀▀ █░█░█▀█░█▀▄░█░█░█▀▀░█░░░█▀█░█░█░█▀▀
█▀█░█░█░█▀▀░█░█░░█░░░█░░█░░ █▄█░█░█░█▀▄░█▀▄░█▀▀░█░░░█░█░█▄█░▀▀█
▀░▀░▀▀▀░▀▀▀░▀░▀░░▀░░▀▀▀░▀▀▀ ▀░▀░▀▀▀░▀░▀░▀░▀░▀░░░▀▀▀░▀▀▀░▀░▀░▀▀▀
```

CONVENTIONS.md's Workflow Banner section updated to match (yaml → properties, with the token-break mechanics noted so the space survives future edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)