### PR TITLE
feat(skills): comments carry only what the code cannot

### DIFF
--- a/agents/workflow-planning-task-author.md
+++ b/agents/workflow-planning-task-author.md
@@ -88,8 +88,9 @@ Author incrementally into the task detail path with `.txt` in place of `.md` usi
 3. **Cross-cutting specs inform** — apply their architectural decisions where relevant (e.g., caching, rate limiting)
 4. **Every field required** — Problem, Solution, Outcome, Do, Acceptance Criteria, Tests are all mandatory
 5. **Tests include edge cases** — not just happy path; reference the edge cases from the task table
-6. **Write tasks to the task detail file incrementally** — each task written to disk before starting the next
-7. **Spec interpretation errors propagate across tasks in a batch** — ground every decision in the specification. When the spec is ambiguous, note the ambiguity in the task's Context section rather than inventing a plausible default.
-8. **No modifications after approval** — what the user sees is what gets logged
-9. **No git writes** — do not commit or stage. Writing the task detail file is your only file write.
-10. **Never lose your work** — the tasks you author must survive the run, and the task detail file is how they survive. Produce the task detail file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the tasks in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
+6. **Do steps direct code and tests, never commentary** — rationale and spec citations stay in the task's Problem/Context fields, never "state in-source that…". A comment may be required only for a non-obvious constraint the code cannot express, directed in one line with the wording left to the executor (see task-design.md → Comments Are Not Task Content).
+7. **Write tasks to the task detail file incrementally** — each task written to disk before starting the next
+8. **Spec interpretation errors propagate across tasks in a batch** — ground every decision in the specification. When the spec is ambiguous, note the ambiguity in the task's Context section rather than inventing a plausible default.
+9. **No modifications after approval** — what the user sees is what gets logged
+10. **No git writes** — do not commit or stage. Writing the task detail file is your only file write.
+11. **Never lose your work** — the tasks you author must survive the run, and the task detail file is how they survive. Produce the task detail file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the tasks in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.

--- a/skills/workflow-implementation-process/references/code-quality.md
+++ b/skills/workflow-implementation-process/references/code-quality.md
@@ -36,6 +36,26 @@ Prefer concrete types over language-level escape hatches that bypass the type sy
 - Prefer pure functions
 - Avoid hidden dependencies
 
+## Comments
+
+Code shows what; a comment earns its place only by carrying what the code cannot. Before writing one, try to make it unnecessary — rename, extract, simplify — and comment what survives. No comment is checked by any compiler or test: every claim one makes is a maintenance liability, so spend them sparingly and keep each claim small.
+
+**A comment is warranted for:**
+- **Why** — rationale, a rejected alternative, a constraint imposed from elsewhere
+- **Warnings** — deliberate-looking-wrong code that must not be "simplified", surprising behaviour, consequences ("not thread-safe", "order matters: the read precedes the discard"). Name the trap in a line or two
+- **Opaque what** — a regex, bit trick, or dense algorithm that stays opaque after refactoring
+- **Public/exported API doc comments** per the language's own conventions — what it does, inputs, outputs, error behaviour; never internal algorithm
+
+**Never in a comment:**
+- Links, URLs, issue ids, or any workflow vocabulary — task ids, phase numbers, spec-section citations. The comment must hold true for a reader with no knowledge of the process that produced the code, long after its artifacts are archived
+- Claims about tests — what a test pins, catches, or proves. A renamed test or moved assertion turns the claim into a confident lie
+- Cardinality claims — "the single caller", "the only site that…", "nothing consumes this yet". Falsified by ordinary additive change far from the comment
+- Worked examples and hand-traced values. An example worth keeping is a test, where it executes
+- The design argument. State the conclusion the code needs ("sorted before dedup — dedup keys on adjacency"), not the debate; the reasoning lives in the project's design artifacts
+- Restated adjacent code, changelog narration, attribution, commented-out code
+
+When a change makes a nearby comment false, fix it in the same edit — and prefer deleting the claim to re-arguing it.
+
 ## Anti-Patterns to Avoid
 - God classes
 - Magic numbers/strings

--- a/skills/workflow-planning-process/references/task-design.md
+++ b/skills/workflow-planning-process/references/task-design.md
@@ -34,6 +34,14 @@ A task whose edits land on another work unit's files under `.workflows/` correct
 
 ---
 
+## Comments Are Not Task Content
+
+**Do** steps direct code and tests, never commentary. Rationale, sequencing notes, and spec citations belong in the task's Problem/Context fields and the plan itself — never directed into source comments ("state in-source that…", "record why in a comment…"). A comment dictated by a task becomes an acceptance criterion the reviewer must police, and its claims go stale as later tasks land.
+
+A task may require a comment only where the code cannot express a constraint — a warning against a tempting wrong simplification, a non-obvious invariant — directed in one line ("comment that the discard must come last") with the wording left to the executor. Never direct comments that reference other tasks, phases, spec sections, or what tests cover.
+
+---
+
 ## Vertical Slicing
 
 Prefer **vertical slices** that deliver complete, testable functionality over horizontal slices that separate by technical layer.


### PR DESCRIPTION
Comment-driven implementation review loops start upstream of the reviewer: plans command in-source essays ("state in-source that…"), executors comply and amplify, and every claim a comment makes is prose no compiler or test checks — falsified by the next behavioural fix, then policed at half an hour per loop. In Portal's theming run, ~40% of post-first review rejections were comment-only.

This PR lands the discipline at every surface that writes or directs comments:

- **code-quality.md** gains a **Comments** section: when a comment is warranted (why, warnings, opaque what, exported-API docs) and what one must never contain (links and workflow vocabulary, claims about tests, cardinality claims, hand-traced examples, the design argument). Written self-contained and project-agnostic so it doubles as standalone instructions for cleanup passes. The executor and the three phase-analysis agents already read this file, so they inherit it unchanged.
- **task-design.md** + the **task-author agent**: Do steps direct code and tests, never commentary — a task may require a comment only for a non-obvious constraint, one line, wording left to the executor. The task designer reads the same file.

Second layer routes comment corrections around the fix loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)