### PR TITLE
feat(review-loop): comment corrections apply without a fix round

### DIFF
--- a/agents/workflow-implementation-task-reviewer.md
+++ b/agents/workflow-implementation-task-reviewer.md
@@ -18,6 +18,7 @@ You receive via the orchestrator's prompt:
 1. **Specification path** — The validated specification for design decision context
 2. **Task content** — Same task content the executor received: internal ID, phase, and all instructional content
 3. **Project skill paths** — Relevant `.claude/skills/` paths for checking framework convention adherence
+4. **code-quality.md path** — Quality standards, including the comment discipline
 
 ## Your Process
 
@@ -25,7 +26,8 @@ You receive via the orchestrator's prompt:
 2. **Check unstaged changes** — use `git diff` and `git status` to identify files changed by the executor
 3. **Read all changed files** — implementation code and test code
 4. **Read project skills** — understand framework conventions, testing patterns, architecture patterns
-5. **Evaluate all five review dimensions** (see below)
+5. **Read code-quality.md** — the quality standards the executor worked to, including its comment discipline
+6. **Evaluate all five review dimensions** (see below), classifying comment findings per **Comment Corrections**
 
 ## Review Dimensions
 
@@ -75,6 +77,14 @@ Is this a sound design decision? Will it compose well with future tasks?
 - Are there structural concerns that should be raised now rather than compounding?
 - Are concrete types used where data structures are known? Flag untyped escape hatches used where concrete types would be clearer and safer.
 
+## Comment Corrections
+
+Check every comment the diff introduced or touched against the code and against code-quality.md's comment discipline: claims the code falsifies, stale references, or content the discipline forbids (workflow vocabulary, claims about tests, cardinality claims, restated design argument).
+
+**Classify findings by their remedy, not their subject.** A finding whose entire remedy is comment text — no executable code, no test, no assertion changes — is a comment correction, never an ISSUE: report it under COMMENT_CORRECTIONS with verbatim OLD text and the replacement, and the orchestrator applies it without a fix round. A false comment whose remedy is a code change (the code violates the invariant the comment documents) is an ISSUE like any other.
+
+Corrections are mandatory findings — an incorrect comment never ships — but they never block: **compute the verdict from ISSUES alone.** Pre-existing comments the diff did not touch are outside the task's scope.
+
 ## Fix Recommendations (needs-changes only)
 
 When your verdict is `needs-changes`, you must also recommend how to fix each issue. You have full context — the spec, the task, the conventions, and the code — so use it.
@@ -103,6 +113,7 @@ When alternatives exist, explain the tradeoff briefly — don't just list option
 6. **Be specific** — Include file paths and line numbers for every issue. Vague findings are not actionable.
 7. **Proportional** — Prioritize by impact. Don't nitpick style when the architecture is wrong.
 8. **Task scope only** — Only review what's in the task. Don't flag issues outside the task's scope.
+9. **Comment fixes never block** — A finding whose entire remedy is comment text goes to COMMENT_CORRECTIONS, never ISSUES. The verdict is computed from ISSUES alone.
 
 ## Your Output
 
@@ -121,6 +132,10 @@ ISSUES:
   FIX: {recommended approach}
   ALTERNATIVE: {other valid approach with tradeoff — optional, only when multiple valid approaches exist}
   CONFIDENCE: {high | medium | low}
+COMMENT_CORRECTIONS:
+- {file:line} — {what is wrong, one clause}
+  OLD: {the comment text as it stands — verbatim, so the edit applies mechanically}
+  NEW: {the replacement text — empty to delete the comment}
 NOTES:
 - {non-blocking observations}
 ```
@@ -128,4 +143,5 @@ NOTES:
 - If VERDICT is `approved`, omit ISSUES entirely (or leave empty)
 - If VERDICT is `needs-changes`, ISSUES must contain specific, actionable items with file:line references AND fix recommendations
 - Each issue must include FIX and CONFIDENCE. ALTERNATIVE is optional — include only when genuinely multiple valid approaches exist
+- COMMENT_CORRECTIONS may accompany either verdict — omit the section when there are none. OLD must match the file byte-for-byte
 - NOTES are for non-blocking observations — things worth noting but not requiring changes

--- a/agents/workflow-review-task-verifier.md
+++ b/agents/workflow-review-task-verifier.md
@@ -98,6 +98,7 @@ Review the implementation as a senior architect would:
 - **Low complexity**: Cyclomatic complexity is reasonable, code paths are clear
 - **Modern idioms**: Uses current language features appropriately
 - **Readability**: Code is self-documenting, intent is clear
+- **Comment accuracy**: Comments in the changed code hold true against it — no claims the code falsifies, no restated code, no references to process artifacts (task ids, phases, spec sections)
 - **Security**: No obvious vulnerabilities (injection, exposure, etc.)
 - **Performance**: No obvious inefficiencies (N+1 queries, unnecessary loops, etc.)
 
@@ -107,7 +108,7 @@ First, apply the floor: a note must propose a concrete change (add X, remove Y, 
 
 Tag each surviving note by the next step required to act on it:
 
-- **`[do-now]`** — Zero risk, no logic impact, applyable on the spot: documentation and comment edits, wording and link fixes, mechanical renames, small test-assertion additions (safe as long as they pass). Small and inline (single file), or trivially mechanical even across files (e.g. a doc-reference sweep). Acting on it needs no decision and touches no executable logic.
+- **`[do-now]`** — Zero risk, no logic impact, applyable on the spot: documentation and comment edits, wording and link fixes, mechanical renames, small test-assertion additions (safe as long as they pass). Small and inline (single file), or trivially mechanical even across files (e.g. a doc-reference sweep). Acting on it needs no decision and touches no executable logic. A comment note states the replacement text, so applying it is transcription.
 - **`[quickfix]`** — Mechanical but touches code or test logic, or is larger than an inline edit: extract a helper, dedupe, a small refactor, a behavioural test. No design decision, but it carries enough risk to route through the pipeline rather than apply on the spot.
 - **`[idea]`** — Requires genuine decision or design judgment: how or whether to do it, architectural trade-offs, new functionality, scope. If the next step is "decide how" or "decide whether", it is an idea.
 - **`[bug]`** — Something is broken or incorrect but non-blocking. Latent bugs, unhandled edge cases, incorrect error mapping. Do not place these in BLOCKING ISSUES.

--- a/skills/workflow-implementation-process/references/invoke-reviewer.md
+++ b/skills/workflow-implementation-process/references/invoke-reviewer.md
@@ -16,6 +16,7 @@ Invoke `workflow-implementation-task-reviewer` with:
 2. **Task content**: same normalised task content the executor received
 3. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} project_skills`)
 4. **Work type**: from the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type`) — `quick-fix` switches the reviewer to completeness-based criteria and verification-workflow checks
+5. **code-quality.md path**: `.claude/skills/workflow-implementation-process/references/code-quality.md` — the standards the executor worked to, including the comment discipline
 
 ---
 
@@ -36,11 +37,16 @@ ISSUES:
   FIX: {recommended approach}
   ALTERNATIVE: {other valid approach with tradeoff — optional}
   CONFIDENCE: {high | medium | low}
+COMMENT_CORRECTIONS:
+- {file:line} — {what is wrong}
+  OLD: {verbatim current comment text}
+  NEW: {replacement — empty to delete}
 NOTES:
 - {non-blocking observations}
 ```
 
 - `approved`: task passes all five review dimensions
 - `needs-changes`: ISSUES contains specific, actionable items with fix recommendations and confidence levels
+- COMMENT_CORRECTIONS may accompany either verdict: prose-only fixes the verdict never counts. On `approved`, stage **D** of the task loop applies them directly; on `needs-changes`, they travel to the executor with the findings
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -163,6 +163,14 @@ Task {status:[blocked|failed]}. How would you like to proceed?
 
 #### If `VERDICT` is `approved`
 
+**If the review carries COMMENT_CORRECTIONS:**
+
+Apply each correction now with the Edit tool — replace its OLD text with its NEW text at the named file, verbatim; an empty NEW deletes the comment. Corrections touch no executable logic, so nothing re-runs and no fix round opens. A correction whose OLD text no longer matches the file is dropped — name it in the result summary at **G**.
+
+→ Proceed to **G. Task Gate**.
+
+**If it carries none:**
+
 → Proceed to **G. Task Gate**.
 
 ---
@@ -174,6 +182,9 @@ Write the reviewer's findings to `.workflows/.cache/{work_unit}/implementation/{
 ```markdown
 ISSUES:
 {copy ISSUES from reviewer output, including FIX, ALTERNATIVE, and CONFIDENCE per issue}
+
+COMMENT_CORRECTIONS:
+{copy COMMENT_CORRECTIONS from reviewer output — omit the section when the review carries none; the executor applies these during the fix round}
 
 NOTES:
 {copy NOTES from reviewer output}
@@ -282,7 +293,7 @@ Task {internal_id}: {Task Name} — approved
 Phase: {phase number} — {phase name}
 ```
 
-Present the executor's SUMMARY as a product-lens summary (markdown, not a code block) in four beats: what this part of the product did before, what it does now, any issues hit on the way, and anything to watch. After a fix round, include what changed since the last gate.
+Present the executor's SUMMARY as a product-lens summary (markdown, not a code block) in four beats: what this part of the product did before, what it does now, any issues hit on the way, and anything to watch. After a fix round, include what changed since the last gate. When comment corrections were applied at **D**, add a line saying so — naming any that were dropped.
 
 Branch on the `task_gate_mode` carried by this task's `start` response.
 

--- a/skills/workflow-review-process/references/review-checklist.md
+++ b/skills/workflow-review-process/references/review-checklist.md
@@ -43,6 +43,7 @@ Review as a senior architect would:
 - **Low complexity**: Reasonable cyclomatic complexity, clear code paths
 - **Modern idioms**: Uses current language features appropriately
 - **Readability**: Self-documenting code, clear intent
+- **Comment accuracy**: Comments in the changed code hold true against it — no claims the code falsifies, no restated code, no references to process artifacts (task ids, phases, spec sections)
 - **Security**: No obvious vulnerabilities (injection, exposure, etc.)
 - **Performance**: No obvious inefficiencies (N+1 queries, unnecessary loops, etc.)
 
@@ -95,6 +96,8 @@ For each phase:
 **Orphaned code**: Code added but not used or tested
 
 **Poor readability**: Code works but is hard to understand
+
+**Stale comment**: A comment contradicts the code it describes — a `[do-now]` note carrying the replacement text, never a blocking issue on its own
 
 ## Writing Feedback
 


### PR DESCRIPTION
A finding whose entire remedy is comment text no longer costs an executor-plus-reviewer cycle (Portal's task 8-10 looped three times — a full round each — on prose-only fixes).

- **Task reviewer** classifies by remedy: prose-only fixes land in a `COMMENT_CORRECTIONS` section with verbatim OLD/NEW text; the verdict is computed from ISSUES alone. A false comment whose remedy is a code change stays an ISSUE.
- **Task loop stage D**: on `approved`, the orchestrator applies corrections mechanically — no re-review, no `fix_attempts`, no gate; dropped corrections are named at the task gate. On `needs-changes` they ride the findings file into the executor's fix round as before.
- **invoke-reviewer** now passes code-quality.md, so both sides of the loop judge comments by the same discipline.
- **Review phase** (phase 9) keeps its existing shape: comment accuracy joins the verifier's quality criteria and the checklist, and a comment note carries its replacement text so the existing `### Do now` lane stays pure transcription.

Stacked on #792 (the discipline the classification refers to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)