### PR TITLE
fix(triage): the queue agenda reads as a list of concerns

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -244,6 +244,8 @@ Unnumbered trees follow the same structure:
 
 Engine-rendered tree rows carry their status as a right-aligned `[term]` column — one shared column per tree, computed against the longest row (`├─ ◐ Menu Management    [researching]`). Rows that carry a body (summaries, provenance) skip the column and spell their state on a trailing `↳ State` line instead — see List Display. Square brackets `[term]` are also the form everywhere a column can't exist: plain list rows (selection sub-views, completed pickers, inbox items) and prose references. Menu options carry status as an italic metadata tail — see Menus. Phase header count summaries use parentheses `(N completed, M pending)`. Never dash-separated.
 
+**Which register applies is decided by the fence, not by taste.** Demoted content — status, provenance, the note under a row — reads italic in a menu and takes `↳` inside a display, because markdown emphasis inside a code fence renders as literal asterisks. A display that wants italics is a display that should not be fenced (`DISPLAY: proposed task`, `DISPLAY: finding`); a display that needs columns or a tree keeps its fence and its `↳`.
+
 Core vocabulary: `in-progress`, `completed`, `ready`, `extracted`, `pending`, `reopened`, `promoted`. Discussion Map uses `pending`, `exploring`, `converging`, `decided`, `deferred`. Phase-specific terms are fine; the tree column and an inline bracket form never mix on one line.
 
 ### Callout Flag

--- a/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
@@ -191,4 +191,32 @@ function treeList(items, { indent = '     ', width = displayWidth() } = {}) {
   return out.join('\n');
 }
 
-module.exports = { DOTS, MENU_GLYPH, section, menuFrame, alignOptions, menu, cmdOption, promptOption, rangeOption, callout, subDetail, treeList };
+/**
+ * Numbered tree list (`├─ N. text`): selection rows whose text is a sentence
+ * rather than a name, so it wraps — under itself, past the number, never back
+ * under the glyph. `note` renders as a `↳` line beneath the row, the demoted
+ * register a fence can carry (markdown emphasis renders literally inside one,
+ * so provenance and status take `↳` here and italics only in menus).
+ * @param {{text: string, note?: string}[]} items
+ * @param {{indent?: string, width?: number}} [opts]
+ * @returns {string}
+ */
+function numberedTreeList(items, { indent = '  ', width = displayWidth() } = {}) {
+  const out = [];
+  items.forEach((item, i) => {
+    const isLast = i === items.length - 1;
+    const head = `${indent}${isLast ? '└─' : '├─'} ${i + 1}. `;
+    // The gutter sits at the indent column; the rest pads out to the text
+    // column, so a wrapped sentence and its note both hang under the title.
+    const cont = `${indent}${isLast ? ' ' : '│'}${' '.repeat(head.length - indent.length - 1)}`;
+    const segs = wrap(item.text, width - head.length);
+    out.push(head + segs[0]);
+    for (const seg of segs.slice(1)) out.push(cont + seg);
+    if (item.note) {
+      for (const seg of wrap(`↳ ${item.note}`, width - cont.length)) out.push(cont + seg);
+    }
+  });
+  return out.join('\n');
+}
+
+module.exports = { DOTS, MENU_GLYPH, section, menuFrame, alignOptions, menu, cmdOption, promptOption, rangeOption, callout, subDetail, treeList, numberedTreeList };

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -12,7 +12,7 @@ const fs = require('fs');
 const path = require('path');
 const { loadManifest } = require('./reads.cjs');
 const { titlecase } = require('./conventions.cjs');
-const { section, menu, cmdOption, promptOption, callout, subDetail, treeList } = require('./projections/surfaces.cjs');
+const { section, menu, cmdOption, promptOption, callout, subDetail, treeList, numberedTreeList } = require('./projections/surfaces.cjs');
 
 /**
  * Parse a 3-segment dotpath `work_unit.phase.topic`, validating the work unit
@@ -801,13 +801,15 @@ function triageOffer(cwd, { dotpath, file }) {
   if (byFile.size !== files.length || files.some((f) => !byFile.has(f))) {
     throw new Error(`render triage-offer: payload items must cover the queue exactly (queue: ${files.join(', ')})`);
   }
+  // Header carries the count, rows hang off it, provenance takes the `↳`
+  // line — the queue is a flat set of concerns from any number of topics, so
+  // origin belongs per row rather than folded into the header.
   const agenda = [
-    callout(`${files.length} rerouted concern${files.length === 1 ? '' : 's'} waiting in this topic's triage queue:`),
-    '',
-    ...files.map((f, i) => {
+    `Triage Queue (${files.length} concern${files.length === 1 ? '' : 's'})`,
+    numberedTreeList(files.map((f) => {
       const it = /** @type {NonNullable<ReturnType<typeof byFile.get>>} */ (byFile.get(f));
-      return `  ${i + 1}. ${it.title} — from ${it.origin} (${it.from_phase}, ${it.from_date})`;
-    }),
+      return { text: it.title, note: `From ${it.origin} · ${it.from_phase} · ${it.from_date}` };
+    })),
   ];
   return [
     section('DISPLAY: triage agenda', 'emit verbatim as a code block', agenda.join('\n')),

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -579,15 +579,35 @@ describe('render concern', () => {
     const out = renderSurface(dir, 'triage-offer', { dotpath: 'wu.discussion.measurement', file });
     assert.ok(out.startsWith([
       '=== DISPLAY: triage agenda (emit verbatim as a code block) ===',
-      "  ⚑ 2 rerouted concerns waiting in this topic's triage queue:",
-      '',
-      '  1. Offline metrics — from ranking (discussion, 2026-08-01)',
-      '  2. Expansion tracking — from synonyms (discussion, 2026-08-02)',
+      'Triage Queue (2 concerns)',
+      '  ├─ 1. Offline metrics',
+      '  │     ↳ From ranking · discussion · 2026-08-01',
+      '  └─ 2. Expansion tracking',
+      '        ↳ From synonyms · discussion · 2026-08-02',
     ].join('\n')), out);
     assert.ok(out.includes("=== MENU: triage offer (emit verbatim as markdown, then STOP for the user's response) ==="));
     assert.ok(out.includes('Work through them now?'));
     assert.ok(/\*\*`d\/discuss`\*\* +→ Surface and discuss them one at a time/.test(out));
     assert.ok(/\*\*`l\/later`\*\* +→ Carry on with the session/.test(out));
+  });
+
+  it('triage-offer wraps a sentence-length title under itself, with the note beneath', () => {
+    writeQueue('measurement', { '001-metrics.md': 'a' });
+    const file = writePayload(dir, 'offer.json', { items: [
+      { file: '001-metrics.md', title: 'A preset binding persists until broken — three revisions to the positioning model', origin: 'note-model', from_phase: 'discussion', from_date: '2026-07-30' },
+    ] });
+    const out = renderSurface(dir, 'triage-offer', { dotpath: 'wu.discussion.measurement', file });
+    assert.ok(out.includes([
+      'Triage Queue (1 concern)',
+      '  └─ 1. A preset binding persists until broken — three revisions',
+      '        to the positioning model',
+      '        ↳ From note-model · discussion · 2026-07-30',
+    ].join('\n')), out);
+    // No agenda row may overflow the pane the display was sized to. Scoped to
+    // the fenced section: markers and markdown menu lines reflow, and are not
+    // width-bound.
+    const agenda = out.split('=== MENU')[0].split('===\n')[1];
+    for (const line of agenda.split('\n')) assert.ok(line.length <= 65, `overflowing row: ${line}`);
   });
 
   it('triage-offer refuses an empty queue, a short payload, and a payload naming a file the queue lacks', () => {


### PR DESCRIPTION
The triage offer — shown on entering a discussion whose queue is not empty — opened on a ⚑ sentence with the concerns indented beneath it and provenance trailing each title inline.

```
Triage Queue (2 concerns)
  ├─ 1. Offline metrics
  │     ↳ From ranking · discussion · 2026-08-01
  └─ 2. Expansion tracking
        ↳ From synonyms · discussion · 2026-08-02
```

Header carries the count, rows hang off it, origin takes its own `↳` line — the queue draws from any number of topics, so provenance is per row. The ⚑ goes: that register belongs to the conclusion blocker, the one that actually stops you.

Adds `numberedTreeList` for rows whose text is a sentence rather than a name, and the CONVENTIONS rule the shape rests on — a demoted note reads italic in a menu and `↳` in a fence, because emphasis inside a fence renders as literal asterisks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)