### PR TITLE
feat(presentation): the version stamps into the art, the title says where you are

### DIFF
--- a/.mint.toml
+++ b/.mint.toml
@@ -27,10 +27,14 @@ diff_exclude = [
 ]
 
 [release]
-# The workflow-start banner byline carries the shipped version; mint mirrors the
-# new version onto that line at release time.
+# The workflow-start banner stamps the shipped version inside the art block,
+# right-aligned under the WS of WORKFLOWS; mint mirrors the new version there at
+# release time. The pattern is deliberately just the token: the match is an
+# unanchored substring and the rewrite replaces only the matched span, so the
+# stamp's leading padding is none of mint's business and stays put. `v0.6.43` is
+# the only semver in the file, so the short pattern is unambiguous.
 version_file = "skills/workflow-start/SKILL.md"
-version_pattern = "Agentic Engineering Workflows`** · *v{version}*"
+version_pattern = "v{version}"
 
 # Release-notes AI needs longer than the 60s default on big releases — the
 # v0.6.0 re-platforming diff (75 squashes) timed out twice at 60s. Seconds.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -149,7 +149,7 @@ Rules:
 
 ### Workflow Banner
 
-The `workflow-start` skill opens with an ASCII art banner (see skill file for exact art) emitted as a properties code block — the fence is what colours the art: each line's first token renders turquoise and everything after the first space red, so the single space between the two words is load-bearing — followed by a markdown title line carrying the product name and version (`# **`■ Agentic Engineering Workflows`** · *vN.N.N*`). No borders; the version rides the title line, where the release tooling pattern-matches it.
+The `workflow-start` skill opens with an ASCII art banner (see skill file for exact art) emitted as a properties code block — the fence is what colours the art: each line's first token renders turquoise and everything after the first space red, so the single space between the two words is load-bearing. The shipped version stamps as a fourth line inside that block, right-aligned under the `WS` of `WORKFLOWS` (the art is 63 columns; `vN.N.NN` is exactly as wide as those two letters). The release tooling pattern-matches the bare token, so the padding is the skill's to own. No borders. The banner is branding, not chrome: the phase title beneath it (`# **`■ Workflow Start`**`) names where the user is, and never repeats what the art already says.
 
 ### Template Placeholders
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -18,18 +18,19 @@ Load **[framework.md](../workflow-shared/references/framework.md)** and follow i
 
 ## Step 0: Initialisation
 
-> *Output the next fenced block as a properties code block (```properties fence — it colours the art; the space between the two words is the token break that splits the colours, so emit every line byte-for-byte):*
+> *Output the next fenced block as a properties code block (```properties fence — it colours the art; the space between the two words is the token break that splits the colours, so emit every line byte-for-byte, the version stamp included):*
 
 ```
 █▀█░█▀▀░█▀▀░█▀█░▀█▀░▀█▀░█▀▀ █░█░█▀█░█▀▄░█░█░█▀▀░█░░░█▀█░█░█░█▀▀
 █▀█░█░█░█▀▀░█░█░░█░░░█░░█░░ █▄█░█░█░█▀▄░█▀▄░█▀▀░█░░░█░█░█▄█░▀▀█
 ▀░▀░▀▀▀░▀▀▀░▀░▀░░▀░░▀▀▀░▀▀▀ ▀░▀░▀▀▀░▀░▀░▀░▀░▀░░░▀▀▀░▀▀▀░▀░▀░▀▀▀
+                                                        v0.6.43
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-# **`■ Agentic Engineering Workflows`** · *v0.6.43*
+# **`■ Workflow Start`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*


### PR DESCRIPTION
The banner said the product's name twice — block art, then an H1 byline one line below it — with the version riding the byline as a trailing italic.

```
█▀█░█▀▀░█▀▀░█▀█░▀█▀░▀█▀░█▀▀ █░█░█▀█░█▀▄░█░█░█▀▀░█░░░█▀█░█░█░█▀▀
█▀█░█░█░█▀▀░█░█░░█░░░█░░█░░ █▄█░█░█░█▀▄░█▀▄░█▀▀░█░░░█░█░█▄█░▀▀█
▀░▀░▀▀▀░▀▀▀░▀░▀░░▀░░▀▀▀░▀▀▀ ▀░▀░▀▀▀░▀░▀░▀░▀░▀░░░▀▀▀░▀▀▀░▀░▀░▀▀▀
                                                        v0.6.43
```
# **`■ Workflow Start`**

The art is 63 columns and the `WS` of `WORKFLOWS` spans exactly seven — exactly `vN.N.NN` — so the stamp sits flush under those two letters with no fudging, taking the turquoise every art line's first token takes.

That frees the H1 to name the phase instead of repeating the art. Dropping it entirely was the alternative, but it would leave the session opening on `□ Initialisation` — a step marker announcing a phase nothing had named.

`.mint.toml` follows: `version_pattern = "v{version}"`. mint's matcher is an unanchored substring whose rewrite replaces only the matched span (`internal/record/versionfile.go`), so the 56 columns of padding never reach the config. Verified by replicating mint's own regex construction against the file — one match, and the rewrite to `v0.6.44` changes only the seven version characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)