### PR TITLE
fix(docs): the sample screens are shown, not re-rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Parenthesised phases are optional.
 
 ## What it looks like
 
-# **`■ Workflow Overview`**
-
 ```
+■ Workflow Overview
+
 Features
   └─ 1. Api Rate Limiting
 
@@ -63,16 +63,17 @@ Epics
 Inbox
   ├─ Smart Retry [idea]
   └─ Tooltip Flicker [bug]
-```
 
 · · · · · · · · · · · ·
+◆ What would you like to do?
 
-**`◆ What would you like to do?`**
+1       → Continue "Api Rate Limiting" — feature, specification (in-progress)
+2       → Continue "Payments Overhaul" — epic
+s/start → Start something new
+i/inbox → View the inbox and start from an item
+```
 
-**`1`**       → Continue "Api Rate Limiting" — *feature, specification (in-progress)*
-**`2`**       → Continue "Payments Overhaul" — *epic*
-**`s/start`** → Start something new
-**`i/inbox`** → View the inbox and start from an item
+In the terminal the chrome is coloured — the title blue and underlined, the keys and the `◆` highlighted, the metadata tails italic. One screen, not four blocks.
 
 Every display is computed by the engine from state on disk and emitted byte-for-byte. Claude cannot editorialise your status.
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -18,10 +18,13 @@ Two habits keep this conversation from sprawling. If a tangential concern surfac
 
 When the signals have converged and held steady, discovery states its read and the specific signals that drove it — concrete enough that you can challenge a particular cue — and asks:
 
-> **`◆ Have I read this right?`**
-> **`y/yes`**       → that's the right shape, set it up
-> **`o/other`**     → it's something else (tell me what)
-> **Keep shaping** → tell me what I'm missing
+```
+◆ Have I read this right?
+
+y/yes        → that's the right shape, set it up
+o/other      → it's something else (tell me what)
+Keep shaping → tell me what I'm missing
+```
 
 This gate is the single most important moment in discovery. **Until you say yes here, nothing exists on disk.** The entire shaping conversation is ephemeral — if you walk away before confirming, there is no half-created work, no stray files, nothing to clean up. The instant you confirm, everything persists at once, in a single commit: the work unit gets its own home and a name (which you confirm), your shared files are copied in as **imports**, any inbox notes that seeded the work are *moved* in as its **seeds** — its permanent record of origin — and a first session log captures the shaping conversation.
 
@@ -37,10 +40,13 @@ One rule you will feel: **topics are never named during the conversation.** Disc
 
 When the conversation converges, discovery drops a light, ambient invitation to harvest — woven into normal prose, requiring no answer, never repeated as a nagging check-in. **You** pull the harvest when you are ready ("let's pull topics," "that covers it," "good enough to start"); discovery never forces it. When you pull, it reads out the distinct surfaces the conversation named, merges the ones that share a domain or decision space, proposes a routing for each — research or discussion — and shows you the proposed topic set as a preview:
 
-> **`◆ Confirm to commit, or tell me what to adjust.`**
-> **`y/yes`**     → commit these topics and conclude
-> **`e/explore`** → go back to exploration; not ready yet
-> **Adjust**     → split, merge, rename, re-route, or reword
+```
+◆ Confirm to commit, or tell me what to adjust.
+
+y/yes     → commit these topics and conclude
+e/explore → go back to exploration; not ready yet
+Adjust    → split, merge, rename, re-route, or reword
+```
 
 There is no pressure toward completeness. Two topics is fine; twenty is fine. The map is expected to keep filling as the work progresses.
 


### PR DESCRIPTION
## Summary

- The README's "What it looks like" was authored as **live markdown**, so GitHub rendered it rather than showing it: `# **`■ Workflow Overview`**` became a giant H1 with a code-span slab, the tree detached into a separate box, and the four menu options **collapsed into a run-on paragraph** (GitHub joins consecutive lines in a `.md` document, taking the arrow column with them).
- The whole screen is now one fenced block, in the shape a session actually shows it, with a line beneath naming the colour a fence cannot carry.
- `docs/discovery.md` had the same fault in blockquote form — two gate menus whose option lines join identically. Same treatment, with the arrow columns set to the alignment the engine computes (`Keep shaping` at 12, `e/explore` at 9).

## Test plan

- No automated coverage: markdown prose only, no code path, nothing in the suite reads README or `docs/`.
- Verify by eye on the rendered PR page: one continuous block under "What it looks like", no oversized heading, and four option lines with their arrows in a column.
- Same check on `docs/discovery.md` for the two gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)