### PR TITLE
fix(triage): review fixes — read precedes arming, stale vocabulary, trim

### DIFF
--- a/skills/workflow-discussion-process/references/initialize-discussion.md
+++ b/skills/workflow-discussion-process/references/initialize-discussion.md
@@ -24,7 +24,7 @@ The seed just read, the brief or carrier the entry skill read at Gather Context,
 
    Populate from the seed, handoff context, and user input. Derive initial subtopics from whatever context is available — the seed, the user's description, the topic itself, obvious architectural concerns. These are seeds, not a complete list — the map grows during discussion.
 
-   Either way, the triage queue is never a seeding source: parked concerns enter through the session loop's triage check — surfaced whole and discussed — and pre-adding their titles to the map forces every fold into the wrong branch.
+   Either way, the triage queue is never a seeding source: parked concerns enter through the session loop's triage check — raised with their full context and discussed — and pre-adding their titles to the map forces every fold into the wrong branch.
 
 5. Seed the Discussion Map — record each initial subtopic (kebab-case name; new subtopics start `pending`):
    ```bash

--- a/skills/workflow-shared/references/rerouted-concerns.md
+++ b/skills/workflow-shared/references/rerouted-concerns.md
@@ -108,9 +108,9 @@ No opt-in. The check re-offers at a later break; the conclusion gate holds regar
 
 ## C. Raise One Concern
 
-Take the lowest-numbered concern still queued — or whichever the user asks for.
+Take the lowest-numbered concern still queued — or whichever the user asks for. Read its queue file — `.workflows/{work_unit}/{phase}/.triage/{topic}/{NNN-slug}.md` — with the Read tool. The entry is your brief, never the user's display: it reaches the conversation only through your breakdown, and the raw entry is shown only when the user asks.
 
-**If `phase` is `discussion`, arm the Discussion Map first** — the map tells the truth while the concern is live. Read the subtopic states:
+**If `phase` is `discussion`, arm the Discussion Map before presenting** — the map tells the truth while the concern is live, and routing a correction needs the body just read. Read the subtopic states:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discussion.{topic} subtopics
@@ -133,9 +133,7 @@ Route on the ground the concern reopens — the subtopic its title names (`{titl
 
 - `exploring` or `converging` — already live. Leave it.
 
-Read the concern's queue file — `.workflows/{work_unit}/{phase}/.triage/{topic}/{NNN-slug}.md` — with the Read tool. The entry is your brief, never the user's display: the origin session carried everything it worked out, and the entry reaches the conversation only through your presentation of it — the fold writes the body into the record, and the raw entry is shown only when the user asks for it.
-
-Present the concern in your own voice — name its origin in a sentence, then break it down. The reopened ground may be days old and the reader cold — the entry is the record, the breakdown is what makes it workable: what the concern actually asks of this topic, how it sits against what this topic already decided, and a concrete rendering of the problem — a worked example in the topic's own terms, a small diagram where shape or flow helps, a before/after. Every substantive point in the entry surfaces in the breakdown — the user decides from the substance, never from the title, and the breakdown is where they meet it. Keep it simple and engineer-level, sized to the concern, and vary the shape across a multi-concern queue — identical breakdowns read as a template, not a colleague. The breakdown covers this concern alone: no other queued concern, open item, or finding rides along, and the closing question spans nothing the user hasn't seen. The test: the user can picture the problem before the first question arrives. End in a single opening question.
+Present the concern in your own voice — name its origin in a sentence, then break it down. The reopened ground may be days old and the reader cold — the entry is the record, the breakdown is what makes it workable: what the concern actually asks of this topic, how it sits against what this topic already decided, and a concrete rendering of the problem — a worked example in the topic's own terms, a small diagram where shape or flow helps, a before/after. Every substantive point in the entry surfaces in the breakdown — the user decides from the substance, never from the title. Keep it simple and engineer-level, sized to the concern, and vary the shape across a multi-concern queue — identical breakdowns read as a template, not a colleague. The breakdown covers this concern alone: no other queued concern, open item, or finding rides along, and the closing question spans nothing the user hasn't seen. The test: the user can picture the problem before the first question arrives. End in a single opening question.
 
 **STOP.** Wait for user response.
 

--- a/tests/prose/cases/discussion-agreement-covers-one-concern/assert.md
+++ b/tests/prose/cases/discussion-agreement-covers-one-concern/assert.md
@@ -12,9 +12,9 @@ The prose should have taken this path:
 4. at the user's navigation cue the check offers: the two-entry
    agenda — titles and origins only, bodies unread — with the offer
    menu, stopping for the user
-5. the user opts in; the first concern is armed on the map
-   (`discussion-map add` then set `exploring`), its queue file read as
-   the session's own brief, and presented as a breakdown in the
+5. the user opts in; the first concern's queue file is read as the
+   session's own brief, the concern armed on the map (`discussion-map
+   add` then set `exploring`), and presented as a breakdown in the
    session's voice — the entry never emitted verbatim — then discussed
    to a resolution; the user answers with broad agreement that names
    "the rest" of the queue

--- a/tests/prose/cases/discussion-corrects-a-stale-reference/assert.md
+++ b/tests/prose/cases/discussion-corrects-a-stale-reference/assert.md
@@ -10,14 +10,14 @@ The prose should have taken this path:
    contextual query; the session loop's first triage check reads the
    queue and renders the one-entry agenda with the offer menu, and
    stops for the user
-4. the user opts in; the raise arms the map — the correction's title
-   names no subtopic, so the subtopic whose recorded content it
+4. the user opts in; the raise reads the concern's queue file as the
+   session's own brief, then arms the map from it — the correction's
+   title names no subtopic, so the subtopic whose recorded content it
    corrects, expansion-source, re-arms from decided to exploring; no
    discussion-map add is issued
-5. the concern's queue file is read as the session's own brief and
-   presented as a breakdown — the entry never emitted verbatim — that
-   covers it alone, and a single question closes the turn; the user
-   accepts the correction as prescribed
+5. the concern is presented as a breakdown — the entry never emitted
+   verbatim — that covers it alone, and a single question closes the
+   turn; the user accepts the correction as prescribed
 6. the fold takes the pure-correction branch: the two citing sites are
    amended in place, each amendment a dated note naming
    behavioural-ranking's retiring decision, the stale table citations

--- a/tests/prose/cases/discussion-drains-a-full-agenda/assert.md
+++ b/tests/prose/cases/discussion-drains-a-full-agenda/assert.md
@@ -14,9 +14,9 @@ The prose should have taken this path:
 4. the user asks for the queue — their explicit ask is the break: the
    check offers the two-entry agenda — both titles with their origins,
    bodies unread — with the offer menu, and stops for the user
-5. the user opts in; the first concern is armed on the map
-   (`discussion-map add` then set `exploring`), its queue file read
-   as the session's own brief, and presented as a breakdown — the
+5. the user opts in; the first concern's queue file is read as the
+   session's own brief, the concern armed on the map (`discussion-map
+   add` then set `exploring`), and presented as a breakdown — the
    entry never emitted verbatim, and never from the title alone —
    then discussed to the baseline decision
 6. the fold documents the decision: a new `##` section whose Context

--- a/tests/prose/cases/discussion-receives-a-mid-session-landing/assert.md
+++ b/tests/prose/cases/discussion-receives-a-mid-session-landing/assert.md
@@ -18,11 +18,11 @@ The prose should have taken this path:
    offers it; the user says later; the concern stays queued untouched
    and the session continues
 6. at the following break the check re-offers — later meant not now,
-   never not this session — and the user takes it; the concern is
-   new ground, so its raise arms the map (`discussion-map add` then
-   set `exploring`) before its queue file is read as the session's
-   own brief and presented as a breakdown — the entry never emitted
-   verbatim — then discussed to a decision
+   never not this session — and the user takes it; the raise reads
+   the queue file as the session's own brief, arms the map — the
+   concern is new ground (`discussion-map add` then set `exploring`)
+   — and presents a breakdown — the entry never emitted verbatim —
+   then the concern is discussed to a decision
 7. the fold writes the armed subtopic: a provenance-led Context, the
    decision documented, the map set `decided`, and the concern
    absorbed under its own commit naming file and origin


### PR DESCRIPTION
## What

Conventions/CLAUDE.md review pass over #801 + #802. Three findings, all fixed here:

1. **Read precedes arming** — `rerouted-concerns.md` C armed the Discussion Map before reading the entry, but routing a correction ("the subtopic whose recorded content it corrects") needs the body. Inherited from the render-after-arm era; the Read now opens the section. Four case asserts that implied arm-then-read flip to match (the corrects case is the one that genuinely depends on it).
2. **Stale inbound reference** — `initialize-discussion.md` still said concerns are "surfaced whole and discussed"; now "raised with their full context and discussed", matching the protocol's own vocabulary.
3. **Prose-economy trim** — the raise's brief paragraph dropped two clauses restating other sections (D. Fold's ownership of the record; a second phrasing of never-the-user's-display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)