### PR TITLE
fix(shared): a gate is its rendered block, never a tool prompt

### DIFF
--- a/skills/workflow-shared/references/instructions.md
+++ b/skills/workflow-shared/references/instructions.md
@@ -17,6 +17,8 @@ Follow these steps EXACTLY as written. Do not skip steps or combine them. Presen
 - Don't invent stops. Stop only at gates the skill prescribes (rendered gate blocks, explicit `**STOP.**` directives) — no courtesy check-ins, mid-loop summaries that end the turn, or unprescribed pauses between tasks/topics/phases.
 - Don't invent approvals. A gate's consent covers only material already surfaced at that gate — never solicit approval that spans gates not yet reached ("shall I do all N?"), and never treat an answer to such a question as consent for unseen items. A question broad enough to pre-answer a later STOP is the same violation as skipping it.
 - Work artifacts record their topic's substance — never the workflow around them. Beyond the markers a flow prescribes (provenance lines, `Sibling check:`, finding ids, revision timestamps), no process observations, documentation conventions, or lessons about how a session ran land in an artifact: the pipeline is not the topic.
+- A prescribed gate or menu is emitted as its rendered block, verbatim, as markdown — never through AskUserQuestion or any other interactive tool. The rendered options are the contract: a tool prompt drops options and free-form routes the block carries, and takes the answer mid-turn instead of ending the turn
+- Failure mode — "this is a decision with discrete options, an interactive tool fits": that substitution IS the violation. The menu is the interface — emit it and end the turn
 - After rendering a gate block, the turn MUST end. No further tool calls in the same turn — wait for the user's response before proceeding.
 - Complete each step fully before moving to the next
 


### PR DESCRIPTION
## What

Two additions to the framework-loaded rules in `skills/workflow-shared/references/instructions.md`:

- **The categorical rule**: a prescribed gate or menu is emitted as its rendered block, verbatim, as markdown — never through AskUserQuestion or any other interactive tool. The rendered options are the contract: a tool prompt drops options and free-form routes the block carries, and takes the answer mid-turn instead of ending the turn.
- **The failure-mode line** naming the trap: "this is a decision with discrete options, an interactive tool fits" — that substitution IS the violation.

## Why

A Portal session hit a threshold-forced fix gate (`fix_attempts` reached 3 under `fix_gate_mode: auto`) and rendered the gate through AskUserQuestion instead of emitting the `MENU: fix gate` section — offering 3 of the menu's 5 options. **Ask** and **Comment** vanished, and Comment is precisely the route a third consecutive fix round most warrants.

The failure was post-compaction: the same session had rendered the same threshold gate verbatim twice before, but a compact boundary replaced those worked examples with a summary stressing "under auto there is no STOP". The first threshold gate after compaction got substituted. Nothing in shipped prose forbade it — `instructions.md` required verbatim emission and a turn-end but never named the interactive-tool shortcut. A categorical rule in `instructions.md` is compaction-resistant: the context-refresh protocol re-loads it by name via `framework.md`.

## Notes

- `node tests/prose/run.cjs select --diff main` intersects all 49 cases (instructions.md loads into every flow) — no walk run; walkers don't carry AskUserQuestion, so the failure mode isn't reproducible in the harness.
- A possible follow-up (separate PR if wanted): a `render fix-gate` engine verb so stage F fetches its menu instead of back-referencing the `fix-attempt` response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)