### PR TITLE
test(prose): case touch-ups from the triage walk campaign

### DIFF
--- a/tests/prose/cases/discussion-drains-a-full-agenda/assert.md
+++ b/tests/prose/cases/discussion-drains-a-full-agenda/assert.md
@@ -50,8 +50,7 @@ Further claims:
   both files deleted by their absorbs, deletions staged by the absorb
   commits
 - git history holds two distinct absorb commits, each naming its
-  concern file and origin, and the delivery commits from the fixture
-  bracket them
+  concern file and origin
 - the manifest holds `discussion.relevance-measurement` as
   `completed`; no research item for it exists
 - neither sibling discussion document changed

--- a/tests/prose/cases/discussion-redecision-lands-timeline/case.json
+++ b/tests/prose/cases/discussion-redecision-lands-timeline/case.json
@@ -15,6 +15,7 @@
     "skills/workflow-discussion-process/SKILL.md",
     "skills/workflow-shared/references/resume-detection.md",
     "skills/workflow-shared/references/read-brief-context.md",
+    "skills/workflow-discussion-process/references/initialize-discussion.md",
     "skills/workflow-discussion-process/references/discussion-guidelines.md",
     "skills/workflow-discussion-process/references/meeting-assistant.md",
     "skills/workflow-discussion-process/references/guidelines.md",


### PR DESCRIPTION
## What

Two case-side findings from the five-walk verification of the merged triage stack (#801–#804) — all five walks passed; these are the carried notes:

- **`discussion-drains-a-full-agenda`**: the assert's further claim that "the delivery commits from the fixture bracket" the absorb commits is unevidencible — the world builder materialises a fixture as a single `world:` commit, so no per-concern delivery commits exist. The claim keeps the two-distinct-absorb-commits pin and drops the bracketing clause.
- **`discussion-redecision-lands-timeline`**: the walk read `initialize-discussion.md` (orientation, on a continue path that bypasses initialization) without it being declared. Per the design's scope ratchet — `files[]` grows from real walks — the file joins the case's declaration.

No prose, engine, or snapshot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)