### PR TITLE
fix(triage): review dispatch waits for an empty triage queue

### DIFF
--- a/skills/workflow-discussion-process/references/review-agent.md
+++ b/skills/workflow-discussion-process/references/review-agent.md
@@ -12,6 +12,7 @@ These instructions are loaded into context at the start of the discussion sessio
 - □ All prior reviews drained? (`agent scan` shows no `review` row in flight, pending, or acknowledged — or no review row exists yet; an in-flight row an earlier session dispatched is dead, not running — incorporate it and count it drained)
 - □ Not the first commit? (the discussion needs enough content to review)
 - □ At least 2-3 conversational exchanges since the last review dispatch?
+- □ Triage queue empty? (a queued rerouted concern is a pending change to this document, so a review dispatched over it is stale on arrival; self-healing like the drain block — the first meaningful commit after the queue empties re-fires the check)
 
 **Why block on undrained reviews**: two reasons, both important. First, dispatching a fresh review while the prior review's findings are still being discussed produces stale analysis — the document will look different once those findings land, and the new review would be critiquing a version the user is already fixing. Second, the block is self-healing: the next meaningful commit after the current review drains to `incorporated` will naturally re-fire the trigger check and dispatch a fresh review, so no trigger is lost. If the session ends before drainage completes, the final review in Step 6 picks up the outstanding findings via the shared surfacing protocol.
 

--- a/skills/workflow-research-process/references/review-agent.md
+++ b/skills/workflow-research-process/references/review-agent.md
@@ -12,6 +12,7 @@ These instructions are loaded into context at the start of the research session.
 - □ All prior reviews drained? (`agent scan` shows no `review` row in flight, pending, or acknowledged — or no review row exists yet; an in-flight row an earlier session dispatched is dead, not running — incorporate it and count it drained)
 - □ Not the first commit? (the research needs enough content to review)
 - □ At least 2-3 conversational exchanges since the last review dispatch?
+- □ Triage queue empty? (a queued rerouted concern is a pending change to the research, so a review dispatched over it is stale on arrival; self-healing like the drain block — the first meaningful commit after the queue empties re-fires the check)
 
 **Why block on undrained reviews**: two reasons, both important. First, dispatching a fresh review while the prior review's findings are still being explored produces stale analysis — the research will look different once those findings are incorporated, and the new review would be critiquing a version the user is already extending. Second, the block is self-healing: the next meaningful commit after the current review drains to `incorporated` will naturally re-fire the trigger check and dispatch a fresh review, so no trigger is lost. If the session ends before drainage completes, the final review at topic conclusion picks up the outstanding findings via the shared surfacing protocol.
 

--- a/skills/workflow-shared/references/rerouted-concerns.md
+++ b/skills/workflow-shared/references/rerouted-concerns.md
@@ -137,7 +137,7 @@ Present the concern in your own voice — name its origin in a sentence, then br
 
 **STOP.** Wait for user response.
 
-Then discuss it as real session material: engage, challenge, connect it to what this topic has already decided. Control belongs to the conversation — this may take one exchange or many, and the loop's other machinery (documenting, commits, dispatch checks) runs as normal around it. The concern on the table is the session's only subject and the only thing the user's agreement can cover: a tangent it surfaces is parked — on the Discussion Map as `pending`, or bookmarked in the research file — and picked up after the queue empties, and no question or proposal spans another queued concern, however the user phrases their steer.
+Then discuss it as real session material: engage, challenge, connect it to what this topic has already decided. Control belongs to the conversation — this may take one exchange or many, and the loop's other machinery (documenting, commits, dispatch checks) runs as normal around it — the dispatch check's triage-queue box holds while entries remain, so no review launches mid-walk. The concern on the table is the session's only subject and the only thing the user's agreement can cover: a tangent it surfaces is parked — on the Discussion Map as `pending`, or bookmarked in the research file — and picked up after the queue empties, and no question or proposal spans another queued concern, however the user phrases their steer.
 
 **If the discussion reaches an outcome** — a decision, a direction, or the user explicitly parking it as a deferred thread:
 

--- a/tests/prose/cases/discussion-agreement-covers-one-concern/case.json
+++ b/tests/prose/cases/discussion-agreement-covers-one-concern/case.json
@@ -64,6 +64,7 @@
       "topic reopen",
       "discovery-map add",
       "--kind perspective",
+      "--kind review",
       "knowledge.cjs index"
     ],
     "calls_in_order": [


### PR DESCRIPTION
## Problem

Mid-triage-walk, the review-agent dispatch CHECKPOINT fires after every commit with no knowledge that the queue exists. A live Fumi session hit it twice in one conversation — all four checklist boxes ticked, the prose forced a background review over a document that four more queued concerns were guaranteed to move, and the user had to kill it by hand. `rerouted-concerns.md` made it worse by affirmatively stating dispatch checks "run as normal" around a live concern.

## Fix

- Fifth trigger-checklist box in both phases' `review-agent.md`: **Triage queue empty?** A queued rerouted concern is a pending change to the document, so a review dispatched over it is stale on arrival. Self-healing like the drain block — the first meaningful commit after the queue empties re-fires the check.
- `rerouted-concerns.md` walk prose aligned: machinery runs as normal, but the triage-queue box holds while entries remain, so no review launches mid-walk.
- The existing Fumi-regression prose case (`discussion-agreement-covers-one-concern`) gains a `--kind review` `calls_exclude` invariant — its walk never has an empty queue at a commit, so a dispatch there is deterministic proof of regression.

Stack: an engine-side hard refusal of `agent dispatch --kind review` over a non-empty queue follows in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)