### PR TITLE
feat(engine): agent dispatch refuses a review over a non-empty triage queue

### DIFF
--- a/skills/workflow-engine/scripts/domain/agent-state.cjs
+++ b/skills/workflow-engine/scripts/domain/agent-state.cjs
@@ -131,6 +131,9 @@ function requireRow(state, phase, topic, id) {
  * Dispatch: allocate the next id for this kind, record the row in-flight,
  * and answer with the content-file path the sub-agent must write. No file
  * is created — the content file's later existence is the completion signal.
+ * A review dispatch refuses while the topic's triage queue holds entries —
+ * a queued rerouted concern is a pending change to the document the review
+ * would read, so the report would be stale on arrival.
  * Numbering starts after both existing rows AND any legacy files already in
  * the cache dir (pre-programme skeletons keep their names; ids never collide).
  * @param {string} cwd @param {string} workUnit @param {string} phase
@@ -159,6 +162,14 @@ function dispatchAgent(cwd, workUnit, phase, topic, { kind, labels = [], set }) 
     throw new Error('a synthesis takes no --label — its identity is synthesis-{set}');
   }
   return io.withWorkUnitLock(workflowsDir(cwd), workUnit, () => {
+    if (kind === 'review' && (phase === 'research' || phase === 'discussion')) {
+      const queueDir = path.join(cwd, '.workflows', workUnit, phase, '.triage', topic);
+      let queued = 0;
+      try { queued = fs.readdirSync(queueDir).filter((n) => n.endsWith('.md')).length; } catch { /* no queue — clear */ }
+      if (queued > 0) {
+        throw new Error(`review dispatch blocked: ${queued} rerouted concern(s) wait in the ${phase}/${topic} triage queue — absorb them (topic absorb) before dispatching a review`);
+      }
+    }
     const state = loadState(cwd, workUnit, phase, topic);
     const dir = agentDir(cwd, workUnit, phase, topic);
     const inTopic = Object.values(state.agents);

--- a/tests/scripts/test-engine-agent-state.cjs
+++ b/tests/scripts/test-engine-agent-state.cjs
@@ -98,6 +98,29 @@ describe('engine agent — lifecycle store', () => {
     assert.match(runFails(dir, ['dispatch', 'pay', 'research', 'alpha', '--kind', 'review', '--label', 'a/b']).error, /Invalid label/);
   });
 
+  it('review dispatch refuses while the triage queue holds entries, clears when it drains', () => {
+    writeContent(dir, '.workflows/pay/discussion/.triage/alpha/001-parked.md', '### Parked\n');
+    const err = runFails(dir, ['dispatch', 'pay', 'discussion', 'alpha', '--kind', 'review']).error;
+    assert.match(err, /review dispatch blocked: 1 rerouted concern/);
+    assert.match(err, /topic absorb/, 'the refusal names the recovery path');
+    assert.ok(!fs.existsSync(path.join(dir, '.workflows/.cache/pay/discussion/alpha/state.json')), 'nothing recorded');
+    fs.unlinkSync(path.join(dir, '.workflows/pay/discussion/.triage/alpha/001-parked.md'));
+    const a = runJson(dir, ['dispatch', 'pay', 'discussion', 'alpha', '--kind', 'review']);
+    assert.strictEqual(a.id, 'review-001', 'a drained queue dispatches normally');
+  });
+
+  it('the triage guard holds review dispatches only — other kinds pass a full queue', () => {
+    writeContent(dir, '.workflows/pay/research/.triage/alpha/001-parked.md', '### Parked\n');
+    const dive = runJson(dir, ['dispatch', 'pay', 'research', 'alpha', '--kind', 'deep-dive', '--label', 'auth']);
+    assert.strictEqual(dive.id, 'deep-dive-001-auth');
+    assert.match(runFails(dir, ['dispatch', 'pay', 'research', 'alpha', '--kind', 'review']).error, /review dispatch blocked/);
+    // Non-.md dirt (editor swap files, .DS_Store) never counts as a queued concern.
+    fs.unlinkSync(path.join(dir, '.workflows/pay/research/.triage/alpha/001-parked.md'));
+    writeContent(dir, '.workflows/pay/research/.triage/alpha/.DS_Store', 'dirt');
+    const a = runJson(dir, ['dispatch', 'pay', 'research', 'alpha', '--kind', 'review']);
+    assert.strictEqual(a.id, 'review-001');
+  });
+
   it('scan promotes in-flight to pending only once the content file exists with content', () => {
     const d = runJson(dir, ['dispatch', 'pay', 'research', 'alpha', '--kind', 'review']);
     let scan = runJson(dir, ['scan', 'pay', 'research', 'alpha']);

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -545,6 +545,11 @@ describe('pipeline simulation', () => {
     const queue = sim.run(['topic', 'queue', wu, 'research', 'delta']);
     assert.strictEqual(queue.count, 1);
     assert.deepStrictEqual(queue.files, [parked.concern_path], 'the read verb lists the delivered concern');
+    // The dispatch gate: a review never launches over a non-empty queue —
+    // each queued concern is a pending change to the document a review
+    // would read. Other kinds stay ungated.
+    sim.refuses(['agent', 'dispatch', wu, 'research', 'delta', '--kind', 'review'], /review dispatch blocked/);
+    sim.run(['agent', 'dispatch', wu, 'research', 'delta', '--kind', 'deep-dive', '--label', 'scope']);
     // topic absorb — the delivery's mirror: deliver a second concern, absorb
     // it, and the self-committing response answers what remains.
     sim.write('.workflows/.cache/scratch/concern-scratch.md',
@@ -577,6 +582,11 @@ describe('pipeline simulation', () => {
     assert.strictEqual(flagged.reconcile_flagged, true);
     assert.strictEqual(sim.manifest(wu).phases.discussion.items.beta.reconcile_needed, 'research');
     assert.strictEqual(sim.manifest(wu).phases.discussion.items.beta.status, 'completed');
+    // The dispatch gate clears the moment the queue drains.
+    sim.refuses(['agent', 'dispatch', wu, 'research', 'beta', '--kind', 'review'], /review dispatch blocked/);
+    sim.run(['topic', 'absorb', wu, 'research', 'beta',
+      '--file', '001-feasibility-question.md', '-m', `research(${wu}/beta): absorb 001-feasibility-question (from alpha)`]);
+    sim.run(['agent', 'dispatch', wu, 'research', 'beta', '--kind', 'review']);
     // Presence: a beat reads live and held (deferral territory for the
     // bridge, in-session territory for the epic view), the orderly clear
     // empties the scan.


### PR DESCRIPTION
## What

Mechanises the prose gate from the previous PR: `engine agent dispatch --kind review` now refuses while the topic's triage queue holds entries, naming the count and the recovery path (`topic absorb`). A queued rerouted concern is a pending change to the document the review would read — the report would be stale on arrival. The check sits inside the work-unit lock, scoped to `review` in the triage-legal phases; deep-dive, perspective, and synthesis dispatches stay ungated (user-initiated), and non-`.md` dirt in the queue dir never counts.

## Tests

- `test-engine-agent-state.cjs`: refusal with recovery path, nothing recorded on refusal, drain clears the gate, kind scoping, dirt tolerance.
- Pipeline simulation: the gate holds at a delivered concern and clears at absorb, in the epic scenario's existing triage seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)