### PR TITLE
fix(triage): one ask per queue file — the landing splits bundled concerns

### DIFF
--- a/skills/workflow-shared/references/triage-landing.md
+++ b/skills/workflow-shared/references/triage-landing.md
@@ -42,6 +42,8 @@ Each rerouted concern is one queue file. Pin this exact content shape — the fo
 
 Carry **everything** worked out about the concern — as many paragraphs as it takes. Do not summarise or trim: the target topic processes this entry from cold when it next runs, so it needs the whole context, not a one-line pointer. One paragraph or ten, write whatever conveys what was discussed. (In practice a concern caught early carries little; that's fine too.)
 
+**One ask per file.** Depth is unbounded; width is one decision. When the worked-out material makes several asks of the target — points it could accept or reject independently — each ask is its own concern: its own entry with its own title, delivered through **C** in turn under the one confirmed reroute, repeating whatever shared context each needs (every entry is read cold). A single ask with several consequences stays one file — the test is whether the target could take one part and refuse another, never paragraph count. The target surfaces queue entries one at a time; a bundled entry defeats that walk before it starts.
+
 ## A. Resolve the Target
 
 Resolution is computed against the **live** state at landing time, never cached — a target created earlier in the same session must resolve correctly:


### PR DESCRIPTION
## Problem

`triage-landing.md` pins entry depth ("carry everything, do not summarise") but not width. The Fumi session's queue held a single entry titled *"three revisions to the positioning model"* — by its own text, "three consequences, all this topic's to accept or reject". The raise protocol surfaces one entry at a time with all its substance, so the bundle arrived as one indigestible wall and the user had to dismantle it by hand.

## Fix

New rule in the Entry Shape section: **one ask per file** — when the worked-out material makes several asks the target could accept or reject independently, each lands as its own entry through **C** under the one confirmed reroute, repeating whatever shared context each needs. The test is independent accept/reject, never paragraph count; a single ask with several consequences stays one file.

All three landing callers (discussion off-topic reroute, research topic awareness, coherence findings gate) inherit it from the shared reference; coherence findings are already per-finding by construction.

Note: this is a judgment-side rule at the origin session — the deterministic perimeter can't exercise it; a walked origin-session case would be the pin if we want one. The next PR in the stack handles entries that arrive bundled anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)