### PR TITLE
feat(engine): transactions answer with pure JSON — receipts become render surfaces

### DIFF
--- a/skills/workflow-bridge/references/bugfix-continuation.md
+++ b/skills/workflow-bridge/references/bugfix-continuation.md
@@ -15,10 +15,14 @@ Bugfix pipeline: Investigation → Specification → Planning → Implementation
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -47,10 +51,14 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render early-completion-g
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline (review skipped)" --pipeline --skipped-review
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline (review skipped)"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline --skipped-review
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-bridge/references/cross-cutting-continuation.md
+++ b/skills/workflow-bridge/references/cross-cutting-continuation.md
@@ -15,10 +15,14 @@ Cross-cutting pipeline: (Research) → Discussion → Specification (terminal)
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-bridge/references/epic-continuation.md
+++ b/skills/workflow-bridge/references/epic-continuation.md
@@ -71,10 +71,14 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render epic-all-done-gate
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete epic pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete epic pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-bridge/references/feature-continuation.md
+++ b/skills/workflow-bridge/references/feature-continuation.md
@@ -15,10 +15,14 @@ Feature pipeline: (Research) → Discussion → Specification → Planning → I
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -47,10 +51,14 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render early-completion-g
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline (review skipped)" --pipeline --skipped-review
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline (review skipped)"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline --skipped-review
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-bridge/references/quickfix-continuation.md
+++ b/skills/workflow-bridge/references/quickfix-continuation.md
@@ -15,10 +15,14 @@ Quick-fix pipeline: Scoping → Implementation → Review
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 
@@ -47,10 +51,14 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render early-completion-g
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline (review skipped)" --pipeline --skipped-review
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline (review skipped)"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline --skipped-review
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-bugfix/references/bugfix-display-and-menu.md
+++ b/skills/workflow-continue-bugfix/references/bugfix-display-and-menu.md
@@ -59,10 +59,14 @@ Store the entry's `action` and `route`.
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete bugfix pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-cross-cutting/references/cross-cutting-display-and-menu.md
+++ b/skills/workflow-continue-cross-cutting/references/cross-cutting-display-and-menu.md
@@ -59,10 +59,14 @@ Store the entry's `action` and `route`.
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete cross-cutting pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -239,7 +239,11 @@ Run the cancel transaction — one command stashes the current status, marks the
 node .claude/skills/workflow-engine/scripts/engine.cjs topic cancel {work_unit} {phase} {topic}
 ```
 
-Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
+Fetch and emit the receipt — the `DISPLAY: kb warning` advisory (when carried) then the `DISPLAY: confirmation` section — adding `--warn` when the response's `warnings` is non-empty:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.{phase}.{topic} --verb cancel
+```
 
 → Return to **A. State Display and Menu**.
 
@@ -269,6 +273,10 @@ Store the selected entry's `phase` and `topic`. Run the reactivate transaction �
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reactivate {work_unit} {phase} {topic}
 ```
 
-Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
+Fetch and emit the receipt — the `DISPLAY: kb warning` advisory (when carried) then the `DISPLAY: confirmation` section — adding `--warn` when the response's `warnings` is non-empty:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.{phase}.{topic} --verb reactivate
+```
 
 → Return to **A. State Display and Menu**.

--- a/skills/workflow-continue-feature/references/feature-display-and-menu.md
+++ b/skills/workflow-continue-feature/references/feature-display-and-menu.md
@@ -59,10 +59,14 @@ Store the entry's `action` and `route`.
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete feature pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-continue-quickfix/references/quickfix-display-and-menu.md
+++ b/skills/workflow-continue-quickfix/references/quickfix-display-and-menu.md
@@ -59,10 +59,14 @@ Store the entry's `action` and `route`.
 Complete the work unit — one command sets `status: completed`, stamps `completed_at`, and commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline" --pipeline
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {work_unit} -m "workflow({work_unit}): complete quick-fix pipeline"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb complete --pipeline
+```
 
 **STOP.** Do not proceed — terminal condition.
 

--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -94,7 +94,11 @@ Close the session — one engine transaction clears the active-session marker (r
 node .claude/skills/workflow-engine/scripts/engine.cjs discovery-session close {work_unit} -m "{message}"
 ```
 
-Emit the response's `DISPLAY: kb warning` section when present, verbatim per its marker — the session is closed and committed either way.
+When the response's `warnings` is non-empty, fetch and emit the `DISPLAY: kb warning` advisory — the session is closed and committed either way:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render session-receipt {work_unit} --warn
+```
 
 → Return to caller.
 

--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -46,7 +46,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render triage-block {work
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic discussion/{topic} --kb -m "discussion({work_unit}): complete {topic} discussion"
    ```
 
-   Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
+   When the `complete` response's `warnings` is non-empty, fetch and emit the `DISPLAY: kb warning` advisory — the warning never blocks:
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.discussion.{topic} --verb complete --warn
+   ```
 
 4. Clear this session's presence and sweep for leavings:
 

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -72,7 +72,7 @@ engine manifest resolve <work-unit>.<phase>[.<topic>]    # artifact paths for KB
 
 ```bash
 engine workunit create <work-unit> <work-type> --description <text> (--session-log-file <path> | --no-session-log) [--import <path> …] [--seed <path> …]
-engine workunit complete <work-unit> -m "<message>" [--pipeline [--skipped-review]]   # --pipeline: the bridge context — the confirmation section is the "{Type} Completed" banner
+engine workunit complete <work-unit> -m "<message>"
 engine workunit cancel <work-unit>
 engine workunit reactivate <work-unit>
 engine workunit pivot <work-unit>
@@ -184,7 +184,7 @@ engine commit --inbox -m "<message>"
 engine commit --workflows -m "<message>"
 ```
 
-**Transaction confirmation sections.** The lifecycle verbs append labelled sections after their JSON line, the same pattern as the `task` gate sections: `workunit complete`/`cancel`/`reactivate` carry `DISPLAY: confirmation` (cancel/reactivate preceded by `DISPLAY: kb warning` when `warnings` is non-empty); `topic cancel`/`reactivate` likewise; `topic complete` and `discovery-session close` carry `DISPLAY: kb warning` alone when `warnings` is non-empty — no confirmation line, the calling flow owns its own conclusion display; `workunit absorb` carries the post-absorption summary, `promote` the promotion summary, and `pivot` a `DISPLAY: kb warning` (when warranted) plus `MENU: pivot continuation`. The JSON line stays the machine contract; the calling flow emits each section verbatim at its marker's named moment and never parses it for decisions.
+**Transaction receipts.** The lifecycle verbs answer with their one-line JSON only. The user-facing receipt — `DISPLAY: confirmation`, the `DISPLAY: kb warning` advisory, the absorption/promotion summaries, the `MENU: pivot continuation` — is fetched by the calling flow right after the verb via the `render` receipt surfaces (`workunit-receipt`, `topic-receipt`, `absorb-receipt`, `promote-receipt`, `pivot-continuation`, `session-receipt`). Each surface validates that the state it renders from matches the verb it receipts and refuses loudly out of place; `--warn` prepends the knowledge advisory, set by the caller when the transaction's JSON carried `warnings` (the failure detail itself stays in the JSON line). The calling flow emits each section verbatim at its marker's named moment and never parses it for decisions.
 
 **`render`** — the surface catalogue (`domain/render.cjs`): named runtime surfaces returning demarcated `=== DISPLAY: … ===` / `=== MENU: … ===` sections the calling flow emits verbatim at each marker's named moment. Address-backed values come from the manifest (JSON state only — the engine never parses markdown artifacts); judgment content arrives as a JSON payload file written to the phase cache with the Write tool and validated loudly per-field. Gate-mode branching happens inside the surface: the response carries the menu when the mode is `gated` and the auto-proceed line when it is `auto` — the calling flow branches on which section arrived, never on the mode itself. No git commit; nothing is written.
 
@@ -215,6 +215,12 @@ engine render fix-threshold <wu>.implementation.<topic>           # the ⚑ esca
 engine render blocked-tasks                                       # the blocked-tasks stop menu — static; the blocked-task list is plan-format state the session renders, this menu carries the decision
 engine render cycle-limit <wu>.implementation.<topic>             # the ⚑ over-limit callout over analysis_cycle_session; refuses within the session limit
 engine render cycle-gate                                          # the analysis cycle-limit menu — static
+engine render workunit-receipt <wu> --verb complete|cancel|reactivate|pivot [--pipeline [--skipped-review]] [--warn]  # lifecycle confirmation from manifest state (--pipeline: the bridge's "{Type} Completed" banner; pivot: advisory-only); refuses when the state doesn't match the verb
+engine render topic-receipt <wu>.<phase>.<topic> --verb complete|cancel|reactivate [--warn]  # topic lifecycle confirmation (complete: advisory-only, empty without --warn; reactivate reads the restored status)
+engine render absorb-receipt <epic> --topic <name> [--moved research,seeds,imports] [--warn]  # the post-absorption summary; --moved lists what the absorb's JSON reported moved
+engine render promote-receipt <wu>.specification.<topic> --to <cc-work-unit> [--warn]  # the promotion summary; refuses unless the spec item is promoted
+engine render pivot-continuation <wu>                             # the manage flow's post-pivot continue/back menu; refuses unless the unit is an epic
+engine render session-receipt <wu> [--warn]                       # discovery-session close advisory — empty without --warn
 ```
 
 The bridge continuation surfaces take a bare `<work_unit>` address (work-unit-level, type read from the manifest). The continue-* selection step is not a `render` surface: each navigation gateway's index dump appends `DISPLAY: selection` / `MENU: selection` sections from the shared selection projection — emitted only at the select step, per their markers.
@@ -223,4 +229,4 @@ The `finding` surface serves both review-findings loops (planning and specificat
 
 The `render` group also keeps its dev/debug primitives (`signpost`, `box`, `wrap`, `tree`) — authoring aids only, never called from skill flows.
 
-**Static chrome stays literal in skill prose; everything parameterised or state-branching renders in code** — adapter-side via projections, shared runtime surfaces via the `render` catalogue above, transaction chrome via the verbs' own appended sections. Only the `render` group's dev primitives (`signpost`, `box`, `wrap`, `tree`) are authoring aids never called from flows.
+**Static chrome stays literal in skill prose; everything parameterised or state-branching renders in code** — adapter-side via projections, shared runtime surfaces (gates, receipts, menus) via the `render` catalogue above. Transactions answer with one JSON line and render nothing. Only the `render` group's dev primitives (`signpost`, `box`, `wrap`, `tree`) are authoring aids never called from flows.

--- a/skills/workflow-engine/scripts/domain/projections/transactions.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/transactions.cjs
@@ -1,33 +1,34 @@
 'use strict';
 
 // ---------------------------------------------------------------------------
-// Domain ring: transaction confirmation sections — the DISPLAY/MENU blocks that follow a
-// lifecycle verb's JSON response (the labelled-section pattern the task verbs
-// established). The response line stays the machine contract; these sections
-// are the user-facing confirmation the calling flow emits verbatim at its
-// prescribed moment. Warnings render above confirmations, exactly as the
-// prose templates they replace.
+// Domain ring: transaction receipts — the DISPLAY/MENU blocks the `render`
+// receipt surfaces serve after a lifecycle verb runs. The verb's one-line
+// JSON is the machine contract; the receipt is fetched by the calling flow
+// at the call site and emitted verbatim. Warnings render as a state-class
+// advisory above the confirmation (the `--warn` flag, set by the caller when
+// the transaction's JSON carried `warnings`) — the failure detail itself
+// stays in the JSON line, already on screen one tool result up.
 // ---------------------------------------------------------------------------
 
 const { titlecase } = require('../conventions.cjs');
 const { section, callout, menu, cmdOption } = require('./surfaces.cjs');
 
 /**
- * The ⚑ warning block: label line, one indented line per warning, and the
- * reassurance tail. Null when there are no warnings.
- * @param {string} label @param {string[] | undefined} warnings @param {string} tail
- * @param {string} [instruction]
- * @returns {string | null}
+ * The ⚑ advisory block: label line and reassurance tail.
+ * @param {string} label @param {string} tail
+ * @returns {string}
  */
-function warningBlock(label, warnings, tail, instruction = 'emit verbatim as a code block, above the confirmation') {
-  if (!Array.isArray(warnings) || warnings.length === 0) return null;
-  const lines = [label, ...warnings.flatMap((w) => String(w).split('\n')), tail];
-  return section('DISPLAY: kb warning', instruction, callout(lines));
+function warningBlock(label, tail) {
+  return section(
+    'DISPLAY: kb warning',
+    'emit verbatim as a code block, above the confirmation',
+    callout([label, tail]),
+  );
 }
 
-/** @param {string} body @param {string} [instruction] */
-function confirmation(body, instruction = 'emit verbatim as a code block after the response') {
-  return section('DISPLAY: confirmation', instruction, body);
+/** @param {string} body */
+function confirmation(body) {
+  return section('DISPLAY: confirmation', 'emit verbatim as a code block after the response', body);
 }
 
 /** @param {(string | null)[]} parts */
@@ -45,156 +46,152 @@ const TYPE_LABELS = {
 };
 
 /**
- * workunit complete / cancel / reactivate. `complete` in pipeline context
- * (the bridge) renders the full "{Type} Completed" banner instead of the
- * one-line confirmation — one transaction, its own chrome.
- * @param {'complete'|'cancel'|'reactivate'} verb
- * @param {{work_unit: string, work_type?: string, warnings?: string[]}} result
- * @param {{pipeline?: boolean, skippedReview?: boolean}} [opts]
+ * workunit complete / cancel / reactivate / pivot receipts. `complete` in
+ * pipeline context (the bridge) renders the full "{Type} Completed" banner
+ * instead of the one-line confirmation. `pivot` is advisory-only — its
+ * user-facing continuation is the pivot-continuation menu, owned by the
+ * caller's menu step.
+ * @param {'complete'|'cancel'|'reactivate'|'pivot'} verb
+ * @param {string} workUnit @param {string|undefined} workType
+ * @param {{pipeline?: boolean, skippedReview?: boolean, warn?: boolean}} [opts]
  * @returns {string}
  */
-function workunitLifecycleSections(verb, result, { pipeline = false, skippedReview = false } = {}) {
-  const name = titlecase(result.work_unit);
+function workunitReceipt(verb, workUnit, workType, { pipeline = false, skippedReview = false, warn = false } = {}) {
+  const name = titlecase(workUnit);
   if (verb === 'complete') {
     if (!pipeline) return confirmation(`"${name}" marked as completed.`);
-    const typeLabel = TYPE_LABELS[result.work_type || ''] || titlecase(String(result.work_type || ''));
+    const typeLabel = TYPE_LABELS[workType || ''] || titlecase(String(workType || ''));
     const body = skippedReview
       ? `"${name}" completed — review skipped.`
-      : result.work_type === 'epic'
+      : workType === 'epic'
         ? `"${name}" has completed all topics through review.`
         : `"${name}" has completed all pipeline phases.`;
     return confirmation(`${typeLabel} Completed\n\n${body}`);
   }
   if (verb === 'cancel') {
     return joined([
-      warningBlock('Knowledge removal warning', result.warnings,
-        'The work unit is cancelled. The removal has been queued and will retry automatically on the next `knowledge remove` or `knowledge compact` call.'),
+      warn ? warningBlock('Knowledge removal warning',
+        'The work unit is cancelled. The removal has been queued and will retry automatically on the next `knowledge remove` or `knowledge compact` call.') : null,
       confirmation(`"${name}" marked as cancelled.`),
     ]);
   }
-  return joined([
-    warningBlock('Knowledge indexing warning', result.warnings, 'Indexing can be retried later.'),
-    confirmation(`"${name}" reactivated.`),
-  ]);
+  if (verb === 'reactivate') {
+    return joined([
+      warn ? warningBlock('Knowledge indexing warning', 'Indexing can be retried later.') : null,
+      confirmation(`"${name}" reactivated.`),
+    ]);
+  }
+  return warn
+    ? warningBlock('Knowledge indexing warning', 'The pivot is complete. Indexing can be retried later.')
+    : '';
 }
 
 /**
- * topic complete / cancel / reactivate. `complete` carries no confirmation
- * line — the calling flow owns its own conclusion display; only the
- * non-blocking indexing warning folds here.
+ * topic complete / cancel / reactivate receipts. `complete` carries no
+ * confirmation line — the calling flow owns its own conclusion display; it
+ * renders the indexing advisory alone, empty without `--warn`.
  * @param {'complete'|'cancel'|'reactivate'} verb
- * @param {{topic: string, phase: string, status?: string|null, warnings?: string[]}} result
+ * @param {string} topic @param {string} phase @param {string|undefined} status
+ * @param {{warn?: boolean}} [opts]
  * @returns {string}
  */
-function topicLifecycleSections(verb, result) {
-  const name = titlecase(result.topic);
+function topicReceipt(verb, topic, phase, status, { warn = false } = {}) {
+  const name = titlecase(topic);
   if (verb === 'complete') {
-    return joined([
-      warningBlock('Knowledge indexing warning', result.warnings,
-        'The artifact is saved. Indexing can be retried later.', 'emit verbatim as a code block'),
-    ]);
+    return warn
+      ? warningBlock('Knowledge indexing warning', 'The artifact is saved. Indexing can be retried later.')
+      : '';
   }
   if (verb === 'cancel') {
     return joined([
-      warningBlock('Knowledge removal warning', result.warnings,
-        'The topic is cancelled. You can run knowledge remove manually later.'),
-      confirmation(`Cancelled "${name}" in ${result.phase}.`),
+      warn ? warningBlock('Knowledge removal warning', 'The topic is cancelled. You can run knowledge remove manually later.') : null,
+      confirmation(`Cancelled "${name}" in ${phase}.`),
     ]);
   }
   return joined([
-    warningBlock('Knowledge indexing warning', result.warnings, 'The artifact is saved. Indexing can be retried later.'),
-    confirmation(`Reactivated "${name}" in ${result.phase}. Status restored to ${result.status}.`),
+    warn ? warningBlock('Knowledge indexing warning', 'The artifact is saved. Indexing can be retried later.') : null,
+    confirmation(`Reactivated "${name}" in ${phase}. Status restored to ${status}.`),
   ]);
 }
 
 /**
  * workunit absorb — the post-absorption summary.
- * @param {{feature: string, epic: string, topic: string, research?: unknown[], seeds?: unknown[], imports?: unknown[], warnings?: string[]}} result
+ * @param {string} epic @param {string} topic @param {string[]} moved
+ * @param {{warn?: boolean}} [opts]
  * @returns {string}
  */
-function absorbSections(result) {
+function absorbReceipt(epic, topic, moved, { warn = false } = {}) {
   // Heading and sentence at column 0; only the fact list is indented, and it
   // earns that by hanging off the sentence above it.
   const lines = [
     'Absorbed into Epic',
     '',
-    `Topic "${titlecase(result.topic)}" added to ${titlecase(result.epic)}.`,
+    `Topic "${titlecase(topic)}" added to ${titlecase(epic)}.`,
     '',
     '  • Discussion: moved',
   ];
-  if (Array.isArray(result.research) && result.research.length > 0) lines.push('  • Research: moved');
-  if (Array.isArray(result.seeds) && result.seeds.length > 0) lines.push('  • Seed: moved');
-  if (Array.isArray(result.imports) && result.imports.length > 0) lines.push('  • Imports: moved');
+  if (moved.includes('research')) lines.push('  • Research: moved');
+  if (moved.includes('seeds')) lines.push('  • Seed: moved');
+  if (moved.includes('imports')) lines.push('  • Imports: moved');
   lines.push('  • Feature: removed');
   return joined([
-    warningBlock('Knowledge sync warning', result.warnings, 'The feature is absorbed. Indexing can be retried later.'),
+    warn ? warningBlock('Knowledge sync warning', 'The feature is absorbed. Indexing can be retried later.') : null,
     confirmation(lines.join('\n')),
   ]);
 }
 
 /**
  * workunit promote — the promotion summary.
- * @param {{work_unit: string, topic: string, cc_work_unit: string, warnings?: string[]}} result
+ * @param {string} workUnit @param {string} topic @param {string} ccWorkUnit
+ * @param {{warn?: boolean}} [opts]
  * @returns {string}
  */
-function promoteSections(result) {
+function promoteReceipt(workUnit, topic, ccWorkUnit, { warn = false } = {}) {
   // Same shape as its sibling above: column-0 sentence, bulleted facts.
   const lines = [
     'Promoted to Cross-Cutting',
     '',
-    `"${titlecase(result.topic)}" has been promoted to its own cross-cutting work unit.`,
+    `"${titlecase(topic)}" has been promoted to its own cross-cutting work unit.`,
     '',
-    `  • Work unit: ${result.cc_work_unit}`,
-    `  • Source: ${result.work_unit}`,
+    `  • Work unit: ${ccWorkUnit}`,
+    `  • Source: ${workUnit}`,
     '  • Discussion files: moved',
     '  • Specification: moved',
     '  • Epic status: promoted',
   ];
   return joined([
-    warningBlock('Knowledge warning', result.warnings,
-      'The promotion is committed. The knowledge base will catch up on the next sync.'),
+    warn ? warningBlock('Knowledge warning', 'The promotion is committed. The knowledge base will catch up on the next sync.') : null,
     confirmation(lines.join('\n')),
   ]);
 }
 
 /**
- * workunit pivot — the kb warning, plus the continuation menu only when the
- * caller asked for it (`--continuation-menu`, the manage flow's menu step).
- * The off-topic reroute paths pivot mid-session with no menu step — an
- * unconditional menu would derail them.
- * @param {{work_unit: string, warnings?: string[]}} result
- * @param {{continuationMenu?: boolean}} [opts]
+ * The pivot continuation menu — the manage flow's post-pivot decision.
+ * @param {string} workUnit
  * @returns {string}
  */
-function pivotSections(result, { continuationMenu = false } = {}) {
-  const name = titlecase(result.work_unit);
-  return joined([
-    warningBlock('Knowledge indexing warning', result.warnings,
-      'The pivot is complete. Indexing can be retried later.', 'emit verbatim as a code block'),
-    continuationMenu
-      ? section(
-          'MENU: pivot continuation',
-          "emit verbatim as markdown, then STOP for the user's response",
-          menu(`**${name}** converted from feature to epic.`, [
-            cmdOption('c', 'continue', `Continue ${name} as epic`),
-            cmdOption('b', 'back', 'Return to previous view'),
-          ]),
-        )
-      : null,
-  ]);
+function pivotContinuationMenu(workUnit) {
+  const name = titlecase(workUnit);
+  return section(
+    'MENU: pivot continuation',
+    "emit verbatim as markdown, then STOP for the user's response",
+    menu(`**${name}** converted from feature to epic.`, [
+      cmdOption('c', 'continue', `Continue ${name} as epic`),
+      cmdOption('b', 'back', 'Return to previous view'),
+    ]),
+  );
 }
 
 /**
- * discovery-session close — the non-blocking indexing warning; the session
- * is closed and committed either way.
- * @param {{warnings?: string[]}} result
+ * discovery-session close — the indexing advisory; the session is closed and
+ * committed either way. Empty without `--warn`.
+ * @param {{warn?: boolean}} [opts]
  * @returns {string}
  */
-function discoverySessionCloseSections(result) {
-  return joined([
-    warningBlock('Knowledge indexing warning', result.warnings,
-      'The session is closed. Indexing can be retried later.', 'emit verbatim as a code block'),
-  ]);
+function sessionReceipt({ warn = false } = {}) {
+  return warn
+    ? warningBlock('Knowledge indexing warning', 'The session is closed. Indexing can be retried later.')
+    : '';
 }
 
-module.exports = { workunitLifecycleSections, topicLifecycleSections, absorbSections, promoteSections, pivotSections, discoverySessionCloseSections };
+module.exports = { workunitReceipt, topicReceipt, absorbReceipt, promoteReceipt, pivotContinuationMenu, sessionReceipt };

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -14,6 +14,7 @@ const { loadManifest } = require('./reads.cjs');
 const { titlecase } = require('./conventions.cjs');
 const { section, menu, cmdOption, promptOption, callout, subDetail, treeList, numberedTreeList } = require('./projections/surfaces.cjs');
 const { blockedTasksMenu, taskGateSection, fixGateSection, fixThresholdDisplay, cycleLimitDisplay, cycleGateMenu } = require('./projections/tasks.cjs');
+const { workunitReceipt, topicReceipt, absorbReceipt, promoteReceipt, pivotContinuationMenu, sessionReceipt } = require('./projections/transactions.cjs');
 const { FIX_THRESHOLD, SESSION_CYCLE_LIMIT } = require('./tasks.cjs');
 
 /**
@@ -1258,6 +1259,107 @@ function cycleGate() {
   return cycleGateMenu();
 }
 
+// ---------------------------------------------------------------------------
+// Transaction receipts — fetched by the calling flow right after its
+// lifecycle verb, so the verb's stdout stays one JSON line. Each surface
+// validates that the state it renders from matches the verb it receipts:
+// a receipt fetched out of place refuses loudly. `--warn` prepends the
+// knowledge advisory — the caller sets it when the transaction's JSON
+// carried `warnings`.
+// ---------------------------------------------------------------------------
+
+const WORKUNIT_RECEIPT_STATUS = { complete: 'completed', cancel: 'cancelled', reactivate: 'in-progress' };
+
+/** @param {string} cwd @param {{dotpath: string, verb?: string, pipeline?: string, 'skipped-review'?: string, warn?: string}} args @returns {string} */
+function workunitReceiptSurface(cwd, args) {
+  const { manifest, workUnit } = resolveWorkUnit(cwd, args.dotpath, 'workunit-receipt');
+  const verb = args.verb;
+  if (verb !== 'complete' && verb !== 'cancel' && verb !== 'reactivate' && verb !== 'pivot') {
+    throw new Error(`render workunit-receipt: --verb must be complete, cancel, reactivate, or pivot, got "${verb}"`);
+  }
+  if (verb === 'pivot') {
+    if (manifest.work_type !== 'epic') {
+      throw new Error(`render workunit-receipt: "${workUnit}" is not an epic — the pivot has not run`);
+    }
+  } else if (manifest.status !== WORKUNIT_RECEIPT_STATUS[verb]) {
+    throw new Error(`render workunit-receipt: "${workUnit}" is "${manifest.status}", not "${WORKUNIT_RECEIPT_STATUS[verb]}" — the ${verb} has not run`);
+  }
+  return workunitReceipt(verb, workUnit, manifest.work_type, {
+    pipeline: args.pipeline === '1',
+    skippedReview: args['skipped-review'] === '1',
+    warn: args.warn === '1',
+  });
+}
+
+/** @param {string} cwd @param {{dotpath: string, verb?: string, warn?: string}} args @returns {string} */
+function topicReceiptSurface(cwd, args) {
+  const { phase, topic, manifest } = resolveAddress(cwd, args.dotpath, 'topic-receipt');
+  const verb = args.verb;
+  if (verb !== 'complete' && verb !== 'cancel' && verb !== 'reactivate') {
+    throw new Error(`render topic-receipt: --verb must be complete, cancel, or reactivate, got "${verb}"`);
+  }
+  const item = itemOf(manifest, phase, topic);
+  if (!item) throw new Error(`render topic-receipt: no ${phase} item "${topic}"`);
+  if (verb === 'complete' && item.status !== 'completed') {
+    throw new Error(`render topic-receipt: "${topic}" is "${item.status}", not "completed" — the complete has not run`);
+  }
+  if (verb === 'cancel' && item.status !== 'cancelled') {
+    throw new Error(`render topic-receipt: "${topic}" is "${item.status}", not "cancelled" — the cancel has not run`);
+  }
+  if (verb === 'reactivate' && item.status === 'cancelled') {
+    throw new Error(`render topic-receipt: "${topic}" is still "cancelled" — the reactivate has not run`);
+  }
+  return topicReceipt(verb, topic, phase, item.status, { warn: args.warn === '1' });
+}
+
+/** @param {string} cwd @param {{dotpath: string, topic?: string, moved?: string, warn?: string}} args @returns {string} */
+function absorbReceiptSurface(cwd, args) {
+  const { manifest, workUnit } = resolveWorkUnit(cwd, args.dotpath, 'absorb-receipt');
+  if (manifest.work_type !== 'epic') {
+    throw new Error(`render absorb-receipt: "${workUnit}" is not an epic`);
+  }
+  const topic = args.topic;
+  if (!topic) throw new Error('render absorb-receipt: --topic is required');
+  if (!itemOf(manifest, 'discussion', topic)) {
+    throw new Error(`render absorb-receipt: no discussion item "${topic}" on "${workUnit}" — the absorb has not run`);
+  }
+  const moved = (args.moved || '').split(',').map((s) => s.trim()).filter(Boolean);
+  const unknown = moved.filter((m) => !['research', 'seeds', 'imports'].includes(m));
+  if (unknown.length > 0) {
+    throw new Error(`render absorb-receipt: --moved entries must be research, seeds, or imports, got "${unknown.join(', ')}"`);
+  }
+  return absorbReceipt(workUnit, topic, moved, { warn: args.warn === '1' });
+}
+
+/** @param {string} cwd @param {{dotpath: string, to?: string, warn?: string}} args @returns {string} */
+function promoteReceiptSurface(cwd, args) {
+  const { workUnit, phase, topic, manifest } = resolveAddress(cwd, args.dotpath, 'promote-receipt');
+  if (phase !== 'specification') {
+    throw new Error(`render promote-receipt: address must be <work_unit>.specification.<topic>, got phase "${phase}"`);
+  }
+  if (!args.to) throw new Error('render promote-receipt: --to is required');
+  const item = itemOf(manifest, 'specification', topic);
+  if (!item || item.status !== 'promoted') {
+    throw new Error(`render promote-receipt: "${topic}" is not "promoted" — the promotion has not run`);
+  }
+  return promoteReceipt(workUnit, topic, args.to, { warn: args.warn === '1' });
+}
+
+/** @param {string} cwd @param {{dotpath: string}} args @returns {string} */
+function pivotContinuation(cwd, args) {
+  const { manifest, workUnit } = resolveWorkUnit(cwd, args.dotpath, 'pivot-continuation');
+  if (manifest.work_type !== 'epic') {
+    throw new Error(`render pivot-continuation: "${workUnit}" is not an epic — the pivot has not run`);
+  }
+  return pivotContinuationMenu(workUnit);
+}
+
+/** @param {string} cwd @param {{dotpath: string, warn?: string}} args @returns {string} */
+function sessionReceiptSurface(cwd, args) {
+  resolveWorkUnit(cwd, args.dotpath, 'session-receipt');
+  return sessionReceipt({ warn: args.warn === '1' });
+}
+
 /** The catalogue: surface name → handler. @type {Record<string, (cwd: string, args: {dotpath: string} & Record<string, string|undefined>) => string>} */
 const SURFACES = {
   'resume-gate': resumeGate,
@@ -1286,6 +1388,12 @@ const SURFACES = {
   'blocked-tasks': blockedTasks,
   'cycle-limit': cycleLimit,
   'cycle-gate': cycleGate,
+  'workunit-receipt': workunitReceiptSurface,
+  'topic-receipt': topicReceiptSurface,
+  'absorb-receipt': absorbReceiptSurface,
+  'promote-receipt': promoteReceiptSurface,
+  'pivot-continuation': pivotContinuation,
+  'session-receipt': sessionReceiptSurface,
 };
 
 /**

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -25,7 +25,6 @@ const { VALID_ROUTINGS } = require('./kernel/manifest-schema.cjs');
 const { sequenceMap, addItem, addItemsBatch, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem } = require('./domain/discovery-map.cjs');
 const { startTopic, triageTopic, queueStatus, absorbConcern, completeTopic, reopenTopic, supersedeTopic, cancelTopic, reactivateTopic } = require('./domain/transitions.cjs');
 const { initTasks, startTask, fixAttempt, completeTask, analysisCycle } = require('./domain/tasks.cjs');
-const txSections = require('./domain/projections/transactions.cjs');
 const { archiveItems, restoreItems, deleteItems } = require('./domain/inbox.cjs');
 const { stampAnalysisCache } = require('./domain/cache.cjs');
 const agentState = require('./domain/agent-state.cjs');
@@ -117,10 +116,10 @@ Commands:
   manifest resolve <work-unit>.<phase>[.<topic>]
   workunit create <work-unit> <work-type> --description <text> --session-log-file <path>|--no-session-log
                   [--import <path> …] [--seed <path> …]
-  workunit complete <work-unit> -m <message> [--pipeline [--skipped-review]]
+  workunit complete <work-unit> -m <message>
   workunit cancel <work-unit>
   workunit reactivate <work-unit>
-  workunit pivot <work-unit> [--continuation-menu]
+  workunit pivot <work-unit>
   workunit absorb <feature> --into <epic> --topic <name>
   workunit promote <work-unit> <topic> --to <cc-work-unit> --description <text>
   discussion-map add <work-unit> <topic> <subtopic> [--parent <subtopic>]
@@ -197,6 +196,12 @@ Commands:
   render blocked-tasks
   render cycle-limit       <wu.implementation.topic>
   render cycle-gate
+  render workunit-receipt  <wu> --verb complete|cancel|reactivate|pivot [--pipeline [--skipped-review]] [--warn]
+  render topic-receipt     <wu.phase.topic> --verb complete|cancel|reactivate [--warn]
+  render absorb-receipt    <epic> --topic <name> [--moved research,seeds,imports] [--warn]
+  render promote-receipt   <wu.specification.topic> --to <cc-work-unit> [--warn]
+  render pivot-continuation <wu>
+  render session-receipt   <wu> [--warn]
   render signpost <label> [--style step|substep] [--width N]     (dev aid)
   render box <title> [--width N]                                 (dev aid)
   render wrap <text> [--width N] [--prefix STR]                  (dev aid)
@@ -273,52 +278,37 @@ function runWorkunit(argv) {
     } else if (command === 'complete') {
       /** @type {string|null} */ let workUnit = null;
       /** @type {string|null} */ let message = null;
-      const completeFlags = new Set();
       for (let i = 0; i < rest.length; i++) {
         const a = rest[i];
         if (a === '-m' || a === '--message') message = rest[++i];
-        else if (a === '--pipeline' || a === '--skipped-review') completeFlags.add(a.slice(2));
         else if (workUnit === null) workUnit = a;
         else throw new Error(`unexpected argument "${a}"`);
       }
       if (!workUnit || !message) {
-        throw new Error('Usage: engine workunit complete <work-unit> -m <message> [--pipeline [--skipped-review]]');
+        throw new Error('Usage: engine workunit complete <work-unit> -m <message>');
       }
-      const res = completeWorkUnit(process.cwd(), workUnit, { message });
-      respond(res);
-      respondSections(txSections.workunitLifecycleSections('complete', res, {
-        pipeline: completeFlags.has('pipeline'),
-        skippedReview: completeFlags.has('skipped-review'),
-      }));
+      respond(completeWorkUnit(process.cwd(), workUnit, { message }));
     } else if (command === 'cancel' || command === 'reactivate' || command === 'pivot') {
       const [workUnit, ...extra] = rest;
-      if (!workUnit || (extra.length > 0 && !(command === 'pivot' && extra.every((a) => a === '--continuation-menu')))) {
-        throw new Error(`Usage: engine workunit ${command} <work-unit>${command === 'pivot' ? ' [--continuation-menu]' : ''}`);
+      if (!workUnit || extra.length > 0) {
+        throw new Error(`Usage: engine workunit ${command} <work-unit>`);
       }
       const fn = command === 'cancel' ? cancelWorkUnit : command === 'reactivate' ? reactivateWorkUnit : pivotWorkUnit;
-      const res = fn(process.cwd(), workUnit);
-      respond(res);
-      respondSections(command === 'pivot'
-        ? txSections.pivotSections(res, { continuationMenu: extra.includes('--continuation-menu') })
-        : txSections.workunitLifecycleSections(command, res));
+      respond(fn(process.cwd(), workUnit));
     } else if (command === 'absorb') {
       const { opts, positional } = parseArgs(rest);
       const [feature] = positional;
       if (!feature || positional.length !== 1 || !opts.into || !opts.topic) {
         throw new Error('Usage: engine workunit absorb <feature> --into <epic> --topic <name>');
       }
-      const res = absorbWorkUnit(process.cwd(), feature, { into: opts.into, topic: opts.topic });
-      respond(res);
-      respondSections(txSections.absorbSections(res));
+      respond(absorbWorkUnit(process.cwd(), feature, { into: opts.into, topic: opts.topic }));
     } else if (command === 'promote') {
       const { opts, positional } = parseArgs(rest);
       const [workUnit, topic] = positional;
       if (!workUnit || !topic || positional.length !== 2 || !opts.to || !opts.description) {
         throw new Error('Usage: engine workunit promote <work-unit> <topic> --to <cc-work-unit> --description <text>');
       }
-      const res = promoteWorkUnit(process.cwd(), workUnit, topic, { to: opts.to, description: opts.description });
-      respond(res);
-      respondSections(txSections.promoteSections(res));
+      respond(promoteWorkUnit(process.cwd(), workUnit, topic, { to: opts.to, description: opts.description }));
     } else {
       throw new Error('Usage: engine workunit <create|complete|cancel|reactivate|pivot|absorb|promote> …');
     }
@@ -507,9 +497,7 @@ function runDiscoverySession(argv) {
       if (!workUnit || !message) {
         throw new Error('Usage: engine discovery-session close <work-unit> -m <message>');
       }
-      const res = closeDiscoverySession(process.cwd(), workUnit, { message });
-      respond(res);
-      respondSections(txSections.discoverySessionCloseSections(res));
+      respond(closeDiscoverySession(process.cwd(), workUnit, { message }));
     } else {
       throw new Error('Usage: engine discovery-session <open|close> …');
     }
@@ -639,11 +627,7 @@ function runTopic(argv) {
     if (!workUnit || !phase || !topic) {
       throw new Error(`Usage: engine topic ${command} <work-unit> <phase> <topic>`);
     }
-    const res = fn(process.cwd(), workUnit, phase, topic);
-    respond(res);
-    if (command === 'complete' || command === 'cancel' || command === 'reactivate') {
-      respondSections(txSections.topicLifecycleSections(command, res));
-    }
+    respond(fn(process.cwd(), workUnit, phase, topic));
   } catch (err) {
     failJson(err);
   }
@@ -1002,7 +986,7 @@ function runCommit(argv) {
 /** @param {string[]} argv */
 function runRender(argv) {
   const [command, ...rest] = argv;
-  const { opts, flags, positional } = parseArgs(rest, ['approve', 'skipped-review', 'own', 'paths']);
+  const { opts, flags, positional } = parseArgs(rest, ['approve', 'skipped-review', 'own', 'paths', 'warn', 'pipeline']);
   const width = opts.width !== undefined ? parseInt(opts.width, 10) : WIDTH;
 
   if (Object.hasOwn(SURFACES, command)) {
@@ -1013,6 +997,8 @@ function runRender(argv) {
       if (flags.has('skipped-review')) args['skipped-review'] = '1';
       if (flags.has('own')) args.own = '1';
       if (flags.has('paths')) args.paths = '1';
+      if (flags.has('warn')) args.warn = '1';
+      if (flags.has('pipeline')) args.pipeline = '1';
       respondSections(renderSurface(process.cwd(), command, args));
     } catch (err) {
       failJson(err);

--- a/skills/workflow-investigation-process/references/conclude-investigation.md
+++ b/skills/workflow-investigation-process/references/conclude-investigation.md
@@ -33,7 +33,11 @@ The user has already reviewed findings and agreed on fix direction. This step co
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "investigation({work_unit}): complete {topic} investigation"
    ```
 
-Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
+When the `complete` response's `warnings` is non-empty, fetch and emit the `DISPLAY: kb warning` advisory — the warning never blocks:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.investigation.{topic} --verb complete --warn
+```
 
 3. Closing recap:
 

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -31,7 +31,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render triage-block {work
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic research/{topic} --kb -m "research({work_unit}): complete {topic} research"
    ```
 
-   Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
+   When the `complete` response's `warnings` is non-empty, fetch and emit the `DISPLAY: kb warning` advisory — the warning never blocks:
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.research.{topic} --verb complete --warn
+   ```
 
 3. Clear this session's presence and sweep for leavings:
 

--- a/skills/workflow-scoping-process/references/write-specification.md
+++ b/skills/workflow-scoping-process/references/write-specification.md
@@ -50,7 +50,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic start {work_unit} s
 node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} specification {topic}
 ```
 
-The `complete` call indexes the specification into the knowledge base. Emit its response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
+The `complete` call indexes the specification into the knowledge base. When the `complete` response's `warnings` is non-empty, fetch and emit the `DISPLAY: kb warning` advisory — the warning never blocks:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.specification.{topic} --verb complete --warn
+```
 
 Commit:
 

--- a/skills/workflow-shared/references/pivot-to-epic.md
+++ b/skills/workflow-shared/references/pivot-to-epic.md
@@ -11,16 +11,19 @@ One engine transaction converts the feature: flips `work_type: epic` in the work
 The caller provides this via context before loading:
 
 - `work_unit` — the feature being converted. Its single topic shares the work unit's name.
-- `continuation_menu` (optional) — `true` when the caller's flow has a menu step for the pivot response's continuation section; omitted otherwise.
 
 ## A. Run the Pivot
 
-Pass `--continuation-menu` only when the caller's flow has a menu step for the response's `MENU: pivot continuation` section (the manage flow does; the off-topic reroute paths do not — they continue their session and must omit the flag).
-
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs workunit pivot {work_unit} [--continuation-menu]
+node .claude/skills/workflow-engine/scripts/engine.cjs workunit pivot {work_unit}
 ```
 
-Emit the response's `DISPLAY: kb warning` section when present, verbatim per its marker. (With `--continuation-menu`, the response also carries `MENU: pivot continuation` — the caller emits it at its menu step.)
+When the response's `warnings` is non-empty, fetch and emit the `DISPLAY: kb warning` advisory — the warning never blocks:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {work_unit} --verb pivot --warn
+```
+
+A caller whose flow has a post-pivot menu step (the manage flow) fetches `render pivot-continuation {work_unit}` at that step; the off-topic reroute paths continue their session and fetch nothing.
 
 → Return to caller.

--- a/skills/workflow-specification-process/references/promote-to-cross-cutting.md
+++ b/skills/workflow-specification-process/references/promote-to-cross-cutting.md
@@ -38,7 +38,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs workunit promote {work_un
 
 ## C. Display
 
-Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
+Fetch and emit the receipt — the `DISPLAY: kb warning` advisory (when carried) then the `DISPLAY: confirmation` summary — adding `--warn` when the response's `warnings` is non-empty:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render promote-receipt {work_unit}.specification.{topic} --to {cc_work_unit}
+```
 
 Invoke the bridge for the EPIC (not the cc work unit — the epic continues its pipeline):
 

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -154,7 +154,11 @@ Commit:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): conclude specification"
 ```
 
-Emit the `complete` response's `DISPLAY: kb warning` section when present, verbatim per its marker — the warning never blocks.
+When the `complete` response's `warnings` is non-empty, fetch and emit the `DISPLAY: kb warning` advisory — the warning never blocks:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.specification.{topic} --verb complete --warn
+```
 
 → Proceed to **E. Handle Source Specifications**.
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -222,7 +222,11 @@ The command succeeded.
 
 ## H. Post-Absorption
 
-Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
+Fetch and emit the receipt — the `DISPLAY: kb warning` advisory (when carried) then the `DISPLAY: confirmation` summary. `--moved` lists whichever of `research`, `seeds`, `imports` the absorb response reported non-empty (comma-separated; omit the flag when none moved), and `--warn` rides when the response's `warnings` is non-empty:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render absorb-receipt {target_epic} --topic {topic} --moved {moved}
+```
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -69,15 +69,23 @@ Run the complete transaction — one command sets `status: completed`, stamps `c
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit complete {selected.name} -m "workflow({selected.name}): mark as completed"
 ```
 
-Emit the response's `DISPLAY: confirmation` section verbatim per its marker.
+Fetch and emit the receipt's `DISPLAY: confirmation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {selected.name} --verb complete
+```
 
 → Return to caller.
 
 #### If user chose `p/pivot`
 
-Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{selected.name}`, continuation_menu = `true` (pass `--continuation-menu` on the pivot command).
+Load **[pivot-to-epic.md](../../workflow-shared/references/pivot-to-epic.md)** with work_unit = `{selected.name}`.
 
-Emit the pivot response's `MENU: pivot continuation` section verbatim per its marker.
+On return, fetch and emit the `MENU: pivot continuation` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render pivot-continuation {selected.name}
+```
 
 **STOP.** Wait for user response.
 
@@ -111,7 +119,11 @@ Run the cancel transaction — one command sets `status: cancelled`, removes the
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit cancel {selected.name}
 ```
 
-Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
+Fetch and emit the receipt — the `DISPLAY: kb warning` advisory (when carried) then the `DISPLAY: confirmation` section — adding `--warn` when the response's `warnings` is non-empty:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {selected.name} --verb cancel
+```
 
 → Return to caller.
 

--- a/skills/workflow-start/references/view-completed.md
+++ b/skills/workflow-start/references/view-completed.md
@@ -72,7 +72,11 @@ Run the reactivate transaction — one command restores `status: in-progress`, c
 node .claude/skills/workflow-engine/scripts/engine.cjs workunit reactivate {selected.name}
 ```
 
-Emit the response's `DISPLAY: kb warning` section when present, then its `DISPLAY: confirmation` section — each verbatim per its marker.
+Fetch and emit the receipt — the `DISPLAY: kb warning` advisory (when carried) then the `DISPLAY: confirmation` section — adding `--warn` when the response's `warnings` is non-empty:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render workunit-receipt {selected.name} --verb reactivate
+```
 
 → Return to caller.
 

--- a/tests/scripts/test-engine-discovery-session.cjs
+++ b/tests/scripts/test-engine-discovery-session.cjs
@@ -212,14 +212,18 @@ describe('engine discovery-session close — happy path', () => {
     assert.strictEqual(readManifest(fix, 'payments').phases.discovery.active_session, undefined);
   });
 
-  it('KB failure is a warning, never a block — the close still lands, commits, and appends the kb-warning section', () => {
+  it('KB failure is a warning, never a block — the close still lands and commits, pure JSON', () => {
     fix = setupFixture();
     const res = engine(fix, CLOSE, { STUB_KNOWLEDGE_EXIT: '1' });
     assert.strictEqual(res.warnings.length, 1, res.warnings.join('\n'));
     assert.match(res.warnings[0], /knowledge index \(discovery\/sessions\/session-002\.md\) failed/);
     assert.strictEqual(res.committed, shortHead(fix));
     assert.strictEqual(readManifest(fix, 'payments').phases.discovery.active_session, undefined);
-    assert.match(engine.lastSections, /=== DISPLAY: kb warning \(emit verbatim as a code block\) ===\n  ⚑ Knowledge indexing warning\n(    .+\n)+    The session is closed\. Indexing can be retried later\./);
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    const receipt = execFileSync('node', [fix.engine, 'render', 'session-receipt', 'payments', '--warn'], { cwd: fix.project, encoding: 'utf8' });
+    assert.match(receipt, /=== DISPLAY: kb warning \(emit verbatim as a code block, above the confirmation\) ===\n  ⚑ Knowledge indexing warning\n    The session is closed\. Indexing can be retried later\./);
+    assert.strictEqual(execFileSync('node', [fix.engine, 'render', 'session-receipt', 'payments'], { cwd: fix.project, encoding: 'utf8' }), '',
+      'no --warn, no advisory — an empty receipt');
   });
 });
 

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1288,7 +1288,7 @@ describe('catalogue dispatch', () => {
   });
 
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, proposed-task, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-gate, fix-gate, fix-threshold, blocked-tasks, cycle-limit, cycle-gate\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, proposed-task, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-gate, fix-gate, fix-threshold, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt\)/);
   });
 });
 

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -69,6 +69,11 @@ function engine(dir, args) {
 }
 engine.lastSections = '';
 
+/** Run `engine render` expecting success; returns the whole stdout (sections). */
+function render(dir, args) {
+  return execFileSync('node', [ENGINE, 'render', ...args], { cwd: dir, encoding: 'utf8' });
+}
+
 /** Run the engine expecting failure; returns the parsed stderr JSON. */
 function engineFails(dir, args) {
   const res = spawnSync('node', [ENGINE, ...args], { cwd: dir, encoding: 'utf8' });
@@ -131,7 +136,9 @@ describe('engine topic cancel', () => {
       previous_order: 2,
     });
     assert.strictEqual(lastMessage(dir), 'workflow(payments): cancel auth-flow (research)');
-    assert.match(engine.lastSections, /Cancelled "Auth Flow" in research\./);
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    assert.match(render(dir, ['topic-receipt', 'payments.research.auth-flow', '--verb', 'cancel', '--warn']),
+      /⚑ Knowledge removal warning[\s\S]*Cancelled "Auth Flow" in research\./);
   });
 
   it('rejects cancelling an already-cancelled topic', () => {
@@ -180,7 +187,9 @@ describe('engine topic reactivate', () => {
     assert.strictEqual(res.warnings.length, 1);
     assert.match(res.warnings[0], /knowledge index failed/);
     assert.strictEqual(lastMessage(dir), 'workflow(payments): reactivate session-model (discussion)');
-    assert.match(engine.lastSections, /⚑ Knowledge indexing warning[\s\S]*Reactivated "Session Model" in discussion\. Status restored to completed\./);
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    assert.match(render(dir, ['topic-receipt', 'payments.discussion.session-model', '--verb', 'reactivate', '--warn']),
+      /⚑ Knowledge indexing warning[\s\S]*Reactivated "Session Model" in discussion\. Status restored to completed\./);
   });
 
   it('rejects reactivating a non-cancelled topic', () => {
@@ -580,8 +589,8 @@ describe('triaged guards across the other verbs', () => {
 });
 
 describe('pipeline completion banner matrix', () => {
-  const { workunitLifecycleSections } = require('../../skills/workflow-engine/scripts/domain/projections/transactions.cjs');
-  const banner = (wt, opts) => workunitLifecycleSections('complete', { work_unit: 'pay-x', work_type: wt }, { pipeline: true, ...opts });
+  const { workunitReceipt } = require('../../skills/workflow-engine/scripts/domain/projections/transactions.cjs');
+  const banner = (wt, opts) => workunitReceipt('complete', 'pay-x', wt, { pipeline: true, ...opts });
 
   it('every work-type label and both body variants render', () => {
     assert.ok(banner('feature').includes('Feature Completed\n\n"Pay X" has completed all pipeline phases.'));
@@ -598,7 +607,7 @@ describe('topic verbs without section folds', () => {
   beforeEach(() => { dir = setupEpicFixture(); });
   afterEach(() => { cleanupFixture(dir); });
 
-  it('start, reopen, and supersede append nothing — only complete/cancel/reactivate fold sections', () => {
+  it('every topic verb appends nothing — receipts are render surfaces', () => {
     engine(dir, ['topic', 'start', 'payments', 'research', 'brand-new']);
     assert.strictEqual(engine.lastSections, '', 'start appends no sections');
     engine(dir, ['topic', 'reopen', 'payments', 'research', 'fee-model']);
@@ -623,8 +632,12 @@ describe('engine topic complete', () => {
     // No KB configured in the fixture — warn-don't-block.
     assert.strictEqual(res.warnings.length, 1);
     assert.match(res.warnings[0], /knowledge index failed/);
-    assert.match(engine.lastSections, /=== DISPLAY: kb warning \(emit verbatim as a code block\) ===\n  ⚑ Knowledge indexing warning\n(    .+\n)+    The artifact is saved\. Indexing can be retried later\./);
-    assert.ok(!engine.lastSections.includes('confirmation'), 'complete folds the warning only — the flow owns its conclusion display');
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    const advisory = render(dir, ['topic-receipt', 'payments.research.auth-flow', '--verb', 'complete', '--warn']);
+    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block, above the confirmation\) ===\n  ⚑ Knowledge indexing warning\n    The artifact is saved\. Indexing can be retried later\./);
+    assert.ok(!advisory.includes('confirmation ==='), 'complete renders the advisory only — the flow owns its conclusion display');
+    assert.strictEqual(render(dir, ['topic-receipt', 'payments.research.auth-flow', '--verb', 'complete']), '',
+      'no --warn, no advisory — an empty receipt');
 
     const m = readManifest(dir, 'payments');
     assert.deepStrictEqual(m.phases.research.items, {
@@ -1077,9 +1090,10 @@ describe('engine workunit complete', () => {
     assert.strictEqual(lastMessage(dir), 'workflow(auth-flow): complete feature pipeline');
     // Scoped: the unrelated file stays uncommitted.
     assert.match(git(dir, ['status', '--porcelain']), /\?\? unrelated\.txt/);
-    // Confirmation section rides after the JSON line; work_type now in the response.
     assert.strictEqual(res.work_type, 'feature');
-    assert.match(engine.lastSections, /=== DISPLAY: confirmation \(emit verbatim as a code block after the response\) ===\n"Auth Flow" marked as completed\./);
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    assert.match(render(dir, ['workunit-receipt', 'auth-flow', '--verb', 'complete']),
+      /=== DISPLAY: confirmation \(emit verbatim as a code block after the response\) ===\n"Auth Flow" marked as completed\./);
   });
 
   it('purges the work unit\'s scratch cache on complete — untracked scratch leaves no dirt', () => {
@@ -1100,19 +1114,21 @@ describe('engine workunit complete', () => {
   });
 
   it('--pipeline renders the "{Type} Completed" banner instead of the one-liner; --skipped-review varies the body', () => {
-    engine(dir, ['workunit', 'complete', 'auth-flow', '-m', 'workflow(auth-flow): complete feature pipeline', '--pipeline']);
-    assert.match(engine.lastSections, /Feature Completed\n\n"Auth Flow" has completed all pipeline phases\./);
-    assert.ok(!engine.lastSections.includes('marked as completed'));
-
-    engine(dir, ['workunit', 'reactivate', 'auth-flow']);
-    engine(dir, ['workunit', 'complete', 'auth-flow', '-m', 'workflow(auth-flow): re-complete (review skipped)', '--pipeline', '--skipped-review']);
-    assert.match(engine.lastSections, /Feature Completed\n\n"Auth Flow" completed — review skipped\./);
+    engine(dir, ['workunit', 'complete', 'auth-flow', '-m', 'workflow(auth-flow): complete feature pipeline']);
+    const banner = render(dir, ['workunit-receipt', 'auth-flow', '--verb', 'complete', '--pipeline']);
+    assert.match(banner, /Feature Completed\n\n"Auth Flow" has completed all pipeline phases\./);
+    assert.ok(!banner.includes('marked as completed'));
+    assert.match(render(dir, ['workunit-receipt', 'auth-flow', '--verb', 'complete', '--pipeline', '--skipped-review']),
+      /Feature Completed\n\n"Auth Flow" completed — review skipped\./);
   });
 
-  it('reactivate carries its confirmation section', () => {
+  it('reactivate renders its confirmation via the receipt surface', () => {
     engine(dir, ['workunit', 'cancel', 'auth-flow']);
     engine(dir, ['workunit', 'reactivate', 'auth-flow']);
-    assert.match(engine.lastSections, /"Auth Flow" reactivated\./);
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    assert.match(render(dir, ['workunit-receipt', 'auth-flow', '--verb', 'reactivate']), /"Auth Flow" reactivated\./);
+    assert.match(engineFails(dir, ['render', 'workunit-receipt', 'auth-flow', '--verb', 'cancel']).error,
+      /not "cancelled" — the cancel has not run/);
   });
 
   it('rejects an already-completed unit and routes a cancelled unit through reactivate', () => {
@@ -1187,10 +1203,12 @@ describe('engine workunit cancel', () => {
     assert.strictEqual(m.status, 'cancelled');
     assert.strictEqual(m.completed_at, undefined);
     assert.strictEqual(lastMessage(dir), 'workflow(auth-flow): mark as cancelled');
-    // Sections: warning above confirmation, both after the JSON line.
-    // Conventions-form callout: 2-space flag, 4-space continuations.
-    assert.match(engine.lastSections, /  ⚑ Knowledge removal warning\n(    .+\n)+    The work unit is cancelled\./);
-    assert.match(engine.lastSections, /"Auth Flow" marked as cancelled\./);
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    // Receipt: warning above confirmation, fetched from the cancelled state.
+    // Conventions-form callout: 2-space flag, 4-space continuation.
+    const receipt = render(dir, ['workunit-receipt', 'auth-flow', '--verb', 'cancel', '--warn']);
+    assert.match(receipt, /  ⚑ Knowledge removal warning\n    The work unit is cancelled\./);
+    assert.match(receipt, /"Auth Flow" marked as cancelled\./);
   });
 
   it('rejects an already-cancelled unit and routes a completed unit through reactivate', () => {

--- a/tests/scripts/test-engine-workunit-absorb.cjs
+++ b/tests/scripts/test-engine-workunit-absorb.cjs
@@ -201,7 +201,11 @@ describe('engine workunit absorb — happy path', () => {
       committed: shortHead(fix),
       warnings: [],
     });
-    assert.match(engine.lastSections, new RegExp([
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    const receipt = execFileSync('node',
+      [fix.engine, 'render', 'absorb-receipt', 'payments', '--topic', 'auth', '--moved', 'research,seeds,imports'],
+      { cwd: fix.project, encoding: 'utf8' });
+    assert.match(receipt, new RegExp([
       'Absorbed into Epic',
       '',
       'Topic "Auth" added to Payments\\.',

--- a/tests/scripts/test-engine-workunit-promote.cjs
+++ b/tests/scripts/test-engine-workunit-promote.cjs
@@ -200,7 +200,11 @@ describe('engine workunit promote — happy path', () => {
       committed: shortHead(fix),
       warnings: [],
     });
-    assert.match(engine.lastSections, new RegExp([
+    assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
+    const receipt = execFileSync('node',
+      [fix.engine, 'render', 'promote-receipt', 'payments.specification.caching-strategy', '--to', 'caching'],
+      { cwd: fix.project, encoding: 'utf8' });
+    assert.match(receipt, new RegExp([
       'Promoted to Cross-Cutting',
       '',
       '"[^"]+" has been promoted to its own cross-cutting work unit\\.',

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -204,10 +204,10 @@ class Sim {
   }
 
   // Transactions answer with pure JSON — display artifacts belong to render
-  // surfaces fetched at their display point. These verb groups still append
-  // sections; the set shrinks as each converts, and empties when the
-  // separation is complete.
-  static SECTION_CARRYING = new Set(['workunit', 'topic', 'discovery-session', 'presence']);
+  // surfaces fetched at their display point. The one section-bearing group
+  // left is presence: its scan is a read-only snapshot whose deferral
+  // advisory rides the dump, the view-family pattern.
+  static SECTION_CARRYING = new Set(['presence']);
 
   /** Engine mutation: expect ok:true JSON, then audit the whole state. */
   run(args) {
@@ -376,9 +376,11 @@ describe('pipeline simulation', () => {
 
     sim.render(['early-completion-gate', wu], { expect: 'content' });
     sim.render(['revisit-gate', wu, '--prev', 'implementation', '--next', 'review'], { expect: 'content' });
-    const done = sim.run(['workunit', 'complete', wu, '-m', `workflow(${wu}): pipeline complete`, '--pipeline']);
+    const done = sim.run(['workunit', 'complete', wu, '-m', `workflow(${wu}): pipeline complete`]);
     assert.strictEqual(done.status, 'completed');
     assert.strictEqual(sim.manifest(wu).status, 'completed');
+    assert.match(sim.render(['workunit-receipt', wu, '--verb', 'complete', '--pipeline'], { expect: 'content' }),
+      /Feature Completed/, 'pipeline completion renders the banner receipt');
   });
 
   it('feature: review skipped at the early-completion gate', () => {
@@ -388,8 +390,10 @@ describe('pipeline simulation', () => {
     sim.run(['topic', 'complete', wu, 'discussion', wu]);
     walkDeliveryPhasesToImplementation(sim, wu, wu);
     sim.render(['early-completion-gate', wu], { expect: 'content' });
-    sim.run(['workunit', 'complete', wu, '-m', `workflow(${wu}): complete feature pipeline (review skipped)`, '--pipeline', '--skipped-review']);
+    sim.run(['workunit', 'complete', wu, '-m', `workflow(${wu}): complete feature pipeline (review skipped)`]);
     assert.strictEqual(sim.manifest(wu).status, 'completed');
+    assert.match(sim.render(['workunit-receipt', wu, '--verb', 'complete', '--pipeline', '--skipped-review'], { expect: 'content' }),
+      /review skipped/, 'skipped-review completion renders its banner');
   });
 
   it('bugfix: investigation → spec (source pinned to topic) → delivery → complete', () => {
@@ -414,7 +418,7 @@ describe('pipeline simulation', () => {
     // The bugfix spec source name is pinned to the topic.
     walkDeliveryPhases(sim, wu, wu, { sources: [wu] });
 
-    sim.run(['workunit', 'complete', wu, '-m', `workflow(${wu}): pipeline complete`, '--pipeline']);
+    sim.run(['workunit', 'complete', wu, '-m', `workflow(${wu}): pipeline complete`]);
     assert.strictEqual(sim.manifest(wu).status, 'completed');
   });
 
@@ -455,7 +459,7 @@ describe('pipeline simulation', () => {
     sim.run(['topic', 'start', wu, 'review', wu]);
     sim.run(['topic', 'complete', wu, 'review', wu]);
 
-    sim.run(['workunit', 'complete', wu, '-m', `workflow(${wu}): pipeline complete`, '--pipeline']);
+    sim.run(['workunit', 'complete', wu, '-m', `workflow(${wu}): pipeline complete`]);
   });
 
   it('quick-fix promotion: work_type flips to feature and the pipeline continues', () => {
@@ -529,10 +533,14 @@ describe('pipeline simulation', () => {
     sim.run(['topic', 'complete', wu, 'discussion', 'beta']);
     sim.run(['topic', 'start', wu, 'research', 'gamma-prime']);
     sim.run(['topic', 'cancel', wu, 'research', 'gamma-prime']);
+    assert.match(sim.render(['topic-receipt', `${wu}.research.gamma-prime`, '--verb', 'cancel'], { expect: 'content' }),
+      /Cancelled "Gamma Prime" in research/, 'topic cancel receipt renders from the cancelled item');
     const cancelled = sim.manifest(wu).phases.discovery.items['gamma-prime'];
     assert.ok(!('order' in cancelled), 'cancel stashes the map order');
     assert.strictEqual(cancelled.previous_order, 3);
     sim.run(['topic', 'reactivate', wu, 'research', 'gamma-prime']);
+    assert.match(sim.render(['topic-receipt', `${wu}.research.gamma-prime`, '--verb', 'reactivate'], { expect: 'content' }),
+      /Reactivated "Gamma Prime" in research/, 'topic reactivate receipt renders from the restored item');
     assert.strictEqual(sim.manifest(wu).phases.discovery.items['gamma-prime'].order, 3,
       'reactivate restores the map order');
     sim.run(['topic', 'cancel', wu, 'research', 'gamma-prime']);
@@ -903,8 +911,12 @@ describe('pipeline simulation', () => {
     assert.strictEqual(sim.manifest(wu).completed_at, undefined, 'reactivate clears the stamp');
     sim.run(['workunit', 'cancel', wu]);
     assert.strictEqual(sim.manifest(wu).status, 'cancelled');
+    assert.match(sim.render(['workunit-receipt', wu, '--verb', 'cancel', '--warn'], { expect: 'content' }),
+      /marked as cancelled/, 'cancel receipt renders from the cancelled state');
     sim.run(['workunit', 'reactivate', wu]);
     assert.strictEqual(sim.manifest(wu).status, 'in-progress');
+    assert.match(sim.render(['workunit-receipt', wu, '--verb', 'reactivate'], { expect: 'content' }),
+      /reactivated/, 'reactivate receipt renders from the restored state');
   });
 
   it('pivot: a feature with a discussion becomes an epic and its topic keeps working', () => {
@@ -917,6 +929,8 @@ describe('pipeline simulation', () => {
 
     sim.run(['workunit', 'pivot', wu]);
     assert.strictEqual(sim.manifest(wu).work_type, 'epic');
+    assert.match(sim.render(['pivot-continuation', wu], { expect: 'content' }),
+      /MENU: pivot continuation/, 'the manage flow can fetch the continuation menu post-pivot');
 
     // The pivoted epic's map and phases still derive; the topic completes.
     sim.run(['topic', 'complete', wu, 'discussion', wu]);
@@ -938,6 +952,8 @@ describe('pipeline simulation', () => {
     assert.strictEqual(m.phases.discussion.items['stray-topic'].status, 'in-progress');
     assert.ok(fs.existsSync(path.join(sim.dir, '.workflows', epic, 'discussion', 'stray-topic.md')),
       'discussion file moved into the epic');
+    assert.match(sim.render(['absorb-receipt', epic, '--topic', 'stray-topic'], { expect: 'content' }),
+      /Absorbed into Epic/, 'absorb receipt renders from the epic post-state');
   });
 
   it('spec promotion: a cross-cutting concern leaves the epic and the spec item goes terminal', () => {
@@ -958,6 +974,8 @@ describe('pipeline simulation', () => {
     sim.run(['workunit', 'promote', wu, 'logging', '--to', 'logging-cc', '--description', 'Logging, project-wide']);
     assert.strictEqual(sim.manifest('logging-cc').work_type, 'cross-cutting');
     assert.strictEqual(sim.manifest(wu).phases.specification.items.logging.status, 'promoted');
+    assert.match(sim.render(['promote-receipt', `${wu}.specification.logging`, '--to', 'logging-cc'], { expect: 'content' }),
+      /Promoted to Cross-Cutting/, 'promote receipt renders from the promoted item');
 
     // Promotion is terminal on the source item.
     sim.refuses(['topic', 'start', wu, 'specification', 'logging'], /promoted/);


### PR DESCRIPTION
## What

Every lifecycle verb — `workunit complete/cancel/reactivate/pivot/absorb/promote`, `topic complete/cancel/reactivate`, `discovery-session close` — now prints exactly one JSON line. The user-facing receipt (confirmation, kb-warning advisory, absorption/promotion summaries, the pivot continuation menu) is fetched by the calling flow right after the verb via six new render surfaces: `workunit-receipt`, `topic-receipt`, `absorb-receipt`, `promote-receipt`, `pivot-continuation`, `session-receipt`.

- Each surface validates that the state it renders from matches the verb it receipts — a receipt fetched out of place refuses loudly.
- `--warn` prepends the knowledge advisory; the caller sets it when the transaction's JSON carried `warnings`. The failure detail stays in the JSON line, visible one tool result up — the advisory is the state-class message (label + reassurance), not an echo of error strings.
- `--pipeline` / `--skipped-review` / `--continuation-menu` move from the transactions to the receipt surfaces.
- ~17 prose call sites across the bridge continuations, continue-* menus, manage/view/absorb/promote flows, phase conclusions, and pivot-to-epic switch from "emit the response's section" to fetch-and-emit.

## Invariant

The simulation's pure-JSON allowlist shrinks to `presence` alone (its `scan` is a read-only snapshot — view family, not a transaction). Every other verb is machine-checked to answer with one JSON line across all 14 scenarios, plus receipt renders asserted at each lifecycle scenario.

`npm test` 1986/1986 · `npm run typecheck` clean

Stack: PR 2 of 4, based on #807.

🤖 Generated with [Claude Code](https://claude.com/claude-code)