### PR TITLE
feat(engine): snapshot-carried gates fetch at their own step

### DIFF
--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -221,6 +221,8 @@ engine render absorb-receipt <epic> --topic <name> [--moved research,seeds,impor
 engine render promote-receipt <wu>.specification.<topic> --to <cc-work-unit> [--warn]  # the promotion summary; refuses unless the spec item is promoted
 engine render pivot-continuation <wu>                             # the manage flow's post-pivot continue/back menu; refuses unless the unit is an epic
 engine render session-receipt <wu> [--warn]                       # discovery-session close advisory — empty without --warn
+engine render absorb-target <feature>                             # the absorb flow's target-epic selection menu; refuses when the absorb guard doesn't hold
+engine render plan-topics <wu>                                    # the view-plan topic selection menu; refuses without a multi-topic epic plan
 ```
 
 The bridge continuation surfaces take a bare `<work_unit>` address (work-unit-level, type read from the manifest). The continue-* selection step is not a `render` surface: each navigation gateway's index dump appends `DISPLAY: selection` / `MENU: selection` sections from the shared selection projection — emitted only at the select step, per their markers.

--- a/skills/workflow-engine/scripts/domain/projections/start.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/start.cjs
@@ -387,30 +387,53 @@ function workingSetView(ws, summaries = {}) {
       '⚑ Work is unavailable while the set mixes types — drop to a single type to enable it.',
     ));
   }
-  if (ws.addable.length > 0) {
-    sections.push(labelled(
-      'DISPLAY: add candidates',
-      'emit verbatim as a code block only at the add-items gate — never at the call',
-      ws.addable.map((item) => `  ${item.n}. ${item.title} [${item.type}] — ${item.date}`).join('\n'),
-    ));
-    sections.push(labelled(
-      'MENU: add gate',
-      'emit verbatim as markdown only at the add-items gate',
-      dotMenu(['Add which? (enter number(s), comma-separated, or **`b/back`**)']),
-    ));
-  }
-  sections.push(labelled(
-    'DISPLAY: drop candidates',
-    'emit verbatim as a code block only at the drop-items gate — never at the call',
-    ws.items.map((item) => `  ${item.n}. ${item.title} [${item.type}]`).join('\n'),
-  ));
-  sections.push(labelled(
-    'MENU: drop gate',
-    'emit verbatim as markdown only at the drop-items gate',
-    dotMenu(['Drop which? (enter number(s), comma-separated, or **`b/back`**)']),
-  ));
 
   return { data, title, display, menu, sections: sections.join('\n') };
+}
+
+/**
+ * The add-items gate over the working set's addable rows, served by the
+ * gateway's `working-set-add-gate` verb at the gate that displays it.
+ * @param {WorkingSetDetail} ws
+ * @returns {string}
+ */
+function workingSetAddGate(ws) {
+  if (ws.addable.length === 0) {
+    throw new Error('working-set-add-gate: nothing addable — the whole inbox is already in the set');
+  }
+  return [
+    labelled(
+      'DISPLAY: add candidates',
+      'emit verbatim as a code block',
+      ws.addable.map((item) => `  ${item.n}. ${item.title} [${item.type}] — ${item.date}`).join('\n'),
+    ),
+    labelled(
+      'MENU: add gate',
+      "emit verbatim as markdown, then STOP for the user's response",
+      dotMenu(['Add which? (enter number(s), comma-separated, or **`b/back`**)']),
+    ),
+  ].join('\n');
+}
+
+/**
+ * The drop-items gate over the working set, served by the gateway's
+ * `working-set-drop-gate` verb at the gate that displays it.
+ * @param {WorkingSetDetail} ws
+ * @returns {string}
+ */
+function workingSetDropGate(ws) {
+  return [
+    labelled(
+      'DISPLAY: drop candidates',
+      'emit verbatim as a code block',
+      ws.items.map((item) => `  ${item.n}. ${item.title} [${item.type}]`).join('\n'),
+    ),
+    labelled(
+      'MENU: drop gate',
+      "emit verbatim as markdown, then STOP for the user's response",
+      dotMenu(['Drop which? (enter number(s), comma-separated, or **`b/back`**)']),
+    ),
+  ].join('\n');
 }
 
 // ---------------------------------------------------------------------------
@@ -463,10 +486,10 @@ function manageListView(detail) {
 
 /**
  * One work unit's manage snapshot: the action menu offering exactly the
- * actions its state allows, plus the deferred absorb-target and view-plan
- * topic gates when those actions are live.
+ * actions its state allows. The absorb-target and view-plan topic gates are
+ * served by their own render surfaces, fetched at each gate.
  * @param {ManageDetail} md
- * @returns {{data: string, menu: string, sections: string}}
+ * @returns {{data: string, menu: string}}
  */
 function manageUnitView(md) {
   /** @type {[string, string][]} */
@@ -516,33 +539,45 @@ function manageUnitView(md) {
     ...options,
   ]);
 
-  const sections = [];
-  if (md.absorb_available) {
-    sections.push(labelled(
-      'MENU: absorb target',
-      'emit verbatim as markdown only at the absorb target gate — never at the call',
-      dotMenu([
-        'Select a target epic:',
-        '',
-        ...md.available_epics.map((name, i) => cmdOption(String(i + 1), null, titlecase(name))),
-        '',
-        cmdOption('b', 'back', 'Return'),
-      ]),
-    ));
-  }
-  if (md.work_type === 'epic' && md.has_plan && md.planning_topics.length > 1) {
-    sections.push(labelled(
-      'MENU: plan topics',
-      'emit verbatim as markdown only at the view-plan topic gate — never at the call',
-      dotMenu([
-        'Which plan would you like to view?',
-        '',
-        ...md.planning_topics.map((t, i) => cmdOption(String(i + 1), null, `${titlecase(t.name)} — *${t.status}*`)),
-      ]),
-    ));
-  }
+  return { data, menu };
+}
 
-  return { data, menu, sections: sections.join('\n') };
+/**
+ * The absorb-target selection menu, served by `render absorb-target` at the
+ * gate that displays it. Numbering follows `available_epics` order.
+ * @param {ManageDetail} md
+ * @returns {string}
+ */
+function absorbTargetMenu(md) {
+  return labelled(
+    'MENU: absorb target',
+    "emit verbatim as markdown, then STOP for the user's response",
+    dotMenu([
+      'Select a target epic:',
+      '',
+      ...md.available_epics.map((name, i) => cmdOption(String(i + 1), null, titlecase(name))),
+      '',
+      cmdOption('b', 'back', 'Return'),
+    ]),
+  );
+}
+
+/**
+ * The view-plan topic selection menu, served by `render plan-topics` at the
+ * gate that displays it. Numbering follows `planning_topics` order.
+ * @param {ManageDetail} md
+ * @returns {string}
+ */
+function planTopicsMenu(md) {
+  return labelled(
+    'MENU: plan topics',
+    "emit verbatim as markdown, then STOP for the user's response",
+    dotMenu([
+      'Which plan would you like to view?',
+      '',
+      ...md.planning_topics.map((t, i) => cmdOption(String(i + 1), null, `${titlecase(t.name)} — *${t.status}*`)),
+    ]),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -647,7 +682,11 @@ module.exports = {
   inboxPickupView,
   archivedView,
   workingSetView,
+  workingSetAddGate,
+  workingSetDropGate,
   manageListView,
   manageUnitView,
+  absorbTargetMenu,
+  planTopicsMenu,
   completedView,
 };

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -15,6 +15,8 @@ const { titlecase } = require('./conventions.cjs');
 const { section, menu, cmdOption, promptOption, callout, subDetail, treeList, numberedTreeList } = require('./projections/surfaces.cjs');
 const { blockedTasksMenu, taskGateSection, fixGateSection, fixThresholdDisplay, cycleLimitDisplay, cycleGateMenu } = require('./projections/tasks.cjs');
 const { workunitReceipt, topicReceipt, absorbReceipt, promoteReceipt, pivotContinuationMenu, sessionReceipt } = require('./projections/transactions.cjs');
+const { absorbTargetMenu, planTopicsMenu } = require('./projections/start.cjs');
+const { manageDetail } = require('./workunit-manage.cjs');
 const { FIX_THRESHOLD, SESSION_CYCLE_LIMIT } = require('./tasks.cjs');
 
 /**
@@ -1360,6 +1362,33 @@ function sessionReceiptSurface(cwd, args) {
   return sessionReceipt({ warn: args.warn === '1' });
 }
 
+// ---------------------------------------------------------------------------
+// Manage-flow gates — scoped selections the manage sub-flows fetch at their
+// own gate, computed fresh from the same detail the manage snapshot reads.
+// ---------------------------------------------------------------------------
+
+/** @param {string} cwd @param {{dotpath: string}} args @returns {string} */
+function absorbTarget(cwd, args) {
+  const { workUnit } = resolveWorkUnit(cwd, args.dotpath, 'absorb-target');
+  const md = manageDetail(cwd, workUnit);
+  if (!md) throw new Error(`render absorb-target: work unit "${workUnit}" not found`);
+  if (!md.absorb_available) {
+    throw new Error(`render absorb-target: "${workUnit}" is not absorbable — the guard (discussion, no spec-or-beyond, an in-progress epic) does not hold`);
+  }
+  return absorbTargetMenu(md);
+}
+
+/** @param {string} cwd @param {{dotpath: string}} args @returns {string} */
+function planTopics(cwd, args) {
+  const { workUnit } = resolveWorkUnit(cwd, args.dotpath, 'plan-topics');
+  const md = manageDetail(cwd, workUnit);
+  if (!md) throw new Error(`render plan-topics: work unit "${workUnit}" not found`);
+  if (!(md.work_type === 'epic' && md.has_plan && md.planning_topics.length > 1)) {
+    throw new Error(`render plan-topics: "${workUnit}" has no multi-topic plan to choose from`);
+  }
+  return planTopicsMenu(md);
+}
+
 /** The catalogue: surface name → handler. @type {Record<string, (cwd: string, args: {dotpath: string} & Record<string, string|undefined>) => string>} */
 const SURFACES = {
   'resume-gate': resumeGate,
@@ -1394,6 +1423,8 @@ const SURFACES = {
   'promote-receipt': promoteReceiptSurface,
   'pivot-continuation': pivotContinuation,
   'session-receipt': sessionReceiptSurface,
+  'absorb-target': absorbTarget,
+  'plan-topics': planTopics,
 };
 
 /**

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -202,6 +202,8 @@ Commands:
   render promote-receipt   <wu.specification.topic> --to <cc-work-unit> [--warn]
   render pivot-continuation <wu>
   render session-receipt   <wu> [--warn]
+  render absorb-target     <feature>
+  render plan-topics       <wu>
   render signpost <label> [--style step|substep] [--width N]     (dev aid)
   render box <title> [--width N]                                 (dev aid)
   render wrap <text> [--width N] [--prefix STR]                  (dev aid)

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -129,6 +129,8 @@ module.exports = {
     inboxPickupView: startProjections.inboxPickupView,
     archivedView: startProjections.archivedView,
     workingSetView: startProjections.workingSetView,
+    workingSetAddGate: startProjections.workingSetAddGate,
+    workingSetDropGate: startProjections.workingSetDropGate,
     manageListView: startProjections.manageListView,
     manageUnitView: startProjections.manageUnitView,
     completedView: startProjections.completedView,

--- a/skills/workflow-specification-entry/SKILL.md
+++ b/skills/workflow-specification-entry/SKILL.md
@@ -51,9 +51,7 @@ node .claude/skills/workflow-specification-entry/scripts/gateway.cjs view {work_
 The output is one snapshot in up to three demarcated sections:
 
 - **DATA** — reasoning surface: `scenario`, counts, `cache_status`, `discussions_checksum`, the discussion/specification detail (statuses, sources, consult references with slice hints), and — for scenarios with a menu — the `ACTIONS` key table (`key  action  topic  verb`). Reason from it; never display or restate it.
-- **TITLE** — the view's chrome heading. Emit verbatim as markdown, directly above the display.
-- **DISPLAY** — the scenario's overview block. Emitted verbatim as a code block, only where a later step directs.
-- **MENU** — the scenario's selection menu. Emitted verbatim as markdown (not a code block), only where a later step directs. Absent for menu-less scenarios.
+- **TITLE** / **DISPLAY** / **MENU** — the scenario's rendered surfaces. Never emitted from this call: the display reference each scenario routes to re-runs the view at its own emission point and emits from that response.
 
 A section is everything beneath its `===` marker up to the next marker — the marker lines themselves are never emitted.
 

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -8,7 +8,13 @@ Prompted when multiple completed discussions exist, no specifications or propose
 
 ## A. Display
 
-Emit the TITLE section (markdown), then the DISPLAY section from the Step 1 snapshot verbatim as a code block.
+Re-run the scoped snapshot — the emission draws from this response, never a carried one:
+
+```bash
+node .claude/skills/workflow-specification-entry/scripts/gateway.cjs view {work_unit}
+```
+
+Emit the TITLE section (markdown), then the DISPLAY section verbatim as a code block.
 
 **Cache-Aware Message**
 

--- a/skills/workflow-specification-entry/references/display-blocks.md
+++ b/skills/workflow-specification-entry/references/display-blocks.md
@@ -6,6 +6,12 @@
 
 Terminal — the phase requires completed discussions and none qualify.
 
-Emit the TITLE section (markdown), then the DISPLAY section from the Step 1 snapshot verbatim as a code block.
+Re-run the scoped snapshot — the emission draws from this response, never a carried one:
+
+```bash
+node .claude/skills/workflow-specification-entry/scripts/gateway.cjs view {work_unit}
+```
+
+Emit the TITLE section (markdown), then the DISPLAY section verbatim as a code block.
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-entry/references/display-groupings.md
+++ b/skills/workflow-specification-entry/references/display-groupings.md
@@ -8,13 +8,11 @@ Shows when proposed groupings exist (directly from routing) or after analysis co
 
 ## A. Display
 
-Arriving from **[analysis-flow.md](analysis-flow.md)**, the manifest changed since the last snapshot — re-run it first:
+Re-run the scoped snapshot — the emission draws from this response, never a carried one:
 
 ```bash
 node .claude/skills/workflow-specification-entry/scripts/gateway.cjs view {work_unit}
 ```
-
-Arriving from routing, use the Step 1 snapshot as-is.
 
 Emit the TITLE section (markdown), then the DISPLAY section verbatim as a code block.
 

--- a/skills/workflow-specification-entry/references/display-single.md
+++ b/skills/workflow-specification-entry/references/display-single.md
@@ -8,7 +8,13 @@ Auto-proceed path — only one completed discussion exists, so no selection menu
 
 ## Display
 
-Emit the TITLE section (markdown), then the DISPLAY section from the Step 1 snapshot verbatim as a code block.
+Re-run the scoped snapshot — the emission draws from this response, never a carried one:
+
+```bash
+node .claude/skills/workflow-specification-entry/scripts/gateway.cjs view {work_unit}
+```
+
+Emit the TITLE section (markdown), then the DISPLAY section verbatim as a code block.
 
 ## After Display
 

--- a/skills/workflow-specification-entry/references/display-specs-menu.md
+++ b/skills/workflow-specification-entry/references/display-specs-menu.md
@@ -8,7 +8,13 @@ Shows when materialized specifications exist and no proposed groupings remain (e
 
 ## A. Display
 
-Emit the TITLE section (markdown), then the DISPLAY section from the Step 1 snapshot verbatim as a code block.
+Re-run the scoped snapshot — the emission draws from this response, never a carried one:
+
+```bash
+node .claude/skills/workflow-specification-entry/scripts/gateway.cjs view {work_unit}
+```
+
+Emit the TITLE section (markdown), then the DISPLAY section verbatim as a code block.
 
 → Proceed to **B. Menu**.
 

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -14,7 +14,11 @@ Merge a feature's discussion into an existing epic as a new topic, then remove t
 > This will move the feature's discussion, research, seed, and imports into the selected epic as a new topic and delete the feature work unit. Git history serves as provenance.
 ```
 
-Emit the `MENU: absorb target` section from the caller's `manage {selected.name}` snapshot verbatim as markdown (not a code block). Its numbering follows the snapshot's `available_epics` order.
+Fetch and emit the `MENU: absorb target` section (its numbering follows the manage snapshot's `available_epics` order):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render absorb-target {selected.name}
+```
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-start/references/inbox-working-set.md
+++ b/skills/workflow-start/references/inbox-working-set.md
@@ -27,7 +27,6 @@ The response carries demarcated sections:
 - **DISPLAY** — the set tree, summaries rendered beneath each item. Emit verbatim as a code block. Never redraw, reflow, or trim it.
 - **MENU** — the set menu. Emit verbatim as markdown (not a code block). The `w/work` option renders only for a type-uniform set.
 - **`DISPLAY: blocker`** — present only on a mixed-type set. Emit directly after the display, verbatim per its marker.
-- **Labelled sections** (`DISPLAY: add candidates`, `MENU: add gate`, `DISPLAY: drop candidates`, `MENU: drop gate`) — deferred: each is emitted only at the gate its marker names (**B** / **C**), never here.
 
 Emit the TITLE section (markdown), then the DISPLAY section, then the `DISPLAY: blocker` section when present, then the MENU section.
 
@@ -87,7 +86,11 @@ Match each named item against the `ADDABLE` table — by title, or by the number
 
 #### Otherwise
 
-Emit the `DISPLAY: add candidates` section verbatim as a code block, then the `MENU: add gate` section verbatim as markdown (not a code block).
+Fetch the add gate over the current set and emit its `DISPLAY: add candidates` section verbatim as a code block, then its `MENU: add gate` section verbatim as markdown (not a code block):
+
+```bash
+node .claude/skills/workflow-start/scripts/gateway.cjs working-set-add-gate {path} [{path} …]
+```
 
 **STOP.** Wait for user response.
 
@@ -117,7 +120,11 @@ Resolve each named item against the working set by title or description. If any 
 
 #### Otherwise
 
-Emit the `DISPLAY: drop candidates` section verbatim as a code block, then the `MENU: drop gate` section verbatim as markdown (not a code block).
+Fetch the drop gate over the current set and emit its `DISPLAY: drop candidates` section verbatim as a code block, then its `MENU: drop gate` section verbatim as markdown (not a code block):
+
+```bash
+node .claude/skills/workflow-start/scripts/gateway.cjs working-set-drop-gate {path} [{path} …]
+```
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-start/references/manage-work-unit.md
+++ b/skills/workflow-start/references/manage-work-unit.md
@@ -47,7 +47,6 @@ The response carries demarcated sections:
 
 - **DATA** — reasoning surface: lifecycle flags (`implementation_completed`, `has_plan`, `absorb_available`, …), `available_epics`, `planning_topics`, and the `ACTIONS` key table. Reason from it; never display or restate it.
 - **MENU** — the action menu, offering exactly the actions this work unit's state allows. Emit verbatim as markdown (not a code block) at this section's gate below.
-- **Labelled sections** (`MENU: absorb target`, `MENU: plan topics`) — deferred: each is emitted only at the gate its marker names (inside **[absorb-into-epic.md](absorb-into-epic.md)** / **[view-plan.md](view-plan.md)**), never here.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-start/references/view-plan.md
+++ b/skills/workflow-start/references/view-plan.md
@@ -32,7 +32,11 @@ Set `topic` to that topic.
 
 **If multiple topics exist:**
 
-Emit the `MENU: plan topics` section from the same snapshot verbatim as markdown (not a code block). Its numbering follows `planning_topics` order.
+Fetch and emit the `MENU: plan topics` section (its numbering follows `planning_topics` order):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render plan-topics {selected.name}
+```
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-start/scripts/gateway.cjs
+++ b/skills/workflow-start/scripts/gateway.cjs
@@ -148,9 +148,10 @@ function archivedView() {
 }
 
 // The working-set snapshot over the caller-held selection: DATA (set + addable
-// tables), the set tree, the set menu, and the deferred blocker/add/drop gate
-// sections. `--summaries <file>` names a JSON payload of model-synthesised
-// item summaries keyed by inbox path — rows render without one.
+// tables), the set tree, the set menu, and the mixed-type blocker.
+// `--summaries <file>` names a JSON payload of model-synthesised item
+// summaries keyed by inbox path — rows render without one. The add/drop gate
+// sections are served by their own verbs below, fetched at each gate.
 function workingSetView(...args) {
   const paths = [];
   let summaries = {};
@@ -182,6 +183,21 @@ function workingSetView(...args) {
   ].filter(Boolean).join('\n');
 }
 
+// The add/drop gates over the caller-held selection — fetched at the gate
+// that displays them, so the candidate lists are computed fresh from the
+// same paths the snapshot took.
+function workingSetGate(builder) {
+  return (...paths) => {
+    let ws;
+    try {
+      ws = engine.detail.workingSetDetail(process.cwd(), paths);
+      return builder(ws);
+    } catch (err) {
+      return engine.gateway.dataBlock({ error: err.message });
+    }
+  };
+}
+
 // manage → the selection snapshot; manage {work_unit} → the unit's action-menu
 // snapshot with its deferred absorb-target / plan-topic gates.
 function manageView(workUnit) {
@@ -202,8 +218,7 @@ function manageView(workUnit) {
   return [
     engine.gateway.dataBlock(v.data),
     engine.gateway.menuBlock(v.menu),
-    v.sections,
-  ].filter(Boolean).join('\n');
+  ].join('\n');
 }
 
 // The completed & cancelled snapshot, optionally filtered to one work type.
@@ -229,6 +244,8 @@ if (require.main === module) {
     inbox: inboxView,
     archived: archivedView,
     'working-set': workingSetView,
+    'working-set-add-gate': workingSetGate(engine.project.workingSetAddGate),
+    'working-set-drop-gate': workingSetGate(engine.project.workingSetDropGate),
     manage: manageView,
     completed: completedView,
     fallback: () => format(discover(process.cwd())),

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1288,7 +1288,7 @@ describe('catalogue dispatch', () => {
   });
 
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, proposed-task, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-gate, fix-gate, fix-threshold, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, proposed-task, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-gate, fix-gate, fix-threshold, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics\)/);
   });
 });
 

--- a/tests/scripts/test-engine-start-projections.cjs
+++ b/tests/scripts/test-engine-start-projections.cjs
@@ -13,8 +13,12 @@ const {
   inboxPickupView,
   archivedView,
   workingSetView,
+  workingSetAddGate,
+  workingSetDropGate,
   manageListView,
   manageUnitView,
+  absorbTargetMenu,
+  planTopicsMenu,
   completedView,
 } = require('../../skills/workflow-engine/scripts/domain/projections/start.cjs');
 const { combinedInbox, workingSetDetail } = require('../../skills/workflow-engine/scripts/domain/inbox-set.cjs');
@@ -433,7 +437,7 @@ describe('start projections: working set', () => {
     createFile(d, '.workflows/.inbox/ideas/2026-06-03--smart-retry.md', '# Smart Retry\n');
   }
 
-  it('uniform bug set: offers work, maps the bugfix pre-seed, and defers add/drop gates', () => {
+  it('uniform bug set: offers work, maps the bugfix pre-seed, and carries no gate sections', () => {
     seedInbox(dir);
     const ws = workingSetDetail(dir, [
       '.workflows/.inbox/bugs/2026-06-01--login-timeout.md',
@@ -473,19 +477,22 @@ describe('start projections: working set', () => {
       '**`b/back`**    → Return to the inbox list',
       '**Ask**       → Ask about the set',
     ].join('\n'));
-    assert.strictEqual(v.sections, [
-      '=== DISPLAY: add candidates (emit verbatim as a code block only at the add-items gate — never at the call) ===',
+    assert.strictEqual(v.sections, '', 'the snapshot carries no gate sections');
+    assert.strictEqual(workingSetAddGate(ws), [
+      '=== DISPLAY: add candidates (emit verbatim as a code block) ===',
       '  1. Smart Retry [idea] — 2026-06-03',
       '',
-      '=== MENU: add gate (emit verbatim as markdown only at the add-items gate) ===',
+      "=== MENU: add gate (emit verbatim as markdown, then STOP for the user's response) ===",
       DOTS,
       'Add which? (enter number(s), comma-separated, or **`b/back`**)',
       '',
-      '=== DISPLAY: drop candidates (emit verbatim as a code block only at the drop-items gate — never at the call) ===',
+    ].join('\n'));
+    assert.strictEqual(workingSetDropGate(ws), [
+      '=== DISPLAY: drop candidates (emit verbatim as a code block) ===',
       '  1. Login Timeout [bug]',
       '  2. Crash On Save [bug]',
       '',
-      '=== MENU: drop gate (emit verbatim as markdown only at the drop-items gate) ===',
+      "=== MENU: drop gate (emit verbatim as markdown, then STOP for the user's response) ===",
       DOTS,
       'Drop which? (enter number(s), comma-separated, or **`b/back`**)',
       '',
@@ -505,15 +512,15 @@ describe('start projections: working set', () => {
     assert.ok(v.data.includes('set_uniform: false'));
   });
 
-  it('idea set maps the none pre-seed; a fully-selected inbox defers no add gate', () => {
+  it('idea set maps the none pre-seed; a fully-selected inbox refuses the add gate', () => {
     createFile(dir, '.workflows/.inbox/ideas/2026-06-03--smart-retry.md', '# Smart Retry\n');
     const ws = workingSetDetail(dir, ['.workflows/.inbox/ideas/2026-06-03--smart-retry.md']);
     assert.strictEqual(ws.set_type, 'none');
     const v = workingSetView(ws);
     assert.ok(v.data.includes('addable_count: 0'));
-    assert.ok(!v.sections.includes('add candidates'));
-    assert.ok(!v.sections.includes('add gate'));
-    assert.ok(v.sections.includes('DISPLAY: drop candidates'));
+    assert.strictEqual(v.sections, '', 'the snapshot carries no gate sections');
+    assert.throws(() => workingSetAddGate(ws), /nothing addable/);
+    assert.ok(workingSetDropGate(ws).includes('DISPLAY: drop candidates'));
   });
 
   it('quick-fix set maps the quick-fix pre-seed', () => {
@@ -611,19 +618,21 @@ describe('start projections: manage unit', () => {
       '**`b/back`**   → Return',
       '**Ask**      → Ask a question about this work unit',
     ].join('\n'));
-    assert.strictEqual(v.sections, '');
+    assert.strictEqual(v.sections, undefined, 'the manage snapshot carries no deferred sections');
   });
 
-  it('absorbable feature: absorb option plus the deferred target menu', () => {
+  it('absorbable feature: absorb option; the target menu renders via its builder', () => {
     createManifest(dir, 'auth-flow', {
       phases: { discussion: { items: { 'auth-flow': { status: 'completed' } } } },
     });
     createManifest(dir, 'v1', { work_type: 'epic' });
     createManifest(dir, 'v2', { work_type: 'epic' });
-    const v = manageUnitView(manageDetail(dir, 'auth-flow'));
+    const md = manageDetail(dir, 'auth-flow');
+    const v = manageUnitView(md);
     assert.ok(/\*\*`a\/absorb`\*\* +→ Merge into an existing epic/.test(v.menu));
-    assert.strictEqual(v.sections, [
-      '=== MENU: absorb target (emit verbatim as markdown only at the absorb target gate — never at the call) ===',
+    assert.strictEqual(v.sections, undefined, 'the manage snapshot carries no deferred sections');
+    assert.strictEqual(absorbTargetMenu(md), [
+      "=== MENU: absorb target (emit verbatim as markdown, then STOP for the user's response) ===",
       '· · · · · · · · · · · ·',
       '**`◆ Select a target epic:`**',
       '',
@@ -645,7 +654,7 @@ describe('start projections: manage unit', () => {
     createManifest(dir, 'v1', { work_type: 'epic' });
     const v = manageUnitView(manageDetail(dir, 'auth-flow'));
     assert.ok(!v.menu.includes('absorb'));
-    assert.strictEqual(v.sections, '');
+    assert.strictEqual(v.sections, undefined, 'the manage snapshot carries no deferred sections');
   });
 
   it('completed implementation offers done; a plan offers view-plan', () => {
@@ -669,10 +678,10 @@ describe('start projections: manage unit', () => {
       '**Ask**         → Ask a question about this work unit',
     ].join('\n'));
     assert.ok(!v.menu.includes('pivot'));
-    assert.strictEqual(v.sections, '');
+    assert.strictEqual(v.sections, undefined, 'the manage snapshot carries no deferred sections');
   });
 
-  it('multi-plan epic defers the plan-topics menu; a single plan does not', () => {
+  it('multi-plan epic renders the plan-topics menu via its builder', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',
       phases: { planning: { items: { 'topic-a': { status: 'completed' }, 'topic-b': { status: 'in-progress' } } } },
@@ -681,9 +690,11 @@ describe('start projections: manage unit', () => {
       work_type: 'epic',
       phases: { planning: { items: { solo: { status: 'in-progress' } } } },
     });
-    const multi = manageUnitView(manageDetail(dir, 'v1'));
-    assert.strictEqual(multi.sections, [
-      '=== MENU: plan topics (emit verbatim as markdown only at the view-plan topic gate — never at the call) ===',
+    const multiMd = manageDetail(dir, 'v1');
+    const multi = manageUnitView(multiMd);
+    assert.strictEqual(multi.sections, undefined, 'the manage snapshot carries no deferred sections');
+    assert.strictEqual(planTopicsMenu(multiMd), [
+      "=== MENU: plan topics (emit verbatim as markdown, then STOP for the user's response) ===",
       '· · · · · · · · · · · ·',
       '**`◆ Which plan would you like to view?`**',
       '',
@@ -693,7 +704,7 @@ describe('start projections: manage unit', () => {
     ].join('\n'));
     assert.ok(multi.data.includes('planning_topics: topic-a [completed], topic-b [in-progress]'));
     const single = manageUnitView(manageDetail(dir, 'v2'));
-    assert.ok(!single.sections.includes('plan topics'));
+    assert.strictEqual(single.sections, undefined, 'the manage snapshot carries no deferred sections');
   });
 
   it('manageDetail is null for a missing work unit', () => {

--- a/tests/scripts/test-gateway-for-start.cjs
+++ b/tests/scripts/test-gateway-for-start.cjs
@@ -563,4 +563,22 @@ describe('workflow-start sub-view sections', () => {
       assert.ok(!display.startsWith(title), `${args[0]} redraws its heading inside the fence: ${out}`);
     }
   });
+
+  it('the add and drop gates render on demand over the caller-held set — never on the snapshot', () => {
+    createFile(dir, '.workflows/.inbox/bugs/2026-06-01--login-timeout.md', '# Login Timeout\n');
+    createFile(dir, '.workflows/.inbox/ideas/2026-06-02--smart-retry.md', '# Smart Retry\n');
+    const set = ['.workflows/.inbox/bugs/2026-06-01--login-timeout.md'];
+
+    const snapshot = run(['working-set', ...set]);
+    assert.ok(!snapshot.includes('add gate') && !snapshot.includes('drop gate'),
+      'the snapshot carries no gate sections');
+
+    const add = run(['working-set-add-gate', ...set]);
+    assert.ok(add.includes('DISPLAY: add candidates') && add.includes('MENU: add gate'), add);
+    assert.ok(add.includes('Smart Retry [idea]'), 'candidates computed fresh from the same paths');
+
+    const drop = run(['working-set-drop-gate', ...set]);
+    assert.ok(drop.includes('DISPLAY: drop candidates') && drop.includes('MENU: drop gate'), drop);
+    assert.ok(drop.includes('Login Timeout [bug]'), drop);
+  });
 });


### PR DESCRIPTION
## What

The three remaining deferred-emission sites convert to fetch-at-display:

- **Manage snapshot** stops carrying `MENU: absorb target` / `MENU: plan topics` — `absorb-into-epic.md` and `view-plan.md` fetch them via two new render surfaces (`render absorb-target <feature>`, `render plan-topics <wu>`), computed fresh from the same manage detail. Each refuses when its guard doesn't hold (not absorbable / no multi-topic plan).
- **Working-set snapshot** stops carrying the add/drop gate sections — the add-items and drop-items gates fetch them via two new gateway verbs (`working-set-add-gate`, `working-set-drop-gate`) over the same caller-held paths. The add gate refuses when nothing is addable. The mixed-type blocker stays on the snapshot — it emits immediately, zero gap.
- **Spec-entry display references** re-run the scoped view at their own emission point and emit from that response. The Step 1 snapshot serves routing (DATA) only; `display-groupings.md`'s conditional re-run becomes the family-wide unconditional rule.

After this PR, every DISPLAY/MENU section in the system is emitted directly beneath the call that produced it — no carried sections, no backward references, anywhere.

## Tests

- Start projections: gate builders byte-pinned standalone; snapshots pinned section-free; add-gate refusal covered.
- Gateway-for-start: the add/drop gate verbs render on demand; the snapshot carries no gate sections.
- Catalogue listing updated for the two new surfaces.

`npm test` 1987/1987 · `npm run test:cli` green · `npm run typecheck` clean

Stack: PR 3 of 4, based on #812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)