### PR TITLE
fix(prose-tests): case pins catch up with the receipt surfaces

### DIFF
--- a/tests/prose/cases/bridge-completes-the-feature/case.json
+++ b/tests/prose/cases/bridge-completes-the-feature/case.json
@@ -45,7 +45,8 @@
       "review(pay): complete review phase",
       "manifest get pay work_type",
       "workflow-bridge/scripts/gateway.cjs pay",
-      "workunit complete pay -m workflow(pay): complete feature pipeline --pipeline"
+      "workunit complete pay -m workflow(pay): complete feature pipeline",
+      "render workunit-receipt pay --verb complete --pipeline"
     ],
     "calls_in_order": [
       "render entry-gate pay.review.pay",

--- a/tests/prose/cases/implementation-loops-on-auto/assert.md
+++ b/tests/prose/cases/implementation-loops-on-auto/assert.md
@@ -53,9 +53,9 @@ Further claims:
 - after the fourth scripted answer, no menu is rendered and no user
   input is consumed — pay-1-2's entire round trip (execute, review,
   fix round, re-review, approve, commit) runs unattended
-- both continuation sections are the engine-rendered lines from their
-  carrying responses (pay-1-2's start and fix-attempt), emitted after
-  the corresponding summary, never before it
+- both continuation sections are engine-rendered lines fetched via
+  `render task-gate` / `render fix-gate` at the gate itself, emitted
+  after the corresponding summary, never before it
 - the turn never ends on a bare summary: each auto gate's summary is
   followed by its continuation line and the action it names
 - each task produced exactly two executor dispatches and two reviewer


### PR DESCRIPTION
## What

Two stale prose-case pins surfaced by the post-merge walks of the render-separation stack:

- **bridge-completes-the-feature** (`case.json`): `calls_include` still pinned `workunit complete … --pipeline` — a call form the engine now refuses, so the pin was unsatisfiable. Both walk runs (Sonnet, plus an Opus confirmation from a fresh world) proved the prose correct: bare completion + `render workunit-receipt … --pipeline`, world delta exact. The pin now names the bare call and adds the receipt render, so the flag's placement stays deterministically covered.
- **implementation-loops-on-auto** (`assert.md`): the further claim describing continuation sections as coming "from their carrying responses" now says they're fetched via `render task-gate` / `render fix-gate` — what the walk record shows.

Prose perimeter green: corpus validation + invariants + snapshot goldens, 110/110.

Not changed: task-loop's commit-subject instruction, despite two walkers briefly writing `T pay-1-1` before self-correcting — the prose already states the constraint verbatim ("`T` immediately followed by the internal id"), both walkers caught it themselves, and more words there would be noise. On file as a watch item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)