### PR TITLE
fix(implementation): reviewer payload lists the executor's report it already receives

### DIFF
--- a/agents/workflow-implementation-task-reviewer.md
+++ b/agents/workflow-implementation-task-reviewer.md
@@ -18,7 +18,9 @@ You receive via the orchestrator's prompt:
 1. **Specification path** — The validated specification for design decision context
 2. **Task content** — Same task content the executor received: internal ID, phase, and all instructional content
 3. **Project skill paths** — Relevant `.claude/skills/` paths for checking framework convention adherence
-4. **code-quality.md path** — Quality standards, including the comment discipline
+4. **Work type** — `quick-fix` switches acceptance criteria and test adequacy to their completeness and verification-workflow variants
+5. **code-quality.md path** — Quality standards, including the comment discipline
+6. **Executor's report** — The executor's structured result for this attempt: claims to verify, not findings to trust
 
 ## Your Process
 

--- a/skills/workflow-implementation-process/references/invoke-reviewer.md
+++ b/skills/workflow-implementation-process/references/invoke-reviewer.md
@@ -19,6 +19,7 @@ Invoke `workflow-implementation-task-reviewer` with:
 3. **Project skill paths**: from `project_skills` in the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} project_skills`)
 4. **Work type**: from the manifest (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} work_type`) — `quick-fix` switches the reviewer to completeness-based criteria and verification-workflow checks
 5. **code-quality.md path**: `.claude/skills/workflow-implementation-process/references/code-quality.md` — the standards the executor worked to, including the comment discipline
+6. **Executor's report**: the structured result the executor returned for this attempt — the claims under review, to be verified against the code, never trusted
 
 ---
 


### PR DESCRIPTION
Review finding on #826. Stage D of the task loop says "Pass the executor's result", but the invoke-reviewer payload list omitted it while claiming to be the reviewer's complete input — a direct contradiction. The reviewer agent's design already assumes the claims are in hand ("Do not trust the executor's self-assessment"), so the fix aligns the lists with stage D rather than removing the pass.

Also aligns the reviewer agent's input contract, which listed 4 items while invoke-reviewer sends 5 — **Work type** was never declared despite the agent's own dimensions branching on quick-fix.

Both new items are framed as claims to verify, never findings to trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)