### PR TITLE
fix(implementation): continuation branch names all three re-entries and its recovery source

### DIFF
--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -45,7 +45,7 @@ A fresh dispatch starts with no memory — this payload is everything the execut
 
 → Proceed to **Expected Result**.
 
-#### If an executor already ran for the current task (fix round or retry)
+#### If an executor already ran for the current task (fix round, retry, or gate comment)
 
 Continue that same executor — it already holds the task, the codebase context it explored, and the code it wrote. Send only the round's new material:
 
@@ -53,7 +53,7 @@ Continue that same executor — it already holds the task, the codebase context 
 - **Task-gate comment (from G)**: the user's feedback
 - **Retry (from C)**: the user's comments
 
-If the task's executor is no longer available — a context refresh or session restart since its dispatch — dispatch a fresh executor with items 1–6 above plus the round's material as items 7 (**User-approved review notes**: verbatim or as modified by the user) and 8 (**Specific issues to address**: the ISSUES from the review); the full payload restores everything the continued executor would have held.
+If the task's executor is no longer available — a context refresh or session restart since its dispatch — dispatch a fresh executor with items 1–6 above plus the round's material as items 7 (**User-approved review notes**: verbatim or as modified by the user) and 8 (**Specific issues to address**: the ISSUES from the review); the full payload restores everything the continued executor would have held. When the conversation no longer holds the round's material, read it from the latest `## Attempt {N}` section of the task's fix tracking file (`.workflows/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md`).
 
 → Proceed to **Expected Result**.
 

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -22,7 +22,7 @@ H. Update progress + phase check + commit
 
 **Engine gate sections**: the loop's state-derived gates render via `engine render` calls — each stage below fetches its own gate at the moment it displays it and emits what returns, so the section always sits in the tool result directly above its emission. DISPLAY sections are emitted verbatim as a code block, MENU sections verbatim as markdown (not a code block). A section is everything beneath its `===` marker up to the end of the response — the marker lines themselves are never emitted. Section content is emitted byte-for-byte — never redrawn, reflowed, or re-derived.
 
-**Agent lifecycle**: every review dispatches a fresh reviewer agent, and every task's first attempt dispatches a fresh executor agent; the only continuation is re-invoking the current task's executor for a fix round or retry. Warm context never justifies crossing these lines — **[invoke-executor.md](invoke-executor.md)** and **[invoke-reviewer.md](invoke-reviewer.md)** carry the dispatch mechanics.
+**Agent lifecycle**: every review dispatches a fresh reviewer agent, and every task's first attempt dispatches a fresh executor agent; the only continuation is re-invoking the current task's executor for a fix round, a retry, or a gate comment round. Warm context never justifies crossing these lines — **[invoke-executor.md](invoke-executor.md)** and **[invoke-reviewer.md](invoke-reviewer.md)** carry the dispatch mechanics.
 
 → Load **[product-lens.md](../../workflow-shared/references/product-lens.md)** and follow its instructions as written — the register and depth for the review and task-result summaries in **E** and **G**. Findings cache files and records stay fully technical.
 


### PR DESCRIPTION
Review findings on #826, executor side:

- The fresh-dispatch fallback fires exactly when conversation context was lost (context refresh / session restart), yet named no durable source for the round's material — a dead end at the moment it matters. It now points at the latest `## Attempt {N}` section of the task's fix tracking file.
- The lifecycle summary in the task-loop preamble and the continuation branch heading under-stated continuation as "fix round or retry", omitting the task-gate comment re-entry (G) that the branch's own payload bullets already cover. Both now name all three re-entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)