### PR TITLE
test(prose): auto-loop case pins the fix round as a continuation, not a second dispatch

### DIFF
--- a/tests/prose/cases/implementation-loops-on-auto/assert.md
+++ b/tests/prose/cases/implementation-loops-on-auto/assert.md
@@ -19,13 +19,13 @@ The prose should have taken this path:
    fetched via `render fix-gate`, and its menu is emitted — the gate
    is still gated, so the loop stops
 6. the third scripted answer opts into auto: fix_gate_mode is set to
-   auto in the manifest and the executor is re-invoked as a fix round
-   in the same flow — no second fix-attempt is recorded for this
-   round's dispatch
-7. the executor's second firing completes; the reviewer's second
-   firing for pay-1-1 approves; the task gate presents the result
-   summary, fetches the gate via `render task-gate`, and emits its
-   MENU
+   auto in the manifest and the fix round continues pay-1-1's own
+   executor in the same flow — no fresh executor dispatch, and no
+   second fix-attempt is recorded for this round
+7. the executor's fix-round firing completes; the reviewer's second
+   firing for pay-1-1 is a fresh dispatch and approves; the task gate
+   presents the result summary, fetches the gate via
+   `render task-gate`, and emits its MENU
 8. the fourth scripted answer opts into auto: task_gate_mode is set
    to auto and progress lands in the same turn — frontmatter flips to
    completed, the engine records completion naming pay-1-2 as next,
@@ -36,8 +36,8 @@ The prose should have taken this path:
     pay-1-2 returns needs-changes; stage E records fix-attempt 1 for
     pay-1-2, summarises the findings, fetches the fix gate via
     `render fix-gate` and emits its DISPLAY: fix gate auto-accepted
-    continuation section, and dispatches the fix round in the same
-    turn — no menu, no stop, no user input
+    continuation section, and continues pay-1-2's executor for the
+    fix round in the same turn — no menu, no stop, no user input
 11. the executor's fix round completes; the reviewer approves; the
     task gate presents the summary, fetches the gate via
     `render task-gate` and emits its DISPLAY: task gate auto-approved
@@ -58,8 +58,10 @@ Further claims:
   after the corresponding summary, never before it
 - the turn never ends on a bare summary: each auto gate's summary is
   followed by its continuation line and the action it names
-- each task produced exactly two executor dispatches and two reviewer
-  dispatches — one initial, one fix round each
+- each task produced exactly one fresh executor dispatch, continued
+  once for its fix round — never a second fresh executor — and exactly
+  two fresh reviewer dispatches, the re-review never continuing the
+  first reviewer
 - exactly one fix-attempt is recorded per task — attempts reset with
   each task start, and the threshold display never renders
 - fix-tracking files exist for both tasks and ride their task commits

--- a/tests/prose/cases/implementation-loops-on-auto/case.json
+++ b/tests/prose/cases/implementation-loops-on-auto/case.json
@@ -34,7 +34,7 @@
     "a — approve this and all future tasks automatically"
   ],
   "stubs": {
-    "executor-task-complete": "each time the workflow-implementation-task-executor agent is dispatched — initial run or fix round alike — create the dispatched task's source and test files as the stub gives them and return that task's STATUS block; two firings per task",
+    "executor-task-complete": "each time the workflow-implementation-task-executor agent is invoked — the task's initial fresh dispatch and its fix-round continuation of that same executor alike — create the task's source and test files as the stub gives them and return that task's STATUS block; one fresh dispatch plus one continuation per task",
     "reviewer-task-flags-then-approves": "each time the workflow-implementation-task-reviewer agent is dispatched — return the stub's first-firing needs-changes block the first time a task is reviewed and its approved block on that task's re-review; write no file"
   },
   "invariants": {


### PR DESCRIPTION
Review finding on #826: `implementation-loops-on-auto` armed its executor stub per-dispatch ("two firings per task") and claimed "exactly two executor dispatches per task" — contradicting the new lifecycle rules, under which the fix round continues the task's own executor.

The stub arming and the expected path now pin one fresh executor dispatch plus one fix-round continuation per task, and two fresh reviewer dispatches with the re-review never continuing the first reviewer. `implementation-executes-the-loop` needed no change — it walks no fix rounds and its per-task dispatch shape already matches the fresh-per-task rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)