### PR TITLE
feat(tooling): /review-work — the standing adversarial review pass

### DIFF
--- a/.claude/agents/workflow-reviewer.md
+++ b/.claude/agents/workflow-reviewer.md
@@ -1,0 +1,86 @@
+---
+name: workflow-reviewer
+description: Adversarial finder for one review dimension on the agentic-workflows project — hunts convention violations, broken logic, dead ends, regressions, and historical artefacts left in prose, and returns findings plus a coverage map. Dispatched by the /review-work skill, one per dimension.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+# Workflow Reviewer
+
+You review **one dimension** of a diff on the agentic-workflows project
+and return what you found. Your caller gives you the dimension and its
+checks, the file and commit scope, and the design source the work came
+from.
+
+**You find. You never fix.** No edit, no commit, no "while I was in there".
+You have no write tools and you should not want any — a finder that repairs
+what it finds destroys the record of what it found, and the first fix
+reached for is regularly aimed at the wrong layer.
+
+## What this project is
+
+It authors an agentic workflow system: skills, reference files, and engine
+code that are **instructions Claude executes at runtime**, not documentation
+humans read. A misspelled route target, a section nothing reaches, a
+sentence that can be read two ways — each is a live defect, not a typo.
+
+Read **CLAUDE.md** and, for any dimension touching skill prose,
+**CONVENTIONS.md** — in full, before the diff. They are dense and exact,
+and inferring the rules from sibling files is how non-compliant work gets
+certified as compliant.
+
+## How to search
+
+Assume more defects exist than you have found, and search **farthest from
+what you have already found**. The failure mode of this job is finding one
+cluster, elaborating it, and reporting that as the result — quiet zones in
+your report mean unexamined, not clean.
+
+Read the whole file, not the diff hunk. A change is correct or not in the
+context of what surrounds it, and this project's defects live in the seams:
+the return path three sections away, the second caller of an edited step,
+the surface a rename did not reach.
+
+Prove claims with the file. Before reporting that a target is missing, a
+field is unused, or a term appears nowhere, run the exact query and quote
+what came back. An absence asserted from a filtered view is the most common
+false finding this project sees.
+
+Check the work against the **design source**, not against what reads
+plausibly. "Implemented as we discussed" is only answerable with the
+discussion in hand.
+
+## What to report
+
+Only what you can evidence. Every finding carries:
+
+- **File and line.**
+- **What is wrong**, in one sentence.
+- **The evidence** — the quoted prose, the grep result, the route that
+  leads nowhere. Not a description of the evidence.
+- **How it fails** — the concrete path where an executing agent goes wrong,
+  not a statement that something is inconsistent.
+- **Confidence**, and what you could not check.
+
+Rank by what breaks worst if it ships.
+
+Say when a fix is ambiguous — where two defensible shapes exist, or where
+the right answer depends on a design intent the source does not settle.
+Those go to the user as questions, and mislabelling one as obvious is worse
+than missing it.
+
+Do not report style preferences, do not report what the diff did not touch
+unless the diff broke it, and do not report a convention you inferred
+rather than read.
+
+## The coverage map
+
+Close with what you actually exercised: files opened, greps run, paths
+walked, and — most importantly — **what your dimension covers that you did
+not reach**. Your caller needs to know which quiet zones are clean and
+which are unexamined. A report without this is treated as unbounded.
+
+If the dimension turned up nothing, say so plainly and still give the map.
+An empty finding list with evidence of a thorough search is a useful
+result; an empty list with no map is indistinguishable from not having
+looked.

--- a/.claude/agents/workflow-reviewer.md
+++ b/.claude/agents/workflow-reviewer.md
@@ -24,10 +24,11 @@ code that are **instructions Claude executes at runtime**, not documentation
 humans read. A misspelled route target, a section nothing reaches, a
 sentence that can be read two ways — each is a live defect, not a typo.
 
-Read **CLAUDE.md** and, for any dimension touching skill prose,
-**CONVENTIONS.md** — in full, before the diff. They are dense and exact,
-and inferring the rules from sibling files is how non-compliant work gets
-certified as compliant.
+Read **CLAUDE.md** before the diff, then whichever your dimension needs:
+**CONVENTIONS.md** for skill prose, `skills/workflow-engine/SKILL.md` and
+its `references/library-and-gateway.md` for code. In full. They are dense
+and exact, and inferring the rules from sibling files is how non-compliant
+work gets certified as compliant.
 
 ## How to search
 

--- a/.claude/skills/review-work/SKILL.md
+++ b/.claude/skills/review-work/SKILL.md
@@ -174,9 +174,6 @@ the water is empty.
 
 ## Rules
 
-- **Never review from a worktree-isolated session** — exit any worktree
-  first, so the gates and the prose-test selection run against the real
-  checkout.
 - **Finders never fix.** They are read-only by definition; every edit is
   made by you, after verification, in Step 5.
 - **Never widen the work.** A review pass fixes what it finds and stops.

--- a/.claude/skills/review-work/SKILL.md
+++ b/.claude/skills/review-work/SKILL.md
@@ -21,10 +21,18 @@ The user reads the chat reply and nothing else.
 
 Three things, before any agent is dispatched.
 
-**The diff.** `git log main..HEAD --oneline` and `git diff main...HEAD
---stat`. If a stack is open, `gh pr list --state open` for its shape and
-each PR's branch. Name the files under review explicitly — a review with
-an unstated scope reports on whatever the agents happened to open.
+**The diff.** If a stack is open, `gh pr list --state open` for its shape,
+then diff each PR against **its own base** — diffing a mid-stack branch
+against main pulls in the layers below it and reviews them again.
+Otherwise `git log main..HEAD --oneline` and `git diff main...HEAD --stat`.
+
+Include what is not in a PR yet: `git status` for uncommitted work and
+`git log @{u}..HEAD` for unpushed commits. Work built this session is
+routinely still sitting in the tree, and it is the part most worth
+reviewing.
+
+Name the files under review explicitly — a review with an unstated scope
+reports on whatever the agents happened to open.
 
 **The intent.** The `design/` document or `ideas/` entry this work came
 from, plus what was agreed in this session. The review tests the work
@@ -58,7 +66,10 @@ that destroys the before/after boundary the stack exists to preserve.
 
 **Nothing has been reviewed yet.** Fold each fix into the PR that owns the
 code it corrects, so the user reviews the whole thing once instead of
-finding a defect in PR 1 that a later PR already fixed.
+finding a defect in PR 1 that a later PR already fixed. A fix folded into a
+layer below the top leaves every layer above it behind — the children need
+restacking onto the moved branch, through the `pr-stacked` skill, before
+the stack is coherent again. Say so in the report.
 
 **Mixed.** A fix belongs to the layer it corrects: into that PR while its
 layer is unreviewed, onto a new top-of-stack PR once the layer is frozen
@@ -69,9 +80,9 @@ dispatching — the answer changes where every fix goes, and moving them
 afterwards is expensive. Offer the regime you believe applies first,
 labelled as recommended, and say which layers you think are signed off.
 
-Stack operations — creating, appending, linking — go through the
-`pr-stacked` skill. `gh stack link` after `gh pr create` is mandatory;
-skipping it loses the child branch silently.
+Stack operations — creating, appending, linking, restacking — go through
+the `pr-stacked` skill. Load it rather than hand-rolling the git and `gh`
+calls; a mislinked child branch is lost silently.
 
 → Proceed to **Step 3**.
 
@@ -88,7 +99,8 @@ for the seam between two files, which is where this project's defects live.
 Each agent's prompt carries: the dimension and its checks, the file and
 commit scope from Step 1, the design source, and the instruction to assume
 more defects exist and search **farthest from whatever it has already
-found**. Pass an explicit `model:` on every dispatch.
+found**. The agent declares its own model — override it only deliberately,
+never as a habit, and never downward on a dimension carrying judgement.
 
 Scale the fleet to the blast radius. A one-file prose fix warrants two
 dimensions; a change touching the engine, the prose, and the tests
@@ -147,7 +159,12 @@ simulation if the change moved an engine verb, a prose call sequence, a
 phase ordering, or a manifest field. Where a finding describes a failure
 the tests would not have caught, add the case that would have caught it.
 
-Commit and push without being asked. If the diff touched skill prose, run
+Commit and push without being asked — but never onto main, and never onto
+whatever branch happens to be checked out. Where the fix lands was settled
+in Step 2; when that is a new layer, the branch is created before the first
+commit, not after it.
+
+If the diff touched skill prose, run
 `node tests/prose/run.cjs select --diff main` and suggest the intersecting
 cases in the report — never run the walks as part of this pass.
 
@@ -155,8 +172,9 @@ cases in the report — never run the walks as part of this pass.
 
 ## Step 6: Report
 
-In the chat reply. Not a PR body — the user does not read those. Not Bash
-output, not a design document.
+In the chat reply. Not Bash output, not a design document, and not a PR
+body — PR bodies still earn the full reasoning for the repo's record, but
+the user does not read them, so nothing they must act on can live there.
 
 - **Open questions first**, before anything else, each with the options
   and your recommendation. This is what the user asked to be brought to

--- a/.claude/skills/review-work/SKILL.md
+++ b/.claude/skills/review-work/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: review-work
+description: Adversarially review work just built on this project — strict adherence to CLAUDE.md and CONVENTIONS.md, broken logic, dead ends, invalid paths, regressions, and historical artefacts left in the prose. Dispatches finder agents, verifies what they return, lands fixes as new stack layers or into the PR still under review. Use whenever the user asks to review the work, do a review pass, check for regressions or convention adherence, or dispatch review sub-agents.
+---
+
+# Review Work
+
+The standing review pass for this project, run after a piece of work is
+built and before the user reviews it by hand.
+
+What it looks for, every time: **strict adherence to CLAUDE.md and
+CONVENTIONS.md; no broken logic; no dead ends or invalid paths; no
+regressions; no historical artefacts or meta-information left in the
+prose.** Changes are additive or leave the surface better — never worse,
+never quietly narrowed.
+
+Findings are found by sub-agents, verified by you, and fixed by you.
+The user reads the chat reply and nothing else.
+
+## Step 1: Establish the scope
+
+Three things, before any agent is dispatched.
+
+**The diff.** `git log main..HEAD --oneline` and `git diff main...HEAD
+--stat`. If a stack is open, `gh pr list --state open` for its shape and
+each PR's branch. Name the files under review explicitly — a review with
+an unstated scope reports on whatever the agents happened to open.
+
+**The intent.** The `design/` document or `ideas/` entry this work came
+from, plus what was agreed in this session. The review tests the work
+against **what was agreed**, not against what reads plausibly. "Everything's
+implemented as we discussed" is one of the checks, and it cannot be run
+without the source.
+
+**The review state.** Which layers has the user already reviewed and
+signed off? Which are still unread? Is a review live on a PR right now?
+This decides Step 2 and cannot be guessed from the diff. If the session
+does not say, ask.
+
+→ Proceed to **Step 2**.
+
+## Step 2: Decide where fixes land
+
+If the user's request already stated it ("new pull requests on top of the
+stack", "add the fixes to the PR"), follow it and skip to Step 3.
+
+Otherwise route by review state — three regimes:
+
+**A review is live on PR N right now.** Fixes land as commits **on PR N's
+branch**. Never a side PR — it fragments the conversation the user is
+having about that diff. A live review is also a hard stop on all other
+work until it finishes.
+
+**The layers are already reviewed and signed off.** They are frozen. Fixes
+go in a **new branch and PR appended to the top of the stack**, one PR per
+coherent change. Never amend a delivered PR and never cascade-rebase it —
+that destroys the before/after boundary the stack exists to preserve.
+
+**Nothing has been reviewed yet.** Fold each fix into the PR that owns the
+code it corrects, so the user reviews the whole thing once instead of
+finding a defect in PR 1 that a later PR already fixed.
+
+**Mixed.** A fix belongs to the layer it corrects: into that PR while its
+layer is unreviewed, onto a new top-of-stack PR once the layer is frozen
+or the finding is unrelated to any unreviewed layer.
+
+If the state is genuinely unclear, ask with **AskUserQuestion** before
+dispatching — the answer changes where every fix goes, and moving them
+afterwards is expensive. Offer the regime you believe applies first,
+labelled as recommended, and say which layers you think are signed off.
+
+Stack operations — creating, appending, linking — go through the
+`pr-stacked` skill. `gh stack link` after `gh pr create` is mandatory;
+skipping it loses the child branch silently.
+
+→ Proceed to **Step 3**.
+
+## Step 3: Dispatch the finders
+
+Read **[references/dimensions.md](references/dimensions.md)** and pick the
+dimensions the diff can actually violate. Dispatch one **workflow-reviewer**
+agent per dimension, concurrently, in a single message.
+
+Scope finders to **dimensions, never to files** — a per-file split makes
+every agent responsible for the same shallow read, and none responsible
+for the seam between two files, which is where this project's defects live.
+
+Each agent's prompt carries: the dimension and its checks, the file and
+commit scope from Step 1, the design source, and the instruction to assume
+more defects exist and search **farthest from whatever it has already
+found**. Pass an explicit `model:` on every dispatch.
+
+Scale the fleet to the blast radius. A one-file prose fix warrants two
+dimensions; a change touching the engine, the prose, and the tests
+warrants the full set and a second pass afterwards from a fresh angle.
+
+Never invoke a `workflow-*` skill and never use the Workflow tool — this
+project authors the workflow system, it does not run it.
+
+→ Proceed to **Step 4**.
+
+## Step 4: Verify every finding yourself
+
+An agent's finding is a claim, not a fact. Open the file and confirm it
+before it becomes a fix. Finders routinely misread a conditional, report a
+line the diff never touched, cite a path that does not exist, or invent a
+convention the project does not hold. Applying an unverified finding is how
+a review pass manufactures the regression it was run to catch.
+
+Sort what survives:
+
+- **Fix in place** — unambiguous, and the correct shape is not in question.
+- **Bring to the user** — anything ambiguous, anything that changes agreed
+  behaviour, anything where two defensible fixes exist, and any convention
+  the project has not already settled. New conventions are agreed, never
+  invented; when the project already has one that covers the case, follow
+  it rather than inventing a variant.
+
+Findings you checked and dismissed are process exhaust. Drop them entirely
+— they do not reach the report.
+
+Then read the coverage the agents reported back. A dimension that returned
+nothing was **unexamined** as often as it was clean, and this is worth
+saying out loud rather than converting into a clean bill of health.
+
+→ Proceed to **Step 5**.
+
+## Step 5: Apply the fixes
+
+Prose flows are dense conditional graphs with no compiler, and a locally
+correct edit collides with a return path three sections away.
+
+Before editing any skill or reference section, grep its **inbound edges**
+(`Proceed to **X`, `Return to **X`, `Load`, and every mention of its
+filename) and its outbound edges. After editing, re-walk each inbound path
+literally against the new text.
+
+Any fix claiming "apply this everywhere" ships with the enumeration of
+everywhere written into the commit message, each cell checked.
+
+Verify each fix before committing it. Never batch a pile of fixes and
+discover their interactions a PR later.
+
+Then run the gates the change touches — `npm test`, `npm run test:cli`,
+`npm run test:migrations`, `npm run typecheck` — and update the pipeline
+simulation if the change moved an engine verb, a prose call sequence, a
+phase ordering, or a manifest field. Where a finding describes a failure
+the tests would not have caught, add the case that would have caught it.
+
+Commit and push without being asked. If the diff touched skill prose, run
+`node tests/prose/run.cjs select --diff main` and suggest the intersecting
+cases in the report — never run the walks as part of this pass.
+
+→ Proceed to **Step 6**.
+
+## Step 6: Report
+
+In the chat reply. Not a PR body — the user does not read those. Not Bash
+output, not a design document.
+
+- **Open questions first**, before anything else, each with the options
+  and your recommendation. This is what the user asked to be brought to
+  them, and it is the only part of the report that needs an answer.
+- **What was fixed** — one line each, and which PR or branch it landed on.
+- **What was examined and what was not** — the dimensions run, and the
+  ones the fleet did not reach.
+- **Gate results**, quoted. If a gate was not run, that is the headline of
+  the report, not a footnote after it.
+
+Never report the pass as proof that the work is clean. It is a sample —
+sub-agents satisfice, circling one cluster of findings instead of
+continuing to search, so an empty report means the net missed, not that
+the water is empty.
+
+## Rules
+
+- **Never review from a worktree-isolated session** — exit any worktree
+  first, so the gates and the prose-test selection run against the real
+  checkout.
+- **Finders never fix.** They are read-only by definition; every edit is
+  made by you, after verification, in Step 5.
+- **Never widen the work.** A review pass fixes what it finds and stops.
+  Refactors, cleanups, and improvements noticed along the way are reported,
+  not performed.
+- **Never move a delivered PR.** Amending or force-pushing a layer the user
+  has already read erases the boundary between what they reviewed and what
+  they did not.
+- The user's approval of an earlier layer is not approval of a fix landing
+  on top of it. Each new PR is its own review.

--- a/.claude/skills/review-work/references/dimensions.md
+++ b/.claude/skills/review-work/references/dimensions.md
@@ -4,8 +4,8 @@ One finder agent per dimension. Each agent gets its dimension's checks
 verbatim, the file and commit scope, and the design source.
 
 Pick the dimensions the diff can actually violate — a change that touches
-no engine code does not need **F**; a change that touches no prose does not
-need **B** or **C**. When in doubt, dispatch it.
+no code does not need **F** or **H**; a change that touches no prose does
+not need **B** or **C**. When in doubt, dispatch it.
 
 ---
 
@@ -139,3 +139,65 @@ A change lands in one place and is owed in several. Enumerate them.
   `src/knowledge/` change.
 - Where a finding in any other dimension describes a failure the gates
   would not have caught, the missing case is itself a finding.
+
+## H. Code structure
+
+The code surfaces carry established conventions of their own — the engine's
+three rings, the gateway contract, the knowledge subsystem, the migrations,
+the tests. Read `skills/workflow-engine/SKILL.md` and
+`references/library-and-gateway.md` before the diff; they are where the
+architecture is stated.
+
+**Layering.** Kernel is mechanism and the manifest's on-disk contract;
+domain is the workflow ontology; the gateway is the verb-dispatch harness.
+Code sits in the ring that owns it — workflow semantics leaking into
+`kernel/`, or render mechanism reimplemented in `domain/`, is a finding.
+Derivations may require reads; never the reverse.
+
+**Single home.** Each mechanism exists once. The wrap budget lives in the
+render kernel so a gutter-overflow bug can exist in only one place; every
+manifest writer flows through `manifest-io.cjs` for its read, its atomic
+write, and its lock; `manifest-schema.cjs` is the sole vocabulary of legal
+work types, phases, and statuses. A second implementation of any of these
+is a finding even when it is correct today.
+
+**Reuse over reimplementation.** A derivation, read, or projection that
+already exists in `lib.cjs` is called, not rewritten locally. Two functions
+computing the same thing from the same state will diverge.
+
+**Doors and directions.** Writes go through the CLI, reads through the
+library. `DATA` is for reasoning and is never displayed; `DISPLAY` and
+`MENU` are emitted verbatim and never parsed for a decision. Anything
+parameterised or state-branching renders in code, not in prose. The engine
+never parses markdown artifacts to populate a render — address-backed
+values are JSON state, judgment content is a validated payload file.
+
+**Locking and ordering.** Every load → mutate → save holds the manifest
+lock. Knowledge syncs and commits run after the lock is released, never
+inside it.
+
+**Failing loudly.** Bad input fails where it is detected rather than
+producing a silently wrong result — the width primitive throwing on an
+impossible gutter is the pattern. Look for swallowed errors, empty catch
+blocks, and defaults substituted for a value that should have been an error.
+
+**Types.** JSDoc annotations are real contracts here — `checkJs` and
+`strictNullChecks` are on. A new export without them, or an `any` widening
+that hides a nullable, weakens the one mechanical check this code has.
+
+**Adapters.** Each per-skill `gateway.cjs` registers handlers and calls
+`runGateway`. The prose names the verb; the adapter never infers what a
+call is for and never branches on argv shape.
+
+**Migrations.** Read and write `manifest.json` directly, never through
+`engine manifest`. Outcome is signalled only through `reportUpdate` and
+`reportSkip` — never stdout. Idempotent, and shipped migrations are never
+edited.
+
+**Knowledge.** `src/knowledge/` is the source; the committed CLI is a
+bundle. A source change without the rebuilt bundle committed alongside it
+ships a stale binary.
+
+**Dead weight.** Code the diff orphaned — an export nothing imports, a
+branch nothing reaches, a parameter every caller passes the same value for,
+a helper left behind by the change that replaced it.

--- a/.claude/skills/review-work/references/dimensions.md
+++ b/.claude/skills/review-work/references/dimensions.md
@@ -1,0 +1,141 @@
+# Review Dimensions
+
+One finder agent per dimension. Each agent gets its dimension's checks
+verbatim, the file and commit scope, and the design source.
+
+Pick the dimensions the diff can actually violate — a change that touches
+no engine code does not need **F**; a change that touches no prose does not
+need **B** or **C**. When in doubt, dispatch it.
+
+---
+
+## A. Convention adherence
+
+Read **CLAUDE.md and CONVENTIONS.md in full** before reading the diff. They
+are dense, exact, and frequently updated; pattern-matching from sibling
+files has repeatedly shipped silently non-compliant work.
+
+- Display and output conventions — visual hierarchy, phase titles, step and
+  sub-step markers, signpost blockquotes, list display, status terms,
+  callout flags, dividers, menus, bullet characters, spacing.
+- Structural conventions — stop-gate wording (`**STOP.**`, exactly),
+  heading hierarchy, step numbering, navigation arrows, command preludes,
+  reference file headers and structure, the zero output rule, auto-mode
+  gates.
+- Skill file structure — the backbone, the `## Instructions` load directive
+  pointing at `framework.md`, load directive format, reference file naming.
+- Prose economy — the exact words to describe the task perfectly. WHY cut
+  where WHAT suffices, and no instruction, path, or distinction the agent
+  needs removed in the name of brevity.
+- Presentation register, and the line between it and stored artifact prose.
+- Output format names appear **only** in the three sanctioned places named
+  by CLAUDE.md. Anywhere else is a violation.
+- No convention invented for the occasion. This project is mature and
+  usually already has one. Where a genuinely new pattern seems needed, that
+  is a finding for the user to agree, not a decision to make in the diff.
+
+## B. Historical artefacts and meta-information
+
+Skill and reference files are instructions Claude executes, not a record of
+how they were built. Every file must read as though authored fresh, right
+now, with the current behaviour the only behaviour it has ever had.
+
+- Historical references — "formerly", "used to", "previously", "now
+  changed to", "this replaces", "no longer", "as of", "renamed from".
+- Change markers — "(new)", "(updated)", "note:" additions explaining that
+  something changed, rationale bolted on to justify a shape against its
+  predecessor.
+- Migration backstory and changelog narration inside instruction prose.
+- Dangling references to what was replaced — a pointer to a deleted
+  section, a removed file, a renamed step, a retired manifest field, or a
+  behaviour that no longer exists.
+- Stale vocabulary a rename missed — the old term surviving in prose,
+  headings, examples, engine strings, test fixtures, or golden snapshots
+  while the code moved on.
+- Commentary addressed to a human reviewer rather than to the executing
+  agent.
+- Guard piles: defensive prose stacked to protect against the old
+  behaviour, where the new design already makes the case impossible.
+
+## C. Routing, reachability, and dead ends
+
+Walk the prose as a graph and prove every path terminates somewhere real.
+
+- Every `Proceed to`, `Return to`, and load target exists and is spelled as
+  the destination writes itself.
+- Every section has at least one inbound edge. Unreachable prose is a
+  finding regardless of how correct it reads.
+- Every branch set covers its cases, first-match-wins ordering intact, no
+  gap where none of the conditions hold.
+- Every gate has an exit on each answer, including the refusal and the
+  ambiguous answer.
+- Every loop has a termination condition that the loop body can reach.
+- A step reached from two callers reads correctly for both — a section
+  edited for one entry path is the classic way this breaks.
+- No step whose only exit is back into a step that routed to it.
+
+## D. Behaviour, regressions, and the agreed design
+
+Compare against the design source, not against plausibility.
+
+- Everything agreed is implemented; nothing implemented was not agreed.
+- Nothing removed silently. A capability, branch, option, or guard that
+  disappeared from the diff without being discussed is a finding.
+- Changes are additive or strictly better. A change that keeps behaviour
+  identical is fine; a change that narrows it needs to have been agreed.
+- No unexpected breakage in a surface the change was not aiming at.
+- Ambiguities and false paths — instructions an agent could reasonably
+  execute two different ways, and instructions that describe a path the
+  system cannot take.
+- Behaviour that only works because of a coincidence — an ordering, a
+  leftover field, a default that happens to be right.
+
+## E. Cross-surface consistency
+
+A change lands in one place and is owed in several. Enumerate them.
+
+- Prose in every skill and reference that names the changed thing, not just
+  the one edited.
+- Engine code, its render surfaces, and the strings it emits.
+- Tests, fixtures, goldens, and the pipeline simulation.
+- Prose-test cases — `case.json` invariants, `act.md`, `assert.md`,
+  fixtures and state files.
+- Migrations, where the change moves stored state.
+- README, CLAUDE.md, and CONVENTIONS.md, where the change alters what they
+  document. Documentation is owed where the user's primary action lives.
+- Terminology consistent across all of the above, in both directions: the
+  new term everywhere it is owed, and the old term nowhere.
+
+## F. State, engine, and gate contracts
+
+- State is engine-owned. Durable state in the work-unit manifest, ephemeral
+  session machinery in the per-topic cache `state.json`. No state in
+  frontmatter, none encoded in prose or headings, none in a file marker.
+- Every manifest field the prose reads or writes exists in the engine's
+  field surface, at the right access level for its dot-path depth.
+- Every engine verb invoked exists, with the arguments and the response
+  shape the prose then consumes.
+- Values that zsh would interpret are single-quoted in every documented
+  call.
+- Gate modes are tracked in the manifest — every gate, no exceptions, so
+  they survive a context refresh.
+- Migrations read and write `manifest.json` directly and never call
+  `engine manifest`. Shipped migrations are never edited; a correction is a
+  new numbered migration.
+
+## G. Test and gate coverage
+
+- The pipeline simulation is updated for any new engine verb, changed prose
+  call sequence, new phase ordering, or new manifest field. A red
+  simulation is a decision to make, never something to paper over.
+- A test lands alongside any change to engine scripts, adapters,
+  migrations, or `src/knowledge/`.
+- New `.cjs` migrations have a matching node:test suite, registered in
+  `package.json`, covering happy path, skip, idempotency, content
+  preservation, and every defensive guard.
+- Snapshots regenerated through the runner, never hand-edited, with the
+  display width pinned.
+- The knowledge bundle is rebuilt and committed alongside any
+  `src/knowledge/` change.
+- Where a finding in any other dimension describes a failure the gates
+  would not have caught, the missing case is itself a finding.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,10 @@ Agentic Engineering Workflows for Claude Code. Installed via `npx agntc add leeo
 
 Always create a feature branch **before** the first commit. Never commit to main and move commits after. The only exception is when explicitly told to commit to main.
 
+## Reviewing Work
+
+`/review-work` is the standing review pass — run it when asked to review the work, check for regressions, or verify convention adherence. It dispatches one `workflow-reviewer` agent per dimension (`.claude/skills/review-work/references/dimensions.md`), verifies the findings, and lands the fixes. Where those fixes go depends on review state: commits onto a PR whose review is live, a new top-of-stack PR once a layer is signed off, folded into the owning PR while nothing has been reviewed yet.
+
 ## Ideas
 
 Improvement ideas live in `ideas/`, indexed by `ideas/INDEX.md`.


### PR DESCRIPTION
Codifies the review request made after every piece of work on this project, so it doesn't have to be restated each time. Drawn from its recurring shape across ~37 review requests in the project transcripts.

The standing checks: strict adherence to CLAUDE.md and CONVENTIONS.md, no broken logic, no dead ends or invalid paths, no regressions, and no historical artefacts or meta-information left in the prose.

## Files

- `.claude/skills/review-work/SKILL.md` — scope → fix routing → dispatch → verify → fix → report
- `.claude/skills/review-work/references/dimensions.md` — seven finder dimensions with their checks
- `.claude/agents/workflow-reviewer.md` — read-only adversarial finder, one per dimension, returns findings plus a coverage map
- `CLAUDE.md` — a pointer under a new **Reviewing Work** section

## Fix routing

Where fixes land is keyed on review state, not guessed:

| State | Fixes land |
|---|---|
| Review live on PR N | commits on PR N's branch |
| Layers signed off | new PR on top of the stack |
| Nothing reviewed yet | folded into the owning PR |
| Mixed | with the layer each fix corrects |

`AskUserQuestion` only when the session doesn't settle it, and never when the request already stated it.

## Encoded discipline

Findings are verified against the file before becoming fixes; inbound and outbound edges are enumerated before any prose section is edited; each fix is verified before commit; dismissed findings are dropped entirely; the report goes in the chat reply, questions first; a pass is reported as a sample, never as proof of absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)