### PR TITLE
fix(display): one announcement per flow — chrome dedup and weight repairs

### DIFF
--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -126,18 +126,6 @@ Then read `discovery_map` from the most recent discovery output and filter for r
 
 #### Otherwise
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**`□ Backfill`**
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> One-time recovery work found — legacy research splits or discovery-map rows missing a summary or description.
-```
-
 Load **[backfill-checks.md](references/backfill-checks.md)** with work_unit = `{work_unit}`, qualifying_sources = `{qualifying_sources}`, items_to_recover = `{items_to_recover}`.
 
 backfill-checks is terminal when it fires — it commits the recovery work and stops, advising the user to `/clear` and re-run `/workflow-start`. Do not proceed to Step 6 on this branch.

--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -214,18 +214,6 @@ Load **[session-loop.md](references/session-loop.md)** and follow its instructio
 
 ## Step 11: Document Review
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**`□ Document Review`**
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reconciling the session log against the conversation before saving — catching anything that drifted, so what's recorded matches what we discussed.
-```
-
 Load **[document-review.md](references/document-review.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 12**.

--- a/skills/workflow-discovery/references/document-review.md
+++ b/skills/workflow-discovery/references/document-review.md
@@ -7,7 +7,7 @@
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-**`▪ Document Review`**
+**`□ Document Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discovery/references/document-review.md
+++ b/skills/workflow-discovery/references/document-review.md
@@ -4,18 +4,6 @@
 
 ---
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**`□ Document Review`**
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reconciling the session log against the conversation before persisting. The audit covers the durable record — Exploration narrative, Edits structured entries, and the synthesised topic set held in conversation memory.
-```
-
 ## A. Check for an Active Log
 
 The session log is created lazily — if no Exploration write, edit, or topic synthesis produced content, no file exists and there is nothing to reconcile.
@@ -35,6 +23,18 @@ Document review — no log file (browse only). Nothing to reconcile.
 → Return to caller.
 
 #### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+**`□ Document Review`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reconciling the session log against the conversation before persisting. The audit covers the durable record — Exploration narrative, Edits structured entries, and the synthesised topic set held in conversation memory.
+```
 
 → Proceed to **B. Re-Read the Session Log**.
 

--- a/skills/workflow-discussion-process/SKILL.md
+++ b/skills/workflow-discussion-process/SKILL.md
@@ -158,18 +158,6 @@ Load **[final-review.md](references/final-review.md)** and follow its instructio
 
 ## Step 7: Document Review
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**`□ Document Review`**
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Reconciling the session conversation against the discussion file to catch substance that was discussed but never captured.
-```
-
 Load **[document-review.md](references/document-review.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 8**.

--- a/skills/workflow-discussion-process/references/document-review.md
+++ b/skills/workflow-discussion-process/references/document-review.md
@@ -11,7 +11,7 @@ Discussion is higher-stakes than research for this check. The Context → Option
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-**`▪ Document Review`**
+**`□ Document Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-discussion-process/references/final-review.md
+++ b/skills/workflow-discussion-process/references/final-review.md
@@ -143,7 +143,7 @@ Findings from the current review are still being drained.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-**`▪ Dispatch Final Review`**
+**`□ Dispatch Final Review`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-start/references/knowledge-gate.md
+++ b/skills/workflow-start/references/knowledge-gate.md
@@ -240,7 +240,7 @@ Knowledge base ready — @if(provider) {provider} · {model} @else keyword-only 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-**`□ Knowledge Base Setup`**
+**`▪ Knowledge Base Setup`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-start/references/knowledge-gate.md
+++ b/skills/workflow-start/references/knowledge-gate.md
@@ -240,7 +240,7 @@ Knowledge base ready — @if(provider) {provider} · {model} @else keyword-only 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-# **`■ Knowledge Base Setup`**
+**`□ Knowledge Base Setup`**
 ```
 
 > *Output the next fenced block as markdown (not a code block):*


### PR DESCRIPTION
## What

A chrome-hierarchy audit of the full marker corpus (~100 markers, 30 files) found three defects; this fixes all of them.

**Duplicated Document Review announcement** (discussion + discovery). The SKILL step emitted `□ Document Review` + signpost, then immediately loaded the reference, which emitted `▪ Document Review` + a near-identical signpost — the user saw the same header twice, back-to-back, since the gate was born (34e9a956). The reference now owns the announcement, promoted to `□` (stage-weight, peer of `□ Discussion Session` / `□ Conclude Discussion`), and the SKILL steps go silent per CONVENTIONS' silent-step rule. Research's document review already had the reference-owned single-announce shape and is untouched — its `▪` is correct where it sits, inside topic completion.

**Backfill double-announcement** (continue-epic). `□ Backfill` in the SKILL sat directly above `□ Summary Backfill` from the reference with nothing rendered between them — the "markers are earned" violation. The caller goes silent; every path through backfill-checks renders its own chrome (legacy split's own skill title, `□ Summary Backfill`, `□ Backfill Complete`).

**Second phase title in one invocation** (knowledge gate). The terminal-wizard detour emitted `# ■ Knowledge Base Setup` inside a workflow-start invocation that had already emitted `# ■ Workflow Start` — CONVENTIONS allows one phase title per invocation. Demoted to a `□` step marker.

## Verification

- Full `npm test` green (1992 tests, incl. the conventions lint over the live corpus)
- Edge enumeration: each edited reference has exactly one caller; no other prose or prose-test case references the removed chrome
- `node tests/prose/run.cjs select --diff main` → 24 intersecting cases (walk on command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)