### PR TITLE
feat(scoping): entry stops relaying the carrier — the process reads it

### DIFF
--- a/skills/workflow-scoping-entry/references/invoke-skill.md
+++ b/skills/workflow-scoping-entry/references/invoke-skill.md
@@ -4,28 +4,11 @@
 
 ---
 
-This skill's purpose is now fulfilled. Construct the handoff and invoke the processing skill.
-
----
-
-## Handoff
-
-Read the durable carrier discovery left, to seed the scoping session. It has two halves — read **both**:
-
-1. The manifest `description`:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} description
-```
-
-2. The latest discovery session log when one exists (`.workflows/{work_unit}/discovery/sessions/session-NNN.md`, highest-numbered) — read its **Exploration** so discovery's shaped context is in hand for scoping-process. A logless quick-fix (e.g. one created before phase-17) has none; scoping-process then gathers from scratch.
-
-Construct the handoff:
+This skill's purpose is now fulfilled. Construct the handoff and invoke the processing skill. The handoff carries session identity only — the durable carrier (manifest `description` + session log) is read by the processing skill, never added to the handoff.
 
 Invoke the **workflow-scoping-process** skill (Skill tool) with the next fenced block as its arguments. Do not act on the gathered context until its instructions load — the skill defines the process.
 
 ```
 Scoping session for: {topic}
 Work unit: {work_unit}
-Description: {description}
 ```

--- a/skills/workflow-scoping-process/references/gather-context.md
+++ b/skills/workflow-scoping-process/references/gather-context.md
@@ -14,7 +14,7 @@ Gather targeted context about the mechanical change. Read the work's seed and th
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit} description
 ```
 
-Read the latest discovery session log's **Exploration** when one exists (`.workflows/{work_unit}/discovery/sessions/session-NNN.md`, highest-numbered) — discovery's shaped context is the carrier's second half. A logless quick-fix has none.
+Read the discovery session log's **Exploration** — single-phase work has exactly one log, at `.workflows/{work_unit}/discovery/sessions/session-001.md`; discovery's shaped context is the carrier's second half. A logless quick-fix has none.
 
 #### If the carrier — seed, description, and exploration — already captures what, where, and why
 

--- a/tests/prose/cases/scoping-defines-the-quickfix/assert.md
+++ b/tests/prose/cases/scoping-defines-the-quickfix/assert.md
@@ -1,7 +1,7 @@
 The prose should have taken this path:
 
-1. the entry finds no scoping recorded, reads the carrier — the
-   description and the session log's exploration — and hands off with it;
+1. the entry finds no scoping recorded and hands off with session
+   identity only — the carrier is the processing skill's to read;
    the entry itself creates and asks nothing
 2. no specification exists, so the pass starts fresh with no resume
    choice put to the user


### PR DESCRIPTION
Completes the fetch-at-initialisation model for the fourth work type. The scoping entry read the carrier (manifest `description` + session-log Exploration) and relayed a `Description:` block — while `scoping-process`'s gather-context reads the same carrier itself. Pure redundancy, and the last `Description:` handoff field in the repo.

- `workflow-scoping-entry/references/invoke-skill.md`: handoff carries session identity only.
- `workflow-scoping-process/references/gather-context.md`: session-log read pinned to `session-001.md` with the single-phase justification, uniform with the other three initialisations.
- `scoping-defines-the-quickfix` assert re-pinned; its `manifest get … description` invariant survives — the read moved into the process and still runs.

Gates: `npm test` 1993/1993.

🤖 Generated with [Claude Code](https://claude.com/claude-code)