### PR TITLE
fix(display): analysis dispatch markers explain themselves

### DIFF
--- a/skills/workflow-shared/references/analysis-approval-gate.md
+++ b/skills/workflow-shared/references/analysis-approval-gate.md
@@ -35,6 +35,12 @@ A processed gate's state is spent — approved candidates live on the map, skipp
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.discovery analysis_staging.{analysis}
 ```
 
+> *Output the next fenced block as a code block:*
+
+```
+Nothing new to review.
+```
+
 → Return to caller.
 
 #### If `K` is `1` or more

--- a/skills/workflow-shared/references/coherence-analysis.md
+++ b/skills/workflow-shared/references/coherence-analysis.md
@@ -18,12 +18,6 @@ The caller provides these via context before loading:
 
 ## A. Read Artifacts
 
-> *Output the next fenced block as a code block:*
-
-```
-Analyzing completed discussions for conflicting or stale decisions...
-```
-
 Read `.workflows/{work_unit}/discussion/{name}.md` for each `completed_discussion` name. Skip files missing on disk. Items with `triaged`, `in-progress`, or `cancelled` status are not in the input set.
 
 For each discussion, note:

--- a/skills/workflow-shared/references/coherence-findings-gate.md
+++ b/skills/workflow-shared/references/coherence-findings-gate.md
@@ -33,6 +33,12 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_uni
 rm -f {staging_file}
 ```
 
+> *Output the next fenced block as a code block:*
+
+```
+Nothing new to review.
+```
+
 → Return to caller.
 
 #### If `K` is `1` or more

--- a/skills/workflow-shared/references/discovery-gap-analysis.md
+++ b/skills/workflow-shared/references/discovery-gap-analysis.md
@@ -18,12 +18,6 @@ The caller provides these via context before loading:
 
 ## A. Read Artifacts
 
-> *Output the next fenced block as a code block:*
-
-```
-Analyzing completed research and discussions for coverage gaps...
-```
-
 Read `.workflows/{work_unit}/research/{name}.md` for each `completed_research` name and `.workflows/{work_unit}/discussion/{name}.md` for each `completed_discussion` name. Skip files missing on disk. Items with `triaged`, `in-progress`, `superseded`, or `cancelled` status are not in the input set.
 
 For each discussion, note:

--- a/skills/workflow-shared/references/research-analysis.md
+++ b/skills/workflow-shared/references/research-analysis.md
@@ -18,12 +18,6 @@ The caller provides these via context before loading:
 
 ## A. Identify Themes
 
-> *Output the next fenced block as a code block:*
-
-```
-Analyzing research documents...
-```
-
 **CRITICAL**: This analysis is the foundation for every downstream phase. The themes extracted here drive topic definition, which drives discussion, which drives specification, planning, and implementation. Anything missed here is invisible to the rest of the pipeline.
 
 Read `.workflows/{work_unit}/research/{name}.md` for each completed item from the precondition set. Skip files missing on disk. Items with `triaged`, `in-progress`, `superseded`, or `cancelled` status are not in the input set.

--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -22,12 +22,6 @@ The caller provides these via context before loading:
 
 ## A. Read Cache State
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-**`▪ Cache Check`**
-```
-
 Run discovery for the work unit:
 
 ```bash
@@ -59,16 +53,26 @@ Research-analysis runs first so that a theme both analyses surface is already on
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-**`▪ Research Analysis`**
+**`□ Research Analysis`**
 ```
+
+**Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.research-analysis`.
+
+**If any candidate there is `pending`** — the analysis was deferred on a prior boot. Reuse the staged file and skip staging; nothing is re-read:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Presenting the follow-up topic candidates you deferred last boot — the analysis has not re-run.
+```
+
+**Otherwise** — stage fresh:
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
 > Reading your completed research for follow-up themes that deserve a topic of their own. Each candidate comes to you for approval before anything lands on the map.
 ```
-
-**Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.research-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:
 
 → Load **[research-analysis.md](research-analysis.md)** with work_unit = `{work_unit}`.
 
@@ -105,16 +109,26 @@ No dispatch.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-**`▪ Gap Analysis`**
+**`□ Gap Analysis`**
 ```
+
+**Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.discovery-gap-analysis`.
+
+**If any candidate there is `pending`** — the analysis was deferred on a prior boot. Reuse the staged file and skip staging; nothing is re-read:
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Reading all completed research and discussions together, looking for what none of them owns — cross-cutting themes, decisions that interact with no topic covering the join. Approved candidates land on the map as new topics.
+> Presenting the gap candidates you deferred last boot — the analysis has not re-run.
 ```
 
-**Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.discovery-gap-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:
+**Otherwise** — stage fresh:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reading all completed research and discussions together for what fell between them — themes no discussion picked up, deferred threads, and decisions that interact where no topic covers the join. Approved candidates join the map as new topics.
+```
 
 → Load **[discovery-gap-analysis.md](discovery-gap-analysis.md)** with work_unit = `{work_unit}`.
 
@@ -151,16 +165,26 @@ No dispatch.
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-**`▪ Coherence Check`**
+**`□ Coherence Check`**
 ```
+
+**Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.coherence-analysis`.
+
+**If any candidate there is `pending`** — the analysis was deferred on a prior boot. Reuse the staged file and skip staging; nothing is re-read:
 
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Re-reading the full discussion corpus for decisions that no longer cohere — unacknowledged conflicts, references to since-changed decisions, ambiguities someone owns. Approved findings reopen the owning discussion through triage.
+> Presenting the coherence findings you deferred last boot — the analysis has not re-run.
 ```
 
-**Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.coherence-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:
+**Otherwise** — stage fresh:
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Re-reading the full discussion corpus for decisions that no longer cohere — unacknowledged conflicts, references to since-changed decisions, ambiguities with one clear home document. Approved findings reopen the yielding discussion through triage.
+```
 
 → Load **[coherence-analysis.md](coherence-analysis.md)** with work_unit = `{work_unit}`.
 

--- a/skills/workflow-shared/references/topic-discovery.md
+++ b/skills/workflow-shared/references/topic-discovery.md
@@ -62,6 +62,12 @@ Research-analysis runs first so that a theme both analyses surface is already on
 **`▪ Research Analysis`**
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reading your completed research for follow-up themes that deserve a topic of their own. Each candidate comes to you for approval before anything lands on the map.
+```
+
 **Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.research-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:
 
 → Load **[research-analysis.md](research-analysis.md)** with work_unit = `{work_unit}`.
@@ -102,6 +108,12 @@ No dispatch.
 **`▪ Gap Analysis`**
 ```
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Reading all completed research and discussions together, looking for what none of them owns — cross-cutting themes, decisions that interact with no topic covering the join. Approved candidates land on the map as new topics.
+```
+
 **Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.discovery-gap-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:
 
 → Load **[discovery-gap-analysis.md](discovery-gap-analysis.md)** with work_unit = `{work_unit}`.
@@ -140,6 +152,12 @@ No dispatch.
 
 ```
 **`▪ Coherence Check`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Re-reading the full discussion corpus for decisions that no longer cohere — unacknowledged conflicts, references to since-changed decisions, ambiguities someone owns. Approved findings reopen the owning discussion through triage.
 ```
 
 **Stage or reuse.** Check the manifest: `manifest get {work_unit}.discovery analysis_staging.coherence-analysis`. If any candidate there is `pending`, the analysis was deferred on a prior boot — reuse the staged file and skip staging. Otherwise stage fresh:


### PR DESCRIPTION
The topic-discovery dispatch announced each stale analysis with a bare sub-step marker — `▪ Gap Analysis` told the user nothing about what was about to read half their corpus (observed in a live Fumi session, where the marker also ended up far up-scroll from the actual pass).

Each of the three analysis markers now carries a signpost stating what the analysis reads, what it hunts for, and where approved output lands:

- **Research Analysis** — completed research → follow-up topic candidates → approval gate → map
- **Gap Analysis** — all completed research + discussions cross-referenced → unowned themes/joins → approval gate → map
- **Coherence Check** — full discussion corpus → conflicts/stale references/owned ambiguities → findings gate → triage reopens the owning discussion

`▪ Cache Check` stays bare — plumbing, not an activity worth explaining.

Conventions lint green over the corpus; prose-only change, no engine or state surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)