### PR TITLE
test(lint): earned-chrome check sees markdown markers

### DIFF
--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -600,7 +600,7 @@ function checkInertLoadChrome(files) {
       }
       let markerLine = -1;
       for (let j = start; j < end; j++) {
-        if (inFence[j] && /^── .+ ─+$/.test(lines[j])) markerLine = j;
+        if (inFence[j] && /^\*\*`[□▪] .+`\*\*$/.test(lines[j])) markerLine = j;
       }
       if (markerLine === -1) continue;
       const substance = [];
@@ -1146,9 +1146,9 @@ test('check 11 (load footers) — catches bare proceed after a load, permits gat
 
 test('check 12 (inert load chrome) — catches unearned markers, skips interactive/structured shapes', () => {
   withTemp((dir) => {
-    const marker = ('── Load Things ').padEnd(49, '─');
+    const marker = '**`□ Load Things`**';
     const step = (body) =>
-      '## Step 1: Load Things\n\n> *Output the next fenced block as a code block:*\n\n```\n' +
+      '## Step 1: Load Things\n\n> *Output the next fenced block as markdown (not a code block):*\n\n```\n' +
       marker +
       '\n```\n\n> *Output the next fenced block as markdown (not a code block):*\n\n```\n> Loading things.\n```\n\n' +
       body +


### PR DESCRIPTION
Found during the review pass on this stack: the conventions lint's check 12 ("earned chrome, decidable slice") keyed its marker detection to the drawn `── Name ──` form that #775 retired and check 2 now bans. With no drawn markers left in the corpus, `markerLine` stayed `-1` for every step and the check examined nothing while reporting clean — the exact defect class the two PRs below fix by hand had no covering test.

Re-keyed the detection to the live markdown marker shape (`**`□ Name`**` / `**`▪ Name`**`) and updated the fixture to build it. The corpus test now genuinely walks every marker-bearing step and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)