### PR TITLE
fix(epic): a declined backfill batch returns to the dashboard

### DIFF
--- a/skills/workflow-continue-epic/SKILL.md
+++ b/skills/workflow-continue-epic/SKILL.md
@@ -128,7 +128,9 @@ Then read `discovery_map` from the most recent discovery output and filter for r
 
 Load **[backfill-checks.md](references/backfill-checks.md)** with work_unit = `{work_unit}`, qualifying_sources = `{qualifying_sources}`, items_to_recover = `{items_to_recover}`.
 
-backfill-checks is terminal when it fires — it commits the recovery work and stops, advising the user to `/clear` and re-run `/workflow-start`. Do not proceed to Step 6 on this branch.
+backfill-checks is terminal when recovery work landed — it commits and stops, advising the user to `/clear` and re-run `/workflow-start`. It returns only when nothing was written (the batch declined); the skipped items re-offer on the next entry.
+
+→ On return, proceed to **Step 6**.
 
 ---
 

--- a/skills/workflow-continue-epic/references/backfill-checks.md
+++ b/skills/workflow-continue-epic/references/backfill-checks.md
@@ -46,6 +46,14 @@ Load **[summary-backfill.md](summary-backfill.md)** with work_unit = `{work_unit
 
 ## C. Advise Restart
 
+#### If nothing was committed this pass
+
+No legacy split ran and the batch wrote nothing (skipped) — no recovery work landed, and nothing context-heavy happened. The skipped items re-offer on the next epic entry.
+
+→ Return to caller.
+
+#### Otherwise
+
 Mutations from A and B are already committed. Returning to the caller would continue Step 6 onward inside the same conversation, but the backfill pass — particularly legacy decomposition — is context-heavy by design. Hand the user a fresh window before the rest of `/workflow-continue-epic` runs.
 
 > *Output the next fenced block as markdown (not a code block):*


### PR DESCRIPTION
Found by the routing finder during the review pass on this stack (pre-existing, not introduced by it): in the epic backfill batch, `s/skip` writes nothing, then `backfill-checks.md` C emits "Backfill work is recorded and committed" (false on this path) and terminal-stops, advising `/clear`. On the next entry the same rows re-qualify and the same batch re-offers — skip could never reach the epic dashboard, and every use of it cost a pointless restart.

`C. Advise Restart` now branches on whether anything was committed this pass:

- **Nothing committed** (no legacy split, batch skipped) → return to the caller, whose new `→ On return, proceed to **Step 6**` footer continues to the dashboard. Skip keeps its postpone semantics — the items re-offer next entry.
- **Anything committed** → the existing restart advice stands, unchanged — that pass genuinely was context-heavy.

All five path permutations re-walked: legacy-only, summary-approved, summary-skipped, dismissals, and both-arms. Conventions lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)