### PR TITLE
fix(granularity): the independence test outranks the source's framing

### DIFF
--- a/skills/workflow-shared/references/topic-granularity.md
+++ b/skills/workflow-shared/references/topic-granularity.md
@@ -22,4 +22,8 @@ A source surfacing pipeline ingestion, schema validation, transformation rules, 
 
 Topics have genuinely different stakeholders, concerns, or decision spaces that can be explored independently.
 
+## Framing is input, not a verdict
+
+How the source carved the material — a user's mid-conversation "split them", a document's own section boundaries — informs the test, never answers it. Apply the independence test to the substance at synthesis time; where its shape disagrees with the framing, propose the test's shape — the confirmation gate downstream is where a genuine override lands, with the proposal in view.
+
 → Return to caller.


### PR DESCRIPTION
The `epic-resumes-and-harvests-topics` prose walk went FLAKY on the granularity judgment: same prose, same scripted user — one walk kept the user's mid-conversation "split them" framing and synthesised four map items (routing the misspelling half of an unknown-framed concern to discussion), the confirming walk applied `topic-granularity.md`'s independence test and merged to three, matching the case's claims.

The reference now states the precedence explicitly (new **Framing is input, not a verdict** section): how the source carved the material informs the test but never answers it; where the test's shape disagrees with the framing, propose the test's shape — the downstream confirmation gate (synthesis confirm, the analyses' approval gates, the legacy-split apply) is where a genuine override lands.

The case that catches regressions already exists — it's the one that found this. Conventions lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)