### PR TITLE
feat(display): sole-section displays carry their continuation line

### DIFF
--- a/skills/workflow-engine/scripts/domain/presence.cjs
+++ b/skills/workflow-engine/scripts/domain/presence.cjs
@@ -19,6 +19,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
+const { section, CONTINUE_INSTRUCTION } = require('./projections/surfaces.cjs');
 
 const STALE_AFTER_SECONDS = 900;
 const PHASES = ['research', 'discussion'];
@@ -235,10 +236,11 @@ function cleanupPresence(cwd, sessionId) {
 function deferralSection(scan) {
   if (scan.live === 0) return '';
   const names = scan.sessions.filter((r) => r.live).map((r) => `${r.phase}/${r.topic}`).join(', ');
-  return (
-    '=== DISPLAY: presence deferral — emit verbatim as a code block, only at the analysis-dispatch deferral ===\n' +
-    `  ⚑ Analyses deferred — ${scan.live} live session(s): ${names}.\n` +
-    '    They re-run at the next entry once those sessions conclude.\n'
+  return section(
+    'DISPLAY: presence deferral',
+    `only at the analysis-dispatch deferral: ${CONTINUE_INSTRUCTION}`,
+    `  ⚑ Analyses deferred — ${scan.live} live session(s): ${names}.\n`
+    + '    They re-run at the next entry once those sessions conclude.',
   );
 }
 

--- a/skills/workflow-engine/scripts/domain/presence.cjs
+++ b/skills/workflow-engine/scripts/domain/presence.cjs
@@ -19,7 +19,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
-const { section, CONTINUE_INSTRUCTION } = require('./projections/surfaces.cjs');
+const { section, CONTINUE_INSTRUCTION, callout } = require('./projections/surfaces.cjs');
 
 const STALE_AFTER_SECONDS = 900;
 const PHASES = ['research', 'discussion'];
@@ -239,8 +239,7 @@ function deferralSection(scan) {
   return section(
     'DISPLAY: presence deferral',
     `only at the analysis-dispatch deferral: ${CONTINUE_INSTRUCTION}`,
-    `  ⚑ Analyses deferred — ${scan.live} live session(s): ${names}.\n`
-    + '    They re-run at the next entry once those sessions conclude.',
+    callout(`Analyses deferred — ${scan.live} live session(s): ${names}. They re-run at the next entry once those sessions conclude.`),
   );
 }
 

--- a/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
@@ -59,6 +59,15 @@ function section(name, instruction, body) {
   return `=== ${name} (${instruction}) ===\n${body.replace(/\n+$/, '')}\n`;
 }
 
+// The instruction for a DISPLAY that is the whole response and does not
+// gate: emitting it leaves the turn open. A section whose response also
+// carries a MENU needs none of this — the menu's own instruction ends the
+// turn — so this belongs only where the display stands alone. It names no
+// next step: where the flow goes next is the prose's to own, and an engine
+// string that duplicated it would be a second routing source to keep in
+// sync.
+const CONTINUE_INSTRUCTION = 'emit verbatim as a code block, then proceed without a gate';
+
 /**
  * The menu frame: an opening dot rule above the content. One-sided by
  * design — output stops while the user chooses, so their own input closes
@@ -219,4 +228,4 @@ function numberedTreeList(items, { indent = '  ', width = displayWidth() } = {})
   return out.join('\n');
 }
 
-module.exports = { DOTS, MENU_GLYPH, section, menuFrame, alignOptions, menu, cmdOption, promptOption, rangeOption, callout, subDetail, treeList, numberedTreeList };
+module.exports = { DOTS, MENU_GLYPH, section, CONTINUE_INSTRUCTION, menuFrame, alignOptions, menu, cmdOption, promptOption, rangeOption, callout, subDetail, treeList, numberedTreeList };

--- a/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/surfaces.cjs
@@ -59,14 +59,18 @@ function section(name, instruction, body) {
   return `=== ${name} (${instruction}) ===\n${body.replace(/\n+$/, '')}\n`;
 }
 
-// The instruction for a DISPLAY that is the whole response and does not
-// gate: emitting it leaves the turn open. A section whose response also
-// carries a MENU needs none of this — the menu's own instruction ends the
-// turn — so this belongs only where the display stands alone. It names no
-// next step: where the flow goes next is the prose's to own, and an engine
-// string that duplicated it would be a second routing source to keep in
-// sync.
-const CONTINUE_INSTRUCTION = 'emit verbatim as a code block, then proceed without a gate';
+// The instructions for a DISPLAY that is the whole response: emitting it
+// leaves the turn open, and the marker says so — a section whose response
+// also carries a MENU needs none of this, because the menu's own
+// instruction ends the turn. Two facts, two strings, never blurred:
+// CONTINUE is for displays where no gate exists at all (the word "gate"
+// never appears — naming one would imply something to skip); AUTO_GATE is
+// for a real gate the user's a/auto choice bypasses, and says exactly
+// that. Neither names a next step: where the flow goes is the prose's to
+// own, and an engine string that duplicated it would be a second routing
+// source to keep in sync.
+const CONTINUE_INSTRUCTION = 'emit verbatim as a code block — do not stop; continue as the workflow instructs';
+const AUTO_GATE_INSTRUCTION = 'emit verbatim as a code block — the user set this gate to auto: do not stop; continue as the workflow instructs';
 
 /**
  * The menu frame: an opening dot rule above the content. One-sided by
@@ -228,4 +232,4 @@ function numberedTreeList(items, { indent = '  ', width = displayWidth() } = {})
   return out.join('\n');
 }
 
-module.exports = { DOTS, MENU_GLYPH, section, CONTINUE_INSTRUCTION, menuFrame, alignOptions, menu, cmdOption, promptOption, rangeOption, callout, subDetail, treeList, numberedTreeList };
+module.exports = { DOTS, MENU_GLYPH, section, CONTINUE_INSTRUCTION, AUTO_GATE_INSTRUCTION, menuFrame, alignOptions, menu, cmdOption, promptOption, rangeOption, callout, subDetail, treeList, numberedTreeList };

--- a/skills/workflow-engine/scripts/domain/projections/tasks.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/tasks.cjs
@@ -30,7 +30,7 @@
 // the action that follows in the same turn.
 // ---------------------------------------------------------------------------
 
-const { section, menu, cmdOption, promptOption } = require('./surfaces.cjs');
+const { section, CONTINUE_INSTRUCTION, menu, cmdOption, promptOption } = require('./surfaces.cjs');
 
 const MENU_INSTRUCTION = "emit verbatim as markdown, then STOP for the user's response";
 
@@ -116,7 +116,7 @@ function fixGateSection(internalId, gateMode, thresholdReached) {
 function fixThresholdDisplay(attempts, internalId) {
   return section(
     'DISPLAY: fix threshold',
-    'emit verbatim as a code block',
+    CONTINUE_INSTRUCTION,
     `⚑ Fix attempt ${attempts} for task ${internalId} — escalation threshold reached.`,
   );
 }
@@ -129,7 +129,7 @@ function fixThresholdDisplay(attempts, internalId) {
 function cycleLimitDisplay(session, limit) {
   return section(
     'DISPLAY: cycle limit',
-    'emit verbatim as a code block',
+    CONTINUE_INSTRUCTION,
     `⚑ Analysis cycle ${session} this session — over the session limit of ${limit}.`,
   );
 }

--- a/skills/workflow-engine/scripts/domain/projections/tasks.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/tasks.cjs
@@ -57,7 +57,7 @@ function taskGateSection(taskId, gateMode) {
   if (gateMode !== 'gated') {
     return section(
       'DISPLAY: task gate auto-approved',
-      'emit verbatim as a code block after the result summary',
+      `after the result summary: ${CONTINUE_INSTRUCTION}`,
       `Task ${taskId} — approved [auto]. Committing and moving to the next task.`,
     );
   }
@@ -86,7 +86,7 @@ function fixGateSection(internalId, gateMode, thresholdReached) {
   if (!thresholdReached && gateMode !== 'gated') {
     return section(
       'DISPLAY: fix gate auto-accepted',
-      'emit verbatim as a code block after the findings summary',
+      `after the findings summary: ${CONTINUE_INSTRUCTION}`,
       `Fix analysis for task ${internalId} — accepted [auto]. Passing the findings to the executor.`,
     );
   }

--- a/skills/workflow-engine/scripts/domain/projections/tasks.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/tasks.cjs
@@ -30,7 +30,7 @@
 // the action that follows in the same turn.
 // ---------------------------------------------------------------------------
 
-const { section, CONTINUE_INSTRUCTION, menu, cmdOption, promptOption } = require('./surfaces.cjs');
+const { section, CONTINUE_INSTRUCTION, AUTO_GATE_INSTRUCTION, menu, cmdOption, promptOption } = require('./surfaces.cjs');
 
 const MENU_INSTRUCTION = "emit verbatim as markdown, then STOP for the user's response";
 
@@ -57,7 +57,7 @@ function taskGateSection(taskId, gateMode) {
   if (gateMode !== 'gated') {
     return section(
       'DISPLAY: task gate auto-approved',
-      `after the result summary: ${CONTINUE_INSTRUCTION}`,
+      `after the result summary: ${AUTO_GATE_INSTRUCTION}`,
       `Task ${taskId} — approved [auto]. Committing and moving to the next task.`,
     );
   }
@@ -86,7 +86,7 @@ function fixGateSection(internalId, gateMode, thresholdReached) {
   if (!thresholdReached && gateMode !== 'gated') {
     return section(
       'DISPLAY: fix gate auto-accepted',
-      `after the findings summary: ${CONTINUE_INSTRUCTION}`,
+      `after the findings summary: ${AUTO_GATE_INSTRUCTION}`,
       `Fix analysis for task ${internalId} — accepted [auto]. Passing the findings to the executor.`,
     );
   }

--- a/skills/workflow-engine/scripts/domain/projections/transactions.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/transactions.cjs
@@ -11,7 +11,7 @@
 // ---------------------------------------------------------------------------
 
 const { titlecase } = require('../conventions.cjs');
-const { section, callout, menu, cmdOption } = require('./surfaces.cjs');
+const { section, CONTINUE_INSTRUCTION, callout, menu, cmdOption } = require('./surfaces.cjs');
 
 /**
  * The ⚑ advisory block: label line and reassurance tail. The instruction
@@ -79,7 +79,7 @@ function workunitReceipt(verb, workUnit, workType, { pipeline = false, skippedRe
     ]);
   }
   return warn
-    ? warningBlock('Knowledge indexing warning', 'The pivot is complete. Indexing can be retried later.', 'emit verbatim as a code block')
+    ? warningBlock('Knowledge indexing warning', 'The pivot is complete. Indexing can be retried later.', CONTINUE_INSTRUCTION)
     : '';
 }
 
@@ -96,7 +96,7 @@ function topicReceipt(verb, topic, phase, status, { warn = false } = {}) {
   const name = titlecase(topic);
   if (verb === 'complete') {
     return warn
-      ? warningBlock('Knowledge indexing warning', 'The artifact is saved. Indexing can be retried later.', 'emit verbatim as a code block')
+      ? warningBlock('Knowledge indexing warning', 'The artifact is saved. Indexing can be retried later.', CONTINUE_INSTRUCTION)
       : '';
   }
   if (verb === 'cancel') {
@@ -187,7 +187,7 @@ function pivotContinuationMenu(workUnit) {
  */
 function sessionReceipt({ warn = false } = {}) {
   return warn
-    ? warningBlock('Knowledge indexing warning', 'The session is closed. Indexing can be retried later.', 'emit verbatim as a code block')
+    ? warningBlock('Knowledge indexing warning', 'The session is closed. Indexing can be retried later.', CONTINUE_INSTRUCTION)
     : '';
 }
 

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -327,7 +327,7 @@ function proposedTask(cwd, args) {
   if (gate === 'auto') {
     parts.push(section(
       'DISPLAY: task auto-approved',
-      'emit verbatim as a code block after recording the approval',
+      `after recording the approval: ${CONTINUE_INSTRUCTION}`,
       `Task ${p.current} of ${p.total}: ${p.title} — approved [auto].`,
     ));
   } else {
@@ -715,7 +715,7 @@ function finding(cwd, { dotpath, file }) {
   if (gateMode === 'auto') {
     parts.push(section(
       'DISPLAY: finding auto-approved',
-      'emit verbatim as a code block after applying the fix',
+      `after applying the fix: ${CONTINUE_INSTRUCTION}`,
       `Finding ${p.n} of ${p.total}: ${p.title} — ${appliedLabel}`,
     ));
   } else {

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -12,7 +12,7 @@ const fs = require('fs');
 const path = require('path');
 const { loadManifest } = require('./reads.cjs');
 const { titlecase } = require('./conventions.cjs');
-const { section, menu, cmdOption, promptOption, callout, subDetail, treeList, numberedTreeList } = require('./projections/surfaces.cjs');
+const { section, CONTINUE_INSTRUCTION, menu, cmdOption, promptOption, callout, subDetail, treeList, numberedTreeList } = require('./projections/surfaces.cjs');
 const { blockedTasksMenu, taskGateSection, fixGateSection, fixThresholdDisplay, cycleLimitDisplay, cycleGateMenu } = require('./projections/tasks.cjs');
 const { workunitReceipt, topicReceipt, absorbReceipt, promoteReceipt, pivotContinuationMenu, sessionReceipt } = require('./projections/transactions.cjs');
 const { absorbTargetMenu, planTopicsMenu } = require('./projections/start.cjs');
@@ -369,7 +369,13 @@ function tasksOverview(cwd, { dotpath, file }) {
     }
     lines.push(`${i + 1}. ${t.title} (${t.severity})`);
   });
-  return section('DISPLAY: tasks overview', 'emit verbatim as a code block', lines.join('\n'));
+  // The walk statement its twin also carries — the overview's own answer to
+  // "what happens now", so the flow never has to compose one. Numberless
+  // where the twin names #1: this surface has a resume path (a mid-approval
+  // cycle re-renders the whole set with some rows already decided), and the
+  // next pending task is not always the first.
+  lines.push('', "Let's work through these one at a time.");
+  return section('DISPLAY: tasks overview', CONTINUE_INSTRUCTION, lines.join('\n'));
 }
 
 // ---------------------------------------------------------------------------
@@ -518,7 +524,7 @@ function findingsSummary(cwd, { dotpath, file }) {
     if (i < p.items.length - 1) lines.push('');
   });
   lines.push('', "Let's work through these one at a time, starting with #1.");
-  return section('DISPLAY: findings summary', 'emit verbatim as a code block', lines.join('\n'));
+  return section('DISPLAY: findings summary', CONTINUE_INSTRUCTION, lines.join('\n'));
 }
 
 // reroute-offer — the off-topic reroute's consent gate. The concern and,
@@ -816,7 +822,7 @@ function triageAnnounce(cwd, { dotpath }) {
   const line = files.length === 1
     ? "1 rerouted concern from another topic waits in this topic's triage queue — I'll raise it once the session finds its footing."
     : `${files.length} rerouted concerns from other topics wait in this topic's triage queue — I'll raise them once the session finds its footing.`;
-  return section('DISPLAY: triage announce', 'emit verbatim as a code block', callout(line));
+  return section('DISPLAY: triage announce', CONTINUE_INSTRUCTION, callout(line));
 }
 
 // triage-block — the conclusion blocker over a non-empty queue. Count comes
@@ -890,7 +896,7 @@ function phaseCompleted(cwd, { dotpath, phase, paths }) {
     : '';
   return section(
     'DISPLAY: phase completed',
-    'emit verbatim as a code block',
+    CONTINUE_INSTRUCTION,
     `${titlecase(phase)} completed for "${titlecase(workUnit)}".${artefacts}`,
   );
 }
@@ -977,7 +983,7 @@ function phaseNote(cwd, { dotpath, verb, noun }) {
   if (!isFilled(verb)) throw new Error('render phase-note: --verb is required (e.g. Resuming, Reopening, Starting)');
   return section(
     'DISPLAY: phase note',
-    'emit verbatim as a code block',
+    CONTINUE_INSTRUCTION,
     `${verb} ${isFilled(noun) ? noun : phase}: ${titlecase(topic)}`,
   );
 }

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -12,7 +12,7 @@ const fs = require('fs');
 const path = require('path');
 const { loadManifest } = require('./reads.cjs');
 const { titlecase } = require('./conventions.cjs');
-const { section, CONTINUE_INSTRUCTION, menu, cmdOption, promptOption, callout, subDetail, treeList, numberedTreeList } = require('./projections/surfaces.cjs');
+const { section, CONTINUE_INSTRUCTION, AUTO_GATE_INSTRUCTION, menu, cmdOption, promptOption, callout, subDetail, treeList, numberedTreeList } = require('./projections/surfaces.cjs');
 const { blockedTasksMenu, taskGateSection, fixGateSection, fixThresholdDisplay, cycleLimitDisplay, cycleGateMenu } = require('./projections/tasks.cjs');
 const { workunitReceipt, topicReceipt, absorbReceipt, promoteReceipt, pivotContinuationMenu, sessionReceipt } = require('./projections/transactions.cjs');
 const { absorbTargetMenu, planTopicsMenu } = require('./projections/start.cjs');
@@ -246,7 +246,7 @@ function taskList(cwd, { dotpath, file, variant: variantArg }) {
   if (gateMode === 'auto') {
     parts.push(section(
       'DISPLAY: task list auto-approved',
-      CONTINUE_INSTRUCTION,
+      AUTO_GATE_INSTRUCTION,
       variant === 'existing'
         ? `Phase ${payload.phase}: ${payload.phase_name} — task list confirmed. Proceeding to authoring.`
         : `Phase ${payload.phase}: ${payload.phase_name} — task list approved. Proceeding to authoring.`,
@@ -327,7 +327,7 @@ function proposedTask(cwd, args) {
   if (gate === 'auto') {
     parts.push(section(
       'DISPLAY: task auto-approved',
-      `after recording the approval: ${CONTINUE_INSTRUCTION}`,
+      `after recording the approval: ${AUTO_GATE_INSTRUCTION}`,
       `Task ${p.current} of ${p.total}: ${p.title} — approved [auto].`,
     ));
   } else {
@@ -715,7 +715,7 @@ function finding(cwd, { dotpath, file }) {
   if (gateMode === 'auto') {
     parts.push(section(
       'DISPLAY: finding auto-approved',
-      `after applying the fix: ${CONTINUE_INSTRUCTION}`,
+      `after applying the fix: ${AUTO_GATE_INSTRUCTION}`,
       `Finding ${p.n} of ${p.total}: ${p.title} — ${appliedLabel}`,
     ));
   } else {

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -246,7 +246,7 @@ function taskList(cwd, { dotpath, file, variant: variantArg }) {
   if (gateMode === 'auto') {
     parts.push(section(
       'DISPLAY: task list auto-approved',
-      'emit verbatim as a code block, then proceed without a gate',
+      CONTINUE_INSTRUCTION,
       variant === 'existing'
         ? `Phase ${payload.phase}: ${payload.phase_name} — task list confirmed. Proceeding to authoring.`
         : `Phase ${payload.phase}: ${payload.phase_name} — task list approved. Proceeding to authoring.`,

--- a/tests/scripts/test-engine-discovery-session.cjs
+++ b/tests/scripts/test-engine-discovery-session.cjs
@@ -221,7 +221,7 @@ describe('engine discovery-session close — happy path', () => {
     assert.strictEqual(readManifest(fix, 'payments').phases.discovery.active_session, undefined);
     assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
     const receipt = execFileSync('node', [fix.engine, 'render', 'session-receipt', 'payments', '--warn'], { cwd: fix.project, encoding: 'utf8' });
-    assert.match(receipt, /=== DISPLAY: kb warning \(emit verbatim as a code block\) ===\n  ⚑ Knowledge indexing warning\n    The session is closed\. Indexing can be retried later\./);
+    assert.match(receipt, /=== DISPLAY: kb warning \(emit verbatim as a code block, then proceed without a gate\) ===\n  ⚑ Knowledge indexing warning\n    The session is closed\. Indexing can be retried later\./);
     assert.strictEqual(execFileSync('node', [fix.engine, 'render', 'session-receipt', 'payments'], { cwd: fix.project, encoding: 'utf8' }), '',
       'no --warn, no advisory — an empty receipt');
   });

--- a/tests/scripts/test-engine-discovery-session.cjs
+++ b/tests/scripts/test-engine-discovery-session.cjs
@@ -221,7 +221,7 @@ describe('engine discovery-session close — happy path', () => {
     assert.strictEqual(readManifest(fix, 'payments').phases.discovery.active_session, undefined);
     assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
     const receipt = execFileSync('node', [fix.engine, 'render', 'session-receipt', 'payments', '--warn'], { cwd: fix.project, encoding: 'utf8' });
-    assert.match(receipt, /=== DISPLAY: kb warning \(emit verbatim as a code block, then proceed without a gate\) ===\n  ⚑ Knowledge indexing warning\n    The session is closed\. Indexing can be retried later\./);
+    assert.match(receipt, /=== DISPLAY: kb warning \(emit verbatim as a code block — do not stop; continue as the workflow instructs\) ===\n  ⚑ Knowledge indexing warning\n    The session is closed\. Indexing can be retried later\./);
     assert.strictEqual(execFileSync('node', [fix.engine, 'render', 'session-receipt', 'payments'], { cwd: fix.project, encoding: 'utf8' }), '',
       'no --warn, no advisory — an empty receipt');
   });

--- a/tests/scripts/test-engine-presence.cjs
+++ b/tests/scripts/test-engine-presence.cjs
@@ -67,8 +67,17 @@ describe('engine presence', () => {
     assert.strictEqual(res.sessions[0].phase, 'discussion');
     assert.strictEqual(res.sessions[0].topic, 'alpha');
     assert.strictEqual(res.sessions[0].live, true);
-    assert.ok(sections.includes('DISPLAY: presence deferral'), 'deferral section rides a live scan');
-    assert.ok(sections.includes('discussion/alpha'));
+    assert.ok(sections.includes(
+      '=== DISPLAY: presence deferral (only at the analysis-dispatch deferral: emit verbatim as a code block — do not stop; continue as the workflow instructs) ===',
+    ), `deferral marker carries its qualifier and the continuation instruction: ${sections}`);
+    assert.ok(sections.includes('  ⚑ Analyses deferred — 1 live session(s): discussion/alpha.'), 'callout flag line');
+    // The body is a callout: wrapped at the display width, continuations at
+    // the 4-space hang — never a hand-wrapped fixed column.
+    const { displayWidth } = require('../../skills/workflow-engine/scripts/kernel/terminal.cjs');
+    for (const line of sections.split('\n')) {
+      if (line.startsWith('===')) continue;
+      assert.ok(line.length <= displayWidth(), `deferral line overflows: ${line}`);
+    }
   });
 
   it('an aged heartbeat reads stale — no deferral section', () => {

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -293,7 +293,7 @@ describe('render task-list', () => {
     const file = writePayload(dir, 'tl.json', { ...payload, tasks: [payload.tasks[0]] });
     const out = renderSurface(dir, 'task-list', { dotpath: 'pay.planning.portal', file });
     assert.ok(out.includes('Phase 1: Adapter Wrapper — 1 task.'));
-    assert.ok(out.includes('=== DISPLAY: task list auto-approved (emit verbatim as a code block, then proceed without a gate) ==='));
+    assert.ok(out.includes('=== DISPLAY: task list auto-approved (emit verbatim as a code block — the user set this gate to auto: do not stop; continue as the workflow instructs) ==='));
     assert.ok(out.includes('Phase 1: Adapter Wrapper — task list approved. Proceeding to authoring.'));
     assert.ok(!out.includes('MENU: task list gate'));
   });
@@ -362,7 +362,7 @@ describe('render findings-summary', () => {
     });
     const out = renderSurface(dir, 'findings-summary', { dotpath: 'pay.planning.portal', file });
     assert.strictEqual(out, [
-      '=== DISPLAY: findings summary (emit verbatim as a code block, then proceed without a gate) ===',
+      '=== DISPLAY: findings summary (emit verbatim as a code block — do not stop; continue as the workflow instructs) ===',
       'Integrity Review — 2 items found',
       '',
       '1. Missing Outcome field (Minor — add-to-task)',
@@ -551,7 +551,7 @@ describe('render triage surfaces', () => {
     assert.throws(() => renderSurface(dir, 'triage-announce', { dotpath: 'wu.discussion.measurement' }), /queue is empty — nothing to announce/);
     writeQueue('measurement', { '001-a.md': 'x' });
     const one = renderSurface(dir, 'triage-announce', { dotpath: 'wu.discussion.measurement' });
-    assert.ok(one.startsWith('=== DISPLAY: triage announce (emit verbatim as a code block, then proceed without a gate) ==='), one);
+    assert.ok(one.startsWith('=== DISPLAY: triage announce (emit verbatim as a code block — do not stop; continue as the workflow instructs) ==='), one);
     assert.ok(one.includes('1 rerouted concern from another topic waits'), one);
     writeQueue('measurement', { '002-b.md': 'y' });
     const two = renderSurface(dir, 'triage-announce', { dotpath: 'wu.discussion.measurement' });
@@ -688,7 +688,7 @@ describe('render finding', () => {
     });
     const out = renderSurface(dir, 'finding', { dotpath: 'pay.specification.portal', file });
     assert.ok(out.includes('=== DISPLAY: finding content (emit verbatim as a code block) ===\nProposed Addition:\n\nNew spec section body.'));
-    assert.ok(out.includes('=== DISPLAY: finding auto-approved (after applying the fix: emit verbatim as a code block, then proceed without a gate) ===\nFinding 1 of 2: Missing Outcome field — approved. Added to specification.'));
+    assert.ok(out.includes('=== DISPLAY: finding auto-approved (after applying the fix: emit verbatim as a code block — the user set this gate to auto: do not stop; continue as the workflow instructs) ===\nFinding 1 of 2: Missing Outcome field — approved. Added to specification.'));
     assert.ok(!out.includes('MENU: finding gate'));
     assert.ok(!out.includes('view full'));
   });
@@ -765,7 +765,7 @@ describe('render proposed-task', () => {
     const gated = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'gated', 'comment-hint': 'Provide feedback to adjust' });
     assert.ok(/\*\*Comment\*\* +→ Provide feedback to adjust/.test(gated));
     const auto = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'auto' });
-    assert.ok(auto.includes('=== DISPLAY: task auto-approved (after recording the approval: emit verbatim as a code block, then proceed without a gate) ===\nTask 2 of 3: Fix adapter leak — approved [auto].'));
+    assert.ok(auto.includes('=== DISPLAY: task auto-approved (after recording the approval: emit verbatim as a code block — the user set this gate to auto: do not stop; continue as the workflow instructs) ===\nTask 2 of 3: Fix adapter leak — approved [auto].'));
     assert.ok(!auto.includes('MENU: task approval'));
   });
 
@@ -791,7 +791,7 @@ describe('render tasks-overview', () => {
     const file = writePayload(dir, 'o.json', { label: 'Analysis cycle 2', tasks: [{ title: 'Fix leak', severity: 'Important' }, { title: 'Add test', severity: 'Minor' }] });
     const out = renderSurface(dir, 'tasks-overview', { dotpath: 'pay.implementation.portal', file });
     assert.strictEqual(out, [
-      '=== DISPLAY: tasks overview (emit verbatim as a code block, then proceed without a gate) ===',
+      '=== DISPLAY: tasks overview (emit verbatim as a code block — do not stop; continue as the workflow instructs) ===',
       'Analysis cycle 2 — 2 proposed tasks',
       '',
       '1. Fix leak (Important)',
@@ -1115,7 +1115,7 @@ describe('render phase-note', () => {
 
   it('renders the one-liner with the phase noun by default and an override when given', () => {
     assert.strictEqual(renderSurface(dir, 'phase-note', { dotpath: 'pay.research.auth-flow', verb: 'Resuming' }),
-      '=== DISPLAY: phase note (emit verbatim as a code block, then proceed without a gate) ===\nResuming research: Auth Flow\n');
+      '=== DISPLAY: phase note (emit verbatim as a code block — do not stop; continue as the workflow instructs) ===\nResuming research: Auth Flow\n');
     assert.ok(renderSurface(dir, 'phase-note', { dotpath: 'pay.planning.auth-flow', verb: 'Reopening', noun: 'plan' })
       .includes('Reopening plan: Auth Flow'));
     assert.throws(() => renderSurface(dir, 'phase-note', { dotpath: 'pay.research.auth-flow' }), /--verb is required/);
@@ -1248,7 +1248,7 @@ describe('render phase-completed --paths', () => {
 
   it('appends the derived spec and plan paths', () => {
     assert.strictEqual(renderSurface(dir, 'phase-completed', { dotpath: 'hotfix', phase: 'scoping', paths: '1' }), [
-      '=== DISPLAY: phase completed (emit verbatim as a code block, then proceed without a gate) ===',
+      '=== DISPLAY: phase completed (emit verbatim as a code block — do not stop; continue as the workflow instructs) ===',
       'Scoping completed for "Hotfix".',
       '',
       '  Spec: .workflows/hotfix/specification/hotfix/specification.md',
@@ -1334,7 +1334,7 @@ describe('single-source invariants', () => {
       for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
         const p = path.join(dir, entry.name);
         if (entry.isDirectory()) walk(p);
-        else if (entry.isFile() && p.endsWith('.cjs') && fs.readFileSync(p, 'utf8').includes('then proceed without a gate')) {
+        else if (entry.isFile() && p.endsWith('.cjs') && fs.readFileSync(p, 'utf8').includes('do not stop; continue as the workflow instructs')) {
           offenders.push(path.relative(scriptsRoot, p));
         }
       }

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1327,6 +1327,22 @@ describe('single-source invariants', () => {
       'option lines must build through cmdOption/rangeOption — hand-formatted options reintroduce the drift class');
   });
 
+  it('the continuation instruction exists in exactly one module — surfaces.cjs', () => {
+    const scriptsRoot = path.join(__dirname, '..', '..', 'skills', 'workflow-engine', 'scripts');
+    const offenders = [];
+    (function walk(dir) {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(p);
+        else if (entry.isFile() && p.endsWith('.cjs') && fs.readFileSync(p, 'utf8').includes('then proceed without a gate')) {
+          offenders.push(path.relative(scriptsRoot, p));
+        }
+      }
+    })(scriptsRoot);
+    assert.deepStrictEqual(offenders, [path.join('domain', 'projections', 'surfaces.cjs')],
+      'continuation phrasing must ride CONTINUE_INSTRUCTION — a second literal drifts on the next reword');
+  });
+
   // No equivalent invariant for the ⚑ callout: the glyph legitimately appears
   // in inline one-line display headers (arrivals lines, not-ready blocks), so
   // a content grep cannot isolate the wrapped-callout idiom without false

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -362,7 +362,7 @@ describe('render findings-summary', () => {
     });
     const out = renderSurface(dir, 'findings-summary', { dotpath: 'pay.planning.portal', file });
     assert.strictEqual(out, [
-      '=== DISPLAY: findings summary (emit verbatim as a code block) ===',
+      '=== DISPLAY: findings summary (emit verbatim as a code block, then proceed without a gate) ===',
       'Integrity Review — 2 items found',
       '',
       '1. Missing Outcome field (Minor — add-to-task)',
@@ -551,7 +551,7 @@ describe('render triage surfaces', () => {
     assert.throws(() => renderSurface(dir, 'triage-announce', { dotpath: 'wu.discussion.measurement' }), /queue is empty — nothing to announce/);
     writeQueue('measurement', { '001-a.md': 'x' });
     const one = renderSurface(dir, 'triage-announce', { dotpath: 'wu.discussion.measurement' });
-    assert.ok(one.startsWith('=== DISPLAY: triage announce (emit verbatim as a code block) ==='), one);
+    assert.ok(one.startsWith('=== DISPLAY: triage announce (emit verbatim as a code block, then proceed without a gate) ==='), one);
     assert.ok(one.includes('1 rerouted concern from another topic waits'), one);
     writeQueue('measurement', { '002-b.md': 'y' });
     const two = renderSurface(dir, 'triage-announce', { dotpath: 'wu.discussion.measurement' });
@@ -791,11 +791,13 @@ describe('render tasks-overview', () => {
     const file = writePayload(dir, 'o.json', { label: 'Analysis cycle 2', tasks: [{ title: 'Fix leak', severity: 'Important' }, { title: 'Add test', severity: 'Minor' }] });
     const out = renderSurface(dir, 'tasks-overview', { dotpath: 'pay.implementation.portal', file });
     assert.strictEqual(out, [
-      '=== DISPLAY: tasks overview (emit verbatim as a code block) ===',
+      '=== DISPLAY: tasks overview (emit verbatim as a code block, then proceed without a gate) ===',
       'Analysis cycle 2 — 2 proposed tasks',
       '',
       '1. Fix leak (Important)',
       '2. Add test (Minor)',
+      '',
+      "Let's work through these one at a time.",
       '',
     ].join('\n'));
   });
@@ -1113,7 +1115,7 @@ describe('render phase-note', () => {
 
   it('renders the one-liner with the phase noun by default and an override when given', () => {
     assert.strictEqual(renderSurface(dir, 'phase-note', { dotpath: 'pay.research.auth-flow', verb: 'Resuming' }),
-      '=== DISPLAY: phase note (emit verbatim as a code block) ===\nResuming research: Auth Flow\n');
+      '=== DISPLAY: phase note (emit verbatim as a code block, then proceed without a gate) ===\nResuming research: Auth Flow\n');
     assert.ok(renderSurface(dir, 'phase-note', { dotpath: 'pay.planning.auth-flow', verb: 'Reopening', noun: 'plan' })
       .includes('Reopening plan: Auth Flow'));
     assert.throws(() => renderSurface(dir, 'phase-note', { dotpath: 'pay.research.auth-flow' }), /--verb is required/);
@@ -1246,7 +1248,7 @@ describe('render phase-completed --paths', () => {
 
   it('appends the derived spec and plan paths', () => {
     assert.strictEqual(renderSurface(dir, 'phase-completed', { dotpath: 'hotfix', phase: 'scoping', paths: '1' }), [
-      '=== DISPLAY: phase completed (emit verbatim as a code block) ===',
+      '=== DISPLAY: phase completed (emit verbatim as a code block, then proceed without a gate) ===',
       'Scoping completed for "Hotfix".',
       '',
       '  Spec: .workflows/hotfix/specification/hotfix/specification.md',

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -688,7 +688,7 @@ describe('render finding', () => {
     });
     const out = renderSurface(dir, 'finding', { dotpath: 'pay.specification.portal', file });
     assert.ok(out.includes('=== DISPLAY: finding content (emit verbatim as a code block) ===\nProposed Addition:\n\nNew spec section body.'));
-    assert.ok(out.includes('=== DISPLAY: finding auto-approved (emit verbatim as a code block after applying the fix) ===\nFinding 1 of 2: Missing Outcome field — approved. Added to specification.'));
+    assert.ok(out.includes('=== DISPLAY: finding auto-approved (after applying the fix: emit verbatim as a code block, then proceed without a gate) ===\nFinding 1 of 2: Missing Outcome field — approved. Added to specification.'));
     assert.ok(!out.includes('MENU: finding gate'));
     assert.ok(!out.includes('view full'));
   });
@@ -765,7 +765,7 @@ describe('render proposed-task', () => {
     const gated = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'gated', 'comment-hint': 'Provide feedback to adjust' });
     assert.ok(/\*\*Comment\*\* +→ Provide feedback to adjust/.test(gated));
     const auto = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'auto' });
-    assert.ok(auto.includes('=== DISPLAY: task auto-approved (emit verbatim as a code block after recording the approval) ===\nTask 2 of 3: Fix adapter leak — approved [auto].'));
+    assert.ok(auto.includes('=== DISPLAY: task auto-approved (after recording the approval: emit verbatim as a code block, then proceed without a gate) ===\nTask 2 of 3: Fix adapter leak — approved [auto].'));
     assert.ok(!auto.includes('MENU: task approval'));
   });
 

--- a/tests/scripts/test-engine-tasks.cjs
+++ b/tests/scripts/test-engine-tasks.cjs
@@ -820,7 +820,7 @@ describe('engine render task surfaces', () => {
     assert.strictEqual(
       render(['fix-threshold', 'auth.implementation.auth-flow']),
       [
-        '=== DISPLAY: fix threshold (emit verbatim as a code block) ===',
+        '=== DISPLAY: fix threshold (emit verbatim as a code block, then proceed without a gate) ===',
         '⚑ Fix attempt 3 for task auth-flow-1-1 — escalation threshold reached.',
         '',
       ].join('\n'));
@@ -843,7 +843,7 @@ describe('engine render task surfaces', () => {
     assert.strictEqual(
       render(['cycle-limit', 'auth.implementation.auth-flow']),
       [
-        '=== DISPLAY: cycle limit (emit verbatim as a code block) ===',
+        '=== DISPLAY: cycle limit (emit verbatim as a code block, then proceed without a gate) ===',
         '⚑ Analysis cycle 4 this session — over the session limit of 3.',
         '',
       ].join('\n'));

--- a/tests/scripts/test-engine-tasks.cjs
+++ b/tests/scripts/test-engine-tasks.cjs
@@ -771,7 +771,7 @@ describe('engine render task surfaces', () => {
     assert.strictEqual(
       render(['task-gate', 'auth.implementation.auth-flow']),
       [
-        '=== DISPLAY: task gate auto-approved (after the result summary: emit verbatim as a code block, then proceed without a gate) ===',
+        '=== DISPLAY: task gate auto-approved (after the result summary: emit verbatim as a code block — the user set this gate to auto: do not stop; continue as the workflow instructs) ===',
         'Task auth-flow-1-1 — approved [auto]. Committing and moving to the next task.',
         '',
       ].join('\n'));
@@ -787,7 +787,7 @@ describe('engine render task surfaces', () => {
     assert.strictEqual(
       render(['fix-gate', 'auth.implementation.auth-flow']),
       [
-        '=== DISPLAY: fix gate auto-accepted (after the findings summary: emit verbatim as a code block, then proceed without a gate) ===',
+        '=== DISPLAY: fix gate auto-accepted (after the findings summary: emit verbatim as a code block — the user set this gate to auto: do not stop; continue as the workflow instructs) ===',
         'Fix analysis for task auth-flow-1-1 — accepted [auto]. Passing the findings to the executor.',
         '',
       ].join('\n'));
@@ -820,7 +820,7 @@ describe('engine render task surfaces', () => {
     assert.strictEqual(
       render(['fix-threshold', 'auth.implementation.auth-flow']),
       [
-        '=== DISPLAY: fix threshold (emit verbatim as a code block, then proceed without a gate) ===',
+        '=== DISPLAY: fix threshold (emit verbatim as a code block — do not stop; continue as the workflow instructs) ===',
         '⚑ Fix attempt 3 for task auth-flow-1-1 — escalation threshold reached.',
         '',
       ].join('\n'));
@@ -843,7 +843,7 @@ describe('engine render task surfaces', () => {
     assert.strictEqual(
       render(['cycle-limit', 'auth.implementation.auth-flow']),
       [
-        '=== DISPLAY: cycle limit (emit verbatim as a code block, then proceed without a gate) ===',
+        '=== DISPLAY: cycle limit (emit verbatim as a code block — do not stop; continue as the workflow instructs) ===',
         '⚑ Analysis cycle 4 this session — over the session limit of 3.',
         '',
       ].join('\n'));

--- a/tests/scripts/test-engine-tasks.cjs
+++ b/tests/scripts/test-engine-tasks.cjs
@@ -771,7 +771,7 @@ describe('engine render task surfaces', () => {
     assert.strictEqual(
       render(['task-gate', 'auth.implementation.auth-flow']),
       [
-        '=== DISPLAY: task gate auto-approved (emit verbatim as a code block after the result summary) ===',
+        '=== DISPLAY: task gate auto-approved (after the result summary: emit verbatim as a code block, then proceed without a gate) ===',
         'Task auth-flow-1-1 — approved [auto]. Committing and moving to the next task.',
         '',
       ].join('\n'));
@@ -787,7 +787,7 @@ describe('engine render task surfaces', () => {
     assert.strictEqual(
       render(['fix-gate', 'auth.implementation.auth-flow']),
       [
-        '=== DISPLAY: fix gate auto-accepted (emit verbatim as a code block after the findings summary) ===',
+        '=== DISPLAY: fix gate auto-accepted (after the findings summary: emit verbatim as a code block, then proceed without a gate) ===',
         'Fix analysis for task auth-flow-1-1 — accepted [auto]. Passing the findings to the executor.',
         '',
       ].join('\n'));

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -634,7 +634,7 @@ describe('engine topic complete', () => {
     assert.match(res.warnings[0], /knowledge index failed/);
     assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
     const advisory = render(dir, ['topic-receipt', 'payments.research.auth-flow', '--verb', 'complete', '--warn']);
-    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block\) ===\n  ⚑ Knowledge indexing warning\n    The artifact is saved\. Indexing can be retried later\./);
+    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block, then proceed without a gate\) ===\n  ⚑ Knowledge indexing warning\n    The artifact is saved\. Indexing can be retried later\./);
     assert.ok(!advisory.includes('confirmation ==='), 'complete renders the advisory only — the flow owns its conclusion display');
     assert.strictEqual(render(dir, ['topic-receipt', 'payments.research.auth-flow', '--verb', 'complete']), '',
       'no --warn, no advisory — an empty receipt');

--- a/tests/scripts/test-engine-transactions.cjs
+++ b/tests/scripts/test-engine-transactions.cjs
@@ -634,7 +634,7 @@ describe('engine topic complete', () => {
     assert.match(res.warnings[0], /knowledge index failed/);
     assert.strictEqual(engine.lastSections, '', 'transactions answer with pure JSON');
     const advisory = render(dir, ['topic-receipt', 'payments.research.auth-flow', '--verb', 'complete', '--warn']);
-    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block, then proceed without a gate\) ===\n  ⚑ Knowledge indexing warning\n    The artifact is saved\. Indexing can be retried later\./);
+    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block — do not stop; continue as the workflow instructs\) ===\n  ⚑ Knowledge indexing warning\n    The artifact is saved\. Indexing can be retried later\./);
     assert.ok(!advisory.includes('confirmation ==='), 'complete renders the advisory only — the flow owns its conclusion display');
     assert.strictEqual(render(dir, ['topic-receipt', 'payments.research.auth-flow', '--verb', 'complete']), '',
       'no --warn, no advisory — an empty receipt');

--- a/tests/scripts/test-engine-workunit-pivot.cjs
+++ b/tests/scripts/test-engine-workunit-pivot.cjs
@@ -168,7 +168,7 @@ describe('engine workunit pivot — happy path', () => {
     assert.ok(menu.includes("=== MENU: pivot continuation (emit verbatim as markdown, then STOP for the user's response) ==="), menu);
     assert.ok(menu.includes('**Auth Flow** converted from feature to epic.'), menu);
     const advisory = execFileSync('node', [fix.engine, 'render', 'workunit-receipt', 'auth-flow', '--verb', 'pivot', '--warn'], { cwd: fix.project, encoding: 'utf8' });
-    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block, then proceed without a gate\) ===\n  ⚑ Knowledge indexing warning\n    The pivot is complete\. Indexing can be retried later\./);
+    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block — do not stop; continue as the workflow instructs\) ===\n  ⚑ Knowledge indexing warning\n    The pivot is complete\. Indexing can be retried later\./);
     assert.strictEqual(
       execFileSync('node', [fix.engine, 'render', 'workunit-receipt', 'auth-flow', '--verb', 'pivot'], { cwd: fix.project, encoding: 'utf8' }),
       '', 'no --warn, no advisory — an empty receipt');

--- a/tests/scripts/test-engine-workunit-pivot.cjs
+++ b/tests/scripts/test-engine-workunit-pivot.cjs
@@ -168,7 +168,7 @@ describe('engine workunit pivot — happy path', () => {
     assert.ok(menu.includes("=== MENU: pivot continuation (emit verbatim as markdown, then STOP for the user's response) ==="), menu);
     assert.ok(menu.includes('**Auth Flow** converted from feature to epic.'), menu);
     const advisory = execFileSync('node', [fix.engine, 'render', 'workunit-receipt', 'auth-flow', '--verb', 'pivot', '--warn'], { cwd: fix.project, encoding: 'utf8' });
-    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block\) ===\n  ⚑ Knowledge indexing warning\n    The pivot is complete\. Indexing can be retried later\./);
+    assert.match(advisory, /=== DISPLAY: kb warning \(emit verbatim as a code block, then proceed without a gate\) ===\n  ⚑ Knowledge indexing warning\n    The pivot is complete\. Indexing can be retried later\./);
     assert.strictEqual(
       execFileSync('node', [fix.engine, 'render', 'workunit-receipt', 'auth-flow', '--verb', 'pivot'], { cwd: fix.project, encoding: 'utf8' }),
       '', 'no --warn, no advisory — an empty receipt');


### PR DESCRIPTION
Render separation made the sole-section response normal: a display arrives alone, the tool result ends, and nothing in it says the turn is still open. #784 fixed that for the two auto-gate branches — a MENU where the loop stops, a continuation DISPLAY where it must not. The rest of the surface never got the same treatment.

A portal analysis cycle ended there: the loop emitted `DISPLAY: tasks overview`, reached the end of the engine's instruction, and closed the turn on a freehand sentence in place of the proposed-task render and its MENU. Fifteen tasks left pending, no gate on screen.

## Changed

Eight sole-section displays now carry `CONTINUE_INSTRUCTION` (`emit verbatim as a code block, then proceed without a gate`):

`tasks overview` · `findings summary` · `triage announce` · `phase completed` · `phase note` · `fix threshold` · `cycle limit` · the three bare `kb warning` overrides

The constant sits beside `section` in `surfaces.cjs` and names no next step — routing stays the prose's, or the engine becomes a second source of truth for it.

`tasks overview` also gains the walk statement its twin `findings-summary` already carried, numberless where the twin names `#1`: this surface has a resume path, and a mid-approval cycle re-renders rows already decided.

## Checked and left alone

`task list` · `finding batch` · `finding content` · `triage agenda` · `phase tree` — each already sits above a MENU or a continuation-bearing display in the same response. `phase tree`'s bare variant exists in the renderer but no prose caller reaches it.

## Gates

`npm test` 2002/2002 · `test:cli` 40 + 357 + 5 · `test:migrations` 46 suites · `typecheck` clean. Ten assertions re-pinned across five suites.

No skill prose touched, so no prose cases intersect this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)