### PR TITLE
test(prose): re-pin the cross-cutting completion to the split call shape

### DIFF
--- a/tests/prose/cases/spec-completes-the-cross-cutting/case.json
+++ b/tests/prose/cases/spec-completes-the-cross-cutting/case.json
@@ -45,7 +45,8 @@
       "spec(error-handling): conclude specification",
       "manifest get error-handling work_type",
       "workflow-bridge/scripts/gateway.cjs error-handling",
-      "workunit complete error-handling -m workflow(error-handling): complete cross-cutting pipeline --pipeline"
+      "workunit complete error-handling -m workflow(error-handling): complete cross-cutting pipeline",
+      "render workunit-receipt error-handling --verb complete --pipeline"
     ],
     "calls_in_order": [
       "render entry-gate error-handling.specification.error-handling",


### PR DESCRIPTION
The walk run failed `spec-completes-the-cross-cutting` identically on both models: the case's `calls_include` demands `workunit complete … --pipeline`, but that flag belongs to `render workunit-receipt` since render separation (#805) — the transaction is flagless and both walks executed the current prose exactly, with the receipt correctly flagged two calls later. World PASS both runs. This is the fifth stale pin from that stack; #822 re-pinned the other four to the split shape this PR now mirrors (flagless `workunit complete` include + a separate `render workunit-receipt … --pipeline` include).

Snapshot untouched and current; corpus validation green. Single-case re-walk to certify runs after this lands or on the branch — verdict reported in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)