### PR TITLE
fix(spec): the cycle-initialization commits carry their command

### DIFF
--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -24,7 +24,11 @@ Set `review_cycle` to 1 via `engine manifest` (`node .claude/skills/workflow-eng
 
 Record the current cycle number — used for tracking file naming (`c{N}`).
 
-Commit the updated manifest.
+Commit the updated manifest:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): begin review cycle {N}"
+```
 
 → Proceed to **C. Phase 1 — Input Review**.
 
@@ -34,7 +38,11 @@ Increment `review_cycle` by 1 via `engine manifest` (`node .claude/skills/workfl
 
 Record the current cycle number — used for tracking file naming (`c{N}`).
 
-Commit the updated manifest.
+Commit the updated manifest:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): begin review cycle {N}"
+```
 
 → Proceed to **B. Cycle Gate**.
 


### PR DESCRIPTION
Found by a DEVIATION marker in #848's certifying re-walk: both arms of `spec-review.md` § A said "Commit the updated manifest." with no fenced command and no literal message — the only commit instruction in the file (and the only surviving one in the corpus, by grep) without them. The walker constructed a command and reused the initialization message, so the record carried two commits under one subject.

Both arms gain the fenced `engine commit` with `spec({work_unit}): begin review cycle {N}` — the message walkers already converge on (yesterday's `spec-extracts-the-discussion` record carried exactly it). `{N}` is defined by the "Record the current cycle number" line directly above in both arms. No routing changes; § A's inbound edges are the file entry only.

Conventions lint 31/31. Certifying re-walk of `spec-extracts-the-discussion` (the deepest § A coverage among the three intersecting cases) reported in chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)