### PR TITLE
fix(discussion): the perspective offer waits for the conversation

### DIFF
--- a/skills/workflow-discussion-process/references/perspective-agents.md
+++ b/skills/workflow-discussion-process/references/perspective-agents.md
@@ -14,7 +14,7 @@ Signals:
 - The domain has known competing paradigms (e.g., relational vs document, monolith vs microservices, sync vs async)
 - Explicit disagreement between orchestrator and user on the best approach
 
-Do not fire when the decision is straightforward, the tradeoffs are already well understood, or the user has already made a confident decision.
+Signals are read from the conversation, never from domain shape alone — a known competing-paradigm pair is not a trigger until the user has engaged the decision and the ambiguity has shown itself. Do not fire when the decision is straightforward, the tradeoffs are already well understood, or the user has already made a confident decision.
 
 When these conditions are met → Proceed to **A. Select Polarity Pair**.
 


### PR DESCRIPTION
The perspective-agent trigger listed "the domain has known competing paradigms" as a signal — the one signal evaluable from domain shape alone, before the user has said anything about the decision. The do-not-fire clause ("the user has already made a confident decision") can't suppress an offer made before the decision exists, so an eager session offers the polarity-pair gate preemptively and a decisive user has to wave it off.

Surfaced by a FLAKY verdict on `discussion-runs-to-convergence`: the first walker offered the gate on the webhooks-vs-polling paradigm match before any user statement on the subtopic (the case pins that no offer renders for a decisive user); the confirmation walker waited, saw the confident decision, and never offered. Both deterministic check sets were identical PASS — the variance was entirely this judgment point, i.e. trigger prose that reads two ways.

One clause added: signals are read from the conversation, never from domain shape alone — a paradigm pair is not a trigger until the user has engaged the decision and the ambiguity has shown itself. The case's claim is unchanged; it now guards the intended behaviour unambiguously.

Conventions lint + prose corpus validation green. Re-walk of the case reported in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)