### PR TITLE
fix(discussion): the mandatory review gate names the drain, and disagreement means unsettled

### DIFF
--- a/skills/workflow-discussion-process/references/closing-gates.md
+++ b/skills/workflow-discussion-process/references/closing-gates.md
@@ -99,7 +99,36 @@ Another final review is declined for this conclusion attempt — Step 6 honours 
 
 ## C. Review Gate — Mandatory
 
-At least one full review pass belongs to every discussion — this one cannot be skipped, only postponed by keeping the conversation open. `{reason}` is the matched classification's quoted description.
+At least one full review pass belongs to every discussion — this one cannot be skipped, only postponed by keeping the conversation open.
+
+#### If the classification is `findings-owed`
+
+Nothing new runs on `yes` — background findings have already come back, and Step 6 walks them. The gate says that plainly, so "another review" is never the reading the user answers to.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Background findings have come back and are still to be walked — they must be heard before concluding.
+Walk them now?
+
+**`y/yes`**      → Walk what came back
+**Keep going** → Tell me what else to explore
+```
+
+**STOP.** Wait for user response.
+
+**If `yes`:**
+
+→ Proceed to **E. In-Flight Agent Check**.
+
+**If keep going:**
+
+→ Return to caller for **B. Session Loop**.
+
+#### Otherwise
+
+`{reason}` is the matched classification's quoted description.
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-discussion-process/references/perspective-agents.md
+++ b/skills/workflow-discussion-process/references/perspective-agents.md
@@ -12,7 +12,7 @@ Signals:
 - Multiple defensible approaches with no clear winner
 - The user expresses uncertainty ("I'm not sure which...", "they both seem fine")
 - The domain has known competing paradigms (e.g., relational vs document, monolith vs microservices, sync vs async)
-- Explicit disagreement between orchestrator and user on the best approach
+- The user disputes a challenge and remains unsettled — a decisive answer to a challenge is settled, not disagreement
 
 Signals are read from the conversation, never from domain shape alone — a known competing-paradigm pair is not a trigger until the user has engaged the decision and the ambiguity has shown itself. Do not fire when the decision is straightforward, the tradeoffs are already well understood, or the user has already made a confident decision.
 


### PR DESCRIPTION
Second round from the confirmed FAIL of `discussion-runs-to-convergence` (both walks failed, different corridors — archives in session).

**closing-gates § C** served `findings-owed`, `review-running`, and `never-reviewed` with one block whose verb fits only the last two. For `findings-owed` nothing new runs — a review has already returned and Step 6 walks it — so "`y/yes` → Run the final review" invited exactly the decline the walk hit: a user whose reviews "already came back clean" refusing a further review that was never on offer, with neither arm able to route the answer (the walker recorded its own DEVIATION). The classification now gets its own branch naming the drain: "Background findings have come back and are still to be walked… `y/yes` → Walk what came back". The other two classifications keep the original wording via `{reason}`.

**perspective-agents.md** — the "Explicit disagreement between orchestrator and user" signal read a meeting-assistant challenge answered decisively as disagreement, offering polarity lenses to a flatly decisive user (the second distinct route to a premature offer; #851 closed the domain-shape route). The signal is now user-anchored: the user disputes a challenge **and remains unsettled** — a decisive answer to a challenge is settled, not disagreement.

Conventions lint + prose corpus green. Re-walk of the case reported in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)