### PR TITLE
feat(implementation): the executor runs at medium effort

### DIFF
--- a/agents/workflow-implementation-task-executor.md
+++ b/agents/workflow-implementation-task-executor.md
@@ -3,6 +3,7 @@ name: workflow-implementation-task-executor
 description: Implements a single task via TDD or verification workflow. Invoked by workflow-implementation-process skill for each task.
 tools: Read, Glob, Grep, Edit, Write, Bash
 model: opus
+effort: medium
 ---
 
 # Implementation Task Executor


### PR DESCRIPTION
Step 1 of the implementation-speed programme (design log: #853). Adds `effort: medium` to the executor agent's frontmatter — subagents previously inherited the session's effort (xhigh in measured Portal usage, ~75% of subagent time spent on inference). Reviewer unchanged at session effort; its bounce rate against the 31% baseline is the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)