### PR TITLE
fix(sessions): the review checkpoint respects a wrap-up signal, and waved-off tangents get no map entry

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -35,7 +35,7 @@ The discussion is an organic conversation. The Discussion Map is your tracking b
    node .claude/skills/workflow-engine/scripts/engine.cjs discussion-map add {work_unit} {topic} {subtopic} [--parent {parent}]
    ```
 
-   A concern that doesn't belong under this topic is not a subtopic — route it through **F. Off-Topic Concerns**.
+   A concern that doesn't belong under this topic is not a subtopic — route it through **F. Off-Topic Concerns**. A concern the user rules out of scope as it surfaces — settled when the work was shaped, not up for discussion — is neither: no map entry, no reroute; acknowledge and move on.
 3. **Navigate** — When a subtopic feels explored or a decision lands, record the transition and guide the user to what's still open:
 
    ```bash
@@ -85,7 +85,7 @@ You own transitions between subtopics. The goal is natural flow, not rigid seque
 
 **When a tangent surfaces a new concern:**
 
-Record it on the map as `pending` (`discussion-map add`, session loop step 2). If it's closely related to the current subtopic, it might become a child (`--parent`). If it's independent, it sits at the top level.
+Record it on the map as `pending` (`discussion-map add`, session loop step 2). If it's closely related to the current subtopic, it might become a child (`--parent`). If it's independent, it sits at the top level. A tangent the user waves out of scope gets no entry — acknowledge and move on.
 
 > "Good catch — I've added {new subtopic} to the map. Let's finish {current} first and we can pick that up after."
 

--- a/skills/workflow-discussion-process/references/review-agent.md
+++ b/skills/workflow-discussion-process/references/review-agent.md
@@ -13,6 +13,7 @@ These instructions are loaded into context at the start of the discussion sessio
 - □ Not the first commit? (the discussion needs enough content to review)
 - □ At least 2-3 conversational exchanges since the last review dispatch?
 - □ Triage queue empty? (`topic queue` shows `count: 0` — the session loop's triage check reads it each iteration; a queued rerouted concern is a pending change to this document, so a review dispatched over it is stale on arrival; self-healing like the drain block — the first meaningful commit after the queue empties re-fires the check)
+- □ The user hasn't signalled conclusion? (a wrap-up signal hands review duty to the closing gates — their final review covers the closing commit; a dispatch now lands `pending` at classification and forces a drain detour)
 
 **Why block on undrained reviews**: two reasons, both important. First, dispatching a fresh review while the prior review's findings are still being discussed produces stale analysis — the document will look different once those findings land, and the new review would be critiquing a version the user is already fixing. Second, the block is self-healing: the next meaningful commit after the current review drains to `incorporated` will naturally re-fire the trigger check and dispatch a fresh review, so no trigger is lost. If the session ends before drainage completes, the final review in Step 6 picks up the outstanding findings via the shared surfacing protocol.
 

--- a/skills/workflow-research-process/references/review-agent.md
+++ b/skills/workflow-research-process/references/review-agent.md
@@ -13,6 +13,7 @@ These instructions are loaded into context at the start of the research session.
 - □ Not the first commit? (the research needs enough content to review)
 - □ At least 2-3 conversational exchanges since the last review dispatch?
 - □ Triage queue empty? (`topic queue` shows `count: 0` — the session loop's triage check reads it each iteration; a queued rerouted concern is a pending change to the research, so a review dispatched over it is stale on arrival; self-healing like the drain block — the first meaningful commit after the queue empties re-fires the check)
+- □ The user hasn't signalled conclusion? (a wrap-up signal hands review duty to the final review at topic conclusion — it covers the closing commit; a dispatch now lands `pending` there)
 
 **Why block on undrained reviews**: two reasons, both important. First, dispatching a fresh review while the prior review's findings are still being explored produces stale analysis — the research will look different once those findings are incorporated, and the new review would be critiquing a version the user is already extending. Second, the block is self-healing: the next meaningful commit after the current review drains to `incorporated` will naturally re-fire the trigger check and dispatch a fresh review, so no trigger is lost. If the session ends before drainage completes, the final review at topic conclusion picks up the outstanding findings via the shared surfacing protocol.
 


### PR DESCRIPTION
Corridor pass on the conclusion path after `discussion-runs-to-convergence` failed twice post-#852, both times on new corridors.

**The race (root cause of both confirmation-walk failures):** session-loop's post-commit CHECKPOINT evaluates the review-agent trigger checklist after every commit — including the commit that documents the final decision in the same turn the user says "that covers it". The dispatched review is `pending` seconds later when closing-gates classifies, forcing `findings-owed` → the mandatory drain detour on every such run, and skipping the conclude gate the `satisfied` route renders. The conclusion flow's own final review exists precisely to cover that closing commit, so the racing dispatch bought nothing. Both review-agent checklists (discussion, research — identical checkpoint shape, verified) gain the missing box: the user hasn't signalled conclusion.

**The waved-off tangent:** the persona rules wallets out of scope on arrival ("cards only for v1, that was settled when the work was shaped"). Session-loop step 2 says record emerging concerns; F covers concerns whose home is another topic; nothing covered raised-and-ruled-out — walkers split on the gap (one WANDER, one FAIL promoting it to permanent map/document material). Both write sites (step 2, D. Navigation) now name the arm: no map entry, no reroute; acknowledge and move on.

**Settled without change:** whether the `findings-owed` drain path owes a conclude re-ask before Steps 7–9. It does not — final-review.md's own design statement routes the drained store to the backbone ("Step 6 returns to the backbone to proceed toward conclusion"), with Step 9's confirm as the universal gate before completion. The satisfied-route `D` ask is that route's courtesy, not a universal invariant.

Conventions lint + prose corpus green. Re-walk reported in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)