### PR TITLE
fix(implementation): executor continuation is attempted, never assumed unavailable

### DIFF
--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -30,7 +30,9 @@ Use **tdd-workflow.md** (`.claude/skills/workflow-implementation-process/referen
 
 #### If this is the current task's first executor dispatch
 
-Dispatch a **fresh** `workflow-implementation-task-executor` agent. Never continue an executor from an earlier task — the task content below is this task's complete framing, and an executor still carrying the previous task's context erodes that boundary.
+Dispatch a **fresh** `workflow-implementation-task-executor` agent via the Task tool. Never continue an executor from an earlier task — the task content below is this task's complete framing, and an executor still carrying the previous task's context erodes that boundary.
+
+The dispatch result names the new agent's id — keep it in session context; the task's later rounds (fix, retry, gate comment) continue this executor by that id.
 
 The dispatch includes these file paths:
 
@@ -47,13 +49,13 @@ A fresh dispatch starts with no memory — this payload is everything the execut
 
 #### If an executor already ran for the current task (fix round, retry, or gate comment)
 
-Continue that same executor — it already holds the task, the codebase context it explored, and the code it wrote. Send only the round's new material:
+Continue that same executor — it already holds the task, the codebase context it explored, and the code it wrote. Send the round's material to the executor's recorded agent id with the SendMessage tool; when SendMessage is not among the active tools, load it first (ToolSearch, query `select:SendMessage`). Unavailability is proven by a failed send, never assumed — do not fall back because the tool needed loading or the continuation seems uncertain. Send only the round's new material:
 
 - **Fix round (from E or F)**: the review notes as approved — verbatim, or as the user modified them — and the ISSUES to address; on F `comment`, the user's commentary as well
 - **Task-gate comment (from G)**: the user's feedback
 - **Retry (from C)**: the user's comments
 
-If the task's executor is no longer available — a context refresh or session restart since its dispatch — dispatch a fresh executor with items 1–6 above plus the round's material as items 7 (**User-approved review notes**: verbatim or as modified by the user) and 8 (**Specific issues to address**: the ISSUES from the review); the full payload restores everything the continued executor would have held. When the conversation no longer holds the round's material, read it from the latest `## Attempt {N}` section of the task's fix tracking file (`.workflows/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md`).
+If the send fails — the recorded id no longer resolves, or a context refresh dropped it — dispatch a fresh executor with items 1–6 above plus the round's material as items 7 (**User-approved review notes**: verbatim or as modified by the user) and 8 (**Specific issues to address**: the ISSUES from the review); the full payload restores everything the continued executor would have held. When the conversation no longer holds the round's material, read it from the latest `## Attempt {N}` section of the task's fix tracking file (`.workflows/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md`).
 
 → Proceed to **Expected Result**.
 


### PR DESCRIPTION
Transcript evidence from Portal (both the live theming-system session and the phase-4 replay) shows the fix-round continuation path in `invoke-executor.md` has never fired: the orchestrator, finding no callable SendMessage in its active toolset, declares the executor unavailable and takes the fresh-dispatch fallback — one replay prompt literally opens "SendMessage to agent … is unavailable — treat this as a continuation".

Three prose changes:
- First-dispatch branch records the agent id from the dispatch result for the task's later rounds.
- Continuation branch names the mechanism: SendMessage to the recorded id, ToolSearch-loading the schema when it isn't active.
- The fallback now triggers on a failed send only — unavailability is proven, never assumed.

Intersecting prose cases (pin `invoke-executor.md`): `implementation-executes-the-loop`, `implementation-loops-on-auto` — worth a walk when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)