### PR TITLE
fix(prose-tests): a clipped record says unproven, never never-ran

### DIFF
--- a/tests/prose/lib/invariants.cjs
+++ b/tests/prose/lib/invariants.cjs
@@ -141,12 +141,26 @@ function engineBeforeWrite(rows) {
   return { ok: true, detail: 'every workflow write followed an engine call' };
 }
 
+// The recorder caps the detail column to keep the asserter's prompt
+// bounded, and marks every cut. A cut falls on the tail — where a
+// command's distinguishing flags live — so a needle absent from a clipped
+// record is unanswered, not answered "no". Saying "never ran" there
+// reports a walk's failure for a recorder's limit, on the one check that
+// is supposed to rest on no judgement.
+const CLIPPED = '…[truncated]';
+
 function callsInclude(rows, wanted) {
   const ran = commands(rows);
   const missing = wanted.filter((w) => !ran.some((c) => ranMatch(c, w)));
-  return missing.length
-    ? { ok: false, detail: `never ran: ${missing.join(', ')}` }
-    : { ok: true, detail: `ran all of: ${wanted.join(', ')}` };
+  if (!missing.length) return { ok: true, detail: `ran all of: ${wanted.join(', ')}` };
+  const clipped = ran.filter((c) => c.includes(CLIPPED));
+  return clipped.length
+    ? {
+      ok: false,
+      detail: `unproven — the record is clipped, so these are unfindable rather than absent: ${missing.join(', ')}`
+        + ` (${clipped.length} clipped row${clipped.length === 1 ? '' : 's'})`,
+    }
+    : { ok: false, detail: `never ran: ${missing.join(', ')}` };
 }
 
 function callsExclude(rows, forbidden) {

--- a/tests/scripts/test-prose-invariants.cjs
+++ b/tests/scripts/test-prose-invariants.cjs
@@ -122,6 +122,28 @@ describe('calls_include / calls_exclude', () => {
     assert.equal(invariants.check(rows, { calls_include: ['task init', 'boot'] })[0].ok, true);
   });
 
+  it('says unproven, not never-ran, when the record was clipped', () => {
+    // Measured: a two-seed promotion recorded past the detail cap lost its
+    // second --seed, and the check reported never-ran on a call whose own
+    // response listed both seeds landed. The cut falls on the tail, which
+    // is where a command's distinguishing flags live.
+    const rows = [bash(`${ENGINE} workunit create saved-filters feature --seed .workflows/.inbox/idea…[truncated]`)];
+    const [result] = invariants.check(rows, { calls_include: ['--seed .workflows/.inbox/ideas/b.md'] });
+    assert.equal(result.ok, false, 'still not a pass — the record cannot answer');
+    assert.match(result.detail, /unproven/, 'named as unanswered');
+    assert.ok(!result.detail.includes('never ran'), 'never asserts a walk omission it cannot see');
+    assert.match(result.detail, /1 clipped row/, 'points at how much of the record is unreadable');
+  });
+
+  it('still says never-ran when the record is whole', () => {
+    // The clipped branch must not swallow real omissions: no marker
+    // anywhere means absence is absence.
+    const rows = [bash(`${ENGINE} boot`)];
+    const [result] = invariants.check(rows, { calls_include: ['task init'] });
+    assert.match(result.detail, /never ran: task init/);
+    assert.ok(!result.detail.includes('unproven'));
+  });
+
   it('fails when a forbidden command ran — the walk went too far', () => {
     const rows = [bash(`${ENGINE} task init pay pay`), bash(`${ENGINE} task start pay pay`)];
     const [result] = invariants.check(rows, { calls_exclude: ['task start'] });


### PR DESCRIPTION
Found by running the prose corpus: `start-promotes-inbox-ideas` came back FLAKY, failing `calls_include` on a `--seed` flag that the same call's own recorded response showed had landed.

## What happened

The recorder caps the detail column (`record-action.cjs:57-65`) to keep the asserter's prompt bounded, and marks every cut with `…[truncated]`. But the cut falls on the **tail** — where a command's distinguishing flags live. A two-seed `workunit create` recorded past the cap reads as one seed, and `calls_include` reported never-ran on a call the walk performed.

## Why the fix is in the check, not the recorder

My first attempt removed the cap. That was wrong, and the existing tests said so: `truncates a genuinely enormous command with the marker` and `a command exactly at the cap is kept whole` both pin the bound deliberately, and the recorder's own comment explains it — the caps protect the asserter's prompt, which every recorded action is read into.

So the cap is not the defect. **The checks ignoring its marker is.** A needle absent from a clipped record is *unanswered*, not answered "no" — and reporting a walk's omission for a recorder's limit is precisely what the deterministic checks exist not to do, being the one part of a verdict that rests on no judgement.

`calls_include` now separates the two cases:
- miss against a record carrying `…[truncated]` → **unproven**, naming how many rows are unreadable
- miss against a whole record → **never ran**, unchanged

## Verification

`npm test` — 2018 pass, 0 fail (2016 before, plus the two new cases below).

Two tests added to `test-prose-invariants.cjs`: the clipped-record branch, and a guard that the new branch does not swallow genuine omissions when no marker is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)