### PR TITLE
fix(prose-tests): a search argument is not the call it names

### DIFF
--- a/tests/prose/lib/invariants.cjs
+++ b/tests/prose/lib/invariants.cjs
@@ -90,8 +90,30 @@ function undeclaredProse(rows, declared) {
 }
 
 /** The commands the walk ran, in order. */
+// Searching for a string is not running it. A walker greps the repo to
+// orient itself — `grep -rl "topic triage" .claude/skills` — and because
+// both sides of a match drop quotes, that search argument is
+// indistinguishable from the call it names. A case failed `calls_exclude`
+// on a command no walk ran, and the asserter could see the string was
+// only ever a grep argument while being unable to overturn a computed
+// check. So a statement that is a search leaves the substrate.
+//
+// Only whole statements go — a pipeline like `engine … | grep foo` still
+// ran the engine call at its head, and dropping the row would trade this
+// false positive for a false negative.
+const SEARCH_HEAD = /^(grep|egrep|fgrep|rg|ag|find)\b/;
+
+function withoutSearches(detail) {
+  return detail
+    .split(/\s*(?:&&|;)\s*/)
+    .filter((segment) => !SEARCH_HEAD.test(segment.trim()))
+    .join(' && ');
+}
+
 function commands(rows) {
-  return rows.filter((r) => r.tool === 'Bash' && r.event === 'PreToolUse').map((r) => r.detail);
+  return rows
+    .filter((r) => r.tool === 'Bash' && r.event === 'PreToolUse')
+    .map((r) => withoutSearches(r.detail));
 }
 
 /**

--- a/tests/scripts/test-prose-invariants.cjs
+++ b/tests/scripts/test-prose-invariants.cjs
@@ -144,6 +144,28 @@ describe('calls_include / calls_exclude', () => {
     assert.ok(!result.detail.includes('unproven'));
   });
 
+  it('does not count a grep argument as the call it names', () => {
+    // Measured: a walk grepped the repo to orient — the string appeared
+    // only inside the search pattern — and calls_exclude reported it as
+    // run. Quotes are stripped on both sides of a match, so the argument
+    // and the invocation look identical.
+    const rows = [bash('cd . && grep -rl "topic triage" .claude/skills')];
+    const [result] = invariants.check(rows, { calls_exclude: ['topic triage'] });
+    assert.equal(result.ok, true, 'searching for a call is not running it');
+  });
+
+  it('still sees a real call in a statement alongside a search', () => {
+    const rows = [bash(`grep -n triage docs.md && ${ENGINE} topic triage pay discussion pay`)];
+    const [result] = invariants.check(rows, { calls_exclude: ['topic triage'] });
+    assert.equal(result.ok, false, 'the engine call is still there to find');
+  });
+
+  it('keeps a command that merely pipes into a search', () => {
+    // The head of the pipeline ran; only whole search statements go.
+    const rows = [bash(`${ENGINE} task init pay pay | grep ok`)];
+    assert.equal(invariants.check(rows, { calls_include: ['task init'] })[0].ok, true);
+  });
+
   it('fails when a forbidden command ran — the walk went too far', () => {
     const rows = [bash(`${ENGINE} task init pay pay`), bash(`${ENGINE} task start pay pay`)];
     const [result] = invariants.check(rows, { calls_exclude: ['task start'] });


### PR DESCRIPTION
Second false-negative found by running the prose corpus. Stacked on #858 — same file, distinct defect.

`start-verifies-a-migration-straggler` failed `calls_exclude` on `topic triage`, reporting "ran what it should not have" for a call **no walk ran**. The string appeared only inside a walker's orientation grep:

```
grep -rl "topic triage" .claude/skills
```

Because `bare()` strips quotes from both sides of a match — deliberately, so dotpath quoting can't decide a verdict — a search argument and the invocation it names become identical.

Worth noting how it surfaced: the asserter *did* spot it, recording that the string "only ever appeared as a grep argument", and correctly refused to overturn a computed check. That division of labour is right, which is exactly why the check has to be correct on its own.

## The fix

A statement that is a search leaves the substrate the call checks match against.

Only **whole statements** go. A pipeline like `engine … | grep foo` still ran the engine call at its head, so dropping the whole row would trade this false positive for a false negative — the split is on `&&` and `;`, never `|`.

## Verification

`npm test` — 2021 pass, 0 fail.

Three tests added: the grep-argument case, a statement carrying both a search and a real call (still caught), and a pipeline into a search (still counted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)