### PR TITLE
fix(specification): the review's phase statuses are held, not recorded

### DIFF
--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -118,7 +118,7 @@ Dispatch the `workflow-specification-review-input` agent via the Task tool:
 
 > **CHECKPOINT**: Do not proceed until the agent has returned its result.
 
-Record its STATUS as `phase_1_status`.
+Hold its STATUS as `phase_1_status` — carried in context for the branch below, never a manifest write.
 
 **If the agent created a tracking file**, record it in progress (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} tracking.{file stem} in-progress`) and commit it:
 
@@ -145,7 +145,7 @@ Dispatch the `workflow-specification-review-gap-analysis` agent via the Task too
 
 > **CHECKPOINT**: Do not proceed until the agent has returned its result.
 
-Record its STATUS as `phase_2_status`.
+Hold its STATUS as `phase_2_status` — carried in context for the branch below, never a manifest write.
 
 **If the agent created a tracking file**, record it in progress (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} tracking.{file stem} in-progress`) and commit it:
 


### PR DESCRIPTION
Found by the corpus run, and the only prose fix that survived the filter — it reproduced.

`spec-completes-the-cross-cutting` and `spec-extracts-the-discussion` — different fixtures, different work units — both narrated *"Recording `phase_1_status` = `clean`"* with no corresponding manifest write anywhere in the record. One asserter flagged it as "the shape a missed write would take".

## There is no missed write

`phase_1_status` and `phase_2_status` appear **nowhere outside this file** — no manifest field, no engine verb, no test. They are values carried in context for the branch at `#### If \`phase_1_status\` is \`clean\` and \`phase_2_status\` is \`clean\`` that reads them.

## The ambiguity is the verb

```
:121   Record its STATUS as `phase_1_status`.          ← no write
:123   record it in progress (`… manifest set …`)      ← a write
```

Same word, two meanings, two lines apart. Both walks read the first as an instruction to write. Two independent walkers reaching the same wrong reading is the prose talking, not walker variance.

Both sites now say what they mean and name what they are not. Behaviour is unchanged — this removes a narration artifact, not a defect.

## Verification

`npm test` — 2016 pass, 0 fail.

`select --diff main` returns the three cases that walk this file: `spec-completes-the-cross-cutting`, `spec-extracts-the-discussion`, `bridge-hands-off-to-planning`. All three already PASSed *before* this change — the misreading never failed a case, it only made the walks claim something they hadn't done. So a re-walk would not evidence the fix either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)