### PR TITLE
feat(formats): each format's reading.md owns its display identifier

### DIFF
--- a/.claude/skills/create-output-format/references/contract.md
+++ b/.claude/skills/create-output-format/references/contract.md
@@ -55,6 +55,7 @@ Instructions for extracting tasks and determining work order.
 
 Must include:
 
+- **Display Identifier** — the task identifier shown beside the internal id in user-facing displays, and how to obtain it — or an explicit `None.` when the format's external ids are machine handles (UUIDs, file paths) a person would not recognise.
 - **Listing Tasks** — how to retrieve all tasks for a plan. Returns summary-level information (id, title, status, phase, priority, dependencies) suitable for building a task graph or overview. Format-specific filtering and query capabilities may be documented here.
 - **Extracting a Task** — how to read full task detail including all properties
 - **Next Available Task** — how to determine the next task to work on. Document how the format uses status, priority, dependencies, and phase ordering to determine sequence.

--- a/.claude/skills/create-output-format/references/scaffolding/reading.md
+++ b/.claude/skills/create-output-format/references/scaffolding/reading.md
@@ -2,6 +2,12 @@
 
 <!-- Instructions for extracting tasks and determining work order -->
 
+## Display Identifier
+
+<!-- The task identifier shown beside the internal id in user-facing displays — or an explicit None when the format's external ids are machine handles (UUIDs, file paths) -->
+
+{How to obtain the display identifier, or "None." with a one-line reason}
+
 ## Listing Tasks
 
 <!-- How to retrieve all tasks for a plan with summary-level data -->

--- a/skills/workflow-implementation-process/references/display-task-result.md
+++ b/skills/workflow-implementation-process/references/display-task-result.md
@@ -22,7 +22,7 @@ Write the payload to `.workflows/.cache/{work_unit}/implementation/{topic}/task-
 
 - `phase` — the task's plan phase, number and name, from the normalised task content (its `PHASE` line).
 - `position` — the in-phase ordinal from the same stage-A listing; omit the field when the listing did not yield the counts.
-- `external` — the plan's display identifier: the `task_map` entry for this internal id (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map`), labelled with the plan's `format` value. Include it only when the mapped id differs from the internal id and is a key a person would recognise — never a UUID or a file path; omit the field otherwise.
+- `external` — the plan format's display identifier, obtained as its **reading.md** → Display Identifier section instructs, labelled with the plan's `format` value. Omit the field when the format declares none.
 
 Render and emit its `DISPLAY: task result` section verbatim at its marked instruction:
 

--- a/skills/workflow-planning-process/references/output-formats/linear/reading.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/reading.md
@@ -9,6 +9,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map
 ```
 
+## Display Identifier
+
+None. `task_map` holds issue UUIDs — machine handles, not identifiers a person recognises. User-facing task displays show the internal id alone.
+
 ## Listing Tasks
 
 To retrieve all tasks for a plan:

--- a/skills/workflow-planning-process/references/output-formats/local-markdown/reading.md
+++ b/skills/workflow-planning-process/references/output-formats/local-markdown/reading.md
@@ -1,5 +1,9 @@
 # Local Markdown: Reading
 
+## Display Identifier
+
+None. The internal id is the task's only identifier; user-facing task displays show it alone.
+
 ## Listing Tasks
 
 To retrieve all tasks for a plan:

--- a/skills/workflow-planning-process/references/output-formats/tick/reading.md
+++ b/skills/workflow-planning-process/references/output-formats/tick/reading.md
@@ -11,6 +11,14 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 `tick list` output does not include refs — correlate internal IDs through `task_map`, or use `tick show <tick-id>` to see a single task's refs.
 
+## Display Identifier
+
+The identifier shown beside the internal id in user-facing task displays is the task's tick id — the plan's `task_map` entry for the internal id:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} task_map.{internal_id}
+```
+
 ## Listing Tasks
 
 To retrieve all tasks for a topic:


### PR DESCRIPTION
Replaces the task-result header's judgment guard ("a key a person would recognise") with a mechanical, format-owned declaration: each format's `reading.md` gains a **Display Identifier** section (tick: the `task_map` entry via a single-key read; linear and local-markdown: `None.`), and `display-task-result.md`'s `external` field follows the declaration. Kills the dead `task_map` read on formats without one. Contract + scaffold updated so new formats must declare it.

Gates: `npm test` 2028 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)