### PR TITLE
fix(engine): the blocked-tasks skip option says what one press does

### DIFF
--- a/skills/workflow-engine/scripts/domain/projections/tasks.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/tasks.cjs
@@ -45,7 +45,7 @@ function blockedTasksMenu() {
     MENU_INSTRUCTION,
     menu('How would you like to proceed?', [
       cmdOption('p', 'proceed', 'Continue with the first blocked task anyway (its blocker will not be completed)'),
-      cmdOption('s', 'skip', 'Skip the blocked tasks and conclude the loop'),
+      cmdOption('s', 'skip', 'Skip the first blocked task (the loop re-checks the rest)'),
       cmdOption('t', 'stop', 'Stop implementation entirely'),
     ]),
   );

--- a/tests/scripts/test-engine-tasks.cjs
+++ b/tests/scripts/test-engine-tasks.cjs
@@ -687,7 +687,7 @@ describe('engine render task surfaces', () => {
     '**\`◆ How would you like to proceed?\`**',
     '',
     '**`p/proceed`** → Continue with the first blocked task anyway (its blocker will not be completed)',
-    '**`s/skip`**    → Skip the blocked tasks and conclude the loop',
+    '**`s/skip`**    → Skip the first blocked task (the loop re-checks the rest)',
     '**`t/stop`**    → Stop implementation entirely',
     '',
   ].join('\n');


### PR DESCRIPTION
## What

Pre-existing copy defect the review pass surfaced: the blocked-tasks menu's `s/skip` label promised "Skip the blocked tasks and conclude the loop", but the prose it fronts (`task-loop.md`) skips the **first** blocked task, loops back to retrieval, and re-presents the menu while blocked tasks remain — one decision per task, each routed through the normal mark-skipped-and-commit stage. The mismatch dates to the menu's codification into the engine (#458): the flow has always been one-at-a-time.

## How

The label now reads "Skip the first blocked task (the loop re-checks the rest)" — matching the flow rather than changing the flow, which would have needed batch-skip machinery the loop never had and would take away the per-task decision. Exactly two sites carried the old copy (the engine string and its byte-pinned test); both updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)