### PR TITLE
Two discussion cases declare the resume path's Step 1 read

### DIFF
--- a/tests/prose/cases/discussion-applies-a-settled-batch/case.json
+++ b/tests/prose/cases/discussion-applies-a-settled-batch/case.json
@@ -15,6 +15,7 @@
     "skills/workflow-discussion-entry/references/invoke-skill.md",
     "skills/workflow-discussion-process/SKILL.md",
     "skills/workflow-shared/references/resume-detection.md",
+    "skills/workflow-discussion-process/references/initialize-discussion.md",
     "skills/workflow-discussion-process/references/discussion-guidelines.md",
     "skills/workflow-discussion-process/references/meeting-assistant.md",
     "skills/workflow-discussion-process/references/guidelines.md",

--- a/tests/prose/cases/discussion-documents-a-decide-batch/case.json
+++ b/tests/prose/cases/discussion-documents-a-decide-batch/case.json
@@ -15,6 +15,7 @@
     "skills/workflow-discussion-entry/references/invoke-skill.md",
     "skills/workflow-discussion-process/SKILL.md",
     "skills/workflow-shared/references/resume-detection.md",
+    "skills/workflow-discussion-process/references/initialize-discussion.md",
     "skills/workflow-discussion-process/references/discussion-guidelines.md",
     "skills/workflow-discussion-process/references/meeting-assistant.md",
     "skills/workflow-discussion-process/references/guidelines.md",


### PR DESCRIPTION
Both real walks of `discussion-documents-a-decide-batch` and `discussion-applies-a-settled-batch` opened `initialize-discussion.md` while orienting at the resume gate (one WANDER, self-corrected; one INERT read). The `files` list is a ratchet harvested from real traversals — this declares the read in both cases so scope reporting and future selection see it. No snapshot changes: `case.json` is not part of the fixture recipe. Corpus validation + snapshot goldens green (69/69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)