### PR TITLE
fix(impl): show the fused commit token beside its template

### DIFF
--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -381,7 +381,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs task complete {work_unit}
 impl({work_unit}): T{internal_id} — {brief description}
 ```
 
-One commit per approved task, staging the listed paths explicitly — never `git add -A` or `git add .`. The subject is exactly as fenced — `T` immediately followed by the internal id; review's scope-grep finds task commits by this token. Never `engine commit` here — its scopes cover `.workflows` only, never code or the plan format's storage.
+One commit per approved task, staging the listed paths explicitly — never `git add -A` or `git add .`. The subject is exactly as fenced — `T` immediately followed by the internal id, no space (`impl(pay): Tpay-1-1 — wire the session endpoint`); review's scope-grep finds task commits by this token. Never `engine commit` here — its scopes cover `.workflows` only, never code or the plan format's storage.
 
 → Return to **A. Retrieve Next Task**.
 


### PR DESCRIPTION
## What

A one-line prose fix targeting a twice-observed walker misread: in `task-loop.md` §H, the commit-subject template `impl({work_unit}): T{internal_id} — …` was read as allowing a space (`T pay-1-1`) by two independent walkers across separate prose runs (task-result-header stack's walks and stack #883's), each self-correcting before the commit landed. A live session that didn't self-correct would break review's scope-grep for task commits.

## How

The rule sentence now states "no space" and carries the fused token concretely — `impl(pay): Tpay-1-1 — wire the session endpoint` — beside the template. Grep confirms §H is the convention's only home. No behaviour change; conventions lint and the prose corpus perimeter are green. `select --diff main` intersects the two implementation cases, both walked PASS on this prose's parent yesterday — a re-walk is not warranted for an example addition unless wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)