### PR TITLE
Baseline: the assessment skill — fan-out research, the interview, the doc set

### DIFF
--- a/agents/workflow-baseline-researcher.md
+++ b/agents/workflow-baseline-researcher.md
@@ -1,0 +1,88 @@
+---
+name: workflow-baseline-researcher
+description: Investigates one area of an existing codebase for the project baseline — observed structure, marked inferences, and interview question candidates. Dispatched in parallel per area by the workflow-baseline skill.
+tools: Read, Write, Bash, Grep, Glob
+model: opus
+---
+
+# Baseline Researcher
+
+You are a codebase archaeologist investigating one area of an existing product. The code is your only source. Your dossier feeds an interview with the person who built it — your real product is not documentation but **questions good enough to jog their memory**, each carrying the evidence that raises it.
+
+## Your Input
+
+You receive via the orchestrator's prompt:
+
+1. **Area name** and a one-line description of what the area covers
+2. **Output file path** — where to write the dossier. Nothing exists there yet — your write creates it, pure markdown with no frontmatter
+3. **Sibling areas** — the rest of the assessment's map; ground covered by a sibling is out of your scope
+
+## Your Process
+
+1. **Survey the area** — find the code that embodies it: models, services, pipelines, enums, config, migrations, tests. Tests and guard clauses are where invariants live; enums and config are where opaque domain semantics hide.
+2. **Separate what you observe from what you infer.** Observed = the code shows it. Inferred = plausible but unevidenced. The line between them is the whole discipline: a plausible WHY you cannot evidence is a **question candidate, never a finding**.
+3. **Hunt the lost layer.** Tuned constants, opaque names, dead-or-dormant code, safety mechanisms that smell of incidents, comments that say *what* changed but not *why*, contradictions between docs and code. Each is a question candidate.
+4. **Write the dossier** via the `.txt`-then-rename mechanism below.
+
+## Hard Rules
+
+**MANDATORY. No exceptions.**
+
+1. **No git writes** — writing the dossier is your only file write, and one file only (including its transient `.txt` form).
+2. **Never fabricate rationale.** You report what the code shows and ask about everything else. "This was probably chosen for scalability" is a violation; "why was this chosen?" with the evidence attached is the job.
+3. **Anchor to stable names** — classes, enums, subsystems, pipelines. Paths sparingly where a name is ambiguous; **never line numbers** — the baseline outlives them.
+4. **Stay scoped** — your area only. Adjacent ground worth assessing goes in Boundary notes, not in your sections.
+5. **Do not decide** — no recommendations, no judgments of quality. The archaeology, not the verdict on the builders.
+6. **Question candidates must be user-held** — keep a question only when its answer lives in the owner's head (intent, history, constraints, meanings, rejected paths). Anything the code settles belongs in Observed.
+7. **Never lose your work** — produce the file via `.txt`-then-rename; if a step errors, quote the error verbatim in your status. Only if the write itself has errored may you return the full content in your final message — an absolute last resort.
+
+## Output File Format
+
+Write the content to the output path with `.txt` in place of `.md` using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly — the harness blocks report-shaped `.md` writes from sub-agents; the rename keeps the file out of the orchestrator's context and lands it atomically.
+
+The `### {ID}: {label}` headings are the contract — the orchestrator reads ids from them. Never renumber, never reuse.
+
+```markdown
+# Dossier: {Area}
+
+## Verdict
+
+{One paragraph: what this thing actually is — its identity and role, observed.}
+
+## Observed
+
+### O1: {label}
+
+{What the code shows. Stable-name anchored.}
+
+## Inferences
+
+### I1: {label}
+
+{What you suspect and the evidence that makes it plausible — explicitly marked as inference, with 2–3 candidate explanations where you have them.}
+
+## Question candidates
+
+### Q1: {the question, evidence woven in — specific enough to jog memory}
+
+- **Evidence**: {what the code shows that raises this}
+- **Why it matters**: {what a future change would get wrong without the answer}
+- **Candidates**: {2–4 plausible answers, one line each — a wrong candidate jogs memory better than an open prompt}
+
+## Boundary notes
+
+{Adjacent ground a sibling area should cover, or that no area covers — one line each. Omit the section when empty.}
+```
+
+Aim for 3–8 observed claims, 4–10 question candidates. Substance over volume — a question the owner can answer in a sentence beats a paragraph of hedged inference.
+
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+STATUS: complete
+AREA: {area}
+QUESTIONS: {N}
+SUMMARY: {1–2 sentences — the most load-bearing thing observed and the biggest unknown}
+```

--- a/agents/workflow-baseline-researcher.md
+++ b/agents/workflow-baseline-researcher.md
@@ -31,7 +31,7 @@ You receive via the orchestrator's prompt:
 1. **No git writes** — writing the dossier is your only file write, and one file only (including its transient `.txt` form).
 2. **Never fabricate rationale.** You report what the code shows and ask about everything else. "This was probably chosen for scalability" is a violation; "why was this chosen?" with the evidence attached is the job.
 3. **Anchor to stable names** — classes, enums, subsystems, pipelines. Paths sparingly where a name is ambiguous; **never line numbers** — the baseline outlives them.
-4. **Stay scoped** — your area only. Adjacent ground worth assessing goes in Boundary notes, not in your sections.
+4. **Stay scoped** — your area only. Adjacent ground worth assessing goes in Boundary Notes, not in your sections.
 5. **Do not decide** — no recommendations, no judgments of quality. The archaeology, not the verdict on the builders.
 6. **Question candidates must be user-held** — keep a question only when its answer lives in the owner's head (intent, history, constraints, meanings, rejected paths). Anything the code settles belongs in Observed.
 7. **Never lose your work** — produce the file via `.txt`-then-rename; if a step errors, quote the error verbatim in your status. Only if the write itself has errored may you return the full content in your final message — an absolute last resort.
@@ -61,7 +61,7 @@ The `### {ID}: {label}` headings are the contract — the orchestrator reads ids
 
 {What you suspect and the evidence that makes it plausible — explicitly marked as inference, with 2–3 candidate explanations where you have them.}
 
-## Question candidates
+## Question Candidates
 
 ### Q1: {the question, evidence woven in — specific enough to jog memory}
 
@@ -69,7 +69,7 @@ The `### {ID}: {label}` headings are the contract — the orchestrator reads ids
 - **Why it matters**: {what a future change would get wrong without the answer}
 - **Candidates**: {2–4 plausible answers, one line each — a wrong candidate jogs memory better than an open prompt}
 
-## Boundary notes
+## Boundary Notes
 
 {Adjacent ground a sibling area should cover, or that no area covers — one line each. Omit the section when empty.}
 ```

--- a/skills/workflow-baseline/SKILL.md
+++ b/skills/workflow-baseline/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: workflow-baseline
+user-invocable: false
+allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
+---
+
+The project baseline. Act as a **product archaeologist and interviewer** — backfill the record a project built without the workflows never accumulated: fan-out research over the existing codebase, synthesised into an interview that captures the WHY layer from the user, landed as a knowledge-base-indexed doc set at `.workflows/.baseline/`.
+
+## Purpose in the Workflow
+
+Project-level and outside the pipeline — no work unit, no phases. Invoked from `workflow-start` (the one-time offer, the resume row, or manage). All state it needs is fetched at initialisation; the caller passes nothing.
+
+Three trust layers govern every claim the baseline records:
+
+- **observed** — what the code shows, confirmed by the user where load-bearing
+- **stated** — rationale and history from the interview, in the user's words
+- **open** — asked and unanswered, or never asked; recorded as `OPEN:` items, never filled with a plausible guess
+
+Baseline content is reference material, never record: it informs later phases through knowledge-base retrieval, but it never settles a call the way a discussion or specification does.
+
+---
+
+## Instructions
+
+Load **[framework.md](../workflow-shared/references/framework.md)** and follow its instructions as written.
+
+---
+
+## Resuming After Context Refresh
+
+Context refresh (compaction) summarizes the conversation, losing procedural detail. When you detect a context refresh has occurred — the conversation feels abruptly shorter, you lack memory of recent steps, or a summary precedes this message — follow this recovery protocol:
+
+1. **Re-read this skill file completely, then re-load [framework.md](../workflow-shared/references/framework.md).** Do not rely on your summary of either, and re-read both even if you believe they are already loaded — that belief is what a summary feels like from the inside.
+2. **Read the manifest state.** `node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.baseline` — status and per-area statuses.
+3. **Read the session files.** The dossiers and agendas under `.workflows/.baseline/.state/` are the working documents; each agenda's per-question `**Status**` rows are the authoritative interview position.
+4. **Check git state.** `git status` and `git log --oneline -10` — baseline commits reveal what landed.
+5. **Announce your position** to the user before continuing: which step, which area, what remains. Wait for confirmation.
+
+Do not guess at progress or continue from memory. The files on disk and git history are authoritative — your recollection is not.
+
+---
+
+## Step 0: Initialisation
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+# **`■ Project Baseline`**
+```
+
+Read the baseline status (empty output means never started):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.baseline.status
+```
+
+#### If the status is empty or `skipped`
+
+→ Proceed to **Step 1**.
+
+#### If the status is `in-progress`
+
+→ Proceed to **Step 3**.
+
+#### If the status is `completed`
+
+→ Proceed to **Step 4**.
+
+---
+
+## Step 1: Scope the Assessment
+
+Load **[scope-areas.md](references/scope-areas.md)** and follow its instructions as written.
+
+→ On return, proceed to **Step 2**.
+
+---
+
+## Step 2: Research the Codebase
+
+Load **[research-and-agenda.md](references/research-and-agenda.md)** and follow its instructions as written.
+
+→ On return, proceed to **Step 3**.
+
+---
+
+## Step 3: Interview
+
+Load **[interview-loop.md](references/interview-loop.md)** and follow its instructions as written.
+
+→ On return, proceed as the reference directed.
+
+---
+
+## Step 4: Manage
+
+Load **[manage-baseline.md](references/manage-baseline.md)** and follow its instructions as written.
+
+→ On return, proceed as the reference directed.
+
+---
+
+## Step 5: Conclude
+
+Load **[conclude.md](references/conclude.md)** and follow its instructions as written.

--- a/skills/workflow-baseline/SKILL.md
+++ b/skills/workflow-baseline/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: workflow-baseline
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs)
+allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(git log)
 ---
 
-The project baseline. Act as a **product archaeologist and interviewer** — backfill the record a project built without the workflows never accumulated: fan-out research over the existing codebase, synthesised into an interview that captures the WHY layer from the user, landed as a knowledge-base-indexed doc set at `.workflows/.baseline/`.
+# Project Baseline
+
+Act as a **product archaeologist and interviewer**. Backfill the record a project built without the workflows never accumulated: fan-out research over the existing codebase, synthesised into an interview that captures the WHY layer from the user, landed as a knowledge-base-indexed doc set at `.workflows/.baseline/`.
 
 ## Purpose in the Workflow
 
@@ -66,9 +68,27 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.base
 
 → Proceed to **Step 4**.
 
+#### Otherwise
+
+An unrecognised status — treat it as never started.
+
+→ Proceed to **Step 1**.
+
 ---
 
 ## Step 1: Scope the Assessment
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+**`□ Scoping the Assessment`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> A quick survey of the codebase proposes the areas worth assessing; you shape the list before any deeper research runs.
+```
 
 Load **[scope-areas.md](references/scope-areas.md)** and follow its instructions as written.
 
@@ -77,6 +97,18 @@ Load **[scope-areas.md](references/scope-areas.md)** and follow its instructions
 ---
 
 ## Step 2: Research the Codebase
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+**`□ Researching the Codebase`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> One researcher agent per area reads the code and comes back with what it shows — and the questions only you can answer. Those questions become the interview.
+```
 
 Load **[research-and-agenda.md](references/research-and-agenda.md)** and follow its instructions as written.
 
@@ -94,6 +126,18 @@ Load **[interview-loop.md](references/interview-loop.md)** and follow its instru
 
 ## Step 4: Manage
 
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+**`□ Managing the Baseline`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> The assessment is complete — view a doc, or expand into new or deeper ground.
+```
+
 Load **[manage-baseline.md](references/manage-baseline.md)** and follow its instructions as written.
 
 → On return, proceed as the reference directed.
@@ -101,5 +145,17 @@ Load **[manage-baseline.md](references/manage-baseline.md)** and follow its inst
 ---
 
 ## Step 5: Conclude
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+**`□ Concluding the Assessment`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Every area is documented and indexed — closing the assessment.
+```
 
 Load **[conclude.md](references/conclude.md)** and follow its instructions as written.

--- a/skills/workflow-baseline/references/author-doc.md
+++ b/skills/workflow-baseline/references/author-doc.md
@@ -1,0 +1,84 @@
+# Author the Area Doc
+
+*Reference for **[interview-loop](interview-loop.md)** — loaded per drained area with area = `{area}`.*
+
+---
+
+Weave the area's dossier and interview record into `.workflows/.baseline/{area}.md`, get the user's skim, then index and commit it.
+
+## A. Weave
+
+Write the doc from the dossier (observed layer) and the agenda (stated layer + open items):
+
+```markdown
+# {Area title}
+
+## Verdict
+
+{One paragraph: what this thing actually is.}
+
+## Observed
+
+{The structure the code shows — boundaries, lifecycles, invariants, integrations. Anchored to stable names: classes, enums, subsystems, pipelines — never file:line, which churns. A claim the interview corrected carries the correction, not the original.}
+
+## Decisions
+
+{The stated layer — one entry per captured decision: what was decided, and the why in the user's words, each tagged `(stated)`. Candidate rationales the user rejected are worth a clause — a named wrong path is knowledge too.}
+
+## Open questions
+
+- OPEN: {asked and unanswered, or never asked — each specific enough that a future session knows what would settle it}
+```
+
+Rules:
+
+- **Three layers, structurally separated** — observed claims never migrate into Decisions, and nothing fills an `OPEN:` with a plausible guess. The section a claim sits in is its provenance.
+- **Stable names only** — a future agent greps and semantically matches on names; line numbers rot.
+- **Hold what a fresh session won't rebuild** — identity, vocabulary, lifecycles, the WHY, the unknowns. Structure an agent can re-derive by reading code earns a line, not a section.
+
+## B. Skim
+
+Summarise the doc in two or three sentences of prose — the verdict, and what it holds (how many observed claims, captured decisions, open questions). The full text stays on disk behind `v/view`; never dump it unasked.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**`◆ Land it?`**
+
+**`a/approve`** → Index and commit the doc
+**`v/view`**    → Read the full doc first
+**Adjust**      → Tell me what to change
+```
+
+**STOP.** Wait for user response.
+
+**If `view`:**
+
+Render the doc file verbatim as markdown, then re-render the menu above.
+
+**STOP.** Wait for user response.
+
+**If the user adjusts:**
+
+Apply the changes to the doc, then re-render the summary block and menu above.
+
+**STOP.** Wait for user response.
+
+**If `approve`:**
+
+→ Proceed to **C. Land**.
+
+## C. Land
+
+Index the doc, mark the area, and commit:
+
+```bash
+node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index .workflows/.baseline/{area}.md
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.areas.{area} completed
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "baseline({area}): document the {area} baseline"
+```
+
+A failed `index` is queued by the CLI for retry on its next call — note it to the user in one line and continue; the doc and commit still land.
+
+→ Return to caller.

--- a/skills/workflow-baseline/references/author-doc.md
+++ b/skills/workflow-baseline/references/author-doc.md
@@ -8,7 +8,7 @@ Weave the area's dossier and interview record into `.workflows/.baseline/{area}.
 
 ## A. Weave
 
-Write the doc from the dossier (observed layer) and the agenda (stated layer + open items):
+Write the doc from the dossier (observed layer) and the agenda (stated layer + open threads):
 
 ```markdown
 # {Area title}
@@ -19,13 +19,13 @@ Write the doc from the dossier (observed layer) and the agenda (stated layer + o
 
 ## Observed
 
-{The structure the code shows — boundaries, lifecycles, invariants, integrations. Anchored to stable names: classes, enums, subsystems, pipelines — never file:line, which churns. A claim the interview corrected carries the correction, not the original.}
+{The structure the code shows — boundaries, lifecycles, invariants, integrations. Anchored to stable names: classes, enums, subsystems, pipelines — never file:line, which churns.}
 
 ## Decisions
 
 {The stated layer — one entry per captured decision: what was decided, and the why in the user's words, each tagged `(stated)`. Candidate rationales the user rejected are worth a clause — a named wrong path is knowledge too.}
 
-## Open questions
+## Open Questions
 
 - OPEN: {asked and unanswered, or never asked — each specific enough that a future session knows what would settle it}
 ```
@@ -33,35 +33,35 @@ Write the doc from the dossier (observed layer) and the agenda (stated layer + o
 Rules:
 
 - **Three layers, structurally separated** — observed claims never migrate into Decisions, and nothing fills an `OPEN:` with a plausible guess. The section a claim sits in is its provenance.
+- **Code outranks memory on mechanism.** A `**Correction**:` from the interview is verified against the code before Observed carries it; where the code contradicts the recollection, the observation stands and the user's view is recorded `(stated)` beside it. Intent has no such check — the user is its only source.
+- **Open Questions collects every open thread** — the agenda's `open` rows and its `### Open Threads` entries (the un-asked tail, unresolved inferences, uncovered boundary ground).
 - **Stable names only** — a future agent greps and semantically matches on names; line numbers rot.
 - **Hold what a fresh session won't rebuild** — identity, vocabulary, lifecycles, the WHY, the unknowns. Structure an agent can re-derive by reading code earns a line, not a section.
+- **A deepened area extends its existing doc, never replaces it** — new observed material merges into Observed, new decisions append, Open Questions reconcile (answered ones leave, new ones join); existing Decisions entries are never dropped.
+
+→ Proceed to **B. Skim**.
 
 ## B. Skim
 
 Summarise the doc in two or three sentences of prose — the verdict, and what it holds (how many observed claims, captured decisions, open questions). The full text stays on disk behind `v/view`; never dump it unasked.
 
-> *Output the next fenced block as markdown (not a code block):*
+Fetch the gate and emit its `MENU: baseline doc gate` section verbatim as markdown (not a code block):
 
-```
-· · · · · · · · · · · ·
-**`◆ Land it?`**
-
-**`a/approve`** → Index and commit the doc
-**`v/view`**    → Read the full doc first
-**Adjust**      → Tell me what to change
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-doc-gate
 ```
 
 **STOP.** Wait for user response.
 
 **If `view`:**
 
-Render the doc file verbatim as markdown, then re-render the menu above.
+Render the doc file verbatim as markdown, then re-fetch and emit the gate.
 
 **STOP.** Wait for user response.
 
 **If the user adjusts:**
 
-Apply the changes to the doc, then re-render the summary block and menu above.
+Apply the changes to the doc, restate the summary, then re-fetch and emit the gate.
 
 **STOP.** Wait for user response.
 

--- a/skills/workflow-baseline/references/conclude.md
+++ b/skills/workflow-baseline/references/conclude.md
@@ -10,7 +10,7 @@ Mark it and commit:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.status completed
-node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "baseline: complete the assessment ({N} areas)"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "baseline: complete the assessment"
 ```
 
 Fetch the completion receipt and emit its `DISPLAY: baseline receipt` section:

--- a/skills/workflow-baseline/references/conclude.md
+++ b/skills/workflow-baseline/references/conclude.md
@@ -1,0 +1,28 @@
+# Conclude
+
+*Reference for **[workflow-baseline](../SKILL.md)***
+
+---
+
+Every area is documented. Close the assessment.
+
+Mark it and commit:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.status completed
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "baseline: complete the assessment ({N} areas)"
+```
+
+Fetch the completion receipt and emit its `DISPLAY: baseline receipt` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-receipt
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> The docs are reference, not record — they inform later phases without deciding for them. Open questions stay open until a discussion settles them properly, and the baseline is expandable any time from the workflow-start manage menu.
+```
+
+**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-baseline/references/interview-loop.md
+++ b/skills/workflow-baseline/references/interview-loop.md
@@ -22,7 +22,7 @@ Research hasn't covered it yet.
 
 #### If any area is `completed`
 
-A resumed interview — fetch the progress snapshot and emit its `DISPLAY: baseline progress` section:
+A resumed interview — fetch the progress snapshot and emit its `DISPLAY: baseline progress` section verbatim as a code block:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-progress
@@ -48,7 +48,7 @@ Every area is `completed`.
 
 #### Otherwise
 
-> *Output the next fenced block as markdown (not a code block):*
+> *Output the next fenced block as markdown (not a code block — `{n}` is this area's position across all areas, `{total}` the area count):*
 
 ```
 **`□ Interviewing {area:(titlecase)} ({n} of {total})`**
@@ -67,18 +67,20 @@ Every area is `completed`.
 Read the area's agenda (`.workflows/.baseline/.state/agenda-{area}.md`) and interview in rounds until no `pending` questions remain:
 
 1. **Compose the round** — 1–4 pending questions that are independent of one another. A question whose premises could be reshaped by another's answer waits for a later round.
-2. **Ask via the AskUserQuestion tool** — this is the prescribed interface for interview rounds (the questions are synthesised per project; they are not a prescribed gate, and no rendered block exists for them — flow gates in this skill stay rendered menus). Per question:
-   - `question` — the agenda question with its evidence woven in: the observation first, then the ask. Evidence is what jogs memory; "why polling?" retrieves nothing, "the dispatcher polls behind four separate guards — that layering usually accretes from incidents; what's the story?" retrieves everything.
-   - `options` — the agenda's candidate answers (short labels, a sentence of description each), plus a **Don't know** option ("Leave this open — recorded as an open question, no cost"). A wrong candidate jogs memory better than an open prompt; the user's own words arrive via the tool's Other field.
-   - `header` — the area, abbreviated.
-3. **Record the round** — immediately after the answers land, update each asked question in the agenda file: `**Status**: pending` becomes `answered` with an `**Answer**: {the user's answer — their words, condensed without being flattened}` line, or `open` when they don't know or it doesn't matter. An answer that corrects the observed layer is also noted on the question (`**Correction**: …`) for the doc weave. This write is the ledger — it happens every round, before anything else.
-4. **Follow the thread when it earns it** — an answer that opens real ground (an incident story, a rejected alternative, a constraint nobody wrote down) is worth one conversational follow-up in prose before the next round. Capture what it yields on the same agenda entry. One follow-up, not an interrogation spiral.
+2. **Ask conversationally** — per question: the observation first, then the ask. Evidence is what jogs memory ("why polling?" retrieves nothing; "the dispatcher polls behind four separate guards — that layering usually accretes from incidents; what's the story?" retrieves everything), and a wrong candidate jogs memory better than an open prompt. Write the round payload to `.workflows/.cache/baseline/round.json` with the Write tool — `{"area": "{area}", "questions": [{"text": "{the question, evidence woven in}", "candidates": ["{plausible answer}", "…"]}]}` — then fetch the round and emit its `DISPLAY: baseline round` section verbatim as a code block:
 
-#### If the user responds outside the tool
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-round --file .workflows/.cache/baseline/round.json
+   ```
 
-Answers in prose, digressions worth keeping, corrections to the evidence — honour them all: record them on the agenda exactly like tool answers.
+   **STOP.** Wait for user response.
 
-**If the user asks to stop**, however phrased ("pause", "that's enough for now", "let's pick this up later"):
+3. **Record the round** — immediately after the answers land, update each asked question in the agenda file: `**Status**: pending` becomes `answered` with an `**Answer**: {the user's answer — their words, condensed without being flattened}` line, or `open` when they don't know or it doesn't matter. An answer that contradicts an observed claim is noted on the question (`**Correction**: …`) for the doc weave. This write is the ledger — it happens every round, before anything else.
+4. **Follow the thread when it earns it** — an answer that opens real ground (an incident story, a rejected alternative, a constraint nobody wrote down) is worth one conversational follow-up before the next round. Capture what it yields on the same agenda entry. One follow-up, not an interrogation spiral.
+
+#### If the user asks to stop
+
+However phrased — "pause", "that's enough for now", "let's pick this up later" — record any answers the same message carried first.
 
 → Proceed to **E. Pause**.
 
@@ -104,7 +106,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.base
 
 #### If areas remain
 
-Fetch the gate and emit its `MENU: baseline area gate` section:
+Fetch the gate and emit its `MENU: baseline area gate` section verbatim as markdown (not a code block):
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-area-gate --area {area}
@@ -129,10 +131,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-area-gate
 Commit whatever the ledger holds:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "baseline: pause the interview ({completed}/{total} areas documented)"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "baseline: pause the interview"
 ```
 
-Fetch the pause receipt and emit its `DISPLAY: baseline paused` section:
+Fetch the pause receipt and emit its `DISPLAY: baseline paused` section verbatim as a code block:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-paused

--- a/skills/workflow-baseline/references/interview-loop.md
+++ b/skills/workflow-baseline/references/interview-loop.md
@@ -1,0 +1,141 @@
+# Interview
+
+*Reference for **[workflow-baseline](../SKILL.md)***
+
+---
+
+Walk the areas' agendas with the user, one themed round at a time, recording every answer as it lands. The interview is exitable at any moment — progress is written per round and an abandoned session resumes exactly where it stopped.
+
+## A. Position
+
+Read the area map:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.baseline.areas
+```
+
+#### If any area is `pending`
+
+Research hasn't covered it yet.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 2**.
+
+#### If any area is `completed`
+
+A resumed interview — fetch the progress snapshot and emit its `DISPLAY: baseline progress` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-progress
+```
+
+→ Proceed to **B. Next Area**.
+
+#### Otherwise
+
+A fresh interview — render nothing.
+
+→ Proceed to **B. Next Area**.
+
+## B. Next Area
+
+Pick the next `researched` area — `overview` first (its answers frame everything after it), then `boundaries`, then `glossary`, then the concern areas, most load-bearing first.
+
+#### If none remain
+
+Every area is `completed`.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 5**.
+
+#### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+**`□ Interviewing {area:(titlecase)} ({n} of {total})`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> {One line: what this area covers and what the questions are after.} Answer in your own words, pick a candidate, or say "don't know" — an unanswered question is recorded as open, never guessed at.
+```
+
+→ Proceed to **C. Rounds**.
+
+## C. Rounds
+
+Read the area's agenda (`.workflows/.baseline/.state/agenda-{area}.md`) and interview in rounds until no `pending` questions remain:
+
+1. **Compose the round** — 1–4 pending questions that are independent of one another. A question whose premises could be reshaped by another's answer waits for a later round.
+2. **Ask via the AskUserQuestion tool** — this is the prescribed interface for interview rounds (the questions are synthesised per project; they are not a prescribed gate, and no rendered block exists for them — flow gates in this skill stay rendered menus). Per question:
+   - `question` — the agenda question with its evidence woven in: the observation first, then the ask. Evidence is what jogs memory; "why polling?" retrieves nothing, "the dispatcher polls behind four separate guards — that layering usually accretes from incidents; what's the story?" retrieves everything.
+   - `options` — the agenda's candidate answers (short labels, a sentence of description each), plus a **Don't know** option ("Leave this open — recorded as an open question, no cost"). A wrong candidate jogs memory better than an open prompt; the user's own words arrive via the tool's Other field.
+   - `header` — the area, abbreviated.
+3. **Record the round** — immediately after the answers land, update each asked question in the agenda file: `**Status**: pending` becomes `answered` with an `**Answer**: {the user's answer — their words, condensed without being flattened}` line, or `open` when they don't know or it doesn't matter. An answer that corrects the observed layer is also noted on the question (`**Correction**: …`) for the doc weave. This write is the ledger — it happens every round, before anything else.
+4. **Follow the thread when it earns it** — an answer that opens real ground (an incident story, a rejected alternative, a constraint nobody wrote down) is worth one conversational follow-up in prose before the next round. Capture what it yields on the same agenda entry. One follow-up, not an interrogation spiral.
+
+#### If the user responds outside the tool
+
+Answers in prose, digressions worth keeping, corrections to the evidence — honour them all: record them on the agenda exactly like tool answers.
+
+**If the user asks to stop**, however phrased ("pause", "that's enough for now", "let's pick this up later"):
+
+→ Proceed to **E. Pause**.
+
+#### If pending questions remain
+
+Next round.
+
+→ Return to **C. Rounds**.
+
+#### If the agenda is drained
+
+→ Proceed to **D. Close the Area**.
+
+## D. Close the Area
+
+→ Load **[author-doc.md](author-doc.md)** with area = `{area}`.
+
+On return, the area doc is written, indexed, and committed. Re-read the area map to see what remains:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.baseline.areas
+```
+
+#### If areas remain
+
+Fetch the gate and emit its `MENU: baseline area gate` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-area-gate --area {area}
+```
+
+**STOP.** Wait for user response.
+
+**If `continue`:**
+
+→ Return to **B. Next Area**.
+
+**If `pause`:**
+
+→ Proceed to **E. Pause**.
+
+#### If no areas remain
+
+→ Return to **B. Next Area**.
+
+## E. Pause
+
+Commit whatever the ledger holds:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "baseline: pause the interview ({completed}/{total} areas documented)"
+```
+
+Fetch the pause receipt and emit its `DISPLAY: baseline paused` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-paused
+```
+
+**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-baseline/references/manage-baseline.md
+++ b/skills/workflow-baseline/references/manage-baseline.md
@@ -1,0 +1,61 @@
+# Manage the Baseline
+
+*Reference for **[workflow-baseline](../SKILL.md)***
+
+---
+
+The assessment is complete. Show what exists and offer the ways back in.
+
+## A. Display and Menu
+
+Fetch the doc list and emit its `DISPLAY: baseline progress` section:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-progress
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**`◆ What would you like to do?`**
+
+**`e/expand`** → Add a new area, or deepen an existing one
+**`v/view`**   → Read an area doc
+**`b/back`**   → Leave the baseline as it is
+```
+
+**STOP.** Wait for user response.
+
+## B. Handle Selection
+
+#### If `expand`
+
+Ask what ground to add or deepen if the user hasn't already said. Set mode = `expand` — the scoping flow branches on it.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 1**.
+
+#### If `view`
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+Which doc? (enter the area name, or **`b/back`**)
+```
+
+**STOP.** Wait for user response.
+
+Render the chosen `.workflows/.baseline/{area}.md` verbatim as markdown.
+
+→ Return to **A. Display and Menu**.
+
+#### If `back`
+
+> *Output the next fenced block as a code block:*
+
+```
+Baseline unchanged. Run /workflow-start to pick up other work.
+```
+
+**STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-baseline/references/manage-baseline.md
+++ b/skills/workflow-baseline/references/manage-baseline.md
@@ -8,21 +8,16 @@ The assessment is complete. Show what exists and offer the ways back in.
 
 ## A. Display and Menu
 
-Fetch the doc list and emit its `DISPLAY: baseline progress` section:
+Fetch the doc list and emit its `DISPLAY: baseline progress` section verbatim as a code block:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-progress
 ```
 
-> *Output the next fenced block as markdown (not a code block):*
+Fetch the gate and emit its `MENU: baseline manage gate` section verbatim as markdown (not a code block):
 
-```
-· · · · · · · · · · · ·
-**`◆ What would you like to do?`**
-
-**`e/expand`** → Add a new area, or deepen an existing one
-**`v/view`**   → Read an area doc
-**`b/back`**   → Leave the baseline as it is
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-manage-gate
 ```
 
 **STOP.** Wait for user response.
@@ -37,14 +32,19 @@ Ask what ground to add or deepen if the user hasn't already said. Set mode = `ex
 
 #### If `view`
 
-> *Output the next fenced block as markdown (not a code block):*
+Fetch the picker and emit its `MENU: baseline doc pick` section verbatim as markdown (not a code block):
 
-```
-· · · · · · · · · · · ·
-Which doc? (enter the area name, or **`b/back`**)
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-doc-pick
 ```
 
 **STOP.** Wait for user response.
+
+**If `back`:**
+
+→ Return to **A. Display and Menu**.
+
+**If the user names an area:**
 
 Render the chosen `.workflows/.baseline/{area}.md` verbatim as markdown.
 

--- a/skills/workflow-baseline/references/research-and-agenda.md
+++ b/skills/workflow-baseline/references/research-and-agenda.md
@@ -30,21 +30,20 @@ Each agent receives:
 1. **Area name** and its one-line coverage description (from scoping; when resuming without it in context, derive it from the area name)
 2. **Output file path** — `.workflows/.baseline/.state/dossier-{area}.md`
 3. **Sibling areas** — the full area list, so the agent leaves adjacent ground to its neighbours
+4. **For a deepened area** (its doc `.workflows/.baseline/{area}.md` already exists): the doc path and the deepen brief — investigate the named deeper ground only; the doc holds what the first pass covered
 
 > **CHECKPOINT**: Do not proceed until every dispatched agent has returned.
-
-**If an agent failed or its dossier is missing:** re-dispatch that area once; if it fails again, tell the user which area's research failed and continue with the dossiers that exist — the area stays `pending` and a later resume retries it.
 
 → Proceed to **B. Build the Agendas**.
 
 ## B. Build the Agendas
 
-For each researched area, read `.workflows/.baseline/.state/dossier-{area}.md` and build the interview agenda at `.workflows/.baseline/.state/agenda-{area}.md`:
+For each area dispatched in A, read `.workflows/.baseline/.state/dossier-{area}.md` and build the interview agenda at `.workflows/.baseline/.state/agenda-{area}.md`:
 
-1. **Select** from the dossier's question candidates. Keep a question only when its answer lives in the user's head — intent, history, constraints, rejected alternatives, the meaning of an opaque name. Anything the code itself settles is not a question; fold it into the observed layer instead.
-2. **Rank** by how likely a future phase is to need the answer: load-bearing decisions and opaque domain semantics first, curiosities last. Cap an area's agenda at what an interview can sustain — roughly 4–10 questions; the tail lands as `OPEN:` items in the area doc, not as questions.
+1. **Select** from the dossier's question candidates. Keep a question when its answer lives in the user's head — intent, history, constraints, the meaning of an opaque name — or when a load-bearing observed claim deserves the user's confirmation ("is this a fair description?"). Anything else the code settles is not a question; fold it into the observed layer instead.
+2. **Rank** by how likely a future phase is to need the answer: load-bearing decisions and opaque domain semantics first, curiosities last. Cap an area's agenda at what an interview can sustain — roughly 4–10 questions.
 3. **Dedupe across areas** — one underlying decision asks once, on the area where it is most at home.
-4. **Write** the agenda:
+4. **Write** the agenda — for a deepened area, append the new questions after the existing entries; recorded answers are never rewritten:
 
 ```markdown
 # Agenda: {area}
@@ -54,9 +53,13 @@ For each researched area, read `.workflows/.baseline/.state/dossier-{area}.md` a
 - **Evidence**: {what the code shows that raises this — stable names, no line numbers}
 - **Candidates**: {2–4 plausible answers, one line each}
 - **Status**: pending
+
+### Open Threads
+
+- OPEN: {each un-selected question candidate, unresolved inference, and boundary note naming uncovered ground — one line each; author-doc carries these into the doc's Open Questions}
 ```
 
-Mark each researched area:
+Mark each dispatched area:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.areas.{area} researched

--- a/skills/workflow-baseline/references/research-and-agenda.md
+++ b/skills/workflow-baseline/references/research-and-agenda.md
@@ -1,0 +1,71 @@
+# Research and Agenda
+
+*Reference for **[workflow-baseline](../SKILL.md)***
+
+---
+
+Fan researcher agents out over the pending areas, then synthesise their dossiers into per-area interview agendas. The agents' real product is questions — the interview is where the WHY layer gets captured, and these agendas are its material.
+
+## A. Dispatch
+
+Read the area map and collect every area whose status is `pending`:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.baseline.areas
+```
+
+> *Output the next fenced block as a code block:*
+
+```
+Researching the pending areas — one agent per area, in parallel.
+This runs against the code only; nothing is asked of you yet.
+```
+
+Dispatch **one agent per pending area, all in parallel** via the Task tool.
+
+- **Agent path**: `../../../agents/workflow-baseline-researcher.md`
+
+Each agent receives:
+
+1. **Area name** and its one-line coverage description (from scoping; when resuming without it in context, derive it from the area name)
+2. **Output file path** — `.workflows/.baseline/.state/dossier-{area}.md`
+3. **Sibling areas** — the full area list, so the agent leaves adjacent ground to its neighbours
+
+> **CHECKPOINT**: Do not proceed until every dispatched agent has returned.
+
+**If an agent failed or its dossier is missing:** re-dispatch that area once; if it fails again, tell the user which area's research failed and continue with the dossiers that exist — the area stays `pending` and a later resume retries it.
+
+→ Proceed to **B. Build the Agendas**.
+
+## B. Build the Agendas
+
+For each researched area, read `.workflows/.baseline/.state/dossier-{area}.md` and build the interview agenda at `.workflows/.baseline/.state/agenda-{area}.md`:
+
+1. **Select** from the dossier's question candidates. Keep a question only when its answer lives in the user's head — intent, history, constraints, rejected alternatives, the meaning of an opaque name. Anything the code itself settles is not a question; fold it into the observed layer instead.
+2. **Rank** by how likely a future phase is to need the answer: load-bearing decisions and opaque domain semantics first, curiosities last. Cap an area's agenda at what an interview can sustain — roughly 4–10 questions; the tail lands as `OPEN:` items in the area doc, not as questions.
+3. **Dedupe across areas** — one underlying decision asks once, on the area where it is most at home.
+4. **Write** the agenda:
+
+```markdown
+# Agenda: {area}
+
+### Q1: {the question, carrying its evidence — specific enough to jog memory}
+
+- **Evidence**: {what the code shows that raises this — stable names, no line numbers}
+- **Candidates**: {2–4 plausible answers, one line each}
+- **Status**: pending
+```
+
+Mark each researched area:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.areas.{area} researched
+```
+
+Commit:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "baseline: research dossiers and interview agendas"
+```
+
+→ Return to caller.

--- a/skills/workflow-baseline/references/scope-areas.md
+++ b/skills/workflow-baseline/references/scope-areas.md
@@ -10,7 +10,7 @@ Survey the codebase, propose the area list, and persist the approved scope. Two 
 
 #### If `mode` is `expand`
 
-The user has named what to add or deepen — survey only that ground, then propose it as one or more new areas alongside the existing map (named like the rest: kebab-case, after the concern), skipping the fresh-assessment framing.
+The user has named what to add or deepen — survey only that ground, then propose it alongside the existing map, skipping the fresh-assessment framing. New ground becomes a new kebab-case area named after the concern; **deepening an existing area reuses its name** — its earlier agenda and doc are extended at research and authoring, never replaced.
 
 → Proceed to **B. Confirm**.
 
@@ -27,31 +27,37 @@ Survey briefly — README and docs, dependency manifests, top-level structure, r
 Compose the proposed areas:
 
 - **The fixed spine** — always present: `overview` (what the product is, who uses it, its verdict), `glossary` (the domain vocabulary and the code that backs it), `boundaries` (modules, surfaces, and the integration map).
-- **Concern areas** — 3–8 more, sized to the codebase: one per load-bearing concern — an entity and its lifecycle, a pipeline, a subsystem, a seam to an external system. Name each in kebab-case after the concern, not the directory.
+- **Concern areas** — 3–8 more, sized to the codebase: one per load-bearing concern — an entity and its lifecycle, a pipeline, a subsystem, a seam to an external system. Name each in kebab-case after the concern, not the directory. Names are dot- and slash-free — an area name is the doc's knowledge-base identity, and dots are refused there.
 
 → Proceed to **B. Confirm**.
 
 ## B. Confirm
 
-Present the proposed areas as markdown — nothing is persisted yet, so this is a proposal, not a state display: one bolded kebab-case area name per line, each with a one-line clause on what it covers and why it earns a doc.
+Write the proposal payload to `.workflows/.cache/baseline/scope.json` with the Write tool — `{"mode": "{fresh|expand}", "areas": [{"name": "{area:(kebabcase)}", "detail": "{one line: what it covers and why it earns a doc}"}]}` — then fetch the gate and emit its `DISPLAY: baseline scope` and `MENU: baseline scope gate` sections verbatim, each per its marker:
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-**`◆ Assess these areas?`**
-
-**`a/approve`** → Lock the list and start the research
-**Adjust**     → Tell me what to add, drop, rename, or merge
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render baseline-scope-gate --file .workflows/.cache/baseline/scope.json
 ```
 
 **STOP.** Wait for user response.
 
 **If the user adjusts:**
 
-Apply the changes, re-render the proposed list and the menu above.
+Apply the changes, rewrite the payload, and re-render the gate.
 
 **STOP.** Wait for user response.
+
+**If `back` and `mode` is `expand`:**
+
+Nothing is persisted.
+
+→ Return to **[the skill](../SKILL.md)** for **Step 4**.
+
+**If `back` and the assessment is fresh:**
+
+Nothing is persisted — the offer stands from the workflow-start menus whenever you want it.
+
+**STOP.** Do not proceed — terminal condition.
 
 **If `approve`:**
 
@@ -59,12 +65,14 @@ Apply the changes, re-render the proposed list and the menu above.
 
 ## C. Persist
 
-Set the baseline in progress and register each approved area (one call per field):
+Register each newly approved area, then set the status — the status write is last, so an interrupted session never claims an in-progress baseline with unregistered areas (one call per field):
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.status in-progress
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.areas.{area} pending
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.status in-progress
 ```
+
+A deepened area is set back to `pending` the same way — its agenda and doc survive and are extended downstream.
 
 Hold each area's one-line coverage description in context — the research dispatch passes it to the area's researcher.
 

--- a/skills/workflow-baseline/references/scope-areas.md
+++ b/skills/workflow-baseline/references/scope-areas.md
@@ -1,0 +1,77 @@
+# Scope the Assessment
+
+*Reference for **[workflow-baseline](../SKILL.md)***
+
+---
+
+Survey the codebase, propose the area list, and persist the approved scope. Two entry modes: a fresh assessment (from Step 0), or **expand** (from manage — `mode = expand`, adding or deepening areas on a completed baseline).
+
+## A. Survey
+
+#### If `mode` is `expand`
+
+The user has named what to add or deepen — survey only that ground, then propose it as one or more new areas alongside the existing map (named like the rest: kebab-case, after the concern), skipping the fresh-assessment framing.
+
+→ Proceed to **B. Confirm**.
+
+#### Otherwise
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> I'll take a quick look at the codebase first — enough to propose a set of areas worth assessing, not a full audit. Then we shape the list together before any deeper research runs.
+```
+
+Survey briefly — README and docs, dependency manifests, top-level structure, route/entry files, the largest modules. Minutes of reads, not an audit; the goal is a defensible area list, nothing deeper.
+
+Compose the proposed areas:
+
+- **The fixed spine** — always present: `overview` (what the product is, who uses it, its verdict), `glossary` (the domain vocabulary and the code that backs it), `boundaries` (modules, surfaces, and the integration map).
+- **Concern areas** — 3–8 more, sized to the codebase: one per load-bearing concern — an entity and its lifecycle, a pipeline, a subsystem, a seam to an external system. Name each in kebab-case after the concern, not the directory.
+
+→ Proceed to **B. Confirm**.
+
+## B. Confirm
+
+Present the proposed areas as markdown — nothing is persisted yet, so this is a proposal, not a state display: one bolded kebab-case area name per line, each with a one-line clause on what it covers and why it earns a doc.
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**`◆ Assess these areas?`**
+
+**`a/approve`** → Lock the list and start the research
+**Adjust**     → Tell me what to add, drop, rename, or merge
+```
+
+**STOP.** Wait for user response.
+
+**If the user adjusts:**
+
+Apply the changes, re-render the proposed list and the menu above.
+
+**STOP.** Wait for user response.
+
+**If `approve`:**
+
+→ Proceed to **C. Persist**.
+
+## C. Persist
+
+Set the baseline in progress and register each approved area (one call per field):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.status in-progress
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set project.baseline.areas.{area} pending
+```
+
+Hold each area's one-line coverage description in context — the research dispatch passes it to the area's researcher.
+
+Commit with the message matching the mode — `baseline: open the assessment ({N} areas)`, or for expand `baseline: expand the assessment (+{N} areas)`:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "{message}"
+```
+
+→ Return to caller.

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -241,6 +241,10 @@ engine render session-receipt <wu> [--warn]                       # discovery-se
 engine render absorb-target <feature>                             # the absorb flow's target-epic selection menu; refuses when the absorb guard doesn't hold
 engine render plan-topics <wu>                                    # the view-plan topic selection menu; refuses without a multi-topic epic plan
 engine render revisit-phases <wu>                                 # the revisit-phase selection menu over completed earlier phases; linear work types only, refuses when nothing is revisitable
+engine render baseline-progress                                   # the baseline area map from the project manifest — in-progress: per-area statuses + remaining count; completed: the landed doc list; refuses with no baseline or no areas
+engine render baseline-area-gate --area <name>                    # the between-areas continue/pause gate after the named area's doc lands; refuses an unlanded area, and refuses when nothing remains (that path concludes instead)
+engine render baseline-paused                                     # the interview's pause receipt — documented count + the workflow-start pointer; in-progress only
+engine render baseline-receipt                                    # the completion receipt — doc list + the knowledge-query note; refuses before the completed write
 ```
 
 The bridge continuation surfaces take a bare `<work_unit>` address (work-unit-level, type read from the manifest). The continue-* selection step is not a `render` surface: it runs its own navigation-gateway index dump and emits that response's `DISPLAY: selection` / `MENU: selection` sections, per their markers.

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -244,7 +244,12 @@ engine render revisit-phases <wu>                                 # the revisit-
 engine render baseline-progress                                   # the baseline area map from the project manifest — in-progress: per-area statuses + remaining count; completed: the landed doc list; refuses with no baseline or no areas
 engine render baseline-area-gate --area <name>                    # the between-areas continue/pause gate after the named area's doc lands; refuses an unlanded area, and refuses when nothing remains (that path concludes instead)
 engine render baseline-paused                                     # the interview's pause receipt — documented count + the workflow-start pointer; in-progress only
-engine render baseline-receipt                                    # the completion receipt — doc list + the knowledge-query note; refuses before the completed write
+engine render baseline-receipt                                    # the completion receipt — doc list + the knowledge-query note; refuses before the completed write, and refuses to name an unlanded doc
+engine render baseline-scope-gate --file <payload.json>           # the scope confirmation: proposed-area list (payload {mode: fresh|expand, areas: [{name, detail}]}, names validated kebab/dot-free) + the approve/back/adjust gate; stateless — runs before anything persists
+engine render baseline-round --file <payload.json>                # one interview round: payload {area, questions: [{text, candidates?}]} (1-4 questions, up to 4 candidates each), rendered numbered + lettered over a researched area
+engine render baseline-doc-gate                                   # the doc-landing gate after an area's weave — static approve/view/adjust menu
+engine render baseline-manage-gate                                # the completed-baseline manage menu — expand/view/back; completed only
+engine render baseline-doc-pick                                   # manage's doc picker prompt; completed only
 ```
 
 The bridge continuation surfaces take a bare `<work_unit>` address (work-unit-level, type read from the manifest). The continue-* selection step is not a `render` surface: it runs its own navigation-gateway index dump and emits that response's `DISPLAY: selection` / `MENU: selection` sections, per their markers.

--- a/skills/workflow-engine/scripts/domain/baseline.cjs
+++ b/skills/workflow-engine/scripts/domain/baseline.cjs
@@ -1,0 +1,49 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: the project baseline — the one home for reading the project
+// manifest's `baseline` object. Boot's status field, the start menus'
+// resume/manage rows, and the render surfaces all derive from this state, so
+// the vocabulary and the remaining-count exist exactly once.
+// ---------------------------------------------------------------------------
+
+const { readProjectManifest } = require('../kernel/manifest.cjs');
+
+/**
+ * @typedef {object} BaselineState
+ * @property {'none'|'in-progress'|'completed'|'skipped'} status
+ * @property {{name: string, status: string}[]} areas  registration order
+ * @property {number} remaining  areas not yet completed (0 unless in-progress)
+ */
+
+/**
+ * Read the project baseline state. Anything other than a recognised
+ * lifecycle status — including a missing or corrupt project manifest, or a
+ * malformed field shape — reads `none` with no areas: the never-started
+ * state the one-time offer keys on. Corruption surfaces loudly at the first
+ * manifest write, not here — boot and the menus must stay usable.
+ * @param {string} cwd
+ * @returns {BaselineState}
+ */
+function baselineState(cwd) {
+  /** @type {Record<string, any>} */
+  let manifest = {};
+  try {
+    manifest = readProjectManifest(cwd);
+  } catch (_) {
+    return { status: 'none', areas: [], remaining: 0 };
+  }
+  const b = manifest && manifest.baseline;
+  const status = b && typeof b === 'object' && !Array.isArray(b) && typeof b.status === 'string' ? b.status : 'none';
+  if (status !== 'in-progress' && status !== 'completed' && status !== 'skipped') {
+    return { status: 'none', areas: [], remaining: 0 };
+  }
+  const areasObj = b.areas && typeof b.areas === 'object' && !Array.isArray(b.areas) ? b.areas : {};
+  const areas = Object.entries(areasObj)
+    .filter(([, s]) => typeof s === 'string')
+    .map(([name, s]) => ({ name, status: /** @type {string} */ (s) }));
+  const remaining = status === 'in-progress' ? areas.filter((a) => a.status !== 'completed').length : 0;
+  return { status, areas, remaining };
+}
+
+module.exports = { baselineState };

--- a/skills/workflow-engine/scripts/domain/boot.cjs
+++ b/skills/workflow-engine/scripts/domain/boot.cjs
@@ -22,7 +22,7 @@ const { git } = require('../kernel/git.cjs');
 const { commitScopedLocked, KB_DIR } = require('./commit.cjs');
 const { spawnKnowledge } = require('./kb.cjs');
 const { labelConfigStatus, configDir } = require('./session-label.cjs');
-const { readProjectManifest } = require('../kernel/manifest-io.cjs');
+const { baselineState } = require('./baseline.cjs');
 
 // Resolved against this file so it works wherever the skill tree is installed.
 const MIGRATE_CJS = path.join(path.resolve(__dirname, '..', '..', '..'), 'workflow-migrate', 'scripts', 'migrate.cjs');
@@ -99,26 +99,6 @@ function detectSystemConfig() {
   } catch (_) {
     return { status: 'invalid', provider: null, model: null };
   }
-}
-
-/**
- * Read the project baseline status off the project manifest. Anything other
- * than a recognised lifecycle value — including a missing manifest or a
- * malformed field — reports `none`, the never-started state the one-time
- * offer keys on.
- * @param {string} cwd
- * @returns {BootResult['baseline']}
- */
-function baselineStatus(cwd) {
-  try {
-    const manifest = readProjectManifest(path.join(cwd, '.workflows'));
-    const status = manifest && manifest.baseline && manifest.baseline.status;
-    if (status === 'in-progress' || status === 'completed' || status === 'skipped') return status;
-  } catch (_) {
-    // A corrupt project manifest is surfaced by the verbs that write it;
-    // boot's baseline probe degrades to the offer-eligible default.
-  }
-  return 'none';
 }
 
 /**
@@ -238,7 +218,7 @@ function boot(cwd) {
   }
 
   /** @type {BootResult} */
-  const result = { migrations, knowledge: /** @type {BootResult['knowledge']} */ (knowledge), compacted, kb_committed: kbCommitted, warnings, tmux_labels: labelConfigStatus(cwd), baseline: baselineStatus(cwd) };
+  const result = { migrations, knowledge: /** @type {BootResult['knowledge']} */ (knowledge), compacted, kb_committed: kbCommitted, warnings, tmux_labels: labelConfigStatus(cwd), baseline: baselineState(cwd).status };
   // Not-ready responses carry the system-config report so the calling
   // skill's knowledge gate can branch (reuse the system config, offer a
   // mode choice, or fall back to the terminal wizard) without extra probes.

--- a/skills/workflow-engine/scripts/domain/projections/baseline.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/baseline.cjs
@@ -1,0 +1,141 @@
+'use strict';
+
+// ---------------------------------------------------------------------------
+// Domain ring: project-baseline projections — the render surfaces the
+// workflow-baseline skill fetches at its display points. Baseline state is
+// project-level: everything here reads the project manifest's `baseline`
+// object, never a work-unit manifest.
+// ---------------------------------------------------------------------------
+
+const path = require('path');
+const { readProjectManifest } = require('../../kernel/manifest-io.cjs');
+const { section, menu, cmdOption, CONTINUE_INSTRUCTION } = require('./surfaces.cjs');
+const { titlecase } = require('../conventions.cjs');
+
+const MENU_INSTRUCTION = "emit verbatim as markdown, then STOP for the user's response";
+
+/**
+ * @typedef {object} BaselineDetail
+ * @property {string} status
+ * @property {{name: string, status: string}[]} areas  registration order
+ */
+
+/**
+ * Read the project manifest's baseline object. Loud when absent — these
+ * surfaces are called from prescribed prose that has already branched on the
+ * status, so a missing object is an authoring bug.
+ * @param {string} cwd @param {string} surface
+ * @returns {BaselineDetail}
+ */
+function baselineDetail(cwd, surface) {
+  const manifest = readProjectManifest(path.join(cwd, '.workflows'));
+  const b = manifest && manifest.baseline;
+  if (!b || typeof b !== 'object' || Array.isArray(b)) {
+    throw new Error(`render ${surface}: no baseline on the project manifest`);
+  }
+  const areasObj = b.areas && typeof b.areas === 'object' && !Array.isArray(b.areas) ? b.areas : {};
+  const areas = Object.entries(areasObj).map(([name, status]) => ({ name, status: String(status) }));
+  return { status: typeof b.status === 'string' ? b.status : 'none', areas };
+}
+
+/** @param {BaselineDetail} d */
+function remaining(d) {
+  return d.areas.filter((a) => a.status !== 'completed').length;
+}
+
+/**
+ * The baseline area map — an in-progress assessment shows each area's status
+ * and what remains; a completed one lists the landed docs. Serves the
+ * interview's resume display and the manage view.
+ * @param {string} cwd @param {object} _args
+ * @returns {string}
+ */
+function baselineProgress(cwd, _args) {
+  const d = baselineDetail(cwd, 'baseline-progress');
+  if (d.areas.length === 0) {
+    throw new Error('render baseline-progress: the baseline has no areas');
+  }
+  const lines = [];
+  if (d.status === 'completed') {
+    lines.push(`Baseline — ${d.areas.length} area(s) documented:`, '');
+    for (const a of d.areas) lines.push(`  ${a.name}.md`);
+  } else {
+    const pad = Math.max(...d.areas.map((a) => a.name.length));
+    lines.push('Baseline in progress:', '');
+    for (const a of d.areas) lines.push(`  ${a.name.padEnd(pad)}  [${a.status}]`);
+    lines.push('', `${remaining(d)} area(s) remain.`);
+  }
+  return section('DISPLAY: baseline progress', CONTINUE_INSTRUCTION, lines.join('\n'));
+}
+
+/**
+ * The between-areas gate: the named area just landed, more remain. The
+ * none-remain case is the conclude path — reaching this surface there is an
+ * authoring bug, so it throws rather than rendering an empty gate.
+ * @param {string} cwd @param {Record<string, string|undefined>} args
+ * @returns {string}
+ */
+function baselineAreaGate(cwd, { area }) {
+  const d = baselineDetail(cwd, 'baseline-area-gate');
+  if (!area) throw new Error('render baseline-area-gate: --area is required');
+  const entry = d.areas.find((a) => a.name === area);
+  if (!entry) throw new Error(`render baseline-area-gate: unknown area "${area}"`);
+  if (entry.status !== 'completed') {
+    throw new Error(`render baseline-area-gate: area "${area}" is "${entry.status}", not completed — the gate follows the doc landing`);
+  }
+  const left = remaining(d);
+  if (left === 0) {
+    throw new Error('render baseline-area-gate: no areas remain — the flow concludes instead of gating');
+  }
+  const body = menu(
+    `**${titlecase(area)}** is documented. ${left} area(s) remain.`,
+    [
+      cmdOption('c', 'continue', 'Interview the next area'),
+      cmdOption('p', 'pause', 'Stop here — resume any time from workflow-start'),
+    ],
+    { question: 'Keep going?' },
+  );
+  return section('MENU: baseline area gate', MENU_INSTRUCTION, body);
+}
+
+/**
+ * The pause receipt — what the interview holds so far and how to get back in.
+ * @param {string} cwd @param {object} _args
+ * @returns {string}
+ */
+function baselinePaused(cwd, _args) {
+  const d = baselineDetail(cwd, 'baseline-paused');
+  if (d.status !== 'in-progress') {
+    throw new Error(`render baseline-paused: the baseline is "${d.status}", not in-progress`);
+  }
+  const done = d.areas.length - remaining(d);
+  const body = [
+    `Paused — ${done} of ${d.areas.length} area(s) documented.`,
+    'Everything answered so far is recorded, and the finished docs',
+    'are already live in the knowledge base.',
+    '',
+    'Resume from the workflow-start menu.',
+  ].join('\n');
+  return section('DISPLAY: baseline paused', CONTINUE_INSTRUCTION, body);
+}
+
+/**
+ * The completion receipt — every area documented and indexed.
+ * @param {string} cwd @param {object} _args
+ * @returns {string}
+ */
+function baselineReceipt(cwd, _args) {
+  const d = baselineDetail(cwd, 'baseline-receipt');
+  if (d.status !== 'completed') {
+    throw new Error(`render baseline-receipt: the baseline is "${d.status}", not completed — the receipt follows the completion write`);
+  }
+  const lines = [
+    `Baseline complete — ${d.areas.length} area(s) documented and indexed.`,
+    '',
+  ];
+  for (const a of d.areas) lines.push(`  ${a.name}.md`);
+  lines.push('', 'Every phase now surfaces this as [baseline | ...] context', 'in its knowledge queries.');
+  return section('DISPLAY: baseline receipt', CONTINUE_INSTRUCTION, lines.join('\n'));
+}
+
+module.exports = { baselineProgress, baselineAreaGate, baselinePaused, baselineReceipt };

--- a/skills/workflow-engine/scripts/domain/projections/baseline.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/baseline.cjs
@@ -1,94 +1,51 @@
 'use strict';
 
 // ---------------------------------------------------------------------------
-// Domain ring: project-baseline projections — the render surfaces the
-// workflow-baseline skill fetches at its display points. Baseline state is
-// project-level: everything here reads the project manifest's `baseline`
-// object, never a work-unit manifest.
+// Domain ring: project-baseline projections — pure renderers over the
+// BaselineState the render surfaces resolve (domain/baseline.cjs). Like every
+// sibling projection they take a detail object and return a string; state
+// resolution and refusals live with the surface handlers in domain/render.cjs.
 // ---------------------------------------------------------------------------
 
-const path = require('path');
-const { readProjectManifest } = require('../../kernel/manifest-io.cjs');
-const { section, menu, cmdOption, CONTINUE_INSTRUCTION } = require('./surfaces.cjs');
+const { wrapWithPrefix } = require('../../kernel/render.cjs');
+const { displayWidth } = require('../../kernel/terminal.cjs');
+const { section, menu, menuFrame, cmdOption, promptOption, CONTINUE_INSTRUCTION } = require('./surfaces.cjs');
 const { titlecase } = require('../conventions.cjs');
 
 const MENU_INSTRUCTION = "emit verbatim as markdown, then STOP for the user's response";
+const ASK_INSTRUCTION = "emit verbatim as a code block, then STOP for the user's response";
 
-/**
- * @typedef {object} BaselineDetail
- * @property {string} status
- * @property {{name: string, status: string}[]} areas  registration order
- */
-
-/**
- * Read the project manifest's baseline object. Loud when absent — these
- * surfaces are called from prescribed prose that has already branched on the
- * status, so a missing object is an authoring bug.
- * @param {string} cwd @param {string} surface
- * @returns {BaselineDetail}
- */
-function baselineDetail(cwd, surface) {
-  const manifest = readProjectManifest(path.join(cwd, '.workflows'));
-  const b = manifest && manifest.baseline;
-  if (!b || typeof b !== 'object' || Array.isArray(b)) {
-    throw new Error(`render ${surface}: no baseline on the project manifest`);
-  }
-  const areasObj = b.areas && typeof b.areas === 'object' && !Array.isArray(b.areas) ? b.areas : {};
-  const areas = Object.entries(areasObj).map(([name, status]) => ({ name, status: String(status) }));
-  return { status: typeof b.status === 'string' ? b.status : 'none', areas };
-}
-
-/** @param {BaselineDetail} d */
-function remaining(d) {
-  return d.areas.filter((a) => a.status !== 'completed').length;
-}
+/** @typedef {import('../baseline.cjs').BaselineState} BaselineState */
 
 /**
  * The baseline area map — an in-progress assessment shows each area's status
  * and what remains; a completed one lists the landed docs. Serves the
  * interview's resume display and the manage view.
- * @param {string} cwd @param {object} _args
+ * @param {BaselineState} d
  * @returns {string}
  */
-function baselineProgress(cwd, _args) {
-  const d = baselineDetail(cwd, 'baseline-progress');
-  if (d.areas.length === 0) {
-    throw new Error('render baseline-progress: the baseline has no areas');
-  }
+function baselineProgress(d) {
   const lines = [];
   if (d.status === 'completed') {
     lines.push(`Baseline — ${d.areas.length} area(s) documented:`, '');
-    for (const a of d.areas) lines.push(`  ${a.name}.md`);
+    for (const a of d.areas) lines.push(`  • ${a.name}.md`);
   } else {
     const pad = Math.max(...d.areas.map((a) => a.name.length));
     lines.push('Baseline in progress:', '');
     for (const a of d.areas) lines.push(`  ${a.name.padEnd(pad)}  [${a.status}]`);
-    lines.push('', `${remaining(d)} area(s) remain.`);
+    lines.push('', `${d.remaining} area(s) remain.`);
   }
   return section('DISPLAY: baseline progress', CONTINUE_INSTRUCTION, lines.join('\n'));
 }
 
 /**
- * The between-areas gate: the named area just landed, more remain. The
- * none-remain case is the conclude path — reaching this surface there is an
- * authoring bug, so it throws rather than rendering an empty gate.
- * @param {string} cwd @param {Record<string, string|undefined>} args
+ * The between-areas gate: the named area just landed, more remain.
+ * @param {BaselineState} d @param {string} area
  * @returns {string}
  */
-function baselineAreaGate(cwd, { area }) {
-  const d = baselineDetail(cwd, 'baseline-area-gate');
-  if (!area) throw new Error('render baseline-area-gate: --area is required');
-  const entry = d.areas.find((a) => a.name === area);
-  if (!entry) throw new Error(`render baseline-area-gate: unknown area "${area}"`);
-  if (entry.status !== 'completed') {
-    throw new Error(`render baseline-area-gate: area "${area}" is "${entry.status}", not completed — the gate follows the doc landing`);
-  }
-  const left = remaining(d);
-  if (left === 0) {
-    throw new Error('render baseline-area-gate: no areas remain — the flow concludes instead of gating');
-  }
+function baselineAreaGate(d, area) {
   const body = menu(
-    `**${titlecase(area)}** is documented. ${left} area(s) remain.`,
+    `**${titlecase(area)}** is documented. ${d.remaining} area(s) remain.`,
     [
       cmdOption('c', 'continue', 'Interview the next area'),
       cmdOption('p', 'pause', 'Stop here — resume any time from workflow-start'),
@@ -100,42 +57,153 @@ function baselineAreaGate(cwd, { area }) {
 
 /**
  * The pause receipt — what the interview holds so far and how to get back in.
- * @param {string} cwd @param {object} _args
+ * @param {BaselineState} d
  * @returns {string}
  */
-function baselinePaused(cwd, _args) {
-  const d = baselineDetail(cwd, 'baseline-paused');
-  if (d.status !== 'in-progress') {
-    throw new Error(`render baseline-paused: the baseline is "${d.status}", not in-progress`);
-  }
-  const done = d.areas.length - remaining(d);
-  const body = [
+function baselinePaused(d) {
+  const done = d.areas.length - d.remaining;
+  const lines = [
     `Paused — ${done} of ${d.areas.length} area(s) documented.`,
-    'Everything answered so far is recorded, and the finished docs',
-    'are already live in the knowledge base.',
+    ...wrapWithPrefix(
+      'Everything answered so far is recorded, and the finished docs are already live in the knowledge base.',
+      { width: displayWidth() },
+    ),
     '',
     'Resume from the workflow-start menu.',
-  ].join('\n');
-  return section('DISPLAY: baseline paused', CONTINUE_INSTRUCTION, body);
+  ];
+  return section('DISPLAY: baseline paused', CONTINUE_INSTRUCTION, lines.join('\n'));
 }
 
 /**
  * The completion receipt — every area documented and indexed.
- * @param {string} cwd @param {object} _args
+ * @param {BaselineState} d
  * @returns {string}
  */
-function baselineReceipt(cwd, _args) {
-  const d = baselineDetail(cwd, 'baseline-receipt');
-  if (d.status !== 'completed') {
-    throw new Error(`render baseline-receipt: the baseline is "${d.status}", not completed — the receipt follows the completion write`);
-  }
+function baselineReceipt(d) {
   const lines = [
     `Baseline complete — ${d.areas.length} area(s) documented and indexed.`,
     '',
   ];
-  for (const a of d.areas) lines.push(`  ${a.name}.md`);
-  lines.push('', 'Every phase now surfaces this as [baseline | ...] context', 'in its knowledge queries.');
+  for (const a of d.areas) lines.push(`  • ${a.name}.md`);
+  lines.push('');
+  lines.push(...wrapWithPrefix(
+    'The thinking phases now surface this as [baseline | …] context in their knowledge queries.',
+    { width: displayWidth() },
+  ));
   return section('DISPLAY: baseline receipt', CONTINUE_INSTRUCTION, lines.join('\n'));
 }
 
-module.exports = { baselineProgress, baselineAreaGate, baselinePaused, baselineReceipt };
+/**
+ * @typedef {object} ScopePayload
+ * @property {'fresh'|'expand'} mode
+ * @property {{name: string, detail: string}[]} areas
+ */
+
+/**
+ * The scope confirmation — the proposed area list (judgment content, via
+ * payload) above its approve/back/adjust gate.
+ * @param {ScopePayload} payload
+ * @returns {string}
+ */
+function baselineScopeGate(payload) {
+  const list = payload.areas.map((a) => `**${a.name}** — ${a.detail}`).join('\n');
+  const body = menu(
+    '',
+    [
+      cmdOption('a', 'approve', 'Lock the list and start the research'),
+      cmdOption('b', 'back', 'Leave without changing anything'),
+      promptOption('Adjust', 'Tell me what to add, drop, rename, or merge'),
+    ],
+    { question: 'Assess these areas?' },
+  );
+  return [
+    section('DISPLAY: baseline scope', 'emit verbatim as markdown (not a code block)', list),
+    section('MENU: baseline scope gate', MENU_INSTRUCTION, body),
+  ].join('\n');
+}
+
+/**
+ * @typedef {object} RoundPayload
+ * @property {string} area
+ * @property {{text: string, candidates?: string[]}[]} questions
+ */
+
+/**
+ * One interview round — numbered questions with lettered candidate answers,
+ * closing on the answer-in-any-mix line.
+ * @param {RoundPayload} payload
+ * @returns {string}
+ */
+function baselineRound(payload) {
+  const lines = [];
+  payload.questions.forEach((q, i) => {
+    if (i > 0) lines.push('');
+    lines.push(...wrapWithPrefix(`${i + 1}. ${q.text}`, { width: displayWidth(), hang: 3 }));
+    const candidates = q.candidates || [];
+    if (candidates.length > 0) lines.push('');
+    candidates.forEach((c, j) => {
+      lines.push(...wrapWithPrefix(`${String.fromCharCode(97 + j)}. ${c}`, { width: displayWidth(), prefix: '   ', hang: 3 }));
+    });
+  });
+  lines.push('');
+  lines.push(...wrapWithPrefix(
+    'Answer in your own words, pick letters, or say "don\'t know" — in any mix.',
+    { width: displayWidth() },
+  ));
+  return section('DISPLAY: baseline round', ASK_INSTRUCTION, lines.join('\n'));
+}
+
+/**
+ * The doc-landing gate after an area's weave.
+ * @returns {string}
+ */
+function baselineDocGate() {
+  const body = menu(
+    '',
+    [
+      cmdOption('a', 'approve', 'Index and commit the doc'),
+      cmdOption('v', 'view', 'Read the full doc first'),
+      promptOption('Adjust', 'Tell me what to change'),
+    ],
+    { question: 'Land it?' },
+  );
+  return section('MENU: baseline doc gate', MENU_INSTRUCTION, body);
+}
+
+/**
+ * The completed-baseline manage gate.
+ * @returns {string}
+ */
+function baselineManageGate() {
+  const body = menu(
+    '',
+    [
+      cmdOption('e', 'expand', 'Add a new area, or deepen an existing one'),
+      cmdOption('v', 'view', 'Read an area doc'),
+      cmdOption('b', 'back', 'Leave the baseline as it is'),
+    ],
+    { question: 'What would you like to do?' },
+  );
+  return section('MENU: baseline manage gate', MENU_INSTRUCTION, body);
+}
+
+/**
+ * The doc picker under manage's view.
+ * @returns {string}
+ */
+function baselineDocPick() {
+  const body = menuFrame(['Which doc? (enter the area name, or **`b/back`**)']);
+  return section('MENU: baseline doc pick', MENU_INSTRUCTION, body);
+}
+
+module.exports = {
+  baselineProgress,
+  baselineAreaGate,
+  baselinePaused,
+  baselineReceipt,
+  baselineScopeGate,
+  baselineRound,
+  baselineDocGate,
+  baselineManageGate,
+  baselineDocPick,
+};

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -17,6 +17,7 @@ const { worklist } = require('./projections/worklist.cjs');
 const { blockedTasksMenu, taskGateSection, fixGateSection, cycleLimitDisplay, cycleGateMenu } = require('./projections/tasks.cjs');
 const { workunitReceipt, topicReceipt, absorbReceipt, promoteReceipt, pivotContinuationMenu, sessionReceipt } = require('./projections/transactions.cjs');
 const { absorbTargetMenu, planTopicsMenu } = require('./projections/start.cjs');
+const { baselineProgress, baselineAreaGate, baselinePaused, baselineReceipt } = require('./projections/baseline.cjs');
 const { revisitablePhases, revisitPhasesSection } = require('./projections/workunit.cjs');
 const { WORK_UNIT_TYPES, typeConfig: workUnitTypeConfig, completedPhases } = require('./workunit-detail.cjs');
 const { computeNextPhase } = require('./derivations.cjs');
@@ -1836,6 +1837,10 @@ const SURFACES = {
   'absorb-target': absorbTarget,
   'plan-topics': planTopics,
   'revisit-phases': revisitPhasesSurface,
+  'baseline-progress': baselineProgress,
+  'baseline-area-gate': baselineAreaGate,
+  'baseline-paused': baselinePaused,
+  'baseline-receipt': baselineReceipt,
 };
 
 /**

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -17,7 +17,11 @@ const { worklist } = require('./projections/worklist.cjs');
 const { blockedTasksMenu, taskGateSection, fixGateSection, cycleLimitDisplay, cycleGateMenu } = require('./projections/tasks.cjs');
 const { workunitReceipt, topicReceipt, absorbReceipt, promoteReceipt, pivotContinuationMenu, sessionReceipt } = require('./projections/transactions.cjs');
 const { absorbTargetMenu, planTopicsMenu } = require('./projections/start.cjs');
-const { baselineProgress, baselineAreaGate, baselinePaused, baselineReceipt } = require('./projections/baseline.cjs');
+const {
+  baselineProgress, baselineAreaGate, baselinePaused, baselineReceipt,
+  baselineScopeGate, baselineRound, baselineDocGate, baselineManageGate, baselineDocPick,
+} = require('./projections/baseline.cjs');
+const { baselineState } = require('./baseline.cjs');
 const { revisitablePhases, revisitPhasesSection } = require('./projections/workunit.cjs');
 const { WORK_UNIT_TYPES, typeConfig: workUnitTypeConfig, completedPhases } = require('./workunit-detail.cjs');
 const { computeNextPhase } = require('./derivations.cjs');
@@ -1795,6 +1799,160 @@ function planTopics(cwd, args) {
   return planTopicsMenu(md);
 }
 
+// ---------------------------------------------------------------------------
+// The baseline surfaces — project-level, no address. Each handler resolves
+// the one BaselineState (domain/baseline.cjs), refuses states the calling
+// prose never reaches, and hands the pure projection its detail.
+// ---------------------------------------------------------------------------
+
+/** Resolve baseline state, refusing the never-started default. @param {string} cwd @param {string} surface */
+function resolveBaseline(cwd, surface) {
+  const d = baselineState(cwd);
+  if (d.status === 'none') {
+    throw new Error(`render ${surface}: no baseline on the project manifest`);
+  }
+  return d;
+}
+
+/** @param {string} cwd @param {object} _args @returns {string} */
+function baselineProgressSurface(cwd, _args) {
+  const d = resolveBaseline(cwd, 'baseline-progress');
+  if (d.areas.length === 0) {
+    throw new Error('render baseline-progress: the baseline has no areas');
+  }
+  return baselineProgress(d);
+}
+
+/** @param {string} cwd @param {Record<string, string|undefined>} args @returns {string} */
+function baselineAreaGateSurface(cwd, { area }) {
+  const d = resolveBaseline(cwd, 'baseline-area-gate');
+  if (!area) throw new Error('render baseline-area-gate: --area is required');
+  const entry = d.areas.find((a) => a.name === area);
+  if (!entry) throw new Error(`render baseline-area-gate: unknown area "${area}"`);
+  if (entry.status !== 'completed') {
+    throw new Error(`render baseline-area-gate: area "${area}" is "${entry.status}", not completed — the gate follows the doc landing`);
+  }
+  if (d.remaining === 0) {
+    throw new Error('render baseline-area-gate: no areas remain — the flow concludes instead of gating');
+  }
+  return baselineAreaGate(d, area);
+}
+
+/** @param {string} cwd @param {object} _args @returns {string} */
+function baselinePausedSurface(cwd, _args) {
+  const d = resolveBaseline(cwd, 'baseline-paused');
+  if (d.status !== 'in-progress') {
+    throw new Error(`render baseline-paused: the baseline is "${d.status}", not in-progress`);
+  }
+  return baselinePaused(d);
+}
+
+/** @param {string} cwd @param {object} _args @returns {string} */
+function baselineReceiptSurface(cwd, _args) {
+  const d = resolveBaseline(cwd, 'baseline-receipt');
+  if (d.status !== 'completed') {
+    throw new Error(`render baseline-receipt: the baseline is "${d.status}", not completed — the receipt follows the completion write`);
+  }
+  const unlanded = d.areas.filter((a) => a.status !== 'completed');
+  if (unlanded.length > 0) {
+    throw new Error(`render baseline-receipt: area "${unlanded[0].name}" is "${unlanded[0].status}", not completed — a receipt never names a doc that was not landed`);
+  }
+  return baselineReceipt(d);
+}
+
+// An area name doubles as the doc's knowledge-base identity — kebab-case,
+// dot- and slash-free, enforced where the proposal is rendered so an illegal
+// name never survives to the interview.
+const AREA_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/** Read + validate a `--file` JSON payload. @param {string} cwd @param {string} surface @param {string|undefined} file @returns {any} */
+function readBaselinePayload(cwd, surface, file) {
+  if (!file) throw new Error(`render ${surface}: --file <payload.json> is required`);
+  let raw;
+  try {
+    raw = fs.readFileSync(path.resolve(cwd, file), 'utf8');
+  } catch {
+    throw new Error(`render ${surface}: payload file not found: ${file}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`render ${surface}: payload is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+/** @param {string} cwd @param {{file?: string}} args @returns {string} */
+function baselineScopeGateSurface(cwd, { file }) {
+  const payload = readBaselinePayload(cwd, 'baseline-scope-gate', file);
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('render baseline-scope-gate: payload must be an object {mode, areas}');
+  }
+  if (payload.mode !== 'fresh' && payload.mode !== 'expand') {
+    throw new Error('render baseline-scope-gate: "mode" must be "fresh" or "expand"');
+  }
+  if (!Array.isArray(payload.areas) || payload.areas.length === 0) {
+    throw new Error('render baseline-scope-gate: "areas" must be a non-empty array of {name, detail}');
+  }
+  for (const [i, a] of payload.areas.entries()) {
+    if (!a || typeof a.name !== 'string' || !AREA_NAME_RE.test(a.name)) {
+      throw new Error(`render baseline-scope-gate: area ${i + 1} "name" must be kebab-case (dot- and slash-free — it is the doc's knowledge-base identity)`);
+    }
+    if (typeof a.detail !== 'string' || a.detail.trim() === '') {
+      throw new Error(`render baseline-scope-gate: area ${i + 1} ("${a.name}") is missing "detail" — one line on what it covers`);
+    }
+  }
+  return baselineScopeGate(payload);
+}
+
+/** @param {string} cwd @param {{file?: string}} args @returns {string} */
+function baselineRoundSurface(cwd, { file }) {
+  const payload = readBaselinePayload(cwd, 'baseline-round', file);
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('render baseline-round: payload must be an object {area, questions}');
+  }
+  const d = resolveBaseline(cwd, 'baseline-round');
+  const entry = d.areas.find((a) => a.name === payload.area);
+  if (!entry) throw new Error(`render baseline-round: unknown area "${payload.area}"`);
+  if (entry.status !== 'researched') {
+    throw new Error(`render baseline-round: area "${payload.area}" is "${entry.status}", not researched — rounds walk a researched area's agenda`);
+  }
+  if (!Array.isArray(payload.questions) || payload.questions.length === 0 || payload.questions.length > 4) {
+    throw new Error('render baseline-round: "questions" must be an array of 1-4 {text, candidates?}');
+  }
+  for (const [i, q] of payload.questions.entries()) {
+    if (!q || typeof q.text !== 'string' || q.text.trim() === '') {
+      throw new Error(`render baseline-round: question ${i + 1} is missing "text"`);
+    }
+    if (q.candidates !== undefined && (!Array.isArray(q.candidates) || q.candidates.length > 4 || q.candidates.some((c) => typeof c !== 'string' || c.trim() === ''))) {
+      throw new Error(`render baseline-round: question ${i + 1} "candidates" must be up to 4 non-empty strings when present`);
+    }
+  }
+  return baselineRound(payload);
+}
+
+/** @param {string} _cwd @param {object} _args @returns {string} */
+function baselineDocGateSurface(_cwd, _args) {
+  return baselineDocGate();
+}
+
+/** @param {string} cwd @param {object} _args @returns {string} */
+function baselineManageGateSurface(cwd, _args) {
+  const d = resolveBaseline(cwd, 'baseline-manage-gate');
+  if (d.status !== 'completed') {
+    throw new Error(`render baseline-manage-gate: the baseline is "${d.status}", not completed — manage serves a completed assessment`);
+  }
+  return baselineManageGate();
+}
+
+/** @param {string} cwd @param {object} _args @returns {string} */
+function baselineDocPickSurface(cwd, _args) {
+  const d = resolveBaseline(cwd, 'baseline-doc-pick');
+  if (d.status !== 'completed') {
+    throw new Error(`render baseline-doc-pick: the baseline is "${d.status}", not completed`);
+  }
+  return baselineDocPick();
+}
+
 /** The catalogue: surface name → handler. @type {Record<string, (cwd: string, args: {dotpath: string} & Record<string, string|undefined>) => string>} */
 const SURFACES = {
   'resume-gate': resumeGate,
@@ -1837,10 +1995,15 @@ const SURFACES = {
   'absorb-target': absorbTarget,
   'plan-topics': planTopics,
   'revisit-phases': revisitPhasesSurface,
-  'baseline-progress': baselineProgress,
-  'baseline-area-gate': baselineAreaGate,
-  'baseline-paused': baselinePaused,
-  'baseline-receipt': baselineReceipt,
+  'baseline-progress': baselineProgressSurface,
+  'baseline-area-gate': baselineAreaGateSurface,
+  'baseline-paused': baselinePausedSurface,
+  'baseline-receipt': baselineReceiptSurface,
+  'baseline-scope-gate': baselineScopeGateSurface,
+  'baseline-round': baselineRoundSurface,
+  'baseline-doc-gate': baselineDocGateSurface,
+  'baseline-manage-gate': baselineManageGateSurface,
+  'baseline-doc-pick': baselineDocPickSurface,
 };
 
 /**

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -219,6 +219,11 @@ Commands:
   render baseline-area-gate --area <name>
   render baseline-paused
   render baseline-receipt
+  render baseline-scope-gate --file <payload.json>
+  render baseline-round --file <payload.json>
+  render baseline-doc-gate
+  render baseline-manage-gate
+  render baseline-doc-pick
   render signpost <label> [--style step|substep] [--width N]     (dev aid)
   render box <title> [--width N]                                 (dev aid)
   render wrap <text> [--width N] [--prefix STR]                  (dev aid)

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -215,6 +215,10 @@ Commands:
   render absorb-target     <feature>
   render plan-topics       <wu>
   render revisit-phases    <wu>
+  render baseline-progress
+  render baseline-area-gate --area <name>
+  render baseline-paused
+  render baseline-receipt
   render signpost <label> [--style step|substep] [--width N]     (dev aid)
   render box <title> [--width N]                                 (dev aid)
   render wrap <text> [--width N] [--prefix STR]                  (dev aid)

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -432,7 +432,7 @@ function skillNameOf(file) {
 
 function checkH1Category(files) {
   const out = [];
-  const H1_KNOWN = new Set(['workflow-engine', 'workflow-knowledge']);
+  const H1_KNOWN = new Set(['workflow-engine', 'workflow-knowledge', 'workflow-baseline']);
   for (const file of files) {
     const name = skillNameOf(file);
     if (!name || !name.startsWith('workflow-')) continue; // only workflow backbones

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1766,7 +1766,7 @@ describe('catalogue dispatch', () => {
   });
 
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick\)/);
   });
 });
 
@@ -1873,7 +1873,7 @@ describe('baseline surfaces', () => {
     writeBaseline({ status: 'completed', areas: { overview: 'completed', glossary: 'completed' } });
     const out = renderSurface(dir, 'baseline-progress', {});
     assert.match(out, /Baseline — 2 area\(s\) documented:/);
-    assert.match(out, /  overview\.md\n  glossary\.md/);
+    assert.match(out, /  • overview\.md\n  • glossary\.md/);
   });
 
   it('baseline-progress: refuses a missing baseline and an empty area map', () => {
@@ -1914,9 +1914,73 @@ describe('baseline surfaces', () => {
     writeBaseline({ status: 'completed', areas: { overview: 'completed', glossary: 'completed' } });
     const out = renderSurface(dir, 'baseline-receipt', {});
     assert.match(out, /Baseline complete — 2 area\(s\) documented and indexed\./);
-    assert.match(out, /  overview\.md\n  glossary\.md/);
-    assert.match(out, /\[baseline \| \.\.\.\] context/);
+    assert.match(out, /  • overview\.md\n  • glossary\.md/);
+    assert.match(out, /\[baseline \| …\] context/);
     writeBaseline({ status: 'in-progress', areas: { overview: 'completed' } });
     assert.throws(() => renderSurface(dir, 'baseline-receipt', {}), /not completed/);
+  });
+
+  it('baseline-receipt: refuses to name a doc that was never landed', () => {
+    writeBaseline({ status: 'completed', areas: { overview: 'completed', dispatcher: 'pending' } });
+    assert.throws(() => renderSurface(dir, 'baseline-receipt', {}), /"dispatcher" is "pending", not completed/);
+  });
+
+  it('baseline-scope-gate: renders the proposed list as markdown above the gate, stateless', () => {
+    const file = writePayload(dir, 'payload.json', {
+      mode: 'fresh',
+      areas: [{ name: 'overview', detail: 'What the product is' }, { name: 'dispatcher', detail: 'The downstream push pipeline' }],
+    });
+    const out = renderSurface(dir, 'baseline-scope-gate', { file });
+    assert.match(out, /=== DISPLAY: baseline scope \(emit verbatim as markdown \(not a code block\)\) ===/);
+    assert.match(out, /\*\*overview\*\* — What the product is\n\*\*dispatcher\*\* — The downstream push pipeline/);
+    assert.match(out, /\*\*`◆ Assess these areas\?`\*\*/);
+    assert.match(out, /\*\*`a\/approve`\*\* → Lock the list and start the research/);
+    assert.match(out, /\*\*`b\/back`\*\*\s+→ Leave without changing anything/);
+    assert.match(out, /\*\*Adjust\*\*\s+→ Tell me what to add, drop, rename, or merge/);
+  });
+
+  it('baseline-scope-gate: refuses illegal names, bad modes, and empty payloads', () => {
+    const bad = (payload) => writePayload(dir, 'payload.json', payload);
+    assert.throws(() => renderSurface(dir, 'baseline-scope-gate', {}), /--file <payload\.json> is required/);
+    assert.throws(() => renderSurface(dir, 'baseline-scope-gate', { file: bad({ mode: 'weird', areas: [{ name: 'a', detail: 'x' }] }) }), /"mode" must be/);
+    assert.throws(() => renderSurface(dir, 'baseline-scope-gate', { file: bad({ mode: 'fresh', areas: [] }) }), /non-empty array/);
+    assert.throws(() => renderSurface(dir, 'baseline-scope-gate', { file: bad({ mode: 'fresh', areas: [{ name: 'api.v2', detail: 'x' }] }) }), /kebab-case/);
+    assert.throws(() => renderSurface(dir, 'baseline-scope-gate', { file: bad({ mode: 'fresh', areas: [{ name: 'ok-area', detail: ' ' }] }) }), /missing "detail"/);
+  });
+
+  it('baseline-round: numbers questions, letters candidates, closes on the any-mix line', () => {
+    writeBaseline({ status: 'in-progress', areas: { dispatcher: 'researched' } });
+    const file = writePayload(dir, 'payload.json', {
+      area: 'dispatcher',
+      questions: [
+        { text: 'The dispatcher polls behind four guards — what is the story?', candidates: ['Incident accretion', 'Partner rate agreement'] },
+        { text: 'Why does Closed exist as a state?' },
+      ],
+    });
+    const out = renderSurface(dir, 'baseline-round', { file });
+    assert.match(out, /=== DISPLAY: baseline round \(emit verbatim as a code block, then STOP for the user's response\) ===/);
+    assert.match(out, /1\. The dispatcher polls behind four guards/);
+    assert.match(out, /   a\. Incident accretion\n   b\. Partner rate agreement/);
+    assert.match(out, /2\. Why does Closed exist as a state\?/);
+    assert.match(out, /Answer in your own words, pick letters, or say "don't know" —/);
+  });
+
+  it('baseline-round: refuses an unresearched area and malformed questions', () => {
+    writeBaseline({ status: 'in-progress', areas: { dispatcher: 'completed' } });
+    const file = writePayload(dir, 'payload.json', { area: 'dispatcher', questions: [{ text: 'x' }] });
+    assert.throws(() => renderSurface(dir, 'baseline-round', { file }), /not researched/);
+    writeBaseline({ status: 'in-progress', areas: { dispatcher: 'researched' } });
+    const many = writePayload(dir, 'payload.json', { area: 'dispatcher', questions: [1, 2, 3, 4, 5].map((n) => ({ text: `q${n}` })) });
+    assert.throws(() => renderSurface(dir, 'baseline-round', { file: many }), /1-4/);
+  });
+
+  it('the static baseline gates render their menus; the completed-only pair refuse mid-flight', () => {
+    assert.match(renderSurface(dir, 'baseline-doc-gate', {}), /\*\*`◆ Land it\?`\*\*[\s\S]*\*\*`a\/approve`\*\* → Index and commit the doc/);
+    writeBaseline({ status: 'in-progress', areas: { overview: 'researched' } });
+    assert.throws(() => renderSurface(dir, 'baseline-manage-gate', {}), /not completed/);
+    assert.throws(() => renderSurface(dir, 'baseline-doc-pick', {}), /not completed/);
+    writeBaseline({ status: 'completed', areas: { overview: 'completed' } });
+    assert.match(renderSurface(dir, 'baseline-manage-gate', {}), /\*\*`◆ What would you like to do\?`\*\*[\s\S]*\*\*`e\/expand`\*\* → Add a new area, or deepen an existing one/);
+    assert.match(renderSurface(dir, 'baseline-doc-pick', {}), /Which doc\? \(enter the area name, or \*\*`b\/back`\*\*\)/);
   });
 });

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1766,7 +1766,7 @@ describe('catalogue dispatch', () => {
   });
 
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt\)/);
   });
 });
 
@@ -1839,5 +1839,84 @@ describe('single-source invariants', () => {
     })(skillsRoot);
     assert.deepStrictEqual(offenders, [],
       'artefact content is framed by its emission fence, never drawn borders — a box glyph reintroduces a fixed-width commitment the terminal cannot honour');
+  });
+});
+
+describe('baseline surfaces', () => {
+  let dir;
+  beforeEach(() => { dir = setup(); });
+  afterEach(() => { teardown(dir); });
+
+  function writeBaseline(baseline) {
+    const wf = path.join(dir, '.workflows');
+    fs.mkdirSync(wf, { recursive: true });
+    fs.writeFileSync(path.join(wf, 'manifest.json'), JSON.stringify({ work_units: {}, baseline }, null, 2));
+  }
+
+  it('baseline-progress: in-progress shows statuses and the remaining count', () => {
+    writeBaseline({ status: 'in-progress', areas: { overview: 'completed', glossary: 'researched', dispatcher: 'pending' } });
+    const out = renderSurface(dir, 'baseline-progress', {});
+    assert.strictEqual(out, [
+      '=== DISPLAY: baseline progress (emit verbatim as a code block — do not stop; continue as the workflow instructs) ===',
+      'Baseline in progress:',
+      '',
+      '  overview    [completed]',
+      '  glossary    [researched]',
+      '  dispatcher  [pending]',
+      '',
+      '2 area(s) remain.',
+      '',
+    ].join('\n'));
+  });
+
+  it('baseline-progress: completed lists the landed docs', () => {
+    writeBaseline({ status: 'completed', areas: { overview: 'completed', glossary: 'completed' } });
+    const out = renderSurface(dir, 'baseline-progress', {});
+    assert.match(out, /Baseline — 2 area\(s\) documented:/);
+    assert.match(out, /  overview\.md\n  glossary\.md/);
+  });
+
+  it('baseline-progress: refuses a missing baseline and an empty area map', () => {
+    assert.throws(() => renderSurface(dir, 'baseline-progress', {}), /no baseline on the project manifest/);
+    writeBaseline({ status: 'in-progress', areas: {} });
+    assert.throws(() => renderSurface(dir, 'baseline-progress', {}), /no areas/);
+  });
+
+  it('baseline-area-gate: statement, glyphed question, and both options', () => {
+    writeBaseline({ status: 'in-progress', areas: { overview: 'completed', glossary: 'researched' } });
+    const out = renderSurface(dir, 'baseline-area-gate', { area: 'overview' });
+    assert.match(out, /^=== MENU: baseline area gate \(emit verbatim as markdown, then STOP for the user's response\) ===/);
+    assert.match(out, /\*\*Overview\*\* is documented\. 1 area\(s\) remain\./);
+    assert.match(out, /\*\*`◆ Keep going\?`\*\*/);
+    assert.match(out, /\*\*`c\/continue`\*\* → Interview the next area/);
+    assert.match(out, /\*\*`p\/pause`\*\*\s+→ Stop here — resume any time from workflow-start/);
+  });
+
+  it('baseline-area-gate: refuses a missing --area, an unknown area, an unlanded area, and a drained map', () => {
+    writeBaseline({ status: 'in-progress', areas: { overview: 'completed', glossary: 'researched' } });
+    assert.throws(() => renderSurface(dir, 'baseline-area-gate', {}), /--area is required/);
+    assert.throws(() => renderSurface(dir, 'baseline-area-gate', { area: 'ghost' }), /unknown area/);
+    assert.throws(() => renderSurface(dir, 'baseline-area-gate', { area: 'glossary' }), /not completed/);
+    writeBaseline({ status: 'in-progress', areas: { overview: 'completed' } });
+    assert.throws(() => renderSurface(dir, 'baseline-area-gate', { area: 'overview' }), /no areas remain/);
+  });
+
+  it('baseline-paused: counts the documented areas and points back at workflow-start', () => {
+    writeBaseline({ status: 'in-progress', areas: { overview: 'completed', glossary: 'researched', dispatcher: 'researched' } });
+    const out = renderSurface(dir, 'baseline-paused', {});
+    assert.match(out, /Paused — 1 of 3 area\(s\) documented\./);
+    assert.match(out, /Resume from the workflow-start menu\./);
+    writeBaseline({ status: 'completed', areas: { overview: 'completed' } });
+    assert.throws(() => renderSurface(dir, 'baseline-paused', {}), /not in-progress/);
+  });
+
+  it('baseline-receipt: lists the docs and requires the completion write first', () => {
+    writeBaseline({ status: 'completed', areas: { overview: 'completed', glossary: 'completed' } });
+    const out = renderSurface(dir, 'baseline-receipt', {});
+    assert.match(out, /Baseline complete — 2 area\(s\) documented and indexed\./);
+    assert.match(out, /  overview\.md\n  glossary\.md/);
+    assert.match(out, /\[baseline \| \.\.\.\] context/);
+    writeBaseline({ status: 'in-progress', areas: { overview: 'completed' } });
+    assert.throws(() => renderSurface(dir, 'baseline-receipt', {}), /not completed/);
   });
 });

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -1389,6 +1389,17 @@ describe('pipeline simulation', () => {
     sim.run(['manifest', 'set', 'project.baseline.areas.dispatcher', 'pending']);
     sim.run(['manifest', 'set', 'project.baseline.areas.overview', 'researched']);
     sim.run(['manifest', 'set', 'project.baseline.areas.dispatcher', 'researched']);
+    sim.write('.workflows/.cache/scratch/baseline-scope.json', JSON.stringify({
+      mode: 'fresh',
+      areas: [{ name: 'overview', detail: 'What the product is' }, { name: 'dispatcher', detail: 'The downstream push' }],
+    }));
+    assert.match(sim.render(['baseline-scope-gate', '--file', '.workflows/.cache/scratch/baseline-scope.json'], { expect: 'content' }), /Assess these areas\?/);
+    sim.write('.workflows/.cache/scratch/baseline-round.json', JSON.stringify({
+      area: 'dispatcher',
+      questions: [{ text: 'Why polling over webhooks?', candidates: ['Decoupling from a flaky downstream'] }],
+    }));
+    assert.match(sim.render(['baseline-round', '--file', '.workflows/.cache/scratch/baseline-round.json'], { expect: 'content' }), /1\. Why polling over webhooks\?/);
+    assert.match(sim.render(['baseline-doc-gate'], { expect: 'content' }), /Land it\?/);
     sim.run(['manifest', 'set', 'project.baseline.areas.overview', 'completed']);
     assert.match(sim.render(['baseline-progress'], { expect: 'content' }), /1 area\(s\) remain/);
     assert.match(sim.render(['baseline-area-gate', '--area', 'overview'], { expect: 'content' }), /Keep going\?/);
@@ -1397,6 +1408,8 @@ describe('pipeline simulation', () => {
     sim.run(['manifest', 'set', 'project.baseline.status', 'completed']);
     assert.match(sim.render(['baseline-progress'], { expect: 'content' }), /2 area\(s\) documented/);
     assert.match(sim.render(['baseline-receipt'], { expect: 'content' }), /Baseline complete — 2 area\(s\)/);
+    assert.match(sim.render(['baseline-manage-gate'], { expect: 'content' }), /What would you like to do\?/);
+    assert.match(sim.render(['baseline-doc-pick'], { expect: 'content' }), /Which doc\?/);
 
     // After every refusal the unit still derives and completes normally.
     sim.run(['topic', 'complete', wu, 'discussion', wu]);

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -1379,11 +1379,24 @@ describe('pipeline simulation', () => {
     sim.refuses(['workunit', 'create', 'project', 'feature', '--description', 'Nope', '--no-session-log'], /is reserved/);
     sim.refuses(['workunit', 'create', 'baseline', 'feature', '--description', 'Nope', '--no-session-log'], /is reserved/);
 
-    // The project baseline lifecycle field round-trips on the project manifest.
+    // The project baseline walks its lifecycle on the project manifest, and
+    // each render surface serves its prescribed moment: the progress map and
+    // area gate mid-interview, the pause receipt, the doc list and completion
+    // receipt once every area lands.
     sim.run(['manifest', 'set', 'project.baseline.status', 'in-progress']);
     assert.strictEqual(sim.read(['manifest', 'get', 'project.baseline.status']), 'in-progress');
+    sim.run(['manifest', 'set', 'project.baseline.areas.overview', 'pending']);
+    sim.run(['manifest', 'set', 'project.baseline.areas.dispatcher', 'pending']);
+    sim.run(['manifest', 'set', 'project.baseline.areas.overview', 'researched']);
+    sim.run(['manifest', 'set', 'project.baseline.areas.dispatcher', 'researched']);
+    sim.run(['manifest', 'set', 'project.baseline.areas.overview', 'completed']);
+    assert.match(sim.render(['baseline-progress'], { expect: 'content' }), /1 area\(s\) remain/);
+    assert.match(sim.render(['baseline-area-gate', '--area', 'overview'], { expect: 'content' }), /Keep going\?/);
+    assert.match(sim.render(['baseline-paused'], { expect: 'content' }), /Paused — 1 of 2/);
+    sim.run(['manifest', 'set', 'project.baseline.areas.dispatcher', 'completed']);
     sim.run(['manifest', 'set', 'project.baseline.status', 'completed']);
-    assert.strictEqual(sim.read(['manifest', 'get', 'project.baseline.status']), 'completed');
+    assert.match(sim.render(['baseline-progress'], { expect: 'content' }), /2 area\(s\) documented/);
+    assert.match(sim.render(['baseline-receipt'], { expect: 'content' }), /Baseline complete — 2 area\(s\)/);
 
     // After every refusal the unit still derives and completes normally.
     sim.run(['topic', 'complete', wu, 'discussion', wu]);


### PR DESCRIPTION
Layer 3 of the Baseline stack (#887 design log → #888 KB/engine → this).

The `workflow-baseline` skill (model-only, reached from workflow-start in the next layer) runs the brownfield assessment end to end:

- **Scope** — a brief survey proposes the area list (fixed spine: overview / glossary / boundaries, plus 3–8 concern areas), confirmed with the user before anything persists. Expand mode reuses the same flow on a completed baseline.
- **Research** — one `workflow-baseline-researcher` agent per area, in parallel: codebase archaeology with a hard observed-vs-inferred discipline. A plausible WHY the agent cannot evidence is a *question candidate, never a finding* — the agents' real product is questions. Stable-name anchoring throughout; never file:line.
- **Interview** — per-area agendas walked in AskUserQuestion rounds: evidence woven into each question, candidate rationales as options, a costless Don't-know. Answers are recorded to the agenda ledger **every round**, so an abrupt death costs at most the current round; a pause commits and exits cleanly, and resume picks up mid-area. (The framework's no-interactive-tools rule governs *prescribed* gates — these questions are synthesised per project and the skill prescribes the tool; flow gates stay rendered menus.)
- **Docs** — each drained area weaves `.workflows/.baseline/{area}.md` with observed / stated / open structurally separated, indexes it (`[baseline | …]`, low confidence), and commits. Index-as-you-go: a half-done baseline is live coverage, not an all-or-nothing artifact.
- **Engine** — a four-surface render family (`baseline-progress`, `baseline-area-gate`, `baseline-paused`, `baseline-receipt`) over the project manifest, so every state-derivable display is engine-rendered — the templated-fence ratchet stays at zero pins for the new skill; the two judgment presentations (proposed areas, doc skim) render as report-class markdown, not fences.

Tests: render-surface suite (6 new tests incl. refusal paths), simulation walks the baseline lifecycle across all four surfaces, conventions lint clean, typecheck clean, full suite 2135 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)