### PR TITLE
prose harness: the deterministic-check substrate outgrows real commands

### DIFF
--- a/tests/prose/lib/record-action.cjs
+++ b/tests/prose/lib/record-action.cjs
@@ -58,11 +58,13 @@ const MAX_OUTPUT = 400;
 const MAX_PRODUCED_OUTPUT = 10000;
 // The detail column is the substrate the deterministic checks match
 // against — a call that ran must be findable in it. It is truncated only
-// after the world path collapses to `.`, and generously: a cap that bit
-// into real commands made four includes report never-ran on calls the
-// walk performed (the world prefix ate the budget and the field name
-// fell off the end).
-const MAX_DETAIL = 600;
+// after the world path collapses to `.`, and generously: every cap that
+// bit into a real command has produced a false never-ran — four includes
+// at the original cap (the world prefix ate the budget), then a two-seed
+// `workunit create` at 600 whose second `--seed` fell off the end. The
+// cap exists only to bound pathological blobs (heredoc scripts, inline
+// payloads), so it sits far above any real engine call.
+const MAX_DETAIL = 4000;
 const WRITE_RESPONSE_TOOLS = new Set(['Bash', 'Write', 'Edit', 'NotebookEdit']);
 
 function read() {

--- a/tests/scripts/test-prose-record-action.cjs
+++ b/tests/scripts/test-prose-record-action.cjs
@@ -106,7 +106,7 @@ describe('prose recorder — tool events', () => {
   });
 
   it('truncates a genuinely enormous command with the marker, after the world collapses', () => {
-    const filler = 'x'.repeat(2000);
+    const filler = 'x'.repeat(8000);
     fire({
       hook_event_name: 'PreToolUse',
       tool_name: 'Bash',
@@ -117,13 +117,13 @@ describe('prose recorder — tool events', () => {
     const detail = row.split('\t')[2];
     assert.ok(detail.endsWith('…[truncated]'), 'oversize is marked, never silently cut');
     assert.ok(detail.startsWith('cd . && echo'), 'the world path collapsed before the cap applied');
-    assert.ok(detail.length <= 600 + '…[truncated]'.length, 'the cap holds');
+    assert.ok(detail.length <= 4000 + '…[truncated]'.length, 'the cap holds');
   });
 
   it('a command exactly at the cap is kept whole with no marker', () => {
     const prefix = `cd ${world} && echo `;
     const collapsed = 'cd . && echo ';
-    const payload = 'y'.repeat(600 - collapsed.length);
+    const payload = 'y'.repeat(4000 - collapsed.length);
     fire({
       hook_event_name: 'PreToolUse',
       tool_name: 'Bash',
@@ -132,7 +132,7 @@ describe('prose recorder — tool events', () => {
     });
     const [row] = logLines();
     const detail = row.split('\t')[2];
-    assert.equal(detail.length, 600, 'exactly the cap');
+    assert.equal(detail.length, 4000, 'exactly the cap');
     assert.ok(!detail.includes('…[truncated]'), 'no marker at the boundary');
   });
 


### PR DESCRIPTION
The walk record's detail column — the substrate `calls_include`/`calls_in_order` match against — capped at 600 chars, which clipped a two-seed `workunit create` mid-argument in today's `start-promotes-inbox-ideas` walk and manufactured a FLAKY out of a correct walk (archive kept). The cap's own comment records the same failure class at the previous, lower cap.

The cap exists only to bound pathological blobs (heredoc scripts, inline payloads), so it now sits at 4000 — far above any real engine call — and the record-action test pins move with it, including the boundary and oversize cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)