### PR TITLE
workflow-start: the baseline offer's Otherwise arm names what it catches

### DIFF
--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -239,6 +239,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit --workflows -m "ba
 
 #### Otherwise
 
+A recorded status (`in-progress`/`completed`/`skipped`), or no pre-existing codebase — render nothing.
+
 → Proceed to **Step 1**.
 
 ---


### PR DESCRIPTION
In today's `start-promotes-inbox-ideas` walk, the walker at `baseline: skipped` recorded that neither Step 0.4 arm read as literally applying and resolved the branch itself rather than raising AMBIGUOUS — correct outcome, misleading read. The Otherwise arm now names both of its catches (a recorded status, or no pre-existing codebase) and its render-nothing behaviour, matching the conditional-chrome convention.

Conventions lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)