### PR TITLE
test(prose): pin the review Q&A gate's render call

### DIFF
--- a/tests/prose/cases/review-approves-the-work/case.json
+++ b/tests/prose/cases/review-approves-the-work/case.json
@@ -40,6 +40,7 @@
       "manifest get pay.planning",
       "impl(pay): T",
       "manifest get pay.implementation.pay project_skills",
+      "render review-qa-gate pay.review.pay",
       "push pay.review.pay reviewed_tasks",
       "review(pay): complete review",
       "topic complete pay review pay",


### PR DESCRIPTION
Follow-up to #892. `review-approves-the-work` already walks the review Q&A gate — `present-review.md` is in its `files`, and its scripted answer is the gate's `c/continue` — but no invariant pinned the call, so re-inlining the menu as prose would leave the walk green. Lint check 17 catches only `@if`-guarded rows; check 13's ratchet catches only templated fences.

One `calls_include` entry. Deterministic prose perimeter green (131 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)