### PR TITLE
review(verifier): findings must verify what they cite

### DIFF
--- a/agents/workflow-review-task-verifier.md
+++ b/agents/workflow-review-task-verifier.md
@@ -115,6 +115,16 @@ Tag each surviving note by the next step required to act on it:
 
 Decide by the next step — apply-now-zero-risk → `[do-now]`; concrete mechanical edit that touches logic → `[quickfix]`; decide-how-or-whether → `[idea]`; fix-incorrect-behaviour → `[bug]`. When torn between `[do-now]` and `[quickfix]`, choose `[quickfix]` — only tag `[do-now]` when there is genuinely zero chance of breaking logic. When torn between `[quickfix]` and `[idea]`, choose `[quickfix]` if there is a concrete edit at a known location, `[idea]` otherwise.
 
+## Citation Discipline
+
+Every finding carries a `file:line` anchor, and every claim inside it must hold when you write it. A finding whose substance is right but whose details are wrong sends its reader to the wrong line, or has them apply an edit that breaks the build.
+
+- **Re-read before citing.** Confirm the line number against the file's current content. Never carry one from an earlier read or infer it from a search result.
+- **Never name a symbol you have not located.** If your change calls a helper, confirm it exists and give its real path. If it does not exist, say so rather than naming what you expected to find.
+- **Assert no count or exclusivity you have not enumerated.** "The only site", "the single caller", "eleven call sites", "no production reader" — count them and state the true number, or drop the claim.
+- **Prove the edit you prescribe.** Your proposed change must be safe applied exactly as written: before saying an import or helper becomes unused, check every other line that could still use it.
+- **Repo-relative paths only.** An absolute path is wrong in every other checkout.
+
 ## Output File Format
 
 Write to `.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md` — in two steps: write the content to the same path with a `.txt` extension using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Use this format:
@@ -167,7 +177,7 @@ SUMMARY: {1 sentence}
 
 1. **One task only** — you verify exactly one plan task per invocation
 2. **Be thorough** — check implementation, tests, AND quality
-3. **Be specific** — include file paths and line numbers
+3. **Be specific** — include file paths and line numbers, verified per **Citation Discipline**
 4. **Balanced test review** — flag both under-testing AND over-testing
 5. **Report findings** — don't fix anything, just report what you find
 6. **No test execution** — Bash is solely for the output-file rename. Judge test adequacy by reading the test code; never try to run the suite or any other command

--- a/skills/workflow-review-process/references/review-checklist.md
+++ b/skills/workflow-review-process/references/review-checklist.md
@@ -116,6 +116,13 @@ Flag test balance issues:
 - **Under-tested**: "Task 2.1 has no test for the error case mentioned in spec section 3.2"
 - **Over-tested**: "Task 2.1 has 5 tests that all verify the same happy path with slight variations"
 
+Verify what you cite:
+
+- Re-read the line before quoting its number; never name a symbol you have not located
+- Count before claiming a count — "the only site", "the single caller", "eleven call sites" are claims, not colour
+- Check that the edit you prescribe is safe applied exactly as written
+- Repo-relative paths only
+
 Distinguish blocking vs non-blocking:
 
 - **Blocking**: Incomplete tasks, missing tests, broken functionality


### PR DESCRIPTION
Adds Citation Discipline to `workflow-review-task-verifier`, mirrored in `review-checklist.md`.

Five rules: re-read before citing a line, never name a symbol you have not located, enumerate before asserting a count or exclusivity, prove the prescribed edit is safe applied as written, repo-relative paths only.

**Why:** on a 366-finding corpus the findings were 98.6% substantively accurate, but their incidentals were not — a helper named that exists nowhere, "~171 occurrences across ~30 files" that was ~87 across 32, an "only place in the tree" with three other sites, and an instruction to drop an import the next line still uses (breaks the build when applied literally).

Verification is cheapest here — the verifier already has the file open. Downstream it costs a re-derivation across the whole corpus.

Prose-only. `npm test` green (2163). Intersecting prose cases: `review-approves-the-work`, `bridge-completes-the-feature`.