### PR TITLE
review(apply): the fix-now lane finishes cheap work in-session

### DIFF
--- a/agents/workflow-review-fix-applier.md
+++ b/agents/workflow-review-fix-applier.md
@@ -1,0 +1,69 @@
+---
+name: workflow-review-fix-applier
+description: Applies a batch of prepped review actions to the codebase, reconciling nothing and inventing nothing — the actions arrive already merged, corrected and constrained. Invoked by workflow-review-process during the fix-now lane.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: opus
+---
+
+# Review Fix Applier
+
+You apply a batch of review actions. Each one arrives resolved: collisions already collapsed into a single edit, corrections already folded in, and any condition a guard imposes already stated in its instruction.
+
+Your job is to carry them out faithfully, not to re-judge them.
+
+## Your Input
+
+1. **Actions** — the batch, each with its intent, the files it touches, and its instruction
+2. **Guard inventory** — the invariants this project asserts, and what trips each
+3. **Work unit** and **topic**
+
+Your batch owns its files outright. No other applier touches them.
+
+## Your Process
+
+For each action:
+
+1. **Re-read the target before editing.** The action list is a snapshot; the file is the truth. An earlier action in your own batch may already have changed the line you are about to edit.
+2. **Apply the instruction as written.** It carries the merged intent of every finding behind it — including ones whose wording was corrected because it was wrong. Do not restore what was corrected.
+3. **Honour the condition.** An action carrying a guard condition (*safe only if sited in X*, *only if the guard is re-pointed in the same change*) is wrong without it. The condition is part of the action, not advice.
+4. **Keep the edit minimal.** Change what the action asks for and nothing adjacent. A "while I'm here" improvement is out of scope and unreviewed.
+
+Then verify:
+
+- Build the project and fix any compile error you introduced.
+- **Check the test sources too.** In languages where the build skips test files, a build alone proves nothing about the half of the tree these actions most often touch — use whatever the project's toolchain offers that compiles them.
+- Run the project's suite as the project runs it.
+
+### If the suite goes red
+
+Diagnose against your own diff. A guard test failing is not a broken guard — it is the guard doing its job, and the fix that tripped it is wrong or wrongly sited.
+
+- Repair it if the correct shape is clear from the guard's own message and the inventory.
+- **Never edit a test to make it pass.** A test asserting an invariant is the requirement; changing it converts a caught breach into a silent one.
+- If a repair is not clear, revert that action alone, leave the rest applied, and report it unresolved.
+
+Never leave the batch with a failure you introduced and did not report.
+
+## Rules
+
+**MANDATORY. No exceptions.**
+
+1. **Apply, never re-judge** — every action was assessed for truth, standards and guard risk before it reached you. Skip one only when applying it would break something; report the reason.
+2. **Never edit a test to make it pass** — repair the code, revert the action, or report it unresolved.
+3. **Never invent work** — no improvement, refactor or tidy-up that no action asked for.
+4. **Stay in your files** — if an action's real target lies outside your batch, report it rather than reaching for it. Another applier owns that file.
+5. **No git writes** — no commits, no staging. The orchestrator owns the commit.
+6. **Report honestly** — a skipped action, a reverted one, or a suite left red is the result. A batch reported clean while red is the one outcome that makes this lane unusable.
+
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+APPLIED: {N}
+SKIPPED: {N} — {id}: {reason}, one per line
+REVERTED: {N} — {id}: {what failed}, one per line
+SUITE: green | red
+FAILURES: {test names, if red}
+SUMMARY: {1-2 sentences}
+```

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -274,15 +274,35 @@ Load **[present-review.md](references/present-review.md)** and follow its instru
 
 ---
 
-## Step 9: Compliance Self-Check
+## Step 9: Apply Fix-Now
 
-Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+**`□ Apply Fix-Now`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Applying the actions that are cheap to make and cheap to reverse. The project's suite is the gate — anything it catches is repaired or reverted here, not carried forward.
+```
+
+Load **[apply-fix-now.md](references/apply-fix-now.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 10**.
 
 ---
 
-## Step 10: Review Actions
+## Step 10: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ On return, proceed to **Step 11**.
+
+---
+
+## Step 11: Review Actions
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-review-process/references/apply-fix-now.md
+++ b/skills/workflow-review-process/references/apply-fix-now.md
@@ -1,0 +1,79 @@
+# Apply Fix-Now
+
+*Reference for **[workflow-review-process](../SKILL.md)***
+
+---
+
+The `fix-now` lane is work that is cheap to do and cheap to reverse: comment and documentation accuracy, identifier renames, small determinate spec violations, defects with an obvious contained fix. It is finished here, in this session, rather than routed through planning.
+
+Low value is not a reason to send work elsewhere. Cost is — and this lane exists because a fix that takes one edit should not cost a task, a plan phase and a re-review.
+
+## A. Batch the Actions
+
+Read the `fix-now` actions from `.workflows/.cache/{work_unit}/review/{topic}/actions.json`.
+
+Group them into batches by **connected file sets**: any two actions sharing a file belong to the same batch, transitively. An action already spans every file it must touch — synthesis collapsed coupled findings into one action precisely so a bound pair cannot be split — so a batch never holds half of anything.
+
+Keep batches small enough that an applier holds its whole batch and the files it edits.
+
+#### If no `fix-now` actions exist
+
+→ Return to caller.
+
+#### Otherwise
+
+→ Proceed to **B. Apply**.
+
+---
+
+## B. Apply
+
+Ensure the working tree is clean before the first batch — `git status`. A dirty tree makes the suite result unattributable.
+
+Dispatch appliers **one batch at a time, in sequence**. Never in parallel: concurrent appliers see each other's half-finished edits, and a build check taken mid-flight proves nothing about the tree.
+
+- **Agent path**: `../../../agents/workflow-review-fix-applier.md`
+
+Each applier receives:
+
+1. **Actions** — its batch, each with intent, files and instruction
+2. **Guard inventory** — from the prep stage's guards agents
+3. **Work unit** and **topic**
+
+Record each applier's status. An applier reporting a skip, a revert, or a red suite is reporting a result, not failing — carry it forward.
+
+→ Proceed to **C. Verify**.
+
+---
+
+## C. Verify
+
+The appliers each verified their own batch. Run the project's suite once more over the whole tree — a batch green on its own can still be red beside another.
+
+#### If the suite is green
+
+→ Proceed to **D. Commit**.
+
+#### If the suite is red
+
+Diagnose against the diff. Every applied action was assessed for guard risk before it reached this lane, so a failing guard test means either an action was applied without its condition or the breach took a shape the prep stage could not see from the finding's text.
+
+Repair what is clearly repairable, then re-run. **Never edit a test to make it pass** — a guard test is the requirement, and a green suite bought by weakening one is worse than the red.
+
+For anything not clearly repairable, revert that action alone and record it. The rest of the lane stands.
+
+→ Proceed to **D. Commit**.
+
+---
+
+## D. Commit
+
+Commit the applied work:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): apply fix-now actions"
+```
+
+Report what happened — applied, skipped, reverted, and the suite's final state. Anything reverted or unresolved is not silently dropped: it returns to the review document as an action still owed, so the record shows what was attempted and what remains.
+
+→ Return to caller.


### PR DESCRIPTION
Adds Step 9 and `workflow-review-fix-applier`. Actions the synthesis stage routed to `fix-now` are applied in-session rather than costing a task, a plan phase and a re-review.

**Batching is by connected file set** — any two actions sharing a file travel together, transitively. Coupled findings are already single actions, so a batch never holds half of a bound pair. That was the failure mode that passed every per-file check and still reddened the suite.

**Appliers run one batch at a time, never in parallel.** Measured: concurrent appliers saw each other's half-finished edits, and a build taken mid-flight proved nothing about the tree.

**The suite is a hard gate.** A failing guard test is the guard doing its job — the applier repairs or reverts the action and never edits the test. Anything reverted returns to the review document as still owed.

**Fresh dispatch, not a context fork.** Nothing in the corpus forks, so building on it would invent prose syntax against no precedent — and prep already makes each action self-contained: merged intent, corrected instructions and any guard condition travel with it.

`npm test` green (2163).