### PR TITLE
review(lanes): present and route the lanes the synthesis assigns

### DIFF
--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -778,17 +778,15 @@ function findingsSummary(cwd, { dotpath, file }) {
   return section('DISPLAY: findings summary', CONTINUE_MARKDOWN_INSTRUCTION, body);
 }
 
-// review-qa-gate — the review presentation's Q&A gate. Membership branches on
-// what the report carries: the do-now row only where zero-risk fixes exist,
-// the surface row only where there are recommendations to surface. Both are
-// judgment reads of the report rather than manifest state, so they ride as
-// flags. The arrow column is then recomputed for whichever set survives —
-// the one thing a hand-written block cannot do, since its padding is fixed
-// at authoring time against an option set that varies at runtime.
+// review-qa-gate — the review presentation's Q&A gate. Membership is fixed:
+// the fix-now lane is applied by its own step rather than offered here, and
+// the inbox receives the bug and idea lanes directly, so neither is a choice
+// the user makes at this gate. What remains is orientation — a lens shift,
+// the full report, questions, and the way onward.
 
 /**
  * @param {string} cwd
- * @param {{dotpath: string, donow?: string, recommendations?: string}} args
+ * @param {{dotpath: string}} args
  * @returns {string}
  */
 function reviewQaGate(cwd, args) {
@@ -796,15 +794,12 @@ function reviewQaGate(cwd, args) {
   if (phase !== 'review') {
     throw new Error(`render review-qa-gate: address must be <work_unit>.review.<topic>, got phase "${phase}"`);
   }
-  const options = [];
-  if (args.donow) options.push(cmdOption('d', 'do-now', 'Apply the zero-risk fixes now'));
-  if (args.recommendations) options.push(cmdOption('s', 'surface', 'Surface recommendations to inbox'));
-  options.push(
+  const options = [
     cmdOption('t', 'technical', "Retell the review from the code's perspective"),
     cmdOption('v', 'view', 'Show the full review report'),
     cmdOption('c', 'continue', 'Proceed to review actions'),
     promptOption('Ask a question', 'Ask about the review findings'),
-  );
+  ];
   return section(
     'MENU: review Q&A gate',
     "emit verbatim as markdown, then STOP for the user's response",

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -180,7 +180,7 @@ Commands:
   render findings-summary <wu.phase.topic> --file <payload.json>
   render finding          <wu.phase.topic> --file <payload.json>
   render finding-batch    <wu.phase.topic> --file <payload.json>
-  render review-qa-gate   <wu.review.topic> [--donow] [--recommendations]
+  render review-qa-gate   <wu.review.topic>
   render triage-announce  <wu.phase.topic>
   render triage-offer     <wu.phase.topic> --file <payload.json>
   render triage-block     <wu.phase.topic>

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -294,15 +294,23 @@ Load **[apply-fix-now.md](references/apply-fix-now.md)** and follow its instruct
 
 ---
 
-## Step 10: Compliance Self-Check
+## Step 10: Route Lanes
 
-Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+Load **[route-lanes.md](references/route-lanes.md)** and follow its instructions as written.
 
 → On return, proceed to **Step 11**.
 
 ---
 
-## Step 11: Review Actions
+## Step 11: Compliance Self-Check
+
+Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
+
+→ On return, proceed to **Step 12**.
+
+---
+
+## Step 12: Review Actions
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-review-process/references/present-review.md
+++ b/skills/workflow-review-process/references/present-review.md
@@ -20,9 +20,11 @@ Verdict: {Approve | Request Changes | Comments Only}
 
 Then render the review summary as a markdown paragraph (not a code block) — a product-lens narrative: what was reviewed, where it stands, and what the findings mean for the product.
 
-Check whether the review contains a `## Recommendations` section with categorized subsections (`### Do now`, `### Quick-fixes`, `### Ideas`, `### Bugs`). Set `has_recommendations`, and set `has_donow`, `has_quickfixes`, `has_ideas`, `has_bugs` per subsection present.
+Read the report's `## Recommendations` lanes. Set `has_recommendations`, and per lane set `fixnow_count`, `has_consolidation`, `has_needsdesign`, `has_bugs`, `has_ideas`, and `dropped_count`.
 
-Render each recommendation as it appears in the report — a one-line item shows its `file:line`; a clustered item shows its sub-bullets. This detail is what lets the user choose do-now versus surface versus ignore, so never collapse it to a bare title. Each `{description}` leads with the behaviour or impact it concerns, mechanism after — reword the report entry where its lead is mechanism.
+**A lane is listed only where the user decides something.** `needs-design`, bug and idea items are shown in full — each is a call they own. The `fix-now` lane is a count: it is applied in the next step whatever they say, and listing hundreds of items they will not read is the noise this shape exists to prevent. Consolidation is one line, because it is one scheduled pass.
+
+Each listed `{description}` leads with the behaviour or impact it concerns, mechanism after — reword the report entry where its lead is mechanism.
 
 #### If verdict is `Approve`
 
@@ -34,29 +36,36 @@ All acceptance criteria met. No blocking issues found.
 @if(has_recommendations)
 Recommendations (non-blocking):
 
-@if(has_donow)
-Do now (zero-risk — applied on request):
-  {N}. {description} ({file:line})
+@if(fixnow_count)
+  {fixnow_count} applied in the next step — comment and documentation accuracy, renames, small determinate fixes.
 @endif
 
-@if(has_quickfixes)
-Quick-fixes (mechanical, logic-touching):
-  {N}. {description} ({file:line})
+@if(has_consolidation)
+  One consolidation pass scheduled: {description}
 @endif
 
-@if(has_ideas)
-Ideas (require a decision):
+@if(has_needsdesign)
+Needs design (a call before it can be built):
   {N}. {description} ({file:line})
 @endif
 
 @if(has_bugs)
-Bugs:
+Bugs (to the inbox):
   {N}. {description} ({file:line})
+@endif
+
+@if(has_ideas)
+Ideas (to the inbox):
+  {N}. {description} ({file:line})
+@endif
+
+@if(dropped_count)
+  {dropped_count} dropped — reasons in the report.
 @endif
 @endif
 ```
 
-Items are numbered sequentially across all categories (matching the report's numbering).
+Listed items are numbered sequentially across the lanes that carry them, matching the report's numbering.
 
 → Proceed to **B. Q&A Loop**.
 
@@ -75,24 +84,31 @@ Required Changes:
 @if(has_recommendations)
 Recommendations (non-blocking):
 
-@if(has_donow)
-Do now (zero-risk — applied on request):
-  {N}. {description} ({file:line})
+@if(fixnow_count)
+  {fixnow_count} applied in the next step — comment and documentation accuracy, renames, small determinate fixes.
 @endif
 
-@if(has_quickfixes)
-Quick-fixes (mechanical, logic-touching):
-  {N}. {description} ({file:line})
+@if(has_consolidation)
+  One consolidation pass scheduled: {description}
 @endif
 
-@if(has_ideas)
-Ideas (require a decision):
+@if(has_needsdesign)
+Needs design (a call before it can be built):
   {N}. {description} ({file:line})
 @endif
 
 @if(has_bugs)
-Bugs:
+Bugs (to the inbox):
   {N}. {description} ({file:line})
+@endif
+
+@if(has_ideas)
+Ideas (to the inbox):
+  {N}. {description} ({file:line})
+@endif
+
+@if(dropped_count)
+  {dropped_count} dropped — reasons in the report.
 @endif
 @endif
 ```
@@ -106,24 +122,31 @@ Bugs:
 ```
 Comments (non-blocking):
 
-@if(has_donow)
-Do now (zero-risk — applied on request):
-  {N}. {description} ({file:line})
+@if(fixnow_count)
+  {fixnow_count} applied in the next step — comment and documentation accuracy, renames, small determinate fixes.
 @endif
 
-@if(has_quickfixes)
-Quick-fixes (mechanical, logic-touching):
-  {N}. {description} ({file:line})
+@if(has_consolidation)
+  One consolidation pass scheduled: {description}
 @endif
 
-@if(has_ideas)
-Ideas (require a decision):
+@if(has_needsdesign)
+Needs design (a call before it can be built):
   {N}. {description} ({file:line})
 @endif
 
 @if(has_bugs)
-Bugs:
+Bugs (to the inbox):
   {N}. {description} ({file:line})
+@endif
+
+@if(has_ideas)
+Ideas (to the inbox):
+  {N}. {description} ({file:line})
+@endif
+
+@if(dropped_count)
+  {dropped_count} dropped — reasons in the report.
 @endif
 ```
 
@@ -133,10 +156,10 @@ Bugs:
 
 ## B. Q&A Loop
 
-Render the gate, passing `--donow` when `has_donow` and `--recommendations` when `has_recommendations`:
+Render the gate:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs render review-qa-gate {work_unit}.review.{topic} [--donow] [--recommendations]
+node .claude/skills/workflow-engine/scripts/engine.cjs render review-qa-gate {work_unit}.review.{topic}
 ```
 
 Emit the call's MENU section verbatim per its marker.
@@ -163,95 +186,6 @@ Render the full content of `.workflows/{work_unit}/review/{topic}/report.md` as 
 
 → Return to **B. Q&A Loop**.
 
-#### If `do-now`
-
-→ Proceed to **D. Do Now**.
-
-#### If `surface`
-
-→ Proceed to **C. Surface to Inbox**.
-
 #### If `continue`
 
 → Return to caller.
-
----
-
-## C. Surface to Inbox
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Which recommendations? (enter numbers, comma-separated, or **`a/all`**)
-```
-
-**STOP.** Wait for user response.
-
-Parse the selection — individual numbers, comma-separated list, or "all".
-
-For each selected recommendation:
-
-1. Determine its category from the grouped display (do-now or quickfix → `quickfixes/`, idea → `ideas/`, bug → `bugs/`) — a surfaced do-now item is one the user chose to defer rather than apply, so it files as a quick-fix
-2. Create the inbox directory:
-   ```bash
-   mkdir -p .workflows/.inbox/{category}
-   ```
-3. Generate a kebab-case slug (2-4 words from the core recommendation, e.g., `volatile-marker-test`, `error-mapping-distinction`)
-4. Write the file to `.workflows/.inbox/{category}/{YYYY-MM-DD}--{slug}.md` (use today's date):
-
-```markdown
-# {Title derived from recommendation}
-
-{Full recommendation description from the review report}
-
-Source: review of {work_unit}/{topic}
-```
-
-> *Output the next fenced block as a code block:*
-
-```
-Surfaced to inbox:
-@foreach(item in surfaced_items)
-  • {item.number} → {item.category}/{item.date}--{item.slug}.md
-@endforeach
-```
-
-Commit — the surfaced files live in `.workflows/.inbox/`, outside the work unit, so use the inbox scope:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit --inbox -m "review({work_unit}): surface recommendations to inbox"
-```
-
-→ Return to **B. Q&A Loop**.
-
----
-
-## D. Do Now
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-> Applying the zero-risk fixes directly. Each touches no executable logic, so it ships without the pipeline.
-```
-
-Apply every item in the `### Do now` subsection of `report.md`:
-
-1. Make each described edit at its `file:line`. Stay within the scope of the note — no opportunistic changes.
-2. Run the project's linters; when any change touched a code or test file, also run the test suite (see the project skills loaded in Step 3 and the topic's configured linters). These are project-specific commands, so they fall outside this skill's allowed-tools and prompt for approval when run.
-3. If a change fails verification, revert that single change and re-tag its item `[quickfix]` in `report.md` — leave the rest applied.
-
-Commit the applied changes with raw git — the fixes touch project files outside the work unit, so the scoped helper cannot cover them. Stage the touched files and the work unit (for any report re-tags), then commit:
-
-```bash
-git add -- .workflows/{work_unit} {files the fixes touched}
-git commit -m "review({work_unit}): apply do-now fixes"
-```
-
-> *Output the next fenced block as a code block:*
-
-```
-Applied {K} do-now fix(es).@if(deferred_count > 0) {D} deferred to quick-fixes (failed verification).@endif
-```
-
-→ Return to **B. Q&A Loop**.

--- a/skills/workflow-review-process/references/route-lanes.md
+++ b/skills/workflow-review-process/references/route-lanes.md
@@ -1,0 +1,48 @@
+# Route Lanes
+
+*Reference for **[workflow-review-process](../SKILL.md)***
+
+---
+
+Three lanes remain once `fix-now` has been applied. Each has one destination, decided by the synthesis stage — nothing is re-judged here.
+
+## A. File the Inbox Lanes
+
+The inbox holds work that earns its own pass through the pipeline later. Synthesis gates it hard: `inbox-bug` is a defect a user will plausibly hit, `inbox-idea` is a genuine new capability. A refactor is neither, and neither is an edge nobody reaches — those were routed elsewhere before reaching this step.
+
+Read the `inbox-bug` and `inbox-idea` actions from `.workflows/.cache/{work_unit}/review/{topic}/actions.json`.
+
+#### If neither lane carries an action
+
+→ Proceed to **B. Record the Consolidation Pass**.
+
+#### Otherwise
+
+Write one file per action, taking the next available number in its directory:
+
+- `inbox-bug` → `.workflows/.inbox/bugs/{NNN}-{slug}.md`
+- `inbox-idea` → `.workflows/.inbox/ideas/{NNN}-{slug}.md`
+
+Each file carries the action's intent, the files it concerns, and where it came from — `{work_unit}` review, and the source finding ids. An item arriving in the inbox months later is read by someone with none of this session's context, so it states the problem rather than referring to it.
+
+→ Proceed to **B. Record the Consolidation Pass**.
+
+---
+
+## B. Record the Consolidation Pass
+
+Duplication worth addressing is worth one deliberate pass over the affected surface, not N separate edits — applying it piecemeal rotates a large body of code for no change in behaviour, against a real risk of breaking what works.
+
+The pass is already recorded in the review document as a single item. Nothing is filed and nothing is scheduled here: it is deliberate work someone picks up with the whole surface in view, and splitting it into inbox items is what turns it back into N separate edits.
+
+→ Proceed to **C. Report**.
+
+---
+
+## C. Report
+
+State what was routed, as one or two markdown sentences — no fence. Name the counts filed to the inbox and split them by kind, say whether a consolidation pass was recorded, and name how many actions still need design, since those are what the next step works through.
+
+Where a lane is empty, it goes unmentioned rather than reported as zero.
+
+→ Return to caller.

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -707,7 +707,7 @@ const RATCHET_PINS = {
   'skills/workflow-research-process/references/epic-session.md': 2,
   'skills/workflow-research-process/references/feature-session.md': 1,
   'skills/workflow-research-process/references/topic-splitting.md': 2,
-  'skills/workflow-review-process/references/present-review.md': 6,
+  'skills/workflow-review-process/references/present-review.md': 4,
   'skills/workflow-scoping-process/SKILL.md': 2,
   'skills/workflow-scoping-process/references/complexity-check.md': 2,
   'skills/workflow-discovery/references/first-phase-routing.md': 1,

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -2089,28 +2089,16 @@ describe('render review-qa-gate', () => {
     '',
   ];
 
-  it('renders both conditional rows and aligns the whole set', () => {
-    const out = renderSurface(dir, 'review-qa-gate', { dotpath: 'pay.review.checkout', donow: '1', recommendations: '1' });
-    assert.strictEqual(out, [
-      ...HEAD,
-      '**`d/do-now`**       → Apply the zero-risk fixes now',
-      '**`s/surface`**      → Surface recommendations to inbox',
-      ...TAIL,
-    ].join('\n'));
-  });
-
-  it('drops both rows and re-aligns against the survivors', () => {
+  it('renders the fixed option set', () => {
     const out = renderSurface(dir, 'review-qa-gate', { dotpath: 'pay.review.checkout' });
     assert.strictEqual(out, [...HEAD, ...TAIL].join('\n'));
   });
 
-  it('carries one row without disturbing the column', () => {
-    const out = renderSurface(dir, 'review-qa-gate', { dotpath: 'pay.review.checkout', recommendations: '1' });
-    assert.strictEqual(out, [
-      ...HEAD,
-      '**`s/surface`**      → Surface recommendations to inbox',
-      ...TAIL,
-    ].join('\n'));
+  it('offers no apply or surface row — the lanes own that work', () => {
+    const out = renderSurface(dir, 'review-qa-gate', { dotpath: 'pay.review.checkout', donow: '1', recommendations: '1' });
+    assert.ok(!out.includes('do-now'), 'fix-now is applied by its own step, never offered here');
+    assert.ok(!out.includes('surface'), 'the inbox receives the bug and idea lanes directly');
+    assert.strictEqual(out, [...HEAD, ...TAIL].join('\n'));
   });
 
   it('refuses an address outside the review phase', () => {


### PR DESCRIPTION
Closes the gap #901 left: `produce-review` wrote lanes while `present-review` still looked for `### Do now` / `### Quick-fixes`, so recommendations rendered empty.

**The presentation now lists only what you decide.** `needs-design`, bugs and ideas show in full. `fix-now` is a count — Step 9 applies it regardless, and listing hundreds of items is exactly the noise this shape exists to prevent. Consolidation is one line, because it is one scheduled pass.

**The Q&A gate loses both conditional rows.** `d/do-now` offered work Step 9 now does unconditionally; `s/surface` offered a wholesale dump the lanes replace. Membership is fixed now, and the surface says so instead of claiming to vary. The superseded Surface-to-Inbox and Do-Now sections go with it.

**`route-lanes.md`** files the bug and idea lanes, and records — rather than files — the consolidation pass. Splitting that into inbox items turns one deliberate pass back into N separate edits, which is the thing it exists to avoid.

Ratchet pin shrinks 6 → 4 with the two removed fences. `npm test` green (2162).