### PR TITLE
review(render): the review presentation becomes an engine surface

### DIFF
--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -778,6 +778,88 @@ function findingsSummary(cwd, { dotpath, file }) {
   return section('DISPLAY: findings summary', CONTINUE_MARKDOWN_INSTRUCTION, body);
 }
 
+// review-presentation — the review's verdict and its lane summary. What the
+// lanes contain is judgment (the report's own items), so it rides as a
+// payload; which lanes list their items and which report a count is a fixed
+// rule this surface owns. A lane is listed only where the user decides
+// something: needs-design, bugs and ideas are calls they make, while fix-now
+// is applied by its own step whatever they say — listing it would put a list
+// nobody reads in front of the one thing that needs reading.
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, file?: string}} args
+ * @returns {string}
+ */
+function reviewPresentation(cwd, { dotpath, file }) {
+  if (!file) throw new Error('render review-presentation: --file <payload.json> is required');
+  const { phase } = resolveAddress(cwd, dotpath, 'review-presentation');
+  if (phase !== 'review') {
+    throw new Error(`render review-presentation: address must be <work_unit>.review.<topic>, got phase "${phase}"`);
+  }
+  const p = readJsonPayload(cwd, file, 'review-presentation');
+  const VERDICTS = { approve: 'Approve', 'request-changes': 'Request Changes', 'comments-only': 'Comments Only' };
+  if (!VERDICTS[p.verdict]) {
+    throw new Error(`render review-presentation: "verdict" must be one of ${Object.keys(VERDICTS).join('/')}`);
+  }
+  if (!isFilled(p.topic)) throw new Error('render review-presentation: "topic" must be a non-empty string');
+
+  const listed = (name) => {
+    const rows = p[name];
+    if (rows === undefined) return [];
+    if (!Array.isArray(rows)) throw new Error(`render review-presentation: "${name}" must be an array of {description, ref?}`);
+    rows.forEach((r, i) => {
+      if (!isFilled(r.description)) throw new Error(`render review-presentation: ${name}[${i}] needs a "description"`);
+    });
+    return rows;
+  };
+  const needsDesign = listed('needs_design');
+  const bugs = listed('bugs');
+  const ideas = listed('ideas');
+  const required = listed('required_changes');
+
+  const out = [`Review: ${p.topic}`, '', `Verdict: ${VERDICTS[p.verdict]}`, ''];
+
+  if (p.verdict === 'approve') out.push('All acceptance criteria met. No blocking issues found.', '');
+  if (required.length) {
+    out.push('Required changes:', '');
+    required.forEach((r, i) => {
+      out.push(`  ${i + 1}. ${r.description}`);
+      if (isFilled(r.ref)) out.push(`     ${r.ref}`);
+    });
+    out.push('');
+  }
+
+  // One running number across the listed lanes, so an item the user names is
+  // unambiguous whichever lane it came from.
+  let n = 0;
+  const lane = (label, rows) => {
+    if (!rows.length) return;
+    out.push(`${label}:`, '');
+    rows.forEach((r) => {
+      n += 1;
+      out.push(`  ${n}. ${r.description}${isFilled(r.ref) ? ` (${r.ref})` : ''}`);
+    });
+    out.push('');
+  };
+
+  const counted = [];
+  if (Number(p.fix_now) > 0) counted.push(`  ${p.fix_now} applied in the next step — accuracy corrections, renames, small determinate fixes.`);
+  if (isFilled(p.consolidation)) counted.push(`  One consolidation pass recorded: ${p.consolidation}`);
+
+  if (counted.length || needsDesign.length || bugs.length || ideas.length) {
+    out.push('Recommendations (non-blocking):', '');
+    counted.forEach((l) => out.push(l));
+    if (counted.length) out.push('');
+    lane('Needs design (a call before it can be built)', needsDesign);
+    lane('Bugs (to the inbox)', bugs);
+    lane('Ideas (to the inbox)', ideas);
+  }
+  if (Number(p.dropped) > 0) out.push(`  ${p.dropped} dropped — reasons in the report.`, '');
+
+  return section('DISPLAY: review presentation', CONTINUE_INSTRUCTION, out.join('\n'));
+}
+
 // review-qa-gate — the review presentation's Q&A gate. Membership is fixed:
 // the fix-now lane is applied by its own step rather than offered here, and
 // the inbox receives the bug and idea lanes directly, so neither is a choice
@@ -2048,6 +2130,7 @@ const SURFACES = {
   'findings-summary': findingsSummary,
   'finding-batch': findingBatch,
   'finding': finding,
+  'review-presentation': reviewPresentation,
   'review-qa-gate': reviewQaGate,
   'triage-announce': triageAnnounce,
   'triage-offer': triageOffer,

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -180,6 +180,7 @@ Commands:
   render findings-summary <wu.phase.topic> --file <payload.json>
   render finding          <wu.phase.topic> --file <payload.json>
   render finding-batch    <wu.phase.topic> --file <payload.json>
+  render review-presentation <wu.review.topic> --file <payload.json>
   render review-qa-gate   <wu.review.topic>
   render triage-announce  <wu.phase.topic>
   render triage-offer     <wu.phase.topic> --file <payload.json>

--- a/skills/workflow-review-process/references/present-review.md
+++ b/skills/workflow-review-process/references/present-review.md
@@ -10,147 +10,33 @@
 
 Read the review file at `.workflows/{work_unit}/review/{topic}/report.md`.
 
-> *Output the next fenced block as a code block:*
+Build the presentation payload from the report and write it with the Write tool to `.workflows/.cache/{work_unit}/review/{topic}/presentation.json`:
 
+```json
+{
+  "topic": "{topic}",
+  "verdict": "approve|request-changes|comments-only",
+  "required_changes": [{"description": "…", "ref": "file:line"}],
+  "fix_now": 0,
+  "consolidation": "the pass's one-line intent, or omitted",
+  "needs_design": [{"description": "…", "ref": "file:line"}],
+  "bugs": [{"description": "…", "ref": "file:line"}],
+  "ideas": [{"description": "…", "ref": "file:line"}],
+  "dropped": 0
+}
 ```
-Review: {topic}
 
-Verdict: {Approve | Request Changes | Comments Only}
+Each `description` leads with the behaviour or impact it concerns, mechanism after — reword the report entry where its lead is mechanism. Which lanes list their items and which report a count is the surface's rule, not a judgment made here.
+
+Render and emit the section verbatim per its marker:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render review-presentation {work_unit}.review.{topic} --file .workflows/.cache/{work_unit}/review/{topic}/presentation.json
 ```
 
 Then render the review summary as a markdown paragraph (not a code block) — a product-lens narrative: what was reviewed, where it stands, and what the findings mean for the product.
 
-Read the report's `## Recommendations` lanes. Set `has_recommendations`, and per lane set `fixnow_count`, `has_consolidation`, `has_needsdesign`, `has_bugs`, `has_ideas`, and `dropped_count`.
-
-**A lane is listed only where the user decides something.** `needs-design`, bug and idea items are shown in full — each is a call they own. The `fix-now` lane is a count: it is applied in the next step whatever they say, and listing hundreds of items they will not read is the noise this shape exists to prevent. Consolidation is one line, because it is one scheduled pass.
-
-Each listed `{description}` leads with the behaviour or impact it concerns, mechanism after — reword the report entry where its lead is mechanism.
-
-#### If verdict is `Approve`
-
-> *Output the next fenced block as a code block:*
-
-```
-All acceptance criteria met. No blocking issues found.
-
-@if(has_recommendations)
-Recommendations (non-blocking):
-
-@if(fixnow_count)
-  {fixnow_count} applied in the next step — comment and documentation accuracy, renames, small determinate fixes.
-@endif
-
-@if(has_consolidation)
-  One consolidation pass scheduled: {description}
-@endif
-
-@if(has_needsdesign)
-Needs design (a call before it can be built):
-  {N}. {description} ({file:line})
-@endif
-
-@if(has_bugs)
-Bugs (to the inbox):
-  {N}. {description} ({file:line})
-@endif
-
-@if(has_ideas)
-Ideas (to the inbox):
-  {N}. {description} ({file:line})
-@endif
-
-@if(dropped_count)
-  {dropped_count} dropped — reasons in the report.
-@endif
-@endif
-```
-
-Listed items are numbered sequentially across the lanes that carry them, matching the report's numbering.
-
-→ Proceed to **B. Q&A Loop**.
-
-#### If verdict is `Request Changes`
-
-> *Output the next fenced block as a code block:*
-
-```
-Required Changes:
-
-  1. {change description}
-     {file:line reference if available}
-
-  2. ...
-
-@if(has_recommendations)
-Recommendations (non-blocking):
-
-@if(fixnow_count)
-  {fixnow_count} applied in the next step — comment and documentation accuracy, renames, small determinate fixes.
-@endif
-
-@if(has_consolidation)
-  One consolidation pass scheduled: {description}
-@endif
-
-@if(has_needsdesign)
-Needs design (a call before it can be built):
-  {N}. {description} ({file:line})
-@endif
-
-@if(has_bugs)
-Bugs (to the inbox):
-  {N}. {description} ({file:line})
-@endif
-
-@if(has_ideas)
-Ideas (to the inbox):
-  {N}. {description} ({file:line})
-@endif
-
-@if(dropped_count)
-  {dropped_count} dropped — reasons in the report.
-@endif
-@endif
-```
-
-→ Proceed to **B. Q&A Loop**.
-
-#### If verdict is `Comments Only`
-
-> *Output the next fenced block as a code block:*
-
-```
-Comments (non-blocking):
-
-@if(fixnow_count)
-  {fixnow_count} applied in the next step — comment and documentation accuracy, renames, small determinate fixes.
-@endif
-
-@if(has_consolidation)
-  One consolidation pass scheduled: {description}
-@endif
-
-@if(has_needsdesign)
-Needs design (a call before it can be built):
-  {N}. {description} ({file:line})
-@endif
-
-@if(has_bugs)
-Bugs (to the inbox):
-  {N}. {description} ({file:line})
-@endif
-
-@if(has_ideas)
-Ideas (to the inbox):
-  {N}. {description} ({file:line})
-@endif
-
-@if(dropped_count)
-  {dropped_count} dropped — reasons in the report.
-@endif
-```
-
-→ Proceed to **B. Q&A Loop**.
+→ On return, proceed to **B. Q&A Loop**.
 
 ---
 

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -707,7 +707,6 @@ const RATCHET_PINS = {
   'skills/workflow-research-process/references/epic-session.md': 2,
   'skills/workflow-research-process/references/feature-session.md': 1,
   'skills/workflow-research-process/references/topic-splitting.md': 2,
-  'skills/workflow-review-process/references/present-review.md': 4,
   'skills/workflow-scoping-process/SKILL.md': 2,
   'skills/workflow-scoping-process/references/complexity-check.md': 2,
   'skills/workflow-discovery/references/first-phase-routing.md': 1,

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1839,7 +1839,7 @@ describe('catalogue dispatch', () => {
   });
 
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, review-qa-gate, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, off-topic-offer, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick, baseline-offer-gate\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, review-presentation, review-qa-gate, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, off-topic-offer, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick, baseline-offer-gate\)/);
   });
 });
 
@@ -2064,6 +2064,86 @@ describe('baseline surfaces', () => {
     writeBaseline({ status: 'completed', areas: { overview: 'completed' } });
     assert.match(renderSurface(dir, 'baseline-manage-gate', {}), /\*\*`◆ What would you like to do\?`\*\*[\s\S]*\*\*`e\/expand`\*\* → Add a new area, or deepen an existing one/);
     assert.match(renderSurface(dir, 'baseline-doc-pick', {}), /Which doc\? \(enter the area name, or \*\*`b\/back`\*\*\)/);
+  });
+});
+
+describe('render review-presentation', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { review: { items: { checkout: { status: 'in-progress' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  const render = (payload) => {
+    fs.writeFileSync(path.join(dir, 'p.json'), JSON.stringify(payload));
+    return renderSurface(dir, 'review-presentation', { dotpath: 'pay.review.checkout', file: 'p.json' });
+  };
+
+  it('counts the lanes the user does not decide and lists the ones they do', () => {
+    const out = render({
+      topic: 'checkout', verdict: 'approve', fix_now: 341, consolidation: 'collapse the scaffolding',
+      needs_design: [{ description: 'the badge key collides', ref: 'union.go:190' }],
+      bugs: [{ description: 'the swatch leaves the background changed', ref: 'main.go:63' }],
+      dropped: 45,
+    });
+    assert.match(out, /341 applied in the next step/);
+    assert.match(out, /One consolidation pass recorded: collapse the scaffolding/);
+    assert.match(out, /1\. the badge key collides \(union\.go:190\)/);
+    assert.match(out, /2\. the swatch leaves the background changed \(main\.go:63\)/);
+    assert.match(out, /45 dropped/);
+  });
+
+  it('never lists the fix-now items — a count is the whole point', () => {
+    const out = render({ topic: 'checkout', verdict: 'approve', fix_now: 300 });
+    assert.match(out, /300 applied in the next step/);
+    assert.ok(!/^\s+\d+\. /m.test(out), 'no numbered item rows when only fix-now carries work');
+  });
+
+  it('numbers one running sequence across the listed lanes', () => {
+    const out = render({
+      topic: 'checkout', verdict: 'comments-only',
+      needs_design: [{ description: 'a' }], bugs: [{ description: 'b' }], ideas: [{ description: 'c' }],
+    });
+    assert.match(out, /1\. a/);
+    assert.match(out, /2\. b/);
+    assert.match(out, /3\. c/);
+  });
+
+  it('carries required changes only where the verdict asks for them', () => {
+    const out = render({
+      topic: 'checkout', verdict: 'request-changes',
+      required_changes: [{ description: 'the loader never closes', ref: 'load.go:20' }],
+    });
+    assert.match(out, /Verdict: Request Changes/);
+    assert.match(out, /Required changes:/);
+    assert.match(out, /1\. the loader never closes/);
+    assert.ok(!out.includes('All acceptance criteria met'));
+  });
+
+  it('renders a clean review as verdict alone', () => {
+    const out = render({ topic: 'checkout', verdict: 'approve' });
+    assert.match(out, /All acceptance criteria met/);
+    assert.ok(!out.includes('Recommendations'), 'no recommendations heading when every lane is empty');
+    assert.ok(!out.includes('dropped'));
+  });
+
+  it('refuses an unknown verdict, a missing topic, and a missing payload', () => {
+    assert.throws(() => render({ topic: 'checkout', verdict: 'ship-it' }), /"verdict" must be one of/);
+    assert.throws(() => render({ verdict: 'approve' }), /"topic" must be a non-empty string/);
+    assert.throws(
+      () => renderSurface(dir, 'review-presentation', { dotpath: 'pay.review.checkout' }),
+      /--file <payload\.json> is required/,
+    );
+  });
+
+  it('refuses an address outside the review phase', () => {
+    writeManifest(dir, 'pay2', { phases: { discussion: { items: { checkout: { status: 'in-progress' } } } } });
+    fs.writeFileSync(path.join(dir, 'p.json'), JSON.stringify({ topic: 'x', verdict: 'approve' }));
+    assert.throws(
+      () => renderSurface(dir, 'review-presentation', { dotpath: 'pay2.discussion.checkout', file: 'p.json' }),
+      /address must be <work_unit>\.review\.<topic>/,
+    );
   });
 });
 


### PR DESCRIPTION
`present-review.md` drew its verdict and recommendations by hand — three near-identical templated fences, one per verdict, each repeating the same lane block with `@if` directives. The ratchet had it pinned as legacy at 6.

Replaces all three with `render review-presentation`, a payload surface. The judgment (which items, worded how) rides as the payload; **which lanes list their items and which report a count is a fixed rule the surface owns**, so the shape cannot drift per verdict or per author.

That rule is the substance, not the plumbing: `needs-design`, bugs and ideas are listed because each is a call the user makes; `fix-now` reports a count because its own step applies it regardless. A 300-item list sitting in front of the two things that need reading is exactly the noise the lanes exist to remove.

**The pin goes to zero** — the site is converted, not re-pinned — and the file drops from 267 lines to 77.

7 new surface tests: lane counting vs listing, one running number across listed lanes, required-changes only where the verdict asks, a clean review rendering as verdict alone, payload validation, and the phase guard. `npm test` green (2169).