### PR TITLE
render(proposed-task): head takes the task-header marker idiom

### DIFF
--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -328,8 +328,12 @@ function proposedTask(cwd, args) {
   if (isFilled(p.placement)) meta.push(`Placement: ${p.placement}`);
   if (isFilled(p.priority)) meta.push(`Priority: ${p.priority}`);
   if (isFilled(p.depends_on)) meta.push(`Depends on: ${p.depends_on}`);
+  // The head takes the task-header marker idiom (see taskHeader): the ordinal
+  // is batch position, not a plan number — a suffix, and noise for a batch of
+  // one, so it renders only when there is a walk to pace.
+  const ordinal = p.total > 1 ? ` (${p.current} of ${p.total})` : '';
   const body = [
-    `**Task ${p.current}/${p.total}: ${p.title}**${isFilled(p.severity) ? ` (${p.severity})` : ''}`,
+    `**\`▪ ${p.title.trim()}${ordinal}\`**${isFilled(p.severity) ? ` (${p.severity})` : ''}`,
     ...meta,
     '',
     `**Problem**: ${p.problem}`,
@@ -351,7 +355,9 @@ function proposedTask(cwd, args) {
     parts.push(section(
       'DISPLAY: task auto-approved',
       `after recording the approval: ${AUTO_GATE_INSTRUCTION}`,
-      `Task ${p.current} of ${p.total}: ${p.title} — approved [auto].`,
+      p.total > 1
+        ? `Task ${p.current} of ${p.total}: ${p.title} — approved [auto].`
+        : `${p.title} — approved [auto].`,
     ));
   } else {
     const hint = isFilled(args['comment-hint']) ? args['comment-hint'] : 'Tell me what to change';

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -987,7 +987,7 @@ describe('render proposed-task', () => {
     const out = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'gated' });
     assert.strictEqual(out, [
       '=== DISPLAY: proposed task (emit verbatim as markdown) ===',
-      '**Task 2/3: Fix adapter leak** (Important)',
+      '**`▪ Fix adapter leak (2 of 3)`** (Important)',
       'Sources: reviewer cycle 1',
       '',
       '**Problem**: The adapter never closes.',
@@ -1190,13 +1190,16 @@ describe('render proposed-task', () => {
     const file = writePayload(dir, 'a.json', adhoc);
     const out = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'gated' });
     const lines = out.split('\n');
-    assert.strictEqual(lines[1], '**Task 1/1: Fix login redirect**');
+    assert.strictEqual(lines[1], '**`▪ Fix login redirect`**');
     assert.strictEqual(lines[2], 'Placement: phase 2');
     assert.strictEqual(lines[3], 'Priority: 1');
     assert.strictEqual(lines[4], 'Depends on: portal-2-3');
     assert.strictEqual(lines[5], '');
     assert.ok(!out.includes('Sources:'));
     assert.ok(out.includes('MENU: task approval'));
+    const auto = renderSurface(dir, 'proposed-task', { dotpath: 'pay.implementation.portal', file, gate: 'auto' });
+    assert.ok(auto.includes('Fix login redirect — approved [auto].'));
+    assert.ok(!auto.includes('Task 1 of 1'));
   });
 });
 

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -1171,6 +1171,8 @@ describe('pipeline simulation', () => {
     assert.match(adhocGate, /Placement: phase 1/, 'ad hoc payload renders its placement line');
     assert.match(adhocGate, /MENU: task approval/, 'ad hoc gate carries the shared approval menu');
     assert.ok(!/Sources:/.test(adhocGate), 'absent synthesis fields render nothing');
+    assert.match(adhocGate, /\*\*`▪ Fix redirect`\*\*/,
+      'head takes the task-header marker idiom, ordinal omitted for a batch of one');
     sim.run(['manifest', 'set', `${wu}.implementation.${wu}`, 'staging.ad-hoc-1.tasks.1', 'approved']);
 
     // A resumed session resets gate modes to gated (session-scoped auto).


### PR DESCRIPTION
The proposed-task surface predates the task-header marker (#896) and still rendered its head as plain bold. It now takes the same idiom as task-brief/task-result: bold code span with the ▪ marker, ordinal as an '(n of N)' suffix — omitted for a batch of one, on the header and the auto-approved continuation line both. The ordinal is batch position, never a plan number.

Serves all three callers of the shared surface: the ad hoc plan-changes gate, the implementation analysis loop, and the review-actions loop.

Tests: render-surfaces pins re-pinned + batch-of-one auto coverage added; pipeline simulation now pins the head shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)