### PR TITLE
feat(impl): the bank — executor and reviewer deposit cross-scope opportunities

### DIFF
--- a/agents/workflow-implementation-task-executor.md
+++ b/agents/workflow-implementation-task-executor.md
@@ -58,13 +58,19 @@ You do **NOT**:
 
 Those are the orchestrator's responsibility.
 
+## Cross-Scope Opportunities
+
+While implementing you may see improvements whose fix reaches beyond this task's surface: logic this task had to duplicate from a sibling task's output, two near-miss helpers that should be one, dead code a superseding change orphaned, complexity that only shows across several tasks' work. Do not build any of it — and do not stay silent: report each under BANK in your result. The orchestrator banks these for a consolidation pass at the phase boundary.
+
+Within your own task's surface none of this banks — writing clean code there is the job, not a finding.
+
 ## Hard Rules
 
 **MANDATORY. No exceptions. Violating these rules invalidates the work.**
 
 1. **Follow the workflow** — TDD means test-first; verification means baseline-first. Read and follow whichever workflow reference you receive.
 2. **No test changes to pass** — Fix the code, not the test.
-3. **No scope expansion** — Only what's in the task. If you think "I should also handle X" — STOP. It's not in the task, don't build it.
+3. **No scope expansion** — Only what's in the task. If you think "I should also handle X" — STOP. It's not in the task, don't build it. When the X is a consolidation opportunity, report it under BANK (see Cross-Scope Opportunities) instead.
 4. **No assumptions** — Uncertain about intent or approach? STOP and report back.
 5. **No git writes** — Do not commit or stage. Reading git history is fine. The orchestrator handles all git writes after review approval.
 6. **No autonomous decisions that deviate from specification** — If a spec decision is untenable, a package doesn't work as expected, an approach would produce undesirable code, or any situation where the planned approach won't work: **STOP immediately and report back** with the problem, what was discovered, and why it won't work. Do NOT choose an alternative. Do NOT work around it. Report and stop.
@@ -80,9 +86,14 @@ TASK: {task name}
 SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
 TEST_RESULTS: {all passing | failures — details only if failures}
 ISSUES: {blockers or deviations — omit if none}
+BANK:
+- {cross-scope consolidation opportunity — one line}
+  DETAIL: {what and where, with file:line references}
+  FILES: {comma-separated paths involved}
 ```
 
 - If STATUS is `blocked` or `failed`, ISSUES **must** explain why and what decision is needed.
 - If STATUS is `complete`, all acceptance criteria must be met and all tests passing.
+- BANK entries are opportunities whose fix reaches beyond this task's scope (see Cross-Scope Opportunities) — never work done, never blockers. Omit the section when there are none.
 
 Keep the report minimal. "All passing" is sufficient for TEST_RESULTS when nothing failed. ISSUES can be omitted entirely on a clean run.

--- a/agents/workflow-implementation-task-reviewer.md
+++ b/agents/workflow-implementation-task-reviewer.md
@@ -87,6 +87,12 @@ Check every comment the diff introduced or touched against the code and against 
 
 Corrections are mandatory findings — an incorrect comment never ships — but they never block: **compute the verdict from ISSUES alone.** Pre-existing comments the diff did not touch are outside the task's scope.
 
+## Banked Opportunities
+
+Reviewing one task against a codebase several sibling tasks are building will surface improvements whose fix crosses the task boundary: this task's code duplicating a sibling task's output, two near-miss helpers that should be one, dead code a superseding change orphaned, complexity that only shows across several tasks' work. These are never ISSUES — the verdict covers this task alone — and never dropped: report each under BANK. The orchestrator banks them for a consolidation pass at the phase boundary.
+
+The line is the fix's reach, not the finding's subject: duplication or complexity the task introduced *within its own scope* stays an ISSUE; an improvement that would touch another task's output goes to BANK. NOTES remain for observations that ask for no change at all.
+
 ## Fix Recommendations (needs-changes only)
 
 When your verdict is `needs-changes`, you must also recommend how to fix each issue. You have full context — the spec, the task, the conventions, and the code — so use it.
@@ -114,7 +120,7 @@ When alternatives exist, explain the tradeoff briefly — don't just list option
 5. **All five dimensions** — Evaluate spec conformance, acceptance criteria, test adequacy, convention adherence, and architectural quality.
 6. **Be specific** — Include file paths and line numbers for every issue. Vague findings are not actionable.
 7. **Proportional** — Prioritize by impact. Don't nitpick style when the architecture is wrong.
-8. **Task scope only** — Only review what's in the task. Don't flag issues outside the task's scope.
+8. **Task scope only** — Only review what's in the task. An improvement whose fix reaches beyond the task's scope is never an ISSUE — report it under BANK (see Banked Opportunities).
 9. **Comment fixes never block** — A finding whose entire remedy is comment text goes to COMMENT_CORRECTIONS, never ISSUES. The verdict is computed from ISSUES alone.
 
 ## Your Output
@@ -138,6 +144,10 @@ COMMENT_CORRECTIONS:
 - {file:line} — {what is wrong, one clause}
   OLD: {the comment text as it stands — verbatim, so the edit applies mechanically}
   NEW: {the replacement text — empty to delete the comment}
+BANK:
+- {cross-scope consolidation opportunity — one line}
+  DETAIL: {what and where, with file:line references}
+  FILES: {comma-separated paths involved}
 NOTES:
 - {non-blocking observations}
 ```
@@ -146,4 +156,5 @@ NOTES:
 - If VERDICT is `needs-changes`, ISSUES must contain specific, actionable items with file:line references AND fix recommendations
 - Each issue must include FIX and CONFIDENCE. ALTERNATIVE is optional — include only when genuinely multiple valid approaches exist
 - COMMENT_CORRECTIONS may accompany either verdict — omit the section when there are none. OLD must match the file byte-for-byte
+- BANK entries may accompany either verdict and never count toward it (see Banked Opportunities) — omit the section when there are none
 - NOTES are for non-blocking observations — things worth noting but not requiring changes

--- a/design/implementation-phase-consolidation.md
+++ b/design/implementation-phase-consolidation.md
@@ -214,3 +214,41 @@ boundary flow.
   flag).
 - The gate's render surface and wording.
 - The finder agent's name.
+
+## Build notes (2026-08-15)
+
+- **The bank needs no engine storage code.** The review phase's
+  `out_of_scope` set is the exact precedent: a plain array field
+  written with the generic `manifest push` (objects JSON-parse on the
+  way in, `pull` removes by deep equality), semantics entirely
+  prose-owned, render surfaces receiving counts as integers. The bank
+  mirrors it: `implementation.{topic}.bank`, entries
+  `{task, source, summary, detail, files}`, deposited at the task
+  loop's stage H from the executor's and reviewer's `BANK` report
+  sections. PR2 becomes the feed (charters + deposit), not an engine
+  surface.
+- **Staging reuses the guarded container.** `staging.<key>.tasks.<n>`
+  validation is key-generic, so the boundary walk records approvals
+  under `staging.p{N}` beside analysis's `staging.c{N}` with no
+  engine change; the `tasks-overview` and `proposed-task` render
+  surfaces are payload-driven and serve the boundary gate as-is. The
+  one real engine touch left is `consolidation_gate_mode` joining the
+  session-reset set in `initTasks`.
+- **The seed rides to the synthesizer, not the analysis agents.**
+  Analysis dispatch has a hard clean-context rule (priming biases
+  results; cross-cycle synthesis lives in the synthesizer by design),
+  so the residual bank becomes a synthesizer input, verified against
+  current code before proposal — and when the analysis agents return
+  clean while residue exists, the synthesizer still runs, over the
+  residue alone.
+- **The boundary lives in the task loop's stage H**, keyed on
+  `completed_phases` vs a `consolidated_phases` marker: a phase whose
+  tasks are done but which is not yet consolidated defers both the
+  plan-side phase-completion transition and `--phase-complete`,
+  detours to the pass, and records completion once the pass (and any
+  tasks it authored, via the task-writer's existing `per-task`
+  placement into the still-open phase) has landed. A retrieve-side
+  guard re-enters an interrupted pass: no task from a later phase
+  starts while the current phase sits complete-but-unrecorded.
+  Synthetic remediation phases (`Analysis (Cycle N)`,
+  `Review Remediation`) never take the detour.

--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -73,12 +73,15 @@ TASK: {task name}
 SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
 TEST_RESULTS: {all passing | failures — details only if failures}
 ISSUES: {blockers or deviations — omit if none}
-BANK: {cross-scope consolidation opportunities — omit if none}
+BANK:
+- {cross-scope consolidation opportunity — one line}
+  DETAIL: {what and where, with file:line references}
+  FILES: {comma-separated paths involved}
 ```
 
 - `complete`: all acceptance criteria met, tests passing
 - `blocked` or `failed`: ISSUES explains why and what decision is needed
-- BANK: opportunities whose fix reaches beyond the task's scope — deposited to the manifest at **H. Update Progress and Commit** ([task-loop.md](task-loop.md)), never acted on mid-task
+- BANK: opportunities whose fix reaches beyond the task's scope, omitted when there are none — deposited to the manifest the moment the report arrives ([task-loop.md](task-loop.md) **B. Execute Task**), never acted on mid-task
 
 Keep the report minimal. "All passing" is sufficient for TEST_RESULTS when nothing failed. ISSUES can be omitted entirely on a clean run.
 

--- a/skills/workflow-implementation-process/references/invoke-executor.md
+++ b/skills/workflow-implementation-process/references/invoke-executor.md
@@ -73,10 +73,12 @@ TASK: {task name}
 SUMMARY: {2-5 lines — commentary, decisions made, anything off-script}
 TEST_RESULTS: {all passing | failures — details only if failures}
 ISSUES: {blockers or deviations — omit if none}
+BANK: {cross-scope consolidation opportunities — omit if none}
 ```
 
 - `complete`: all acceptance criteria met, tests passing
 - `blocked` or `failed`: ISSUES explains why and what decision is needed
+- BANK: opportunities whose fix reaches beyond the task's scope — deposited to the manifest at **H. Update Progress and Commit** ([task-loop.md](task-loop.md)), never acted on mid-task
 
 Keep the report minimal. "All passing" is sufficient for TEST_RESULTS when nothing failed. ISSUES can be omitted entirely on a clean run.
 

--- a/skills/workflow-implementation-process/references/invoke-reviewer.md
+++ b/skills/workflow-implementation-process/references/invoke-reviewer.md
@@ -44,6 +44,10 @@ COMMENT_CORRECTIONS:
 - {file:line} — {what is wrong}
   OLD: {verbatim current comment text}
   NEW: {replacement — empty to delete}
+BANK:
+- {cross-scope consolidation opportunity}
+  DETAIL: {what and where}
+  FILES: {paths}
 NOTES:
 - {non-blocking observations}
 ```
@@ -51,5 +55,6 @@ NOTES:
 - `approved`: task passes all five review dimensions
 - `needs-changes`: ISSUES contains specific, actionable items with fix recommendations and confidence levels
 - COMMENT_CORRECTIONS may accompany either verdict — prose-only fixes that never count toward the verdict. On `approved`, the orchestrator applies them directly; on `needs-changes`, they travel to the executor with the findings
+- BANK may accompany either verdict and never counts toward it — opportunities whose fix reaches beyond the task's scope, deposited to the manifest at **H. Update Progress and Commit** ([task-loop.md](task-loop.md))
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/invoke-reviewer.md
+++ b/skills/workflow-implementation-process/references/invoke-reviewer.md
@@ -55,6 +55,6 @@ NOTES:
 - `approved`: task passes all five review dimensions
 - `needs-changes`: ISSUES contains specific, actionable items with fix recommendations and confidence levels
 - COMMENT_CORRECTIONS may accompany either verdict — prose-only fixes that never count toward the verdict. On `approved`, the orchestrator applies them directly; on `needs-changes`, they travel to the executor with the findings
-- BANK may accompany either verdict and never counts toward it — opportunities whose fix reaches beyond the task's scope, deposited to the manifest at **H. Update Progress and Commit** ([task-loop.md](task-loop.md))
+- BANK may accompany either verdict and never counts toward it — opportunities whose fix reaches beyond the task's scope, deposited to the manifest the moment the report arrives ([task-loop.md](task-loop.md) **D. Review Task**)
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -115,6 +115,12 @@ The turn does not end here — the executor dispatch follows in the same turn.
 
 > **CHECKPOINT**: Do not proceed until the executor has returned its result.
 
+**Deposit banked opportunities** — every executor report that carries BANK entries deposits them the moment it arrives, whatever its STATUS. They are decided at the phase boundary, which may be tasks away, and conversation context does not survive that long — the manifest does; the pushes ride the next commit that stages it. Push each entry:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest push {work_unit}.implementation.{topic} bank '{"task":"{internal_id}","source":"executor","summary":"{one line}","detail":"{what and where, file:line}","files":["{path}"]}'
+```
+
 #### If `STATUS` is `blocked` or `failed`
 
 → Proceed to **C. Handle Executor Block**.
@@ -167,6 +173,8 @@ The turn does not end here — the executor dispatch follows in the same turn.
 → Load **[invoke-reviewer.md](invoke-reviewer.md)** and follow its instructions as written. Pass the executor's result.
 
 > **CHECKPOINT**: Do not proceed until the reviewer has returned its result.
+
+**Deposit banked opportunities** — every review that carries BANK entries deposits them the moment it arrives, whatever its verdict: push each as at **B. Execute Task**, with `"source":"reviewer"`. A near-duplicate of an earlier round's entry is fine — the boundary pass folds them.
 
 #### If `VERDICT` is `needs-changes`
 
@@ -365,12 +373,6 @@ Include the user's feedback when re-invoking.
 **Update task progress in the plan** — follow the format's **updating.md** instructions to mark the task complete — or, when this stage was reached via a skip path (stage C `skip`, or the blocked-tasks `skip`), its skip transition instead.
 
 **Check for phase completion** — use the format's **reading.md** to list remaining tasks in the current phase. If no tasks remain open or in-progress, follow the format's **updating.md** instructions for phase completion.
-
-**Deposit banked opportunities** — collect the BANK entries from the task's final executor report and the approving review. They are decided at the phase boundary, which may be tasks away, and conversation context does not survive that long — the manifest does. Push each entry onto the durable set (skip this when neither report carries any):
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest push {work_unit}.implementation.{topic} bank '{"task":"{internal_id}","source":"{executor|reviewer}","summary":"{one line}","detail":"{what and where, file:line}","files":["{path}"]}'
-```
 
 **Record progress via the engine** — add `--phase-complete` when the current phase has no remaining open/in-progress tasks, and `--skipped` when the task was skipped rather than implemented:
 ```bash

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -366,6 +366,12 @@ Include the user's feedback when re-invoking.
 
 **Check for phase completion** — use the format's **reading.md** to list remaining tasks in the current phase. If no tasks remain open or in-progress, follow the format's **updating.md** instructions for phase completion.
 
+**Deposit banked opportunities** — collect the BANK entries from the task's final executor report and the approving review. They are decided at the phase boundary, which may be tasks away, and conversation context does not survive that long — the manifest does. Push each entry onto the durable set (skip this when neither report carries any):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest push {work_unit}.implementation.{topic} bank '{"task":"{internal_id}","source":"{executor|reviewer}","summary":"{one line}","detail":"{what and where, file:line}","files":["{path}"]}'
+```
+
 **Record progress via the engine** — add `--phase-complete` when the current phase has no remaining open/in-progress tasks, and `--skipped` when the task was skipped rather than implemented:
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs task complete {work_unit} {topic} {internal_id} --phase {N} --next-task '{next_task_id or ~}' [--skipped] [--phase-complete]

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -363,6 +363,17 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
   assert.strictEqual(implInit.mode, 'created', 'fresh implementation takes the created arm');
   sim.run(['commit', wu, '-m', `impl(${wu}): start implementation`]);
   sim.run(['task', 'start', wu, topic, `${topic}-1-1`]);
+  // The task loop's stage H deposits cross-scope consolidation opportunities
+  // from the executor's and reviewer's BANK sections — durable on the
+  // manifest, drained at the phase boundary.
+  const bankPush = sim.run(['manifest', 'push', `${wu}.implementation.${topic}`, 'bank',
+    `{"task":"${topic}-1-1","source":"executor","summary":"helper duplicated from a sibling task","detail":"src/a.js:12 mirrors src/b.js:40","files":["src/a.js","src/b.js"]}`]);
+  assert.strictEqual(bankPush.length, 1, 'first bank deposit creates the array');
+  sim.run(['manifest', 'push', `${wu}.implementation.${topic}`, 'bank',
+    `{"task":"${topic}-1-1","source":"reviewer","summary":"dead scaffolding a later task orphaned","detail":"src/c.js:8 export unused","files":["src/c.js"]}`]);
+  const bank = JSON.parse(sim.read(['manifest', 'get', `${wu}.implementation.${topic}`, 'bank']));
+  assert.strictEqual(bank.length, 2, 'bank accumulates entries');
+  assert.strictEqual(bank[0].source, 'executor', 'entries store as objects, not strings');
   sim.run(['task', 'complete', wu, topic, `${topic}-1-1`, '--next-task', '~', '--phase-complete']);
   sim.run(['topic', 'complete', wu, 'implementation', topic]);
 

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -363,9 +363,9 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
   assert.strictEqual(implInit.mode, 'created', 'fresh implementation takes the created arm');
   sim.run(['commit', wu, '-m', `impl(${wu}): start implementation`]);
   sim.run(['task', 'start', wu, topic, `${topic}-1-1`]);
-  // The task loop's stage H deposits cross-scope consolidation opportunities
-  // from the executor's and reviewer's BANK sections — durable on the
-  // manifest, drained at the phase boundary.
+  // Each executor and reviewer report's BANK entries deposit the moment the
+  // report arrives (task-loop B/D) — durable on the manifest, drained at the
+  // phase boundary.
   const bankPush = sim.run(['manifest', 'push', `${wu}.implementation.${topic}`, 'bank',
     `{"task":"${topic}-1-1","source":"executor","summary":"helper duplicated from a sibling task","detail":"src/a.js:12 mirrors src/b.js:40","files":["src/a.js","src/b.js"]}`]);
   assert.strictEqual(bankPush.length, 1, 'first bank deposit creates the array');


### PR DESCRIPTION
PR2 of the consolidation stack. Executor and reviewer charters gain a BANK report section (act in-scope, bank cross-scope); task-loop stage H deposits entries onto `implementation.{topic}.bank` via the generic manifest push; simulation covers the feed. Build notes land in the design log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)