### PR TITLE
feat(impl): the analysis loop opens seeded — bank residue rides to the synthesizer

### DIFF
--- a/agents/workflow-implementation-analysis-synthesizer.md
+++ b/agents/workflow-implementation-analysis-synthesizer.md
@@ -17,16 +17,18 @@ You receive via the orchestrator's prompt:
 2. **Work unit** — the work unit name (for path construction)
 3. **Topic name** — the implementation topic
 4. **Cycle number** — which analysis cycle this is
+5. **Banked residue** (when present) — opportunities the phase boundaries left for this loop, as JSON entries with file evidence
 
 ## Your Process
 
 1. **Read all findings files** from `.workflows/{work_unit}/implementation/{topic}/` — look for `analysis-duplication-c{cycle-number}.md`, `analysis-standards-c{cycle-number}.md`, and `analysis-architecture-c{cycle-number}.md`
-2. **Deduplicate** — same issue found by multiple agents → one finding, note all sources
-3. **Group related findings** — multiple findings about the same pattern become one task (e.g., 3 duplication findings about the same helper pattern = 1 "extract helper" task)
-4. **Filter** — discard low-severity findings unless they cluster into a pattern. Never discard high-severity.
-5. **Normalize** — convert each group into a task using the canonical task template (Problem / Solution / Outcome / Do / Acceptance Criteria / Tests)
-6. **Write report** — output to `.workflows/{work_unit}/implementation/{topic}/analysis-report-c{cycle-number}.md`
-7. **Write staging file** — if actionable tasks exist, write the task content to `.workflows/{work_unit}/implementation/{topic}/analysis-tasks-c{cycle-number}.md` — pure markdown, no frontmatter and no status lines; the orchestrator tracks approvals in its own store
+2. **Verify the banked residue** — read the files each entry names and check its claim against the current code (later work may have resolved it). Still real → it joins the findings pool with source `bank`; resolved → discard, named in the report. When no findings files exist for this cycle, the residue is the entire input.
+3. **Deduplicate** — same issue found by multiple agents (or already banked) → one finding, note all sources
+4. **Group related findings** — multiple findings about the same pattern become one task (e.g., 3 duplication findings about the same helper pattern = 1 "extract helper" task)
+5. **Filter** — discard low-severity findings unless they cluster into a pattern. Never discard high-severity.
+6. **Normalize** — convert each group into a task using the canonical task template (Problem / Solution / Outcome / Do / Acceptance Criteria / Tests)
+7. **Write report** — output to `.workflows/{work_unit}/implementation/{topic}/analysis-report-c{cycle-number}.md`
+8. **Write staging file** — if actionable tasks exist, write the task content to `.workflows/{work_unit}/implementation/{topic}/analysis-tasks-c{cycle-number}.md` — pure markdown, no frontmatter and no status lines; the orchestrator tracks approvals in its own store
 
 ## Write Mechanism
 
@@ -43,13 +45,14 @@ Write the report file with this structure:
 
 - Total findings: {N}
 - Deduplicated findings: {N}
+- Banked residue: {N verified in, M resolved — omit when none was passed}
 - Proposed tasks: {N}
 
 ## Summary
 {2-3 sentence overview of findings}
 
 ## Discarded Findings
-- {title} — {reason for discarding}
+- {title} — {reason for discarding; a resolved bank entry names what resolved it}
 ```
 
 ## Staging File Format

--- a/agents/workflow-implementation-analysis-synthesizer.md
+++ b/agents/workflow-implementation-analysis-synthesizer.md
@@ -7,7 +7,7 @@ model: opus
 
 # Implementation Analysis: Synthesizer
 
-You locate the analysis findings files written by the analysis agents using the topic name, then read them, deduplicate and group findings, normalize into tasks, and write a staging file for user approval.
+You locate the analysis findings files written by the analysis agents using the topic name, then read them — together with any banked residue the prompt passes — deduplicate and group findings, normalize into tasks, and write a staging file for user approval.
 
 ## Your Input
 
@@ -22,7 +22,7 @@ You receive via the orchestrator's prompt:
 ## Your Process
 
 1. **Read all findings files** from `.workflows/{work_unit}/implementation/{topic}/` — look for `analysis-duplication-c{cycle-number}.md`, `analysis-standards-c{cycle-number}.md`, and `analysis-architecture-c{cycle-number}.md`
-2. **Verify the banked residue** — read the files each entry names and check its claim against the current code (later work may have resolved it). Still real → it joins the findings pool with source `bank`; resolved → discard, named in the report. When no findings files exist for this cycle, the residue is the entire input.
+2. **Verify the banked residue** — read the files each entry names and check its claim against the current code (later work may have resolved it). Still real → it joins the findings pool with source `bank`; resolved → discard, named in the report; beyond the work unit's remit entirely → discard, named in the report — nothing downstream consumes it. When no findings files exist for this cycle, the residue is the entire input.
 3. **Deduplicate** — same issue found by multiple agents (or already banked) → one finding, note all sources
 4. **Group related findings** — multiple findings about the same pattern become one task (e.g., 3 duplication findings about the same helper pattern = 1 "extract helper" task)
 5. **Filter** — discard low-severity findings unless they cluster into a pattern. Never discard high-severity.
@@ -86,7 +86,7 @@ sources: duplication, architecture
 1. **No new features** — only improve existing implementation. Every proposed task must address something that already exists.
 2. **Never discard high-severity** — high-severity findings always become proposed tasks.
 3. **Self-contained tasks** — every proposed task must be independently executable. No task should depend on another proposed task.
-4. **Faithful synthesis** — do not invent findings. Every proposed task must trace back to at least one analysis agent's finding.
+4. **Faithful synthesis** — do not invent findings. Every proposed task must trace back to at least one analysis agent's finding or one verified bank entry.
 5. **No git writes** — do not commit or stage. Writing the report and staging files are your only file writes.
 6. **Never lose your work** — the knowledge you generate must survive the run, and the output files are how it survives. Produce each file via the `.txt`-then-rename mechanism (see Write Mechanism); if a step errors, quote the error verbatim in your status. Never conclude a write is blocked without attempting it. Only if a write itself has errored may you return that file's full content in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -30,7 +30,7 @@ While tasks are built one at a time, each was written in isolation — and thing
 
 ## After the tasks
 
-Building every task is not quite the end. Once the task list is drained, an analysis loop runs. The system takes a checkpoint — flagging any unexpected files first — then dispatches agents to review what was actually built against the plan and the spec, and a synthesiser proposes any remediation tasks the review turned up. You approve those tasks the same way you approved the originals; approved ones are written into the plan, and the build loop runs again over them. Build, analyse, perhaps build again — this repeats until the analysis finds nothing more, capped at three cycles per session. At the cap the system shows the convergence diagnostic and asks whether to continue or stop; it never silently gives up, and never silently loops.
+Building every task is not quite the end. Once the task list is drained, an analysis loop runs. The system takes a checkpoint — flagging any unexpected files first — then dispatches agents to review what was actually built against the plan and the spec, and a synthesiser proposes any remediation tasks the review turned up — verdicting anything still banked from the phase boundaries along the way. You approve those tasks the same way you approved the originals; approved ones are written into the plan, and the build loop runs again over them. Build, analyse, perhaps build again — this repeats until the analysis finds nothing more, capped at three cycles per session. At the cap the system shows the convergence diagnostic and asks whether to continue or stop; it never silently gives up, and never silently loops.
 
 ## The quick-fix variant
 

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -168,13 +168,13 @@ Commit the analysis findings — the scoped commit covers the findings files and
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — findings"
 ```
 
-#### If all three agents returned `STATUS: clean` and the manifest holds a `bank` with entries
+#### If all three agents returned `STATUS: clean` and the manifest holds a `bank` with entries (`manifest get {work_unit}.implementation.{topic} bank` — an absent field prints empty)
 
 The phase boundaries left residue — the synthesizer runs over the bank alone for its verdicts.
 
 → Proceed to **D. Dispatch Synthesis Agent**.
 
-#### If all three agents returned `STATUS: clean`
+#### If all three agents returned `STATUS: clean` and the manifest holds no `bank` entries
 
 → Return to **[the skill](../SKILL.md)** for **Step 8**.
 

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -168,6 +168,12 @@ Commit the analysis findings — the scoped commit covers the findings files and
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — findings"
 ```
 
+#### If all three agents returned `STATUS: clean` and the manifest holds a `bank` with entries
+
+The phase boundaries left residue — the synthesizer runs over the bank alone for its verdicts.
+
+→ Proceed to **D. Dispatch Synthesis Agent**.
+
 #### If all three agents returned `STATUS: clean`
 
 → Return to **[the skill](../SKILL.md)** for **Step 8**.

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -22,6 +22,12 @@
 
 #### If `yes`
 
+**If the manifest still holds a `bank`** (`manifest exists {work_unit}.implementation.{topic} bank` — a session exited the analysis loop with residue undecided): delete it — implementation is over and the residue's consumer with it:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.implementation.{topic} bank
+```
+
 Complete the phase item:
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit} implementation {topic}

--- a/skills/workflow-implementation-process/references/invoke-synthesizer.md
+++ b/skills/workflow-implementation-process/references/invoke-synthesizer.md
@@ -18,6 +18,7 @@ Pass via the orchestrator's prompt:
 2. **Work unit** — the work unit name (for path construction)
 3. **Topic name** — the implementation topic
 4. **Cycle number** — the current analysis cycle number
+5. **Banked residue** — the manifest's `bank` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} bank`): entries the phase boundaries left for this loop. Omit when the field is absent or empty.
 
 The agent locates findings files and writes output files using the work unit and topic name.
 
@@ -37,6 +38,14 @@ SUMMARY: {1-2 sentences}
 - `clean`: no actionable findings — orchestrator should proceed to completion
 
 ---
+
+## Consume the Bank
+
+**If banked residue was passed**, the synthesizer has verdicted every entry — proposed into the staging or discarded in its report. Delete the field; the deletion rides the synthesis commit:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.implementation.{topic} bank
+```
 
 ## Initialise Gate State
 

--- a/skills/workflow-implementation-process/references/invoke-synthesizer.md
+++ b/skills/workflow-implementation-process/references/invoke-synthesizer.md
@@ -47,6 +47,8 @@ SUMMARY: {1-2 sentences}
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.implementation.{topic} bank
 ```
 
+---
+
 ## Initialise Gate State
 
 **If `STATUS` is `tasks_proposed`**, initialise the cycle's gate state — one batched write, one `pending` per task from `TASKS_PROPOSED`:

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -384,6 +384,9 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
   sim.run(['task', 'complete', wu, topic, `${topic}-1-1`, '--phase', '1', '--next-task', '~']);
   sim.run(['manifest', 'push', `${wu}.implementation.${topic}`, 'consolidated_phases', '1']);
   sim.run(['task', 'complete', wu, topic, `${topic}-1-1`, '--phase', '1', '--phase-complete']);
+  // The analysis loop's synthesizer consumes the residue (invoke-synthesizer.md);
+  // conclude's hygiene covers a loop that never got its verdicts in.
+  sim.run(['manifest', 'delete', `${wu}.implementation.${topic}`, 'bank']);
   sim.run(['topic', 'complete', wu, 'implementation', topic]);
 
   // Review — verification, then the prepped pipeline: out-of-scope
@@ -1232,6 +1235,12 @@ describe('pipeline simulation', () => {
     sim.run(['manifest', 'set', `${wu}.implementation.${wu}`, 'staging.c1.tasks.1=pending', 'staging.c1.tasks.2=pending']);
     sim.run(['manifest', 'set', `${wu}.implementation.${wu}`, 'staging.c1.tasks.1', 'skipped']);
     sim.run(['manifest', 'set', `${wu}.implementation.${wu}`, 'staging.c1.tasks.2', 'skipped']);
+
+    // The synthesizer's dispatch consumes the residual bank — verdicts land in
+    // its report, then the field is deleted (invoke-synthesizer.md).
+    sim.run(['manifest', 'push', `${wu}.implementation.${wu}`, 'bank',
+      `{"task":"${wu}-1-2","source":"executor","summary":"pre-existing debt","detail":"src/legacy.js predates the phase","files":["src/legacy.js"]}`]);
+    sim.run(['manifest', 'delete', `${wu}.implementation.${wu}`, 'bank']);
 
     // The ad hoc plan-changes gate stages under its own family key (ad-hoc-plan-changes.md E/F)
     // and renders the shared proposed-task surface without the synthesis-only fields.


### PR DESCRIPTION
PR4 of the consolidation stack. Residue reaches the synthesizer (never the analysis agents — their clean-context rule stands); verified against current code, proposed or discarded with reasons, field deleted on consumption. Clean-agents-with-residue still dispatches synthesis; conclude carries the hygiene delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)