### PR TITLE
fix(review): the clean path's verdict derives from the absent actions.json

### DIFF
--- a/skills/workflow-review-process/references/produce-review.md
+++ b/skills/workflow-review-process/references/produce-review.md
@@ -8,7 +8,7 @@ Aggregate QA findings into a review document using the **[template.md](template.
 
 Write the review to `.workflows/{work_unit}/review/{topic}/report.md`. The review is always per-plan.
 
-**Verdict** — derived by the synthesis stage, never chosen here. Read it from `actions.json`:
+**Verdict** — derived by the synthesis stage, never chosen here. Read it from `actions.json`; when no findings were collected the file does not exist and the verdict is **Pass** by the same derivation — nothing outstanding:
 - **Pass** — nothing outstanding needs planning. `do-now` work and `out-of-scope` findings do not block: the first is already applied, the second was never part of this specification
 - **Fail** — a blocking issue, or an action routed to `replan`. The work is not delivered while something needs going back to plan
 

--- a/tests/prose/cases/bridge-completes-the-feature/assert.md
+++ b/tests/prose/cases/bridge-completes-the-feature/assert.md
@@ -8,12 +8,13 @@ The prose should have taken this path:
    scopes verification from the per-task implementation commits, and
    dispatches a verifier per task — stubbed clean; both task ids land
    on the reviewed list
-3. the review report is produced with an Approve verdict and committed;
-   the verdict is presented, the scripted answer continues past the
-   questions gate, and the compliance self-check runs
-4. the actions loop finds every verdict Approve: the no-actionable
-   display renders, the review completes through the engine, and the
-   completion commit lands
+3. the review report is produced with a Pass verdict — no
+   `actions.json` exists on the clean path, so the verdict derives
+   from nothing outstanding — and committed; the presentation renders
+   with zero counts, the scripted answer continues past the gate, and
+   the compliance self-check runs
+4. the review completes through the engine, and the completion commit
+   lands
 5. the pipeline continuation invokes the bridge with the work unit and
    the completed phase review, and the walk crosses into the bridge
 6. the bridge reads the work type — feature, not discovery, not epic —
@@ -39,7 +40,7 @@ Further claims:
   ids in reviewed_tasks
 - no cache directory for the work unit remains at
   `.workflows/.cache/pay/` after the completion
-- the review report at `.workflows/pay/review/pay/report.md` holds an
-  Approve verdict; one per-task report file exists per task suffix
+- the review report at `.workflows/pay/review/pay/report.md` holds a
+  Pass verdict; one per-task report file exists per task suffix
 - the plan, tasks, specification, and source files are untouched; no
   second work unit exists


### PR DESCRIPTION
From the walk run's one DEVIATION: produce-review read the verdict unconditionally from a file the no-findings arm never creates. One-sentence prose fix naming the derivation; the bridge case's assert aligned to the current flow and vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)