### PR TITLE
fix(impl): the boundary's findings commit fires only when a file was written

### DIFF
--- a/skills/workflow-implementation-process/references/consolidation-pass.md
+++ b/skills/workflow-implementation-process/references/consolidation-pass.md
@@ -75,7 +75,7 @@ The pass ran; only the phase record is outstanding.
 
 > **CHECKPOINT**: Do not proceed until the finder has returned.
 
-Commit the findings (the scoped commit covers the findings file and the manifest):
+When the finder wrote its file, commit the findings (the scoped commit covers the file and the manifest):
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): phase {N} consolidation — findings"

--- a/tests/prose/cases/implementation-loops-on-auto/assert.md
+++ b/tests/prose/cases/implementation-loops-on-auto/assert.md
@@ -52,7 +52,8 @@ The prose should have taken this path:
     impl(pay): Tpay-1-2, and the stage routes to the consolidation
     pass
 12. the pass announces itself, reads consolidation_gate_mode and the
-    durable state (both prints empty), sees a plan-authored phase
+    durable state (the staging and consolidated_phases prints are
+    empty; the gate mode reads gated), sees a plan-authored phase
     label with no resume state, and dispatches the consolidation
     finder — the stub returns clean with no file; the pass records the
     phase: consolidated_phases gains 1, the plan-side phase completion


### PR DESCRIPTION
From the walk run's notes: the pass's stage A committed unconditionally (a graceful no-op on every clean sweep — noise, not harm); now conditional on the finder having written its file. The auto case's assert names the three prelude reads precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)