### PR TITLE
chore(impl-entry): drop the dead environment-setup cat allowance

### DIFF
--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-implementation-entry
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(cat .workflows/.state/environment-setup.md)
+allowed-tools: Bash(node .claude/skills/workflow-engine/scripts/engine.cjs)
 ---
 
 Act as **precise intake coordinator**. Follow each step literally without interpretation. Do not engage with the subject matter — your role is preparation, not processing.


### PR DESCRIPTION
From the walk run's observation: the entry skill declares Bash(cat .workflows/.state/environment-setup.md) but never reads the file — the check moved to the process skill long ago, and reads there via the Read tool. Dead allowance removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)