### PR TITLE
review(prose): the executes-the-loop assert stops expecting the skipped clean-path commit

### DIFF
--- a/tests/prose/cases/implementation-executes-the-loop/assert.md
+++ b/tests/prose/cases/implementation-executes-the-loop/assert.md
@@ -59,8 +59,8 @@ The prose should have taken this path:
     consolidation_gate_mode and the durable state (the staging and
     consolidated_phases reads print empty), sees a plan-authored phase
     label with no resume state, and dispatches the consolidation
-    finder — the stub returns clean with no file; the findings commit
-    has nothing to pick up; the clean announce renders
+    finder — the stub returns clean with no file, so no findings
+    commit runs; the clean announce renders
 18. the pass records the phase: nothing to pull from the bank (no
     entry was ever deposited), consolidated_phases gains 1, the
     plan-side phase completion lands via the format's updating


### PR DESCRIPTION
One-line case alignment owed by #922: the clean path no longer runs the findings commit, so the assert stops describing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)