### PR TITLE
fix(impl): the commit example keeps its fused token and loses its copyable tail

### DIFF
--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -424,7 +424,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs task complete {work_unit}
 impl({work_unit}): T{internal_id} — {brief description}
 ```
 
-One commit per approved task, staging the listed paths explicitly — never `git add -A` or `git add .`. The subject is exactly as fenced — `T` immediately followed by the internal id, no space (`impl(pay): Tpay-1-1 — wire the session endpoint`); review's scope-grep finds task commits by this token. Never `engine commit` here — its scopes cover `.workflows` only, never code or the plan format's storage.
+One commit per approved task, staging the listed paths explicitly — never `git add -A` or `git add .`. The subject is exactly as fenced — `T` immediately followed by the internal id, no space (`impl(pay): Tpay-1-1 — …`); review's scope-grep finds task commits by this token. Never `engine commit` here — its scopes cover `.workflows` only, never code or the plan format's storage.
 
 #### If `{disposition}` is `boundary`
 


### PR DESCRIPTION
The recurring commit-token WANDER: walkers copy the example's description tail into real commits. #885's fused-token demonstration stays (`impl(pay): Tpay-1-1 — …`); the copyable prose goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)