### PR TITLE
fix(impl): the approved header counts needs-changes rounds, not fix rounds it cannot know ran

### DIFF
--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -1769,7 +1769,7 @@ function taskBrief(cwd, args) {
 /** @type {Record<string, (attempts: number) => string>} */
 const TASK_RESULT_VERDICTS = {
   approved: (attempts) => attempts > 0
-    ? `**✓ Approved** — *${attempts} fix round${attempts === 1 ? '' : 's'}*`
+    ? `**✓ Approved** — *after ${attempts} needs-changes round${attempts === 1 ? '' : 's'}*`
     : '**✓ Approved**',
   'needs-changes': (attempts) => attempts >= FIX_THRESHOLD
     ? `**◐ Needs changes** — *attempt ${attempts}, escalation threshold reached*`

--- a/tests/scripts/test-engine-tasks.cjs
+++ b/tests/scripts/test-engine-tasks.cjs
@@ -880,7 +880,7 @@ describe('engine render task surfaces', () => {
     const file = writeResultPayload({ id: 'auth-flow-1-1', title: 'Wire the login form', phase: '1 — Core' });
     assert.match(
       render(['task-result', 'auth.implementation.auth-flow', '--file', file, '--result', 'approved']),
-      /\*\*✓ Approved\*\* — \*1 fix round\*/);
+      /\*\*✓ Approved\*\* — \*after 1 needs-changes round\*/);
 
     cleanupFixture(dir);
     dir = setupFixture();
@@ -888,7 +888,7 @@ describe('engine render task surfaces', () => {
     const file2 = writeResultPayload({ id: 'auth-flow-1-1', title: 'Wire the login form', phase: '1 — Core' });
     assert.match(
       render(['task-result', 'auth.implementation.auth-flow', '--file', file2, '--result', 'approved']),
-      /\*\*✓ Approved\*\* — \*2 fix rounds\*/);
+      /\*\*✓ Approved\*\* — \*after 2 needs-changes rounds\*/);
   });
 
   it('task-result needs-changes below the threshold: the calm verdict with the attempt count, optional rows omitted', () => {

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -1160,7 +1160,7 @@ describe('pipeline simulation', () => {
       /\*\*◐ Needs changes\*\* — \*attempt 3, escalation threshold reached\*/,
       'threshold-forced needs-changes names the reached threshold');
     assert.match(sim.render(['task-result', `${wu}.implementation.${wu}`, '--file', resultPayload, '--result', 'approved'], { expect: 'content' }),
-      /\*\*✓ Approved\*\* — \*3 fix rounds\*/, 'approval after fix rounds names the count');
+      /\*\*✓ Approved\*\* — \*after 3 needs-changes rounds\*/, 'approval names the needs-changes round count');
     assert.match(sim.render(['fix-gate', `${wu}.implementation.${wu}`], { expect: 'content' }),
       /MENU: fix gate/, 'threshold-forced fix gate renders its menu');
     sim.run(['task', 'complete', wu, wu, `${wu}-1-1`, '--phase', '1', '--next-task', `${wu}-1-2`]);


### PR DESCRIPTION
From the challenge case's first walk: `render task-result --result approved` derived '*N fix round(s)*' from fix_attempts, which counts recorded needs-changes verdicts — on the challenge path no fix round executes. The tail now reads '*after N needs-changes round(s)*'. One code line + three pinned goldens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)