### PR TITLE
review(roadmap-skill): the harvest joins the loop, genesis folds into an open session, the gate handles its answers

### DIFF
--- a/skills/workflow-discovery/references/continuity-load.md
+++ b/skills/workflow-discovery/references/continuity-load.md
@@ -29,8 +29,7 @@ Synthesise the recent-in-full logs into a short briefing that resumes the conver
 ```
 Where we'd got to:
 
-  {2–4 lines from the recent session(s): the threads we were
-  circling, what you were leaning toward, what was still open}
+  {2–4 lines from the recent session(s): the threads circled, what the user was leaning toward, what was still open}
 
   {older sessions, if any: one line each from their Conclusion,
   under an "Earlier:" lead — only when it aids orientation}

--- a/skills/workflow-roadmap/SKILL.md
+++ b/skills/workflow-roadmap/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: workflow-roadmap
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-roadmap/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(mkdir -p .workflows/), Bash(rm .workflows/), Bash(rm -f .workflows/)
+allowed-tools: Bash(node .claude/skills/workflow-roadmap/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(git log)
 ---
+
+# Product Roadmap
 
 The product layer above the work unit. Hold the product-altitude conversation, keep the roadmap — horizons of shaped-but-uncommitted items — and pull slices into delivery as fenced work units.
 
@@ -12,10 +14,11 @@ The product layer above the work unit. Hold the product-altitude conversation, k
 
 The roadmap is project-level and outside the pipeline — no work unit, no phases. Sessions record at `.workflows/.roadmap/sessions/`, the map lives on the project manifest (`roadmap`: ordered horizons + items), and item lifecycle is computed by joining `pulled_to` against the work unit it became — waiting is the absence of a join. Work units are born here at the **pull** — the commitment point — already fenced to the pulled items; the pipeline itself is untouched.
 
-Two invocation modes, dispatched at Step 1:
+Three invocation modes, dispatched at Step 1:
 
 - **genesis** — from discovery's shaping gate: the conversation is live and just read as product-altitude. Persist the shaping so far, continue the conversation at this altitude.
 - **open** — from the `r/roadmap` start-menu row: show the map, then converse, pull, or leave.
+- **pull** — from a recognition offer: the user accepted pulling an existing waiting item, straight to the pull ceremony.
 
 **Stay in your lane**: shape the product and its staging — what exists, what's next, what waits. Capability-grain only: an item is whatever you'd move around a roadmap as one thing. Topic shaping, mechanism, and design decisions belong to the work units the pull creates; a pulled item's substance belongs to its epic. Right of a pull the work unit is authoritative — the map edits waiting items freely and only watches joined ones.
 
@@ -58,7 +61,7 @@ Read the positional argument:
 # **`■ Roadmap`**
 ```
 
-→ Proceed to **Step 9**.
+→ Proceed to **Step 8**.
 
 #### Otherwise
 
@@ -88,14 +91,24 @@ The shaping conversation before this point was ephemeral — persist it now:
    node .claude/skills/workflow-engine/scripts/engine.cjs roadmap import {path} {path}
    ```
 
-2. **Open the session.** Draft the log at `.workflows/.cache/roadmap/session-draft.md` per [session-template.md](references/session-template.md), backfilling **Exploration** with a strong-summary of the shaping conversation so far (the product intent, the capabilities named, any staging language heard — prose, not transcript). Then:
+2. **Open the session.** Read the state first:
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs roadmap state
+   ```
+
+   **If `active_session` is set** (a product session was left open): the shaping folds into it — read its log in full, append a strong-summary of the shaping conversation so far to **Exploration** (the product intent, the capabilities named, any staging language heard — prose, not transcript), commit (`engine commit --roadmap -m "roadmap: genesis continuation — session {active_session}"`), and set `session_number` from `active_session`.
+
+   **Otherwise:** draft the log at `.workflows/.cache/roadmap/session-draft.md` per [session-template.md](references/session-template.md), backfilling **Exploration** with that same strong-summary. Then:
 
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs roadmap session open --session-log-file .workflows/.cache/roadmap/session-draft.md
    node .claude/skills/workflow-engine/scripts/engine.cjs commit --roadmap -m "roadmap: open session {session}"
    ```
 
-   Set `session_number` from the response's `session`. Hold `genesis_continuation` = true.
+   Set `session_number` from the response's `session`.
+
+3. Hold `genesis_continuation` = true.
 
 → Proceed to **Step 4**.
 
@@ -103,13 +116,7 @@ The shaping conversation before this point was ephemeral — persist it now:
 
 ## Step 3: Home
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-# **`■ Roadmap`**
-```
-
-Render the roadmap home snapshot:
+Render the roadmap home snapshot (its TITLE section is the phase title):
 
 ```bash
 node .claude/skills/workflow-roadmap/scripts/gateway.cjs view
@@ -129,7 +136,7 @@ Set `session_number` from the DATA's `active_session` when one is open (the loop
 
 #### If `action` is `pull`
 
-→ Proceed to **Step 9**.
+→ Proceed to **Step 8**.
 
 #### If `action` is `back`
 
@@ -143,9 +150,9 @@ Set `session_number` from the DATA's `active_session` when one is open (the loop
 
 #### If the user asks a question
 
-Answer from the DATA and the map, then re-render the menu section from the snapshot above by re-running the gateway.
+Answer from the DATA and the map.
 
-**STOP.** Wait for user response.
+→ Return to **Step 3**.
 
 ---
 
@@ -171,35 +178,21 @@ Load **[roadmap-guidelines.md](references/roadmap-guidelines.md)** and follow it
 > The product conversation — ideas, staging, what matters when. Items and horizons crystallise at the harvest, when you pull them; say "lay it out" whenever it feels ready.
 ```
 
-Load **[session-loop.md](references/session-loop.md)** and follow its instructions as written.
+Load **[session-loop.md](references/session-loop.md)** and follow its instructions as written — the harvest runs inside it, and it returns only once a sort is confirmed.
 
 → On return, proceed to **Step 6**.
 
 ---
 
-## Step 6: Harvest
-
-Load **[harvest.md](references/harvest.md)** and follow its instructions as written. It owns its own confirmation and returns an outcome:
-
-#### If the outcome is `confirmed`
-
-→ Proceed to **Step 7**.
-
-#### If the outcome is `explore`
-
-→ Return to **Step 5**.
-
----
-
-## Step 7: Document Review
+## Step 6: Document Review
 
 Load **[document-review.md](references/document-review.md)** and follow its instructions as written.
 
-→ On return, proceed to **Step 8**.
+→ On return, proceed to **Step 7**.
 
 ---
 
-## Step 8: Conclude
+## Step 7: Conclude
 
 Load **[compliance-check.md](../workflow-shared/references/compliance-check.md)** and follow its instructions as written.
 
@@ -209,7 +202,7 @@ On return, load **[conclude.md](references/conclude.md)** and follow its instruc
 
 ---
 
-## Step 9: Pull
+## Step 8: Pull
 
 > *Output the next fenced block as markdown (not a code block):*
 

--- a/skills/workflow-roadmap/references/conclude.md
+++ b/skills/workflow-roadmap/references/conclude.md
@@ -8,7 +8,13 @@ Close the session, then offer the pull. Stopping here is first-class — a harve
 
 ## A. Close the Session
 
-#### If no session log exists (browse only)
+Read the roadmap state:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs roadmap state
+```
+
+#### If `active_session` is `null` (browse only — no session was ever opened)
 
 Nothing to close.
 
@@ -32,11 +38,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render roadmap-session-re
 
 ## B. Stop or Pull
 
-Read the roadmap state:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs roadmap state
-```
+Branch on the state read in **A**:
 
 #### If `totals.waiting` is `0`
 
@@ -66,7 +68,7 @@ Nothing is pullable.
 
 #### If `pull`
 
-→ Return to **[the skill](../SKILL.md)** for **Step 9**.
+→ Return to **[the skill](../SKILL.md)** for **Step 8**.
 
 #### If `stop`
 

--- a/skills/workflow-roadmap/references/harvest.md
+++ b/skills/workflow-roadmap/references/harvest.md
@@ -1,12 +1,14 @@
 # Harvest
 
-*Reference for **[workflow-roadmap](../SKILL.md)***
+*Reference for **[session-loop](session-loop.md)** — loaded at the user's pull*
 
 ---
 
 The sort ceremony. Analyse the session's exploration as a whole, propose the item set in horizons, confirm it with the user, persist. Coarse on purpose: horizons and items, provenance pointers, no briefs, no topic shaping — an item's substance stays in the session logs the pointers name, distilled only when a pull creates the topic to brief.
 
 ## A. Gather Source Material
+
+If no session is open yet (a browse that grew content without an Exploration pause), conjure the log now — [session-template.md](session-template.md)'s lazy creation, **Exploration** backfilled from the conversation — so the sort's provenance pointers resolve and the close has a session to close.
 
 Three sources of truth, cross-referenced:
 
@@ -23,6 +25,14 @@ Read out the **capability-grain chunks** the exploration named — each one thin
 Sort the chunks into horizons using the conversation's own staging language, crystallised into named horizons — existing ones where they fit, new ones where the conversation named a stage the map lacks. "Someday" is the conventional tail for real-but-unscheduled. When no staging language emerged, offer **Now / Next / Later** as a suggested default set. Position carries the semantics — order the horizons as the user talks about them.
 
 An item whose ground already sits on the map is not a new item: deepenings of a **waiting** item fold into its summary (an `Edits` entry); a thread that deepened a **pulled** item's ground flags the join instead (`engine roadmap flag {name}` — guidelines **C**).
+
+#### If no new items emerged
+
+The session surfaced nothing beyond what the map already holds — grooming, folds, and flags are already recorded under **Edits**. There is nothing to sort; tell the user in one line. Outcome: `confirmed`.
+
+→ Return to caller.
+
+#### Otherwise
 
 → Proceed to **C. Render Proposal**.
 
@@ -46,6 +56,7 @@ Read `=== DATA` to reason from (never display it) — a per-name flag row for ea
 
 - `exists_on_roadmap=true` — the name collides with an existing item. Fold the material into that item or pick a different name (revise the set, rewrite the file, re-run) before rendering the gate.
 - `legal_name=false` — dots or slashes break manifest addressing. Rename and re-run.
+- `legal_horizon=false` — the release word itself carries a dot or slash ("v1.5"). Respell it with the user's blessing at the gate ("v1-5", "v15") and re-run — the persist refuses it as written.
 - `new_horizon=true` — informational: the horizon will be created at persist, in the file's order.
 
 Emit the `=== DISPLAY` section verbatim **as a code block** — the proposed items over the existing roadmap, so the full picture is visible.
@@ -87,7 +98,7 @@ Land the whole set in one transaction (horizons are created JIT in entry order; 
 node .claude/skills/workflow-engine/scripts/engine.cjs roadmap add-batch --file .workflows/.cache/roadmap/proposed-items.json
 ```
 
-Apply any horizon re-ordering the confirmed sort implies (`roadmap horizon reorder {name} {name} …` — the complete order). Then write the log's **Items Sorted** section (one subsection per item: horizon + one-line why) and any **Edits** entries the harvest produced, and commit:
+Apply any horizon re-ordering the conversation's staging stated (`roadmap horizon reorder {name} {name} …` — the complete order; the user's words are the order, never the display's append order). Then write the log's **Items Sorted** section (one subsection per item: horizon + one-line why) and any **Edits** entries the harvest produced, and commit:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs commit --roadmap -m "roadmap: harvest — session-{session_number}"

--- a/skills/workflow-roadmap/references/pull.md
+++ b/skills/workflow-roadmap/references/pull.md
@@ -4,7 +4,7 @@
 
 ---
 
-The commitment point. Select waiting items, shape them into a work unit, create it fenced, join the items, route into delivery. The unit's seed set stays derivable from the joins — nothing is mirrored onto it; the record crosses as the session-log backfill plus the items' source pointers. The pull takes whole items — wanting half an item means the item is two items; split it on the map first (`roadmap horizon split` / a rename-and-add), never inline here.
+The commitment point. Select waiting items, shape them into a work unit, create it fenced, join the items, route into delivery. The unit's seed set stays derivable from the joins — nothing is mirrored onto it; the record crosses as the session-log backfill plus the items' source pointers. The pull takes whole items — wanting half an item means the item is two items; split it on the map first (rename the item to one half, `roadmap add` the other), never inline here.
 
 ## A. Select the Working Set
 
@@ -14,7 +14,7 @@ Render the pull working set:
 node .claude/skills/workflow-roadmap/scripts/gateway.cjs pull-set
 ```
 
-The output arrives in demarcated sections: read `=== DATA` to reason from (the `ITEMS` table resolves selection numbers — never display it); emit the TITLE section (markdown), then the DISPLAY section verbatim as a code block, then the MENU section verbatim as markdown.
+The output arrives in demarcated sections: read `=== DATA` to reason from (the `ITEMS` table resolves selection numbers — never display it); emit the DISPLAY section verbatim as a code block, then the MENU section verbatim as markdown.
 
 **STOP.** Wait for user response.
 
@@ -32,7 +32,7 @@ Resolve the selected number(s) through the `ITEMS` table and hold the item names
 
 Decide the unit's shape with the user. The default is **one epic** — several items become its rough topic shapes, and even one broad item usually opens into several. A **feature** fits only a single pulled item that reads as one coherent, single-topic build; infer its first phase (`discussion` when the material is decision-shaped, `research` when unknowns dominate) and hold it as `routing`.
 
-Compile a one-line `description` for the unit from the pulled items' summaries and the record. Then confirm the shape (state your read and why above the gate — when the selection is a whole horizon, its name is the natural work-unit name):
+Compile a one-line `description` for the unit from the pulled items' summaries and the record. Then confirm the shape — state your read and why above the gate, **naming the remainder** so a partial pull is spoken at the moment of choice (*"3 items stay waiting in mvp"*); when the selection is a whole horizon, its name is the natural work-unit name:
 
 > *Output the next fenced block as markdown (not a code block):*
 
@@ -62,7 +62,7 @@ Apply the user's changes to the shape, framing, or pulled set, then re-render th
 
 ## C. Read the Record
 
-The items' substance lives in the session logs their `sources` name (the home snapshot's `ITEMS`/`SESSIONS` tables and `engine manifest get project.roadmap.items.{name} sources` resolve them). Read every named log **not already current in this conversation's context** in full — a same-session pull has nothing to read; a return-visit pull reads the record cold.
+The items' substance lives in the session logs their `sources` name (the home snapshot's `ITEMS`/`SESSIONS` tables and `engine manifest get project.roadmap.items.{name}.sources` resolve them). Read every named log **not already current in this conversation's context** in full — a same-session pull has nothing to read; a return-visit pull reads the record cold. An item with no `sources` (a pre-commit shaping park) has only its summary — its ground is the live conversation and whatever a KB query surfaces; never invent a record for it.
 
 → Proceed to **D. Author the Backfill**.
 

--- a/skills/workflow-roadmap/references/roadmap-guidelines.md
+++ b/skills/workflow-roadmap/references/roadmap-guidelines.md
@@ -12,6 +12,7 @@ The product session runs on discovery's exploration stance — the register, the
 
 - **Capability-grain, always.** An item is whatever the user would move around a roadmap as one thing — "loyalty", "white-label". It may turn out to be a topic, three topics, or a whole epic; nobody knows yet and nobody needs to. No granularity discipline applies here — the independence tests belong to the epic's harvest, after a pull.
 - **Whether and when, not how.** The conversation decides what the product needs and what order it earns — mechanism, feasibility depth, and design decisions belong to the work units a pull creates. Substance is still welcome the way discovery welcomes it (soft decisions, rejected paths, recorded plainly); what changes is where the conversation anchors when a thread has given what it has.
+- **No self-healing analyses run at this level.** The roadmap fills through conversation, parks, and grooming alone — nothing auto-adds later, so harvest what the session actually surfaced. Documentation cadence and map operations live in the roadmap's own [session-loop.md](session-loop.md), never in the epic loop the imported guidance points at.
 
 ## B. The Staging Current
 
@@ -22,8 +23,11 @@ Listen for now/next/later throughout — staging language is this altitude's sha
 Items joined to work units are windows, not material:
 
 - A thread about a **waiting** item is this session's business — explore, re-sort, edit freely.
-- A thread about a **pulled, in-flight** item belongs to its work unit. When the session materially deepens its ground, record the exploration in the log and flag the join so the epic re-examines (`engine roadmap flag {name}`); never treat the roadmap as the place to redirect in-flight work — re-bucketing or removing a pulled item is refused engine-side, and the recovery is the epic's cancel.
-- An add aimed at a horizon that is fully in delivery takes the routed confirm (`engine render roadmap-add-gate --horizon {h}`) — into the epic as a fresh topic, or another horizon; no waiting side-door into a release that is now an epic.
+- A thread about a **pulled, in-flight** item belongs to its work unit. When the session materially deepens its ground, record the exploration in the log and flag the join so the epic re-examines (`engine roadmap flag {name}`; a join the epic has not yet bound to a topic answers `committed: null` with a note — nothing lands, the epic reads the record fresh at its harvest; relay that in a line). Never treat the roadmap as the place to redirect in-flight work — re-bucketing or removing a pulled item is refused engine-side, and the recovery is the epic's cancel.
+- An add aimed at a horizon with **any member in delivery** takes the routed confirm (`engine render roadmap-add-gate --horizon {h}` — emit its section verbatim, then STOP for the answer). While waiting members remain the menu is three-way; once the horizon is fully in delivery it is strict two-way — no waiting side-door into a release that is now an epic. Route the answer:
+  - **Into the delivery** (`1`) — the item is delivery scope now: `roadmap add` it into the horizon, then `roadmap pull-forward {name} --into {unit} --routing {research|discussion, per the thread's need}` (when the gate named several units, the user's answer names which). Record both under **Edits**.
+  - **Waiting beside the uncommitted members** (`2`, three-way only) — a plain `roadmap add`.
+  - **Another horizon** — the user names it; a plain `roadmap add` there.
 
 ## D. Tangents
 

--- a/skills/workflow-roadmap/references/session-loop.md
+++ b/skills/workflow-roadmap/references/session-loop.md
@@ -6,7 +6,7 @@
 
 Follow the stance and hard rules from **[roadmap-guidelines.md](roadmap-guidelines.md)** throughout. No background agents, no review cycles.
 
-**A. Open** picks the opening shape from how the session arrived; **B. Session Loop** runs the exploration; **C. Harvest** hands over when the user pulls.
+**A. Open** picks the opening shape from how the session arrived; **B. Session Loop** runs the exploration; **C. Harvest** sorts when the user pulls — an unconfirmed sort drops straight back into **B**.
 
 ## A. Open
 
@@ -26,6 +26,8 @@ say here commits you to building anything.
 Where do you want to dig in?
 ```
 
+Clear `genesis_continuation` — the transition is spent; any later pass through **A** takes the resume or fresh branch.
+
 **STOP.** Wait for user response.
 
 → Proceed to **B. Session Loop**.
@@ -39,8 +41,7 @@ The log at `.workflows/.roadmap/sessions/session-{session_number}.md` is the wor
 ```
 Where we'd got to:
 
-  {2–4 lines from the recent session(s): the threads we were
-  circling, what you were leaning toward, what was still open}
+  {2–4 lines from the recent session(s): the threads circled, what the user was leaning toward, what was still open}
 ```
 
 > *Output the next fenced block as a code block:*
@@ -78,10 +79,10 @@ What's on your mind?
 No fixed cadence — follow the conversation, not a checklist. **The loop is the exploration.** Items and horizons are sorted at the harvest in **C**, when the user pulls.
 
 1. **Listen.** Take in what the user just said.
-2. **Recognise intent.** The user's message may contain:
+2. **Recognise intent.** An **Edits** write below conjures the log first when none exists yet — the lazy rule, [session-template.md](session-template.md). The user's message may contain:
    - **Exploration content** — the product's shape, who it serves, what matters when. Continue the conversation per the guidelines' stance, the staging current running throughout.
-   - **A map operation on an existing item or horizon** — *"move X to v2"*, *"rename X"*, *"merge those horizons"*. Run the matching engine verb (`roadmap move|rename|edit|remove`, `roadmap horizon …` — each validates and self-commits; a refusal on a pulled item is the authority split speaking: relay it, offer the epic-side path). Record the op under **Edits**. An add aimed at a fully-delivered horizon takes the routed confirm first (guidelines **C**).
-   - **A direct add** — a placed capability named mid-conversation with no more shaping owed: `roadmap add {name} --horizon {h} --summary "{one-liner}" --source .roadmap/sessions/session-{session_number}.md` (origin defaults to `harvest`). Most material waits for the harvest instead — add directly only when the user places it themselves.
+   - **A map operation on an existing item or horizon** — *"move X to v2"*, *"rename X"*, *"merge those horizons"*. Run the matching engine verb (`roadmap move|rename|edit|remove`, `roadmap horizon …` — each validates and self-commits; a refusal on a pulled item is the authority split speaking: relay it, offer the epic-side path). Record the op under **Edits**. An add aimed at a horizon with any member in delivery takes the routed confirm first (guidelines **C**).
+   - **A direct add** — a placed capability named mid-conversation with no more shaping owed: `roadmap add {name} --horizon {h} --summary "{one-liner}" --source .roadmap/sessions/session-{session_number}.md` (origin defaults to `harvest`; the same guidelines-**C** confirm applies when the horizon has a member in delivery). Most material waits for the harvest instead — add directly only when the user places it themselves.
    - **Grooming an inbox idea on** — archive first so the pointer is durable, then add with the archived path as the source: `engine inbox archive {path}`, then `roadmap add {name} --horizon {h} --summary "{one-liner}" --origin inbox:{slug} --source .inbox/.archived/ideas/{file}`.
    - **Shared files** — paths offered in conversation land via `engine roadmap import {path} …` (self-commits; on `missing_imports`, re-prompt); read them for the conversation and record under **Edits**.
    - **A request to see the map** — *"show roadmap"*. Re-run `gateway.cjs view` and emit its TITLE and DISPLAY sections per their markers (skip the menu — the conversation is live). No STOP; render and continue.
@@ -95,10 +96,20 @@ No fixed cadence — follow the conversation, not a checklist. **The loop is the
    node .claude/skills/workflow-engine/scripts/engine.cjs commit --roadmap -m "roadmap: exploration notes — session-{session_number}"
    ```
 
-→ On return, proceed to **C. Harvest** when the user pulls (recognised in step 2). Otherwise loop within **B**.
+→ Proceed to **C. Harvest** when the user pulls (recognised in step 2); otherwise loop within **B**.
 
 ## C. Harvest
 
 Reached from **B** step 2 when the user pulls. The sort is user-pulled — there is no Claude-side gate here.
 
+→ Load **[harvest.md](harvest.md)** and follow its instructions as written. It owns its own confirmation and returns an outcome:
+
+#### If the outcome is `confirmed`
+
 → Return to caller.
+
+#### If the outcome is `explore`
+
+The conversation continues where it left off — no re-open, no fresh chrome.
+
+→ Return to **B. Session Loop**.

--- a/skills/workflow-roadmap/scripts/gateway.cjs
+++ b/skills/workflow-roadmap/scripts/gateway.cjs
@@ -6,7 +6,9 @@
 // this script selects which view the skill's flow needs and sections it.
 //
 //   gateway.cjs view                       → DATA + TITLE + DISPLAY + MENU home snapshot
-//   gateway.cjs pull-set                   → DATA + TITLE + DISPLAY + MENU pull working set
+//   gateway.cjs pull-set                   → DATA + DISPLAY + MENU pull working set
+//                                            (no TITLE — the skill's step marker
+//                                            heads the ceremony)
 //   gateway.cjs proposal --file {path}     → harvest overlay: the proposed item
 //                                            set (model-authored JSON) rendered
 //                                            over the existing roadmap
@@ -76,7 +78,6 @@ function pullSet() {
   }
   return [
     engine.gateway.dataBlock(v.data),
-    engine.gateway.titleBlock('Pull Into Delivery'),
     engine.gateway.displayBlock(v.display),
     engine.gateway.menuBlock(v.menu),
   ].join('\n');

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -432,7 +432,7 @@ function skillNameOf(file) {
 
 function checkH1Category(files) {
   const out = [];
-  const H1_KNOWN = new Set(['workflow-engine', 'workflow-knowledge', 'workflow-baseline']);
+  const H1_KNOWN = new Set(['workflow-engine', 'workflow-knowledge', 'workflow-baseline', 'workflow-roadmap']);
   for (const file of files) {
     const name = skillNameOf(file);
     if (!name || !name.startsWith('workflow-')) continue; // only workflow backbones
@@ -663,6 +663,7 @@ const RATCHET_PINS = {
   'skills/workflow-continue-epic/references/epic-display-and-menu.md': 3,
   'skills/workflow-continue-epic/references/summary-backfill.md': 3,
   'skills/workflow-discovery/references/confirm-trigger.md': 1,
+  'skills/workflow-discovery/references/continuity-load.md': 1,
   'skills/workflow-discovery/references/map-operations.md': 9,
   'skills/workflow-discovery/references/name-resolution.md': 2,
   'skills/workflow-discovery/references/opener-pattern.md': 1,
@@ -707,6 +708,7 @@ const RATCHET_PINS = {
   'skills/workflow-research-process/references/epic-session.md': 2,
   'skills/workflow-research-process/references/feature-session.md': 1,
   'skills/workflow-research-process/references/topic-splitting.md': 2,
+  'skills/workflow-roadmap/references/session-loop.md': 1,
   'skills/workflow-scoping-process/SKILL.md': 2,
   'skills/workflow-scoping-process/references/complexity-check.md': 2,
   'skills/workflow-discovery/references/first-phase-routing.md': 1,

--- a/tests/scripts/test-gateway-for-roadmap.cjs
+++ b/tests/scripts/test-gateway-for-roadmap.cjs
@@ -93,7 +93,7 @@ describe('workflow-roadmap gateway: pull-set', () => {
     assert.match(res.stdout, /ITEMS \(n {2}name {2}horizon\):/);
     assert.match(res.stdout, /  1 {2}menus {2}mvp/);
     assert.match(res.stdout, /  2 {2}loyalty {2}v1/);
-    assert.match(res.stdout, /=== TITLE[\s\S]*Pull Into Delivery/);
+    assert.ok(!/=== TITLE/.test(res.stdout), 'no TITLE — the skill step marker heads the ceremony');
     assert.match(res.stdout, /=== MENU[\s\S]*What goes into delivery\?/);
   });
 


### PR DESCRIPTION
The review pass's roadmap-skill prose layer, stacked on #939.

**The explore bounce is gone.** The harvest now runs inside the session loop (discovery's own shape): declining the sort drops straight back into the conversation — no genesis cold-open replay, no re-briefing chrome. `genesis_continuation` clears at first use, and the backbone renumbers (document review 6, conclude 7, pull 8; every inbound edge re-walked).

**Genesis can't die on an open session.** A product session left open no longer refuses the unconditional `session open` with the shaping conversation unpersisted — the shaping folds into the open log instead.

**The harvest closes its gaps.** A browse-only or grooming session has a legal exit (`If no new items emerged`); the log is conjured before sorting when the lazy rule left none, so `Items Sorted` and the close always have a session; `legal_horizon=false` is fixed at the gate ("v1.5" respells with the user) instead of dying inside the persist; reordering follows the conversation's stated staging, never the display's append order.

**Conclude keys on the marker** (`active_session`), matching the engine's own discriminator — a harvest-created log no longer walks into "no active roadmap session".

**Decision 28 is wired.** The add-to-joined-horizon confirm fires for *any* joined member (the everyday partly-delivered case included), and all three answers route — "into the delivery" is `roadmap add` + `roadmap pull-forward` into the named unit. Park valves stay light by design (ruled in review). `flag`'s not-yet-bound note is relayed rather than swallowed.

**Pull fixes:** item split is a rename-and-add (the horizon verb splits horizons); the manifest read embeds its field in the dot-path; the remainder is named at the shape gate ("3 items stay waiting in mvp") per decision 30; a `sources`-less item's record is never invented; the pull-set surface drops its TITLE — the step marker heads the ceremony, killing the duplicate heading.

**Chrome and conventions:** `# Product Roadmap` H1 (the baseline precedent, lint-allowlisted); three invocation modes stated; Step 3's byte-identical duplicate title dropped (the gateway TITLE owns it); the ask branch routes back to Home; dead `mkdir`/`rm` allowances dropped and `git log` added for the recovery protocol. The two wrapped continuity placeholders (roadmap session-loop + discovery continuity-load) unwrap to single lines and register in `RATCHET_PINS` — correcting fences that existed but evaded the count, per review ruling.

Gates: conventions lint 35/35, prose corpus + snapshot goldens green, roadmap suites 58/58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)