### PR TITLE
review(discovery): the harvest binds, parks carry their provenance, the parks-only sort speaks its own labels

### DIFF
--- a/skills/workflow-discovery/SKILL.md
+++ b/skills/workflow-discovery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-discovery
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(git log), Bash(mkdir -p .workflows/), Bash(rm .workflows/), Bash(rm -f .workflows/)
+allowed-tools: Bash(node .claude/skills/workflow-discovery/scripts/gateway.cjs), Bash(node .claude/skills/workflow-roadmap/scripts/gateway.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(git log), Bash(mkdir -p .workflows/), Bash(rm .workflows/), Bash(rm -f .workflows/)
 hooks:
   SessionEnd:
     - hooks:
@@ -27,10 +27,10 @@ Discovery is the universal **first phase** — every work type begins here. It s
 
 It runs in two modes:
 
-- **New mode** — from `workflow-start`. Decide the work type (epic / feature / bugfix / quick-fix / cross-cutting), shape the outline, persist at the work-type commit, route to the first phase.
-- **Existing-epic mode** — from `workflow-continue-epic`. The work type is already known; re-shape the epic's discovery map (refinement or resuming an interrupted sketch).
+- **New mode** — from `workflow-start`. Decide the work type (epic / feature / bugfix / quick-fix / cross-cutting), shape the outline, persist at the work-type commit, route to the first phase. A **product-altitude** read — no single unit of work on the table — routes out to the roadmap instead, before any unit exists.
+- **Existing-epic mode** — from `workflow-continue-epic`, or continuing straight from a roadmap pull that just created the epic. The work type is already known; shape (or re-shape) the epic's discovery map.
 
-**Stay in your lane**: Discovery settles *what the work is* and shapes it — determine the type first (epic / feature / bugfix / quick-fix / cross-cutting), then route it into the pipeline. How much substance the conversation engages is set per work type by the guidance loaded on each path, not fixed here: while determining the type you shape rather than resolve; once an epic is settled, its path opens into deep exploration. Name the work, shape it, route it.
+**Stay in your lane**: Discovery settles *what the work is* and shapes it — determine the type first (epic / feature / bugfix / quick-fix / cross-cutting, or the product road when no single unit is on the table), then route it into the pipeline. How much substance the conversation engages is set per work type by the guidance loaded on each path, not fixed here: while determining the type you shape rather than resolve; once an epic is settled, its path opens into deep exploration. Name the work, shape it, route it.
 
 ---
 
@@ -71,7 +71,7 @@ New work — nothing is on disk yet; pre-confirmation shaping is ephemeral.
 
 #### Otherwise
 
-`$1` names an existing epic. Skip macro shaping and re-shape its map.
+`$1` names an existing epic. Skip macro shaping and shape its map — a re-shape on a return visit, a first shaping when a roadmap pull created the epic moments ago (the map is empty; `pull_continuation` is held).
 
 → Proceed to **Step 6**.
 

--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -16,7 +16,7 @@ The topic set was confirmed at the end of [topic-synthesis.md](topic-synthesis.m
 
 No new topics — this is an edits-only, parks-only, or browse-only session.
 
-→ Proceed to **A2. Persist Parks and Pull-Forwards**.
+→ Proceed to **A2. Persist Parks, Pull-Forwards, and Binds**.
 
 #### Otherwise
 
@@ -46,27 +46,33 @@ Notes:
 - The response's `map_total` is `{T}` for the Conclusion line in **C**, and `added` lists every persisted topic — no re-read needed.
 - `brief_path` records where the topic's brief lives; the brief file itself was written at harvest by [brief-synthesis.md](brief-synthesis.md).
 
-→ Proceed to **A2. Persist Parks and Pull-Forwards**.
+→ Proceed to **A2. Persist Parks, Pull-Forwards, and Binds**.
 
-## A2. Persist Parks and Pull-Forwards
+## A2. Persist Parks, Pull-Forwards, and Binds
 
-Each verb validates and self-commits; record every landing under the log's **Edits** (`Parked: {name} → {horizon}` / `Pulled forward: {name}`). Skip whichever set is empty.
+Each verb validates and self-commits; record every landing under the log's **Edits** (`Parked: {name} → {horizon}` / `Pulled forward: {name}` / `Bound: {name} → {topic}`). Skip whichever set is empty.
 
-**Park set** — one batch (`origin` marks the provenance):
-
-```json
-[{"name": "{item}", "horizon": "{horizon}", "summary": "{one-line summary}", "origin": "park:{work_unit}", "sources": ["{work_unit}/discovery/sessions/session-{session_number}.md"]}]
-```
+**Park set** — one batch over the file the synthesis gate already wrote in full (provenance included; nothing to rewrite):
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs roadmap add-batch --file .workflows/.cache/{work_unit}/discovery/proposed-parks.json
 ```
 
-**Pull-forward set** — one call per item (the map topic + the re-aimed join, one commit each):
+**Pull-forward set** — one call per item (the map topic + its join, one commit each):
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs roadmap pull-forward {name} --into {work_unit} --routing {research|discussion}
 ```
+
+A refusal naming a previously dismissed topic is the user's earlier removal speaking — the gate's confirmation was the deliberate re-add, so re-run with `--force-dismissed`.
+
+**Binds** — the harvest's closing move for items pulled into this epic before it had a map. Read the roadmap state (`engine roadmap state`); for every item whose row names this work unit with **no `topic`**, bind it to the confirmed topic its ground crystallised as — usually the same-named one; when its ground split across several topics, the one carrying its identity:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs roadmap bind {item} --topic {topic}
+```
+
+A harvest that renamed a bound item's topic re-runs the bind — re-binding re-aims the join.
 
 → Proceed to **B. Write Topics Identified**.
 

--- a/skills/workflow-discovery/references/continuity-load.md
+++ b/skills/workflow-discovery/references/continuity-load.md
@@ -16,7 +16,7 @@ Bounded regardless of how many sessions exist:
 - **Recent in full** — read the most recent **2** session logs in full: their **Exploration**, **Edits**, and **Topics Identified**. On the resume branch the active log is the most recent and already loaded (re-reading is idempotent) — read the next concluded log below it.
 - **Older — one-line index** — for every session older than the recent two, read **only its `## Conclusion` line** (the finalisation digest: topics added, edits applied, map size). One line each. This is the bound — older sessions never load their full Exploration.
 
-**KB-on-demand.** Once discovery logs are knowledge-base indexed, an older session's full thinking can be pulled back by semantic query when a live thread calls for it. Until then, older sessions stay at the one-line Conclusion index, and recent-in-full is the floor — enough to resume on its own. A pulled epic's chain extends upward the same way: the product-level record (the roadmap sessions its items' `sources` name — read in full at the pull and backfilled into session-001) is KB-indexed and reachable by query whenever a thread reaches past the backfill.
+**KB-on-demand.** Discovery logs are indexed at each session's close, so an older session's full thinking can be pulled back by semantic query when a live thread calls for it — older sessions stay at the one-line Conclusion index here, and recent-in-full is the floor, enough to resume on its own. A pulled epic's chain extends upward the same way: the product-level record (the roadmap sessions its items' `sources` name — read in full at the pull and backfilled into session-001) is indexed and reachable by query whenever a thread reaches past the backfill.
 
 → Proceed to **B. Briefing**.
 

--- a/skills/workflow-discovery/references/detection-core.md
+++ b/skills/workflow-discovery/references/detection-core.md
@@ -12,7 +12,7 @@ These rules apply only to the work-type decision during shaping (Step 4) — a o
 
 Two levels, gathered simultaneously, committed in dependency order:
 
-- **Macro / work type** — *what kind of work is this?* (epic / feature / bugfix / quick-fix / cross-cutting). Resolved first.
+- **Macro / work type** — *what kind of work is this?* (epic / feature / bugfix / quick-fix / cross-cutting — or none: a product-altitude read routes out to the roadmap before any unit exists). Resolved first.
 - **Micro / topic** — topic existence (one coherent thing vs many) and, where the type has it, per-topic routing. For example, you cannot route an epic's topics, or choose research-vs-discussion for a feature or cross-cutting concern, until you know which it is.
 
 **Gather freely; commit in order.** Work-type cues and topic seeds co-emerge in the same breath — never sequence the *conversation* into "first interrogate type, then topics." Only *commitment* is ordered.
@@ -107,7 +107,7 @@ When a tangential concern surfaces that doesn't fit the current shape, offer to 
 
 If the user accepts, invoke the matching capture skill (`/workflow-log-idea`, `/workflow-log-bug`, or `/workflow-log-quickfix` — default to idea if unsure). The capture skill writes the inbox file but does not commit it, so commit it now (`node .claude/skills/workflow-engine/scripts/engine.cjs commit --inbox -m "workflow(inbox): capture {slug}"`) — it's a side-excursion from the main work, easy to leave uncommitted otherwise, and committing it means the capture survives even if this discovery session is abandoned. Note the surfacing so it's recoverable, then continue with the original work, now without scope creep. If the user says it's actually part of this work, fold it in. Soft, conversational — no structured gate.
 
-**The bucket is the ticket.** When the tangent is a product capability the user *places on the timeline* (*"that's a v2 thing"*), it parks on the roadmap instead — confirmed placement, then `engine roadmap add {name} --horizon {h} --summary "{one-liner}" --origin park:discovery` (self-commits; the roadmap is born at the first park). An unplaced thought stays the inbox's — when ambiguous, inbox: grooming promotes cheaply later, while a wrong horizon reads as a decision someone made.
+**The stated placement is the ticket.** When the tangent is a product capability the user *places on the timeline* (*"that's a v2 thing"*), it parks on the roadmap instead — confirmed placement, then `engine roadmap add {name} --horizon {h} --summary "{one-liner}" --origin park:discovery` (self-commits; the roadmap is born at the first park). An unplaced thought stays the inbox's — when ambiguous, inbox: grooming promotes cheaply later, while a wrong horizon reads as a decision someone made.
 
 ## H. Anchor and return — shape, don't dive
 
@@ -131,7 +131,11 @@ Commit only when signals have **converged AND been stable** across the last few 
 
 The forming work may already have a home the user forgot: a waiting roadmap item, or an inbox capture. The opener read both indexes; as the shape converges, match it against them by name and theme — a match earns one soft question, a miss earns silence.
 
-- **A waiting roadmap item holds this ground** — a fresh work unit beside it would strand its record and twin the item. Offer the pull instead: *"Loyalty is already on your roadmap (v1) — pull it from there so the record comes along?"* On accept, invoke `/workflow-roadmap pull` via the Skill tool — this skill ends, terminal. On decline, continue shaping; never create the twin silently — a deliberate fresh start renames.
+- **A waiting roadmap item holds this ground** — epic- and feature-shaped reads only; bugs and quick-fixes never touch the roadmap. A fresh work unit beside the item would strand its record and twin it. Offer the pull instead: *"Loyalty is already on your roadmap (v1) — pull it from there so the record comes along?"* On decline, continue shaping; never create the twin silently — a deliberate fresh start renames.
 - **A live inbox item captured this thought** — *"You logged 'checkout race' on 12 Jul — read it in as the seed?"* On accept, add the item's path to `inbox_seeds` and read it — it becomes the work's seed through the normal confirm-trigger landing. On decline, continue.
+
+**If the user accepts a pull offer:** invoke `/workflow-roadmap pull` via the Skill tool. This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
+
+**Otherwise** — no match, a declined offer, or an inbox seed read in:
 
 → Return to caller.

--- a/skills/workflow-discovery/references/initialize-discovery.md
+++ b/skills/workflow-discovery/references/initialize-discovery.md
@@ -6,13 +6,13 @@
 
 1. Ensure the session-log and briefs directories exist: `mkdir -p .workflows/{work_unit}/discovery/sessions/ .workflows/{work_unit}/discovery/briefs/` (safe to re-run).
 2. Hold the following in conversation memory — the lazy session-log write records them in the log's header sections ([template.md](template.md) → *Description*, *Seeds*, *Imports*), and the session loop's opener and seed/import-launchpad branch read them:
-   - `session_number` — set before this step (Step 6 on resume, Step 7 for a fresh session, or the confirm-trigger for a new epic).
+   - `session_number` — set before this step (Step 6 on resume, Step 7 for a fresh session, the confirm-trigger for a new epic, or the roadmap pull for a pull-born one).
    - `description` — from the most recent discovery output.
    - `seeds` — from the most recent discovery output (may be empty — treat as "none"). The work unit's origin when it was promoted from the inbox.
    - `imports` — from the most recent discovery output (may be empty — treat as "none").
    - `map_state_at_start` — `map_summary` from the most recent discovery output. Write `(empty — first session)` when the map is empty.
 
-**Do not create the session log file here.** For a new epic the confirm-trigger already wrote `session-001.md`; otherwise the file is conjured lazily on the first state change — see [template.md](template.md) → *Lazy creation and finalisation*.
+**Do not create the session log file here.** For a new epic `session-001.md` is already on disk — written by the confirm-trigger, or by the roadmap pull's backfill; otherwise the file is conjured lazily on the first state change — see [template.md](template.md) → *Lazy creation and finalisation*.
 
 No commit at this step.
 

--- a/skills/workflow-discovery/references/name-resolution.md
+++ b/skills/workflow-discovery/references/name-resolution.md
@@ -4,7 +4,7 @@
 
 ---
 
-Resolve the work-unit name and clear any collision before the confirm-trigger creates the manifest. Loaded by [confirm-trigger.md](confirm-trigger.md). On return, `work_unit` is a confirmed, collision-free kebab-case name.
+Resolve the work-unit name and clear any collision before the unit is created. Loaded by [confirm-trigger.md](confirm-trigger.md) and by the roadmap pull ([pull.md](../../workflow-roadmap/references/pull.md)). On return, `work_unit` is a confirmed, collision-free kebab-case name.
 
 Inputs held from earlier steps: `work_type` (for phrasing), `inbox_seeds` (the promoted inbox file path(s), if the work came from the inbox), and the shaped one-line `description`.
 

--- a/skills/workflow-discovery/references/resume-detection.md
+++ b/skills/workflow-discovery/references/resume-detection.md
@@ -10,7 +10,7 @@ Detect an interrupted prior shaping session before re-shaping an existing epic's
 
 → Return to caller.
 
-Otherwise, read the active-session marker:
+**Otherwise:** read the active-session marker:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.discovery active_session

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -147,18 +147,20 @@ No fixed cadence — follow the conversation, not a checklist. **The loop is the
 2. **Recognise intent.** The user's message may contain:
    - **Exploration content** — answers to your questions, new surfaces, descriptions of how parts work or connect, positions taken on a decision. Continue the conversation: push on the thread the user opened, counter-frame, follow where it leads. See [discovery-guidelines.md](discovery-guidelines.md) → *The Exploration Stance — How* for the register and where to push.
    - **An edit operation on an existing map item** — *"remove X"*, *"rename X to Y"*, *"edit summary of X"*, etc. Only possible when the map is non-empty. Delegate to [map-operations.md](map-operations.md) — it handles the operation, writes to the **Edits** section, commits.
-   - **A staged product capability — the park valve.** The user places a surfaced capability beyond this epic (*"that's a v2 thing"*), or confirms your proposed placement. Park it on the roadmap (born at the first park; the verb validates and self-commits), record it under **Edits** (`Parked: {name} → {horizon}`), and continue — capture-weight, never shaping:
+   - **A staged product capability — the park valve.** The user places a surfaced capability beyond this epic (*"that's a v2 thing"*), or confirms your proposed placement. Park it on the roadmap (born at the first park; the verb validates and self-commits), record it under **Edits** (`Parked: {name} → {horizon}` — the lazy-creation rule applies when no log exists yet, [template.md](template.md)), and continue — capture-weight, never shaping:
 
      ```bash
      node .claude/skills/workflow-engine/scripts/engine.cjs roadmap add {name} --horizon {horizon} --summary "{one-liner}" --origin park:{work_unit} --source {work_unit}/discovery/sessions/session-{session_number}.md
      ```
 
      A thought about an item already **pulled into in-flight work** is that work's business, not a park — when this session materially deepened its ground, flag the join instead (`engine roadmap flag {name}`). An unplaced tangent stays the inbox's (the scope-down in the detection core).
-   - **A roadmap item pulled forward** — *"actually, bring loyalty into this epic"*. One composed transaction lands it as a map topic (source `roadmap`) and re-aims the join; record it under **Edits** (`Pulled forward: {name}`):
+   - **A roadmap item pulled forward** — *"actually, bring loyalty into this epic"*. One composed transaction lands it as a map topic (source `roadmap`) and writes its join; record it under **Edits** (`Pulled forward: {name}`):
 
      ```bash
      node .claude/skills/workflow-engine/scripts/engine.cjs roadmap pull-forward {name} --into {work_unit} --routing {research|discussion}
      ```
+
+     A refusal naming a previously dismissed topic needs the user's deliberate re-add — confirm it, then re-run with `--force-dismissed`.
    - **A request to see the map** — *"show map"*, *"what's on the map"*. Re-run `gateway.cjs map-view {work_unit}` and emit its TITLE section (markdown) then its `=== DISPLAY` section verbatim as a code block. No STOP gate; just render and continue.
    - **A request to see dismissed items** — *"show dismissed"*, *"what was removed"*. Load [show-dismissed.md](show-dismissed.md).
    - **A KB query for prior context** — when a conversational thread would benefit from prior work on this or sibling work units, invoke `knowledge query` with a query derived from the thread (see [contextual-query.md](../../workflow-knowledge/references/contextual-query.md) for the pattern).

--- a/skills/workflow-discovery/references/shape-and-confirm.md
+++ b/skills/workflow-discovery/references/shape-and-confirm.md
@@ -47,7 +47,19 @@ The work type is committed. Set `work_type`; compile a one-line `description` fr
 
 #### If `other`
 
-Take the user's call as authoritative — adjust the read without re-litigating (if they describe rather than name a shape, map it via the detection core and reflect back for a quick confirm). A settled product-road read routes exactly as `yes` does — hold `import_paths`, invoke `/workflow-roadmap genesis`, terminal. Once a work type is settled, set `work_type` and compile the `description`.
+Take the user's call as authoritative — adjust the read without re-litigating (if they describe rather than name a shape, map it via the detection core and reflect back for a quick confirm).
+
+**If the settled read is the product road:**
+
+Hold any import paths surfaced during shaping as `import_paths`.
+
+Invoke `/workflow-roadmap genesis` via the Skill tool.
+
+This skill ends. The invoked skill will load into context and provide additional instructions. Terminal.
+
+**If the settled read is a work type:**
+
+Set `work_type` and compile the `description`.
 
 → Return to caller.
 

--- a/skills/workflow-discovery/references/topic-synthesis.md
+++ b/skills/workflow-discovery/references/topic-synthesis.md
@@ -40,11 +40,9 @@ For continuing sessions, also check: does any new candidate overlap with an exis
 
 #### If no candidates remain and the park set is non-empty
 
-Everything the harvest surfaced stages beyond this epic. Skip routing; render only the roadmap overlay from **E** (write and render `proposed-parks.json`, no topic proposal) and its confirmation gate. On `yes`, synthesis outcome: `confirmed` with an **empty working list** and the park set held for Step 12; `explore` and adjust behave as in **E**.
+Everything the harvest surfaced stages beyond this epic — nothing routes; the sort is the roadmap's.
 
-→ Load **[brief-synthesis.md](brief-synthesis.md)** and follow its instructions as written — with the empty working list, its pass covers the existing map topics this session's exploration materially deepened.
-
-→ Return to caller.
+→ Proceed to **F. Parks-Only Gate**.
 
 #### If no candidates remain
 
@@ -87,11 +85,17 @@ The output arrives in demarcated sections. Read `=== DATA` to reason from (never
 - `exists_on_map=true` — the name collides with an active map item. Fold the exploration into that item or pick a different name (revise the set, rewrite the file, re-run) before rendering the gate.
 - `legal_name=false` — dots or slashes break manifest addressing. Rename and re-run.
 - `matches_dismissed=true` — the name was previously dismissed. Fine to proceed — confirming at the gate below is the re-add decision; hold the flag for Step 12, which passes `--force-dismissed` on the write.
-- `waiting_on_roadmap=true` — the anti-twin rule: a waiting roadmap item already holds this ground, and a fresh topic beside it would strand its record. Never leave it in the working list — move it to the **pull-forward set** when it belongs in this epic (Step 12 lands it as a map topic with its join re-aimed), or drop it from the proposal to leave it waiting.
+- `waiting_on_roadmap=true` — the anti-twin rule: a waiting roadmap item already holds this ground, and a fresh topic beside it would strand its record. Never leave it in the working list — move it to the **pull-forward set** when it belongs in this epic (Step 12 lands it as a map topic and writes its join), or drop it from the proposal to leave it waiting.
 
 Emit the `=== DISPLAY` section verbatim **as a code block** — it shows the proposed topics with the existing map unchanged below, so the full picture is visible.
 
-**If the park set is non-empty:** write it to `.workflows/.cache/{work_unit}/discovery/proposed-parks.json` (`[{"name", "horizon", "summary"}]`) and render the roadmap overlay beneath the topic proposal, emitting its `=== DISPLAY` section verbatim as a code block (its DATA flags follow the same rules — `exists_on_roadmap=true` folds into the existing item or renames):
+**If the park set is non-empty:** write it to `.workflows/.cache/{work_unit}/discovery/proposed-parks.json` in the shape Step 12 persists as-is — provenance included:
+
+```json
+[{"name": "{item}", "horizon": "{horizon}", "summary": "{one-line summary}", "origin": "park:{work_unit}", "sources": ["{work_unit}/discovery/sessions/session-{session_number}.md"]}]
+```
+
+Then render the roadmap overlay beneath the topic proposal, emitting its `=== DISPLAY` section verbatim as a code block (its DATA flags follow the same rules — `exists_on_roadmap=true` folds into the existing item or renames):
 
 ```bash
 node .claude/skills/workflow-roadmap/scripts/gateway.cjs proposal --file .workflows/.cache/{work_unit}/discovery/proposed-parks.json
@@ -139,3 +143,50 @@ Apply the named adjustments to the working set:
 After applying, rewrite `proposed-topics.json`, re-render the proposal (back to the top of **E**), and ask again. Loop until confirmed or `explore` is chosen.
 
 → Return to **E. Render Proposal**.
+
+## F. Parks-Only Gate
+
+Reached from **C** when the harvest produced parks and no topics. Write the park set to `.workflows/.cache/{work_unit}/discovery/proposed-parks.json` in the shape Step 12 persists as-is — provenance included:
+
+```json
+[{"name": "{item}", "horizon": "{horizon}", "summary": "{one-line summary}", "origin": "park:{work_unit}", "sources": ["{work_unit}/discovery/sessions/session-{session_number}.md"]}]
+```
+
+Render the roadmap overlay, emitting its `=== DISPLAY` section verbatim as a code block (its DATA flags follow **E**'s park rules):
+
+```bash
+node .claude/skills/workflow-roadmap/scripts/gateway.cjs proposal --file .workflows/.cache/{work_unit}/discovery/proposed-parks.json
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+· · · · · · · · · · · ·
+**`◆ Park these on the roadmap, or tell me what to adjust.`**
+
+**`y/yes`**     → Commit these items to the roadmap and conclude
+**`e/explore`** → Go back to exploration; not ready to commit yet
+**Adjust**    → Tell me what to change (move between horizons, rename, re-word)
+```
+
+**STOP.** Wait for user response.
+
+#### If `yes`
+
+Synthesis outcome: `confirmed`, with an **empty working list** and the park set held for Step 12.
+
+→ Load **[brief-synthesis.md](brief-synthesis.md)** and follow its instructions as written — with the empty working list, its pass covers the existing map topics this session's exploration materially deepened.
+
+→ Return to caller.
+
+#### If `explore`
+
+The user isn't ready — no working list, and no parks land. Synthesis outcome: `explore`.
+
+→ Return to caller.
+
+#### If adjust
+
+Apply the changes — move between horizons, rename, re-word summaries, drop. Rewrite `proposed-parks.json` and re-ask.
+
+→ Return to **F. Parks-Only Gate**.

--- a/skills/workflow-discussion-process/references/off-topic-epic.md
+++ b/skills/workflow-discussion-process/references/off-topic-epic.md
@@ -6,6 +6,18 @@
 
 The caller provides `work_unit`, `topic`, and the `concern` with its discussed context. The concern is already judged off-topic for this discussion — on an epic it belongs to a sibling topic, existing or new. Offer the reroute, resolve the target yourself, and land the concern where it belongs.
 
+**If the concern is a staged product capability** — the user placed it beyond this epic (*"that's a v2 thing"*), or your proposed placement is confirmed in conversation: its home is the roadmap, not a sibling topic. Park it (born at the first park; the verb validates and self-commits), note it in the discussion's running record, and continue — capture-weight, never shaping:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs roadmap add {name} --horizon {horizon} --summary "{one-liner}" --origin park:{work_unit} --source {work_unit}/discussion/{topic}.md
+```
+
+→ Return to caller for **B. Session Loop**.
+
+**Otherwise:**
+
+→ Proceed to **A. Resolve the Target**.
+
 ## A. Resolve the Target
 
 Read the live map:
@@ -14,15 +26,7 @@ Read the live map:
 node .claude/skills/workflow-discovery/scripts/gateway.cjs {work_unit}
 ```
 
-**If the concern is a staged product capability** — the user placed it beyond this epic (*"that's a v2 thing"*), or your proposed placement is confirmed in conversation: its home is the roadmap, not a sibling topic. Park it (born at the first park; the verb validates and self-commits), note it in the discussion's running record, and continue — capture-weight, never shaping:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs roadmap add {name} --horizon {horizon} --summary "{one-liner}" --origin park:{topic} --source {work_unit}/discussion/{topic}.md
-```
-
-→ Return to caller for **B. Session Loop**.
-
-Otherwise: you hold the conversation and the map — resolve the target yourself from each topic's name, summary, routing, and lifecycle. The concern's home is the topic whose remit it falls under; when nothing fits, a new kebab-case topic name you derive from the concern. Don't put the reading back on the user. Judge `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** — the concern's nature decides, so the judgement holds whatever the target.
+You hold the conversation and the map — resolve the target yourself from each topic's name, summary, routing, and lifecycle. The concern's home is the topic whose remit it falls under; when nothing fits, a new kebab-case topic name you derive from the concern. Don't put the reading back on the user. Judge `landing_phase` per **Judging the Landing Phase** in **[triage-landing.md](../../workflow-shared/references/triage-landing.md)** — the concern's nature decides, so the judgement holds whatever the target.
 
 #### If the resolved target is the current topic
 

--- a/skills/workflow-discussion-process/references/off-topic-non-epic.md
+++ b/skills/workflow-discussion-process/references/off-topic-non-epic.md
@@ -48,7 +48,7 @@ Capture the concern via the `workflow-log-idea` skill so it lands in the inbox f
 Confirm the horizon in conversation (propose from the user's own staging words when they placed it; ask when they didn't), then park — the roadmap is born at the first park, and the verb validates and self-commits:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs roadmap add {name} --horizon {horizon} --summary "{one-liner}" --origin park:{topic} --source {work_unit}/discussion/{topic}.md
+node .claude/skills/workflow-engine/scripts/engine.cjs roadmap add {name} --horizon {horizon} --summary "{one-liner}" --origin park:{work_unit} --source {work_unit}/discussion/{topic}.md
 ```
 
 Note the park in the Summary so the discussion records where the concern went.

--- a/skills/workflow-shared/references/reconcile-advisory.md
+++ b/skills/workflow-shared/references/reconcile-advisory.md
@@ -171,7 +171,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_uni
 
 #### If output is `roadmap` (the product record deepened beneath this work)
 
-A roadmap session materially deepened this item's ground after the work started. The joined roadmap item's `sources` name the record — read the roadmap state, find the item whose `pulled_to` names this work unit and topic, and read its most recent source log fresh into context. Then clear the flag.
+A roadmap session materially deepened this item's ground after the work started. The joined roadmap item's `sources` name the record — read the roadmap state, find the item whose row's `work_unit` and `topic` name this work, and read its most recent source log fresh into context. Then clear the flag.
 
 > *Output the next fenced block as a code block:*
 


### PR DESCRIPTION
The review pass's discovery/discussion prose layer, stacked on #940.

**The bind lands.** `confirm-and-persist` A2 (now *Persist Parks, Pull-Forwards, and Binds*) closes the loop the whole review converged on: every item joined to this epic at unit grain binds to the topic its ground crystallised as — same-named in the mainline, the identity-carrier on a split (per review ruling), re-bound on a harvest rename. `roadmap flag`, the `reconcile_needed: "roadmap"` advisory, and topic-level cancel-revert now fire for plain-pulled items.

**Parks keep their provenance.** The synthesis gate writes `proposed-parks.json` once, in full (`origin: park:{work_unit}` + session-log `sources`), and A2 consumes it as-is — epic-harvest parks no longer land as `origin: harvest` with no pointer back into the record.

**The parks-only sort speaks its own labels.** A harvest whose every candidate stages beyond the epic routes to its own gate (`F. Parks-Only Gate`): park labels, explicit yes/explore/adjust outcomes, briefs regenerated only on yes — never "Commit these topics" over zero topics, never `reconcile_needed` stamped by a declined sort.

**Recognition respects decision 13.** The roadmap-pull offer fires only on epic- and feature-shaped reads, and its accepted pull is a proper terminal exit (the section's return no longer follows it). `shape-and-confirm`'s `other` branch splits the product road from a work type the same way `yes` does.

**Smaller closures:** pull-forward call sites handle the dismissed-name refusal (`--force-dismissed` after the user's confirmed re-add); `park:{origin}` standardises on the containing work unit; "the bucket is the ticket" rewords to avoid detection-core's own bucket vocabulary; section A names the sixth outcome; the discovery backbone frames the product-road exit and the pull-born epic; `initialize-discovery`/`name-resolution` learn their third caller; `continuity-load`'s stale "until then" hedge clears (discovery logs are indexed at close); `resume-detection`'s else takes the bold form; the reconcile advisory names the fields `roadmap state` actually emits (`work_unit`/`topic`, not raw `pulled_to`); the off-topic park check moves to the sanctioned prelude position with an explicit otherwise; discovery's frontmatter gains the roadmap gateway its harvest calls.

Gates: conventions lint 35/35, prose corpus + snapshot goldens green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)