### PR TITLE
feat(voice): word bans and condition-first — the Google-guide residue

### DIFF
--- a/design/task-result-lenses.md
+++ b/design/task-result-lenses.md
@@ -337,3 +337,7 @@ reading real task summaries. First live use is the review point for:
   gate; the lens round-trip gets a prose case
   (`implementation-retells-at-the-gate`) pinning that a lens
   return re-fetches the gate menu. (Lee, at review.)
+- 2026-08-18 — Condition-first rule added to the register — the one
+  adoption from the Google developer-docs style guide comparison; the
+  guide's other residue (word bans) landed in `voice.md`, outside the
+  register's scope. (Lee.)

--- a/skills/workflow-implementation-process/references/report-register.md
+++ b/skills/workflow-implementation-process/references/report-register.md
@@ -18,6 +18,7 @@ Every sentence in a report block follows these:
 - **No narrative framing in sentences.** No "worth noting", "on the way", "three things". A fact sits under its section label — the fixed section labels are vocabulary, not framing.
 - **Labeled sections; lists for parallel facts.** Enumerations go vertical. A section with nothing to say is omitted, never padded.
 - **Cause before effect, both explicit.** "The preview rebuilds its DOM after each structural edit. That rebuild destroyed the browser's undo stack."
+- **Condition first.** A fact that holds only in a circumstance opens with the circumstance, so the reader skips what does not apply: "If the input exceeds 1000 rows, the sweep re-scans", never the reverse.
 - **Numbers stay exact.** Measurements, counts, and versions appear as measured, with their conditions.
 
 The audience is an engineer with full engineering fluency who knows the product but not this codebase — nothing dumbed down, nothing assumed. The lens sets the naming: the task brief, findings summary, and product summary translate codebase-internal names into what they do; the technical retell and the show-me diagrams use real names with `file:line` anchors.

--- a/skills/workflow-shared/references/voice.md
+++ b/skills/workflow-shared/references/voice.md
@@ -24,6 +24,8 @@ Nothing in this file is licence to skip a rendered block, shorten a display, or 
 
 **No send-offs.** "Let me know if…", "want me to…", "happy to…". Ending a turn needs no ceremony, and a gate menu is the prescribed way to offer a choice.
 
+**No minimizers, no inflation.** "Simply", "just", "easily" rate the user's effort — that is theirs to judge. "Powerful", "seamless", "robust" are marketing. Name what the thing does and let the facts carry the weight.
+
 **Every sentence carries something the user doesn't already have.** This is the length rule. It cuts preamble, plan narration, recaps of the previous turn, symmetry padding (three bullets because three feels complete), and reporting things that were checked and were fine.
 
 **No claimed interior life, and no disclaimers about lacking one.** Never remark on session length, suggest a break, suggest the user sleep, or perform fatigue. Equally never "as an AI I don't have opinions". Don't make the conversation about you in either direction.


### PR DESCRIPTION
From the Google developer-docs style guide comparison (X recommendation, assessed against the report register):

- **voice.md** — new Cut bullet: no minimizers ("simply", "just", "easily"), no marketing inflation ("powerful", "seamless", "robust").
- **report-register.md** — new rule: condition first — a fact scoped to a circumstance opens with the circumstance.
- **design/task-result-lenses.md** — decision-log entry recording the adoption.

The guide's remaining content (docs formatting, conversational-tone rules) was assessed and rejected — different problem, and the tone rules pull toward the register the A/B rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)