### PR TITLE
fix(sessions): the install resolves {NNN} — the durable header matches the filename

### DIFF
--- a/skills/workflow-discovery/references/template.md
+++ b/skills/workflow-discovery/references/template.md
@@ -102,7 +102,7 @@ To create it, draft the complete log at the staging path `.workflows/.cache/{wor
 node .claude/skills/workflow-engine/scripts/engine.cjs discovery-session open {work_unit} --session-log-file .workflows/.cache/{work_unit}/discovery/session-draft.md
 ```
 
-The engine allocates the session number, installs the draft as `discovery/sessions/session-{NNN}.md`, and sets the active-session marker so it always pairs with an existing log. The response's `session` is authoritative — set `session_number` from it. Later writes this session edit the installed file directly. The caller's own commit step stages and commits the log and marker.
+The engine allocates the session number, resolves any literal `{NNN}` in the draft to it (leave the header as the template writes it), installs the log as `discovery/sessions/session-{NNN}.md`, and sets the active-session marker so it always pairs with an existing log. The response's `session` is authoritative — set `session_number` from it. Later writes this session edit the installed file directly. The caller's own commit step stages and commits the log and marker.
 
 The `(none)` Conclusion is the **resume-detection signal** in concert with the `phases.discovery.active_session` manifest marker (see [resume-detection](resume-detection.md)). Always replace it at finalisation so the next entry sees a closed state.
 

--- a/skills/workflow-engine/scripts/domain/discovery-session.cjs
+++ b/skills/workflow-engine/scripts/domain/discovery-session.cjs
@@ -108,9 +108,14 @@ function openDiscoverySession(cwd, workUnit, { sessionLogFile }) {
 
     // Log first, marker second: a failure between the two leaves a log
     // without a marker (a closed-looking session — recoverable), never a
-    // marker naming a missing log (corrupt state).
+    // marker naming a missing log (corrupt state). The install resolves any
+    // literal {NNN} to the allocated number — the template's placeholder,
+    // written before the number exists — so the durable header matches the
+    // filename. Write-then-unlink preserves the move; a crash between the
+    // two leaves only a scratch draft behind.
     fs.mkdirSync(sessionsDir, { recursive: true });
-    fs.renameSync(draftPath, path.join(cwd, rel));
+    fs.writeFileSync(path.join(cwd, rel), draft.split('{NNN}').join(session));
+    fs.unlinkSync(draftPath);
     ensureContainer(ensureContainer(manifest, 'phases', 'phases'), 'discovery', 'phases.discovery').active_session = session;
     saveWorkUnitManifest(cwd, workUnit, manifest);
     return { work_unit: workUnit, session, path: rel };

--- a/skills/workflow-engine/scripts/domain/roadmap-session.cjs
+++ b/skills/workflow-engine/scripts/domain/roadmap-session.cjs
@@ -93,9 +93,14 @@ function openRoadmapSession(cwd, { sessionLogFile }) {
 
     // Log first, marker second: a failure between the two leaves a log
     // without a marker (a closed-looking session — recoverable), never a
-    // marker naming a missing log (corrupt state).
+    // marker naming a missing log (corrupt state). The install resolves any
+    // literal {NNN} to the allocated number — the template's placeholder,
+    // written before the number exists — so the durable header matches the
+    // filename. Write-then-unlink preserves the move; a crash between the
+    // two leaves only a scratch draft behind.
     fs.mkdirSync(sessionsDir, { recursive: true });
-    fs.renameSync(draftPath, path.join(cwd, rel));
+    fs.writeFileSync(path.join(cwd, rel), draft.split('{NNN}').join(session));
+    fs.unlinkSync(draftPath);
     roadmap.active_session = session;
     writeProjectManifestAtomic(cwd, manifest);
     return { session, path: rel };

--- a/skills/workflow-roadmap/references/session-template.md
+++ b/skills/workflow-roadmap/references/session-template.md
@@ -73,7 +73,7 @@ On the `open` path the log is **not created at session start** — it is conjure
 node .claude/skills/workflow-engine/scripts/engine.cjs roadmap session open --session-log-file .workflows/.cache/roadmap/session-draft.md
 ```
 
-The engine allocates the number, installs the draft, and sets `roadmap.active_session`. The response's `session` is authoritative — set `session_number` from it. Later writes edit the installed file directly; commit with `engine commit --roadmap`. Browse-and-bail produces no file.
+The engine allocates the number, resolves any literal `{NNN}` in the draft to it (leave the header as the template writes it), installs the log, and sets `roadmap.active_session`. The response's `session` is authoritative — set `session_number` from it. Later writes edit the installed file directly; commit with `engine commit --roadmap`. Browse-and-bail produces no file.
 
 The `(none)` Conclusion plus the `roadmap.active_session` marker is the resume signal. At finalisation (conclude), replace it with one of:
 

--- a/tests/scripts/test-engine-discovery-session.cjs
+++ b/tests/scripts/test-engine-discovery-session.cjs
@@ -321,6 +321,17 @@ describe('engine discovery-session open — happy path', () => {
     assert.strictEqual(fs.existsSync(path.join(fix.project, '.workflows/payments/.lock')), false);
   });
 
+  it('a template-literal {NNN} in the draft resolves to the allocated number at install', () => {
+    fix = setupFixture({ epic: closedEpicManifest() });
+    writeFile(fix.project, DRAFT_REL, '# Discovery Session {NNN}\n\nMore exploration ({NNN}).\n');
+    const res = engine(fix, OPEN);
+    assert.strictEqual(res.session, '003');
+    assert.strictEqual(
+      fs.readFileSync(path.join(fix.project, '.workflows/payments/discovery/sessions/session-003.md'), 'utf8'),
+      '# Discovery Session 003\n\nMore exploration (003).\n',
+      'the durable header matches the filename');
+  });
+
   it('a legacy manifest with no discovery phase and no logs opens session 001', () => {
     const epic = closedEpicManifest();
     epic.phases = {};

--- a/tests/scripts/test-engine-roadmap.cjs
+++ b/tests/scripts/test-engine-roadmap.cjs
@@ -531,10 +531,14 @@ describe('engine CLI: roadmap sessions and imports', () => {
     return name;
   }
 
-  it('open installs the draft as session-001, sets the marker, JIT-births the node — no commit', () => {
+  it('open installs the draft as session-001, resolves {NNN}, sets the marker, JIT-births the node — no commit', () => {
     const head = git(dir, ['rev-parse', 'HEAD']).trim();
-    const res = runOk(dir, ['session', 'open', '--session-log-file', draft('draft.md', '# Roadmap Session 001\n')]);
+    const res = runOk(dir, ['session', 'open', '--session-log-file', draft('draft.md', '# Roadmap Session {NNN}\n')]);
     assert.strictEqual(res.session, '001');
+    assert.strictEqual(
+      fs.readFileSync(path.join(dir, '.workflows', '.roadmap', 'sessions', 'session-001.md'), 'utf8'),
+      '# Roadmap Session 001\n',
+      'the template-literal {NNN} resolves to the allocated number at install');
     assert.strictEqual(res.path, '.workflows/.roadmap/sessions/session-001.md');
     assert.strictEqual(fs.existsSync(path.join(dir, 'draft.md')), false, 'draft consumed (moved)');
     assert.strictEqual(readProject(dir).roadmap.active_session, '001');


### PR DESCRIPTION
Surfaced by the post-fix re-walk of `roadmap-genesis-lays-out-the-map`: the installed session log's header read the literal `# Roadmap Session {NNN}` — permanently, in the durable record. The template's placeholder is written before the number exists ("the engine allocates NNN at open"), and both `session open` verbs installed the draft byte-for-byte, naming only the *file* with the real number.

The install now resolves any literal `{NNN}` in the draft to the allocated number — `roadmap session open` and `discovery-session open` alike, since discovery's lazy open shares the same draft pattern and template placeholder. Implementation is write-then-unlink (preserving the move semantics and the log-first/marker-second crash ordering; a crash between the two leaves only a scratch draft). Both templates note the placeholder is the engine's to fill.

Tests pin the resolution in both suites (`{NNN}` in header and body → the allocated number). Gates: `npm test` 2272 pass, typecheck clean, `test:cli` 40/370/5.

Independent of #946 (no overlapping lines) — both stand alone off main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)