### PR TITLE
fix(resume): the continue arm names its skip; the opener case declares its read

### DIFF
--- a/skills/workflow-shared/references/resume-detection.md
+++ b/skills/workflow-shared/references/resume-detection.md
@@ -20,7 +20,7 @@ Emit each returned section verbatim at its marked instruction — the triage war
 
 #### If `continue`
 
-→ Return to caller for **{continue_step}**.
+→ Return to caller for **{continue_step}**. The steps before it are the fresh path's — the artifact's existence means they already ran.
 
 #### If `restart`
 

--- a/tests/prose/cases/discussion-raises-problem-then-position/case.json
+++ b/tests/prose/cases/discussion-raises-problem-then-position/case.json
@@ -15,6 +15,7 @@
     "skills/workflow-discussion-entry/references/invoke-skill.md",
     "skills/workflow-discussion-process/SKILL.md",
     "skills/workflow-shared/references/resume-detection.md",
+    "skills/workflow-discussion-process/references/initialize-discussion.md",
     "skills/workflow-discussion-process/references/discussion-guidelines.md",
     "skills/workflow-discussion-process/references/meeting-assistant.md",
     "skills/workflow-discussion-process/references/guidelines.md",


### PR DESCRIPTION
Two findings from the prose-walk verification run of #948, both small:

- **The resume-gate wander, recurred ×3.** `resume-detection.md`'s continue arm — `→ Return to caller for **{continue_step}**.` — reads like it skips work: three walkers across runs hesitated over the unexecuted Step 1 before following it correctly. The arm now carries the reason the skip is right: the steps before `{continue_step}` belong to the fresh path, and the artifact's existence means they already ran. Verified against all four callers (research, discussion, investigation Step 2; specification Step 3) — in each, the skipped steps are creation-time setup.
- **Scope declaration.** `discussion-raises-problem-then-position` adds `initialize-discussion.md` to its `files` list — the walker legitimately reads it on the continue path, and the scope ratchet flagged the omission.

`npm test` green (2273).

🤖 Generated with [Claude Code](https://claude.com/claude-code)