### PR TITLE
fix(prose): the adhoc case forbids the write, not the glance

### DIFF
--- a/tests/prose/cases/implementation-records-an-adhoc-task/assert.md
+++ b/tests/prose/cases/implementation-records-an-adhoc-task/assert.md
@@ -49,8 +49,9 @@ The prose should have taken this path:
     adapter
 13. the writer records the created task in planning.md — one row
     appended to Phase 1's existing #### Tasks table — and does not
-    touch phase-1-tasks.md, whatever its drifted contents suggest
-    about where later tasks go. It records task_map.pay-1-4 and, the
+    write phase-1-tasks.md, whatever its drifted contents suggest
+    about where later tasks go (reading it is not a violation; the
+    file ending changed is). It records task_map.pay-1-4 and, the
     plan's external_id being unset, sets it to the topic name per the
     format. No graph adapter mechanics run — the staged task carried
     no priority and no depends_on

--- a/tests/prose/cases/implementation-records-an-adhoc-task/case.json
+++ b/tests/prose/cases/implementation-records-an-adhoc-task/case.json
@@ -76,7 +76,6 @@
       "render task-gate pay.implementation.pay"
     ],
     "calls_exclude": [
-      "phase-1-tasks",
       "task complete pay pay pay-1-1",
       "task start pay pay pay-1-2",
       "task start pay pay pay-1-3",


### PR DESCRIPTION
First live walk of `implementation-records-an-adhoc-task` came back FLAKY on the case's own strictness, not on the prose: in both walks the task-writer appended planning.md's row and wrote nothing to phase-1-tasks.md, but walk 1's harmless Bash `cat` of the file tripped the `calls_exclude: "phase-1-tasks"` substring while walk 2's Read-tool peek could not — the entry scans Bash rows only, so it fires on innocent reads and is structurally blind to the Edit-tool write it was meant to forbid.

Two edits, prose untouched: the exclusion entry is dropped (the write prohibition already lives in the assert's byte-identical world-delta claim, which passed both walks), and the expected path's step 13 says "does not write" instead of "does not touch", so a read can no longer fail the path.

`npm test` green (2274/2274); fixture unchanged, no snapshot regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)