### PR TITLE
fix(agents): the designer's draft marker goes — approvals live in the manifest

### DIFF
--- a/agents/workflow-planning-task-designer.md
+++ b/agents/workflow-planning-task-designer.md
@@ -57,7 +57,6 @@ Phase {N}: {Phase Name}
 
 ```markdown
 #### Tasks
-status: draft
 
 | Internal ID | Name | Edge Cases |
 |-------------|------|------------|


### PR DESCRIPTION
`agents/workflow-planning-task-designer.md` still emitted `status: draft` in its task-table template, which define-tasks writes verbatim into planning.md. The analysis-state programme moved approvals to the manifest and nothing reads, flips, or strips this marker — so every plan shipped a permanently-false "draft" label in its phase sections, the exact state-in-document-body disease that programme ended, with the emit side missed.

One line deleted. Enumeration: the `plan-tasks-designed-p1` stub never carried the line, no prose fixture does, and the only test-tree occurrences are a frozen migration-029 fixture (historical era, correct as-is) and an unrelated knowledge fixture.

`npm test` green (2274/2274).

🤖 Generated with [Claude Code](https://claude.com/claude-code)