### PR TITLE
fix(prose): the walker crosses agent boundaries by reading, like skills

### DIFF
--- a/.claude/agents/prose-walker.md
+++ b/.claude/agents/prose-walker.md
@@ -100,6 +100,13 @@ any harness substitutions. Follow it exactly.
   as a live invocation would have loaded it. Expected, not a
   `DEVIATION`, no marker. Where the task says to stop at the handoff,
   stop there.
+- **Crossing an agent boundary is the same, when nothing substitutes.**
+  Where the prose dispatches an agent and an armed substitution names
+  that moment, the stub fires — `SUBSTITUTED:`, as ever. Where none
+  does, there is no Task tool here either: read the named agent's file
+  under `.claude/agents/` and follow it with the inputs the prose
+  passes, exactly as the dispatched agent would have received them.
+  Expected, not a `DEVIATION`, no marker.
 - **A report-shaped `.md` write may be refused.** The harness blocks
   subagents writing report-looking `.md` files. Where the prose or an
   armed substitution calls for one, write the same path with a `.txt`


### PR DESCRIPTION
The clean PASS of `implementation-records-an-adhoc-task` carried one structural marker: the walker recorded a DEVIATION at the task-writer dispatch because its boundary-crossing rule names skills only — no Task tool exists in walker sessions, and nothing told it that reading the agent file is the sanctioned crossing. It did exactly that anyway (the crossing the case's expected path prescribes), but every future unstubbed-agent walk would re-raise the same false marker by design.

One sibling bullet in `.claude/agents/prose-walker.md` after the skill-boundary rule: an armed substitution still fires first (`SUBSTITUTED:`, unchanged); with none armed, the walker reads the named agent's file under `.claude/agents/` and follows it with the inputs the prose passes — expected, not a `DEVIATION`, no marker. Aligns with the design's P4a: what a stub covers is not under test, so some case must walk it unstubbed.

`npm test` green (2274/2274).

🤖 Generated with [Claude Code](https://claude.com/claude-code)