### PR TITLE
feat(spec): a source claim that fails measurement routes like a conflict

### DIFF
--- a/skills/workflow-specification-process/references/resolve-source-incoherence.md
+++ b/skills/workflow-specification-process/references/resolve-source-incoherence.md
@@ -1,16 +1,40 @@
 # Resolve Source Incoherence
 
-*Reference for **[workflow-specification-process](../SKILL.md)** — loaded by [spec-construction.md](spec-construction.md) when source material disagrees or cannot be extracted without assumption.*
+*Reference for **[workflow-specification-process](../SKILL.md)** — loaded by [spec-construction.md](spec-construction.md) when source material disagrees — with itself, another source, or the codebase it describes — or cannot be extracted without assumption.*
 
 ---
 
 Specification makes decisions clear; it never makes them — and classification is yours. `{doc}` throughout is the owning source's topic name; its artifact path resolves per the source ladder in **[spec-review.md](spec-review.md)** (sources can be investigations or research files, not only discussions). `{work_unit}` and `{topic}` are in context from the construction session.
 
-Three moves, by effort. Anything the record settles is derived silently — that is the phase doing its job, and it earns no mention. A point a brief exchange settles stops for the user and lands their answer in the owning document. A gap needing real discussion work stops, routes back, and pauses the spec. Start at **A. Classify**.
+Three moves, by effort. Anything the record settles is derived silently — that is the phase doing its job, and it earns no mention. A point a brief exchange settles stops for the user and lands their answer in the owning document. A gap needing real discussion work stops, routes back, and pauses the spec. A measured falsehood is never a silent derivation: reality corrects the record, and the correction lands in the owning document — never in the spec alone. Start at **A. Classify**.
 
 ## A. Classify
 
 Pick by first match:
+
+#### If direct measurement contradicts it
+
+A claim about the codebase or toolchain fails against the tree. Re-run the measurement before classifying — quote the command and its result in the exchange that follows; a remembered figure, or one asserted as verified earlier in the session, is not a measurement.
+
+**If the mismatch is value-only and every conclusion citing the claim survives the corrected value:**
+
+Tell the user in one line what was measured and what it corrects — no gate; the measurement made the choice.
+
+→ Proceed to **C. Landing a Resolution** with resolution = `{the corrected claim, carrying its command and result}`, doc = `{the owning source's topic}`.
+
+**If the corrected value undermines a conclusion, decision, or insight built on the claim:**
+
+**This stop overrides `auto`.** Put the measurement to the user in conversation — what the document asserts, what the command measured, which conclusion leans on it — and take a stance on whether the conclusion survives. No engine surface: this is an exchange, not a gate.
+
+**STOP.** Wait for user response.
+
+**If the answer settles it:**
+
+→ Proceed to **C. Landing a Resolution** with resolution = `{the settled position, carrying the corrected measurement}`, doc = `{the owning source's topic}`.
+
+**If the exchange shows it needs more than this session can give:**
+
+→ Proceed to **B. The Gap Exit**.
 
 #### If the record settles it
 
@@ -148,7 +172,7 @@ The resolution is written into the owning source document in that phase's own id
 
    → Proceed to step 2.
 
-2. **Edit the document** — targeted, in the owning phase's own idiom. A discussion's decided Decision block is revised as its format prescribes (**[../../workflow-discussion-process/references/template.md](../../workflow-discussion-process/references/template.md)** → Decision revisions): the new decision lands as a dated timeline entry above the prior prose, wrapped verbatim under `#### Initial`, with the `Trigger:` line citing the substantive cause — the colliding decision, never this session. Citing prose the resolution invalidates is repaired in place. Investigation and research documents carry no timeline rule — edit the affected passages directly.
+2. **Edit the document** — targeted, in the owning phase's own idiom. A discussion's decided Decision block is revised as its format prescribes (**[../../workflow-discussion-process/references/template.md](../../workflow-discussion-process/references/template.md)** → Decision revisions): the new decision lands as a dated timeline entry above the prior prose, wrapped verbatim under `#### Initial`, with the `Trigger:` line citing the substantive cause — the colliding decision or the failed measurement, never this session. Citing prose the resolution invalidates is repaired in place. A correction that revises no decision — a measured value and the prose citing it — is repaired in place wherever it sits. Investigation and research documents carry no timeline rule — edit the affected passages directly.
 3. **Reindex it**: `node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index {the resolved artifact path}` — the knowledge base serves the resolution for the rest of the work.
 4. **Stale the other extractions** — only when `{doc}` is a discussion (the reverse join covers discussion sources; single-topic work types have no sibling specs and skip this): `node .claude/skills/workflow-engine/scripts/engine.cjs sources stale {work_unit} {doc} --except {topic}`. When the response's `staled` is non-empty, tell the user in one line which specification(s) it named.
 5. **Commit**: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "{source phase}({work_unit}/{doc}): {what the resolution settled}" --topic {source phase}/{doc} --kb`.

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -19,7 +19,7 @@ F. Topic complete → loop back to A or exit
 
 ## A. Exhaustive Extraction
 
-Every topic's content must be derivable from its sources. When source material disagrees — with itself, or with another source — or is too unclear to extract without assumption, never silently pick a side: load **[resolve-source-incoherence.md](resolve-source-incoherence.md)** and follow its instructions as written, in the moment it surfaces; on return, continue where extraction left off. Tension notes held from session setup are raised the same way when the topic that touches them arrives.
+Every topic's content must be derivable from its sources. When source material disagrees — with itself, with another source, or with the codebase or toolchain it describes — or is too unclear to extract without assumption, never silently pick a side and never patch the mismatch in the spec alone: load **[resolve-source-incoherence.md](resolve-source-incoherence.md)** and follow its instructions as written, in the moment it surfaces; on return, continue where extraction left off. Tension notes held from session setup are raised the same way when the topic that touches them arrives.
 
 → Load **[exhaustive-extraction.md](exhaustive-extraction.md)** and follow its instructions as written.
 
@@ -87,7 +87,7 @@ Already-`addressed` references are skipped on later topic cycles.
 
 Check the draft against the one-home rule (**[specification-format.md](specification-format.md)**): a fact already stated in the specification is referenced at its home, never restated. If the new topic should own the fact, move it — edits to already-logged content go through **Context Resurfacing**.
 
-Source disagreement first noticed here — while forcing two sources into one draft — routes exactly as it does during extraction: load **[resolve-source-incoherence.md](resolve-source-incoherence.md)** and follow its instructions as written; its stops override `auto`. Never let the auto branch below absorb an unresolved conflict.
+Source disagreement or a measured mismatch first noticed here — while forcing two sources into one draft — routes exactly as it does during extraction: load **[resolve-source-incoherence.md](resolve-source-incoherence.md)** and follow its instructions as written; its stops override `auto`. Never let the auto branch below absorb an unresolved conflict.
 
 Present your understanding to the user **in the format it would appear in the specification** (shown in both modes):
 

--- a/skills/workflow-specification-process/references/specification-principles.md
+++ b/skills/workflow-specification-process/references/specification-principles.md
@@ -87,6 +87,8 @@ The specification is the **golden document** — planning uses only this. If inf
 
 **Surface conflicts**: When sources contain conflicting decisions, flag the conflict to the user. Don't silently pick one — let the user decide what makes it into the specification, per **[resolve-source-incoherence.md](resolve-source-incoherence.md)**. Dated supersession inside one Decision block's timeline is not a conflict — the top entry governs.
 
+**Measure load-bearing claims**: When a source claim about the codebase or toolchain is load-bearing — a decision, gate, or scope leans on it — verify it against the tree before extracting it, and extract it with the command and result. A claim that fails measurement routes per **[resolve-source-incoherence.md](resolve-source-incoherence.md)** — never extracted as-is, never corrected only in the spec: a "validated correction" the owning document never received is the source rotting in place.
+
 ## Self-Check: Are You Following the Rules?
 
 Before ANY write operation to the specification, ask yourself:


### PR DESCRIPTION
## Why

Idea 40, observed live: `resolve-source-incoherence.md` triggers only on source-vs-source disagreement, so a single internally-coherent discussion carrying seven false claims about the tree extracted cleanly — and the one falsehood construction did catch was patched in the spec alone as a "validated correction", leaving the completed discussion asserting it on disk.

## What

- **Trigger widened** (`spec-construction.md` §A and §B, the reference's attribution): source material disagreeing *with the codebase or toolchain it describes* routes exactly like a conflict — never patched in the spec alone.
- **New first-match classify branch** in `resolve-source-incoherence.md`: re-run the measurement before classifying (an asserted-as-verified figure is not a measurement); value-only mismatch whose citing conclusions survive → lands in the owning document via §C with a one-line notify, no gate; a mismatch that undermines a conclusion → conversational stop that overrides `auto`, then the existing settle/gap ladder.
- **§C in-place repair clause** for corrections that revise no decision, and the `Trigger:` line may now cite a failed measurement.
- **Construction principle** (`specification-principles.md`): load-bearing tree claims are verified before extraction and extracted with their command and result.

Stacks on #954. Part 2 of the idea-40 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)