### PR TITLE
feat(spec): review findings that indict a source route back, never apply

### DIFF
--- a/agents/workflow-specification-review-gap-analysis.md
+++ b/agents/workflow-specification-review-gap-analysis.md
@@ -60,6 +60,7 @@ No source material — this phase looks inward only.
    - Terms used inconsistently across sections
    - "It should" without defining what "it" is
    - Implicit assumptions that aren't stated
+   - Open-decision markers — "Decision required", "TBD", "to be decided", or any marker parking an unmade decision in the artifact. A specification decides nothing and defers nothing; flag every marker as Critical — the parked question must be resolved, not shipped
 
    **Contradictions**
    - Requirements that conflict with each other

--- a/agents/workflow-specification-review-input.md
+++ b/agents/workflow-specification-review-input.md
@@ -29,6 +29,7 @@ You receive via the orchestrator's prompt:
 - Technical details that seemed minor at the time
 - Error handling, validation rules, or boundary conditions
 - Integration points or data flows mentioned but not elaborated
+- Content in the specification that traces to no source — a requirement or design decision the sources never made
 
 ## Your Process
 
@@ -46,16 +47,18 @@ You receive via the orchestrator's prompt:
    - Decisions made early that may have been overshadowed
    - Error handling, validation rules, or boundary conditions
    - Integration points or data flows mentioned but not elaborated
-6. **Categorize each finding**:
+6. **Check the reverse direction** — for each requirement or design decision the specification states, can you point to source material that decides it? A normative choice with real consequence that no source makes — a rule, a threshold, a scope call, a mechanism choice — is a finding: category **Unsourced decision**, quoting the spec content and naming the sources you checked. Spec-native scaffolding (structure, wording, organisation, faithful derivations of what sources do decide) is not a decision. Treat any open-decision marker in the spec ("Decision required", "TBD", "to be decided") as this finding class — a parked decision is still a decision the sources never made.
+7. **Categorize each finding**:
    - **Enhancement to existing topic** — details that belong in an already-documented section. Note which section.
    - **New topic** — something that warrants its own section but was glossed over.
-7. **Surface potential gaps** — after reviewing source material, consider whether the specification has gaps the sources didn't address:
+   - **Unsourced decision** — spec content deciding what no source decides. The orchestrator routes these back toward the source record — never propose spec text for them.
+8. **Surface potential gaps** — after reviewing source material, consider whether the specification has gaps the sources didn't address:
    - Edge cases that weren't discussed
    - Error scenarios not covered
    - Integration points that seem implicit but aren't specified
    - Behaviors that are ambiguous without clarification
    This should be infrequent — most gaps come from source material. But occasionally sources have blind spots worth surfacing.
-8. **Write findings** to `.workflows/{work_unit}/specification/{topic}/review-input-tracking-c{cycle-number}.md` using the tracking format, via the `.txt`-then-rename mechanism (see Output File Format)
+9. **Write findings** to `.workflows/{work_unit}/specification/{topic}/review-input-tracking-c{cycle-number}.md` using the tracking format, via the `.txt`-then-rename mechanism (see Output File Format)
 
 ## Hard Rules
 
@@ -63,7 +66,7 @@ You receive via the orchestrator's prompt:
 
 1. **No git writes** — do not commit or stage. Writing the output file is your only file write.
 2. **One concern only** — source material comparison. Do not assess standalone document quality, internal consistency, or planning readiness — that's the gap analysis agent's job.
-3. **Never fabricate** — every item you flag must trace back to specific source material. If you can't point to where it came from, don't suggest it. The goal is to catch missed content, not invent new requirements.
+3. **Never fabricate** — every item you flag must trace back to specific source material. If you can't point to where it came from, don't suggest it. The goal is to catch missed content, not invent new requirements. The one class where the evidence is an absence is **Unsourced decision** — there, quote the spec content and name the sources checked.
 4. **Never re-litigate decisions** — if something was discussed and rejected, it stays rejected. Where a source Decision block holds dated timeline entries, the top entry is the current decision — earlier entries are superseded lineage, never missing content.
 5. **No padding** — only flag what's genuinely missing and relevant. Don't inflate findings for thoroughness.
 6. **Never propose that the specification state its own pipeline position** — readiness for planning, incorporation status, or review-cycle counts. That state lives in the work unit's manifest; source material carrying such a statement is not missing content.
@@ -81,8 +84,8 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-input-tracking-c{c
 
 ### 1. {Brief Title}
 
-**Source**: {file/section reference where this came from}
-**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity
+**Source**: {file/section reference where this came from, or "No source decides this" for Unsourced decision}
+**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Unsourced decision
 **Affects**: {which section(s) of the specification}
 
 **Details**:

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -1137,6 +1137,10 @@ function finding(cwd, { dotpath, file }) {
   }
   if (!isFilled(p.details)) throw new Error('render finding: "details" must be a non-empty string');
   if (p.diff && p.content) throw new Error('render finding: pass "diff" or "content", not both');
+  const FINDING_CATEGORIES = ['enhancement', 'new-topic', 'gap', 'duplication'];
+  if (p.category !== undefined && !FINDING_CATEGORIES.includes(p.category)) {
+    throw new Error(`render finding: unknown category "${p.category}" (expected ${FINDING_CATEGORIES.join('/')})`);
+  }
 
   const applyLabel = isFilled(p.apply_label) ? p.apply_label : 'Apply verbatim';
   const appliedLabel = isFilled(p.applied_label) ? p.applied_label : 'approved. Applied.';
@@ -1168,7 +1172,9 @@ function finding(cwd, { dotpath, file }) {
   }
 
   const items = (((manifest.phases || {})[phase] || {}).items || {})[topic] || {};
-  const gateMode = items.finding_gate_mode === 'auto' ? 'auto' : 'gated';
+  // A gap finding is a question, not a correction — auto covers applying
+  // agreed corrections, never answering questions on the user's behalf.
+  const gateMode = items.finding_gate_mode === 'auto' && p.category !== 'gap' ? 'auto' : 'gated';
 
   if (gateMode === 'auto') {
     parts.push(section(

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -59,7 +59,7 @@ A finding whose Category is **Source defect** or **Unsourced decision** indicts 
 
 → Load **[resolve-source-incoherence.md](resolve-source-incoherence.md)** with doc = `{the owning source's topic}` (for an unsourced decision, the source that should own the missing decision), taking the finding's Details as the material to classify.
 
-On return, update the tracking file — Resolution `Routed`, a note naming what landed where — and commit. (The gap exit does not return: the specification pauses and the reference routes the session out; the tracking entry stays `in-progress` in the manifest, and its remaining findings re-process at the next entry.)
+On return, re-align the specification's own copy: the resolution now stands in the corrected source, so the affected spec content is updated to match it — a fidelity repair the record settles, logged without a gate. Then update the tracking file — Resolution `Routed`, a note naming what landed where — and commit. (The gap exit does not return: the specification pauses and the reference routes the session out; the tracking entry stays `in-progress` in the manifest, and its remaining findings re-process at the next entry.)
 
 → Return to **B. Process One Item at a Time**.
 

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -36,8 +36,8 @@ Write the summary payload to `.workflows/.cache/{work_unit}/specification/{topic
 {"review_label": "{review_type}", "items": [{"title": "…", "tag": "…", "summary": "{1-2 line summary from the Details field}", "status": "…"}]}
 ```
 
-- `tag` — the Category's token: `enhancement` (Enhancement to existing topic), `new-topic` (New topic), `gap` (Gap/Ambiguity), `duplication` (Duplication). The tracking file keeps the full phrase.
-- `status` — the finding's Resolution: `Approved` or `Adjusted` → `approved`, `Skipped` → `skipped`, `Pending` or unset → `pending`.
+- `tag` — the Category's token: `enhancement` (Enhancement to existing topic), `new-topic` (New topic), `gap` (Gap/Ambiguity), `duplication` (Duplication), `source-defect` (Source defect), `unsourced-decision` (Unsourced decision). The tracking file keeps the full phrase.
+- `status` — the finding's Resolution: `Approved`, `Adjusted`, or `Routed` → `approved`, `Skipped` → `skipped`, `Pending` or unset → `pending`.
 
 Render and emit the section verbatim at its marked instruction:
 
@@ -51,7 +51,17 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render findings-summary {
 
 ## B. Process One Item at a Time
 
-Work through each unresolved finding **sequentially** — a finding whose Resolution is already `Approved`, `Adjusted`, or `Skipped` was settled in an earlier sitting; never re-present or re-apply it. For each finding: present it, show the proposed content, then route through the gate.
+Work through each unresolved finding **sequentially** — a finding whose Resolution is already `Approved`, `Adjusted`, `Routed`, or `Skipped` was settled in an earlier sitting; never re-present or re-apply it. For each finding: present it, show the proposed content, then route through the gate.
+
+### Route Source-Lane Findings
+
+A finding whose Category is **Source defect** or **Unsourced decision** indicts a source, not the specification — it is never applied, adjusted, or skipped here, and never rides `auto`. Instead of presenting it:
+
+→ Load **[resolve-source-incoherence.md](resolve-source-incoherence.md)** with doc = `{the owning source's topic}` (for an unsourced decision, the source that should own the missing decision), taking the finding's Details as the material to classify.
+
+On return, update the tracking file — Resolution `Routed`, a note naming what landed where — and commit. (The gap exit does not return: the specification pauses and the reference routes the session out; the tracking entry stays `in-progress` in the manifest, and its remaining findings re-process at the next entry.)
+
+→ Return to **B. Process One Item at a Time**.
 
 ### Present Finding
 
@@ -61,6 +71,7 @@ Write the finding payload to `.workflows/.cache/{work_unit}/specification/{topic
 
 - `n`, `total`, `title` — the finding's position and titlecased brief title.
 - `meta` — `[label, value]` pairs: Source / Category / Affects, plus Priority for Gap Analysis findings.
+- `category` — the Category's token (`enhancement`, `new-topic`, `gap`, `duplication`). A `gap` finding is a question, not a correction — the surface renders its gate even when the manifest holds `auto`.
 - `details` — the Details field.
 - If a Current field is present: `diff` — `{"context_above": […], "current": […], "proposed": […], "context_below": […]}` with only the changed lines and 2 context lines each side (Proposed Change as the proposed lines).
 - Otherwise: `content` — `{"label": "Proposed Change", "lines": […]}` with the proposed content.

--- a/skills/workflow-specification-process/references/resolve-source-incoherence.md
+++ b/skills/workflow-specification-process/references/resolve-source-incoherence.md
@@ -1,6 +1,6 @@
 # Resolve Source Incoherence
 
-*Reference for **[workflow-specification-process](../SKILL.md)** — loaded by [spec-construction.md](spec-construction.md) when source material disagrees — with itself, another source, or the codebase it describes — or cannot be extracted without assumption.*
+*Reference for **[workflow-specification-process](../SKILL.md)** — loaded by [spec-construction.md](spec-construction.md) and [process-review-findings.md](process-review-findings.md) when source material disagrees — with itself, another source, or the codebase it describes — or cannot be extracted without assumption.*
 
 ---
 

--- a/skills/workflow-specification-process/references/review-tracking-format.md
+++ b/skills/workflow-specification-process/references/review-tracking-format.md
@@ -24,7 +24,7 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 ### 1. [Brief Title]
 
 **Source**: [Where this came from — file/section reference, or "Specification analysis" for Gap Analysis]
-**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Duplication
+**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Duplication | Source defect | Unsourced decision
 **Priority**: [Gap Analysis only — Critical | Important | Minor. Omit for Input Review.]
 **Affects**: [Which section(s) of the specification]
 
@@ -37,7 +37,7 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 **Proposed Change**:
 [What you would add or change in the specification — leave blank until discussed]
 
-**Resolution**: Pending | Approved | Adjusted | Skipped
+**Resolution**: Pending | Approved | Adjusted | Skipped | Routed
 **Notes**: [Any discussion notes or adjustments made]
 
 ---
@@ -47,6 +47,11 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 ```
 
 Some tracking files name the **Proposed Change** field **Proposed Addition** — read both as the same field.
+
+Two categories indict a source rather than the specification, and their findings are never applied, adjusted, or skipped against the spec — the orchestrator routes them per [resolve-source-incoherence.md](resolve-source-incoherence.md), and the resolution lands as `Routed`:
+
+- **Source defect** — the specification faithfully carries a source claim or decision that is itself wrong: it fails direct measurement against the tree, or rests on ground the record has since superseded.
+- **Unsourced decision** — the specification states a requirement or design decision that no source makes. The spec makes decisions clear; it never makes them.
 
 ## Workflow with Tracking Files
 

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1017,12 +1017,29 @@ describe('render finding', () => {
     assert.ok(!out.includes('view full'));
   });
 
+  it('a gap finding renders its gate even when the manifest holds auto — a question never auto-applies', () => {
+    writeManifest(dir, 'pay', { phases: { specification: { items: { portal: { status: 'in-progress', finding_gate_mode: 'auto' } } } } });
+    const file = writePayload(dir, 'f.json', { ...base, category: 'gap' });
+    const out = renderSurface(dir, 'finding', { dotpath: 'pay.specification.portal', file });
+    assert.ok(out.includes('MENU: finding gate'));
+    assert.ok(!out.includes('finding auto-approved'));
+  });
+
+  it('a non-gap category rides auto as before', () => {
+    writeManifest(dir, 'pay', { phases: { specification: { items: { portal: { status: 'in-progress', finding_gate_mode: 'auto' } } } } });
+    const file = writePayload(dir, 'f.json', { ...base, category: 'enhancement' });
+    const out = renderSurface(dir, 'finding', { dotpath: 'pay.specification.portal', file });
+    assert.ok(out.includes('finding auto-approved'));
+    assert.ok(!out.includes('MENU: finding gate'));
+  });
+
   it('validates loudly: shape, exclusivity, and empty diff', () => {
     const cases = [
       [{ ...base, n: 0 }, /"n" must be a positive integer/],
       [{ ...base, total: 0 }, /"total" must be an integer/],
       [{ ...base, meta: [['x']] }, /"meta" must be an array of \[label, value\] pairs/],
       [{ ...base, details: ' ' }, /"details" must be a non-empty string/],
+      [{ ...base, category: 'source-defect' }, /unknown category "source-defect"/],
       [{ ...base, diff: { current: [], proposed: [] }, content: { label: 'X', lines: ['y'] } }, /pass "diff" or "content", not both/],
       [{ ...base, diff: { current: [], proposed: [] } }, /"diff" must carry at least one/],
       [{ ...base, content: { label: 'X', lines: [] } }, /"content.lines" must be non-empty/],


### PR DESCRIPTION
## Why

Idea 40: `process-review-findings.md` had exactly three verbs — apply, adjust, skip — all against the spec. A finding revealing that the *source* is wrong had no route; the observed session could only patch the spec and leave the completed discussion asserting falsehoods. Separately, 16 undiscussed design decisions sat in the spec behind invented "Decision required" markers, shielded from review, and gap findings auto-applied orchestrator-authored content under `finding_gate_mode: auto`.

## What

- **Two source-lane categories** (`review-tracking-format.md`): `Source defect` and `Unsourced decision` — never applied/adjusted/skipped, never ride `auto`; the orchestrator routes them through `resolve-source-incoherence.md` (new **Route Source-Lane Findings** section in `process-review-findings.md`), resolution lands as `Routed`. A gap exit pauses the spec via the existing machinery; the in-progress tracking entry re-processes at next entry.
- **Reverse fidelity** in the input agent: spec content tracing to *no* source — a decision the sources never made — is a finding; open-decision markers count. Doc-vs-doc, would have caught all 16.
- **Marker detection** in the gap-analysis agent: any "Decision required"/"TBD" marker is Critical — a spec decides nothing and defers nothing.
- **Engine**: `render finding` accepts an optional `category`; `gap` renders its gate even under `auto` — a question never auto-applies. Unknown categories throw (routed categories reaching this surface is a caller bug). Tests added.

Stacks on #955. Part 3 of the idea-40 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)