### PR TITLE
feat(spec): a claims-verification pass measures the spec against the tree

### DIFF
--- a/agents/workflow-specification-review-claims.md
+++ b/agents/workflow-specification-review-claims.md
@@ -1,0 +1,101 @@
+---
+name: workflow-specification-review-claims
+description: Verifies the specification's empirical claims about the codebase and toolchain against the working tree. Invoked by workflow-specification-process skill during review cycle.
+tools: Read, Write, Grep, Bash
+model: opus
+---
+
+# Specification Review: Claims Verification
+
+You are measuring a specification's empirical claims against the thing they describe. Both other review phases compare documents against documents — a false claim present in the spec and its sources reads to them as a perfect fidelity match. You are the pass that touches ground truth.
+
+## Your Input
+
+You receive via the orchestrator's prompt:
+
+1. **Work unit** — the work unit name (for output path construction)
+2. **Specification path** — the specification file to review
+3. **Source material paths** — the spec's source documents, resolved to file paths by the orchestrator (for locating where a failed claim originates — not for fidelity comparison)
+4. **Topic name** — the specification topic
+5. **Cycle number** — which review cycle this is (used in output file naming)
+6. **Review tracking format path** — the tracking file format reference
+
+## Your Focus
+
+Empirical claims — statements about the codebase or toolchain that a command can check:
+
+- Counts and enumerations ("fourteen files over 1,000 lines", "splits six ways")
+- Universal assertions ("every X is Y", "no Z does W", "all eight are dual-clause")
+- Existence claims (a file, symbol, interface, or pattern the spec says is there)
+- Tool and command behaviour the spec asserts (flags, outputs, exit behaviour)
+
+Prioritise **load-bearing** claims — a decision, gate, scope boundary, or key insight leans on them. A trivially true aside nobody builds on earns no measurement.
+
+## Your Process
+
+1. **Read the review tracking format** — understand the output file structure
+2. **Read the specification end-to-end** — collect every empirical claim, noting which are load-bearing
+3. **Measure each load-bearing claim** — run the claim's recorded command where it carries one (the spec format records measurements as `command → result`); construct the obvious measurement where it doesn't. Reuse nothing: not the documents' own figures, not prior cycles' tracking files, not any assertion that something was "verified" — a stated verification is a claim, not a measurement.
+4. **Verdict each claim**:
+   - **Holds** — measurement matches. No finding.
+   - **Fails** — measurement contradicts the claim. Grep the source material for the same assertion:
+     - Present in a source → category **Source defect**. The spec faithfully carries a defective source; the fix belongs to the source record, not the spec.
+     - Spec-only → category **Enhancement to existing topic**, Proposed Change = the corrected claim carrying its command and result.
+   - **Unreproducible** — no command you can construct checks it as written, or checking would mutate state → category **Gap/Ambiguity**: the claim must be restated measurably, sourced, or removed.
+5. **Write findings** to `.workflows/{work_unit}/specification/{topic}/review-claims-tracking-c{cycle-number}.md` using the tracking format, via the `.txt`-then-rename mechanism (see Output File Format). Every finding's Details quotes the claim, the command, and its output.
+
+## Hard Rules
+
+**MANDATORY. No exceptions.**
+
+1. **No git writes** — do not commit or stage. Writing the output file is your only file write.
+2. **Read-only measurement** — commands must not mutate anything: no builds, installs, formatters, watchers, or writes outside your output file. A claim only checkable by mutation is Unreproducible.
+3. **Measure, never trust** — every verdict rests on a command you ran in this session, quoted with its output. No verdict from memory, from the documents, or from prior review cycles.
+4. **One concern only** — truth against the tree. Do not assess source fidelity or standalone document quality — those are the other agents' jobs.
+5. **Never re-litigate decisions** — a decision's wisdom is not yours to weigh. You verify the factual claims decisions lean on, nothing more.
+6. **No padding** — only flag failed or unreproducible load-bearing claims. Don't inflate findings for thoroughness, and don't report claims that hold.
+7. **No tracking file when clean** — only write the output file if findings exist.
+8. **Never lose your findings** — when findings exist they must survive the run, and the tracking file is how they survive. Produce the tracking file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the findings in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
+
+## Output File Format
+
+Write to `.workflows/{work_unit}/specification/{topic}/review-claims-tracking-c{cycle-number}.md` — in two steps: write the content to the same path with a `.txt` extension using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Use this format:
+
+```markdown
+# Review Tracking: {Topic Name} - Claims Verification
+
+## Findings
+
+### 1. {Brief Title}
+
+**Source**: Tree measurement — `{command}`
+**Category**: Enhancement to existing topic | Gap/Ambiguity | Source defect
+**Affects**: {which section(s) of the specification}
+
+**Details**:
+{The claim verbatim, the command, its output, and the mismatch. For Source defect: which source document and section carries the claim.}
+
+**Current**:
+{For Enhancement findings only — the existing specification content that will be modified. Omit for Gap/Ambiguity and Source defect findings.}
+
+**Proposed Change**:
+{The corrected claim carrying its command and result — Enhancement findings only. Leave blank for Source defect: the fix belongs to the source record.}
+
+**Resolution**: Pending
+**Notes**:
+
+---
+
+### 2. {Next Finding}
+...
+```
+
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+STATUS: findings | clean
+FINDINGS_COUNT: {N}
+SUMMARY: {1 sentence}
+```

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -386,6 +386,39 @@ function proposedTask(cwd, args) {
 }
 
 // ---------------------------------------------------------------------------
+// spec-review-gate — the review loop's two gates, variant-keyed and
+// payload-less: the options are static, the state that picks the variant
+// (cycle count, gate mode, finding statuses) lives with the caller.
+//   continue — the cycle-count escape hatch: keep reviewing or skip out
+//   reloop   — after findings: another full cycle or proceed to completion
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string, variant?: string}} args
+ * @returns {string}
+ */
+function specReviewGate(cwd, { dotpath, variant }) {
+  if (variant === undefined || !['continue', 'reloop'].includes(variant)) {
+    throw new Error('render spec-review-gate: --variant must be "continue" or "reloop"');
+  }
+  const { phase } = resolveAddress(cwd, dotpath, 'spec-review-gate');
+  if (phase !== 'specification') {
+    throw new Error(`render spec-review-gate: address must be <work_unit>.specification.<topic>, got phase "${phase}"`);
+  }
+  const stop = 'emit verbatim as markdown, then STOP for the user\'s response';
+  if (variant === 'continue') {
+    return section('MENU: spec review continue gate', stop, menu('', [
+      cmdOption('p', 'proceed', 'Continue review'),
+      cmdOption('s', 'skip', 'Skip review, proceed to completion'),
+    ], { question: 'Continue with review?' }));
+  }
+  return section('MENU: spec review reloop gate', stop, menu('', [
+    cmdOption('r', 'reanalyse', 'Run another review cycle (all three phases)'),
+    cmdOption('p', 'proceed', 'Proceed to completion'),
+  ], { question: 'Run another review cycle?' }));
+}
+
 // incoherence-gate — spec construction's Resolve Source Incoherence raises.
 // Three variants; the stops here override the construction auto mode by
 // design, so no --gate flag exists.
@@ -2293,6 +2326,7 @@ const SURFACES = {
   'finding': finding,
   'review-presentation': reviewPresentation,
   'review-gate': reviewGate,
+  'spec-review-gate': specReviewGate,
   'triage-announce': triageAnnounce,
   'triage-offer': triageOffer,
   'triage-block': triageBlock,

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -205,6 +205,7 @@ Commands:
   render finding-batch    <wu.phase.topic> --file <payload.json>
   render review-presentation <wu.review.topic> --file <payload.json>
   render review-gate      <wu.review.topic> --verdict pass|fail [--replan N] [--out-of-scope N]
+  render spec-review-gate <wu.specification.topic> --variant continue|reloop
   render triage-announce  <wu.phase.topic>
   render triage-offer     <wu.phase.topic> --file <payload.json>
   render triage-block     <wu.phase.topic>

--- a/skills/workflow-shared/references/convergence-analysis.md
+++ b/skills/workflow-shared/references/convergence-analysis.md
@@ -17,7 +17,7 @@ The caller provides these via context before loading:
 
 ## Threshold Check
 
-Cross-cycle analysis requires at least 2 data points. Determine the number of available cycles from how the loop type stores them: the `fix` loop appends every cycle as an `## Attempt {N}` section inside its single tracking file — count those sections; the other three loop types write numbered `-c{N}` files, up to two per cycle — count the **distinct `{N}` suffixes**, never the files.
+Cross-cycle analysis requires at least 2 data points. Determine the number of available cycles from how the loop type stores them: the `fix` loop appends every cycle as an `## Attempt {N}` section inside its single tracking file — count those sections; the other three loop types write numbered `-c{N}` files, up to one per stream per cycle — count the **distinct `{N}` suffixes**, never the files.
 
 #### If fewer than 2 cycles of data exist
 
@@ -80,16 +80,17 @@ For each cycle, extract:
 
 Read tracking files for all available cycles:
 ```
+.workflows/{work_unit}/specification/{topic}/review-claims-tracking-c{1..N}.md
 .workflows/{work_unit}/specification/{topic}/review-input-tracking-c{1..N}.md
 .workflows/{work_unit}/specification/{topic}/review-gap-analysis-tracking-c{1..N}.md
 ```
 
 For each cycle, extract:
 - Each finding's title
-- Which stream it came from (input review or gap analysis — by tracking file)
+- Which stream it came from (claims, input review, or gap analysis — by tracking file)
 - Affects field (which specification section)
 - Category
-- Resolution (Approved/Adjusted/Skipped)
+- Resolution (Approved/Adjusted/Skipped/Routed)
 
 → Proceed to **B. Classify Findings**.
 
@@ -109,7 +110,7 @@ Compute:
 - `resolved_count` — findings from prior cycles no longer appearing
 - `recurring_count` — findings persisting across cycles
 - `new_count` — findings appearing for the first time in the latest cycle
-- `stream_counts` — (two-stream loop types only: `spec-review`, `planning-review`) latest-cycle finding counts per tracking stream
+- `stream_counts` — (multi-stream loop types only: `spec-review`, `planning-review`) latest-cycle finding counts per tracking stream, rendered `{label} {count}` and ` · `-joined in stream order
 - `trend` (first match wins):
   - **churning** — recurring_count is 0 or near 0 while resolved_count and new_count are both above 0 and roughly equal (every cycle's findings are new — the edits themselves are generating them)
   - **converging** — resolved_count > new_count (progress is being made)
@@ -132,7 +133,7 @@ Open with one markdown sentence above the block — what the cycles show, in pla
   Trend: {trend:[churning|converging|stable|diverging]}
   Latest cycle: {finding_count} findings ({new_count} new, {recurring_count} recurring)
   @if(loop_type is spec-review or planning-review)
-  Per stream: {stream_a_label} {stream_a_count} · {stream_b_label} {stream_b_count}
+  Per stream: {stream_counts}
   @endif
 
   @if(resolved_count > 0)
@@ -180,7 +181,7 @@ Where `loop_type_label` maps:
 - `spec-review` → `Spec Review`
 
 Stream labels map:
-- `spec-review` → `input review` / `gap analysis`
+- `spec-review` → `claims` / `input review` / `gap analysis`
 - `planning-review` → `traceability` / `integrity`
 
 → Return to caller.

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -191,7 +191,7 @@ Load **[dependencies.md](references/dependencies.md)** and follow its instructio
 > *Output the next fenced block as markdown (not a code block):*
 
 ```
-> Reviewing the specification. Agents will analyse it against source material for gaps and inconsistencies. You'll approve or dismiss each finding.
+> Reviewing the specification. Agents will measure its claims against the codebase and analyse it against source material for gaps and inconsistencies. You'll approve or dismiss each finding.
 ```
 
 Load **[spec-review.md](references/spec-review.md)** and follow its instructions as written.

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -6,7 +6,7 @@
 
 Process findings from a review phase interactively with the user. The analysis phase writes findings to a tracking file. Read the tracking file and present each finding for approval.
 
-**Review type**: `{review_type:[Input Review|Gap Analysis]}` — set by the calling context (C or D in spec-review.md).
+**Review type**: `{review_type:[Claims Verification|Input Review|Gap Analysis]}` — set by the calling context (C, D, or E in spec-review.md).
 
 Check if the tracking file exists at the expected path.
 

--- a/skills/workflow-specification-process/references/review-tracking-format.md
+++ b/skills/workflow-specification-process/references/review-tracking-format.md
@@ -9,8 +9,9 @@ Review tracking files capture analysis findings so work persists across context 
 ## Location
 
 Store tracking files in the specification directory (`.workflows/{work_unit}/specification/{topic}/`), cycle-numbered:
-- `review-input-tracking-c{N}.md` — Phase 1 findings for cycle N
-- `review-gap-analysis-tracking-c{N}.md` — Phase 2 findings for cycle N
+- `review-claims-tracking-c{N}.md` — Phase 1 (Claims Verification) findings for cycle N
+- `review-input-tracking-c{N}.md` — Phase 2 (Input Review) findings for cycle N
+- `review-gap-analysis-tracking-c{N}.md` — Phase 3 (Gap Analysis) findings for cycle N
 
 Tracking files are **never deleted** — pure markdown, no frontmatter; previous cycles' files persist as analysis history. The orchestrator records each file's gate state in the manifest (`tracking.{file stem}`: `in-progress` at dispatch, `complete` when all findings are processed).
 

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -72,7 +72,7 @@ No assessment needed — feature, bugfix, and cross-cutting work types always pr
 
 ## B. Verify Tracking Files Complete
 
-Before proceeding to sign-off, read `manifest get {work_unit}.specification.{topic} tracking` — every entry across all cycles must be `complete` (`review-input-tracking-c{N}` after each Phase 1, `review-gap-analysis-tracking-c{N}` after each Phase 2).
+Before proceeding to sign-off, read `manifest get {work_unit}.specification.{topic} tracking` — every entry across all cycles must be `complete` (`review-claims-tracking-c{N}` after each Phase 1, `review-input-tracking-c{N}` after each Phase 2, `review-gap-analysis-tracking-c{N}` after each Phase 3).
 
 If any entry is `in-progress`, that file's findings were not fully processed — work them per **[process-review-findings.md](process-review-findings.md)**, then re-verify. A tracking file on disk with no manifest entry is a crash orphan (the session died before recording it) — record it `in-progress` and process it the same way.
 

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -4,13 +4,13 @@
 
 ---
 
-Two-phase review of the specification. Phase 1 (Input Review) compares against source material. Phase 2 (Gap Analysis) reviews the specification as a standalone document.
+Three-phase review of the specification. Phase 1 (Claims Verification) measures the specification's empirical claims against the working tree. Phase 2 (Input Review) compares against source material. Phase 3 (Gap Analysis) reviews the specification as a standalone document.
 
-**CRITICAL**: Phases are strictly sequential — never dispatch both agents in parallel. Phase 1 findings are applied to the specification before Phase 2 runs, so gap analysis reviews the updated document.
+**CRITICAL**: Phases are strictly sequential — never dispatch two agents in parallel. Claims run first because a false claim carried faithfully from a source reads to fidelity review as a perfect match — its routing must land before Phase 2 compares; Phase 2 findings are applied before Phase 3 reviews the updated document.
 
 **Why this matters**: The specification is the golden document. Plans are built from it, and those plans inform implementation. If a detail isn't in the specification, it won't make it to the plan, and therefore won't be built. Worse, the implementation agent may hallucinate to fill gaps, potentially getting it wrong. The goal is a specification robust enough that an agent or human could pick it up, create plans, break it into tasks, and write the code.
 
-→ Load **[review-tracking-format.md](review-tracking-format.md)** — internalize the tracking file format for both phases.
+→ Load **[review-tracking-format.md](review-tracking-format.md)** — internalize the tracking file format for all three phases.
 
 ---
 
@@ -30,7 +30,7 @@ Commit the updated manifest:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): begin review cycle {N}"
 ```
 
-→ Proceed to **C. Phase 1 — Input Review**.
+→ Proceed to **C. Phase 1 — Claims Verification**.
 
 #### If `review_cycle` is already set
 
@@ -54,13 +54,13 @@ Check `finding_gate_mode` via `engine manifest` (`node .claude/skills/workflow-e
 
 #### If `review_cycle` <= 3
 
-→ Proceed to **C. Phase 1 — Input Review**.
+→ Proceed to **C. Phase 1 — Claims Verification**.
 
 #### If `review_cycle` > 3 and `finding_gate_mode` is `auto`
 
-Auto mode is active — pass through to review. Section E's safety cap (cycle 5) handles escalation.
+Auto mode is active — pass through to review. Section F's safety cap (cycle 5) handles escalation.
 
-→ Proceed to **C. Phase 1 — Input Review**.
+→ Proceed to **C. Phase 1 — Claims Verification**.
 
 #### If `review_cycle` > 3 and `finding_gate_mode` is `gated` (or not set)
 
@@ -68,14 +68,10 @@ Auto mode is active — pass through to review. Section E's safety cap (cycle 5)
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `spec-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
-> *Output the next fenced block as markdown (not a code block):*
+Fetch the gate and emit its section verbatim at its marked instruction:
 
-```
-· · · · · · · · · · · ·
-**`◆ Continue with review?`**
-
-**`p/proceed`** → Continue review
-**`s/skip`**    → Skip review, proceed to completion
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render spec-review-gate {work_unit}.specification.{topic} --variant continue
 ```
 
 You MUST NOT choose on the user's behalf.
@@ -84,19 +80,19 @@ You MUST NOT choose on the user's behalf.
 
 **If `proceed`:**
 
-→ Proceed to **C. Phase 1 — Input Review**.
+→ Proceed to **C. Phase 1 — Claims Verification**.
 
 **If `skip`:**
 
-→ Proceed to **F. Completion**.
+→ Proceed to **G. Completion**.
 
 ---
 
-## C. Phase 1 — Input Review
+## C. Phase 1 — Claims Verification
 
-Dispatch the `workflow-specification-review-input` agent via the Task tool:
+Dispatch the `workflow-specification-review-claims` agent via the Task tool:
 
-- **Agent file**: `../../../agents/workflow-specification-review-input.md`
+- **Agent file**: `../../../agents/workflow-specification-review-claims.md`
 - **Work unit**: the current work unit
 - **Specification path**: the specification file path
 - **Source material paths**: resolve source names to file paths. Read source names and work type from the manifest:
@@ -123,16 +119,44 @@ Hold its STATUS as `phase_1_status` — carried in context for the branch below,
 **If the agent created a tracking file**, record it in progress (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} tracking.{file stem} in-progress`) and commit it:
 
 ```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): claims verification cycle {N}"
+```
+
+→ Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
+
+→ On return, proceed to **D. Phase 2 — Input Review**.
+
+---
+
+## D. Phase 2 — Input Review
+
+Dispatch the `workflow-specification-review-input` agent via the Task tool:
+
+- **Agent file**: `../../../agents/workflow-specification-review-input.md`
+- **Work unit**: the current work unit
+- **Specification path**: the specification file path
+- **Source material paths**: the paths resolved in **C** — re-resolve via the ladder there when they are no longer in context
+- **Topic name**: the current topic
+- **Cycle number**: the current cycle number
+- **Review tracking format path**: `review-tracking-format.md` (in this references directory)
+
+> **CHECKPOINT**: Do not proceed until the agent has returned its result.
+
+Hold its STATUS as `phase_2_status` — carried in context for the branch below, never a manifest write.
+
+**If the agent created a tracking file**, record it in progress (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} tracking.{file stem} in-progress`) and commit it:
+
+```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): input review cycle {N}"
 ```
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
 
-→ On return, proceed to **D. Phase 2 — Gap Analysis**.
+→ On return, proceed to **E. Phase 3 — Gap Analysis**.
 
 ---
 
-## D. Phase 2 — Gap Analysis
+## E. Phase 3 — Gap Analysis
 
 Dispatch the `workflow-specification-review-gap-analysis` agent via the Task tool:
 
@@ -145,7 +169,7 @@ Dispatch the `workflow-specification-review-gap-analysis` agent via the Task too
 
 > **CHECKPOINT**: Do not proceed until the agent has returned its result.
 
-Hold its STATUS as `phase_2_status` — carried in context for the branch below, never a manifest write.
+Hold its STATUS as `phase_3_status` — carried in context for the branch below, never a manifest write.
 
 **If the agent created a tracking file**, record it in progress (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} tracking.{file stem} in-progress`) and commit it:
 
@@ -155,11 +179,11 @@ node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "sp
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
 
-→ On return, proceed to **E. Re-Loop Prompt**.
+→ On return, proceed to **F. Re-Loop Prompt**.
 
 ---
 
-## E. Re-Loop Prompt
+## F. Re-Loop Prompt
 
 Check `finding_gate_mode` and `review_cycle` via `engine manifest`:
 ```bash
@@ -167,9 +191,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic} review_cycle
 ```
 
-#### If `phase_1_status` is `clean` and `phase_2_status` is `clean`
+#### If `phase_1_status`, `phase_2_status`, and `phase_3_status` are all `clean`
 
-→ Proceed to **F. Completion**.
+→ Proceed to **G. Completion**.
 
 #### If findings were surfaced and `finding_gate_mode` is `auto` and `review_cycle` < 5
 
@@ -185,14 +209,10 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `spec-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
-> *Output the next fenced block as markdown (not a code block):*
+Fetch the gate and emit its section verbatim at its marked instruction:
 
-```
-· · · · · · · · · · · ·
-**`◆ Run another review cycle?`**
-
-**`r/reanalyse`** → Run another review cycle (Phase 1 + Phase 2)
-**`p/proceed`**   → Proceed to completion
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render spec-review-gate {work_unit}.specification.{topic} --variant reloop
 ```
 
 **STOP.** Wait for user response.
@@ -203,20 +223,16 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 **If `proceed`:**
 
-→ Proceed to **F. Completion**.
+→ Proceed to **G. Completion**.
 
 #### If findings were surfaced and `finding_gate_mode` is `gated`
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `spec-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
-> *Output the next fenced block as markdown (not a code block):*
+Fetch the gate and emit its section verbatim at its marked instruction:
 
-```
-· · · · · · · · · · · ·
-**`◆ Run another review cycle?`**
-
-**`r/reanalyse`** → Run another review cycle (Phase 1 + Phase 2)
-**`p/proceed`**   → Proceed to completion
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render spec-review-gate {work_unit}.specification.{topic} --variant reloop
 ```
 
 **STOP.** Wait for user response.
@@ -227,11 +243,11 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 **If `proceed`:**
 
-→ Proceed to **F. Completion**.
+→ Proceed to **G. Completion**.
 
 ---
 
-## F. Completion
+## G. Completion
 
 1. **Verify tracking is complete** — read `manifest get {work_unit}.specification.{topic} tracking`; every entry across all cycles must be `complete`.
 

--- a/skills/workflow-specification-process/references/specification-format.md
+++ b/skills/workflow-specification-process/references/specification-format.md
@@ -10,6 +10,8 @@ The specification is a single file per topic. Structure is **flexible** — orga
 
 Structure is flexible; facts are not. Every value, rule, threshold, and enumeration has exactly one section that states it — its **home**. Every other mention references the home and never restates it. Reference only to avoid restating — never to justify, compare, or note consistency: if deleting the sentence containing a reference loses no information, delete the sentence. Never state a derived fact (a count or summary of a list sitting beside it) — it drifts when the list changes.
 
+An empirical claim about the codebase or toolchain — a count, an enumeration, an "all X are Y" — is recorded at its home with the command that measured it (`… (rg -l 'pattern' | wc -l → 14)`). A claim with no command is a claim review cannot re-check; a load-bearing claim that cannot be measured is written as observation, not fact. A specification carries no open-decision markers — "Decision required", "TBD", and kin park a decision the record never made; the point routes per **[resolve-source-incoherence.md](resolve-source-incoherence.md)** instead of landing in the document.
+
 > **CHECKPOINT**: You should NOT be creating or writing to this file unless you have explicit user approval for specific content. If you're about to create this file with content you haven't presented and had approved, **STOP**. That violates the workflow.
 
 ---

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -958,6 +958,38 @@ describe('render triage surfaces', () => {
   });
 });
 
+describe('render spec-review-gate', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { phases: { specification: { items: { portal: { status: 'in-progress' } } } } });
+  });
+  afterEach(() => teardown(dir));
+
+  it('continue variant renders the escape-hatch menu', () => {
+    const out = renderSurface(dir, 'spec-review-gate', { dotpath: 'pay.specification.portal', variant: 'continue' });
+    assert.ok(out.includes('=== MENU: spec review continue gate'));
+    assert.ok(out.includes('**`◆ Continue with review?`**'));
+    assert.ok(/\*\*`p\/proceed`\*\* +→ Continue review/.test(out));
+    assert.ok(/\*\*`s\/skip`\*\* +→ Skip review, proceed to completion/.test(out));
+  });
+
+  it('reloop variant renders the another-cycle menu', () => {
+    const out = renderSurface(dir, 'spec-review-gate', { dotpath: 'pay.specification.portal', variant: 'reloop' });
+    assert.ok(out.includes('=== MENU: spec review reloop gate'));
+    assert.ok(out.includes('**`◆ Run another review cycle?`**'));
+    assert.ok(/\*\*`r\/reanalyse`\*\* +→ Run another review cycle \(all three phases\)/.test(out));
+    assert.ok(/\*\*`p\/proceed`\*\* +→ Proceed to completion/.test(out));
+  });
+
+  it('rejects a missing or unknown variant and a non-specification address', () => {
+    assert.throws(() => renderSurface(dir, 'spec-review-gate', { dotpath: 'pay.specification.portal' }), /--variant must be "continue" or "reloop"/);
+    assert.throws(() => renderSurface(dir, 'spec-review-gate', { dotpath: 'pay.specification.portal', variant: 'again' }), /--variant must be "continue" or "reloop"/);
+    writeManifest(dir, 'pay', { phases: { planning: { items: { portal: { status: 'in-progress' } } } } });
+    assert.throws(() => renderSurface(dir, 'spec-review-gate', { dotpath: 'pay.planning.portal', variant: 'reloop' }), /address must be <work_unit>\.specification\.<topic>/);
+  });
+});
+
 describe('render finding', () => {
   let dir;
   const base = {
@@ -1856,7 +1888,7 @@ describe('catalogue dispatch', () => {
   });
 
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, review-presentation, review-gate, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, off-topic-offer, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, roadmap-view, roadmap-add-gate, roadmap-session-receipt, roadmap-harvest-gate, roadmap-parks-gate, roadmap-shape-gate, roadmap-conclude-gate, name-gate, shape-gate, synthesis-gate, query-failure-gate, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick, baseline-offer-gate\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-batch, finding, review-presentation, review-gate, spec-review-gate, triage-announce, triage-offer, triage-block, reroute-offer, reroute-candidates, off-topic-offer, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, roadmap-view, roadmap-add-gate, roadmap-session-receipt, roadmap-harvest-gate, roadmap-parks-gate, roadmap-shape-gate, roadmap-conclude-gate, name-gate, shape-gate, synthesis-gate, query-failure-gate, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick, baseline-offer-gate\)/);
   });
 });
 

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -894,9 +894,17 @@ describe('pipeline simulation', () => {
 
     // Staging, candidate, and tracking state walks the manifest with
     // validated vocabularies at every step.
+    sim.run(['manifest', 'set', `${wu}.specification.unified`, 'tracking.review-claims-tracking-c1', 'in-progress']);
+    sim.run(['manifest', 'set', `${wu}.specification.unified`, 'tracking.review-claims-tracking-c1', 'complete']);
     sim.run(['manifest', 'set', `${wu}.specification.unified`, 'tracking.review-input-tracking-c1', 'in-progress']);
     sim.run(['manifest', 'set', `${wu}.specification.unified`, 'tracking.review-input-tracking-c1', 'complete']);
     sim.refuses(['manifest', 'set', `${wu}.specification.unified`, 'tracking.review-input-tracking-c1', 'done'], /Invalid tracking status/);
+    // The review loop's two gates render from the same address the prose
+    // fetches them at; a non-specification address refuses.
+    assert.match(sim.render(['spec-review-gate', `${wu}.specification.unified`, '--variant', 'continue'], { expect: 'content' }),
+      /Continue with review\?/);
+    assert.match(sim.render(['spec-review-gate', `${wu}.specification.unified`, '--variant', 'reloop'], { expect: 'content' }),
+      /Run another review cycle\?/);
     sim.run(['manifest', 'set', `${wu}.review.unified`, 'staging.c1.gate_mode=gated', 'staging.c1.tasks.1=pending', 'staging.c1.tasks.2=pending']);
     sim.run(['manifest', 'set', `${wu}.review.unified`, 'staging.c1.tasks.1', 'approved']);
     sim.refuses(['manifest', 'set', `${wu}.review.unified`, 'staging.c1.tasks.2', 'later'], /Invalid staging task status/);


### PR DESCRIPTION
## Why

Idea 40: both review agents compare documents against documents. A false empirical claim present in both the spec and its source is a perfect fidelity match — seven such claims survived six observed review cycles, and the only pass that caught them was an unauthorised remit rewrite. For a spec whose content is largely codebase measurements, nothing prescribed ever touched ground truth.

## What

- **New agent** `workflow-specification-review-claims`: opens every review cycle (Phase 1). Collects the spec's empirical claims, re-runs each load-bearing one's recorded command (never trusting the documents, prior cycles, or asserted-as-verified figures), and verdicts hold / fail / unreproducible. A failing claim that lives in a source becomes a **Source defect** finding (routes back via #957's lane); a spec-only failure carries the corrected measurement; unreproducible load-bearing claims must be restated measurably or removed. Read-only measurement is a hard rule.
- **`spec-review.md`** becomes three sequential phases — claims first, so a false-in-both claim routes before fidelity review reads it as a match. Sections relettered C–G.
- **`specification-format.md`**: empirical claims are recorded with their measuring command (`cmd → result`) at their home — what makes re-verification mechanical; open-decision markers are banned from the document outright.
- **Menu migration** (touching-a-file rule): the review loop's cycle gate and re-loop prompts move to a new engine surface `render spec-review-gate --variant continue|reloop`, with render tests and a pipeline-simulation extension; `convergence-analysis.md` and `spec-completion.md` pick up the third stream.

Stacks on #957. Part 4 of the idea-40 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)