### PR TITLE
test(prose): the flush case's stop names the dispatch check it depends on

### DIFF
--- a/tests/prose/cases/discussion-flushes-the-calls-queue/act.md
+++ b/tests/prose/cases/discussion-flushes-the-calls-queue/act.md
@@ -1,5 +1,6 @@
 Execute skills/workflow-discussion-entry/SKILL.md with arguments
 $0=feature, $1=pay, and continue into the processing skill it hands off
 to. Play the described user. Stop once the queued calls have been
-documented and committed and the turn ends — do not open a new subtopic
-of your own, and do not conclude the discussion.
+documented and committed and the dispatch check that rides those
+commits has completed — do not open a new subtopic of your own, and do
+not conclude the discussion.


### PR DESCRIPTION
Follow-up to #972. Its re-walks failed `discussion-flushes-the-calls-queue` in the opposite direction: #972 moved `agent dispatch` from `calls_exclude` to `calls_include`, and both walkers then stopped *before* the checkpoint — "no further dispatch check ran after that point per the task's stop instruction".

Across four walks over two rounds the split is 2–2. The defect is in `act.md`: "documented and committed and the turn ends" does not settle whether the session loop's dispatch check is in scope, so each walker decided for itself and the case scored whichever way it guessed. The stop now names the check.

Stopping *before* it instead would fight the CHECKPOINT rule the session loop states ("Do not respond to the user until this check is complete"), which a faithful walker obeys — so the scope moves to include it rather than exclude it.

Gates: `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)