### PR TITLE
test(prose): the flush case expects the dispatch check to stay quiet, not to fire

### DIFF
--- a/tests/prose/cases/discussion-flushes-the-calls-queue/assert.md
+++ b/tests/prose/cases/discussion-flushes-the-calls-queue/assert.md
@@ -31,12 +31,11 @@ The prose should have taken this path:
 7. the flush re-enters, finds `items` and `pulled` both empty, deletes
    the queue file, confirms in one line, and the session resumes — no
    further screen, no conclusion gate
-8. the dispatch check rides those commits as the session loop
-   prescribes, and on this topic every condition holds — the calls
-   queue is now drained, no review has ever run, so the first review
-   is free — so a background review dispatches and is announced in one
-   line. The walk does not wait on it: nothing is scanned, read, or
-   surfaced from it before the turn ends
+8. the dispatch check rides each of those commits as the session loop
+   prescribes, and stays quiet at every one: the queue still holds the
+   calls not yet landed when each commit is made, so its box is
+   unchecked and no review dispatches. The drain that follows is not a
+   commit, so nothing re-fires the check before the turn ends
 
 Presentation claims — deliberate display claims; the flush's shape is
 the behaviour under test:
@@ -54,10 +53,9 @@ the behaviour under test:
 
 Further claims:
 
-- the calls queue and the agent store stay separate: the flush itself
-  reads and writes neither agent rows nor findings, and the only agent
-  verb the walk runs is the dispatch its commits arm — no ack, no
-  surface, no incorporate, since nothing has come back yet
+- no agent verbs run beyond the scan: no dispatch, no ack, no surface,
+  no incorporate — the queue is not the agent store, and a flush arms
+  no review
 - each documented call lands as a new section whose Decision block
   opens with the derivation marker naming its determinant; no finding
   id appears anywhere (these calls came from the conversation, not a
@@ -69,7 +67,6 @@ Further claims:
 EXPECTED WORLD — the fixture plus: the Discussion Map carries two new
 subtopics, both `decided`; the discussion file carries a new section
 per call, each Decision opening with the **Settled by derivation**
-marker; each call is committed on its own;
+marker; each call is committed on its own; and
 `.workflows/.cache/pay/discussion/pay/calls-queue.json` no longer
-exists; and the agent store holds one `review` row in flight with the
-stub's report on disk.
+exists. The agent store is untouched.

--- a/tests/prose/cases/discussion-flushes-the-calls-queue/case.json
+++ b/tests/prose/cases/discussion-flushes-the-calls-queue/case.json
@@ -41,22 +41,19 @@
       "render finding-batch pay.discussion.pay",
       "calls-batch.json",
       "discussion-map add pay pay",
-      "discussion-map set pay pay",
-      "agent dispatch pay discussion pay --kind review"
+      "discussion-map set pay pay"
     ],
     "calls_in_order": [
       "manifest get pay.discussion.pay status",
       "render finding-batch pay.discussion.pay"
     ],
     "calls_exclude": [
+      "agent dispatch",
       "agent ack",
       "agent surface",
       "agent incorporate",
       "topic complete",
       "knowledge.cjs index"
     ]
-  },
-  "stubs": {
-    "discussion-review-clean": "when the engine records a dispatch of kind review — write the content to the path the dispatch response returned"
   }
 }


### PR DESCRIPTION
Reverts my own error in #972, keeping the useful half of #974.

#974 made the walk run to the dispatch checkpoint instead of stopping short of it — and both walks then showed the dispatch is **not** owed:

> at both checkpoints the calls-queue box was unchecked (the queue file still held un-landed items until after the write-up loop finished), so per review-agent.md's 'If any unchecked' branch, no dispatch fired either time.

The flush writes and commits each call *before* removing landed items, and the drain that follows is not a commit, so nothing re-fires the check. The prose deterministically yields no dispatch. The original case was right; the two earlier walks that dispatched were the deviant ones (draining early, or re-running the check without a commit).

- `calls_exclude` regains `agent dispatch`; `calls_include` loses it; the `discussion-review-clean` stub is un-armed.
- `assert.md` step 8 now pins the *quiet* and says why (queue non-empty at each commit; the drain is not a commit) — a stronger claim than the original silence.
- #974's `act.md` stop stays: running to the checkpoint is what makes the case prove this rather than guess.

Design note, not changed here: a calls-queue flush can never arm a review, by construction of the write-then-drain order.

Gates: `npm test` 2317/2317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)