### PR TITLE
fix(discovery): the openers are prose, not fenced output

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -681,7 +681,7 @@ Task {M} of {total}: {Task Name} — authored. Logging to plan.
 
 ### Rendering Instructions for Ask Blocks
 
-When a step asks the user a question, wrap it in a rendering instruction and code block — don't use bare `Ask:` labels:
+When a step asks the user a question, wrap it in a rendering instruction — never a bare `Ask:` label. **The fence is for asks whose structure carries meaning**: a question with enumerated prompts beneath it, where the list is part of what is being asked. A conversational opening — Claude speaking a paragraph to the user — is emitted as markdown instead, one authored line per paragraph, so the renderer reflows it at any width. A fence would hand-wrap prose at a column the author had to guess.
 
 ```
 > *Output the next fenced block as a code block:*

--- a/skills/workflow-discovery/references/opener-pattern.md
+++ b/skills/workflow-discovery/references/opener-pattern.md
@@ -38,15 +38,14 @@ Render the opener matching what the caller told us.
 
 The seeds share one type (the working set only carries items of one kind). Name that type, pluralised with a count when there are several, and give one combined sketch across them.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 I've read your {bug | idea | quick-fix — pluralised with a count when several, e.g. "3 ideas"}. Here's the shape I'm picking up:
 
-  {one-line sketch — a single combined picture across the item(s)}
+{one-line sketch — a single combined picture across the item(s)}
 
-{Targeted opening question that pulls on the shape.} If you have any
-related files or notes, share the path(s) and I'll read them too.
+{Targeted opening question that pulls on the shape.} If you have any related files or notes, share the path(s) and I'll read them too.
 ```
 
 **STOP.** Wait for user response.
@@ -55,12 +54,10 @@ related files or notes, share the path(s) and I'll read them too.
 
 #### If `work_type` pre-seed is `epic`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Tell me about the epic. I'll ask open questions to pull on it before
-we synthesise topics. If you have notes or research files, share the
-path(s) and I'll read them in.
+Tell me about the epic. I'll ask open questions to pull on it before we synthesise topics. If you have notes or research files, share the path(s) and I'll read them in.
 ```
 
 **STOP.** Wait for user response.
@@ -69,11 +66,10 @@ path(s) and I'll read them in.
 
 #### If `work_type` pre-seed is `feature`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Tell me about the feature. If you have notes or files for it, share
-the path(s) and I'll read them in.
+Tell me about the feature. If you have notes or files for it, share the path(s) and I'll read them in.
 ```
 
 **STOP.** Wait for user response.
@@ -82,11 +78,10 @@ the path(s) and I'll read them in.
 
 #### If `work_type` pre-seed is `bugfix`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-What's broken? If you have logs, error reports, or related files,
-share the path(s) and I'll read them in.
+What's broken? If you have logs, error reports, or related files, share the path(s) and I'll read them in.
 ```
 
 **STOP.** Wait for user response.
@@ -95,11 +90,10 @@ share the path(s) and I'll read them in.
 
 #### If `work_type` pre-seed is `quick-fix`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-What's the change? If there's a file or note that frames it, share
-the path and I'll read it in.
+What's the change? If there's a file or note that frames it, share the path and I'll read it in.
 ```
 
 **STOP.** Wait for user response.
@@ -108,12 +102,10 @@ the path and I'll read it in.
 
 #### If `work_type` pre-seed is `cross-cutting`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Tell me about the cross-cutting concern — the pattern or policy you're
-defining. If you have notes or reference docs, share the path(s) and
-I'll read them in.
+Tell me about the cross-cutting concern — the pattern or policy you're defining. If you have notes or reference docs, share the path(s) and I'll read them in.
 ```
 
 **STOP.** Wait for user response.
@@ -124,12 +116,10 @@ I'll read them in.
 
 No pre-seed (`s/start`). Open fully and fold the "we'll figure out the shape together" framing into the question itself.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Tell me what's on your mind. Describe it the way it sits in your head —
-I'll ask open questions and we'll figure out the shape together. If you
-have notes or files, share the path(s) and I'll read them in.
+Tell me what's on your mind. Describe it the way it sits in your head — I'll ask open questions and we'll figure out the shape together. If you have notes or files, share the path(s) and I'll read them in.
 ```
 
 **STOP.** Wait for user response.


### PR DESCRIPTION
Standalone — deliberately **not** on stack #976, because this is a convention amendment rather than a surface conversion.

## The problem

Seven opener branches in `opener-pattern.md` sat inside code fences, hand-wrapped at ~68 columns:

```
Tell me about the epic. I'll ask open questions to pull on it before
we synthesise topics. If you have notes or research files, share the
path(s) and I'll read them in.
```

On a narrower pane, every over-long line breaks back to column zero — the same failure as the hypothesis board, on the first thing a user sees in **every** new work unit of every type.

**Six of the seven carry no placeholders at all**, so the templated-fence ratchet is blind to them: it classifies static fences as always fine. That is a real gap in the lint, not just in these files (see below).

## Why prose, not a surface

There is nothing for the engine to do. No data, no columns, no state-derived content, nothing to align — an `engine render opener --variant epic|feature|…` would be a lookup table of seven sentences behind a tool call. The engine earns its place where layout or derivation exists; here neither does.

As markdown they reflow at any width, and the hand-wrapping disappears because there is nothing left to hand-wrap. The seeded opener's sketch sheds its two-space indent, which meant nothing outside a fence anyway. The copy discipline is unchanged — the instruction still says "emit as markdown", which is how every menu already works.

## The convention, narrowed not overturned

CONVENTIONS' "Rendering Instructions for Ask Blocks" prescribed a fence. Its own example is a question with enumerated prompts beneath it — a *structured* ask, where the list is part of what is being asked. The rule now says that explicitly, and says a conversational opening is markdown. It states what the example already showed.

## Banked, not fixed here

A scan of all 190 rendering-instructed code fences found **19 that are hand-wrapped prose** — the openers plus 13 more across `session-loop` (×4), `plan-review` (×2), `knowledge-gate` (×2), `roadmap/session-loop` (×2), and singles in `define-phases`, `plan-construction`, `resolve-dependencies`, `analyze-task-graph`, and four `specification-entry` files. Every one is invisible to the ratchet for the same reason. Whether the lint should grow a "fenced prose paragraph" check is a bigger question than this PR, and worth deciding rather than my quietly extending it.

## Gates

`npm test` (2317 pass) and the conventions lint green. `node tests/prose/run.cjs select --diff main` intersects: `discovery-commits-new-epic`, `discovery-commits-new-feature`, `roadmap-genesis-lays-out-the-map`, `start-promotes-inbox-ideas`, `discussion-flushes-the-calls-queue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)