### PR TITLE
fix(discussion): the flush's dispatch check is evaluated before the queue removal

### DIFF
--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -251,7 +251,7 @@ Emit the call's DISPLAY and MENU sections, each verbatim per its marker — exce
 
 **If `yes`:**
 
-Document each call in turn — into the subtopic that owns it (the template's full structure where the subtopic has no section yet, a dated revision entry where a decided block exists), the Decision block carrying the template's derivation marker; when no subtopic on the Discussion Map owns it, add one and set it `decided` in the same move (`discussion-map add`, then `discussion-map set … decided`). Each call's write-up is its own edit and its own commit (session loop step 5's dispatch check included) before the next begins — never two calls in one write — then remove the landed items from the queue file's `items`.
+Document each call in turn — into the subtopic that owns it (the template's full structure where the subtopic has no section yet, a dated revision entry where a decided block exists), the Decision block carrying the template's derivation marker; when no subtopic on the Discussion Map owns it, add one and set it `decided` in the same move (`discussion-map add`, then `discussion-map set … decided`). Each call's write-up is its own edit and its own commit (session loop step 5's dispatch check included) before the next begins — never two calls in one write — then remove the landed items from the queue file's `items`. The dispatch check is evaluated where it falls, at each commit and before that removal: the call just landed is still in the queue at that moment, so the check's calls-queue box holds it quiet.
 
 Confirm in one line total — `All {N} documented.` — never a per-call recap. Nothing is pending, so the turn continues.
 


### PR DESCRIPTION
Closes the FLAKY that #978's re-walk exposed on `discussion-flushes-the-calls-queue`.

Both walks read the mechanism identically and split on one point of sequencing:

- **passing run** — evaluated commit 2's dispatch check at the commit, before the batch removal; the just-landed call was still in the queue, so the calls-queue box held it quiet. 8/8, world PASS.
- **failing run** — drained and deleted the queue first, *then* evaluated; every box clear, so it dispatched `review-001`. 7/8, world FAIL (agent store written).

§I put the check at the commit and the removal after it, but never said the check is evaluated *before* the removal — so batching the removal ahead of it is a legal reading. One clause now pins it, matching the passing run and the design note that a flush never arms a review.

Gates: `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)