### PR TITLE
fix(prose): conversational output is markdown, not fenced

### DIFF
--- a/skills/workflow-discovery/references/continuity-load.md
+++ b/skills/workflow-discovery/references/continuity-load.md
@@ -24,15 +24,14 @@ Bounded regardless of how many sessions exist:
 
 Synthesise the recent-in-full logs into a short briefing that resumes the conversation — the threads being circled, what the user was leaning toward, what was left open. When the most recent log is an in-progress resume, note the edits already applied this session. Surface the *thinking*; don't restate the map.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Where we'd got to:
 
-  {2–4 lines from the recent session(s): the threads circled, what the user was leaning toward, what was still open}
+{2–4 lines from the recent session(s): the threads circled, what the user was leaning toward, what was still open}
 
-  {older sessions, if any: one line each from their Conclusion,
-  under an "Earlier:" lead — only when it aids orientation}
+{older sessions, if any: one line each from their Conclusion, under an "Earlier:" lead — only when it aids orientation}
 ```
 
 The caller renders its own opener prompt and STOP after this briefing.

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -18,11 +18,10 @@ If `.workflows/.baseline/overview.md` exists, read it in full — silent ambient
 
 The slice was fenced at the pull and its record backfilled into `session-{session_number}.md` — the conversation continues, narrower. Name the fenced slice in one conversational sentence (the pulled items, by name), then render the transition:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Topics come later — they fall out once we've deepened the slice;
-the pulled items are the rough shapes.
+Topics come later — they fall out once we've deepened the slice; the pulled items are the rough shapes.
 
 Anything to reshape before we go deeper — or shall we dig in?
 ```
@@ -35,12 +34,10 @@ Anything to reshape before we go deeper — or shall we dig in?
 
 The macro shaping at Step 4 already explored the work enough to confirm it's an epic and surfaced the first topic seeds; the confirm-trigger backfilled that into `session-{session_number}.md`. Don't re-open with a cold prompt — the conversation is already live. Render a brief transition that moves from "what is this" into exploring the whole:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-That's an epic — work unit created. We've started sketching the shape;
-now let's get into it properly. Topics come later — they fall out once
-we've thought the whole thing through.
+That's an epic — work unit created. We've started sketching the shape; now let's get into it properly. Topics come later — they fall out once we've thought the whole thing through.
 
 What do you want to dig into first?
 ```
@@ -57,7 +54,7 @@ Brief across the prior sessions, then ask where to pick up:
 
 → Load **[continuity-load.md](continuity-load.md)** and follow its instructions as written.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Where do you want to take it from here?
@@ -83,14 +80,10 @@ With the map rendered, read the prior sessions to resume the conversation:
 
 Then frame the opener:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-You can open a fresh thread — a new area of the work you want
-to sketch out — and we'll explore it the same way we did first
-time, then synthesise topics at the end. Or you can name changes
-to existing items: remove, rename, re-route, edit summary,
-edit description, mark handled. Both in one go is fine.
+You can open a fresh thread — a new area of the work you want to sketch out — and we'll explore it the same way we did first time, then synthesise topics at the end. Or you can name changes to existing items: remove, rename, re-route, edit summary, edit description, mark handled. Both in one go is fine.
 
 Say "show map" anytime to pull the map back up.
 
@@ -105,16 +98,14 @@ What's on your mind for this map?
 
 Fresh first-session with seed material. Read each file listed under `seeds[]` then `imports[]` (paths are relative to `.workflows/{work_unit}/`) — the seed is the primary launchpad, imports are supporting. Use this content to launch the conversation: reflect what's there, ask exploratory questions about it. Don't dump it back at the user verbatim — synthesise.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Read your {seed | import(s) | seed and import(s)}. Here's the shape
-I'm picking up:
+Read your {seed | import(s) | seed and import(s)}. Here's the shape I'm picking up:
 
-  {one-line summary of what the seed/import material describes}
+{one-line summary of what the seed/import material describes}
 
-Before we name topics, let's pull on a few things — {one or two
-exploratory questions drawn from the seed material}.
+Before we name topics, let's pull on a few things — {one or two exploratory questions drawn from the seed material}.
 ```
 
 **STOP.** Wait for user response.
@@ -125,14 +116,12 @@ exploratory questions drawn from the seed material}.
 
 Fresh first-session, no map, no imports. The work-unit description has been read silently — don't narrate or summarise it back. Open with this prompt:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Tell me about what you want to build. Don't worry about
-structure — describe it the way it sits in your head right now.
+Tell me about what you want to build. Don't worry about structure — describe it the way it sits in your head right now.
 
-I'll ask some open questions to pull on the idea before we
-synthesise topics.
+I'll ask some open questions to pull on the idea before we synthesise topics.
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-planning-process/references/analyze-task-graph.md
+++ b/skills/workflow-planning-process/references/analyze-task-graph.md
@@ -10,11 +10,10 @@ This step uses the `workflow-planning-dependency-grapher` agent (`../../../agent
 
 ## A. Analyze
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-All tasks are authored. Now I'll analyze internal dependencies and
-priorities across the full plan.
+All tasks are authored. Now I'll analyze internal dependencies and priorities across the full plan.
 ```
 
 Read the `format`, the plan's `external_id`, and the `task_map` from the manifest:

--- a/skills/workflow-planning-process/references/define-phases.md
+++ b/skills/workflow-planning-process/references/define-phases.md
@@ -14,7 +14,7 @@ Read the planning file at `.workflows/{work_unit}/planning/{topic}/planning.md`.
 
 #### If phases exist
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Phase structure already exists. I'll present it for your review.
@@ -24,12 +24,10 @@ Phase structure already exists. I'll present it for your review.
 
 #### If no phases exist
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-I'll delegate phase design to a specialist agent. It will read the full
-specification and propose a phase structure — how we break this into
-independently testable stages.
+I'll delegate phase design to a specialist agent. It will read the full specification and propose a phase structure — how we break this into independently testable stages.
 ```
 
 Read `work_type` from the manifest:

--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -24,12 +24,10 @@ Navigation stays within plan construction. It cannot skip past the end of this s
 
 → Load **[define-phases.md](define-phases.md)** and follow its instructions as written.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-I'll now work through each phase — presenting existing work for review
-and designing or authoring anything still pending. You'll approve at
-every stage.
+I'll now work through each phase — presenting existing work for review and designing or authoring anything still pending. You'll approve at every stage.
 ```
 
 → On return, proceed to **B. Process Current Phase**.

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -144,12 +144,10 @@ Review cycle {N} complete — findings applied. Running follow-up cycle.
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `planning-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Fixes applied this cycle may have shifted dependencies, introduced gaps,
-or affected other tasks. A follow-up round reviews the corrected plan
-with fresh context — 2-3 cycles typically surface anything cascading.
+> Fixes applied this cycle may have shifted dependencies, introduced gaps, or affected other tasks. A follow-up round reviews the corrected plan with fresh context — 2-3 cycles typically surface anything cascading.
 ```
 
 > *Output the next fenced block as markdown (not a code block):*
@@ -176,12 +174,10 @@ with fresh context — 2-3 cycles typically surface anything cascading.
 
 → Load **[convergence-analysis.md](../../workflow-shared/references/convergence-analysis.md)** with loop_type = `planning-review`, work_unit = `{work_unit}`, topic = `{topic}`.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Fixes applied this cycle may have shifted dependencies, introduced gaps,
-or affected other tasks. A follow-up round reviews the corrected plan
-with fresh context — 2-3 cycles typically surface anything cascading.
+> Fixes applied this cycle may have shifted dependencies, introduced gaps, or affected other tasks. A follow-up round reviews the corrected plan with fresh context — 2-3 cycles typically surface anything cascading.
 ```
 
 > *Output the next fenced block as markdown (not a code block):*

--- a/skills/workflow-planning-process/references/resolve-dependencies.md
+++ b/skills/workflow-planning-process/references/resolve-dependencies.md
@@ -4,11 +4,10 @@
 
 ---
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-All phases and tasks are written. Now I'll check for external
-dependencies — things this plan needs from other topics or systems.
+All phases and tasks are written. Now I'll check for external dependencies — things this plan needs from other topics or systems.
 ```
 
 Handle external dependencies — things this plan needs from other topics or systems.
@@ -172,7 +171,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest apply {work_unit
 
 #### If no changes were made (no deps to write, no reverse resolutions)
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 No external dependencies for this topic. No reverse resolutions needed.

--- a/skills/workflow-roadmap/references/session-loop.md
+++ b/skills/workflow-roadmap/references/session-loop.md
@@ -16,12 +16,10 @@ If `.workflows/.baseline/overview.md` exists, read it in full — silent ambient
 
 The conversation is already live and its record persisted at Step 2 — don't re-open with a cold prompt. Render a brief transition that moves from "what is this" into laying the product out:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-This is product territory — we'll lay the whole thing out, then
-pull the first slice into delivery when you're ready. Nothing we
-say here commits you to building anything.
+This is product territory — we'll lay the whole thing out, then pull the first slice into delivery when you're ready. Nothing we say here commits you to building anything.
 
 Where do you want to dig in?
 ```
@@ -36,15 +34,15 @@ Clear `genesis_continuation` — the transition is spent; any later pass through
 
 The log at `.workflows/.roadmap/sessions/session-{session_number}.md` is the working state — read it in full. Then brief across the record before re-opening: read the most recent prior session log in full too (the `SESSIONS` table from the home snapshot lists them; older sessions contribute their `## Conclusion` line only), and synthesise a short catch-up — the threads being circled, what the user was leaning toward, what was left open.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Where we'd got to:
 
-  {2–4 lines from the recent session(s): the threads circled, what the user was leaning toward, what was still open}
+{2–4 lines from the recent session(s): the threads circled, what the user was leaning toward, what was still open}
 ```
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Where do you want to take it from here?
@@ -58,14 +56,10 @@ Where do you want to take it from here?
 
 A fresh session over the map just rendered at Step 3. Brief across the record first when prior sessions exist (most recent log in full, older Conclusions one line each — as the resume branch does), skipping silently when none do. Then open:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-The map's above. You can open a new thread — something the product
-needs that we haven't shaped — or name changes to what's there:
-move, rename, remove, re-order horizons, groom an inbox idea on.
-Both in one go is fine. Say "show roadmap" anytime to pull it back
-up.
+The map's above. You can open a new thread — something the product needs that we haven't shaped — or name changes to what's there: move, rename, remove, re-order horizons, groom an inbox idea on. Both in one go is fine. Say "show roadmap" anytime to pull it back up.
 
 What's on your mind?
 ```

--- a/skills/workflow-specification-entry/references/confirm-continue.md
+++ b/skills/workflow-specification-entry/references/confirm-continue.md
@@ -133,11 +133,10 @@ Previously extracted (for reference):
 
 **If single discussion (no menu to return to):**
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Understood. Continue working on discussions, or re-run this
-command when ready.
+Understood. Continue working on discussions, or re-run this command when ready.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-entry/references/confirm-create.md
+++ b/skills/workflow-specification-entry/references/confirm-create.md
@@ -96,11 +96,10 @@ After completion:
 
 **If single discussion (no menu to return to):**
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Understood. Continue working on discussions, or re-run this
-command when ready.
+Understood. Continue working on discussions, or re-run this command when ready.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-entry/references/confirm-refine.md
+++ b/skills/workflow-specification-entry/references/confirm-refine.md
@@ -46,11 +46,10 @@ All sources extracted:
 
 **If single discussion (no menu to return to):**
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Understood. Continue working on discussions, or re-run this
-command when ready.
+Understood. Continue working on discussions, or re-run this command when ready.
 ```
 
 **STOP.** Do not proceed — terminal condition.

--- a/skills/workflow-specification-entry/references/display-analyze.md
+++ b/skills/workflow-specification-entry/references/display-analyze.md
@@ -69,11 +69,10 @@ rm .workflows/{work_unit}/.state/discussion-consolidation-analysis.md
 
 #### If `no`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Understood. Continue working on discussions, or re-run this
-command when ready.
+Understood. Continue working on discussions, or re-run this command when ready.
 ```
 
 **STOP.** Do not proceed — terminal condition.


### PR DESCRIPTION
Follows #979 — same defect, the rest of the corpus.

## The rule applied

**If it's Claude addressing the user, it's markdown, whatever its length.** Twenty fences across five phases held exactly that — openers, transitions, briefings, "I'll now work through each phase…" — hand-wrapped at a guessed column, breaking to column zero on a narrow pane.

Two things deliberately keep their fence:

- **Templated status lines** — `Phase {N}: {Name} — complete ({M} tasks authored)`, `Review cycle {N} complete — findings applied`. A receipt, not a turn, and CONVENTIONS already sanctions the fenced one-line announcement.
- **Asks whose structure carries meaning** — `knowledge-gate`'s endpoint questions and `spec-entry`'s grouping-context prompt each pair a question with the list of values it wants. The list is part of the ask, which is the #979 rule.

`plan-review`'s two cycle explanations become **signpost blockquotes** rather than plain prose — they explain why a gate is being offered, which is what that register is for, and the border then carries across every wrapped line.

Indented judgment placeholders in the briefings lose their indent: two spaces meant nothing outside a fence, and four would have opened a code block.

## Scope note

The original scan found 13 sites; reading the files found **20**. The heuristic only flags a line ending mid-sentence, so single-line conversational turns (`Where do you want to take it from here?`, `Phase structure already exists. I'll present it for your review.`) slipped past it — as did two whole blocks in `discovery/session-loop.md`. That gap is why this was read rather than scripted.

| File | Sites |
|---|---|
| `workflow-discovery/references/session-loop.md` | 6 |
| `workflow-roadmap/references/session-loop.md` | 4 |
| `workflow-specification-entry/` (4 files, same sentence) | 4 |
| `workflow-planning-process/references/plan-review.md` | 2 (→ signpost) |
| `workflow-planning-process/` — define-phases ×2, resolve-dependencies ×2, plan-construction, analyze-task-graph | 6 |
| `workflow-discovery/references/continuity-load.md` | 1 |

## Gates

`npm test` (2342 pass) and the conventions lint green. Ratchet pins unchanged — the templated blocks stay templated, they just emit as markdown now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)