### PR TITLE
fix(planning): step completions are Claude speaking, so they are prose

### DIFF
--- a/skills/workflow-planning-process/references/plan-construction.md
+++ b/skills/workflow-planning-process/references/plan-construction.md
@@ -100,7 +100,7 @@ If the manifest still carries a `staging.author-p{N}` subtree for this phase (ch
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.planning.{topic} staging.author-p{N}
 ```
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Phase {N}: {Phase Name} — all tasks already authored.
@@ -136,7 +136,7 @@ Commit:
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): complete Phase {N} tasks"
 ```
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Phase {N}: {Phase Name} — complete ({M} tasks authored).

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -215,7 +215,7 @@ Read `manifest get {work_unit}.planning.{topic} tracking`. If any entry is `in-p
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "planning({work_unit}): complete plan review (cycle {N})"
    ```
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Plan review complete — {N} cycle(s), all tracking files finalised.


### PR DESCRIPTION
Fixes an inconsistency #981 left behind.

## The bad line

#981 kept three status lines fenced on the basis that they carry a `{placeholder}`. That isn't a principle — it's an accident of whether the sentence needed a number. `No external dependencies for this topic.` went to prose while `Plan review complete — {N} cycle(s)…` stayed fenced, and both are the same act: Claude reporting a step to the user.

## The line that holds

**A fenced one-liner is sanctioned for the auto-mode gate announcement** — the thing that stands in for a STOP the user chose to bypass (CONVENTIONS, Auto-Mode Gates). `Review cycle {N} complete — findings applied. Running follow-up cycle.` sits under `finding_gate_mode is auto` and keeps its fence for that reason, now stated rather than incidental.

The other three announce nothing about a gate, so they become prose:

- `plan-review.md:218` — `Plan review complete — {N} cycle(s), all tracking files finalised.`
- `plan-construction.md:103` — `Phase {N}: {Phase Name} — all tasks already authored.`
- `plan-construction.md:139` — `Phase {N}: {Phase Name} — complete ({M} tasks authored).`

## Gates

`npm test` (2342 pass), conventions lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)