### PR TITLE
fix(prose): plain questions are prose, so the rule and the corpus agree

### DIFF
--- a/skills/workflow-continue-epic/references/summary-backfill.md
+++ b/skills/workflow-continue-epic/references/summary-backfill.md
@@ -86,7 +86,7 @@ No manifest writes, no commit.
 
 ## C. Edit Loop
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Which line would you like to edit? Enter the number, or `done` to accept the current set.
@@ -100,7 +100,7 @@ Which line would you like to edit? Enter the number, or `done` to accept the cur
 
 #### If a number
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 New summary for "{item.name:(titlecase)}":

--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -59,7 +59,7 @@ Load **[ensure-discovery-item.md](../workflow-shared/references/ensure-discovery
 
 #### If no `topic`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 What topic would you like to discuss?

--- a/skills/workflow-discussion-entry/references/gather-context-continue.md
+++ b/skills/workflow-discussion-entry/references/gather-context-continue.md
@@ -18,7 +18,7 @@
 
 Read the existing discussion document first, then ask:
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Continuing: {topic}

--- a/skills/workflow-discussion-entry/references/gather-context-fresh.md
+++ b/skills/workflow-discussion-entry/references/gather-context-fresh.md
@@ -22,7 +22,7 @@ Ask each question below **one at a time**. After each, stop and wait for the use
 
 ## A. Core Problem
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 New discussion: {topic}
@@ -40,7 +40,7 @@ Remember the response — it defines the central problem or decision that the di
 
 ## B. Constraints
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Any constraints or context I should know about?
@@ -56,7 +56,7 @@ Remember the response — these constraints will bound the solution space during
 
 ## C. Codebase
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Are there specific files in the codebase I should review first?

--- a/skills/workflow-implementation-process/references/environment-setup.md
+++ b/skills/workflow-implementation-process/references/environment-setup.md
@@ -35,11 +35,10 @@ Execute each instruction and verify it succeeds before proceeding.
 
 #### If setup document is missing
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-No environment setup document found. Are there any setup instructions
-I should follow before implementing?
+No environment setup document found. Are there any setup instructions I should follow before implementing?
 ```
 
 **STOP.** Wait for user response.

--- a/skills/workflow-planning-process/references/output-formats/linear/about.md
+++ b/skills/workflow-planning-process/references/output-formats/linear/about.md
@@ -20,7 +20,7 @@ Requires the Linear MCP server to be configured.
 
 Check if Linear MCP is available by looking for Linear tools. If not configured, inform the user that Linear MCP is required for this format.
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Which team should own this project?

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -45,7 +45,7 @@ Resolve filename:
 
 #### If no `topic`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 What topic would you like to research?

--- a/skills/workflow-scoping-process/SKILL.md
+++ b/skills/workflow-scoping-process/SKILL.md
@@ -156,7 +156,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} storage_paths '{format storage pathspecs}'
 ```
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
 Revisiting scoping for "{topic:(titlecase)}".

--- a/skills/workflow-start/references/absorb-into-epic.md
+++ b/skills/workflow-start/references/absorb-into-epic.md
@@ -81,11 +81,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest exists {target_e
 
 #### If `true`
 
-> *Output the next fenced block as a code block:*
+> *Output the next fenced block as markdown (not a code block):*
 
 ```
-Topic "{topic}" already exists in {target_epic:(titlecase)}.
-Enter a different name (kebab-case):
+Topic "{topic}" already exists in {target_epic:(titlecase)}. Enter a different name (kebab-case):
 ```
 
 **STOP.** Wait for user response.


### PR DESCRIPTION
The agreed subset — the plain asks, not the whole ~40.

## What changed (12 sites)

CONVENTIONS reserves the fence for **asks whose structure carries meaning** — a question with the list of values it wants beneath it. These twelve carry no such structure, so they render as Claude asking:

- `discussion-entry/SKILL.md` — *What topic would you like to discuss?*
- `gather-context-fresh.md` ×3 — the core-problem, constraints and files questions
- `gather-context-continue.md` — the continuing-discussion opener
- `research-entry/SKILL.md` — *What topic would you like to research?*
- `scoping-process/SKILL.md` — the revisit prompt
- `summary-backfill.md` ×2 — the edit prompt and the new-summary prompt
- `linear/about.md` — *Which team should own this project?*
- `environment-setup.md`, `absorb-into-epic.md`

## Two were still broken

`environment-setup.md` and `absorb-into-epic.md` were authored past the width and break to column zero. **#983's scan missed them** — its tell was a continuation line starting lower-case, and both resume on a capital (`…setup instructions / I should follow…`). Found by reading, not by the heuristic. Worth knowing the detector has that blind spot if we ever lean on it again.

`` `done` `` in the summary-backfill prompt was always meant as a code span; outside a fence it finally renders as one.

## Untouched, each for its own reason

- **Terminal states** (`No bugfixes in progress.`) — CONVENTIONS gives these the red `properties` register; they are meant to look unlike chat.
- **Transaction receipts** (`Logged bug: {slug}`, `Archived {count} items`) — already bound for the verbs that produce them, per the render-surface programme.
- **Auto-mode gate announcements** — they stand in for a STOP the user chose to bypass.
- **`map-operations.md` ×5 and `knowledge-gate.md:252`** — display-shaped and command-bearing respectively; both explained in #983.

## Gates

`npm test` (2342 pass), conventions lint green. No wrapped-prose fence remains outside those six deliberate ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)