### PR TITLE
Review agents classify by move and write findings as reports

### DIFF
--- a/agents/workflow-planning-review-integrity.md
+++ b/agents/workflow-planning-review-integrity.md
@@ -31,13 +31,13 @@ You receive file paths and context via the orchestrator's prompt:
 
 ## Writing Full Fix Content
 
-For each finding, the tracking file must contain the **exact content** that would be written to the plan if the fix is approved. The orchestrator presents this content to the user as-is — what the user sees is what gets applied.
+For each `settled` finding, the tracking file must contain the **exact content** that would be written to the plan if the fix is approved — the orchestrator renders small changes as diffs at the gate and holds whole content behind a view option, and what you write is what gets applied on approval. A `choice` finding carries Options and no fix content: the pick is the reader's, and content written before they pick is a decision dressed as done.
 
 - **Current**: Copy the existing content verbatim from the plan/task file. This shows the user exactly what's there now.
 - **Proposed**: Write the replacement content in full plan format. This is what will replace the current content if approved.
 
 For `add-task` or `add-phase`, omit **Current** and write the complete new content in **Proposed**.
-For `remove-task` or `remove-phase`, include **Current** for reference and omit **Proposed**.
+For `remove-task` or `remove-phase`, include **Current** for reference and omit **Proposed Text**.
 
 **Task structure**: Read `task-design.md` before writing any proposed content. All task content — whether new tasks (`add-task`) or modifications to existing tasks (`update-task`, `add-to-task`) — must follow the canonical task template and field requirements defined there. This is the same template the planning agents used to create the plan.
 
@@ -51,7 +51,7 @@ For `remove-task` or `remove-phase`, include **Current** for reference and omit 
 2. **Write only the tracking file** — do not modify the plan or tasks
 3. **No git writes** — do not commit or stage. Writing the tracking file is your only file write.
 4. **No user interaction** — return status to the orchestrator
-5. **Full fix content** — every finding must include complete Current/Proposed content in plan format. No summaries.
+5. **Full fix content on settled findings** — a `settled` finding includes complete Current/Proposed Text content in plan format; a `choice` carries Options and no fix content. No summaries on either.
 6. **Proportional** — prioritize by impact. Don't nitpick style when architecture is wrong.
 7. **Task scope only** — check the plan as built; don't redesign it
 8. **No tracking file when clean** — only write the output file if findings exist.

--- a/agents/workflow-planning-review-integrity.md
+++ b/agents/workflow-planning-review-integrity.md
@@ -34,9 +34,9 @@ You receive file paths and context via the orchestrator's prompt:
 For each `settled` finding, the tracking file must contain the **exact content** that would be written to the plan if the fix is approved — the orchestrator renders small changes as diffs at the gate and holds whole content behind a view option, and what you write is what gets applied on approval. A `choice` finding carries Options and no fix content: the pick is the reader's, and content written before they pick is a decision dressed as done.
 
 - **Current**: Copy the existing content verbatim from the plan/task file. This shows the user exactly what's there now.
-- **Proposed**: Write the replacement content in full plan format. This is what will replace the current content if approved.
+- **Proposed Text**: Write the replacement content in full plan format. This is what will replace the current content if approved.
 
-For `add-task` or `add-phase`, omit **Current** and write the complete new content in **Proposed**.
+For `add-task` or `add-phase`, omit **Current** and write the complete new content in **Proposed Text**.
 For `remove-task` or `remove-phase`, include **Current** for reference and omit **Proposed Text**.
 
 **Task structure**: Read `task-design.md` before writing any proposed content. All task content — whether new tasks (`add-task`) or modifications to existing tasks (`update-task`, `add-to-task`) — must follow the canonical task template and field requirements defined there. This is the same template the planning agents used to create the plan.

--- a/agents/workflow-planning-review-traceability.md
+++ b/agents/workflow-planning-review-traceability.md
@@ -37,9 +37,9 @@ You receive file paths and context via the orchestrator's prompt:
 For each `settled` finding, the tracking file must contain the **exact content** that would be written to the plan if the fix is approved — the orchestrator renders small changes as diffs at the gate and holds whole content behind a view option, and what you write is what gets applied on approval. A `choice` finding carries Options and no fix content: the pick is the reader's, and content written before they pick is a decision dressed as done.
 
 - **Current**: Copy the existing content verbatim from the plan/task file. This shows the user exactly what's there now.
-- **Proposed**: Write the replacement content in full plan format. This is what will replace the current content if approved.
+- **Proposed Text**: Write the replacement content in full plan format. This is what will replace the current content if approved.
 
-For `add-task` or `add-phase`, omit **Current** and write the complete new content in **Proposed**.
+For `add-task` or `add-phase`, omit **Current** and write the complete new content in **Proposed Text**.
 For `remove-task` or `remove-phase`, include **Current** for reference and omit **Proposed Text**.
 
 **Task structure**: Read `task-design.md` before writing any proposed content. All task content — whether new tasks (`add-task`) or modifications to existing tasks (`update-task`, `add-to-task`) — must follow the canonical task template and field requirements defined there.

--- a/agents/workflow-planning-review-traceability.md
+++ b/agents/workflow-planning-review-traceability.md
@@ -34,13 +34,13 @@ You receive file paths and context via the orchestrator's prompt:
 
 ## Writing Full Fix Content
 
-For each finding, the tracking file must contain the **exact content** that would be written to the plan if the fix is approved. The orchestrator presents this content to the user as-is — what the user sees is what gets applied.
+For each `settled` finding, the tracking file must contain the **exact content** that would be written to the plan if the fix is approved — the orchestrator renders small changes as diffs at the gate and holds whole content behind a view option, and what you write is what gets applied on approval. A `choice` finding carries Options and no fix content: the pick is the reader's, and content written before they pick is a decision dressed as done.
 
 - **Current**: Copy the existing content verbatim from the plan/task file. This shows the user exactly what's there now.
 - **Proposed**: Write the replacement content in full plan format. This is what will replace the current content if approved.
 
 For `add-task` or `add-phase`, omit **Current** and write the complete new content in **Proposed**.
-For `remove-task` or `remove-phase`, include **Current** for reference and omit **Proposed**.
+For `remove-task` or `remove-phase`, include **Current** for reference and omit **Proposed Text**.
 
 **Task structure**: Read `task-design.md` before writing any proposed content. All task content — whether new tasks (`add-task`) or modifications to existing tasks (`update-task`, `add-to-task`) — must follow the canonical task template and field requirements defined there.
 
@@ -54,7 +54,7 @@ For `remove-task` or `remove-phase`, include **Current** for reference and omit 
 2. **Write only the tracking file** — do not modify the plan, tasks, or specification
 3. **No git writes** — do not commit or stage. Writing the tracking file is your only file write.
 4. **No user interaction** — return status to the orchestrator. The orchestrator handles presentation and approval.
-5. **Full fix content** — every finding must include complete Current/Proposed content in plan format. No summaries.
+5. **Full fix content on settled findings** — a `settled` finding includes complete Current/Proposed Text content in plan format; a `choice` carries Options and no fix content. No summaries on either.
 6. **Trace, don't invent** — if content can't be traced to the spec, flag it. Don't justify it.
 7. **Spec-grounded fixes** — proposed content must come from the specification. Do not hallucinate plan content.
 8. **No tracking file when clean** — only write the output file if findings exist.

--- a/agents/workflow-specification-review-claims.md
+++ b/agents/workflow-specification-review-claims.md
@@ -101,10 +101,10 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-claims-tracking-c{
 {The claim verbatim, the command, and its output. For Source defect: which source document and section carries the claim.}
 
 **Current**:
-{For Enhancement findings only — the existing specification content that will be modified. Omit for Gap/Ambiguity and Source defect findings.}
+{Move `settled` with existing content to correct — the specification content that will be modified. Omit where nothing existing is being replaced, and for `route`.}
 
 **Proposed Text**:
-{The exact replacement wording — Enhancement findings only. Leave blank for Source defect: the fix belongs to the source record.}
+{The exact replacement wording — Move `settled` only. Leave blank for `route`: the fix belongs to the source record.}
 
 **Resolution**: Pending
 **Notes**:

--- a/agents/workflow-specification-review-claims.md
+++ b/agents/workflow-specification-review-claims.md
@@ -40,9 +40,9 @@ Prioritise **load-bearing** claims — a decision, gate, scope boundary, or key 
    - **Holds** — measurement matches. No finding.
    - **Fails** — measurement contradicts the claim. Grep the source material for the same assertion:
      - Present in a source → category **Source defect**. The spec faithfully carries a defective source; the fix belongs to the source record, not the spec.
-     - Spec-only → category **Enhancement to existing topic**, Proposed Change = the corrected claim carrying its command and result.
+     - Spec-only → category **Enhancement to existing topic**, move `settled`, Proposed Text = the corrected claim carrying its command and result.
    - **Unreproducible** — no command you can construct checks it as written, or checking would mutate state → category **Gap/Ambiguity**: the claim must be restated measurably, sourced, or removed.
-5. **Write findings** to `.workflows/{work_unit}/specification/{topic}/review-claims-tracking-c{cycle-number}.md` using the tracking format, via the `.txt`-then-rename mechanism (see Output File Format). Every finding's Details quotes the claim, the command, and its output.
+5. **Write findings** to `.workflows/{work_unit}/specification/{topic}/review-claims-tracking-c{cycle-number}.md` using the tracking format, via the `.txt`-then-rename mechanism (see Output File Format). Every finding's Evidence quotes the claim, the command, and its output.
 
 ## Hard Rules
 
@@ -58,6 +58,20 @@ Prioritise **load-bearing** claims — a decision, gate, scope boundary, or key 
 8. **Never lose your findings** — when findings exist they must survive the run, and the tracking file is how they survive. Produce the tracking file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the findings in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
 9. **Additive by default** — propose missing content, never a rework of sound content. Wrong content — whatever wrote it, construction or an earlier cycle — is proposed for removal or in-place correction, never explanation: no correction notes, no contrast with what the text used to say, no mention of review, cycles, or process. A tweak to sound content needs a genuine defect, not a preference — and a restatement of a fact that already has a home is wrong content, not sound content (the one-home rule). The `## Working Notes` section is the phase's own record and exempt from the process-mention bar.
 
+## The Move
+
+Every finding names the **move** it owes the reader — what they have to do about it. The move, never the category, decides how the finding is presented.
+
+- **settled** — the record admits exactly one defensible answer. Write the **Proposal**: the call and what determined it. Most findings are this.
+- **choice** — real options exist and only the reader can pick between them. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
+- **route** — the answer belongs to a source document rather than to the specification. Every Source defect and Unsourced decision is this move. Write neither Proposal nor Proposed Text: the fix belongs to the source record.
+
+A call you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
+
+The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
+
+A measured falsehood is almost always **settled**: reality decided it. An unreproducible claim is settled too — restate it measurably, source it, or remove it, whichever the specification's own shape makes obvious. Reach for **choice** only where those three genuinely diverge and the pick changes what gets built.
+
 ## Output File Format
 
 Write to `.workflows/{work_unit}/specification/{topic}/review-claims-tracking-c{cycle-number}.md` — in two steps: write the content to the same path with a `.txt` extension using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Use this format:
@@ -71,16 +85,26 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-claims-tracking-c{
 
 **Source**: Tree measurement — `{command}`
 **Category**: Enhancement to existing topic | Gap/Ambiguity | Source defect
+**Move**: settled | choice | route
 **Affects**: {which section(s) of the specification}
 
-**Details**:
-{The claim verbatim, the command, its output, and the mismatch. For Source defect: which source document and section carries the claim.}
+**Problem**:
+{What the specification gets wrong about the system, in the terms the reader cares about — what it would have them believe, and what is actually true.}
+
+**Proposal**:
+{Move `settled` — the corrected claim and the measurement that determined it. Omit for `choice` and `route`.}
+
+**Options**:
+{Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled` and `route`.}
+
+**Evidence**:
+{The claim verbatim, the command, and its output. For Source defect: which source document and section carries the claim.}
 
 **Current**:
 {For Enhancement findings only — the existing specification content that will be modified. Omit for Gap/Ambiguity and Source defect findings.}
 
-**Proposed Change**:
-{The corrected claim carrying its command and result — Enhancement findings only. Leave blank for Source defect: the fix belongs to the source record.}
+**Proposed Text**:
+{The exact replacement wording — Enhancement findings only. Leave blank for Source defect: the fix belongs to the source record.}
 
 **Resolution**: Pending
 **Notes**:

--- a/agents/workflow-specification-review-gap-analysis.md
+++ b/agents/workflow-specification-review-gap-analysis.md
@@ -63,7 +63,7 @@ No source material — this phase looks inward only.
    - Open-decision markers — "Decision required", "TBD", "to be decided", or any marker parking an unmade decision in the artifact. A specification decides nothing and defers nothing; flag every marker as Critical, category **Unsourced decision** — the marker itself is the evidence that no validated decision stands behind the text, no source comparison needed. The orchestrator routes these back toward the source record — never propose spec text for them
 
    **Contradictions**
-   - Requirements that conflict with each other
+   - Requirements that conflict with each other — category **Contradiction**: the document supports two incompatible readings; quote both
    - Behaviors defined differently in different sections
    - Constraints that make other requirements impossible
 
@@ -132,7 +132,7 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-gap-analysis-track
 ### 1. {Brief Title}
 
 **Source**: Specification analysis
-**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Duplication | Unsourced decision
+**Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Contradiction | Duplication | Unsourced decision
 **Move**: settled | choice | route
 **Priority**: Critical | Important | Minor
 **Affects**: {which section(s) of the specification}
@@ -147,7 +147,7 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-gap-analysis-track
 {Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled` and `route`.}
 
 **Current**:
-{For findings that modify existing content (Enhancement, Duplication) — copy the existing specification content that will be modified. This enables diff presentation to the user. Omit for New topic, Gap/Ambiguity, and Unsourced decision findings.}
+{For findings that modify existing content (Enhancement, Duplication, Contradiction) — copy the existing specification content that will be modified; a Contradiction quotes the readings that collide. This enables diff presentation to the user. Omit for New topic, Gap/Ambiguity, and Unsourced decision findings.}
 
 **Proposed Text**:
 {The exact wording that lands in the specification — Move `settled` only. Leave blank permanently for Unsourced decision: the fix belongs to the source record}

--- a/agents/workflow-specification-review-gap-analysis.md
+++ b/agents/workflow-specification-review-gap-analysis.md
@@ -72,7 +72,7 @@ No source material — this phase looks inward only.
    - A count or summary restating a list or table that sits beside it
    - A cross-reference that justifies, compares, or notes consistency instead of pointing at a fact's home
 
-   Flag duplication even when the copies still agree — copies drift apart under later edits and return as contradictions. One finding per restated site: name the fact's home in Details, put the site's current content in Current, and propose replacing the restatement with a reference to the home (or deleting it, where a reference adds nothing).
+   Flag duplication even when the copies still agree — copies drift apart under later edits and return as contradictions. One finding per restated site: name the fact's home in Problem, put the site's current content in Current, and propose replacing the restatement with a reference to the home (or deleting it, where a reference adds nothing).
 
    **Edge Cases Within Scope**
    - For the behaviors specified, what happens at boundaries?
@@ -101,10 +101,24 @@ No source material — this phase looks inward only.
 3. **Don't expand scope** — look for gaps *within* what's specified, not suggesting features the product should have. A feature spec for "user login" doesn't need you to ask about password reset if it wasn't in scope.
 4. **No gold-plating** — only flag gaps that would actually impact implementation of what's specified.
 5. **Don't second-guess decisions** — the spec reflects validated decisions. Check for clarity and completeness, not re-open debates.
-6. **Never propose that the specification state its own pipeline position** — readiness for planning, incorporation status, or review-cycle counts. That state lives in the work unit's manifest; a Proposed Change may remove such a statement, never add one.
+6. **Never propose that the specification state its own pipeline position** — readiness for planning, incorporation status, or review-cycle counts. That state lives in the work unit's manifest; a Proposed Text may remove such a statement, never add one.
 7. **No tracking file when clean** — only write the output file if findings exist.
 8. **Never lose your findings** — when findings exist they must survive the run, and the tracking file is how they survive. Produce the tracking file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the findings in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
 9. **Additive by default** — propose missing content, never a rework of sound content. Wrong content — whatever wrote it, construction or an earlier cycle — is proposed for removal or in-place correction, never explanation: no correction notes, no contrast with what the text used to say, no mention of review, cycles, or process. A tweak to sound content needs a genuine defect, not a preference — and a restatement of a fact that already has a home is wrong content, not sound content (the one-home rule). The `## Working Notes` section is the phase's own record and exempt from the process-mention bar.
+
+## The Move
+
+Every finding names the **move** it owes the reader — what they have to do about it. The move, never the category, decides how the finding is presented.
+
+- **settled** — the record admits exactly one defensible answer. Write the **Proposal**: the call and what determined it. Most findings are this.
+- **choice** — real options exist and only the reader can pick between them. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
+- **route** — the answer belongs to a source document rather than to the specification. Every Source defect and Unsourced decision is this move. Write neither Proposal nor Proposed Text: the fix belongs to the source record.
+
+A call you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
+
+The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
+
+An ambiguity the specification's own decisions resolve is **settled** — say which decision resolves it. An ambiguity that survives the whole document is a **choice**: frame the ways it could go and take a stance.
 
 ## Output File Format
 
@@ -119,17 +133,24 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-gap-analysis-track
 
 **Source**: Specification analysis
 **Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Duplication | Unsourced decision
+**Move**: settled | choice | route
 **Priority**: Critical | Important | Minor
 **Affects**: {which section(s) of the specification}
 
-**Details**:
-{Explanation of what was found and why it matters}
+**Problem**:
+{What a builder reading this specification would get wrong, or be unable to decide, in the terms the reader cares about. Name the consequence, not the analysis that found it.}
+
+**Proposal**:
+{Move `settled` — what you would add or change, and what determined it. Omit for `choice` and `route`.}
+
+**Options**:
+{Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled` and `route`.}
 
 **Current**:
 {For findings that modify existing content (Enhancement, Duplication) — copy the existing specification content that will be modified. This enables diff presentation to the user. Omit for New topic, Gap/Ambiguity, and Unsourced decision findings.}
 
-**Proposed Change**:
-{What you would add or change in the specification — leave blank until discussed. Leave blank permanently for Unsourced decision: the fix belongs to the source record}
+**Proposed Text**:
+{The exact wording that lands in the specification — Move `settled` only. Leave blank permanently for Unsourced decision: the fix belongs to the source record}
 
 **Resolution**: Pending
 **Notes**:

--- a/agents/workflow-specification-review-gap-analysis.md
+++ b/agents/workflow-specification-review-gap-analysis.md
@@ -62,8 +62,8 @@ No source material — this phase looks inward only.
    - Implicit assumptions that aren't stated
    - Open-decision markers — "Decision required", "TBD", "to be decided", or any marker parking an unmade decision in the artifact. A specification decides nothing and defers nothing; flag every marker as Critical, category **Unsourced decision** — the marker itself is the evidence that no validated decision stands behind the text, no source comparison needed. The orchestrator routes these back toward the source record — never propose spec text for them
 
-   **Contradictions**
-   - Requirements that conflict with each other — category **Contradiction**: the document supports two incompatible readings; quote both
+   **Contradictions** — category **Contradiction**: the document supports two incompatible readings
+   - Requirements that conflict with each other
    - Behaviors defined differently in different sections
    - Constraints that make other requirements impossible
 
@@ -147,7 +147,7 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-gap-analysis-track
 {Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled` and `route`.}
 
 **Current**:
-{For findings that modify existing content (Enhancement, Duplication, Contradiction) — copy the existing specification content that will be modified; a Contradiction quotes the readings that collide. This enables diff presentation to the user. Omit for New topic, Gap/Ambiguity, and Unsourced decision findings.}
+{For findings that modify existing content (Enhancement, Duplication, Contradiction) — copy the existing specification content that will be modified. A Contradiction's Current holds only the passage being corrected; name the colliding reading in the Problem with its section. This enables diff presentation to the user. Omit for New topic, Gap/Ambiguity, and Unsourced decision findings.}
 
 **Proposed Text**:
 {The exact wording that lands in the specification — Move `settled` only. Leave blank permanently for Unsourced decision: the fix belongs to the source record}

--- a/agents/workflow-specification-review-input.md
+++ b/agents/workflow-specification-review-input.md
@@ -74,6 +74,20 @@ You receive via the orchestrator's prompt:
 8. **Never lose your findings** — when findings exist they must survive the run, and the tracking file is how they survive. Produce the tracking file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the findings in full in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.
 9. **Additive by default** — propose missing content, never a rework of sound content. Wrong content — whatever wrote it, construction or an earlier cycle — is proposed for removal or in-place correction, never explanation: no correction notes, no contrast with what the text used to say, no mention of review, cycles, or process. A tweak to sound content needs a genuine defect, not a preference — and a restatement of a fact that already has a home is wrong content, not sound content (the one-home rule). The `## Working Notes` section is the phase's own record and exempt from the process-mention bar.
 
+## The Move
+
+Every finding names the **move** it owes the reader — what they have to do about it. The move, never the category, decides how the finding is presented.
+
+- **settled** — the record admits exactly one defensible answer. Write the **Proposal**: the call and what determined it. Most findings are this.
+- **choice** — real options exist and only the reader can pick between them. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
+- **route** — the answer belongs to a source document rather than to the specification. Every Source defect and Unsourced decision is this move. Write neither Proposal nor Proposed Text: the fix belongs to the source record.
+
+A call you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
+
+The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
+
+Content a source decides but the specification missed is **settled** — the source made the call, and carrying it across is not a decision. A gap the sources never addressed is a **choice** wherever the ways to close it trade real things against each other, and settled only where the specification's own shape leaves one answer standing.
+
 ## Output File Format
 
 Write to `.workflows/{work_unit}/specification/{topic}/review-input-tracking-c{cycle-number}.md` — in two steps: write the content to the same path with a `.txt` extension using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Bash is for this rename only. Use this format:
@@ -87,16 +101,23 @@ Write to `.workflows/{work_unit}/specification/{topic}/review-input-tracking-c{c
 
 **Source**: {file/section reference where this came from, or "No source decides this" for Unsourced decision}
 **Category**: Enhancement to existing topic | New topic | Gap/Ambiguity | Unsourced decision
+**Move**: settled | choice | route
 **Affects**: {which section(s) of the specification}
 
-**Details**:
-{Explanation of what was found and why it matters}
+**Problem**:
+{What the specification would have built wrong, or leave unbuilt, in the terms the reader cares about. Name the consequence, not the comparison that found it.}
+
+**Proposal**:
+{Move `settled` — what you would add or change, and what determined it. Omit for `choice` and `route`.}
+
+**Options**:
+{Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled` and `route`.}
 
 **Current**:
 {For Enhancement findings only — copy the existing specification content in the affected section that will be modified. This enables diff presentation to the user. Omit for New topic, Gap/Ambiguity, and Unsourced decision findings.}
 
-**Proposed Change**:
-{What you would add or change in the specification — leave blank until discussed. Leave blank permanently for Unsourced decision: the fix belongs to the source record}
+**Proposed Text**:
+{The exact wording that lands in the specification — Move `settled` only. Leave blank permanently for Unsourced decision: the fix belongs to the source record}
 
 **Resolution**: Pending
 **Notes**:

--- a/skills/workflow-planning-process/references/invoke-review-integrity.md
+++ b/skills/workflow-planning-process/references/invoke-review-integrity.md
@@ -33,6 +33,6 @@ FINDINGS_COUNT: {N}
 ```
 
 - `clean`: plan meets structural quality standards. No findings to process.
-- `findings`: tracking file contains findings with full fix content for the orchestrator to present to the user.
+- `findings`: tracking file contains findings, each carrying its move — a `settled` finding with full fix content, a `choice` with options and no fix.
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/invoke-review-traceability.md
+++ b/skills/workflow-planning-process/references/invoke-review-traceability.md
@@ -34,6 +34,6 @@ FINDINGS_COUNT: {N}
 ```
 
 - `clean`: plan is a faithful, complete translation of the specification. No findings to process.
-- `findings`: tracking file contains findings with full fix content for the orchestrator to present to the user.
+- `findings`: tracking file contains findings, each carrying its move — a `settled` finding with full fix content, a `choice` with options and no fix.
 
 → Return to caller.

--- a/skills/workflow-planning-process/references/review-integrity.md
+++ b/skills/workflow-planning-process/references/review-integrity.md
@@ -85,6 +85,20 @@ Categorize each finding by severity:
 
 Tracking files are **never deleted** — pure markdown, no frontmatter; previous cycles' files persist as review history. The orchestrator records each file's gate state in the manifest (`tracking.{file stem}`: `in-progress` at dispatch, `complete` when all findings are processed).
 
+## The Move
+
+Every finding names the **move** it owes the reader — what they have to do about it. The move, never the category, decides how the finding is presented.
+
+- **settled** — the record admits exactly one defensible answer. Write the **Proposal**: the call and what determined it. Most findings are this.
+- **choice** — real options exist and only the reader can pick between them. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
+- Planning findings never route: the plan is the document under review, and its answers live in the specification or the record.
+
+A call you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
+
+The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
+
+A plan defect the specification or the plan's own conventions determine is **settled**. Where the plan could go two defensible ways — how to split a task, which phase owns a slice — it is a **choice**.
+
 **Format**:
 ```markdown
 # Review Tracking: {Topic Name} - Integrity
@@ -96,10 +110,17 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 **Severity**: Critical | Important | Minor
 **Plan Reference**: [Phase/task in plan]
 **Category**: [Which review criterion — e.g., "Task Template Compliance", "Vertical Slicing"]
+**Move**: settled | choice
 **Change Type**: [update-task | add-to-task | remove-from-task | add-task | remove-task | add-phase | remove-phase]
 
-**Details**:
-[What the issue is and why it matters for implementation]
+**Problem**:
+[What this would build wrong, or fail to build, in the terms the reader cares about. Name the consequence, not the criterion it failed.]
+
+**Proposal**:
+[Move `settled` — the fix and what determined it. Omit for `choice`.]
+
+**Options**:
+[Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled`.]
 
 **Current**:
 [The existing content as it appears in the plan — omit for add-task/add-phase]

--- a/skills/workflow-planning-process/references/review-integrity.md
+++ b/skills/workflow-planning-process/references/review-integrity.md
@@ -73,18 +73,6 @@ Read the plan end-to-end — carefully, as if you were about to implement it. Fo
 
 ---
 
-## Tracking File
-
-After completing the analysis, create a tracking file at `.workflows/{work_unit}/planning/{topic}/review-integrity-tracking-c{N}.md` (where N is the current review cycle).
-
-Categorize each finding by severity:
-
-- **Critical**: Would block implementation or cause incorrect behavior
-- **Important**: Would force implementer to guess or make design decisions
-- **Minor**: Polish or improvement that strengthens the plan
-
-Tracking files are **never deleted** — pure markdown, no frontmatter; previous cycles' files persist as review history. The orchestrator records each file's gate state in the manifest (`tracking.{file stem}`: `in-progress` at dispatch, `complete` when all findings are processed).
-
 ## The Move
 
 Every finding names the **move** it owes the reader — what they have to do about it. The move, never the category, decides how the finding is presented.
@@ -98,6 +86,18 @@ A call you cannot yourself stand behind is a **choice**, never a settled answer 
 The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
 
 A plan defect the specification or the plan's own conventions determine is **settled**. Where the plan could go two defensible ways — how to split a task, which phase owns a slice — it is a **choice**.
+
+## Tracking File
+
+After completing the analysis, create a tracking file at `.workflows/{work_unit}/planning/{topic}/review-integrity-tracking-c{N}.md` (where N is the current review cycle).
+
+Categorize each finding by severity:
+
+- **Critical**: Would block implementation or cause incorrect behavior
+- **Important**: Would force implementer to guess or make design decisions
+- **Minor**: Polish or improvement that strengthens the plan
+
+Tracking files are **never deleted** — pure markdown, no frontmatter; previous cycles' files persist as review history. The orchestrator records each file's gate state in the manifest (`tracking.{file stem}`: `in-progress` at dispatch, `complete` when all findings are processed).
 
 **Format**:
 ```markdown
@@ -125,8 +125,8 @@ A plan defect the specification or the plan's own conventions determine is **set
 **Current**:
 [The existing content as it appears in the plan — omit for add-task/add-phase]
 
-**Proposed**:
-[The replacement/new content in full plan format — omit for remove-task/remove-phase]
+**Proposed Text**:
+[The replacement/new content in full plan format — omit for remove-task/remove-phase. Older tracking files name this field **Proposed** — read both as the same field.]
 
 **Resolution**: Pending
 **Notes**:

--- a/skills/workflow-planning-process/references/review-integrity.md
+++ b/skills/workflow-planning-process/references/review-integrity.md
@@ -123,10 +123,10 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 [Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled`.]
 
 **Current**:
-[The existing content as it appears in the plan — omit for add-task/add-phase]
+[Move `settled` only — the existing content as it appears in the plan. Omit for add-task/add-phase, and always for `choice`: a choice carries no fix content.]
 
 **Proposed Text**:
-[The replacement/new content in full plan format — omit for remove-task/remove-phase. Older tracking files name this field **Proposed** — read both as the same field.]
+[Move `settled` only — the replacement/new content in full plan format. Omit for remove-task/remove-phase, and always for `choice`: a choice carries no fix content. Older tracking files name this field **Proposed** — read both as the same field.]
 
 **Resolution**: Pending
 **Notes**:

--- a/skills/workflow-planning-process/references/review-traceability.md
+++ b/skills/workflow-planning-process/references/review-traceability.md
@@ -63,6 +63,18 @@ After completing the analysis, create a tracking file at `.workflows/{work_unit}
 
 Tracking files are **never deleted** — pure markdown, no frontmatter; previous cycles' files persist as review history. The orchestrator records each file's gate state in the manifest (`tracking.{file stem}`: `in-progress` at dispatch, `complete` when all findings are processed).
 
+## The Move
+
+Every finding names the **move** it owes the reader — what they have to do about it. The move, never the Type, decides how the finding is presented.
+
+- **settled** — the record admits exactly one defensible answer. Write the **Proposal**: the fix and what determined it. Most traceability findings are this: the specification already decided, and carrying its decision into the plan is not a new decision.
+- **choice** — real options exist and only the reader can pick between them. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
+- Planning findings never route: the plan is the document under review, and its answers live in the specification or the record.
+
+A fix you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
+
+The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the plan's own wording read back at them.
+
 **Format**:
 ```markdown
 # Review Tracking: {Topic Name} - Traceability
@@ -74,10 +86,17 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 **Type**: Missing from plan | Hallucinated content | Incomplete coverage
 **Spec Reference**: [Section/decision in specification, or "N/A"]
 **Plan Reference**: [Phase/task in plan, or "N/A" for missing content]
+**Move**: settled | choice
 **Change Type**: [update-task | add-to-task | remove-from-task | add-task | remove-task | add-phase | remove-phase]
 
-**Details**:
-[What was found and why it matters]
+**Problem**:
+[What this would build wrong, or fail to build, in the terms the reader cares about. Name the consequence, not the trace that found it.]
+
+**Proposal**:
+[Move `settled` — the fix and what determined it. Omit for `choice`.]
+
+**Options**:
+[Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled`.]
 
 **Current**:
 [The existing content as it appears in the plan — omit for add-task/add-phase]

--- a/skills/workflow-planning-process/references/review-traceability.md
+++ b/skills/workflow-planning-process/references/review-traceability.md
@@ -99,10 +99,10 @@ Tracking files are **never deleted** — pure markdown, no frontmatter; previous
 [Move `choice` — one line per option, "(recommended)" on at most one. Omit for `settled`.]
 
 **Current**:
-[The existing content as it appears in the plan — omit for add-task/add-phase]
+[Move `settled` only — the existing content as it appears in the plan. Omit for add-task/add-phase, and always for `choice`: a choice carries no fix content.]
 
 **Proposed Text**:
-[The replacement/new content in full plan format — omit for remove-task/remove-phase. Older tracking files name this field **Proposed** — read both as the same field.]
+[Move `settled` only — the replacement/new content in full plan format. Omit for remove-task/remove-phase, and always for `choice`: a choice carries no fix content. Older tracking files name this field **Proposed** — read both as the same field.]
 
 **Resolution**: Pending
 **Notes**:

--- a/skills/workflow-planning-process/references/review-traceability.md
+++ b/skills/workflow-planning-process/references/review-traceability.md
@@ -57,12 +57,6 @@ Is everything in the plan actually from the specification? This is the anti-hall
 
 ---
 
-## Tracking File
-
-After completing the analysis, create a tracking file at `.workflows/{work_unit}/planning/{topic}/review-traceability-tracking-c{N}.md` (where N is the current review cycle).
-
-Tracking files are **never deleted** — pure markdown, no frontmatter; previous cycles' files persist as review history. The orchestrator records each file's gate state in the manifest (`tracking.{file stem}`: `in-progress` at dispatch, `complete` when all findings are processed).
-
 ## The Move
 
 Every finding names the **move** it owes the reader — what they have to do about it. The move, never the Type, decides how the finding is presented.
@@ -74,6 +68,12 @@ Every finding names the **move** it owes the reader — what they have to do abo
 A fix you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
 
 The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the plan's own wording read back at them.
+
+## Tracking File
+
+After completing the analysis, create a tracking file at `.workflows/{work_unit}/planning/{topic}/review-traceability-tracking-c{N}.md` (where N is the current review cycle).
+
+Tracking files are **never deleted** — pure markdown, no frontmatter; previous cycles' files persist as review history. The orchestrator records each file's gate state in the manifest (`tracking.{file stem}`: `in-progress` at dispatch, `complete` when all findings are processed).
 
 **Format**:
 ```markdown
@@ -101,8 +101,8 @@ The **Problem** is what is wrong in the terms the reader cares about — the pro
 **Current**:
 [The existing content as it appears in the plan — omit for add-task/add-phase]
 
-**Proposed**:
-[The replacement/new content in full plan format — omit for remove-task/remove-phase]
+**Proposed Text**:
+[The replacement/new content in full plan format — omit for remove-task/remove-phase. Older tracking files name this field **Proposed** — read both as the same field.]
 
 **Resolution**: Pending
 **Notes**:


### PR DESCRIPTION
Layer 2 of the finding-gate programme. Stacked on #988. Design log: #987.

Layer 1 gave the gate three shapes and had the loops classify anything arriving without a move. This teaches the five review agents to classify at the source, and to write findings the user would want to read.

## Problem, not Details

Every agent wrote a **Details** field — "explanation of what was found and why it matters", in the register of the analysis that found it. The gate had nothing else to lead with, so it led with artifact source instead.

**Problem** replaces it: what would get built wrong, or left unbuilt, in the terms the reader cares about. Never the comparison, measurement, or trace that surfaced it, and never the document's own wording read back.

## The move, at the source

Each finding names `settled`, `choice`, or `route`:

- **settled** carries **Proposal** — the call and what determined it
- **choice** carries **Options** — one line each, at most one `(recommended)` — and no Proposal
- **route** (specification only) carries neither; Source defect and Unsourced decision are always this

Each agent gets the bar its own material needs. A measured falsehood is settled because reality decided it. Source content the spec missed is settled because the source decided it. An ambiguity the document's own decisions resolve is settled — name the decision. Where the ways to close a gap trade real things against each other, it is a choice, framed with a stance.

`Proposed Change` / `Proposed` become **Proposed Text** on the specification side (the tracking format reads all three, so files already on disk still process); planning keeps `Proposed`.

## Gates

`npm test` 2350/2350 · `npm run typecheck` clean · conventions lint and prose corpus validation green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)