### PR TITLE
A resumed planning review settles its live findings before opening a cycle

### DIFF
--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -10,6 +10,8 @@ Two-part review dispatched to sub-agents. Traceability runs first — its approv
 
 ## A. Cycle Initialization
 
+Before opening a cycle, read `manifest get {work_unit}.planning.{topic} tracking` — an `in-progress` entry is a prior cycle's tracking file whose findings were never fully processed. Work each one now per **[process-review-findings.md](process-review-findings.md)** for that file; never open a fresh cycle over live findings.
+
 Check the `review_cycle` field in the manifest:
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.planning.{topic} review_cycle

--- a/skills/workflow-planning-process/references/plan-review.md
+++ b/skills/workflow-planning-process/references/plan-review.md
@@ -10,7 +10,7 @@ Two-part review dispatched to sub-agents. Traceability runs first — its approv
 
 ## A. Cycle Initialization
 
-Before opening a cycle, read `manifest get {work_unit}.planning.{topic} tracking` — an `in-progress` entry is a prior cycle's tracking file whose findings were never fully processed. Work each one now per **[process-review-findings.md](process-review-findings.md)** for that file; never open a fresh cycle over live findings.
+Before opening a cycle, read `manifest get {work_unit}.planning.{topic} tracking` — an `in-progress` entry is a prior cycle's tracking file whose findings were never fully processed — and list the `review-*-tracking-c*.md` files beside the plan: a tracking file on disk with no manifest entry is a crash orphan (the session died before recording it) — record it `in-progress`. Work each one now per **[process-review-findings.md](process-review-findings.md)** for that file, traceability before integrity — the order the review runs; never open a fresh cycle over live findings.
 
 Check the `review_cycle` field in the manifest:
 ```bash

--- a/skills/workflow-planning-process/references/process-review-findings.md
+++ b/skills/workflow-planning-process/references/process-review-findings.md
@@ -6,7 +6,7 @@
 
 Process findings from a review agent interactively with the user. The agent writes findings to a tracking file, each carrying the **move** it owes the user: `settled` (the record admits one defensible answer — the finding carries the fix and what determined it) or `choice` (real options exist and picking is the user's — the finding carries the options and proposes none). Read the tracking file and present each finding by its move.
 
-**Review type**: `{review_type:[traceability|integrity]}` — set by the calling context (C or D in plan-review.md).
+**Review type**: `{review_type:[traceability|integrity]}` — set by the calling context (C or D in plan-review.md); a caller that names a tracking file rather than a phase derives it, and the file's path, from the tracking stem (`review-traceability-…` → traceability, `review-integrity-…` → integrity). Such a caller enters with the file in hand — read it and proceed to **A. Summary**; the `STATUS` branches below serve the agent-return callers.
 
 **Commits in this file**: applying a finding writes through the format adapter; commit with `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "<message>" --plan {topic}` — it stages the work unit and the plan's declared storage.
 

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -16,7 +16,7 @@ Three-phase review of the specification. Phase 1 (Claims Verification) measures 
 
 ## A. Cycle Initialization
 
-Before opening a cycle, read `manifest get {work_unit}.specification.{topic} tracking` — an `in-progress` entry is a prior cycle's tracking file whose findings were never fully processed. Work each one now per **[process-review-findings.md](process-review-findings.md)** for that file; never open a fresh cycle over live findings.
+Before opening a cycle, read `manifest get {work_unit}.specification.{topic} tracking` — an `in-progress` entry is a prior cycle's tracking file whose findings were never fully processed — and list the `review-*-tracking-c*.md` files beside the specification: a tracking file on disk with no manifest entry is a crash orphan (the session died before recording it) — record it `in-progress`. Work each one now per **[process-review-findings.md](process-review-findings.md)** for that file, claims before input before gap analysis — the order the cycle runs; never open a fresh cycle over live findings.
 
 Check the `review_cycle` field via `engine manifest` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.specification.{topic} review_cycle`).
 


### PR DESCRIPTION
Layer 6 of the finding-gate programme (replaces #997, which GitHub's stack state wedged onto the wrong base — same branch, same commits). Stacked on #994; #995's cases sit on top. Design log: #987.

`planning-declines-and-picks-a-choice` failed twice from fresh worlds on the same inversion — precisely what the case was authored to catch. Resumed with an in-progress cycle-1 tracking file carrying two Pending findings, `plan-review.md` §A took its literal `review_cycle >= 1` branch: incremented to cycle 2 and ran a complete fresh review pass **before** the orphaned findings were ever presented. Only §F's checkpoint caught them — after a follow-up cycle had reviewed an unsettled plan.

`spec-review.md` has carried the guard at §A all along. Changes, mirrored on both sides where they apply:

- planning's §A opens on the same live-findings sweep, before any cycle-number branch
- both §A sweeps also see the **crash orphan** (a tracking file on disk with no manifest row — both phases record in-progress only after the agent writes, so the window is real), the clause planning's §F checkpoint has carried all along, now at the front door of both mirrors; multiple orphans work in the order the review runs
- the planning loop gains the file-named entry the sweep (and §F, which always routed this way) needs

Verification: `planning-declines-and-picks-a-choice` re-walked **PASS** (8/8, world PASS) against this fix; `planning-resumes-a-review-mid-walk` re-pinned to settle-first and re-walked **PASS** (11/11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)