### PR TITLE
Declining a proposed task says what it is

### DIFF
--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -377,7 +377,7 @@ function proposedTask(cwd, args) {
       menu('Approve this task?', [
         cmdOption('y', 'yes', 'Approve this task'),
         cmdOption('a', 'auto', 'Approve this and all remaining tasks automatically'),
-        cmdOption('s', 'skip', 'Skip this task'),
+        cmdOption('d', 'decline', 'Decline this task — it will not be built'),
         promptOption('Comment', hint),
       ]),
     ));

--- a/skills/workflow-implementation-process/references/ad-hoc-plan-changes.md
+++ b/skills/workflow-implementation-process/references/ad-hoc-plan-changes.md
@@ -162,9 +162,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 
 → Return to **F. Approve Each Task**.
 
-**If `skip`:**
+**If `decline`:**
 
-Record the skip: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} staging.ad-hoc-{n}.tasks.{k} skipped`.
+Record the decline: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} staging.ad-hoc-{n}.tasks.{k} skipped`.
 
 → Return to **F. Approve Each Task**.
 

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -266,9 +266,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 
 → Return to **F. Process Task**.
 
-**If `skip`:**
+**If `decline`:**
 
-Record the skip: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} staging.c{N}.tasks.{n} skipped`.
+Record the decline: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} staging.c{N}.tasks.{n} skipped`.
 
 → Return to **F. Process Task**.
 
@@ -286,12 +286,12 @@ Revise the task content in the staging file based on the user's feedback.
 
 → Proceed to **H. Create Tasks in Plan**.
 
-#### If all tasks were skipped
+#### If all tasks were declined
 
 Commit the cycle's decisions (the scoped commit covers the manifest):
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — tasks skipped"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — tasks declined"
 ```
 
 → Return to **[the skill](../SKILL.md)** for **Step 8**.

--- a/skills/workflow-implementation-process/references/consolidation-pass.md
+++ b/skills/workflow-implementation-process/references/consolidation-pass.md
@@ -210,9 +210,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 
 → Return to **D. Process Task**.
 
-**If `skip`:**
+**If `decline`:**
 
-Record the skip: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} staging.p{N}.tasks.{n} skipped`.
+Record the decline: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} staging.p{N}.tasks.{n} skipped`.
 
 → Return to **D. Process Task**.
 

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -80,7 +80,7 @@ A crash between the synthesizer's write and the init — initialise the cycle no
 
 #### If the latest cycle's remediation phase is in the plan and none of its tasks are in `completed_tasks`
 
-The session died between **F**'s plan write and **G**'s re-open (task ids land in `completed_tasks` when the re-opened implementation runs them, skips included). Re-enter **F** — the task writer is idempotent and completes any partial `task_map`, and its commit picks up whatever the crash left unstaged.
+The session died between **F**'s plan write and **G**'s re-open (task ids land in `completed_tasks` when the re-opened implementation runs them, declines included). Re-enter **F** — the task writer is idempotent and completes any partial `task_map`, and its commit picks up whatever the crash left unstaged.
 
 → Proceed to **F. Create Tasks in Plan**.
 
@@ -170,9 +170,9 @@ Record both in one write: `node .claude/skills/workflow-engine/scripts/engine.cj
 
 → Return to **D. Process Task**.
 
-**If `skip`:**
+**If `decline`:**
 
-Record the skip: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.review.{topic} staging.c{N}.tasks.{n} skipped`.
+Record the decline: `node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.review.{topic} staging.c{N}.tasks.{n} skipped`.
 
 → Return to **D. Process Task**.
 
@@ -190,7 +190,7 @@ Revise the task content in the staging file based on the user's feedback.
 
 → Proceed to **F. Create Tasks in Plan**.
 
-#### If all tasks were skipped
+#### If all tasks were declined
 
 Mark the review completed:
 
@@ -201,7 +201,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit
 Commit the cycle's decisions (the scoped commit covers the manifest):
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — tasks skipped"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — tasks declined"
 ```
 
 **Pipeline continuation** — Invoke `/workflow-bridge {work_unit} review`.

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1853,10 +1853,10 @@ describe('render proposed-task', () => {
       '· · · · · · · · · · · ·',
       '**`◆ Approve this task?`**',
       '',
-      '**`y/yes`**   → Approve this task',
-      '**`a/auto`**  → Approve this and all remaining tasks automatically',
-      '**`s/skip`**  → Skip this task',
-      '**Comment** → Tell me what to change',
+      '**`y/yes`**     → Approve this task',
+      '**`a/auto`**    → Approve this and all remaining tasks automatically',
+      '**`d/decline`** → Decline this task — it will not be built',
+      '**Comment**   → Tell me what to change',
       '',
     ].join('\n'));
   });


### PR DESCRIPTION
Closes the first banked item from the finding-gate programme (design log #987): the proposed-task gate's `s/skip` renamed to `d/decline`.

The distinction, per the ruling that kept the option: the finding gate's skip dismissed *a defect in a document* — deleted in #988, decline there is conversational-only. This gate declines *work to build* — scope and appetite, legitimately a keystroke. The word now says so: **`d/decline`** → Decline this task — it will not be built.

One engine option (the `proposed-task` surface serves all four callers), the four prose branches (analysis loop, consolidation pass, ad hoc plan changes, review synthesis loop), and the completion headings. The stored staging value stays `skipped` — shared manifest/worklist vocabulary, same glyph `Declined` already displays through on the review side; renaming stored state would cost a migration for zero behaviour.

Deliberately kept as skips, because they are: the cycle-level "skip analysis" and the commit-scope "exclude unexpected files".

`npm test` 2361/2361 · typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)