### PR TITLE
fix(spec-review): findings carry the spec's substance, not its section numbers

### DIFF
--- a/agents/workflow-specification-review-claims.md
+++ b/agents/workflow-specification-review-claims.md
@@ -68,7 +68,7 @@ Every finding names the **move** it owes the reader — what they have to do abo
 
 A call you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
 
-The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
+The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them. The reader has not read the specification and won't: **Affects** is the one home for section numbers, and a bare section reference never carries weight in Problem, Proposal, or Options — state the substance the section holds, so the finding reads whole on its own.
 
 A measured falsehood is almost always **settled**: reality decided it. An unreproducible claim is settled too — restate it measurably, source it, or remove it, whichever the specification's own shape makes obvious. Reach for **choice** only where those three genuinely diverge and the pick changes what gets built.
 

--- a/agents/workflow-specification-review-gap-analysis.md
+++ b/agents/workflow-specification-review-gap-analysis.md
@@ -116,7 +116,7 @@ Every finding names the **move** it owes the reader — what they have to do abo
 
 A call you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
 
-The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
+The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them. The reader has not read the specification and won't: **Affects** is the one home for section numbers, and a bare section reference never carries weight in Problem, Proposal, or Options — state the substance the section holds, so the finding reads whole on its own.
 
 An ambiguity the specification's own decisions resolve is **settled** — say which decision resolves it. An ambiguity that survives the whole document is a **choice**: frame the ways it could go and take a stance.
 

--- a/agents/workflow-specification-review-input.md
+++ b/agents/workflow-specification-review-input.md
@@ -84,7 +84,7 @@ Every finding names the **move** it owes the reader — what they have to do abo
 
 A call you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
 
-The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
+The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them. The reader has not read the specification and won't: **Affects** is the one home for section numbers, and a bare section reference never carries weight in Problem, Proposal, or Options — state the substance the section holds, so the finding reads whole on its own.
 
 Content a source decides but the specification missed is **settled** — the source made the call, and carrying it across is not a decision. A gap the sources never addressed is a **choice** wherever the ways to close it trade real things against each other, and settled only where the specification's own shape leaves one answer standing.
 

--- a/skills/workflow-specification-process/references/process-review-findings.md
+++ b/skills/workflow-specification-process/references/process-review-findings.md
@@ -109,6 +109,8 @@ Write the finding payload to `.workflows/.cache/{work_unit}/specification/{topic
 - `diff` and `content` — `settled` only; a `choice` proposes nothing and carries neither. Where a Current field is present: `diff` — `{"context_above": […], "current": […], "proposed": […], "context_below": […]}` with only the changed lines and 2 context lines each side (Proposed Text as the proposed lines). Where there is no Current and the Proposed Text is short — a sentence to a handful of lines — `diff` with `"current": []`, so the wording is visible at the gate. A whole proposed section: `content` — `{"label": "Proposed Text", "lines": […]}`, held for `v/view`, never rendered at the gate.
 - `apply_label`: `"Apply to the specification verbatim"` · `applied_label`: `"approved. Applied to specification."`
 
+The user decides from the presentation alone — they have not read the specification. Where the tracking file's Problem, Proposal, or Options lean on a section reference, replace it with the substance that section holds; the `meta` Affects row is the one place a section number belongs.
+
 Render, then emit each returned section verbatim at its marked instruction — the diff body as a ` ```diff ` fence:
 
 ```bash


### PR DESCRIPTION
## Problem

Live spec-review sessions present findings whose Problem prose and choice options argue in section numbers — "§7.2 deletes it, §9.4's two guards are re-pointed" — to a user who has not read the specification and isn't meant to. The § scaffolding makes a `choice` finding undecidable from the presentation alone, which is exactly the finding shape that must stand on its own (it stops even under `auto`).

## Fix

Two layers, matching where the § references leak in:

- **The three review agents** (`workflow-specification-review-{gap-analysis,claims,input}.md`) — the shared Problem paragraph in each agent's "The Move" section now states: the reader has not read the specification and won't; **Affects** is the one home for section numbers, and Problem/Proposal/Options state the substance the section holds so the finding reads whole on its own.
- **The presenter** (`workflow-specification-process/references/process-review-findings.md`) — the finding-payload guidance now translates at render time: where a tracking file's Problem, Proposal, or Options lean on a section reference, the substance replaces it. This covers tracking files already written under the old guidance.

The `meta` Affects row ("Affects: §2.1, §7.2, §9.4") is unchanged — a locator row is where section numbers belong.

Out of scope: planning's findings presenter shares the `problem` field but has no Affects meta row and plans are referenced by phase/task, not §; left untouched.

## Gates

- `npm test` — 2379 pass, 0 fail.
- `node tests/prose/run.cjs select --diff main` intersects 10 cases: bridge-hands-off-to-planning, spec-auto-applies-settled-stops-on-choice, spec-completes-the-cross-cutting, spec-discusses-and-declines-a-finding, spec-extracts-the-discussion, spec-measures-a-false-claim, spec-resolves-a-source-conflict, spec-review-routes-a-source-defect, spec-routes-a-gap-to-discussion, spec-routes-an-unsourced-decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)