### PR TITLE
blocked-plans(build-order): no menu row, tree cue, key line, unblock sub-view

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -813,6 +813,7 @@ No other verbs — never `→ Go to`, `→ Jump to`, `→ Skip to`, `→ Continu
 | `→ Proceed to **Step N**.` | Next step in the backbone |
 | `→ Proceed to **B. Section Name**.` | Next lettered section in a reference file |
 | `→ On return, proceed to **Step N**.` | Footer after a Load directive — applies when the loaded reference returns (see Load Directive Format) |
+| `→ On return, return to **A. Section Name**.` | The same footer with a backward target — the loaded reference completes, then flow re-enters an earlier section |
 
 
 #### Backward (within a file)

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -753,7 +753,7 @@ Load **[name.md](references/name.md)** and follow its instructions as written.
 Rules:
 - No arrow (`→`) before the Load line — it's the step's content, not a routing instruction
 - Bold the markdown link: `**[name.md](path)**`
-- `→ On return, proceed to` is the footer after a Load directive, separated by a blank line — the loaded reference runs to completion (its STOP gates and loops included) before the proceed applies. A bare `→ Proceed to` here reads as the immediate next action and overshoots the reference
+- `→ On return, proceed to` is the footer after a Load directive, separated by a blank line — the loaded reference runs to completion (its STOP gates and loops included) before the proceed applies. A bare `→ Proceed to` here reads as the immediate next action and overshoots the reference. A backward target takes `→ On return, return to **A. Section Name**.`
 - When a `**STOP.**` gate or a bold conditional sits between the Load directive and the routing line, the routing is keyed to the user's response or the branch, not the return — those use the bare `→ Proceed to`
 - The final step has no routing footer (it's terminal)
 - A footer governs only the reference's bare `→ Return to caller.` exits — never the branches the reference routes itself (see Navigation & Return Patterns → backbone escape). Where every exit routes to a named step, no branch is left for a footer to serve and naming one would name a step that never runs: the footer instead defers, `→ On return, proceed as the reference directed.` A step is never left with no footer at all — silence reads as the end of the step, and the next heading gets treated as the fall-through
@@ -813,7 +813,6 @@ No other verbs — never `→ Go to`, `→ Jump to`, `→ Skip to`, `→ Continu
 | `→ Proceed to **Step N**.` | Next step in the backbone |
 | `→ Proceed to **B. Section Name**.` | Next lettered section in a reference file |
 | `→ On return, proceed to **Step N**.` | Footer after a Load directive — applies when the loaded reference returns (see Load Directive Format) |
-| `→ On return, return to **A. Section Name**.` | The same footer with a backward target — the loaded reference completes, then flow re-enters an earlier section |
 
 
 #### Backward (within a file)
@@ -821,6 +820,7 @@ No other verbs — never `→ Go to`, `→ Jump to`, `→ Skip to`, `→ Continu
 | Instruction | Context |
 |---|---|
 | `→ Return to **A. Section Name**.` | Earlier lettered section in the same reference file |
+| `→ On return, return to **A. Section Name**.` | Footer after a Load directive with a backward target — the loaded reference completes, then flow re-enters an earlier section. The bare `→ Return to` after a Load remains valid; the footer form makes the after-the-reference timing explicit |
 
 Internal routing (both forward and backward) uses bold text, never links.
 

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -51,7 +51,17 @@ Match the user's input to its `ACTIONS` entry by `key` — a number, or a comman
 
 #### If `action` is `resequence_build_order`
 
-The user judges the current order wrong — re-derive it wholesale.
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+**`□ Sequence Build Order`**
+```
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Re-deriving the build order across the specification topics.
+```
 
 → Load **[sequence-build-order.md](../../workflow-shared/references/sequence-build-order.md)** with work_unit = `{work_unit}`.
 

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -49,6 +49,12 @@ Match the user's input to its `ACTIONS` entry by `key` — a number, or a comman
 
 → Proceed to **G. Unblock Plan**.
 
+#### If `action` is `resequence_build_order`
+
+The user judges the current order wrong — re-derive it wholesale. Load **[sequence-build-order.md](../../workflow-shared/references/sequence-build-order.md)** with work_unit = `{work_unit}`.
+
+→ On return, return to **A. State Display and Menu**.
+
 #### If `action` is `resume_completed`
 
 → Proceed to **D. Resume Completed**.

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -28,7 +28,7 @@ node .claude/skills/workflow-continue-epic/scripts/gateway.cjs view {work_unit} 
 
 The output is one snapshot in four demarcated sections:
 
-- **DATA** — reasoning surface: state flags, `phase_counts` (in-progress / proposed / total per phase), and the `ACTIONS` table — one line per menu key, `key  action  topic  → route`, with `(recommended)` / `(blocked: …)` / `(in session: …)` markers. Reason from it; never display or restate it.
+- **DATA** — reasoning surface: state flags, `phase_counts` (in-progress / proposed / total per phase), and the `ACTIONS` table — one line per menu key, `key  action  topic  → route`, with `(recommended)` / `(in session: …)` markers. Reason from it; never display or restate it.
 - **TITLE** — the view's chrome heading. Emit verbatim as markdown, directly above the display.
 - **DISPLAY** — the dashboard and key. Emit verbatim as a code block. Never redraw, reflow, or trim it.
 - **MENU** — the selection menu. Emit verbatim as markdown (not a code block).
@@ -51,7 +51,9 @@ Match the user's input to its `ACTIONS` entry by `key` — a number, or a comman
 
 #### If `action` is `resequence_build_order`
 
-The user judges the current order wrong — re-derive it wholesale. Load **[sequence-build-order.md](../../workflow-shared/references/sequence-build-order.md)** with work_unit = `{work_unit}`.
+The user judges the current order wrong — re-derive it wholesale.
+
+→ Load **[sequence-build-order.md](../../workflow-shared/references/sequence-build-order.md)** with work_unit = `{work_unit}`.
 
 → On return, return to **A. State Display and Menu**.
 
@@ -173,18 +175,10 @@ Emit the TITLE section (markdown), then the DISPLAY section, then the MENU secti
 
 #### If user chose a numbered topic
 
-Store the selected entry's `phase` and `topic`. Confirm with the user:
+Store the selected entry's `phase` and `topic`. Fetch and emit the confirm's `MENU: cancel gate` section:
 
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-Cancelling **{topic:(titlecase)}** in {phase} will mark it as cancelled — it can be reactivated later.
-
-**`◆ Cancel it?`**
-
-**`y/yes`** → Confirm cancellation
-**`n/no`**  → Return to menu
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render cancel-gate {work_unit}.{phase}.{topic}
 ```
 
 **STOP.** Wait for user response.
@@ -195,7 +189,7 @@ Cancelling **{topic:(titlecase)}** in {phase} will mark it as cancelled — it c
 
 **If user chose `yes`:**
 
-Run the cancel transaction — one command stashes the current status, marks the item cancelled, drops the topic's discovery-map order, removes its knowledge-base chunks, and commits:
+Run the cancel transaction — one command stashes the current status, marks the item cancelled, stashes the topic's execution order (a research/discussion cancel stashes the discovery map's, a specification cancel the build order's), removes its knowledge-base chunks, and commits:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs topic cancel {work_unit} {phase} {topic}
@@ -243,7 +237,7 @@ Emit the TITLE section (markdown), then the DISPLAY section, then the MENU secti
 
 #### If user chose a numbered topic
 
-Store the selected entry's `phase` and `topic`. Run the reactivate transaction — one command restores the stashed status, removes `previous_status`, re-indexes the artifact into the knowledge base when the restored status is `completed` in an indexed phase (research / discussion / investigation / specification), and commits:
+Store the selected entry's `phase` and `topic`. Run the reactivate transaction — one command restores the stashed status and execution order (a build-order number returns only while no live topic holds it — otherwise the next sequencing pass seats the topic), removes `previous_status`, re-indexes the artifact into the knowledge base when the restored status is `completed` in an indexed phase (research / discussion / investigation / specification), and commits:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs topic reactivate {work_unit} {phase} {topic}

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -45,47 +45,9 @@ Emit the TITLE section (markdown), then the DISPLAY section, then the MENU secti
 
 Match the user's input to its `ACTIONS` entry by `key` — a number, or a command option's letter / long form. Every decision below reads the entry's `action` value, never its label text.
 
-#### If the selected entry carries a `(blocked: …)` marker
+#### If `action` is `unblock_plan`
 
-The item is shown for visibility but not selectable. Explain what blocks it, using the marker's `{dep}:{task} — {reason}` detail:
-
-> *Output the next fenced block as a code block:*
-
-```
-"{topic:(titlecase)}" cannot start implementation yet.
-
-Blocking dependencies:
-  • {dep_topic}:{internal_id} — {reason}
-  • {dep_topic} — {reason}
-```
-
-> *Output the next fenced block as markdown (not a code block):*
-
-```
-· · · · · · · · · · · ·
-**`◆ Unblock a dependency?`**
-
-**`u/unblock`** → Mark a dependency as satisfied externally
-**`b/back`**    → Return to menu
-```
-
-**STOP.** Wait for user response.
-
-**If user chose `unblock`:**
-
-Ask which dependency to mark as satisfied. Update via `engine manifest`:
-
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} external_dependencies.{dep_topic}.state satisfied_externally
-```
-
-Commit the change.
-
-→ Return to **A. State Display and Menu**.
-
-**If user chose `back`:**
-
-→ Return to **A. State Display and Menu**.
+→ Proceed to **G. Unblock Plan**.
 
 #### If `action` is `resume_completed`
 
@@ -119,7 +81,7 @@ node .claude/skills/workflow-continue-epic/scripts/gateway.cjs in-session-gate {
 
 Continue with the **Hard gate check** below.
 
-**Hard gate check** — specification reads the settled record; this refusal comes before the soft gate. Read `phase_counts` from DATA. (Blocked specs never reach here — the menu carries no row for them; the display tree shows their `blocked` cue.)
+**Hard gate check** — specification reads the settled record; this refusal comes before the soft gate. Read `phase_counts` from DATA. (Blocked items never reach here — a blocked spec or a dep-blocked plan carries no menu row; the display tree shows the `blocked` cue and the ⚑ list carries the detail.)
 
 **If `action` is `analyze_discussions` and `phase_counts` shows discussion items in-progress and no specification items exist:**
 
@@ -286,5 +248,35 @@ Fetch and emit the receipt — the `DISPLAY: kb warning` advisory (when carried)
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.{phase}.{topic} --verb reactivate [--warn]
 ```
+
+→ Return to **A. State Display and Menu**.
+
+---
+
+## G. Unblock Plan
+
+A dep-blocked plan carries no implementation row — this is its escape hatch. Render the blocked-plans list and pick menu:
+
+```bash
+node .claude/skills/workflow-continue-epic/scripts/gateway.cjs unblock-menu {work_unit}
+```
+
+Emit the TITLE section (markdown), then the DISPLAY section, then the MENU section. Match the user's input to its `ACTIONS` entry by `key`.
+
+**STOP.** Wait for user response.
+
+#### If user chose `back`
+
+→ Return to **A. State Display and Menu**.
+
+#### If user chose a numbered dependency
+
+Store the selected entry's `topic` (the plan) and its `(dep: …)` value (the dependency to mark). Record the user's call — the dependency is satisfied outside the workflow:
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} external_dependencies.{dep}.state satisfied_externally
+```
+
+Commit: `impl({work_unit}): mark {dep} dependency as satisfied externally`
 
 → Return to **A. State Display and Menu**.

--- a/skills/workflow-continue-epic/scripts/gateway.cjs
+++ b/skills/workflow-continue-epic/scripts/gateway.cjs
@@ -237,7 +237,6 @@ function view(workUnit, newArrivalsJson) {
   for (const k of menu.keys) {
     let line = `  ${k.key}  ${k.action}  ${k.topic || '—'}  → ${k.route || '(internal)'}`;
     if (k.recommended) line += '  (recommended)';
-    if (k.blocked) line += `  (blocked: ${(k.deps_blocking || []).map(b => b.topic + (b.internal_id ? ':' + b.internal_id : '') + ' — ' + b.reason).join('; ')})`;
     if (k.in_session) line += `  (in session: last active ${engine.presence.fmtAge(k.session_age || 0)} ago)`;
     dataLines.push(line);
   }
@@ -274,7 +273,7 @@ function inSessionGate(workUnit, key) {
   return engine.project.epicInSessionGate(entry);
 }
 
-// One selection sub-view (sections D–F): the keys table as DATA, the view's
+// One selection sub-view (sections D–G): the keys table as DATA, the view's
 // heading as TITLE, the grouped list as DISPLAY, the pick menu as MENU.
 /** @param {string} workUnit @param {(name: string, detail: object) => {keys: object[], title: string, display: string, rendered: string}} projection */
 function subView(workUnit, projection) {

--- a/skills/workflow-continue-epic/scripts/gateway.cjs
+++ b/skills/workflow-continue-epic/scripts/gateway.cjs
@@ -6,12 +6,13 @@
 // engine answers the skill's flow needs and sections the output.
 //
 //   gateway.cjs               → thin index dump, all active epics (head insert)
-//   gateway.cjs {work_unit}   → scoped state dump, one epic (Steps 5–7, bridge)
+//   gateway.cjs {work_unit}   → scoped state dump, one epic (Steps 5–8, bridge)
 //   gateway.cjs view {work_unit} [new_arrivals_json]
-//                               → DATA + DISPLAY + MENU snapshot (Step 8)
+//                               → DATA + DISPLAY + MENU snapshot (Step 9)
 //   gateway.cjs completed-menu {work_unit}   → Resume Completed sub-view (D)
 //   gateway.cjs cancel-menu {work_unit}      → Cancel Topic sub-view (E)
 //   gateway.cjs reactivate-menu {work_unit}  → Reactivate Topic sub-view (F)
+//   gateway.cjs unblock-menu {work_unit}     → Unblock Plan sub-view (G)
 //
 // Those calls are the whole legal surface: a verb without its work unit, an
 // unknown verb, or excess arguments is a usage error (stderr, exit 1) — never
@@ -288,7 +289,9 @@ function subView(workUnit, projection) {
   const dataLines = [`work_unit: ${e.name}`];
   dataLines.push('ACTIONS (key  action  topic  phase  → route):');
   for (const k of view.keys) {
-    dataLines.push(`  ${k.key}  ${k.action}  ${k.topic || '—'}  ${k.phase || '—'}  → ${k.route || '(internal)'}`);
+    let line = `  ${k.key}  ${k.action}  ${k.topic || '—'}  ${k.phase || '—'}  → ${k.route || '(internal)'}`;
+    if (k.dep) line += `  (dep: ${k.dep})`;
+    dataLines.push(line);
   }
 
   return [
@@ -299,7 +302,7 @@ function subView(workUnit, projection) {
   ].join('\n');
 }
 
-const USAGE = 'Usage: gateway.cjs | gateway.cjs {work_unit} | gateway.cjs view {work_unit} [new_arrivals_json] | gateway.cjs (completed-menu|cancel-menu|reactivate-menu) {work_unit}';
+const USAGE = 'Usage: gateway.cjs | gateway.cjs {work_unit} | gateway.cjs view {work_unit} [new_arrivals_json] | gateway.cjs (completed-menu|cancel-menu|reactivate-menu|unblock-menu) {work_unit}';
 
 /** Reject the call: usage to stderr, exit 1. @param {string} message @returns {string} */
 function usageError(message) {
@@ -326,6 +329,7 @@ if (require.main === module) {
     'completed-menu': subViewHandler('completed-menu', (name, d) => engine.project.epicCompletedMenu(name, d)),
     'cancel-menu': subViewHandler('cancel-menu', (name, d) => engine.project.epicCancelMenu(d)),
     'reactivate-menu': subViewHandler('reactivate-menu', (name, d) => engine.project.epicReactivateMenu(d)),
+    'unblock-menu': subViewHandler('unblock-menu', (name, d) => engine.project.epicUnblockMenu(d)),
     'in-session-gate': (workUnit, key, ...rest) => (!workUnit || !key || rest.length > 0
       ? usageError('in-session-gate takes a work unit and a menu key')
       : inSessionGate(workUnit, key)),

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -279,6 +279,7 @@ engine render phase-tree <wu>.planning.<topic> --file <payload> [--approve]     
 engine render phase-completed <wu> --phase <phase> [--paths]      # one-line phase-completed display; --paths appends the derived spec/plan artifact paths (scoping's conclusion)
 engine render early-completion-gate <wu>                          # bridge gate: proceed to review / complete without review
 engine render revisit-gate <wu> --prev <phase> --next <phase>     # bridge gate: proceed to next / revisit an earlier phase
+engine render cancel-gate <wu>.<phase>.<topic>   # epic menu's bare cancel confirm — statement + y/n; the cascade case renders cancel-cascade-gate instead
 engine render epic-all-done-gate <wu>                             # bridge gate: mark epic completed / return to menu
 engine render epic-soft-gate <wu> --action <action> [--topic <topic>]   # epic menu's advisory phase gate — empty on pass; planning/implementation rows read the build order, discovery-side rows count; an unknown action refuses; an unknown or unordered topic passes silently
 engine render phase-note <wu>.<phase>.<topic> --verb <Word> [--noun <word>]   # entry one-liner: "{Word} {noun|phase}: {Topic}"

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -279,7 +279,7 @@ engine render phase-tree <wu>.planning.<topic> --file <payload> [--approve]     
 engine render phase-completed <wu> --phase <phase> [--paths]      # one-line phase-completed display; --paths appends the derived spec/plan artifact paths (scoping's conclusion)
 engine render early-completion-gate <wu>                          # bridge gate: proceed to review / complete without review
 engine render revisit-gate <wu> --prev <phase> --next <phase>     # bridge gate: proceed to next / revisit an earlier phase
-engine render cancel-gate <wu>.<phase>.<topic>   # epic menu's bare cancel confirm — statement + y/n; the cascade case renders cancel-cascade-gate instead
+engine render cancel-gate <wu.phase.topic>   # epic menu's bare cancel confirm — statement + y/n; the cascade case renders cancel-cascade-gate instead
 engine render epic-all-done-gate <wu>                             # bridge gate: mark epic completed / return to menu
 engine render epic-soft-gate <wu> --action <action> [--topic <topic>]   # epic menu's advisory phase gate — empty on pass; planning/implementation rows read the build order, discovery-side rows count; an unknown action refuses; an unknown or unordered topic passes silently
 engine render phase-note <wu>.<phase>.<topic> --verb <Word> [--noun <word>]   # entry one-liner: "{Word} {noun|phase}: {Topic}"

--- a/skills/workflow-engine/references/library-and-gateway.md
+++ b/skills/workflow-engine/references/library-and-gateway.md
@@ -88,6 +88,7 @@ engine.project.epicMenu(wu, detail)               // → { keys, rendered } — 
 engine.project.epicCompletedMenu(wu, detail)      // → { keys, title, display, rendered } — Completed Topics resume sub-view
 engine.project.epicCancelMenu(detail)             // → { keys, title, display, rendered } — Cancellable Topics pick menu
 engine.project.epicReactivateMenu(detail)         // → { keys, title, display, rendered } — Cancelled Topics reactivate menu
+engine.project.epicUnblockMenu(detail)            // → { keys, title, display, rendered } — Blocked Plans unblock menu, one row per blocking dependency (`dep` on the key)
 engine.project.discoveryMapView(wu, map)          // → Discovery Map display block (box + tier header + rows)
 engine.project.discoverySynthesisView(wu, map, proposed) // → harvest proposal block (proposed set over the existing map)
 engine.project.discussionMap(topic, manifest)     // → Discussion Map display block

--- a/skills/workflow-engine/scripts/domain/epic-detail.cjs
+++ b/skills/workflow-engine/scripts/domain/epic-detail.cjs
@@ -242,12 +242,16 @@ function epicDetail(cwd, manifest) {
         }
       }
 
-      // Enrich planning items with format and dependency data
+      // Enrich planning items with format and dependency data. Terminal
+      // items get no dep computation — a cancelled plan must never carry
+      // the blocked cue, surface in the ⚑ list, or take an unblock write.
       if (phase === 'planning') {
         if (item.format) entry.format = item.format;
-        const { deps_satisfied, deps_blocking } = resolveDeps(manifest, item);
-        entry.deps_satisfied = deps_satisfied;
-        if (deps_blocking.length > 0) entry.deps_blocking = deps_blocking;
+        if (!TERMINAL_STATUSES.includes(item.status || '')) {
+          const { deps_satisfied, deps_blocking } = resolveDeps(manifest, item);
+          entry.deps_satisfied = deps_satisfied;
+          if (deps_blocking.length > 0) entry.deps_blocking = deps_blocking;
+        }
       }
 
       // Enrich implementation items with progress data

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -152,9 +152,10 @@ function displayOrder(phase, items) {
 /** Build the tree nodes for one build/flat phase — a completed item with a live reconcile flag carries the `· input moved` cue. @param {string} phase @param {PhaseEntry[]} items */
 function phaseNodes(phase, items) {
   return displayOrder(phase, items).map((item) => {
+    const depBlocked = Array.isArray(item.deps_blocking) && item.deps_blocking.length > 0;
     const tagText = item.status === 'completed' && item.reconcile_needed !== undefined
       ? 'completed · input moved'
-      : (item.blocked_by !== undefined ? `${item.status} · blocked` : item.status);
+      : (item.blocked_by !== undefined || depBlocked ? `${item.status} · blocked` : item.status);
     const head = title({ label: titlecase(item.name) });
     // The plan format rides inside the tag rather than after it: anything
     // appended past the tag column would break the alignment for every row.
@@ -398,6 +399,10 @@ const CUE_BLOCKED =
   '    blocked — a source discussion is back in-progress; re-conclude\n'
   + '              it and the item returns to the menu';
 
+const CUE_PLAN_BLOCKED =
+  '    blocked — implementation waits on another plan; the ⚑ list\n'
+  + '              names the dependency, u/unblock is the override';
+
 /**
  * Section B — the Key block, showing only categories present in the display
  * whose vocabulary the rows don't spell out themselves: phase-item status
@@ -427,6 +432,7 @@ function epicKey(detail) {
   const cueLines = [];
   if (anyFlagged) cueLines.push(CUE_RECONCILE);
   if (specBlockedAny) cueLines.push(CUE_BLOCKED);
+  if (anyBlocked) cueLines.push(CUE_PLAN_BLOCKED);
   if (cueLines.length > 0) blocks.push('  Cue:\n' + cueLines.join('\n'));
   if (anyBlocked) blocks.push(KEY_BLOCKING);
   if (blocks.length === 0) return '';
@@ -480,9 +486,6 @@ function startVerbLabel(n, srcFlagged) {
   const t = titlecase(n.name);
   const cue = srcFlagged ? ' · input moved' : '';
   if (n.action === 'start_implementation') {
-    if (n.blocked) {
-      return `Start implementation of "${t}" — blocked by ${(n.deps_blocking || []).map(depRef).join(', ')}${cue}`;
-    }
     return `Start implementation of "${t}" — *${n.label}*${cue}`;
   }
   const phase = ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (n.action)];
@@ -520,6 +523,10 @@ function startEntries(workUnit, detail, phase) {
     const srcPhase = EPIC_PIPELINE[EPIC_PIPELINE.indexOf(phase) - 1];
     const srcItem = srcPhase ? (detail.phases[srcPhase] || []).find((i) => i.name === n.name) : undefined;
     const srcFlagged = srcItem !== undefined && srcItem.reconcile_needed !== undefined;
+    // A dep-blocked implementation start is not actionable — no menu row;
+    // the ⚑ plans-not-ready block and the tree cue carry its blocked state,
+    // and the u/unblock command option is the escape hatch.
+    if (n.blocked) continue;
     /** @type {MenuKey} */
     const entry = {
       key: '',
@@ -529,10 +536,6 @@ function startEntries(workUnit, detail, phase) {
       label: startVerbLabel(n, srcFlagged),
       ...(srcFlagged ? { input_moved: true } : {}),
     };
-    if (n.blocked) {
-      entry.blocked = true;
-      entry.deps_blocking = n.deps_blocking;
-    }
     out.push(entry);
   }
   return out;
@@ -592,6 +595,11 @@ function commandOptions(workUnit, detail, hasMap) {
   }
   if (detail.cancelled.length > 0) {
     opts.push({ key: 'e', word: 'reactivate', action: 'reactivate_topic', topic: null, route: null, label: 'Reactivate a cancelled topic' });
+  }
+  const anyPlanBlocked = (detail.phases.planning || [])
+    .some((p) => Array.isArray(p.deps_blocking) && p.deps_blocking.length > 0);
+  if (anyPlanBlocked) {
+    opts.push({ key: 'u', word: 'unblock', action: 'unblock_plan', topic: null, route: null, label: 'Unblock a plan — mark a dependency as satisfied externally' });
   }
   return opts;
 }
@@ -805,6 +813,7 @@ function epicInSessionGate(entry) {
  * @property {string|null} phase
  * @property {string|null} route      skill invocation, or null when the flow continues internally
  * @property {string} label
+ * @property {string} [dep]           unblock rows — the dependency topic to mark satisfied
  */
 
 /**
@@ -814,6 +823,7 @@ function epicInSessionGate(entry) {
  * @property {string} row     display line (unindented; the branch glyph and `{key}. ` are prefixed)
  * @property {string} label   pick-menu option label
  * @property {string|null} route
+ * @property {string} [dep]   unblock rows — the dependency topic to mark satisfied
  */
 
 /** The back option every sub-view menu closes with. @returns {SubViewKey} */
@@ -842,7 +852,7 @@ function selectionSubView(title, empty, question, action, rows) {
   let phase = null;
   rows.forEach((r, i) => {
     const key = String(i + 1);
-    keys.push({ key, action, topic: r.topic, phase: r.phase, route: r.route, label: r.label });
+    keys.push({ key, action, topic: r.topic, phase: r.phase, route: r.route, label: r.label, ...(r.dep ? { dep: r.dep } : {}) });
     if (r.phase !== phase) {
       if (displayLines.length) displayLines.push('');
       displayLines.push(titlecase(r.phase));
@@ -918,6 +928,32 @@ function epicCancelMenu(detail) {
 }
 
 /**
+ * Section G — the blocked-plans list and pick menu, one row per blocking
+ * dependency (a plan with two blockers gets two rows). The `topic` slot
+ * carries the plan, the `dep` field the dependency topic to mark satisfied.
+ * No routes — the flow runs the manifest write.
+ * @param {EpicDetail} detail
+ * @returns {{keys: SubViewKey[], title: string, display: string, rendered: string}}
+ */
+function epicUnblockMenu(detail) {
+  /** @type {(SubViewRow & {dep?: string})[]} */
+  const rows = [];
+  for (const item of detail.phases.planning || []) {
+    for (const dep of item.deps_blocking || []) {
+      rows.push({
+        phase: 'planning',
+        topic: item.name,
+        dep: dep.topic,
+        row: `${title({ label: titlecase(item.name) })} — blocked by ${depRef(dep)} (${dep.reason})`,
+        label: `Unblock "${titlecase(item.name)}" — *mark ${depRef(dep)} satisfied externally*`,
+        route: null,
+      });
+    }
+  }
+  return selectionSubView('Blocked Plans', 'No blocked plans.', 'Which dependency has been satisfied?', 'unblock', rows);
+}
+
+/**
  * Section F — the Cancelled Topics list and pick menu, each row carrying the
  * stashed `previous_status`. No routes — the flow runs the reactivate
  * transaction.
@@ -938,4 +974,4 @@ function epicReactivateMenu(detail) {
   return selectionSubView('Cancelled Topics', 'No cancelled topics.', 'Which topic would you like to reactivate?', 'reactivate', rows);
 }
 
-module.exports = { epicDashboard, epicKey, epicMenu, epicInSessionGate, epicCompletedMenu, epicCancelMenu, epicReactivateMenu, SOFT_GATE_ACTIONS };
+module.exports = { epicDashboard, epicKey, epicMenu, epicInSessionGate, epicCompletedMenu, epicCancelMenu, epicReactivateMenu, epicUnblockMenu, SOFT_GATE_ACTIONS };

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -391,16 +391,19 @@ const KEY_BLOCKING =
   + '    blocked by {plan}        — dependency unresolved';
 
 const CUE_RECONCILE =
-  '    input moved — an upstream artifact was revised since this item\n'
-  + '                  completed; the item\'s entry flow reconciles it';
+  '    input moved             — an upstream artifact was revised since\n'
+  + '                              this item completed; the item\'s entry\n'
+  + '                              flow reconciles it';
 
 const CUE_BLOCKED =
-  '    blocked (specification) — a source discussion is back in-progress;\n'
-  + '              re-conclude it and the item returns to the menu';
+  '    blocked (specification) — a source discussion is back\n'
+  + '                              in-progress; re-conclude it and the\n'
+  + '                              item returns to the menu';
 
 const CUE_PLAN_BLOCKED =
-  '    blocked (planning) — implementation waits on another plan; the\n'
-  + '              ⚑ list names the dependency, u/unblock is the override';
+  '    blocked (planning)      — implementation waits on another plan;\n'
+  + '                              the ⚑ list names the dependency,\n'
+  + '                              u/unblock is the override';
 
 /**
  * Section B — the Key block, showing only categories present in the display
@@ -598,7 +601,7 @@ function commandOptions(workUnit, detail, hasMap) {
   const anyPlanBlocked = (detail.phases.planning || [])
     .some((p) => Array.isArray(p.deps_blocking) && p.deps_blocking.length > 0);
   if (anyPlanBlocked) {
-    opts.push({ key: 'u', word: 'unblock', action: 'unblock_plan', topic: null, route: null, label: 'Unblock a plan — *mark a dependency as satisfied externally*' });
+    opts.push({ key: 'u', word: 'unblock', action: 'unblock_plan', topic: null, route: null, label: 'Unblock a plan — mark a dependency as satisfied externally' });
   }
   // The build order's manual escape hatch: the automatic triggers fire on a
   // missing or stale order, never on a wrong one.
@@ -864,9 +867,9 @@ function selectionSubView(title, empty, question, action, rows) {
       phase = r.phase;
     }
     const lastInGroup = i === rows.length - 1 || rows[i + 1].phase !== r.phase;
-    // Rows wrap at the display width like every other engine tree —
-    // continuations align under the row text, and the rail never carries on
-    // (a sub-view row has no children beneath it).
+    // Sub-views are plain list rows (CONVENTIONS: selection sub-views use
+    // the [term] form, not trees) — the branch glyphs are visual grouping,
+    // so wrapped continuations align under the row text with no rail.
     const glyph = lastInGroup ? '└─' : '├─';
     displayLines.push(...wrapWithPrefix(`${key}. ${r.row}`, {
       width: TREE_WIDTH, prefix: `  ${glyph} `, hang: `${key}. `.length,

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -15,6 +15,7 @@ const { WORK_TYPE_PIPELINES } = require('../../kernel/manifest-schema.cjs');
 const { TREE_WIDTH, treeHeader, titlecase, title, derivedFrom, stateNote, materialBlock, discoveryGlyph, discoveryLifecycleLabel } = require('../conventions.cjs');
 const { section, menuFrame, cmdOption, callout } = require('./surfaces.cjs');
 const { fmtAge } = require('../presence.cjs');
+const { buildOrderLive } = require('../build-order.cjs');
 
 /** @typedef {import('../epic-detail.cjs').EpicDetail} EpicDetail */
 /** @typedef {import('../epic-detail.cjs').MapRow} MapRow */
@@ -38,9 +39,7 @@ const { fmtAge } = require('../presence.cjs');
  * @property {string|null} route      skill invocation, or null for internal flows
  * @property {string} label
  * @property {boolean} [recommended]
- * @property {boolean} [blocked]
  * @property {boolean} [input_moved]   the entry's item (or its source item) carries a live reconcile flag
- * @property {DepBlocking[]} [deps_blocking]
  * @property {boolean} [in_session]    a held session elsewhere occupies this topic's phase
  * @property {number} [session_age]    that session's last-active age in seconds
  */
@@ -396,12 +395,12 @@ const CUE_RECONCILE =
   + '                  completed; the item\'s entry flow reconciles it';
 
 const CUE_BLOCKED =
-  '    blocked — a source discussion is back in-progress; re-conclude\n'
-  + '              it and the item returns to the menu';
+  '    blocked (specification) — a source discussion is back in-progress;\n'
+  + '              re-conclude it and the item returns to the menu';
 
 const CUE_PLAN_BLOCKED =
-  '    blocked — implementation waits on another plan; the ⚑ list\n'
-  + '              names the dependency, u/unblock is the override';
+  '    blocked (planning) — implementation waits on another plan; the\n'
+  + '              ⚑ list names the dependency, u/unblock is the override';
 
 /**
  * Section B — the Key block, showing only categories present in the display
@@ -599,12 +598,11 @@ function commandOptions(workUnit, detail, hasMap) {
   const anyPlanBlocked = (detail.phases.planning || [])
     .some((p) => Array.isArray(p.deps_blocking) && p.deps_blocking.length > 0);
   if (anyPlanBlocked) {
-    opts.push({ key: 'u', word: 'unblock', action: 'unblock_plan', topic: null, route: null, label: 'Unblock a plan — mark a dependency as satisfied externally' });
+    opts.push({ key: 'u', word: 'unblock', action: 'unblock_plan', topic: null, route: null, label: 'Unblock a plan — *mark a dependency as satisfied externally*' });
   }
   // The build order's manual escape hatch: the automatic triggers fire on a
   // missing or stale order, never on a wrong one.
-  const anyLiveSpec = (detail.phases.specification || [])
-    .some((i) => !['cancelled', 'superseded', 'promoted'].includes(i.status));
+  const anyLiveSpec = (detail.phases.specification || []).some((i) => buildOrderLive(i));
   if (anyLiveSpec) {
     opts.push({ key: 'o', word: 'order', action: 'resequence_build_order', topic: null, route: null, label: 'Re-sequence the build order' });
   }
@@ -645,7 +643,7 @@ function pickRecommendation(detail, numbered, options, hasMap) {
     // An input-moved entry is never the recommendation: recommending a start
     // that propagates known-stale input contradicts its own cue — the
     // reconcile (via the flagged item's entry flow) comes first.
-    const build = numbered.find((e) => e.action.startsWith('start_') && !e.blocked && !e.input_moved
+    const build = numbered.find((e) => e.action.startsWith('start_') && !e.input_moved
       && BUILD_PHASES.includes(ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (e.action)]));
     if (build) return build;
     // With a flagged completed item and nothing else to start, the reconcile
@@ -680,7 +678,7 @@ function pickRecommendation(detail, numbered, options, hasMap) {
   if (specs.length > 0 && specs.every((i) => i.status === 'completed') && planEntry) return planEntry;
 
   const plans = liveItems(detail, 'planning');
-  const implEntry = numbered.find((e) => e.action === 'start_implementation' && !e.blocked && !e.input_moved);
+  const implEntry = numbered.find((e) => e.action === 'start_implementation' && !e.input_moved);
   if (plans.length > 0 && plans.every((i) => i.status === 'completed') && implEntry) return implEntry;
 
   const impls = liveItems(detail, 'implementation');
@@ -866,7 +864,13 @@ function selectionSubView(title, empty, question, action, rows) {
       phase = r.phase;
     }
     const lastInGroup = i === rows.length - 1 || rows[i + 1].phase !== r.phase;
-    displayLines.push(`  ${lastInGroup ? '└─' : '├─'} ${key}. ${r.row}`);
+    // Rows wrap at the display width like every other engine tree —
+    // continuations align under the row text, and the rail never carries on
+    // (a sub-view row has no children beneath it).
+    const glyph = lastInGroup ? '└─' : '├─';
+    displayLines.push(...wrapWithPrefix(`${key}. ${r.row}`, {
+      width: TREE_WIDTH, prefix: `  ${glyph} `, hang: `${key}. `.length,
+    }).map((line, li) => (li === 0 ? line : line.replace(`  ${glyph} `, '     '))));
   });
   keys.push(backKey());
 
@@ -935,32 +939,6 @@ function epicCancelMenu(detail) {
 }
 
 /**
- * Section G — the blocked-plans list and pick menu, one row per blocking
- * dependency (a plan with two blockers gets two rows). The `topic` slot
- * carries the plan, the `dep` field the dependency topic to mark satisfied.
- * No routes — the flow runs the manifest write.
- * @param {EpicDetail} detail
- * @returns {{keys: SubViewKey[], title: string, display: string, rendered: string}}
- */
-function epicUnblockMenu(detail) {
-  /** @type {(SubViewRow & {dep?: string})[]} */
-  const rows = [];
-  for (const item of detail.phases.planning || []) {
-    for (const dep of item.deps_blocking || []) {
-      rows.push({
-        phase: 'planning',
-        topic: item.name,
-        dep: dep.topic,
-        row: `${title({ label: titlecase(item.name) })} — blocked by ${depRef(dep)} (${dep.reason})`,
-        label: `Unblock "${titlecase(item.name)}" — *mark ${depRef(dep)} satisfied externally*`,
-        route: null,
-      });
-    }
-  }
-  return selectionSubView('Blocked Plans', 'No blocked plans.', 'Which dependency has been satisfied?', 'unblock', rows);
-}
-
-/**
  * Section F — the Cancelled Topics list and pick menu, each row carrying the
  * stashed `previous_status`. No routes — the flow runs the reactivate
  * transaction.
@@ -979,6 +957,32 @@ function epicReactivateMenu(detail) {
     };
   });
   return selectionSubView('Cancelled Topics', 'No cancelled topics.', 'Which topic would you like to reactivate?', 'reactivate', rows);
+}
+
+/**
+ * Section G — the blocked-plans list and pick menu, one row per blocking
+ * dependency (a plan with two blockers gets two rows). The `topic` slot
+ * carries the plan, the `dep` field the dependency topic to mark satisfied.
+ * No routes — the flow runs the manifest write.
+ * @param {EpicDetail} detail
+ * @returns {{keys: SubViewKey[], title: string, display: string, rendered: string}}
+ */
+function epicUnblockMenu(detail) {
+  /** @type {SubViewRow[]} */
+  const rows = [];
+  for (const item of detail.phases.planning || []) {
+    for (const dep of item.deps_blocking || []) {
+      rows.push({
+        phase: 'planning',
+        topic: item.name,
+        dep: dep.topic,
+        row: `${title({ label: titlecase(item.name) })} — blocked by ${depRef(dep)} (${dep.reason})`,
+        label: `Unblock "${titlecase(item.name)}" — *mark ${depRef(dep)} satisfied externally*`,
+        route: null,
+      });
+    }
+  }
+  return selectionSubView('Blocked Plans', 'No blocked plans.', 'Which dependency has been satisfied?', 'unblock', rows);
 }
 
 module.exports = { epicDashboard, epicKey, epicMenu, epicInSessionGate, epicCompletedMenu, epicCancelMenu, epicReactivateMenu, epicUnblockMenu, SOFT_GATE_ACTIONS };

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -601,6 +601,13 @@ function commandOptions(workUnit, detail, hasMap) {
   if (anyPlanBlocked) {
     opts.push({ key: 'u', word: 'unblock', action: 'unblock_plan', topic: null, route: null, label: 'Unblock a plan — mark a dependency as satisfied externally' });
   }
+  // The build order's manual escape hatch: the automatic triggers fire on a
+  // missing or stale order, never on a wrong one.
+  const anyLiveSpec = (detail.phases.specification || [])
+    .some((i) => !['cancelled', 'superseded', 'promoted'].includes(i.status));
+  if (anyLiveSpec) {
+    opts.push({ key: 'o', word: 'order', action: 'resequence_build_order', topic: null, route: null, label: 'Re-sequence the build order' });
+  }
   return opts;
 }
 

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -2394,6 +2394,26 @@ function revisitGate(cwd, { dotpath, prev, next }) {
 }
 
 /**
+ * The epic menu's bare topic-cancel confirm — the statement stays context,
+ * the short question takes the glyph. The cascade case (a live spec sources
+ * the topic) renders through cancel-cascade-gate instead.
+ * @param {string} cwd
+ * @param {{dotpath: string}} args
+ * @returns {string}
+ */
+function cancelGate(cwd, { dotpath }) {
+  const { phase, topic } = resolveAddress(cwd, dotpath, 'cancel-gate');
+  return section(
+    'MENU: cancel gate',
+    "emit verbatim as markdown, then STOP for the user's response",
+    menu(`Cancelling **${titlecase(topic)}** in ${phase} will mark it as cancelled — it can be reactivated later.`, [
+      cmdOption('y', 'yes', 'Confirm cancellation'),
+      cmdOption('n', 'no', 'Return to menu'),
+    ], { question: 'Cancel it?' }),
+  );
+}
+
+/**
  * @param {string} cwd
  * @param {{dotpath: string}} args
  * @returns {string}
@@ -3407,6 +3427,7 @@ const SURFACES = {
   'entry-gate': entryGate,
   'early-completion-gate': earlyCompletionGate,
   'revisit-gate': revisitGate,
+  'cancel-gate': cancelGate,
   'epic-all-done-gate': epicAllDoneGate,
   'epic-soft-gate': epicSoftGate,
   'task-brief': taskBrief,

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -239,7 +239,7 @@ Commands:
   render entry-gate        <wu.phase.topic> [--own]  (planning|implementation|review|specification)
   render early-completion-gate <wu>
   render revisit-gate      <wu> --prev <phase> --next <phase>
-  render cancel-gate <wu>.<phase>.<topic>
+  render cancel-gate <wu.phase.topic>
   render epic-all-done-gate <wu>
   render epic-soft-gate <wu> --action <action> [--topic <topic>]
   render task-brief        <wu.implementation.topic> --file <payload.json>

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -239,6 +239,7 @@ Commands:
   render entry-gate        <wu.phase.topic> [--own]  (planning|implementation|review|specification)
   render early-completion-gate <wu>
   render revisit-gate      <wu> --prev <phase> --next <phase>
+  render cancel-gate <wu>.<phase>.<topic>
   render epic-all-done-gate <wu>
   render epic-soft-gate <wu> --action <action> [--topic <topic>]
   render task-brief        <wu.implementation.topic> --file <payload.json>

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -129,6 +129,7 @@ module.exports = {
     epicCompletedMenu: epicProjections.epicCompletedMenu,
     epicCancelMenu: epicProjections.epicCancelMenu,
     epicReactivateMenu: epicProjections.epicReactivateMenu,
+    epicUnblockMenu: epicProjections.epicUnblockMenu,
     discoveryMapView: discoveryProjections.discoveryMapView,
     discoverySynthesisView: discoveryProjections.discoverySynthesisView,
     roadmapTitle: roadmapProjections.roadmapTitle,

--- a/tests/prose/cases/start-cancels-a-sourced-discussion/case.json
+++ b/tests/prose/cases/start-cancels-a-sourced-discussion/case.json
@@ -20,12 +20,14 @@
     "calls_include": [
       "engine.cjs boot",
       "workflow-continue-epic/scripts/gateway.cjs view search-relevance",
+      "render cancel-gate search-relevance.discussion.synonym-handling",
       "topic cancel search-relevance discussion synonym-handling",
       "render cancel-cascade-gate search-relevance.discussion.synonym-handling",
       "topic cancel search-relevance discussion synonym-handling --cascade",
       "render topic-receipt search-relevance.discussion.synonym-handling --verb cancel"
     ],
     "calls_in_order": [
+      "render cancel-gate search-relevance.discussion.synonym-handling",
       "topic cancel search-relevance discussion synonym-handling",
       "render cancel-cascade-gate search-relevance.discussion.synonym-handling",
       "topic cancel search-relevance discussion synonym-handling --cascade"

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -660,7 +660,6 @@ function checkInertLoadChrome(files) {
 // the ratchet working, not a reason to adjust it.
 /** @type {Record<string, number>} */
 const RATCHET_PINS = {
-  'skills/workflow-continue-epic/references/epic-display-and-menu.md': 1,
   'skills/workflow-continue-epic/references/summary-backfill.md': 3,
   'skills/workflow-discovery/references/confirm-trigger.md': 1,
   'skills/workflow-discovery/references/continuity-load.md': 1,

--- a/tests/scripts/test-conventions-lint.cjs
+++ b/tests/scripts/test-conventions-lint.cjs
@@ -660,7 +660,7 @@ function checkInertLoadChrome(files) {
 // the ratchet working, not a reason to adjust it.
 /** @type {Record<string, number>} */
 const RATCHET_PINS = {
-  'skills/workflow-continue-epic/references/epic-display-and-menu.md': 2,
+  'skills/workflow-continue-epic/references/epic-display-and-menu.md': 1,
   'skills/workflow-continue-epic/references/summary-backfill.md': 3,
   'skills/workflow-discovery/references/confirm-trigger.md': 1,
   'skills/workflow-discovery/references/continuity-load.md': 1,

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -8,7 +8,7 @@ const { execFileSync } = require('child_process');
 const { setupFixture, cleanupFixture, createManifest } = require('./discovery-test-utils.cjs');
 const { discover } = require('../../skills/workflow-continue-epic/scripts/gateway.cjs');
 const {
-  epicDashboard, epicKey, epicMenu, epicInSessionGate, epicCompletedMenu, epicCancelMenu, epicReactivateMenu,
+  epicDashboard, epicKey, epicMenu, epicInSessionGate, epicCompletedMenu, epicCancelMenu, epicReactivateMenu, epicUnblockMenu,
 } = require('../../skills/workflow-engine/scripts/domain/projections/epic.cjs');
 const { TREE_WIDTH } = require('../../skills/workflow-engine/scripts/domain/conventions.cjs');
 
@@ -352,7 +352,9 @@ describe('epic projections: key', () => {
         planning: { items: { billing: { status: 'completed', external_dependencies: { auth: { description: 'd', state: 'unresolved' } } } } },
       },
     });
-    assert.strictEqual(epicKey(d), 'Key:\n' + STATUS + '\n\n' + BLOCKING);
+    assert.strictEqual(epicKey(d), 'Key:\n' + STATUS
+      + '\n\n  Cue:\n    blocked — implementation waits on another plan; the \u2691 list\n              names the dependency, u/unblock is the override'
+      + '\n\n' + BLOCKING);
   });
 
   it('no-map branch shows the Status block', () => {
@@ -432,8 +434,6 @@ describe('epic projections: menu', () => {
       '**`1`**           → Start specification for "Billing Grouping" —',
       `${NB(14)}*grouping ready* (recommended)`,
       '**`2`**           → Continue "Auth Spec" — *specification [in-progress]*',
-      '**`3`**           → Start implementation of "Reporting" — blocked by',
-      `${NB(14)}core-features:core-2-3`,
       '**`s/spec`**      → Analyze / regroup discussions — *2 discussion(s) not*',
       `${NB(14)}*yet grouped*`,
       '**`d/discuss`**   → Start a discussion on a new topic',
@@ -441,6 +441,8 @@ describe('epic projections: menu', () => {
       '**`i/discovery`** → Continue discovery',
       '**`c/completed`** → Resume a completed topic',
       '**`a/cancel`**    → Cancel a topic (phase work)',
+      '**`u/unblock`**   → Unblock a plan — mark a dependency as satisfied',
+      `${NB(14)}externally`,
     ].join('\n'));
   });
 
@@ -451,18 +453,19 @@ describe('epic projections: menu', () => {
       [
         ['1', 'start_specification', 'billing-grouping', '/workflow-specification-entry epic quiz-competition-v1 billing-grouping'],
         ['2', 'continue_specification', 'auth-spec', '/workflow-specification-entry epic quiz-competition-v1 auth-spec'],
-        ['3', 'start_implementation', 'reporting', '/workflow-implementation-entry epic quiz-competition-v1 reporting'],
         ['s', 'analyze_discussions', null, '/workflow-specification-entry epic quiz-competition-v1'],
         ['d', 'new_discussion', null, '/workflow-discussion-entry epic quiz-competition-v1'],
         ['r', 'new_research', null, '/workflow-research-entry epic quiz-competition-v1'],
         ['i', 'continue_discovery', null, '/workflow-discovery epic quiz-competition-v1'],
         ['c', 'resume_completed', null, null],
         ['a', 'cancel_topic', null, null],
+        ['u', 'unblock_plan', null, null],
       ]
     );
     assert.strictEqual(keys[0].recommended, true);
-    assert.strictEqual(keys[2].blocked, true);
-    assert.deepStrictEqual(keys[2].deps_blocking, [{ topic: 'core-features', internal_id: 'core-2-3', reason: 'task not yet completed' }]);
+    // A dep-blocked implementation start carries no menu row — the ⚑ block
+    // and the u/unblock option carry the state instead.
+    assert.ok(!keys.some((k) => k.action === 'start_implementation'), 'blocked start never surfaces');
     assert.ok(!keys.some((k) => k.action === 'start_planning'), 'gated start_planning never surfaces');
   });
 
@@ -841,6 +844,52 @@ describe('epic projections: selection sub-views', () => {
     assert.ok(view.display.includes('  ├─ 1. Parked Topic [triaged]'), view.display);
     assert.ok(view.display.includes('  └─ 2. Menu Admin [in-progress]'), view.display);
     assert.ok(/\*\*`1`\*\* +→ Cancel "Parked Topic" — \*research \[triaged\]\*/.test(view.rendered), view.rendered);
+  });
+
+  it('unblock-menu: one row per blocking dependency, dep carried on the key', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        planning: {
+          items: {
+            reporting: {
+              status: 'completed',
+              external_dependencies: {
+                'core-features': { description: 'd', state: 'resolved', internal_id: 'core-2-3' },
+                'auth': { description: 'd', state: 'unresolved' },
+              },
+            },
+            clean: { status: 'completed' },
+          },
+        },
+      },
+    });
+    const view = epicUnblockMenu(d);
+    assert.strictEqual(view.title, 'Blocked Plans');
+    assert.strictEqual(view.display, [
+      'Planning',
+      '  ├─ 1. Reporting — blocked by core-features:core-2-3 (task not yet completed)',
+      '  └─ 2. Reporting — blocked by auth (dependency unresolved)',
+      '',
+    ].join('\n'));
+    assert.deepStrictEqual(
+      view.keys.map((k) => [k.key, k.action, k.topic, k.dep ?? null]),
+      [
+        ['1', 'unblock', 'reporting', 'core-features'],
+        ['2', 'unblock', 'reporting', 'auth'],
+        ['b', 'back', null, null],
+      ]
+    );
+    assert.ok(/Which dependency has been satisfied\?/.test(view.rendered), view.rendered);
+  });
+
+  it('unblock-menu: empty state when no plan is blocked', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: { planning: { items: { clean: { status: 'completed' } } } },
+    });
+    const view = epicUnblockMenu(d);
+    assert.strictEqual(view.display, 'No blocked plans.\n');
   });
 
   it('reactivate-menu: numbered rows with (was: previous_status)', () => {

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -443,6 +443,7 @@ describe('epic projections: menu', () => {
       '**`a/cancel`**    → Cancel a topic (phase work)',
       '**`u/unblock`**   → Unblock a plan — mark a dependency as satisfied',
       `${NB(14)}externally`,
+      '**`o/order`**     → Re-sequence the build order',
     ].join('\n'));
   });
 
@@ -460,6 +461,7 @@ describe('epic projections: menu', () => {
         ['c', 'resume_completed', null, null],
         ['a', 'cancel_topic', null, null],
         ['u', 'unblock_plan', null, null],
+        ['o', 'resequence_build_order', null, null],
       ]
     );
     assert.strictEqual(keys[0].recommended, true);

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -159,7 +159,7 @@ describe('epic projections: dashboard (map branch)', () => {
     const out = epicDashboard('v1', d);
     assert.match(out, /Menu Admin\s+\[completed · input moved\]/, out);
     const key = epicKey(d);
-    assert.ok(key.includes('input moved — an upstream artifact was revised'), key);
+    assert.ok(key.includes('input moved             — an upstream artifact was revised'), key);
     const { keys } = epicMenu('v1', d);
     const start = keys.find((k) => k.action === 'start_planning');
     assert.ok(start, 'start_planning entry present');
@@ -180,7 +180,7 @@ describe('epic projections: dashboard (map branch)', () => {
     const out = epicDashboard('v1', d);
     assert.match(out, /✓ Fees\s+↳ Decided · input moved/, out);
     const key = epicKey(d);
-    assert.ok(key.includes('input moved — an upstream artifact was revised'), key);
+    assert.ok(key.includes('input moved             — an upstream artifact was revised'), key);
   });
 
   it('the completed-topics picker carries the input-moved cue on flagged rows', () => {
@@ -353,7 +353,7 @@ describe('epic projections: key', () => {
       },
     });
     assert.strictEqual(epicKey(d), 'Key:\n' + STATUS
-      + '\n\n  Cue:\n    blocked (planning) — implementation waits on another plan; the\n              \u2691 list names the dependency, u/unblock is the override'
+      + '\n\n  Cue:\n    blocked (planning)      — implementation waits on another plan;\n                              the \u2691 list names the dependency,\n                              u/unblock is the override'
       + '\n\n' + BLOCKING);
   });
 
@@ -441,8 +441,8 @@ describe('epic projections: menu', () => {
       '**`i/discovery`** → Continue discovery',
       '**`c/completed`** → Resume a completed topic',
       '**`a/cancel`**    → Cancel a topic (phase work)',
-      '**`u/unblock`**   → Unblock a plan — *mark a dependency as satisfied*',
-      `${NB(14)}*externally*`,
+      '**`u/unblock`**   → Unblock a plan — mark a dependency as satisfied',
+      `${NB(14)}externally`,
       '**`o/order`**     → Re-sequence the build order',
     ].join('\n'));
   });
@@ -957,7 +957,7 @@ describe('epic projections: selection sub-views', () => {
     });
     const key = epicKey(d);
     assert.ok(key.includes('blocked (specification) —'), key);
-    assert.ok(key.includes('blocked (planning) —'), key);
+    assert.ok(key.includes('blocked (planning)      —'), key);
   });
 
   it('unblock-menu: empty state when no plan is blocked', () => {

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -353,7 +353,7 @@ describe('epic projections: key', () => {
       },
     });
     assert.strictEqual(epicKey(d), 'Key:\n' + STATUS
-      + '\n\n  Cue:\n    blocked — implementation waits on another plan; the \u2691 list\n              names the dependency, u/unblock is the override'
+      + '\n\n  Cue:\n    blocked (planning) — implementation waits on another plan; the\n              \u2691 list names the dependency, u/unblock is the override'
       + '\n\n' + BLOCKING);
   });
 
@@ -425,7 +425,7 @@ describe('epic projections: menu', () => {
     };
   }
 
-  it('orders the recommendation first, filters gated starts, flags blocked entries', () => {
+  it('orders the recommendation first, filters gated starts, and carries no row for a blocked start', () => {
     const menu = epicMenu('quiz-competition-v1', settledDetail());
     assert.strictEqual(menu.rendered, [
       '· · · · · · · · · · · ·',
@@ -441,13 +441,13 @@ describe('epic projections: menu', () => {
       '**`i/discovery`** → Continue discovery',
       '**`c/completed`** → Resume a completed topic',
       '**`a/cancel`**    → Cancel a topic (phase work)',
-      '**`u/unblock`**   → Unblock a plan — mark a dependency as satisfied',
-      `${NB(14)}externally`,
+      '**`u/unblock`**   → Unblock a plan — *mark a dependency as satisfied*',
+      `${NB(14)}*externally*`,
       '**`o/order`**     → Re-sequence the build order',
     ].join('\n'));
   });
 
-  it('keys carry actions, topics, routes, and the recommended/blocked flags', () => {
+  it('keys carry actions, topics, and routes; a blocked start never surfaces', () => {
     const { keys } = epicMenu('quiz-competition-v1', settledDetail());
     assert.deepStrictEqual(
       keys.map((k) => [k.key, k.action, k.topic, k.route]),
@@ -870,7 +870,8 @@ describe('epic projections: selection sub-views', () => {
     assert.strictEqual(view.title, 'Blocked Plans');
     assert.strictEqual(view.display, [
       'Planning',
-      '  ├─ 1. Reporting — blocked by core-features:core-2-3 (task not yet completed)',
+      '  ├─ 1. Reporting — blocked by core-features:core-2-3 (task',
+      '        not yet completed)',
       '  └─ 2. Reporting — blocked by auth (dependency unresolved)',
       '',
     ].join('\n'));
@@ -883,6 +884,80 @@ describe('epic projections: selection sub-views', () => {
       ]
     );
     assert.ok(/Which dependency has been satisfied\?/.test(view.rendered), view.rendered);
+  });
+
+  it('a dep-blocked planning row carries the blocked cue; a clean one does not; a cancelled one never does', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discussion: { items: { blocked: { status: 'completed' }, clean: { status: 'completed' } } },
+        planning: {
+          items: {
+            blocked: { status: 'completed', external_dependencies: { upstream: { description: 'd', state: 'unresolved' } } },
+            clean: { status: 'completed' },
+            dead: { status: 'cancelled', previous_status: 'completed', external_dependencies: { upstream: { description: 'd', state: 'unresolved' } } },
+          },
+        },
+      },
+    });
+    const out = epicDashboard('v1', d);
+    assert.match(out, /Blocked    \[completed · blocked\]/);
+    assert.match(out, /Clean      \[completed\]/);
+    assert.match(out, /Dead       \[cancelled\]/);
+    // The terminal item carries no deps at all — no ⚑ row, no unblock offer.
+    assert.ok(!out.includes('Dead\n  └─ Blocked'), out);
+    const menu = epicMenu('v1', d);
+    const unblock = menu.keys.find((k) => k.action === 'unblock_plan');
+    assert.ok(unblock, 'unblock option present for the live blocked plan');
+    const { epicUnblockMenu: unblockMenu } = require('../../skills/workflow-engine/scripts/domain/projections/epic.cjs');
+    const rows = unblockMenu(d).keys.filter((k) => k.action === 'unblock');
+    assert.deepStrictEqual(rows.map((r) => r.topic), ['blocked'], 'the cancelled plan takes no row');
+  });
+
+  it('two different blocked plans list in build order', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        specification: { items: {
+          zeta: { status: 'completed', order: 1 }, alpha: { status: 'completed', order: 2 },
+        } },
+        planning: {
+          items: {
+            alpha: { status: 'completed', external_dependencies: { up: { description: 'd', state: 'unresolved' } } },
+            zeta: { status: 'completed', external_dependencies: { up: { description: 'd', state: 'unresolved' } } },
+          },
+        },
+      },
+    });
+    const { epicUnblockMenu: unblockMenu } = require('../../skills/workflow-engine/scripts/domain/projections/epic.cjs');
+    const rows = unblockMenu(d).keys.filter((k) => k.action === 'unblock');
+    assert.deepStrictEqual(rows.map((r) => r.topic), ['zeta', 'alpha']);
+  });
+
+  it('o/order withdraws when no live spec topic exists', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        specification: { items: { gone: { status: 'cancelled', previous_status: 'in-progress' } } },
+        discussion: { items: { auth: { status: 'in-progress' } } },
+      },
+    });
+    const { keys } = epicMenu('v1', d);
+    assert.ok(!keys.some((k) => k.action === 'resequence_build_order'), 'no live spec — no re-sequence');
+  });
+
+  it('both blocked kinds render two qualified legend lines', () => {
+    const d = detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discussion: { items: { src: { status: 'in-progress' } } },
+        specification: { items: { spec: { status: 'completed', sources: { src: { status: 'stale' } } } } },
+        planning: { items: { spec: { status: 'completed', external_dependencies: { up: { description: 'd', state: 'unresolved' } } } } },
+      },
+    });
+    const key = epicKey(d);
+    assert.ok(key.includes('blocked (specification) —'), key);
+    assert.ok(key.includes('blocked (planning) —'), key);
   });
 
   it('unblock-menu: empty state when no plan is blocked', () => {

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -40,6 +40,23 @@ function writePayload(dir, rel, obj) {
   return rel;
 }
 
+describe('cancel-gate', () => {
+  let dir;
+  beforeEach(() => { dir = setup(); });
+  afterEach(() => { teardown(dir); });
+
+  it('renders the bare cancel confirm with the statement/question split', () => {
+    writeManifest(dir, 'pay', {
+      phases: { discussion: { items: { auth: { status: 'in-progress' } } } },
+    });
+    const out = renderSurface(dir, 'cancel-gate', { dotpath: 'pay.discussion.auth' });
+    assert.match(out, /MENU: cancel gate/);
+    assert.match(out, /Cancelling \*\*Auth\*\* in discussion will mark it as cancelled — it can be reactivated later\./);
+    assert.match(out, /◆ Cancel it\?/);
+    assert.match(out, /\*\*`y\/yes`\*\* → Confirm cancellation/);
+  });
+});
+
 describe('epic-soft-gate', () => {
   let dir;
   beforeEach(() => { dir = setup(); });
@@ -2827,7 +2844,7 @@ describe('catalogue dispatch', () => {
   });
 
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-announce, finding-batch, finding, review-presentation, review-gate, spec-review-gate, spec-completion-gate, convergence-diagnostic, carry-note-gate, hypothesis-board, fix-direction, validation-gate, validation-report, project-skills, linters, triage-announce, triage-offer, triage-block, requeue-offer, reroute-offer, reroute-candidates, off-topic-offer, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, epic-all-done-gate, epic-soft-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, roadmap-view, roadmap-add-gate, roadmap-session-receipt, roadmap-harvest-gate, roadmap-parks-gate, roadmap-shape-gate, roadmap-conclude-gate, name-gate, shape-gate, synthesis-gate, query-failure-gate, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick, baseline-offer-gate\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-announce, finding-batch, finding, review-presentation, review-gate, spec-review-gate, spec-completion-gate, convergence-diagnostic, carry-note-gate, hypothesis-board, fix-direction, validation-gate, validation-report, project-skills, linters, triage-announce, triage-offer, triage-block, requeue-offer, reroute-offer, reroute-candidates, off-topic-offer, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, cancel-gate, epic-all-done-gate, epic-soft-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, roadmap-view, roadmap-add-gate, roadmap-session-receipt, roadmap-harvest-gate, roadmap-parks-gate, roadmap-shape-gate, roadmap-conclude-gate, name-gate, shape-gate, synthesis-gate, query-failure-gate, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick, baseline-offer-gate\)/);
   });
 });
 

--- a/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
@@ -1769,7 +1769,7 @@ describe('workflow-continue-epic CLI dispatch', () => {
   const path = require('path');
   const { spawnSync } = require('child_process');
   const GATEWAY = path.join(__dirname, '../../skills/workflow-continue-epic/scripts/gateway.cjs');
-  const USAGE = 'Usage: gateway.cjs | gateway.cjs {work_unit} | gateway.cjs view {work_unit} [new_arrivals_json] | gateway.cjs (completed-menu|cancel-menu|reactivate-menu) {work_unit}\n';
+  const USAGE = 'Usage: gateway.cjs | gateway.cjs {work_unit} | gateway.cjs view {work_unit} [new_arrivals_json] | gateway.cjs (completed-menu|cancel-menu|reactivate-menu|unblock-menu) {work_unit}\n';
 
   let dir;
   beforeEach(() => { dir = setupFixture(); });
@@ -1883,7 +1883,7 @@ describe('workflow-continue-epic CLI dispatch', () => {
 
   it('each sub-view verb errors without its work unit instead of rendering the first epic', () => {
     epicFixture();
-    for (const verb of ['completed-menu', 'cancel-menu', 'reactivate-menu']) {
+    for (const verb of ['completed-menu', 'cancel-menu', 'reactivate-menu', 'unblock-menu']) {
       const res = run([verb]);
       assert.strictEqual(res.status, 1, verb);
       assert.strictEqual(res.stdout, '', verb);
@@ -1893,7 +1893,7 @@ describe('workflow-continue-epic CLI dispatch', () => {
 
   it('each sub-view verb errors on excess positionals', () => {
     epicFixture();
-    for (const verb of ['completed-menu', 'cancel-menu', 'reactivate-menu']) {
+    for (const verb of ['completed-menu', 'cancel-menu', 'reactivate-menu', 'unblock-menu']) {
       const res = run([verb, 'v1', 'extra']);
       assert.strictEqual(res.status, 1, verb);
       assert.strictEqual(res.stdout, '', verb);

--- a/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
@@ -1787,6 +1787,18 @@ describe('workflow-continue-epic CLI dispatch', () => {
     return spawnSync('node', [GATEWAY, ...args], { cwd: dir, encoding: 'utf8' });
   }
 
+  it('unblock-menu emits the dep column in DATA byte-exactly', () => {
+    createManifest(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discussion: { items: { auth: { status: 'completed' } } },
+        planning: { items: { tmpl: { status: 'completed', external_dependencies: { auth: { description: 'd', state: 'resolved', internal_id: 'auth-1-4' } } } } },
+      },
+    });
+    const out = run(['unblock-menu', 'v1']).stdout;
+    assert.ok(out.includes('  1  unblock  tmpl  planning  → (internal)  (dep: auth)'), out.split('===')[1] || out);
+  });
+
   it('the view snapshot carries the build-order flag line', () => {
     createManifest(dir, 'v1', {
       work_type: 'epic',

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -51,6 +51,7 @@ const GATEWAYS = {
 };
 const BRIDGE = require(path.join(ROOT, 'skills/workflow-bridge/scripts/gateway.cjs'));
 const SPEC_GATEWAY = require(path.join(ROOT, 'skills/workflow-specification-entry/scripts/gateway.cjs'));
+const EPIC_GATEWAY = require(path.join(ROOT, 'skills/workflow-continue-epic/scripts/gateway.cjs'));
 const { specificationDetail } = require(path.join(ROOT, 'skills/workflow-engine/scripts/domain/specification.cjs'));
 
 // Spec-entry detail for one work unit — the spec boundary's derived view.
@@ -916,6 +917,29 @@ describe('pipeline simulation', () => {
     // The soft gate is engine-rendered and empty when nothing sits ahead —
     // unified is the whole live set, so planning it raises no concern.
     sim.render(['epic-soft-gate', wu, '--action', 'start_planning', '--topic', 'unified'], { expect: 'empty' });
+
+    // A dep-blocked plan loses its implementation row; the u/unblock option
+    // and the unblock-menu sub-view are the escape hatch, and marking the
+    // dependency satisfied externally restores the row.
+    sim.run(['topic', 'start', wu, 'planning', 'unified']);
+    sim.run(['topic', 'complete', wu, 'planning', 'unified']);
+    sim.run(['manifest', 'set', `${wu}.planning.unified`,
+      'external_dependencies.alpha.description=Needs alpha shipped',
+      'external_dependencies.alpha.state=unresolved']);
+    const epicDetailNow = () => EPIC_GATEWAY.discover(sim.dir, wu).epics[0].detail;
+    const menuNow = () => require(path.join(ROOT, 'skills/workflow-engine/scripts/lib.cjs')).project.epicMenu(wu, epicDetailNow());
+    let keys = menuNow().keys;
+    assert.ok(!keys.some((k) => k.action === 'start_implementation' && k.topic === 'unified'),
+      'a dep-blocked implementation start carries no menu row');
+    assert.ok(keys.some((k) => k.action === 'unblock_plan'), 'the unblock option surfaces');
+    const unblockView = require(path.join(ROOT, 'skills/workflow-engine/scripts/lib.cjs')).project.epicUnblockMenu(epicDetailNow());
+    assert.deepStrictEqual(unblockView.keys.map((k) => [k.key, k.action, k.topic, k.dep ?? null])[0],
+      ['1', 'unblock', 'unified', 'alpha']);
+    sim.run(['manifest', 'set', `${wu}.planning.unified`, 'external_dependencies.alpha.state', 'satisfied_externally']);
+    keys = menuNow().keys;
+    assert.ok(keys.some((k) => k.action === 'start_implementation' && k.topic === 'unified'),
+      'a satisfied dependency restores the implementation row');
+    assert.ok(!keys.some((k) => k.action === 'unblock_plan'), 'the unblock option withdraws');
 
     // Supersession is terminal: the absorbed spec cannot restart or complete.
     sim.refuses(['topic', 'start', wu, 'specification', 'alpha'], /superseded/);


### PR DESCRIPTION
Layer 4 of the build-order programme (design: #970), stacked on #1008 — B9.

A dep-blocked implementation start follows the blocked-spec rule: no menu row. The dashboard carries the state (planning tree cue + plan Cue legend + the existing ⚑ block), and `u/unblock` — surfaced only while a plan is blocked — routes to a new `unblock-menu` sub-view, one row per blocking dependency.

Simulation drives the full block → unblock → restore round-trip.

Gates: npm test 2397 pass, CLI green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)