### PR TITLE
cases(build-order): the two walk defects the first run surfaced

### DIFF
--- a/tests/prose/cases/spec-grouping-births-the-build-order/case.json
+++ b/tests/prose/cases/spec-grouping-births-the-build-order/case.json
@@ -1,5 +1,5 @@
 {
-  "origin": "build-order programme (design/build-order.md B1) — the grouping analysis assigns the build order in the same reconcile it persists the groupings with; nothing exercised the birth path",
+  "origin": "build-order programme (design/build-order.md B1) \u2014 the grouping analysis assigns the build order in the same reconcile it persists the groupings with; nothing exercised the birth path",
   "entry": "workflow-specification-entry",
   "world": "claims",
   "files": [
@@ -15,7 +15,8 @@
     "skills/workflow-specification-entry/references/check-prerequisites.md",
     "skills/workflow-specification-entry/references/route-scenario.md",
     "skills/workflow-specification-entry/references/analysis-flow.md",
-    "skills/workflow-specification-entry/references/display-groupings.md"
+    "skills/workflow-specification-entry/references/display-groupings.md",
+    "skills/workflow-specification-entry/references/display-analyze.md"
   ],
   "invariants": {
     "engine_before_write": true,
@@ -29,5 +30,6 @@
       "topic complete",
       "topic cancel"
     ]
-  }
+  },
+  "conduct": "The user wants the grouping analysis run and is hands-off about it: to any proceed-style confirmation they answer yes; to the pre-analysis question asking for context on how the discussions relate they answer 'none \u2014 the concluded discussions speak for themselves'; once the groupings menu is presented they stop engaging."
 }

--- a/tests/prose/cases/start-cancels-a-sourced-discussion/case.json
+++ b/tests/prose/cases/start-cancels-a-sourced-discussion/case.json
@@ -13,7 +13,8 @@
     "skills/workflow-continue-epic/references/validate-selection.md",
     "skills/workflow-shared/references/topic-discovery-dispatch.md",
     "skills/workflow-shared/references/sequence-discovery-map.md",
-    "skills/workflow-continue-epic/references/epic-display-and-menu.md"
+    "skills/workflow-continue-epic/references/epic-display-and-menu.md",
+    "skills/workflow-shared/references/ask-or-decide.md"
   ],
   "conduct": "The user returns to abandon the synonym-handling topic \u2014 it is no longer worth pursuing. They navigate the start menu into the epic, pick the cancel option, and select synonym-handling. They confirm the cancellation. When told a live specification (expansion) is built from it and asked whether to cancel them together, they confirm that too \u2014 losing the started spec is exactly what abandoning the ground means, and they note they could reactivate later. They would object to being asked to cancel the specification as a separate manual step, and to any hand-composed warning that does not come from the engine. After the receipt they are done.",
   "invariants": {


### PR DESCRIPTION
Post-merge walk run over the build-order set: 4 PASS, 1 FAIL. The failure was the case — both runs halted at `analysis-flow.md` §A's context question, which the case scripted nothing for.

- `spec-grouping-births-the-build-order`: conduct added for the analysis prompts; `display-analyze.md` declared (scope lint, both runs). **Re-walked: PASS 4/4, world PASS** — the birth claims proven live.
- `start-cancels-a-sourced-discussion`: `ask-or-decide.md` declared (scope line from its passing walk).

Corpus validation + snapshot goldens green (159 pass); no snapshots move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)