### PR TITLE
cases: the wordings the topic-spawning walks flagged

### DIFF
--- a/tests/prose/cases/discussion-wraps-when-all-decided/assert.md
+++ b/tests/prose/cases/discussion-wraps-when-all-decided/assert.md
@@ -56,8 +56,10 @@ EXPECTED WORLD — from a feature holding only its discovery carrier:
 - the manifest holding the discussion in progress with every subtopic
   `decided` — none pending, exploring, or deferred; the discussion is
   NOT completed
-- the agent store holding one or more review rows, every one
-  incorporated
+- the agent store holding one or more review rows; every review that
+  was surfaced during the session is incorporated, while a review
+  dispatched at the close itself may still be pending at the stop —
+  the walk ends before its findings are walked
 - no research, specification, planning, implementation, or review
   artifacts anywhere; the work-unit description unchanged; no second
   work unit

--- a/tests/prose/cases/epic-entry-resequences-a-stale-order/assert.md
+++ b/tests/prose/cases/epic-entry-resequences-a-stale-order/assert.md
@@ -1,7 +1,7 @@
 The prose should have taken this path:
 
 1. workflow-start routes into continue-epic for the one active epic
-2. topic discovery dispatches nothing (both caches settled) and the
+2. topic discovery dispatches nothing (the gap-analysis cache settled) and the
    map sequencing step is silent (every map topic already ordered)
 3. the build-order sequencing step fires — the scoped discovery output
    reports `build_order_needs_sequencing: true`, from the stale flag

--- a/tests/prose/cases/epic-resumes-and-harvests-topics/assert.md
+++ b/tests/prose/cases/epic-resumes-and-harvests-topics/assert.md
@@ -7,8 +7,8 @@ The prose should have taken this path:
 2. the epic continuation re-reads state through its own gateway and
    validates the name, then runs the scoped read for the state surface
 3. the legacy detect script runs and finds nothing to recover; with
-   both analysis caches absent nothing dispatches, and with nothing to
-   sequence no sequencing pass runs
+   the gap-analysis cache absent nothing dispatches, and with nothing
+   to sequence no sequencing pass runs
 4. the dashboard renders with its no-work-started flag and the menu;
    the scripted choice resumes the in-progress discovery session by
    its stored route into the discovery skill

--- a/tests/prose/cases/gap-analysis-gate-walks-straight-in/assert.md
+++ b/tests/prose/cases/gap-analysis-gate-walks-straight-in/assert.md
@@ -30,7 +30,8 @@ The prose should have taken this path:
    candidate blocks — a reuse boot never re-derived a full topic list —
    and the stamp records a checksum over the completed research and both
    completed discussions
-9. the sweep finds the tree dirty (cache file, staging file, manifest)
+9. the sweep finds the tree dirty (the cache file and the manifest —
+   on this reuse boot the staged candidates file was never rewritten)
    and commits the bookkeeping; the dispatch then re-runs the epic
    gateway so the caller sees the new item
 10. the refreshed output reports the map unsequenced — the new item
@@ -51,8 +52,10 @@ Further claims:
   map topic, nothing more
 - search-analytics-dashboard appears nowhere on the map, and its name is
   the only entry on the dismissed list
-- `analysis_staging` is absent from the discovery phase entirely — the
-  subtree was deleted, not left behind marked `approved`/`skipped`
+- the `analysis_staging.discovery-gap-analysis` subtree is gone — the
+  gate deleted it rather than leaving candidates marked
+  `approved`/`skipped` (the engine's delete may leave the parent
+  `analysis_staging` container behind empty; that residue is fine)
 - nothing anywhere reads or writes research-analysis state; the only
   boot-time analysis is the gap one
 - the three harvested map items keep their harvest summaries and
@@ -64,7 +67,7 @@ Further claims:
 EXPECTED WORLD — the fixture plus: `signal-freshness-contract` on the
 discovery map with gap-analysis provenance and an order within a
 contiguous 1..4; `search-analytics-dashboard` on the discovery phase's
-dismissed list and nowhere else; no `analysis_staging` subtree; a
+dismissed list and nowhere else; no `analysis_staging.discovery-gap-analysis` subtree; a
 rewritten `.state/discovery-gap-analysis.md` naming the staged
 candidates, with `gap_analysis_cache` stamped over the current input
 set; and no new phase items, artifacts, or work units.

--- a/tests/prose/cases/roadmap-pull-fences-the-epic/case.json
+++ b/tests/prose/cases/roadmap-pull-fences-the-epic/case.json
@@ -27,8 +27,7 @@
     "p — pull into delivery",
     "1, 2 — ordering and menu management",
     "y — shape it as an epic",
-    "A different name — call it mvp",
-    "y — the name is fine"
+    "A different name — call it mvp"
   ],
   "conduct": "The user shaped Orderflow's roadmap in an earlier session and has come back ready to start building. They want the first slice small: customer ordering and menu upkeep now, the kitchen display to follow once those stand. They confirm the epic shape when it is proposed, name the unit 'mvp' themselves, and stop as soon as the epic's discovery opens — they will deepen it another day.",
   "invariants": {

--- a/tests/prose/cases/start-continues-an-epic-into-discussion/assert.md
+++ b/tests/prose/cases/start-continues-an-epic-into-discussion/assert.md
@@ -10,8 +10,8 @@ The prose should have taken this path:
 3. the backfill checks find nothing — no qualifying legacy sources,
    no map rows missing a summary or description — and the backfill
    reference is never loaded
-4. topic discovery reads both analysis caches as absent and dispatches
-   nothing; new_arrivals stays empty
+4. topic discovery reads the gap-analysis cache as absent and
+   dispatches nothing; new_arrivals stays empty
 5. the map needs sequencing, so the sequencing reference runs: work
    type confirmed epic, the discovery subtree read once, a full
    1..3 order assigned over the three live topics in a single


### PR DESCRIPTION
The 49-case post-release walk run (45 PASS / 4 FLAKY / 0 FAIL) flagged four case-side staleness items — all case wording, no prose or engine changes, no snapshot movement:

- **"both analysis caches"** in three cases' expected paths → the single gap-analysis cache (the release retired research-analysis; three independent walks flagged it).
- **gap-analysis-gate-walks-straight-in**: the world claim now accepts the engine's empty `analysis_staging` container after the subtree delete, and step 9 no longer names the staged-candidates file as dirty on the reuse boot (it was reused unmodified).
- **discussion-wraps-when-all-decided**: the every-review-incorporated claim couldn't hold at the case's own stop point — a review dispatched at the close is legitimately still pending there.
- **roadmap-pull-fences-the-epic**: dropped the sixth scripted answer no gate consumes.

Prose suites green: cases + invariants + snapshots 162/0 (all worlds rebuilt byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)