### PR TITLE
feat(engine): concurrent phases — presence widening, mechanical beats, confined commits

### DIFF
--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -59,7 +59,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render triage-block {work
    git status --porcelain -- .workflows
    ```
 
-   **If dirt remains under another topic's paths:** run `node .claude/skills/workflow-engine/scripts/engine.cjs presence scan {work_unit}`. Dirt under a `held` row's topic belongs to that session — leave it, however long it has idled. For each dirty topic with no held presence — a dead session's leavings — commit it action-scoped: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{dirty_topic} -m "chore({work_unit}/{dirty_topic}): sweep session leavings"`.
+   **If dirt remains under another topic's paths:** run `node .claude/skills/workflow-engine/scripts/engine.cjs presence scan {work_unit}`. Dirt under a `held` row's topic belongs to that session — leave it, however long it has idled. For each dirty topic with no held presence — a dead session's leavings — commit it action-scoped: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{dirty_topic} --sweep -m "chore({work_unit}/{dirty_topic}): sweep session leavings"`.
 
    **Otherwise:** nothing to sweep — continue.
 

--- a/skills/workflow-engine/SKILL.md
+++ b/skills/workflow-engine/SKILL.md
@@ -25,6 +25,8 @@ Two doors:
 
 Output sections are one-directional: `DATA` is for reasoning and is never displayed; `DISPLAY` and `MENU` are emitted to the user verbatim and never parsed for decisions.
 
+**Sessions run concurrently, so every write is confined.** Manifest writes hold the work unit's lock; cache state is partitioned per topic; and every engine commit — the `commit` helper and every transaction tail — commits a pathspec, never the index, so no commit can reach outside the paths its own action wrote. Session liveness rides the same principle: heartbeats are stamped by the engine as a side effect of the verbs a session runs on its own topic (`presence`), never by prose.
+
 **Anything parameterised or state-branching renders in code.** Static chrome lives as literal blocks in skill prose; adapter-side chrome is rendered in-process by projections; shared runtime surfaces (gates, menus, parameterised displays) are served by the `render` surface catalogue in `engine.cjs`, which returns demarcated sections the flow emits verbatim. The engine never parses markdown artifacts to populate a render — address-backed values are JSON state, judgment content is a validated payload file.
 
 ## Reference

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -156,7 +156,7 @@ engine sources stale <work-unit> <discussion> [--except <spec-topic>]
 |---|---|
 | `commit --topic {phase}/{topic}` | beats — the session-cadence commit, so "last active" means "time since the last real write" |
 | `commit --topic … --kb` | **clears** — the terminal conclusion commit; a beat here would re-stamp the topic after it concluded and it would read held forever |
-| `commit --topic … --sweep` | suppressed — the conclude sweep commits a dead session's leavings; a sweeper stamping the topic it just cleaned would resurrect the hold |
+| `commit --topic … --sweep` | suppressed — the commit is on a topic this session is not working (the conclude sweep's leavings, a foreign-topic delivery's retry); stamping it would manufacture a hold |
 | `commit --paths … --for {wu} {phase}/{topic}` | beats the named code topic |
 | `topic queue` | beats — the session loops' findings check polls it every turn, so a turn with no writes still registers |
 | `topic start` · `topic complete` · `topic absorb` | beat — opening, closing, and folding a concern into the session's own topic |
@@ -251,7 +251,7 @@ The scope by form: `.workflows/{wu}` bare, `.workflows/.inbox` with `--inbox`, `
 
 `--plan <topic>` widens the work-unit scope with the plan's declared storage: `.workflows/manifest.json` and every `storage_paths` entry recorded on the planning item at plan init (the format's authoring doc declares them; entries are validated relative-only, while deleted-but-tracked paths still commit their deletions). A planning item without `storage_paths` (pre-upgrade plan) fails loudly with the one-line repair. Code never rides a `--plan` commit — code has its own form below.
 
-`--topic <phase>/<topic>` is the session-cadence form: the topic's artifact (`{phase}/{topic}.md` for research/discussion/investigation, `{phase}/{topic}/` for specification/planning/implementation/review) plus the topic's triage-queue directory (research/discussion) plus the work-unit manifest. The KB dir does not ride by default; `--kb` adds it for the moments whose own action dirtied the store — a conclusion commit right after `topic complete`'s knowledge index. `--sweep` marks the conclude sweep's commit of a dead session's leavings. Both riders carry presence semantics — see the beat table under `presence`. Mutually exclusive with `--plan` and `--discovery`.
+`--topic <phase>/<topic>` is the session-cadence form: the topic's artifact (`{phase}/{topic}.md` for research/discussion/investigation, `{phase}/{topic}/` for specification/planning/implementation/review) plus the topic's triage-queue directory (research/discussion) plus the work-unit manifest. The KB dir does not ride by default; `--kb` adds it for the moments whose own action dirtied the store — a conclusion commit right after `topic complete`'s knowledge index. `--sweep` marks a commit made on a topic the session is not working — the conclude sweep's leavings, or the retry a foreign-topic delivery's pending note prescribes. Both riders carry presence semantics — see the beat table under `presence`. Mutually exclusive with `--plan` and `--discovery`.
 
 `--discovery` is the discovery session's cadence form: `discovery/sessions/`, `discovery/briefs/`, and the work-unit manifest (the map lives there). Discovery runs beside live research and discussion sessions on the same work unit, so it slices its own paths and never theirs.
 

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -6,7 +6,7 @@
 
 The CLI door: `node .claude/skills/workflow-engine/scripts/engine.cjs <command> [args]`. Skill prose prescribes these calls at exact points; this catalogue exists for understanding a command's full contract.
 
-**Response contract (every mutation/transaction):** one decision-ready JSON line on stdout — `{"ok": true, …}` with derived state riding so no follow-up read is needed. Failures: `{"ok": false, "error": "…"}` on stderr, exit 1. Knowledge-base side effects are warn-don't-block — failures land in `warnings`, never abort. Commands that commit report `committed` (short sha, or `null` plus a note on a clean tree); commands documented as commit-free rely on the calling flow's commit cadence. Every engine-made commit also stages `.workflows/.knowledge` when it exists.
+**Response contract (every mutation/transaction):** one decision-ready JSON line on stdout — `{"ok": true, …}` with derived state riding so no follow-up read is needed. Failures: `{"ok": false, "error": "…"}` on stderr, exit 1. Knowledge-base side effects are warn-don't-block — failures land in `warnings`, never abort. Commands that commit report `committed` (short sha, or `null` plus a note on a clean scope); commands documented as commit-free rely on the calling flow's commit cadence. Every engine-made commit is confined to the paths its action wrote, and a commit whose action touched the knowledge store carries `.workflows/.knowledge` with it.
 
 ## Grammar
 
@@ -148,12 +148,32 @@ engine topic reactivate <work-unit> <phase> <topic>
 engine sources stale <work-unit> <discussion> [--except <spec-topic>]
 ```
 
-**`presence`** — the per-topic session heartbeat, cache-resident (`.workflows/.cache/{wu}/{phase}/{topic}/presence`, gitignored). Awareness, never mutual exclusion. `beat` refreshes it — session loops beat at their per-turn check — writing the owning session's identity (`CLAUDE_PID` + its process start time + `CLAUDE_CODE_SESSION_ID`); the mtime is the activity signal. `clear` drops it — the concludes' orderly exit. `scan` reads every heartbeat in the work unit with two verdicts per row: `held` — the owning process still runs (pid + start time verified, so a dead or recycled pid reads unheld instantly; an identity-less record falls back to mtime aging), however long it has idled — and `live` — held *and* beaten within `stale_after_seconds` (900). Response `{"live": N, "held": N, "stale_after_seconds": 900, "sessions": [{phase, topic, age_seconds, held, live, session_id}…]}`, plus a `DISPLAY: presence deferral` section after the JSON line when anything is live — emitted verbatim at the same call, at the analysis-dispatch deferral. `cleanup` sweeps every heartbeat the named session owns across all work units — the SessionEnd hook target on research and discussion, covering the exits that keep the process alive (/clear, logout); the session id comes from the argument or the hook's stdin JSON, and it never errors on missing state. Consumers: the epic view marks held topics (menu strike-through, recommendation skip, in-session confirm gate); the topic-discovery dispatch defers a stale-cache analysis while a peer session is live; the conclude sweep leaves a held row's dirt alone and commits a dead session's leavings action-scoped; the spec-side resolution flow checks the target discussion before editing its document in place.
+**`presence`** — the per-topic session heartbeat, cache-resident (`.workflows/.cache/{wu}/{phase}/{topic}/presence`, gitignored). Awareness, never mutual exclusion. Every phase a session sits in carries one — research, discussion, investigation, scoping, specification, planning, implementation, review — except discovery, which `discovery-session open` already serialises to one session per epic.
+
+**Beats are mechanical, and no prose ever issues one.** The engine stamps the heartbeat as a side effect of the verbs a session already runs, and only where the verb is structurally self-referential — the session acting on its own topic. A beat writes *this* process's identity, so a beat from a verb acting on another topic would manufacture a false hold there.
+
+| Verb | Beat |
+|---|---|
+| `commit --topic {phase}/{topic}` | beats — the session-cadence commit, so "last active" means "time since the last real write" |
+| `commit --topic … --kb` | **clears** — the terminal conclusion commit; a beat here would re-stamp the topic after it concluded and it would read held forever |
+| `commit --topic … --sweep` | suppressed — the conclude sweep commits a dead session's leavings; a sweeper stamping the topic it just cleaned would resurrect the hold |
+| `commit --paths … --for {wu} {phase}/{topic}` | beats the named code topic |
+| `topic queue` | beats — the session loops' findings check polls it every turn, so a turn with no writes still registers |
+| `topic start` · `topic complete` · `topic absorb` | beat — opening, closing, and folding a concern into the session's own topic |
+| `manifest set <wu>.<phase>.<topic>` | beats — every state transition on the session's own topic (a discovery-addressed write no-ops, like any phase outside the set) |
+| `agent dispatch` · `scan` · `ack` · `announce` · `surface` · `incorporate` | beat — the session's own background agents |
+| `topic triage` | never — delivery acts on the **target** topic from the origin's session |
+| `topic requeue` · `cancel` · `reactivate` · `supersede` · `reopen` · `sources stale` · `manifest apply` | never — analysis and navigation actors reaching across topics |
+| every other read, render, and projection verb | never |
+
+A beat is best-effort: it never throws, never changes a verb's response, and no-ops on a phase outside the set or a work unit with no directory.
+
+`beat` and `clear` remain as explicit verbs for tests and repair. `scan` reads every heartbeat with two verdicts per row: `held` — the owning process still runs (pid + start time verified, so a dead or recycled pid reads unheld instantly; an identity-less record falls back to mtime aging), however long it has idled — and `live` — held *and* beaten within `stale_after_seconds` (900). With a work unit: `{"work_unit": "…", "live": N, "held": N, "stale_after_seconds": 900, "sessions": [{phase, topic, age_seconds, held, live, session_id}…]}`, plus a `DISPLAY: presence deferral` section after the JSON line when anything is live — emitted verbatim at the same call, at the analysis-dispatch deferral. Without one, it walks the whole cache root for the code gate's project-wide read: the same totals and row shape with `work_unit` on each row and `"scope": "project"` in place of `work_unit`, and no deferral section (the deferral is the dispatch's, and the dispatch always names a work unit). `cleanup` sweeps every heartbeat the named session owns across all work units — the SessionEnd hook target on the session skills, covering the exits that keep the process alive (/clear, logout); the session id comes from the argument or the hook's stdin JSON, and it never errors on missing state. Consumers: the epic view marks held topics (menu strike-through, recommendation skip, in-session confirm gate); the topic-discovery dispatch defers a stale-cache analysis while a peer session is live; the conclude sweep leaves a held row's dirt alone and commits a dead session's leavings action-scoped; the spec-side resolution flow checks the target discussion before editing its document in place.
 
 ```bash
-engine presence beat <work-unit> <phase> <topic>    # research|discussion only
+engine presence beat <work-unit> <phase> <topic>    # every phase but discovery
 engine presence clear <work-unit> <phase> <topic>
-engine presence scan <work-unit>
+engine presence scan [work-unit]                    # work-unit-less: the whole project
 engine presence cleanup [session-id]                # SessionEnd hook target; reads stdin JSON when no argument
 ```
 
@@ -225,16 +245,23 @@ engine roadmap horizon remove <name>               # empty horizons only
 engine cache stamp <work-unit> gap-analysis
 ```
 
-**`commit`** — the scoped commit helper: `git add -- .workflows/{wu}` (`.workflows/.inbox` with `--inbox`, or the whole `.workflows` tree with `--workflows` — migrations touch many work units plus `.workflows/.state`) plus commit. Every engine-made commit — this helper and every transaction — also stages `.workflows/.knowledge` when it exists (exists-guarded, `domain/commit.cjs`): transactions dirty the store as a side effect of their knowledge sync, and that dirt belongs with the write that produced it. A clean tree is fine: `{"ok": true, "committed": null, "note": "nothing to commit"}`, exit 0. `--plan <topic>` widens the scope with the plan's declared storage: it stages `.workflows/manifest.json` and every `storage_paths` entry recorded on the planning item at plan init (the format's authoring doc declares them; entries are validated relative-only and skipped when neither on disk nor tracked, while deleted-but-tracked paths still stage their deletions). A planning item without `storage_paths` (pre-upgrade plan) fails loudly with the one-line repair. Code never rides a `--plan` commit — implementation's code commits stay with the session and raw git.
+**`commit`** — the scoped commit helper. **Every engine commit is confined to a pathspec** — this helper and every transaction tail alike: `git add -- <paths>` then `git commit -m … -- <paths>`, which builds a temporary index from HEAD plus the worktree content of those paths. Nothing outside the declared scope can ride, so a concurrent session's dirty or staged files (and the user's own staged code) are ignored and left exactly as they were. Pathspecs matching neither disk nor index are dropped before the add — a scope naming a path its action never created is normal. A clean scope is fine: `{"ok": true, "committed": null, "note": "nothing to commit"}`, exit 0.
 
-`--topic <phase>/<topic>` is the action-scoped form for concurrent sessions: `git commit -- <paths>` confined to the topic's artifact (`{phase}/{topic}.md` for research/discussion/investigation, `{phase}/{topic}/` for specification/planning/implementation/review) plus the topic's triage-queue directory (research/discussion) plus the work-unit manifest, exists-guarded like `--plan`. Another session's dirty or staged files never ride the commit and are left exactly as they were. The KB dir does not ride by default; `--kb` adds it for the moments whose own action dirtied the store — a conclusion commit right after `topic complete`'s knowledge index. Mutually exclusive with `--plan`.
+The scope by form: `.workflows/{wu}` bare, `.workflows/.inbox` with `--inbox`, `.workflows/.roadmap` plus the project manifest with `--roadmap` (the product session's cadence commit — the roadmap node lives on the project manifest), the whole `.workflows` tree with `--workflows` (migrations touch many work units plus `.workflows/.state`). The work-unit forms also stage `.workflows/.knowledge` when it exists (exists-guarded, `domain/commit.cjs`) — a transaction dirties the store as a side effect of its knowledge sync, and that dirt belongs with the write that produced it. Transactions that never touch the store take the rider-less door: sweeping up store dirt an action did not create is the theft the confinement removes.
+
+`--plan <topic>` widens the work-unit scope with the plan's declared storage: `.workflows/manifest.json` and every `storage_paths` entry recorded on the planning item at plan init (the format's authoring doc declares them; entries are validated relative-only, while deleted-but-tracked paths still commit their deletions). A planning item without `storage_paths` (pre-upgrade plan) fails loudly with the one-line repair. Code never rides a `--plan` commit — code has its own form below.
+
+`--topic <phase>/<topic>` is the session-cadence form: the topic's artifact (`{phase}/{topic}.md` for research/discussion/investigation, `{phase}/{topic}/` for specification/planning/implementation/review) plus the topic's triage-queue directory (research/discussion) plus the work-unit manifest. The KB dir does not ride by default; `--kb` adds it for the moments whose own action dirtied the store — a conclusion commit right after `topic complete`'s knowledge index. `--sweep` marks the conclude sweep's commit of a dead session's leavings. Both riders carry presence semantics — see the beat table under `presence`. Mutually exclusive with `--plan` and `--discovery`.
+
+`--discovery` is the discovery session's cadence form: `discovery/sessions/`, `discovery/briefs/`, and the work-unit manifest (the map lives there). Discovery runs beside live research and discussion sessions on the same work unit, so it slices its own paths and never theirs.
+
+`--paths <file> …` is the code commit — the one scope no layout derives (code has none), so the session declares it and the engine checks it: every path must resolve inside the project, be literal (a pattern is refused — it would commit whatever it matched), be on disk or tracked, and never live under `.workflows/`, whose artifacts have derived scopes of their own. Required `--for <work-unit> <implementation|review>/<topic>` names the code topic, which the commit beats. The response adds `left_dirty` — every tracked modification and untracked file still outside `.workflows` — so the session can close the loop on a path it forgot to name. `.workflows` dirt is excluded on purpose: document sessions run concurrently with the code session by design, and their dirt is theirs.
 
 Every engine commit runs under a process-wide commit lock (`.git/workflows-commit.lock` — in the `.git` dir so it can never be staged; same stale-break discipline as the manifest lock), and index-mutating git operations retry briefly through `index.lock` contention before surfacing git's error. Transaction-tail commits degrade rather than abort: the state write has landed, so a git failure leaves the verb `ok` with `"note": "commit pending — state saved; retry with engine commit"` and the git error appended to `warnings`.
 
-`--roadmap` is the product session's cadence commit: the roadmap dir (`.workflows/.roadmap` — sessions, imports) plus the project manifest (the roadmap node lives there), exists-guarded like `--plan`'s pathspecs. Another session's work-unit dirt never rides.
-
 ```bash
-engine commit <work-unit> -m "<message>" [--plan <topic> | --topic <phase>/<topic> [--kb]]
+engine commit <work-unit> -m "<message>" [--plan <topic> | --discovery | --topic <phase>/<topic> [--kb] [--sweep]]
+engine commit --paths <file> … -m "<message>" --for <work-unit> <implementation|review>/<topic>
 engine commit --inbox -m "<message>"
 engine commit --roadmap -m "<message>"
 engine commit --workflows -m "<message>"

--- a/skills/workflow-engine/references/library-and-gateway.md
+++ b/skills/workflow-engine/references/library-and-gateway.md
@@ -71,6 +71,11 @@ engine.agents.reviewArming(cwd, wu, topic)        // → { armed, cycles, map_mo
 // domain: discovery-session queries
 engine.session.nextSessionNumber(sessionsDir)     // → next session-NNN number from the on-disk logs (1 when none)
 
+// domain: session presence
+engine.presence.scanPresence(cwd, wu)             // → { work_unit, live, held, stale_after_seconds, sessions[] } — one work unit's heartbeats
+engine.presence.scanProject(cwd)                  // → the same shape with `scope: "project"` and `work_unit` per row — every heartbeat in the project
+engine.presence.fmtAge(seconds)                   // → a row's age as `40s` / `12m` / `3h` / `2d`
+
 // domain: detail builders + projections
 engine.detail.epicDetail(cwd, manifest)           // → EpicDetail (the one structured object per epic)
 engine.detail.EPIC_DETAIL_PHASES                  // string[] — every phase the epic detail surfaces (discovery first, then the pipeline)

--- a/skills/workflow-engine/scripts/domain/boot.cjs
+++ b/skills/workflow-engine/scripts/domain/boot.cjs
@@ -19,7 +19,7 @@ const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const { git } = require('../kernel/git.cjs');
-const { commitScopedLocked, KB_DIR } = require('./commit.cjs');
+const { commitPathspecScoped, KB_DIR } = require('./commit.cjs');
 const { spawnKnowledge } = require('./kb.cjs');
 const { labelConfigStatus, repairSessionLabels, configDir } = require('./session-label.cjs');
 const { baselineState } = require('./baseline.cjs');
@@ -158,17 +158,16 @@ function boot(cwd) {
   // (permission/hook plumbing) and the repo-root .gitignore. The skill's
   // .workflows-scoped migration commit misses those, leaving them dirty after
   // boot for some later unrelated commit to sweep up. When migrations changed,
-  // commit whichever of the two exist on disk — existence-guarded, since a
-  // `git add` on a nonexistent path errors (the same lesson commit.cjs's
-  // KB_DIR guard encodes) and an all-clean stage simply commits nothing. The
-  // migration files are already applied, so a commit failure is a warning,
-  // never a block.
+  // commit whichever of the two exist on disk, confined to them — a boot runs
+  // beside live sessions and beside the user's own staged work, and neither
+  // belongs in a migration commit. The migration files are already applied,
+  // so a commit failure is a warning, never a block.
   if (migrations.changed) {
     try {
       const configSpecs = ['.claude/settings.json', '.gitignore']
         .filter((p) => fs.existsSync(path.join(cwd, p)));
       if (configSpecs.length > 0) {
-        commitScopedLocked(cwd, configSpecs, 'chore: apply workflow migration config changes');
+        commitPathspecScoped(cwd, configSpecs, 'chore: apply workflow migration config changes');
       }
     } catch (err) {
       warnings.push(`migration config commit failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -211,7 +210,7 @@ function boot(cwd) {
         const message = status.split('\n').some((l) => l.startsWith('??'))
           ? 'chore(knowledge): initialise store'
           : 'chore(knowledge): compact store';
-        kbCommitted = commitScopedLocked(cwd, KB_DIR, message);
+        kbCommitted = commitPathspecScoped(cwd, KB_DIR, message);
       }
     } catch (err) {
       warnings.push(`knowledge store commit failed: ${err instanceof Error ? err.message : String(err)}`);

--- a/skills/workflow-engine/scripts/domain/build-order.cjs
+++ b/skills/workflow-engine/scripts/domain/build-order.cjs
@@ -20,7 +20,7 @@
 // ---------------------------------------------------------------------------
 
 const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock } = require('../kernel/manifest.cjs');
-const { commitTailWithKb, noteCommitOutcome } = require('./commit.cjs');
+const { commitTailPathspec, noteCommitOutcome } = require('./commit.cjs');
 const { phaseItems } = require('./derivations.cjs');
 const { TERMINAL_STATUSES } = require('../kernel/manifest-schema.cjs');
 
@@ -46,7 +46,7 @@ function buildOrderLive(item) {
 
 /**
  * Record the build order across an epic's specification topics: set each
- * topic's `order`, clear the staleness flag, commit scoped to the work unit.
+ * topic's `order`, clear the staleness flag, commit the manifest write.
  * The assignment must be the whole live set — every non-terminal
  * specification topic exactly once, orders a contiguous permutation of 1..N.
  * @param {string} cwd project root
@@ -108,7 +108,10 @@ function sequenceBuildOrder(cwd, workUnit, orders) {
 
   /** @type {string[]} */
   const warnings = [];
-  const outcome = commitTailWithKb(cwd, `.workflows/${workUnit}`, `specification(${workUnit}): sequence build order`, warnings);
+  // The sequencing pass runs from the epic entry, beside whatever sessions
+  // hold the unit's topics: it wrote the manifest and nothing else, so that
+  // is all it commits.
+  const outcome = commitTailPathspec(cwd, `.workflows/${workUnit}/manifest.json`, `specification(${workUnit}): sequence build order`, warnings);
   /** @type {BuildOrderSequenceResult} */
   const result = { ordered: orders, committed: outcome.committed };
   if (outcome.failed) result.warnings = warnings;

--- a/skills/workflow-engine/scripts/domain/commit.cjs
+++ b/skills/workflow-engine/scripts/domain/commit.cjs
@@ -2,14 +2,19 @@
 
 // ---------------------------------------------------------------------------
 // Domain ring: the engine's commit door. Every engine-made commit routes
-// through here, for two guarantees:
+// through here, for three guarantees:
 //
-// - The knowledge store rides along: transactions mutate the store
-//   (index/remove) as a side effect of manifest writes, and a commit that
-//   staged only the work unit would leave `.workflows/.knowledge` dirty for
-//   some later, unrelated commit to sweep up. The pathspec is appended
-//   exists-guarded — staging a nonexistent path is a git error (the
-//   conditional-inbox lesson), and keyword-less projects may have no store.
+// - Commits are confined: each one names the paths its action wrote and
+//   commits `-- <paths>`, so a peer session's dirty or staged files are never
+//   swept up under someone else's message. No engine commit can reach outside
+//   its declared scope.
+//
+// - The knowledge store rides along where the action touched it: transactions
+//   mutate the store (index/remove) as a side effect of manifest writes, and
+//   their commit must carry that dirt. The pathspec is appended
+//   exists-guarded — keyword-less projects may have no store. Transactions
+//   that never call the store take the rider-less siblings; sweeping store
+//   dirt an action did not create is the theft the confinement removes.
 //
 // - Commits are serialised: a process-wide lock (`.git/workflows-commit.lock`,
 //   same discipline as the manifest lock, on a longer clock) holds each
@@ -19,11 +24,27 @@
 
 const fs = require('fs');
 const path = require('path');
-const { git, commitScoped, commitPathspec } = require('../kernel/git.cjs');
+const { git, commitPathspec } = require('../kernel/git.cjs');
 const { acquireLockFile, releaseLockFile } = require('../kernel/manifest-io.cjs');
 
 const KB_DIR = '.workflows/.knowledge';
 const PROJECT_MANIFEST_SPEC = '.workflows/manifest.json';
+
+/**
+ * The discovery scope — what a discovery session writes: its session logs,
+ * the briefs it synthesises at the harvest, and the work-unit manifest (the
+ * map lives there). Shared by `commit --discovery` and the discovery
+ * transaction tails so the session's every commit slices the same paths.
+ * @param {string} workUnit
+ * @returns {string[]}
+ */
+function discoveryScope(workUnit) {
+  return [
+    `.workflows/${workUnit}/discovery/sessions`,
+    `.workflows/${workUnit}/discovery/briefs`,
+    `.workflows/${workUnit}/manifest.json`,
+  ];
+}
 
 /**
  * The commit lock lives in the `.git` dir (like git's own transient locks) —
@@ -62,47 +83,49 @@ function withCommitLock(cwd, fn) {
 }
 
 /**
- * `commitScoped` under the commit lock, with the knowledge store staged
- * alongside the caller's pathspec whenever it exists on disk. Same contract:
- * short sha, or null when nothing was staged.
- * @param {string} cwd      project root
- * @param {string|string[]} pathspec
- * @param {string} message
- * @returns {string|null}
+ * The caller's pathspec with the knowledge store appended when it exists on
+ * disk — for the transactions whose own action dirtied the store.
+ * @param {string} cwd @param {string|string[]} pathspec
+ * @returns {string[]}
  */
-function commitScopedWithKb(cwd, pathspec, message) {
+function withKbSpec(cwd, pathspec) {
   const specs = Array.isArray(pathspec) ? [...pathspec] : [pathspec];
   if (!specs.includes(KB_DIR) && fs.existsSync(path.join(cwd, KB_DIR))) {
     specs.push(KB_DIR);
   }
-  return withCommitLock(cwd, () => commitScoped(cwd, specs, message));
-}
-
-/**
- * `commitScoped` under the commit lock, the caller's pathspec only — boot's
- * config and store commits, which must not drag the KB dir in implicitly.
- * @param {string} cwd @param {string|string[]} pathspec @param {string} message
- * @returns {string|null}
- */
-function commitScopedLocked(cwd, pathspec, message) {
-  return withCommitLock(cwd, () => commitScoped(cwd, pathspec, message));
+  return specs;
 }
 
 /**
  * `commitPathspec` under the commit lock: commit exactly the named paths,
  * leaving every other process's dirty or staged files untouched. The KB dir
- * never rides implicitly — an action-scoped commit names what its action
- * wrote, and no KB-touching verb precedes it.
+ * never rides — this is the door for actions that never touched the store.
  * @param {string} cwd @param {string|string[]} pathspec @param {string} message
+ * @param {() => void} [beforeInLock] index-mutating prep (e.g. git rm) that
+ *   must run inside the same commit-lock hold as the commit that lands it
  * @returns {string|null}
  */
-function commitPathspecScoped(cwd, pathspec, message) {
-  return withCommitLock(cwd, () => commitPathspec(cwd, pathspec, message));
+function commitPathspecScoped(cwd, pathspec, message, beforeInLock) {
+  return withCommitLock(cwd, () => {
+    if (beforeInLock) beforeInLock();
+    return commitPathspec(cwd, pathspec, message);
+  });
 }
 
 /**
- * Stamp a transaction result when nothing was staged. `commitScopedWithKb`
- * returns null on a clean tree; `nothing to commit` is the one note every
+ * `commitPathspecScoped` with the knowledge store staged alongside the
+ * caller's pathspec — the door for actions that indexed or removed chunks.
+ * @param {string} cwd @param {string|string[]} pathspec @param {string} message
+ * @param {() => void} [beforeInLock]
+ * @returns {string|null}
+ */
+function commitPathspecWithKb(cwd, pathspec, message, beforeInLock) {
+  return commitPathspecScoped(cwd, withKbSpec(cwd, pathspec), message, beforeInLock);
+}
+
+/**
+ * Stamp a transaction result when nothing was committed. The commit doors
+ * return null on a clean scope; `nothing to commit` is the one note every
  * engine transaction shares for that outcome. Mutates the result in place.
  * @param {{note?: string}} result @param {string|null} committed
  */
@@ -120,17 +143,9 @@ function noteIfNothingCommitted(result, committed) {
  *   must run inside the same commit-lock hold as the commit that lands it
  * @returns {{committed: string|null, failed: boolean}}
  */
-function commitTailWithKb(cwd, pathspec, message, warnings, beforeInLock) {
+function commitTailPathspec(cwd, pathspec, message, warnings, beforeInLock) {
   try {
-    const specs = Array.isArray(pathspec) ? [...pathspec] : [pathspec];
-    if (!specs.includes(KB_DIR) && fs.existsSync(path.join(cwd, KB_DIR))) {
-      specs.push(KB_DIR);
-    }
-    const committed = withCommitLock(cwd, () => {
-      if (beforeInLock) beforeInLock();
-      return commitScoped(cwd, specs, message);
-    });
-    return { committed, failed: false };
+    return { committed: commitPathspecScoped(cwd, pathspec, message, beforeInLock), failed: false };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     warnings.push(`commit failed: ${detail}`);
@@ -139,15 +154,16 @@ function commitTailWithKb(cwd, pathspec, message, warnings, beforeInLock) {
 }
 
 /**
- * `commitTailWithKb`'s pathspec-confined sibling: commit exactly the named
- * paths at a transaction tail, degrading a git failure to a warning.
+ * `commitTailPathspec` for a transaction that touched the knowledge store —
+ * the store's dirt commits with the write that produced it.
  * @param {string} cwd @param {string|string[]} pathspec @param {string} message
  * @param {string[]} warnings
+ * @param {() => void} [beforeInLock]
  * @returns {{committed: string|null, failed: boolean}}
  */
-function commitTailPathspec(cwd, pathspec, message, warnings) {
+function commitTailWithKb(cwd, pathspec, message, warnings, beforeInLock) {
   try {
-    return { committed: commitPathspecScoped(cwd, pathspec, message), failed: false };
+    return { committed: commitPathspecWithKb(cwd, pathspec, message, beforeInLock), failed: false };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     warnings.push(`commit failed: ${detail}`);
@@ -171,14 +187,14 @@ function noteCommitOutcome(result, outcome) {
 }
 
 module.exports = {
-  commitScopedWithKb,
-  commitScopedLocked,
   commitPathspecScoped,
-  commitTailWithKb,
+  commitPathspecWithKb,
   commitTailPathspec,
+  commitTailWithKb,
   noteCommitOutcome,
   noteIfNothingCommitted,
   withCommitLock,
+  discoveryScope,
   KB_DIR,
   PROJECT_MANIFEST_SPEC,
 };

--- a/skills/workflow-engine/scripts/domain/discovery-map.cjs
+++ b/skills/workflow-engine/scripts/domain/discovery-map.cjs
@@ -23,7 +23,7 @@
 const fs = require('fs');
 const path = require('path');
 const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock, ensureContainer } = require('../kernel/manifest.cjs');
-const { commitTailWithKb, noteCommitOutcome } = require('./commit.cjs');
+const { commitTailPathspec, noteCommitOutcome, discoveryScope } = require('./commit.cjs');
 const { computeTopicLifecycle, phaseItems } = require('./derivations.cjs');
 const { VALID_ROUTINGS } = require('../kernel/manifest-schema.cjs');
 
@@ -175,7 +175,7 @@ function sequenceMap(cwd, workUnit, orders) {
 
   /** @type {string[]} */
   const warnings = [];
-  const outcome = commitTailWithKb(cwd, `.workflows/${workUnit}`, `discovery(${workUnit}): sequence topic map`, warnings);
+  const outcome = commitTailPathspec(cwd, discoveryScope(workUnit), `discovery(${workUnit}): sequence topic map`, warnings);
   /** @type {SequenceResult} */
   const result = { ordered: orders, committed: outcome.committed };
   if (outcome.failed) result.warnings = warnings;
@@ -409,13 +409,13 @@ function removeItem(cwd, workUnit, name) {
   // back to the map on removal — the stretch-scope wrap's revert. Lazy
   // require and after the work-unit lock closes, mirroring the cancel hop —
   // and like that hop the project manifest is staged in its own commit (the
-  // map op itself stays cadence-committed, wu-scoped, which never covers the
+  // map op itself stays cadence-committed, and no work-unit scope reaches the
   // project manifest).
   const { revertJoins } = require('./roadmap.cjs');
   const reverted = revertJoins(cwd, workUnit, { topic: name });
   if (reverted.length > 0) {
     result.roadmap_reverted = reverted;
-    const { commitTailPathspec, PROJECT_MANIFEST_SPEC } = require('./commit.cjs');
+    const { PROJECT_MANIFEST_SPEC } = require('./commit.cjs');
     /** @type {string[]} */
     const warnings = [];
     commitTailPathspec(cwd, PROJECT_MANIFEST_SPEC, `roadmap: un-pull ${reverted.join(', ')} (${name} removed from ${workUnit})`, warnings);

--- a/skills/workflow-engine/scripts/domain/discovery-session.cjs
+++ b/skills/workflow-engine/scripts/domain/discovery-session.cjs
@@ -26,7 +26,7 @@
 const fs = require('fs');
 const path = require('path');
 const { loadWorkUnitManifest, saveWorkUnitManifest, withWorkUnitLock, ensureContainer } = require('../kernel/manifest.cjs');
-const { commitTailWithKb, noteCommitOutcome } = require('./commit.cjs');
+const { commitTailWithKb, noteCommitOutcome, discoveryScope } = require('./commit.cjs');
 const { knowledge } = require('./kb.cjs');
 
 /**
@@ -136,8 +136,10 @@ function openDiscoverySession(cwd, workUnit, { sessionLogFile }) {
  * Close the work unit's active discovery session: delete
  * `phases.discovery.active_session` (so resume detection on the next entry
  * sees a closed session), index the marker's session log into the knowledge
- * base (warn-don't-block), and commit scoped to the work unit with the
- * caller's message — one call covers whatever the session left dirty.
+ * base (warn-don't-block), and commit the discovery scope (sessions, briefs,
+ * manifest) plus the store, with the caller's message — one call covers
+ * whatever the session left dirty. A peer session's topic files are never
+ * swept: discovery runs beside live research and discussion sessions.
  * @param {string} cwd project root
  * @param {string} workUnit
  * @param {{message: string}} opts  commit message — varies by caller
@@ -167,7 +169,7 @@ function closeDiscoverySession(cwd, workUnit, { message }) {
   const warnings = [];
   knowledge(cwd, ['index', session.rel], `knowledge index (discovery/sessions/session-${session.number}.md)`, warnings);
 
-  const outcome = commitTailWithKb(cwd, `.workflows/${workUnit}`, message, warnings);
+  const outcome = commitTailWithKb(cwd, discoveryScope(workUnit), message, warnings);
   /** @type {DiscoverySessionCloseResult} */
   const result = { work_unit: workUnit, session: session.number, session_log: session.rel, committed: outcome.committed, warnings };
   noteCommitOutcome(result, outcome);

--- a/skills/workflow-engine/scripts/domain/inbox.cjs
+++ b/skills/workflow-engine/scripts/domain/inbox.cjs
@@ -14,7 +14,7 @@
 const fs = require('fs');
 const path = require('path');
 const { removeFiles } = require('../kernel/git.cjs');
-const { commitTailWithKb, noteCommitOutcome } = require('./commit.cjs');
+const { commitTailPathspec, noteCommitOutcome } = require('./commit.cjs');
 
 const INBOX = '.workflows/.inbox';
 const FOLDERS = ['ideas', 'bugs', 'quickfixes'];
@@ -115,7 +115,7 @@ function moveAndCommit(cwd, items, destDir, verb) {
   }
   /** @type {string[]} */
   const warnings = [];
-  const outcome = commitTailWithKb(cwd, INBOX, commitMessage(verb, items), warnings);
+  const outcome = commitTailPathspec(cwd, INBOX, commitMessage(verb, items), warnings);
   /** @type {{moved: string[], committed: string|null, note?: string, warnings?: string[]}} */
   const result = { moved, committed: outcome.committed };
   if (outcome.failed) {
@@ -161,9 +161,9 @@ function deleteItems(cwd, paths) {
   /** @type {string[]} */
   const warnings = [];
   // The git rm stages index changes, so it belongs inside the same commit
-  // lock as the commit that lands them — a concurrent whole-index commit
-  // must never sweep the deletions under its own message.
-  const outcome = commitTailWithKb(cwd, INBOX, commitMessage('delete', items), warnings, () => {
+  // lock as the commit that lands them — no peer's add+commit sequence may
+  // interleave between the two.
+  const outcome = commitTailPathspec(cwd, INBOX, commitMessage('delete', items), warnings, () => {
     removeFiles(cwd, items.map((i) => i.given));
   });
   /** @type {{deleted: string[], committed: string|null, note?: string, warnings?: string[]}} */

--- a/skills/workflow-engine/scripts/domain/presence.cjs
+++ b/skills/workflow-engine/scripts/domain/presence.cjs
@@ -5,16 +5,27 @@
 // cache directory. Awareness, never mutual exclusion: the epic view marks
 // topics another session holds open, the analysis dispatch defers an epic-wide
 // analysis while a peer session is live, the conclude sweep leaves a held
-// peer's dirt alone, and the spec-side resolution flow checks the target
-// discussion before editing its document in place. The file records the
+// peer's dirt alone, the code gate reads the whole project's rows, and the
+// spec-side resolution flow checks the target discussion before editing its
+// document in place. The file records the
 // owning Claude process's identity
 // (pid + start time + session id); `held` is true while that exact process
 // still runs — however long it sits idle — and the mtime is the activity
 // signal (`live` = held and beaten within the staleness window). A record
 // without identity (no CLAUDE_PID at beat time) degrades to mtime-only.
-// Sessions beat at their per-turn check, clear at conclusion; the SessionEnd
-// hook on the session skills sweeps by session id for the exits that keep
-// the process alive (/clear, logout).
+//
+// Beats are mechanical: the engine stamps them as a side effect of the verbs
+// a session already runs on its own topic (`beatQuietly`), and the terminal
+// conclusion commit clears (`clearQuietly`). A beat writes THIS process's
+// identity, so only a structurally self-referential verb may beat — stamping
+// it from a verb acting on another topic manufactures a false hold. The
+// SessionEnd hook on the session skills sweeps by session id for the exits
+// that keep the process alive (/clear, logout).
+//
+// Every phase a session sits in carries presence except discovery:
+// `discovery-session open` already refuses a second session per epic
+// (`active_session`), so it is engine-serialised with nothing for a heartbeat
+// to add.
 // ---------------------------------------------------------------------------
 
 const fs = require('fs');
@@ -23,7 +34,7 @@ const { processStartTime, processAlive } = require('../kernel/process.cjs');
 const { section, CONTINUE_INSTRUCTION, callout } = require('./projections/surfaces.cjs');
 
 const STALE_AFTER_SECONDS = 900;
-const PHASES = ['research', 'discussion'];
+const PHASES = ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
 
 /** @param {string} cwd @param {string} wu @param {string} phase @param {string} topic */
 function presencePath(cwd, wu, phase, topic) {
@@ -100,6 +111,32 @@ function clearPresence(cwd, workUnit, phase, topic) {
 }
 
 /**
+ * The mechanical beat: a verb's heartbeat as a side effect, never observable.
+ * Silent on every failure — a phase outside PHASES, a work unit with no
+ * directory, an unwritable cache — because no verb's outcome may turn on
+ * whether its heartbeat landed.
+ * @param {string} cwd @param {string} workUnit @param {string} phase @param {string} topic
+ */
+function beatQuietly(cwd, workUnit, phase, topic) {
+  try {
+    if (!PHASES.includes(phase)) return;
+    beatPresence(cwd, workUnit, phase, topic);
+  } catch { /* liveness is advisory — never fail a verb over it */ }
+}
+
+/**
+ * `beatQuietly`'s terminal sibling: drop the heartbeat as a side effect of the
+ * verb that ends the session's work on the topic. Same silence.
+ * @param {string} cwd @param {string} workUnit @param {string} phase @param {string} topic
+ */
+function clearQuietly(cwd, workUnit, phase, topic) {
+  try {
+    if (!PHASES.includes(phase)) return;
+    clearPresence(cwd, workUnit, phase, topic);
+  } catch { /* liveness is advisory — never fail a verb over it */ }
+}
+
+/**
  * @typedef {object} PresenceRow
  * @property {string} phase
  * @property {string} topic
@@ -111,22 +148,27 @@ function clearPresence(cwd, workUnit, phase, topic) {
  */
 
 /**
- * Every heartbeat in the work unit's cache, with liveness applied — the one
- * read every consumer shares. `held` answers "does a session hold this topic
- * open" (unbounded by time); `live` answers "is it actively working".
- * @param {string} cwd @param {string} workUnit
- * @returns {{work_unit: string, stale_after_seconds: number, live: number, held: number, sessions: PresenceRow[]}}
+ * Memoised process start times — one `ps` per pid across a whole scan.
+ * @returns {(pid: number) => string|null|undefined}
  */
-function scanPresence(cwd, workUnit) {
-  assertArgs(cwd, workUnit, undefined);
-  /** @type {PresenceRow[]} */
-  const sessions = [];
+function startTimeReader() {
   /** @type {Map<number, string|null>} */
-  const startCache = new Map();
-  const startOf = (/** @type {number} */ pid) => {
-    if (!startCache.has(pid)) startCache.set(pid, processStartTime(pid));
-    return startCache.get(pid);
+  const cache = new Map();
+  return (pid) => {
+    if (!cache.has(pid)) cache.set(pid, processStartTime(pid));
+    return cache.get(pid);
   };
+}
+
+/**
+ * Every heartbeat under one work unit's cache, liveness applied.
+ * @param {string} cwd @param {string} workUnit
+ * @param {(pid: number) => string|null|undefined} startOf
+ * @returns {PresenceRow[]}
+ */
+function collectRows(cwd, workUnit, startOf) {
+  /** @type {PresenceRow[]} */
+  const rows = [];
   for (const phase of PHASES) {
     const dir = path.join(cwd, '.workflows', '.cache', workUnit, phase);
     /** @type {string[]} */
@@ -148,16 +190,59 @@ function scanPresence(cwd, workUnit) {
       } else {
         held = age < STALE_AFTER_SECONDS;
       }
-      sessions.push({
+      rows.push({
         phase, topic, age_seconds: age,
         held, live: held && age < STALE_AFTER_SECONDS,
         session_id: record ? record.session_id || null : null,
       });
     }
   }
-  sessions.sort((a, b) => a.age_seconds - b.age_seconds);
+  return rows;
+}
+
+/**
+ * Every heartbeat in the work unit's cache, with liveness applied — the one
+ * read every consumer shares. `held` answers "does a session hold this topic
+ * open" (unbounded by time); `live` answers "is it actively working".
+ * @param {string} cwd @param {string} workUnit
+ * @returns {{work_unit: string, stale_after_seconds: number, live: number, held: number, sessions: PresenceRow[]}}
+ */
+function scanPresence(cwd, workUnit) {
+  assertArgs(cwd, workUnit, undefined);
+  const sessions = collectRows(cwd, workUnit, startTimeReader()).sort((a, b) => a.age_seconds - b.age_seconds);
   return {
     work_unit: workUnit,
+    stale_after_seconds: STALE_AFTER_SECONDS,
+    live: sessions.filter((r) => r.live).length,
+    held: sessions.filter((r) => r.held).length,
+    sessions,
+  };
+}
+
+/**
+ * Every heartbeat in the project, work unit named per row — the read the code
+ * gate needs, which asks "is any session anywhere in a code phase" and has no
+ * work unit to scope by. Same row shape and same totals as the per-work-unit
+ * scan, plus `work_unit`; `scope` names the form.
+ * @param {string} cwd
+ * @returns {{scope: string, stale_after_seconds: number, live: number, held: number, sessions: (PresenceRow & {work_unit: string})[]}}
+ */
+function scanProject(cwd) {
+  const cacheRoot = path.join(cwd, '.workflows', '.cache');
+  /** @type {string[]} */
+  let workUnits = [];
+  try {
+    workUnits = fs.readdirSync(cacheRoot, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch { /* nothing cached yet */ }
+  const startOf = startTimeReader();
+  /** @type {(PresenceRow & {work_unit: string})[]} */
+  const sessions = [];
+  for (const wu of workUnits.sort()) {
+    for (const row of collectRows(cwd, wu, startOf)) sessions.push({ work_unit: wu, ...row });
+  }
+  sessions.sort((a, b) => a.age_seconds - b.age_seconds);
+  return {
+    scope: 'project',
     stale_after_seconds: STALE_AFTER_SECONDS,
     live: sessions.filter((r) => r.live).length,
     held: sessions.filter((r) => r.held).length,
@@ -223,4 +308,8 @@ function deferralSection(scan) {
   );
 }
 
-module.exports = { beatPresence, clearPresence, scanPresence, cleanupPresence, deferralSection, fmtAge, STALE_AFTER_SECONDS };
+module.exports = {
+  beatPresence, clearPresence, beatQuietly, clearQuietly,
+  scanPresence, scanProject, cleanupPresence, deferralSection,
+  fmtAge, PHASES, STALE_AFTER_SECONDS,
+};

--- a/skills/workflow-engine/scripts/domain/transitions.cjs
+++ b/skills/workflow-engine/scripts/domain/transitions.cjs
@@ -444,7 +444,10 @@ function triageTopic(cwd, workUnit, phase, topic, opts = {}) {
     result.warnings = warnings;
     noteCommitOutcome(result, outcome);
     if (outcome.failed) {
-      result.note = `commit pending — state saved; retry with: engine commit ${workUnit} --topic ${phase}/${topic} -m "<message>"`;
+      // `--sweep` on the retry for the same reason the delivery itself never
+      // beats: the origin's session is committing into the TARGET topic, and
+      // a heartbeat there would manufacture a hold no session is holding.
+      result.note = `commit pending — state saved; retry with: engine commit ${workUnit} --topic ${phase}/${topic} --sweep -m "<message>"`;
     }
   }
 
@@ -666,7 +669,9 @@ function requeueConcern(cwd, workUnit, fromPhase, toPhase, topic, { file, messag
   result.warnings = warnings;
   noteCommitOutcome(result, outcome);
   if (outcome.failed) {
-    result.note = `commit pending — the concern is moved; retry with: engine commit ${workUnit} --topic ${toPhase}/${topic} -m "<message>"`;
+    // `--sweep` keeps the retry as beat-free as the move: requeue is a
+    // repair across a topic's two phase-sides, not a session working one.
+    result.note = `commit pending — the concern is moved; retry with: engine commit ${workUnit} --topic ${toPhase}/${topic} --sweep -m "<message>"`;
   }
   return result;
 }

--- a/skills/workflow-engine/scripts/domain/transitions.cjs
+++ b/skills/workflow-engine/scripts/domain/transitions.cjs
@@ -897,7 +897,7 @@ function supersedeTopic(cwd, workUnit, phase, topic, { by }) {
 /**
  * Cancel an epic topic: stash the current status into `previous_status`, set
  * `status: cancelled`, drop the topic's discovery-map `order`, remove its
- * knowledge-base chunks (warn-don't-block), commit scoped to the work unit.
+ * knowledge-base chunks (warn-don't-block), commit the manifest write.
  *
  * Cancelling a discussion a live specification sources collapses that spec:
  * the bare cancel refuses, naming the affected spec item(s); `cascade: true`
@@ -988,9 +988,12 @@ function cancelTopic(cwd, workUnit, phase, topic, opts = {}) {
   const lifecycleAfter = computeTopicLifecycle(loadWorkUnitManifest(cwd, workUnit), topic).lifecycle;
   const reverted = lifecycleAfter === 'cancelled' ? revertJoins(cwd, workUnit, { topic }) : [];
 
+  // A cancel writes the work-unit manifest (and the project manifest when a
+  // roadmap join reverted) and nothing else on disk — it runs from the epic
+  // menu, beside sessions holding the unit's other topics.
   const cancelSpec = reverted.length > 0
-    ? [`.workflows/${workUnit}`, '.workflows/manifest.json']
-    : `.workflows/${workUnit}`;
+    ? [`.workflows/${workUnit}/manifest.json`, '.workflows/manifest.json']
+    : `.workflows/${workUnit}/manifest.json`;
   const outcome = commitTailWithKb(cwd, cancelSpec, `workflow(${workUnit}): cancel ${topic} (${phase})`, warnings);
   /** @type {TopicTransitionResult} */
   const result = { topic, phase, status: 'cancelled', committed: outcome.committed, warnings };
@@ -1004,8 +1007,8 @@ function cancelTopic(cwd, workUnit, phase, topic, opts = {}) {
 /**
  * Reactivate a cancelled epic topic: restore `previous_status` to `status`,
  * delete the stash, re-index the artifact when the restored status is
- * `completed` in an indexed phase (warn-don't-block), commit scoped to the
- * work unit.
+ * `completed` in an indexed phase (warn-don't-block), commit the manifest
+ * write.
  * @param {string} cwd project root
  * @param {string} workUnit
  * @param {string} phase
@@ -1065,7 +1068,7 @@ function reactivateTopic(cwd, workUnit, phase, topic) {
     knowledge(cwd, ['index', artifact(workUnit, topic)], 'knowledge index', warnings);
   }
 
-  const outcome = commitTailWithKb(cwd, `.workflows/${workUnit}`, `workflow(${workUnit}): reactivate ${topic} (${phase})`, warnings);
+  const outcome = commitTailWithKb(cwd, `.workflows/${workUnit}/manifest.json`, `workflow(${workUnit}): reactivate ${topic} (${phase})`, warnings);
   /** @type {TopicTransitionResult} */
   const result = { topic, phase, status: restored, committed: outcome.committed, warnings };
   noteCommitOutcome(result, outcome);

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -30,7 +30,7 @@ const { archiveItems, restoreItems, deleteItems } = require('./domain/inbox.cjs'
 const { stampAnalysisCache } = require('./domain/cache.cjs');
 const agentState = require('./domain/agent-state.cjs');
 const { boot } = require('./domain/boot.cjs');
-const { beatPresence, clearPresence, scanPresence, cleanupPresence, deferralSection } = require('./domain/presence.cjs');
+const { beatPresence, clearPresence, beatQuietly, clearQuietly, scanPresence, scanProject, cleanupPresence, deferralSection } = require('./domain/presence.cjs');
 const { applySessionLabel, restoreSessionLabel, repairSessionLabels, setLabelConfig } = require('./domain/session-label.cjs');
 const { createWorkUnit } = require('./domain/workunit-create.cjs');
 const { completeWorkUnit, cancelWorkUnit, reactivateWorkUnit, pivotWorkUnit } = require('./domain/workunit-lifecycle.cjs');
@@ -150,7 +150,7 @@ Commands:
   topic requeue <work-unit> <from-phase> <to-phase> <topic> --file <NNN-slug.md> -m <message>
   presence beat <work-unit> <phase> <topic>
   presence clear <work-unit> <phase> <topic>
-  presence scan <work-unit>
+  presence scan [work-unit]
   presence cleanup [session-id]
   session label <work-unit> <phase> <topic>
   session label-config <true|false>
@@ -671,7 +671,14 @@ function runPresence(argv) {
     }
     if (command === 'scan') {
       const [workUnit] = rest;
-      if (!workUnit || rest.length !== 1) throw new Error('Usage: engine presence scan <work-unit>');
+      if (rest.length > 1) throw new Error('Usage: engine presence scan [work-unit]');
+      // Work-unit-less: the project-wide read the code gate takes. The
+      // deferral section is the analysis dispatch's, which always scans one
+      // work unit — a project scan renders nothing.
+      if (!workUnit) {
+        respond(scanProject(process.cwd()));
+        return;
+      }
       const res = scanPresence(process.cwd(), workUnit);
       respond(res);
       respondSections(deferralSection(res));

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -19,7 +19,8 @@
 const fs = require('fs');
 const path = require('path');
 const { signpost, box, wrapWithPrefix, renderTree, WIDTH } = require('./kernel/render.cjs');
-const { commitScopedWithKb, commitPathspecScoped, KB_DIR } = require('./domain/commit.cjs');
+const { commitPathspecScoped, commitPathspecWithKb, discoveryScope, KB_DIR } = require('./domain/commit.cjs');
+const { dirtyPaths, stageableSpecs } = require('./kernel/git.cjs');
 const { recordSubtopicAdd, recordSubtopicState, recordSubtopicStates, SUBTOPIC_STATES } = require('./domain/discussion-map.cjs');
 const { VALID_ROUTINGS } = require('./kernel/manifest-schema.cjs');
 const { sequenceMap, addItem, addItemsBatch, editItem, removeItem, renameItem, rerouteItem, handleItem, unhandleItem } = require('./domain/discovery-map.cjs');
@@ -197,7 +198,8 @@ Commands:
   agent announce <work-unit> <phase> <topic> <id>
   agent surface  <work-unit> <phase> <topic> <id> <finding>[,<finding>…]
   agent incorporate <work-unit> <phase> <topic> <id>
-  commit <work-unit> -m <message> [--plan <topic>]
+  commit <work-unit> -m <message> [--plan <topic> | --discovery | --topic <phase>/<topic> [--kb] [--sweep]]
+  commit --paths <file> … -m <message> --for <work-unit> <implementation|review>/<topic>
   commit --inbox -m <message>
   commit --roadmap -m <message>
   commit --workflows -m <message>
@@ -298,7 +300,25 @@ Commands:
 // CLI's bare stdout byte-for-byte — prose substitution surfaces, including
 // their exit-code convention (2 = expected miss) — while mutations
 // (set/push/pull/delete) answer with the engine's one-line JSON response.
+//
+// A topic-addressed `set` heartbeats: every state transition a session
+// records on its own topic is a sign of life. `apply` never does — it is the
+// batch door, written across topics by the analyses that reshape a whole
+// work unit, and a beat would stamp the analysis session onto topics it does
+// not hold.
 // ---------------------------------------------------------------------------
+
+/**
+ * The heartbeat a topic-addressed field write earns. Three dot-path segments
+ * naming a presence phase is the session-on-its-own-topic shape; anything
+ * shorter (work unit, phase) or the `project` prefix is not.
+ * @param {string} dotpath
+ */
+function beatForDotpath(dotpath) {
+  const parts = String(dotpath).split('.');
+  if (parts.length !== 3) return;
+  beatQuietly(process.cwd(), parts[0], parts[1], parts[2]);
+}
 
 /** @param {string[]} argv */
 function runManifest(argv) {
@@ -314,7 +334,9 @@ function runManifest(argv) {
     return;
   }
   try {
-    respond(/** @type {object} */ (runFieldCommand(process.cwd(), command ?? '', rest)));
+    const result = /** @type {{path?: string}} */ (runFieldCommand(process.cwd(), command ?? '', rest));
+    if (command === 'set' && result && typeof result.path === 'string') beatForDotpath(result.path);
+    respond(/** @type {object} */ (result));
   } catch (err) {
     failJson(err);
   }
@@ -639,9 +661,23 @@ function runDiscoverySession(argv) {
 // one transaction per call: manifest write, knowledge-base sync
 // (warn-don't-block), scoped git commit. The JSON response reports what
 // happened — no follow-up read needed.
+//
+// Heartbeats ride the self-referential verbs — the session acting on its own
+// topic: `start` (opening it), `complete` (closing it; the conclusion commit
+// that follows carries `--kb` and clears), `absorb` (folding a concern into
+// its own document), and `queue` (the findings check polls it every turn, so
+// a turn with no writes still registers). `triage` never beats — delivery
+// acts on the TARGET topic from the origin's session, and a beat there would
+// stamp the origin process onto a topic it does not hold. Nor do `requeue`,
+// `cancel`, `reactivate`, `supersede` or `reopen`: those are analysis and
+// navigation actors reaching across topics.
 // ---------------------------------------------------------------------------
 
 const TOPIC_COMMANDS = { start: startTopic, triage: triageTopic, complete: completeTopic, reopen: reopenTopic, cancel: cancelTopic, reactivate: reactivateTopic };
+
+// The self-referential verbs among those dispatched through TOPIC_COMMANDS;
+// `queue` and `absorb` beat at their own branches.
+const TOPIC_BEATS = ['start', 'complete'];
 
 /**
  * A SessionEnd hook target's session id: the argument when given, else the
@@ -775,7 +811,9 @@ function runTopic(argv) {
       if (!workUnit || !phase || !topic || rest.length !== 3) {
         throw new Error('Usage: engine topic queue <work-unit> <phase> <topic>');
       }
-      respond(queueStatus(process.cwd(), workUnit, phase, topic));
+      const status = queueStatus(process.cwd(), workUnit, phase, topic);
+      beatQuietly(process.cwd(), workUnit, phase, topic);
+      respond(status);
       return;
     }
     if (command === 'absorb') {
@@ -792,7 +830,9 @@ function runTopic(argv) {
       if (!workUnit || !phase || !topic || pos.length !== 3 || !file || !message) {
         throw new Error('Usage: engine topic absorb <work-unit> <phase> <topic> --file <NNN-slug.md> -m <message>');
       }
-      respond(absorbConcern(process.cwd(), workUnit, phase, topic, { file, message }));
+      const absorbed = absorbConcern(process.cwd(), workUnit, phase, topic, { file, message });
+      beatQuietly(process.cwd(), workUnit, phase, topic);
+      respond(absorbed);
       return;
     }
     if (command === 'requeue') {
@@ -849,7 +889,9 @@ function runTopic(argv) {
     if (!workUnit || !phase || !topic) {
       throw new Error(`Usage: engine topic ${command} <work-unit> <phase> <topic>`);
     }
-    respond(fn(process.cwd(), workUnit, phase, topic));
+    const result = fn(process.cwd(), workUnit, phase, topic);
+    if (TOPIC_BEATS.includes(command)) beatQuietly(process.cwd(), workUnit, phase, topic);
+    respond(result);
   } catch (err) {
     failJson(err);
   }
@@ -1111,6 +1153,8 @@ function runCache(argv) {
 
 // ---------------------------------------------------------------------------
 // agent — the background-agent lifecycle store (domain/agent-state.cjs).
+// Every verb addresses the session's own topic — dispatching, scanning, and
+// walking its own agents' findings — so every one heartbeats.
 // ---------------------------------------------------------------------------
 
 /** @param {string[]} argv */
@@ -1120,18 +1164,23 @@ function runAgent(argv) {
     const { opts, flags, lists, positional } = parseArgs(rest, ['clean', 'final'], ['label']);
     const [workUnit, phase, topic, id, finding] = positional;
     const cwd = process.cwd();
+    /** @param {object} result */
+    const answer = (result) => {
+      beatQuietly(cwd, workUnit, phase, topic);
+      respond(result);
+    };
     if (command === 'dispatch') {
       if (!workUnit || !phase || !topic || positional.length !== 3 || !opts.kind) {
         throw new Error('Usage: engine agent dispatch <work-unit> <phase> <topic> --kind <kind> [--label <slug> …] [--set <NNN>] [--final]');
       }
-      respond(agentState.dispatchAgent(cwd, workUnit, phase, topic, { kind: opts.kind, labels: lists.label || [], set: opts.set, final: flags.has('final') }));
+      answer(agentState.dispatchAgent(cwd, workUnit, phase, topic, { kind: opts.kind, labels: lists.label || [], set: opts.set, final: flags.has('final') }));
       return;
     }
     if (command === 'scan') {
       if (!workUnit || !phase || !topic || positional.length !== 3) {
         throw new Error('Usage: engine agent scan <work-unit> <phase> <topic>');
       }
-      respond(agentState.scanAgents(cwd, workUnit, phase, topic));
+      answer(agentState.scanAgents(cwd, workUnit, phase, topic));
       return;
     }
     if (command === 'ack') {
@@ -1140,7 +1189,7 @@ function runAgent(argv) {
         throw new Error('Usage: engine agent ack <work-unit> <phase> <topic> <id> (--findings <F1,F2,…> | --clean)');
       }
       const findings = hasFindings ? opts.findings.split(',').map((f) => f.trim()) : [];
-      respond(agentState.ackAgent(cwd, workUnit, phase, topic, id, { findings }));
+      answer(agentState.ackAgent(cwd, workUnit, phase, topic, id, { findings }));
       return;
     }
     if (command === 'announce' || command === 'incorporate') {
@@ -1148,14 +1197,14 @@ function runAgent(argv) {
         throw new Error(`Usage: engine agent ${command} <work-unit> <phase> <topic> <id>`);
       }
       const fn = command === 'announce' ? agentState.announceAgent : agentState.incorporateAgent;
-      respond(fn(cwd, workUnit, phase, topic, id));
+      answer(fn(cwd, workUnit, phase, topic, id));
       return;
     }
     if (command === 'surface') {
       if (!workUnit || !phase || !topic || !id || !finding || positional.length !== 5) {
         throw new Error('Usage: engine agent surface <work-unit> <phase> <topic> <id> <finding>[,<finding>…]');
       }
-      respond(agentState.surfaceFinding(cwd, workUnit, phase, topic, id, finding));
+      answer(agentState.surfaceFinding(cwd, workUnit, phase, topic, id, finding));
       return;
     }
     throw new Error('Usage: engine agent <dispatch|scan|ack|announce|surface|incorporate> <work-unit> <phase> <topic> …');
@@ -1178,10 +1227,13 @@ function runBoot() {
 }
 
 // ---------------------------------------------------------------------------
-// commit — the scoped commit helper: stage `.workflows/{wu}` (the inbox with
-// --inbox, or the whole tree with --workflows) and commit. The knowledge
-// store rides along whenever it exists (domain/commit.cjs). A clean tree is
-// fine: {committed: null}.
+// commit — the scoped commit helper. Every form computes a pathspec and
+// commits confined to it: the work unit (`.workflows/{wu}`), the inbox, the
+// roadmap, the whole `.workflows` tree, one topic's artifacts (`--topic`),
+// the discovery session's paths (`--discovery`), a plan's declared storage
+// (`--plan`), or declared code paths (`--paths`). The knowledge store rides
+// the work-unit forms whenever it exists (domain/commit.cjs). A clean scope
+// is fine: {committed: null}.
 // ---------------------------------------------------------------------------
 
 // Per-phase artifact pathspecs for `commit --topic` — the paths a topic's
@@ -1198,55 +1250,60 @@ const TOPIC_COMMIT_ARTIFACTS = /** @type {Record<string, (wu: string, topic: str
   review: (wu, t) => [`.workflows/${wu}/review/${t}`],
 });
 
+// The code-commit verb's phases: implementation and review are the only ones
+// that write the tree, and one session holds them at a time.
+const CODE_PHASES = ['implementation', 'review'];
+
 /**
- * Whether the directory holds any file, at any depth. An existing-but-empty
- * directory is a git no-man's-land: `git add` tolerates its pathspec
- * silently while `git commit -- <paths>` refuses it — the state every
- * triage queue reaches once its last concern's deletion is committed.
- * @param {string} dirAbs
- * @returns {boolean}
+ * Validate one declared code path. Code has no layout to derive a pathspec
+ * from, so the paths are Claude's to name — and every one is checked before
+ * anything is staged: inside the project, literal (a glob would commit
+ * whatever it happened to match), and never a workflow artifact, which has a
+ * derived scope of its own.
+ * @param {string} cwd @param {string} given
+ * @returns {string} the project-relative path
  */
-function dirHasFiles(dirAbs) {
-  /** @type {fs.Dirent[]} */
-  let entries;
-  try {
-    entries = fs.readdirSync(dirAbs, { withFileTypes: true });
-  } catch {
-    return false;
+function codePathSpec(cwd, given) {
+  if (given === '' || given === '-') throw new Error(`commit --paths: "${given}" is not a path`);
+  if (/[*?\[\]]/.test(given) || given.startsWith(':')) {
+    throw new Error(`commit --paths: "${given}" is a pattern — name each file literally`);
   }
-  for (const e of entries) {
-    if (e.isDirectory()) {
-      if (dirHasFiles(path.join(dirAbs, e.name))) return true;
-    } else {
-      return true;
-    }
+  const abs = path.resolve(cwd, given);
+  const rel = path.relative(cwd, abs);
+  if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error(`commit --paths: "${given}" resolves outside the project`);
   }
-  return false;
+  const spec = rel.split(path.sep).join('/');
+  if (spec === '.workflows' || spec.startsWith('.workflows/')) {
+    throw new Error(`commit --paths: "${given}" is a workflow artifact — those commit by their own scope (--topic/--discovery/--plan)`);
+  }
+  if (stageableSpecs(cwd, [spec]).length === 0) {
+    throw new Error(`commit --paths: "${given}" is neither on disk nor tracked`);
+  }
+  return spec;
 }
 
 /**
- * Keep pathspecs the whole add+commit sequence will accept: a file on disk,
- * a directory with content, or a path holding index entries (a
- * deleted-but-tracked path still stages its deletions). An empty directory
- * with no index entries is dropped — see dirHasFiles.
- * @param {string} cwd @param {string[]} specs
- * @returns {string[]}
+ * The code commit: the declared paths, committed confined under the commit
+ * lock, answering with what the working tree still holds. `left_dirty` is the
+ * backstop for a forgotten path — every tracked modification and untracked
+ * file left outside `.workflows` (a doc session's dirt is its own, and runs
+ * concurrently by design).
+ * @param {string} cwd @param {string[]} paths @param {string} message
+ * @param {{workUnit: string, phase: string, topic: string}} target
  */
-function stageableSpecs(cwd, specs) {
-  const { execFileSync } = require('child_process');
-  return specs.filter((p) => {
-    const abs = path.join(cwd, p);
-    if (fs.existsSync(abs)) {
-      if (!fs.statSync(abs).isDirectory()) return true;
-      if (dirHasFiles(abs)) return true;
-    }
-    try {
-      return execFileSync('git', ['ls-files', '--', p], { cwd, encoding: 'utf8' }).trim() !== '';
-    } catch {
-      return false;
-    }
-  });
+function commitCodePaths(cwd, paths, message, target) {
+  const specs = paths.map((p) => codePathSpec(cwd, p));
+  const committed = commitPathspecScoped(cwd, specs, message);
+  beatQuietly(cwd, target.workUnit, target.phase, target.topic);
+  const left = dirtyPaths(cwd).filter((p) => p !== '.workflows' && !p.startsWith('.workflows/'));
+  /** @type {{committed: string|null, left_dirty: string[], note?: string}} */
+  const result = { committed, left_dirty: left };
+  if (committed === null) result.note = 'nothing to commit';
+  respond(result);
 }
+
+const COMMIT_USAGE = 'Usage: engine commit <work-unit> -m <message> [--plan <topic> | --discovery | --topic <phase>/<topic> [--kb] [--sweep]] | engine commit --paths <file> … -m <message> --for <work-unit> <implementation|review>/<topic> | engine commit --inbox -m <message> | engine commit --roadmap -m <message> | engine commit --workflows -m <message>';
 
 /** @param {string[]} argv */
 function runCommit(argv) {
@@ -1255,29 +1312,58 @@ function runCommit(argv) {
     /** @type {string|null} */ let message = null;
     /** @type {string|null} */ let plan = null;
     /** @type {string|null} */ let topicSpec = null;
+    /** @type {string[]} */ const files = [];
+    /** @type {string[]} */ const forSpec = [];
+    let paths = false;
+    let discovery = false;
     let inbox = false;
     let workflows = false;
     let roadmapScope = false;
     let kb = false;
+    let sweep = false;
     for (let i = 0; i < argv.length; i++) {
       const a = argv[i];
       if (a === '-m' || a === '--message') message = argv[++i];
       else if (a === '--plan') plan = argv[++i];
       else if (a === '--topic') topicSpec = argv[++i];
+      else if (a === '--paths') paths = true;
+      // The code commit's target: work unit and phase/topic, in containment
+      // order, for the beat and nothing else.
+      else if (a === '--for') forSpec.push(argv[++i], argv[++i]);
       else if (a === '--kb') kb = true;
+      else if (a === '--sweep') sweep = true;
+      else if (a === '--discovery') discovery = true;
       else if (a === '--inbox') inbox = true;
       else if (a === '--workflows') workflows = true;
       else if (a === '--roadmap') roadmapScope = true;
+      else if (paths) files.push(a);
       else if (workUnit === null) workUnit = a;
       else throw new Error(`unexpected argument "${a}"`);
     }
-    const scopeCount = [inbox, workflows, roadmapScope, workUnit !== null].filter(Boolean).length;
-    if (!message || scopeCount !== 1 || (plan !== null && workUnit === null) || plan === '' || plan === undefined ||
-        (topicSpec !== null && workUnit === null) || topicSpec === '' || topicSpec === undefined ||
-        (topicSpec !== null && plan !== null) || (kb && topicSpec === null)) {
-      throw new Error('Usage: engine commit <work-unit> -m <message> [--plan <topic> | --topic <phase>/<topic> [--kb]] | engine commit --inbox -m <message> | engine commit --roadmap -m <message> | engine commit --workflows -m <message>');
-    }
     const cwd = process.cwd();
+
+    if (paths) {
+      // Code commits are the one scope no layout derives (P7): declared,
+      // validated, confined, and answered with the residual dirt.
+      const [forWorkUnit, forTopicSpec] = forSpec;
+      const parts = (forTopicSpec || '').split('/');
+      if (!message || files.length === 0 || forSpec.length !== 2 || !forWorkUnit || parts.length !== 2
+          || !CODE_PHASES.includes(parts[0]) || !parts[1] || plan !== null || topicSpec !== null
+          || discovery || inbox || workflows || roadmapScope || kb || sweep || workUnit !== null) {
+        throw new Error(COMMIT_USAGE);
+      }
+      commitCodePaths(cwd, files, message, { workUnit: forWorkUnit, phase: parts[0], topic: parts[1] });
+      return;
+    }
+
+    const scopeCount = [inbox, workflows, roadmapScope, workUnit !== null].filter(Boolean).length;
+    const workUnitFlags = [plan !== null, topicSpec !== null, discovery].filter(Boolean).length;
+    if (!message || scopeCount !== 1 || forSpec.length > 0 || (workUnitFlags > 0 && workUnit === null) ||
+        workUnitFlags > 1 || plan === '' || plan === undefined ||
+        topicSpec === '' || topicSpec === undefined ||
+        (kb && topicSpec === null) || (sweep && topicSpec === null)) {
+      throw new Error(COMMIT_USAGE);
+    }
     /** @type {string|string[]} */ let scope;
     if (workflows) {
       scope = '.workflows';
@@ -1321,11 +1407,25 @@ function runCommit(argv) {
           ...artifact(wu, topic),
           ...(kb ? [KB_DIR] : []),
         ]);
-        if (specs.length === 0) {
-          respond({ committed: null, note: 'nothing to commit' });
-          return;
-        }
-        const committed = commitPathspecScoped(cwd, specs, message);
+        const committed = specs.length === 0 ? null : commitPathspecScoped(cwd, specs, message);
+        // The session's own cadence commit is its heartbeat. `--kb` is the
+        // terminal one (the conclusion, right after `topic complete`): it
+        // clears instead, or the topic would read held forever. `--sweep` is
+        // the conclude sweep committing a dead session's leavings — a
+        // sweeper stamping its identity on the topic it just cleaned would
+        // resurrect the hold.
+        if (kb) clearQuietly(cwd, wu, phase, topic);
+        else if (!sweep) beatQuietly(cwd, wu, phase, topic);
+        if (committed === null) respond({ committed: null, note: 'nothing to commit' });
+        else respond({ committed });
+        return;
+      }
+      if (discovery) {
+        // --discovery: the discovery session's cadence commit. Discovery runs
+        // beside live research and discussion sessions, so it slices its own
+        // paths — session logs, briefs, the manifest the map lives in.
+        const specs = stageableSpecs(cwd, discoveryScope(wu));
+        const committed = specs.length === 0 ? null : commitPathspecScoped(cwd, specs, message);
         if (committed === null) respond({ committed: null, note: 'nothing to commit' });
         else respond({ committed });
         return;
@@ -1360,7 +1460,7 @@ function runCommit(argv) {
         scope = [scope, ...stageableSpecs(cwd, ['.workflows/manifest.json', ...declared])];
       }
     }
-    const committed = commitScopedWithKb(cwd, scope, message);
+    const committed = commitPathspecWithKb(cwd, scope, message);
     if (committed === null) respond({ committed: null, note: 'nothing to commit' });
     else respond({ committed });
   } catch (err) {

--- a/skills/workflow-engine/scripts/kernel/git.cjs
+++ b/skills/workflow-engine/scripts/kernel/git.cjs
@@ -1,11 +1,16 @@
 'use strict';
 
 // ---------------------------------------------------------------------------
-// Kernel: scoped git operations — stage a pathspec, commit, report the sha.
+// Kernel: scoped git operations — stage a pathspec, commit it confined to
+// exactly those paths, report the sha.
+//
+// Every commit is pathspec-confined: no engine commit can sweep a path
+// outside its declared scope, so concurrent sessions never take each other's
+// work under their own messages.
 //
 // Mechanism only: it knows nothing about work units or the inbox. Every call
 // spawns `git` with an explicit cwd (the project root). Failures throw loud
-// with git's own stderr; a clean index is not a failure — `commitScoped`
+// with git's own stderr; a clean scope is not a failure — `commitPathspec`
 // reports it as `null` so callers can treat an empty pause as fine.
 //
 // Index-mutating operations (add, commit, rm) retry on `index.lock`
@@ -14,6 +19,8 @@
 // holder that outlives it surfaces git's original error.
 // ---------------------------------------------------------------------------
 
+const fs = require('fs');
+const path = require('path');
 const { spawnSync } = require('child_process');
 
 const INDEX_RETRY_MS = 100;
@@ -75,19 +82,6 @@ function gitIndexed(cwd, args) {
 }
 
 /**
- * Whether the index holds staged changes against HEAD.
- * @param {string} cwd
- * @returns {boolean}
- */
-function hasStagedChanges(cwd) {
-  const res = spawnSync('git', ['diff', '--cached', '--quiet'], { cwd, encoding: 'utf8' });
-  if (res.error) throw new Error(`git diff failed: ${res.error.message}`);
-  if (res.status === 0) return false;
-  if (res.status === 1) return true;
-  throw new Error(`git diff failed: ${(res.stderr || `exit ${res.status}`).trim()}`);
-}
-
-/**
  * Whether the given pathspecs differ from HEAD (worktree or index).
  * @param {string} cwd
  * @param {string[]} specs
@@ -98,30 +92,72 @@ function hasChangesInPaths(cwd, specs) {
 }
 
 /**
- * Stage one or more pathspecs and commit with the given message. The commit
- * itself takes the whole index — anything another process staged rides
- * along. Use `commitPathspec` when the commit must be confined to the named
- * paths.
- * @param {string} cwd      project root
- * @param {string|string[]} pathspec e.g. `.workflows/{wu}` or `.workflows/.inbox`
- * @param {string} message
- * @returns {string|null} the short commit sha, or null when nothing was staged
+ * Whether the directory holds any file, at any depth. An existing-but-empty
+ * directory is a git no-man's-land: `git add` tolerates its pathspec silently
+ * while `git commit -- <paths>` refuses it — the state every triage queue
+ * reaches once its last concern's deletion is committed.
+ * @param {string} dirAbs
+ * @returns {boolean}
  */
-function commitScoped(cwd, pathspec, message) {
-  const specs = Array.isArray(pathspec) ? pathspec : [pathspec];
-  gitIndexed(cwd, ['add', '--', ...specs]);
-  if (!hasStagedChanges(cwd)) return null;
-  gitIndexed(cwd, ['commit', '-m', message]);
-  return git(cwd, ['rev-parse', '--short', 'HEAD']).trim();
+function dirHasFiles(dirAbs) {
+  /** @type {fs.Dirent[]} */
+  let entries;
+  try {
+    entries = fs.readdirSync(dirAbs, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (dirHasFiles(path.join(dirAbs, e.name))) return true;
+    } else {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Keep pathspecs the whole add+commit sequence will accept: a file on disk, a
+ * directory with content, or a path holding index entries (a deleted-but-
+ * tracked path still commits its deletions). An empty directory with no index
+ * entries is dropped — see dirHasFiles.
+ * @param {string} cwd @param {string[]} specs
+ * @returns {string[]}
+ */
+function stageableSpecs(cwd, specs) {
+  return specs.filter((p) => {
+    const abs = path.join(cwd, p);
+    if (fs.existsSync(abs)) {
+      if (!fs.statSync(abs).isDirectory()) return true;
+      if (dirHasFiles(abs)) return true;
+    }
+    const res = spawnSync('git', ['ls-files', '--', p], { cwd, encoding: 'utf8' });
+    return res.status === 0 && (res.stdout || '').trim() !== '';
+  });
+}
+
+/**
+ * Whether the pathspec holds changes staged against HEAD. The one state
+ * `stageableSpecs` cannot see: a `git rm` leaves the path in neither the
+ * worktree nor the index, so only HEAD still knows it — and `git commit`
+ * accepts that pathspec where `git add` refuses it.
+ * @param {string} cwd @param {string} spec
+ * @returns {boolean}
+ */
+function hasStagedDeletions(cwd, spec) {
+  const res = spawnSync('git', ['diff', '--cached', '--name-only', '--', spec], { cwd, encoding: 'utf8' });
+  return res.status === 0 && (res.stdout || '').trim() !== '';
 }
 
 /**
  * Commit exactly the named pathspecs — `git commit -- <paths>` builds a
  * temporary index from HEAD plus the worktree content of those paths, so
  * other processes' dirty or staged files are ignored and left untouched.
- * The `add` catches untracked files among the paths. Every pathspec must
- * exist on disk or hold index entries — `git add` refuses a pathspec that
- * matches nothing; callers exists-guard.
+ * The `add` catches untracked files among the paths. Pathspecs git knows
+ * nothing about are dropped: it refuses one that matches nothing, and a
+ * scope naming a path its transaction never created is normal (an absent
+ * triage queue, a work unit with no imports).
  * @param {string} cwd      project root
  * @param {string|string[]} pathspec
  * @param {string} message
@@ -129,10 +165,33 @@ function commitScoped(cwd, pathspec, message) {
  */
 function commitPathspec(cwd, pathspec, message) {
   const specs = Array.isArray(pathspec) ? pathspec : [pathspec];
-  gitIndexed(cwd, ['add', '--', ...specs]);
-  if (!hasChangesInPaths(cwd, specs)) return null;
-  gitIndexed(cwd, ['commit', '-m', message, '--', ...specs]);
+  const addable = stageableSpecs(cwd, specs);
+  if (addable.length > 0) gitIndexed(cwd, ['add', '--', ...addable]);
+  const known = specs.filter((p) => addable.includes(p) || hasStagedDeletions(cwd, p));
+  if (known.length === 0 || !hasChangesInPaths(cwd, known)) return null;
+  gitIndexed(cwd, ['commit', '-m', message, '--', ...known]);
   return git(cwd, ['rev-parse', '--short', 'HEAD']).trim();
+}
+
+/**
+ * Every path in the working tree that differs from HEAD — tracked
+ * modifications and untracked, non-ignored files alike — project-relative.
+ * NUL-separated so paths with spaces or non-ASCII bytes survive; a rename
+ * record's second field (the source path) is consumed with it.
+ * @param {string} cwd
+ * @returns {string[]}
+ */
+function dirtyPaths(cwd) {
+  const fields = git(cwd, ['status', '--porcelain', '-z']).split('\0');
+  /** @type {string[]} */
+  const paths = [];
+  for (let i = 0; i < fields.length; i++) {
+    const entry = fields[i];
+    if (entry.length < 4) continue;
+    paths.push(entry.slice(3));
+    if (entry[0] === 'R' || entry[0] === 'C') i += 1;
+  }
+  return paths;
 }
 
 /**
@@ -145,4 +204,4 @@ function removeFiles(cwd, paths) {
   gitIndexed(cwd, ['rm', '-q', '--', ...paths]);
 }
 
-module.exports = { git, commitScoped, commitPathspec, hasStagedChanges, removeFiles };
+module.exports = { git, commitPathspec, dirtyPaths, stageableSpecs, removeFiles };

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -99,6 +99,7 @@ module.exports = {
   },
   presence: {
     scanPresence: presence.scanPresence,
+    scanProject: presence.scanProject,
     fmtAge: presence.fmtAge,
   },
   detail: {

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -48,7 +48,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render triage-block {work
    git status --porcelain -- .workflows
    ```
 
-   **If dirt remains under another topic's paths:** run `node .claude/skills/workflow-engine/scripts/engine.cjs presence scan {work_unit}`. Dirt under a `held` row's topic belongs to that session — leave it, however long it has idled. For each dirty topic with no held presence — a dead session's leavings — commit it action-scoped: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{dirty_topic} -m "chore({work_unit}/{dirty_topic}): sweep session leavings"`.
+   **If dirt remains under another topic's paths:** run `node .claude/skills/workflow-engine/scripts/engine.cjs presence scan {work_unit}`. Dirt under a `held` row's topic belongs to that session — leave it, however long it has idled. For each dirty topic with no held presence — a dead session's leavings — commit it action-scoped: `node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{dirty_topic} --sweep -m "chore({work_unit}/{dirty_topic}): sweep session leavings"`.
 
    **Otherwise:** nothing to sweep — continue.
 

--- a/skills/workflow-shared/references/correcting-historical-artifacts.md
+++ b/skills/workflow-shared/references/correcting-historical-artifacts.md
@@ -67,7 +67,7 @@ Present the full correction list — each wrong claim, its evidence, and its pro
    node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index {specification path}
    ```
 
-4. **Commit.** Scoped to the owning unit; the store rides along (every engine commit stages `.workflows/.knowledge`):
+4. **Commit.** Scoped to the owning unit; the store rides along (the work-unit commit carries `.workflows/.knowledge` when it exists):
 
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {owning_work_unit} -m "specification({owning_work_unit}): corrigendum from {correcting_work_unit}"

--- a/tests/scripts/test-engine-commit-door.cjs
+++ b/tests/scripts/test-engine-commit-door.cjs
@@ -633,4 +633,31 @@ describe('commit door: transaction-tail degrade', () => {
     const manifest = JSON.parse(fs.readFileSync(path.join(dir, '.workflows/payments/manifest.json'), 'utf8'));
     assert.strictEqual(manifest.phases.research.items['auth-flow'].status, 'cancelled', 'state landed despite the failed commit');
   });
+
+  it('a foreign-topic tail prescribes a retry that beats no more than the verb did', () => {
+    // The notes are contract surface: a session follows the command verbatim,
+    // so a delivery's retry must carry the same suppression the delivery has.
+    writeFile(dir, '.workflows/.cache/scratch/c.md', '### Q\n*From: topic-a · discussion · d*\n\nBody.\n');
+    fs.writeFileSync(path.join(dir, '.git', 'index.lock'), '');
+    const delivered = engine(dir, ['topic', 'triage', 'payments', 'discussion', 'topic-b',
+      '--concern', '.workflows/.cache/scratch/c.md', '--slug', 'q', '-m', 'discussion(payments/topic-a): reroute to topic-b'],
+    { WORKFLOWS_GIT_LOCK_BUDGET_MS: '200' });
+    assert.strictEqual(delivered.committed, null);
+    assert.match(delivered.note, /--topic discussion\/topic-b --sweep -m/, 'the delivery\'s retry never beats the target');
+
+    const moved = engine(dir, ['topic', 'requeue', 'payments', 'discussion', 'research', 'topic-b',
+      '--file', '001-q.md', '-m', 'research(payments/topic-b): move 001-q to the research side'],
+    { WORKFLOWS_GIT_LOCK_BUDGET_MS: '200' });
+    assert.strictEqual(moved.committed, null);
+    assert.match(moved.note, /--topic research\/topic-b --sweep -m/, 'the move\'s retry never beats the destination');
+
+    // Absorb is the session folding a concern into its own document — its
+    // retry beats, exactly as the verb does.
+    const absorbed = engine(dir, ['topic', 'absorb', 'payments', 'research', 'topic-b',
+      '--file', '001-q.md', '-m', 'research(payments/topic-b): absorb 001-q (from topic-a)'],
+    { WORKFLOWS_GIT_LOCK_BUDGET_MS: '200' });
+    assert.strictEqual(absorbed.committed, null);
+    assert.match(absorbed.note, /--topic research\/topic-b -m/, 'the owning session\'s retry carries no suppression');
+    assert.ok(!absorbed.note.includes('--sweep'));
+  });
 });

--- a/tests/scripts/test-engine-commit-door.cjs
+++ b/tests/scripts/test-engine-commit-door.cjs
@@ -29,6 +29,9 @@ function setupGitFixture() {
   git(dir, ['config', 'user.name', 'Test']);
   git(dir, ['config', 'commit.gpgsign', 'false']);
   fs.mkdirSync(path.join(dir, '.workflows'), { recursive: true });
+  // The nested gitignore every booted project carries (migration 049) — the
+  // cache is ephemeral session machinery, mechanical heartbeats included.
+  fs.writeFileSync(path.join(dir, '.workflows', '.gitignore'), '.cache/\n.manifest.json.*.tmp\n');
   return dir;
 }
 
@@ -235,6 +238,222 @@ describe('engine commit --topic: pathspec isolation', () => {
   });
 });
 
+describe('engine commit --discovery: the discovery session\'s scope', () => {
+  let dir;
+  beforeEach(() => { dir = setupTwoTopicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('commits sessions, briefs and the manifest — never a live peer\'s topic', () => {
+    writeFile(dir, '.workflows/payments/discovery/sessions/session-001.md', '# Session 001\n');
+    writeFile(dir, '.workflows/payments/discovery/briefs/topic-a.md', '# Brief — topic A\n');
+    writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(epicManifest(), null, 2) + '\n\n');
+    writeFile(dir, '.workflows/payments/discussion/topic-b.md', '# Topic B\npeer session dirt\n');
+
+    const res = engine(dir, ['commit', 'payments', '--discovery', '-m', 'discovery(payments): shape the map']);
+
+    assert.match(res.committed, /^[0-9a-f]+$/);
+    const files = headFiles(dir);
+    assert.ok(files.includes('.workflows/payments/discovery/sessions/session-001.md'), 'session log committed');
+    assert.ok(files.includes('.workflows/payments/discovery/briefs/topic-a.md'), 'brief committed');
+    assert.ok(files.includes('.workflows/payments/manifest.json'), 'manifest committed');
+    assert.ok(!files.includes('.workflows/payments/discussion/topic-b.md'), 'the peer session\'s topic is not swept');
+    assert.deepStrictEqual(statusLines(dir), [' M .workflows/payments/discussion/topic-b.md'], 'peer dirt untouched');
+  });
+
+  it('reports nothing to commit on a work unit with no discovery content', () => {
+    const clean = engine(dir, ['commit', 'payments', '--discovery', '-m', 'noop']);
+    assert.strictEqual(clean.committed, null);
+    assert.strictEqual(clean.note, 'nothing to commit');
+  });
+
+  it('refuses --discovery beside another scope flag', () => {
+    assert.match(engineFails(dir, ['commit', 'payments', '--discovery', '-m', 'x', '--topic', 'discussion/topic-a']).error, /Usage/);
+    assert.match(engineFails(dir, ['commit', '--discovery', '-m', 'x']).error, /Usage/);
+  });
+});
+
+describe('engine commit --plan: confined to the plan\'s storage', () => {
+  let dir;
+  beforeEach(() => { dir = setupTwoTopicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('commits the work unit and the declared storage, leaving foreign dirt behind', () => {
+    const manifest = epicManifest();
+    manifest.phases.planning = { items: { 'topic-a': { status: 'in-progress', storage_paths: ['plans/topic-a'] } } };
+    writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(manifest, null, 2) + '\n');
+    writeFile(dir, 'plans/topic-a/tasks.md', '# Tasks\n');
+    writeFile(dir, 'src/app.js', 'const x = 1;\n');
+    commitAll(dir, 'plan storage');
+
+    writeFile(dir, 'plans/topic-a/tasks.md', '# Tasks\n- one\n');
+    writeFile(dir, 'src/app.js', 'const x = 2;\n');
+
+    const res = engine(dir, ['commit', 'payments', '-m', 'plan(payments): author', '--plan', 'topic-a']);
+
+    assert.match(res.committed, /^[0-9a-f]+$/);
+    const files = headFiles(dir);
+    assert.ok(files.includes('plans/topic-a/tasks.md'), 'the declared storage rides');
+    assert.ok(!files.includes('src/app.js'), 'code outside the plan\'s storage never rides a --plan commit');
+    assert.deepStrictEqual(statusLines(dir), [' M src/app.js'], 'the code is left exactly as it was');
+  });
+
+  it('never takes another process\'s staged code', () => {
+    const manifest = epicManifest();
+    manifest.phases.planning = { items: { 'topic-a': { status: 'in-progress', storage_paths: [] } } };
+    writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(manifest, null, 2) + '\n');
+    writeFile(dir, 'src/app.js', 'const x = 1;\n');
+    commitAll(dir, 'code');
+
+    writeFile(dir, '.workflows/payments/planning/topic-a/planning.md', '# Plan\n');
+    writeFile(dir, 'src/app.js', 'const x = 2;\n');
+    git(dir, ['add', '--', 'src/app.js']);
+
+    engine(dir, ['commit', 'payments', '-m', 'plan(payments): author', '--plan', 'topic-a']);
+
+    assert.ok(headFiles(dir).includes('.workflows/payments/planning/topic-a/planning.md'), 'the plan lands');
+    assert.ok(!headFiles(dir).includes('src/app.js'), 'staged code is not swept into a plan commit');
+    assert.strictEqual(git(dir, ['diff', '--cached', '--name-only']).trim(), 'src/app.js', 'and stays staged');
+  });
+});
+
+describe('engine commit --paths: the code commit', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setupTwoTopicFixture();
+    writeFile(dir, 'src/app.js', 'const x = 1;\n');
+    writeFile(dir, 'src/other.js', 'const y = 1;\n');
+    writeFile(dir, 'src/gone.js', 'const z = 1;\n');
+    commitAll(dir, 'code');
+  });
+  afterEach(() => { cleanupFixture(dir); });
+
+  const forTopic = ['--for', 'payments', 'implementation/topic-a'];
+
+  it('commits the named paths and answers the dirt still outside .workflows', () => {
+    writeFile(dir, 'src/app.js', 'const x = 2;\n');
+    writeFile(dir, 'src/new.js', 'const n = 1;\n');
+    writeFile(dir, 'src/other.js', 'const y = 2;\n');
+    writeFile(dir, '.workflows/payments/discussion/topic-b.md', '# Topic B\na doc session\'s dirt\n');
+
+    const res = engine(dir, ['commit', '--paths', 'src/app.js', 'src/new.js', '-m', 'feat(topic-a): the task', ...forTopic]);
+
+    assert.match(res.committed, /^[0-9a-f]+$/);
+    const files = headFiles(dir);
+    assert.deepStrictEqual(files.sort(), ['src/app.js', 'src/new.js'], 'exactly the named paths — untracked included');
+    assert.deepStrictEqual(res.left_dirty, ['src/other.js'],
+      'the forgotten path is named; a doc session\'s .workflows dirt is its own');
+  });
+
+  it('records a task\'s deletion and beats the named code topic', () => {
+    fs.unlinkSync(path.join(dir, 'src/gone.js'));
+
+    const res = engine(dir, ['commit', '--paths', 'src/gone.js', '-m', 'refactor(topic-a): drop the module', ...forTopic]);
+
+    assert.ok(headFiles(dir).includes('src/gone.js'), 'the deletion rides the commit');
+    assert.deepStrictEqual(res.left_dirty, []);
+    assert.ok(fs.existsSync(path.join(dir, '.workflows/.cache/payments/implementation/topic-a/presence')),
+      '--for beats the code topic');
+  });
+
+  it('answers nothing to commit when the named paths are clean', () => {
+    const res = engine(dir, ['commit', '--paths', 'src/app.js', '-m', 'noop', ...forTopic]);
+    assert.strictEqual(res.committed, null);
+    assert.strictEqual(res.note, 'nothing to commit');
+  });
+
+  it('refuses patterns, escapes, workflow artifacts, and a missing target', () => {
+    assert.match(engineFails(dir, ['commit', '--paths', 'src/*.js', '-m', 'x', ...forTopic]).error, /is a pattern/);
+    assert.match(engineFails(dir, ['commit', '--paths', '../elsewhere.js', '-m', 'x', ...forTopic]).error, /resolves outside the project/);
+    assert.match(engineFails(dir, ['commit', '--paths', '/etc/hosts', '-m', 'x', ...forTopic]).error, /resolves outside the project/);
+    assert.match(engineFails(dir, ['commit', '--paths', '.workflows/payments/discussion/topic-a.md', '-m', 'x', ...forTopic]).error,
+      /workflow artifact/);
+    assert.match(engineFails(dir, ['commit', '--paths', 'src/never-written.js', '-m', 'x', ...forTopic]).error, /neither on disk nor tracked/);
+    assert.match(engineFails(dir, ['commit', '--paths', '-m', 'x', ...forTopic]).error, /Usage/);
+    assert.match(engineFails(dir, ['commit', '--paths', 'src/app.js', '-m', 'x']).error, /Usage/);
+    assert.match(engineFails(dir, ['commit', '--paths', 'src/app.js', '-m', 'x', '--for', 'payments', 'discussion/topic-a']).error, /Usage/);
+    assert.match(engineFails(dir, ['commit', '--paths', 'src/app.js', '--for', 'payments', 'review/topic-a']).error, /Usage/);
+    assert.match(engineFails(dir, ['commit', 'payments', '--paths', 'src/app.js', '-m', 'x', ...forTopic]).error, /Usage/);
+    assert.strictEqual(statusLines(dir).length, 0, 'a refusal touches nothing');
+  });
+});
+
+describe('mechanical heartbeats: the self-referential rule', () => {
+  let dir;
+  beforeEach(() => { dir = setupTwoTopicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  const beatFile = (phase, topic) => path.join(dir, '.workflows/.cache/payments', phase, topic, 'presence');
+  const beaten = (phase, topic) => fs.existsSync(beatFile(phase, topic));
+
+  it('the session-cadence commit beats; --kb clears; --sweep suppresses', () => {
+    writeFile(dir, '.workflows/payments/discussion/topic-a.md', '# Topic A\nprogress\n');
+    engine(dir, ['commit', 'payments', '-m', 'discussion(payments/topic-a): progress', '--topic', 'discussion/topic-a']);
+    assert.ok(beaten('discussion', 'topic-a'), 'the cadence commit is the heartbeat');
+
+    // The conclusion: `topic complete` then the --kb commit. Clearing is what
+    // stops a concluded topic reading held forever.
+    writeFile(dir, '.workflows/payments/discussion/topic-a.md', '# Topic A\nconcluded\n');
+    engine(dir, ['commit', 'payments', '-m', 'discussion(payments): complete topic-a', '--topic', 'discussion/topic-a', '--kb']);
+    assert.ok(!beaten('discussion', 'topic-a'), '--kb clears instead of beating');
+
+    // The conclude sweep committing a dead session's leavings must not
+    // resurrect the hold it just swept.
+    writeFile(dir, '.workflows/payments/discussion/topic-b.md', '# Topic B\ndead session leavings\n');
+    engine(dir, ['commit', 'payments', '-m', 'chore(payments/topic-b): sweep session leavings', '--topic', 'discussion/topic-b', '--sweep']);
+    assert.ok(!beaten('discussion', 'topic-b'), '--sweep never stamps the swept topic');
+  });
+
+  it('the topic verbs a session runs on its own topic beat — and triage never does', () => {
+    engine(dir, ['topic', 'queue', 'payments', 'discussion', 'topic-a']);
+    assert.ok(beaten('discussion', 'topic-a'), 'the per-turn queue poll is turn coverage');
+
+    engine(dir, ['topic', 'start', 'payments', 'planning', 'topic-a']);
+    assert.ok(beaten('planning', 'topic-a'), 'start opens the session\'s own topic');
+    engine(dir, ['topic', 'complete', 'payments', 'planning', 'topic-a']);
+    assert.ok(beaten('planning', 'topic-a'), 'complete is the session\'s own close');
+
+    writeFile(dir, '.workflows/payments/discussion/.triage/topic-a/001-first.md', '### First\nbody\n');
+    commitAll(dir, 'a delivered concern');
+    engine(dir, ['topic', 'absorb', 'payments', 'discussion', 'topic-a', '--file', '001-first.md',
+      '-m', 'discussion(payments/topic-a): absorb 001-first (from topic-b)']);
+    assert.ok(beaten('discussion', 'topic-a'), 'absorb folds a concern into the session\'s own document');
+
+    // Delivery acts on the TARGET topic from the origin's session — a beat
+    // there would manufacture a hold on a topic no session is in.
+    writeFile(dir, '.workflows/.cache/scratch/c.md', '### Q\n*From: topic-a · discussion · d*\n\nBody.\n');
+    engine(dir, ['topic', 'triage', 'payments', 'discussion', 'topic-b',
+      '--concern', '.workflows/.cache/scratch/c.md', '--slug', 'q', '-m', 'discussion(payments/topic-a): reroute to topic-b']);
+    assert.ok(!beaten('discussion', 'topic-b'), 'triage never beats the target');
+  });
+
+  it('a topic-addressed manifest set beats; the batch apply does not', () => {
+    engine(dir, ['manifest', 'set', 'payments.discussion.topic-a', 'status', 'in-progress']);
+    assert.ok(beaten('discussion', 'topic-a'), 'every state transition heartbeats');
+
+    engine(dir, ['manifest', 'set', 'payments.discussion', 'gate_mode', 'gated']);
+    assert.ok(!beaten('discussion', 'topic-b'), 'a phase-level write names no topic');
+
+    const ops = JSON.stringify([{ op: 'set', path: 'payments.discussion.topic-b', fields: { status: 'in-progress' } }]);
+    writeFile(dir, '.workflows/.cache/scratch/ops.json', ops);
+    engine(dir, ['manifest', 'apply', 'payments', '--file', '.workflows/.cache/scratch/ops.json']);
+    assert.ok(!beaten('discussion', 'topic-b'), 'apply writes across topics — the analysis session holds none of them');
+  });
+
+  it('agent-store writes beat the topic they address', () => {
+    engine(dir, ['agent', 'dispatch', 'payments', 'discussion', 'topic-b', '--kind', 'review']);
+    assert.ok(beaten('discussion', 'topic-b'), 'the dispatching session holds the topic');
+  });
+
+  it('a beat is best-effort: a phase outside presence changes nothing', () => {
+    const res = engine(dir, ['topic', 'start', 'payments', 'discovery', 'topic-a'].slice(0, 3).concat(['discussion', 'topic-a']));
+    assert.strictEqual(res.ok, true);
+    // Discovery carries no heartbeat — `discovery-session open` serialises it.
+    engine(dir, ['manifest', 'set', 'payments.discovery.topic-a', 'routing', 'discussion']);
+    assert.ok(!fs.existsSync(path.join(dir, '.workflows/.cache/payments/discovery/topic-a/presence')),
+      'discovery stays out of presence');
+  });
+});
+
 describe('commit door: index.lock retry and the commit lock', () => {
   let dir;
   beforeEach(() => { dir = setupTwoTopicFixture(); });
@@ -279,6 +498,116 @@ describe('commit door: index.lock retry and the commit lock', () => {
 
     assert.match(res.committed, /^[0-9a-f]+$/);
     assert.ok(!fs.existsSync(lock), 'stale lock cleared');
+  });
+});
+
+describe('commit door: transaction tails commit their own scope', () => {
+  let dir;
+  beforeEach(() => { dir = setupTwoTopicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  it('a deletion that empties its scope still commits (inbox delete)', () => {
+    writeFile(dir, '.workflows/.inbox/.archived/ideas/a-thought.md', '# A thought\n');
+    commitAll(dir, 'an archived idea');
+    writeFile(dir, '.workflows/payments/discussion/topic-b.md', '# Topic B\npeer dirt\n');
+
+    const res = engine(dir, ['inbox', 'delete', '.workflows/.inbox/.archived/ideas/a-thought.md']);
+
+    assert.match(res.committed, /^[0-9a-f]+$/, 'the staged deletion commits even though nothing is left on disk');
+    assert.ok(headFiles(dir).includes('.workflows/.inbox/.archived/ideas/a-thought.md'), 'the deletion is in the commit');
+    assert.deepStrictEqual(statusLines(dir), [' M .workflows/payments/discussion/topic-b.md'], 'the live session\'s dirt is untouched');
+  });
+
+  it('a topic cancel commits the manifest write alone', () => {
+    writeFile(dir, '.workflows/payments/discussion/topic-a.md', '# Topic A\nlive session dirt\n');
+
+    const res = engine(dir, ['topic', 'cancel', 'payments', 'discussion', 'topic-b']);
+
+    assert.match(res.committed, /^[0-9a-f]+$/);
+    assert.deepStrictEqual(headFiles(dir), ['.workflows/payments/manifest.json'],
+      'a cancel from the epic menu takes nothing a session is holding');
+    assert.deepStrictEqual(statusLines(dir), [' M .workflows/payments/discussion/topic-a.md']);
+  });
+
+  it('the discovery session close commits the discovery scope, not the work unit', () => {
+    const manifest = epicManifest();
+    manifest.phases.discovery.active_session = '001';
+    writeFile(dir, '.workflows/payments/manifest.json', JSON.stringify(manifest, null, 2) + '\n');
+    writeFile(dir, '.workflows/payments/discovery/sessions/session-001.md', '# Session 001\n');
+    commitAll(dir, 'an open session');
+
+    writeFile(dir, '.workflows/payments/discovery/sessions/session-001.md', '# Session 001\n\n## Conclusion\n');
+    writeFile(dir, '.workflows/payments/discovery/briefs/topic-a.md', '# Brief\n');
+    writeFile(dir, '.workflows/payments/discussion/topic-a.md', '# Topic A\na peer session mid-turn\n');
+
+    const res = engine(dir, ['discovery-session', 'close', 'payments', '-m', 'discovery(payments): synthesise 1 topic']);
+
+    assert.match(res.committed, /^[0-9a-f]+$/);
+    const files = headFiles(dir);
+    assert.ok(files.includes('.workflows/payments/discovery/sessions/session-001.md'));
+    assert.ok(files.includes('.workflows/payments/discovery/briefs/topic-a.md'));
+    assert.ok(!files.includes('.workflows/payments/discussion/topic-a.md'), 'the peer\'s half-written document stays uncommitted');
+  });
+});
+
+describe('commit door: two live sessions on one checkout', () => {
+  let dir;
+  beforeEach(() => { dir = setupTwoTopicFixture(); });
+  afterEach(() => { cleanupFixture(dir); });
+
+  // One session's turn loop: write its own topic file, commit it, repeat —
+  // the cadence the discussion and research flows run.
+  const SESSION = [
+    "const fs = require('fs');",
+    "const { execFileSync } = require('child_process');",
+    'const [engine, dir, topic, turns] = process.argv.slice(1);',
+    'const file = dir + "/.workflows/payments/discussion/" + topic + ".md";',
+    'for (let i = 1; i <= Number(turns); i++) {',
+    '  fs.writeFileSync(file, "# " + topic + "\\n" + Array.from({length: i}, (_, n) => "line " + (n + 1)).join("\\n") + "\\n");',
+    '  execFileSync("node", [engine, "commit", "payments", "-m",',
+    '    "discussion(payments/" + topic + "): turn " + i, "--topic", "discussion/" + topic],',
+    '    { cwd: dir, encoding: "utf8" });',
+    '}',
+  ].join('\n');
+
+  /** @param {string} topic @param {number} turns */
+  function session(dir, topic, turns) {
+    const proc = spawn('node', ['-e', SESSION, ENGINE, dir, topic, String(turns)], { cwd: dir });
+    let stderr = '';
+    proc.stderr.on('data', (chunk) => { stderr += chunk; });
+    return new Promise((resolve) => proc.on('exit', (code) => resolve({ code, stderr })));
+  }
+
+  it('no commit ever contains a foreign session\'s path, and nothing is lost', async () => {
+    const turns = 6;
+    const results = await Promise.all([session(dir, 'topic-a', turns), session(dir, 'topic-b', turns)]);
+    for (const r of results) assert.strictEqual(r.code, 0, `a session crashed: ${r.stderr}`);
+
+    // Every commit either session made, message and file list together.
+    const log = git(dir, ['log', '--format=%H%x00%s', '--name-only', '-z', 'HEAD']);
+    const commits = git(dir, ['log', '--format=%H', 'HEAD']).trim().split('\n');
+    assert.ok(commits.length >= 2 * turns, `expected a commit per turn, got ${commits.length - 1}`);
+
+    for (const sha of commits) {
+      const subject = git(dir, ['log', '--format=%s', '-1', sha]).trim();
+      if (!subject.startsWith('discussion(payments/')) continue;
+      const mine = subject.slice('discussion(payments/'.length).split(')')[0];
+      const foreign = mine === 'topic-a' ? 'topic-b' : 'topic-a';
+      const files = git(dir, ['show', '--name-only', '--pretty=format:', sha]).trim().split('\n').filter(Boolean);
+      assert.ok(!files.includes(`.workflows/payments/discussion/${foreign}.md`),
+        `${subject} (${sha}) swept a foreign session's file:\n${files.join('\n')}\n${log}`);
+      assert.deepStrictEqual(files, [`.workflows/payments/discussion/${mine}.md`],
+        `${subject} committed more than its own action`);
+    }
+
+    // Both sessions' last turn is in HEAD, and the tree is clean.
+    for (const topic of ['topic-a', 'topic-b']) {
+      const committed = git(dir, ['show', `HEAD:.workflows/payments/discussion/${topic}.md`]);
+      assert.strictEqual(committed, fs.readFileSync(path.join(dir, `.workflows/payments/discussion/${topic}.md`), 'utf8'),
+        `${topic}'s last turn never reached a commit`);
+      assert.ok(committed.trim().endsWith(`line ${turns}`), `${topic} lost a turn`);
+    }
+    assert.deepStrictEqual(statusLines(dir), [], 'nothing left dirty');
   });
 });
 

--- a/tests/scripts/test-engine-commit-door.cjs
+++ b/tests/scripts/test-engine-commit-door.cjs
@@ -444,13 +444,13 @@ describe('mechanical heartbeats: the self-referential rule', () => {
     assert.ok(beaten('discussion', 'topic-b'), 'the dispatching session holds the topic');
   });
 
-  it('a beat is best-effort: a phase outside presence changes nothing', () => {
-    const res = engine(dir, ['topic', 'start', 'payments', 'discovery', 'topic-a'].slice(0, 3).concat(['discussion', 'topic-a']));
+  it('a beat never changes a verb\'s answer, and discovery stays out of presence', () => {
+    // Discovery carries no heartbeat — `discovery-session open` serialises it
+    // engine-side — so the write lands and the beat silently no-ops.
+    const res = engine(dir, ['manifest', 'set', 'payments.discovery.topic-a', 'routing', 'discussion']);
     assert.strictEqual(res.ok, true);
-    // Discovery carries no heartbeat — `discovery-session open` serialises it.
-    engine(dir, ['manifest', 'set', 'payments.discovery.topic-a', 'routing', 'discussion']);
-    assert.ok(!fs.existsSync(path.join(dir, '.workflows/.cache/payments/discovery/topic-a/presence')),
-      'discovery stays out of presence');
+    assert.deepStrictEqual(res.set, { routing: 'discussion' }, 'the response is the field surface\'s, untouched');
+    assert.ok(!fs.existsSync(path.join(dir, '.workflows/.cache/payments/discovery/topic-a/presence')));
   });
 });
 

--- a/tests/scripts/test-engine-presence.cjs
+++ b/tests/scripts/test-engine-presence.cjs
@@ -101,12 +101,53 @@ describe('engine presence', () => {
     assert.strictEqual(engine(dir, ['presence', 'clear', 'pay', 'discussion', 'alpha']).res.cleared, true);
   });
 
+  it('covers every phase a session sits in — discovery excepted', () => {
+    for (const phase of ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review']) {
+      assert.strictEqual(engine(dir, ['presence', 'beat', 'pay', phase, 'alpha']).res.beat, true, `${phase} beats`);
+    }
+    const scan = engine(dir, ['presence', 'scan', 'pay']).res;
+    assert.strictEqual(scan.sessions.length, 8, 'every phase reports a row');
+    assert.strictEqual(scan.live, 8);
+    // Discovery is engine-serialised by `discovery-session open` — no heartbeat.
+    assert.match(engineFails(dir, ['presence', 'beat', 'pay', 'discovery', 'x']).error, /presence is research\|discussion\|/);
+  });
+
   it('refuses illegal phases, unknown work units, and malformed calls', () => {
-    assert.match(engineFails(dir, ['presence', 'beat', 'pay', 'planning', 'x']).error, /research\|discussion only/);
+    assert.match(engineFails(dir, ['presence', 'beat', 'pay', 'grooming', 'x']).error, /got "grooming"/);
     assert.match(engineFails(dir, ['presence', 'beat', 'pay', 'discussion', '../../escapee']).error, /invalid topic name/);
     assert.match(engineFails(dir, ['presence', 'scan', 'ghost']).error, /no work unit directory/);
     assert.match(engineFails(dir, ['presence', 'beat', 'pay', 'discussion']).error, /Usage/);
+    assert.match(engineFails(dir, ['presence', 'scan', 'pay', 'extra']).error, /Usage/);
     assert.match(engineFails(dir, ['presence', 'bogus']).error, /Usage/);
+  });
+
+  it('the work-unit-less scan walks the whole cache root, naming each row\'s work unit', () => {
+    fs.mkdirSync(path.join(dir, '.workflows', 'ship'), { recursive: true });
+    engine(dir, ['presence', 'beat', 'pay', 'discussion', 'alpha']);
+    engine(dir, ['presence', 'beat', 'ship', 'implementation', 'beta']);
+
+    const { res, sections } = engine(dir, ['presence', 'scan']);
+    assert.strictEqual(res.scope, 'project');
+    assert.strictEqual(res.stale_after_seconds, 900);
+    assert.strictEqual(res.live, 2);
+    assert.strictEqual(res.held, 2);
+    assert.deepStrictEqual(
+      res.sessions.map((r) => `${r.work_unit}/${r.phase}/${r.topic}`).sort(),
+      ['pay/discussion/alpha', 'ship/implementation/beta'],
+    );
+    assert.ok(res.sessions.every((r) => 'held' in r && 'live' in r && 'age_seconds' in r && 'session_id' in r), 'the row shape is the scan\'s');
+    assert.strictEqual(sections, '', 'the deferral section belongs to the work-unit scan');
+    assert.strictEqual(engine(dir, ['presence', 'scan', 'pay']).res.work_unit, 'pay', 'the per-work-unit form is unchanged');
+  });
+
+  it('the project scan answers empty on a project that has never cached anything', () => {
+    const bare = fs.mkdtempSync(path.join(os.tmpdir(), 'engine-presence-bare-'));
+    fs.mkdirSync(path.join(bare, '.workflows'), { recursive: true });
+    const res = engine(bare, ['presence', 'scan']).res;
+    assert.deepStrictEqual(res.sessions, []);
+    assert.strictEqual(res.live, 0);
+    assert.strictEqual(res.held, 0);
+    cleanup(bare);
   });
 
   it('beat records the owning session identity; scan reports it held', () => {

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -202,6 +202,9 @@ class Sim {
     git(this.dir, ['config', 'user.name', 'Sim']);
     git(this.dir, ['config', 'commit.gpgsign', 'false']);
     fs.mkdirSync(path.join(this.dir, '.workflows'), { recursive: true });
+    // The nested gitignore every booted project carries (migration 049): the
+    // cache is ephemeral session machinery, mechanical heartbeats included.
+    fs.writeFileSync(path.join(this.dir, '.workflows', '.gitignore'), '.cache/\n.manifest.json.*.tmp\n');
     this.step = 0;
     // Hermetic session-label environment: the config dir pins into the
     // sandbox and the tmux identity is stripped, so `session label` can
@@ -385,6 +388,18 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
   assert.strictEqual(implInit.mode, 'created', 'fresh implementation takes the created arm');
   sim.run(['commit', wu, '-m', `impl(${wu}): start implementation`]);
   sim.run(['task', 'start', wu, topic, `${topic}-1-1`]);
+  // The task's code commit: declared paths, validated and confined, with the
+  // residual dirt answered back so nothing the task touched is left behind.
+  // Code has no layout to derive a scope from — this is the one commit whose
+  // paths Claude names.
+  sim.write(`src/${topic}.js`, `module.exports = ${JSON.stringify(topic)};\n`);
+  sim.write(`src/${topic}-untouched.js`, '// a file this task did not write\n');
+  const codeCommit = sim.run(['commit', '--paths', `src/${topic}.js`, '-m', `feat(${topic}): the task`,
+    '--for', wu, `implementation/${topic}`]);
+  assert.deepStrictEqual(codeCommit.left_dirty, [`src/${topic}-untouched.js`],
+    'the forgotten path comes back as the reconcile signal');
+  sim.run(['commit', '--paths', `src/${topic}-untouched.js`, '-m', `chore(${topic}): the rest`,
+    '--for', wu, `implementation/${topic}`]);
   // Each executor and reviewer report's BANK entries deposit the moment the
   // report arrives (task-loop B/D) — durable on the manifest, drained at the
   // phase boundary.
@@ -620,6 +635,9 @@ describe('pipeline simulation', () => {
     sim.run(['discovery-map', 'edit', wu, 'gamma', '--summary', 'Gamma, sharpened']);
     sim.run(['discovery-map', 'rename', wu, 'gamma', 'gamma-prime']);
     sim.run(['discovery-map', 'reroute', wu, 'gamma-prime', 'research']);
+    // The discovery session's cadence commit: its own paths only — a live
+    // research or discussion session's topic file is never swept.
+    sim.run(['commit', wu, '--discovery', '-m', `discovery(${wu}): shape the map`]);
     sim.run(['discovery-session', 'close', wu, '-m', `discovery(${wu}): synthesise 3 topics`]);
 
     // Alpha: research then discussion; regenerated-brief reconcile flag rides.
@@ -790,17 +808,24 @@ describe('pipeline simulation', () => {
     sim.run(['topic', 'absorb', wu, 'research', 'beta',
       '--file', '001-feasibility-question.md', '-m', `research(${wu}/beta): absorb 001-feasibility-question (from alpha)`]);
     sim.run(['agent', 'dispatch', wu, 'research', 'beta', '--kind', 'review']);
-    // Presence: a beat reads live and held (deferral territory for the
-    // bridge, in-session territory for the epic view), the orderly clear
-    // empties the scan.
+    // Presence: heartbeats are mechanical, so the verbs already run on this
+    // work unit's topics have stamped them — no prose ever beats.
+    const rowOf = (scan, phase, topic) => scan.sessions.find((r) => r.phase === phase && r.topic === topic);
+    assert.ok(rowOf(sim.run(['presence', 'scan', wu]), 'research', 'beta'),
+      'the verbs a session runs on its own topic leave a heartbeat behind');
+    // A beat reads live and held (deferral territory for the bridge,
+    // in-session territory for the epic view); the orderly clear drops it.
     sim.run(['presence', 'beat', wu, 'research', 'alpha']);
     const present = sim.run(['presence', 'scan', wu]);
-    assert.strictEqual(present.live, 1);
-    assert.strictEqual(present.held, 1);
-    assert.strictEqual(present.sessions[0].topic, 'alpha');
-    assert.strictEqual(present.sessions[0].held, true);
+    assert.strictEqual(rowOf(present, 'research', 'alpha').live, true);
+    assert.strictEqual(rowOf(present, 'research', 'alpha').held, true);
     sim.run(['presence', 'clear', wu, 'research', 'alpha']);
-    assert.strictEqual(sim.run(['presence', 'scan', wu]).live, 0);
+    assert.strictEqual(rowOf(sim.run(['presence', 'scan', wu]), 'research', 'alpha'), undefined);
+    // The project-wide scan is the code gate's read: every work unit's rows,
+    // each naming its own.
+    const project = sim.run(['presence', 'scan']);
+    assert.strictEqual(project.scope, 'project');
+    assert.ok(project.sessions.every((r) => typeof r.work_unit === 'string'), 'every row names its work unit');
     // The SessionEnd cleanup sweeps by owning session id — a peer session's
     // heartbeat survives.
     sim.write(`.workflows/.cache/${wu}/discussion/beta/presence`,
@@ -809,9 +834,9 @@ describe('pipeline simulation', () => {
       JSON.stringify({ pid: null, pid_start: null, session_id: 'peer-sess' }) + '\n');
     const swept = sim.run(['presence', 'cleanup', 'sim-sess']);
     assert.deepStrictEqual(swept.cleared, [{ work_unit: wu, phase: 'discussion', topic: 'beta' }]);
-    assert.deepStrictEqual(sim.run(['presence', 'scan', wu]).sessions.map((r) => r.topic), ['gamma']);
+    assert.ok(rowOf(sim.run(['presence', 'scan', wu]), 'discussion', 'gamma'), 'the peer\'s heartbeat is left alone');
     sim.run(['presence', 'cleanup', 'peer-sess']);
-    assert.strictEqual(sim.run(['presence', 'scan', wu]).sessions.length, 0);
+    assert.strictEqual(rowOf(sim.run(['presence', 'scan', wu]), 'discussion', 'gamma'), undefined);
     // Session labels, as every process skill's Step 0 issues them: an
     // unconfigured opt-in answers a disabled no-op — even on a bad argument,
     // since the enable check precedes validation; opted in but outside tmux


### PR DESCRIPTION
PR 2 of the concurrent-phases stack (design: #1027, `design/concurrent-phases.md`).

The engine layer that lets every document phase run concurrently and prepares the code gate:

- **Presence widening**: `PHASES` grows to every phase a session sits in (discovery stays out — `active_session` already serialises it). `presence scan` with no argument walks the whole project for the code gate's read.
- **Mechanical heartbeats**: the engine stamps beats as a side effect of self-referential verbs — session-cadence `commit --topic`, `topic queue/start/complete/absorb`, topic-addressed `manifest set`, agent-store writes. The terminal `--kb` commit clears; `--sweep` suppresses (the conclude sweep, foreign-topic delivery retries); foreign-acting verbs never beat. No prose ever issues a beat again.
- **Confined commits everywhere**: `commitScoped` (stage scope, commit the whole index) is deleted; every engine commit — the `commit` helper and every transaction tail — commits `-- <paths>`, so no commit can sweep a peer session's work. Transaction-tail scopes audited per site (narrowed where the action writes less; multi-work-unit transactions verified complete).
- **`--discovery` scope**: discovery's cadence commit slices sessions + briefs + manifest — closes the live theft where discovery's whole-index commits swept a peer's half-written topic file.
- **`--paths`**: the code-commit verb — declared paths validated (in-project, literal, never `.workflows/`), committed under the commit lock, answering `left_dirty` as the reconcile signal. Beats its `--for` code topic.
- **`--plan` confinement**: commits its computed pathspec set instead of the whole index.
- **Tests**: commit-door suite (+18), presence suite (+3), simulation exercises the new verbs, and a two-process stress test pins the headline invariant — *no commit ever contains a foreign session's path*.

Includes the `--sweep` rider in the two conclude-sweep prose templates so this PR lands regression-free (a sweeper must not stamp its identity onto the dead topic it just cleaned).

Gates: `npm test` 2509/0 · `npm run test:cli` 414/0 · `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)