### PR TITLE
feat(discovery): the session's commits slice the discovery scope

### DIFF
--- a/skills/workflow-continue-epic/references/summary-backfill.md
+++ b/skills/workflow-continue-epic/references/summary-backfill.md
@@ -154,7 +154,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest apply {work_unit
 Single commit covering all writes:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): backfill {N} discovery provenance field(s) from source files"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): backfill {N} discovery provenance field(s) from source files" --discovery
 ```
 
 → Return to caller.

--- a/skills/workflow-discovery/references/conclude-discovery.md
+++ b/skills/workflow-discovery/references/conclude-discovery.md
@@ -18,7 +18,7 @@ Two anti-patterns (all work types):
 Commit any residual changes (e.g. an endpoint's Conclusion write or marker clear) — a clean tree reports `committed: null` and is fine:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): finalise session log"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): finalise session log" --discovery
 ```
 
 → Proceed to **B. Bridge**.

--- a/skills/workflow-discovery/references/confirm-and-persist.md
+++ b/skills/workflow-discovery/references/confirm-and-persist.md
@@ -116,7 +116,7 @@ Pick the commit message:
 
 #### If the log file exists
 
-Close the session — one engine transaction clears the active-session marker (resume detection on the next entry sees a closed session) and indexes the finalised log into the knowledge base so this epic's discovery is retrievable by later phases and sibling epics (idempotent — re-indexing the same session replaces its chunks; distinct sessions coexist under their own identity), then commits. One call covers whatever this session left dirty: the manifest writes from **A**, the Topics Identified write, the Conclusion replacement, and the briefs written and reconciled at harvest by [brief-synthesis.md](brief-synthesis.md):
+Close the session — one engine transaction clears the active-session marker (resume detection on the next entry sees a closed session) and indexes the finalised log into the knowledge base so this epic's discovery is retrievable by later phases and sibling epics (idempotent — re-indexing the same session replaces its chunks; distinct sessions coexist under their own identity), then commits. One call covers everything a discovery session writes — its logs, its briefs, the manifest: the manifest writes from **A**, the Topics Identified write, the Conclusion replacement, and the briefs written and reconciled at harvest by [brief-synthesis.md](brief-synthesis.md):
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs discovery-session close {work_unit} -m "{message}"
@@ -132,10 +132,10 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render session-receipt {w
 
 #### If no log file exists
 
-Browse-only session — the marker was never set and there is nothing to index. Commit whatever the session left dirty; a clean tree reports `committed: null` and is fine:
+Browse-only session — the marker was never set and there is nothing to index. Commit anything the session left in the discovery scope; a clean tree reports `committed: null` and is fine:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): finalise session log"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): finalise session log" --discovery
 ```
 
 → Return to caller.

--- a/skills/workflow-discovery/references/document-review.md
+++ b/skills/workflow-discovery/references/document-review.md
@@ -63,7 +63,7 @@ Briefs (`discovery/briefs/`) are views — regenerated at each harvest, never re
 Apply corrections directly to the file, then commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "docs(discovery/{work_unit}): reconcile session log with conversation"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "docs(discovery/{work_unit}): reconcile session log with conversation" --discovery
 ```
 
 → Proceed to **D. Brief the User**.

--- a/skills/workflow-discovery/references/map-operations.md
+++ b/skills/workflow-discovery/references/map-operations.md
@@ -190,7 +190,7 @@ Append a single batch entry to the session log under **Edits**. The session log 
 Single commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): edit {N} summary(ies)"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): edit {N} summary(ies)" --discovery
 ```
 
 → Return to **C. Apply** for the next group.
@@ -230,7 +230,7 @@ Append an Edits entry to the session log. If the log doesn't exist yet, create i
 Per-item commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): remove {name} from map"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): remove {name} from map" --discovery
 ```
 
 → Return to **C. Apply** for the next group.
@@ -272,7 +272,7 @@ Append an Edits entry to the session log. If the log doesn't exist yet, create i
 Per-item commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): rename {old} → {new}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): rename {old} → {new}" --discovery
 ```
 
 → Return to **C. Apply** for the next group.
@@ -310,7 +310,7 @@ Append an Edits entry to the session log. If the log doesn't exist yet, create i
 Per-item commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): re-route {name} to {new routing}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): re-route {name} to {new routing}" --discovery
 ```
 
 → Return to **C. Apply** for the next group.
@@ -353,7 +353,7 @@ Append a single batch entry to the session log under **Edits**. If the log doesn
 Single commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): edit {N} description(s)"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): edit {N} description(s)" --discovery
 ```
 
 → Return to **C. Apply** for the next group.
@@ -391,7 +391,7 @@ Append an Edits entry to the session log. If the log doesn't exist yet, create i
 Per-item commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): close {name} as dead end"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): close {name} as dead end" --discovery
 ```
 
 → Return to **C. Apply** for the next group.
@@ -429,7 +429,7 @@ Append an Edits entry to the session log. If the log doesn't exist yet, create i
 Per-item commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): reopen {name}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): reopen {name}" --discovery
 ```
 
 → Return to **C. Apply** for the next group.

--- a/skills/workflow-discovery/references/resume-detection.md
+++ b/skills/workflow-discovery/references/resume-detection.md
@@ -61,7 +61,7 @@ Delete the in-progress log, clear the marker, and commit:
 ```bash
 rm .workflows/{work_unit}/discovery/sessions/session-{active_session}.md
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest delete {work_unit}.discovery active_session
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): restart interrupted session"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): restart interrupted session" --discovery
 ```
 
 `session_number` will be set at Step 7 from discovery's `next_session_number`.

--- a/skills/workflow-discovery/references/session-loop.md
+++ b/skills/workflow-discovery/references/session-loop.md
@@ -168,7 +168,7 @@ No fixed cadence — follow the conversation, not a checklist. **The loop is the
    The lazy-creation rule applies: this may create the session log file if it doesn't exist yet — see [template.md](template.md) → *Lazy creation and finalisation*, which opens the session via `engine discovery-session open` (installing the log and setting the active-session marker). After writing, commit:
 
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): exploration notes — session-{session_number:03d}"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "discovery({work_unit}): exploration notes — session-{session_number:03d}" --discovery
    ```
 
 → On return, proceed to **C. Harvest** when the user pulls the harvest (a harvest pull recognised in step 2). Otherwise loop within **B** — convergence (step 4) cues the nudge but stays in the loop.


### PR DESCRIPTION
PR 3 of the concurrent-phases stack (design: #1027; engine layer: #1028).

Discovery's prose commit sites convert from whole-work-unit `engine commit {wu}` to the confined `--discovery` scope (sessions + briefs + manifest) — closing the live theft where a discovery session's commits swept a concurrent research/discussion session's half-written topic file under a `discovery(…)` message.

- 13 sites converted: the session loop's cadence commit, document review, restart, conclude, both close paths in confirm-and-persist, the seven map operations, and the epic entry's summary backfill (`manifest apply` — manifest only).
- 1 site deliberately kept work-unit-wide: the discovery-gap-analysis commit in `workflow-shared/references/topic-discovery.md`, whose action writes `.state/` staging and knowledge-store dirt — outside the discovery scope by design (work-unit-wide staging, protected by the live-presence deferral).
- Two stale wide-scope claims in `confirm-and-persist.md` re-worded to describe the confined scope.
- Empirically verified on the riskiest site (restart: the tracked log is `rm`'d before the commit) — the deletion and manifest ride, a live peer's dirty document stays untouched.

No menus migrated, no restructuring — mechanical command conversions only; the files' real conversions stay with their owning PRs.

Gates: `npm test` 2509/0 · `npm run test:cli` 414/0 · `npm run typecheck` clean. Prose-test select names 4 intersecting cases, none pinning the changed command text; no snapshot regeneration owed (recipes and engine sources untouched by this layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)