### PR TITLE
feat(spec): the specification session commits its own topic — and the beats leave the prose

### DIFF
--- a/skills/workflow-discussion-process/references/conclude-discussion.md
+++ b/skills/workflow-discussion-process/references/conclude-discussion.md
@@ -52,10 +52,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render triage-block {work
    node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.discussion.{topic} --verb complete --warn
    ```
 
-4. Clear this session's presence and sweep for leavings:
+4. Sweep for leavings:
 
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs presence clear {work_unit} discussion {topic}
    git status --porcelain -- .workflows
    ```
 

--- a/skills/workflow-discussion-process/references/discussion-session.md
+++ b/skills/workflow-discussion-process/references/discussion-session.md
@@ -20,7 +20,7 @@ Two types of background agent operate during the discussion, and the topic's tri
 
 The discussion is an organic conversation. The Discussion Map is your tracking backbone — it tells you where you are, what's been decided, what's still open, and where to go next. It is typed state in the manifest (`phases.discussion.items.{topic}.subtopics`): you make every state call, the engine `discussion-map` commands record it, and the adapter renders it (see **E**). Follow this loop:
 
-1. **Check for findings** — Beat presence first, once per check — `node .claude/skills/workflow-engine/scripts/engine.cjs presence beat {work_unit} discussion {topic}` — before the gated checks below: any of them can end in a STOP that closes the turn, and the beat must not miss its iteration.
+1. **Check for findings** — anything waiting is surfaced before the conversation moves on.
 
    Check the triage queue first: follow **A. Check** in **[rerouted-concerns.md](../../workflow-shared/references/rerouted-concerns.md)**. Its offer and raise gates end the turn — the agent checks below wait for a later iteration; an absorb never ends the turn, the protocol itself continues to the next raise.
 

--- a/skills/workflow-research-process/references/conclude-research.md
+++ b/skills/workflow-research-process/references/conclude-research.md
@@ -41,10 +41,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render triage-block {work
    node .claude/skills/workflow-engine/scripts/engine.cjs render topic-receipt {work_unit}.research.{topic} --verb complete --warn
    ```
 
-3. Clear this session's presence and sweep for leavings:
+3. Sweep for leavings:
 
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs presence clear {work_unit} research {topic}
    git status --porcelain -- .workflows
    ```
 

--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -8,7 +8,7 @@
 
 Not a rigid checklist — a natural cadence for productive research conversations:
 
-1. **Check for findings** — Beat presence first, once per check — `node .claude/skills/workflow-engine/scripts/engine.cjs presence beat {work_unit} research {topic}` — before the gated checks below: any of them can end in a STOP that closes the turn, and the beat must not miss its iteration.
+1. **Check for findings** — anything waiting is surfaced before the conversation moves on.
 
    Check the triage queue first: follow **A. Check** in **[rerouted-concerns.md](../../workflow-shared/references/rerouted-concerns.md)**. Its offer and raise gates end the turn — the agent checks below wait for a later iteration; an absorb never ends the turn, the protocol itself continues to the next raise.
 

--- a/skills/workflow-specification-process/SKILL.md
+++ b/skills/workflow-specification-process/SKILL.md
@@ -6,6 +6,8 @@ hooks:
   SessionEnd:
     - hooks:
         - type: command
+          command: 'node "$CLAUDE_PROJECT_DIR/.claude/skills/workflow-engine/scripts/engine.cjs" presence cleanup'
+        - type: command
           command: 'node "$CLAUDE_PROJECT_DIR/.claude/skills/workflow-engine/scripts/engine.cjs" session cleanup'
 ---
 
@@ -62,9 +64,9 @@ Do not guess at progress or continue from memory. The files on disk and git hist
 
 1. **STOP AND WAIT** for explicit approval before any write to the specification. Present content, wait for the user to explicitly approve (`y/yes` or equivalent), then log. No exceptions.
 2. **Log verbatim** — when approved, write exactly what was presented. No silent modifications.
-3. **Commit frequently** — commit at natural breaks and before any context refresh. Context refresh = lost work. Work-unit commits go through the scoped helper:
+3. **Commit frequently** — commit at natural breaks and before any context refresh. Context refresh = lost work. Commits go through the scoped helper, action-scoped to this topic — the specification directory and the work-unit manifest, never a sibling session's files:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "{message}"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "{message}" --topic specification/{topic}
    ```
 
 ---

--- a/skills/workflow-specification-process/references/initialize-specification.md
+++ b/skills/workflow-specification-process/references/initialize-specification.md
@@ -59,7 +59,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 Commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): initialize specification"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): initialize specification" --topic specification/{topic}
 ```
 
 → Return to caller.

--- a/skills/workflow-specification-process/references/reconcile-stale-sources.md
+++ b/skills/workflow-specification-process/references/reconcile-stale-sources.md
@@ -29,7 +29,7 @@ The revision is not final — defer: leave the row `stale` and tell the user rec
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} sources.{source-name}.status incorporated
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): reconcile stale source {source-name}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): reconcile stale source {source-name}" --topic specification/{topic}
 ```
 
 → Return to caller.

--- a/skills/workflow-specification-process/references/resolve-source-incoherence.md
+++ b/skills/workflow-specification-process/references/resolve-source-incoherence.md
@@ -194,7 +194,7 @@ Each gap gets its own raise, acknowledgement, and landing; the specification pau
 An `incorporated` row for each routed source has flipped to `stale` and reconciles at re-entry; a still-`pending` row simply re-extracts the updated document when construction resumes — either way the engine refuses to conclude this spec, and its entry blocks, until every routed source re-concludes. Commit the session's work:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): pause — gap routed to {doc}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): pause — gap routed to {doc}" --topic specification/{topic}
 ```
 
 Tell the user: this specification is blocked until the reopened item(s) re-conclude — name them (`{doc}`, each of them). Do not run document dependencies, review, or conclusion.

--- a/skills/workflow-specification-process/references/spec-completion.md
+++ b/skills/workflow-specification-process/references/spec-completion.md
@@ -143,7 +143,7 @@ Specification is complete when:
 Commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): conclude specification"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): conclude specification" --topic specification/{topic} --kb
 ```
 
 When the `complete` response's `warnings` is non-empty, fetch and emit the `DISPLAY: kb warning` advisory — the warning never blocks:
@@ -180,7 +180,7 @@ Only supersede sources whose status is **not** `proposed`. A proposed source is 
 2. Inform the user which topics were updated
 3. Commit:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): mark source specifications as superseded"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): mark source specifications as superseded" --topic specification/{topic} --kb
    ```
 
 → Proceed to **F. Pipeline Continuation**.

--- a/skills/workflow-specification-process/references/spec-construction.md
+++ b/skills/workflow-specification-process/references/spec-construction.md
@@ -168,7 +168,7 @@ If you are uncertain whether the user approved, **ASK**: "Ready to log it, or do
 2. After completing exhaustive extraction from a source (all relevant content presented and logged), update that source's status to `incorporated` via `engine manifest` (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} sources.{source-name}.status incorporated`). `{source-name}` is the registered key — read the existing `sources` map and flip that row, never invent a new name (for a bugfix it is `{topic}`). See **[specification-format.md](specification-format.md)** for source status details.
 3. Commit at natural breaks — after significant exchanges, after each major topic, and before any context refresh:
    ```bash
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): {what changed}"
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): {what changed}" --topic specification/{topic}
    ```
 
 → Proceed to **F. Topic Complete**.

--- a/skills/workflow-specification-process/references/spec-review.md
+++ b/skills/workflow-specification-process/references/spec-review.md
@@ -33,7 +33,7 @@ Record the current cycle number — used for tracking file naming (`c{N}`).
 Commit the updated manifest:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): begin review cycle {N}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): begin review cycle {N}" --topic specification/{topic}
 ```
 
 → Proceed to **C. Phase 1 — Claims Verification**.
@@ -47,7 +47,7 @@ Record the current cycle number — used for tracking file naming (`c{N}`).
 Commit the updated manifest:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): begin review cycle {N}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): begin review cycle {N}" --topic specification/{topic}
 ```
 
 → Proceed to **B. Cycle Gate**.
@@ -125,7 +125,7 @@ Hold its STATUS as `phase_1_status` — carried in context for the branch below,
 **If the agent created a tracking file**, record it in progress (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} tracking.{file stem} in-progress`) and commit it:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): claims verification cycle {N}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): claims verification cycle {N}" --topic specification/{topic}
 ```
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
@@ -153,7 +153,7 @@ Hold its STATUS as `phase_2_status` — carried in context for the branch below,
 **If the agent created a tracking file**, record it in progress (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} tracking.{file stem} in-progress`) and commit it:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): input review cycle {N}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): input review cycle {N}" --topic specification/{topic}
 ```
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
@@ -180,7 +180,7 @@ Hold its STATUS as `phase_3_status` — carried in context for the branch below,
 **If the agent created a tracking file**, record it in progress (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.specification.{topic} tracking.{file stem} in-progress`) and commit it:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): gap analysis cycle {N}"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): gap analysis cycle {N}" --topic specification/{topic}
 ```
 
 → Load **[process-review-findings.md](process-review-findings.md)** and follow its instructions as written.
@@ -264,7 +264,7 @@ If any entry is `in-progress`, that file's findings were not fully processed —
 2. **Commit** all review tracking files:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): complete specification review (cycle {N})"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "spec({work_unit}): complete specification review (cycle {N})" --topic specification/{topic}
 ```
 
 > *Output the next fenced block as a code block:*

--- a/tests/prose/cases/discussion-corrects-a-stale-reference/assert.md
+++ b/tests/prose/cases/discussion-corrects-a-stale-reference/assert.md
@@ -30,7 +30,7 @@ The prose should have taken this path:
 8. the user wraps; the closing gates run the review machinery per the
    conduct (the stubbed review returns clean); the conclude gate reads
    the empty queue; the discussion completes with the `--kb` commit;
-   presence clears and the walk stops at the bridge invocation
+   the walk stops at the bridge invocation
 
 Further claims:
 

--- a/tests/prose/cases/discussion-drains-a-full-agenda/assert.md
+++ b/tests/prose/cases/discussion-drains-a-full-agenda/assert.md
@@ -31,8 +31,8 @@ The prose should have taken this path:
    machinery per the conduct (the stubbed review returns clean); the
    conclude gate reads the queue, finds it empty, and the discussion
    completes with the `--kb` commit
-9. presence clears, the sweep finds no leavings, and the walk stops at
-   the bridge invocation
+9. the sweep finds no leavings, and the walk stops at the bridge
+   invocation
 
 Further claims:
 

--- a/tests/prose/cases/discussion-receives-a-mid-session-landing/assert.md
+++ b/tests/prose/cases/discussion-receives-a-mid-session-landing/assert.md
@@ -29,8 +29,8 @@ The prose should have taken this path:
 8. the user wraps; the closing gates run the review machinery per the
    conduct (the stubbed review returns clean); the conclude gate reads
    the queue, finds it empty again, and the discussion completes with
-   the `--kb` commit; presence clears, the sweep finds no leavings,
-   and the walk stops at the bridge invocation
+   the `--kb` commit; the sweep finds no leavings, and the walk stops
+   at the bridge invocation
 
 Further claims:
 

--- a/tests/prose/cases/discussion-redecision-lands-timeline/assert.md
+++ b/tests/prose/cases/discussion-redecision-lands-timeline/assert.md
@@ -49,8 +49,8 @@ The prose should have taken this path:
    without unwinding the timeline — the revision landing survives
    reconciliation intact
 8. the conclusion marks the discussion complete (`topic complete`),
-   commits, clears the session's presence heartbeat, finds no
-   leavings to sweep, and the walk stops at the bridge invocation
+   commits, finds no leavings to sweep, and the walk stops at the
+   bridge invocation
 
 Further claims:
 

--- a/tests/prose/cases/discussion-reroutes-a-carry-note/assert.md
+++ b/tests/prose/cases/discussion-reroutes-a-carry-note/assert.md
@@ -36,8 +36,8 @@ The prose should have taken this path:
 8. compliance runs its re-read discipline, and the conclusion follows:
    the topic's own queue is empty, the user confirms, `topic complete`
    marks the discussion completed and indexes it, the commit lands,
-   presence clears with no leavings to sweep, and the walk stops at
-   the bridge invocation
+   the sweep finds no leavings, and the walk stops at the bridge
+   invocation
 
 Further claims:
 

--- a/tests/prose/cases/discussion-reroutes-to-research/assert.md
+++ b/tests/prose/cases/discussion-reroutes-to-research/assert.md
@@ -34,8 +34,8 @@ The prose should have taken this path:
    gates run the review machinery per the conduct (the stubbed review
    returns clean), the conclude gate finds the queue still empty, and
    the discussion completes with the `--kb` commit
-8. presence clears, the sweep finds no leavings, and the walk stops
-   at the bridge invocation
+8. the sweep finds no leavings, and the walk stops at the bridge
+   invocation
 
 Further claims:
 

--- a/tests/prose/cases/research-dead-ends-at-conclusion/case.json
+++ b/tests/prose/cases/research-dead-ends-at-conclusion/case.json
@@ -53,8 +53,7 @@
       "render research-conclude-gate search-relevance.research.vector-search-migration --dead-end",
       "discovery-map handle search-relevance vector-search-migration",
       "topic complete search-relevance research vector-search-migration",
-      "research(search-relevance): complete vector-search-migration research",
-      "presence clear search-relevance research vector-search-migration"
+      "research(search-relevance): complete vector-search-migration research"
     ],
     "calls_in_order": [
       "manifest get search-relevance.research.vector-search-migration status",


### PR DESCRIPTION
PR 4 of the concurrent-phases stack (design: #1027; engine: #1028; discovery: #1029).

**Specification joins the concurrent set.** Fourteen spec-process commit sites convert to `--topic specification/{topic}` (the completion and supersession commits take `--kb`, whose engine-side clear is the spec session's terminal presence semantics); the two spec-entry analysis commits stay work-unit-wide by design (`.state/` staging, protected by the live-presence deferral). The spec SKILL.md gains the `presence cleanup` SessionEnd hook.

**The presence strip.** Beats and clears are mechanical since #1028, so the prose stops mentioning them: the research/discussion session loops drop the beat-first instruction (the findings check's `topic queue` poll beats engine-side), and the conclude flows drop the explicit `presence clear` (the `--kb` conclusion commit clears). `presence scan` stays everywhere it feeds a judgment — the sweep, the held-doc check.

Prose-test pins updated with the strip: one `calls_include` invariant and six assert.md expected-path clauses that named the clear as a walk action (leaving them would have produced false FAILs); all `presence scan` pins deliberately kept.

Gates: `npm test` 2509/0 · `npm run test:cli` 414/0 · `npm run typecheck` clean. No snapshot regeneration owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)