### PR TITLE
feat(code-phases): implementation and review commit through the engine — code and artifacts apart

### DIFF
--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-implementation-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(git log), Bash(git diff)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(git log), Bash(git diff), Bash(git status)
 hooks:
   SessionEnd:
     - hooks:

--- a/skills/workflow-implementation-process/SKILL.md
+++ b/skills/workflow-implementation-process/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: workflow-implementation-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(git log), Bash(git diff), Bash(git add), Bash(git commit)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(git log), Bash(git diff)
 hooks:
   SessionEnd:
     - hooks:
+        - type: command
+          command: 'node "$CLAUDE_PROJECT_DIR/.claude/skills/workflow-engine/scripts/engine.cjs" presence cleanup'
         - type: command
           command: 'node "$CLAUDE_PROJECT_DIR/.claude/skills/workflow-engine/scripts/engine.cjs" session cleanup'
 ---
@@ -84,7 +86,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs task init {work_unit} {to
 Commit the tracking (the scoped commit covers the manifest):
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): start implementation"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): start implementation" --topic implementation/{topic}
 ```
 
 → Proceed to **Step 1**.

--- a/skills/workflow-implementation-process/references/ad-hoc-plan-changes.md
+++ b/skills/workflow-implementation-process/references/ad-hoc-plan-changes.md
@@ -181,7 +181,7 @@ Revise the staged task in the staging file based on the user's feedback (content
 Commit the staging record:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): ad hoc tasks declined"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): ad hoc tasks declined" --topic implementation/{topic}
 ```
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -127,29 +127,32 @@ Pre-analysis checkpoint — unexpected files detected:
 
 **STOP.** Wait for user response.
 
+The checkpoint is a code commit — name the files, and the engine confines the commit to them. A `.workflows` path among the unexpected files is never named here: those belong to their own phase's scope, and the loop's own commits carry them.
+
 **If `yes`:**
 
-Stage all files (implementation and unexpected). Commit:
-```
-impl({work_unit}): pre-analysis checkpoint
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --paths {implementation and unexpected files} -m "impl({work_unit}): pre-analysis checkpoint" --for {work_unit} implementation/{topic}
 ```
 
 → Proceed to **C. Dispatch Analysis Agents**.
 
 **If `skip`:**
 
-Stage only implementation files. Leave unexpected files unstaged. Commit:
-```
-impl({work_unit}): pre-analysis checkpoint
+Name only the implementation files; the unexpected ones stay uncommitted, and come back in the response's `left_dirty`.
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --paths {implementation files} -m "impl({work_unit}): pre-analysis checkpoint" --for {work_unit} implementation/{topic}
 ```
 
 → Proceed to **C. Dispatch Analysis Agents**.
 
 **If comment:**
 
-Stage the files the user specified alongside implementation files. Commit:
-```
-impl({work_unit}): pre-analysis checkpoint
+Name the implementation files plus the ones the user specified.
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --paths {implementation files and the named ones} -m "impl({work_unit}): pre-analysis checkpoint" --for {work_unit} implementation/{topic}
 ```
 
 → Proceed to **C. Dispatch Analysis Agents**.
@@ -165,7 +168,7 @@ impl({work_unit}): pre-analysis checkpoint
 Commit the analysis findings — the scoped commit covers the findings files and the manifest's cycle counters:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — findings"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — findings" --topic implementation/{topic}
 ```
 
 Read the bank (an absent field prints empty):
@@ -199,7 +202,7 @@ The phase boundaries left residue — the synthesizer runs over the bank alone f
 Commit the synthesis output — the scoped commit covers the report, any staging file, and the manifest's gate state:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — synthesis"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — synthesis" --topic implementation/{topic}
 ```
 
 #### If `STATUS` is `clean`
@@ -291,7 +294,7 @@ Revise the task content in the staging file based on the user's feedback.
 Commit the cycle's decisions (the scoped commit covers the manifest):
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — tasks declined"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — tasks declined" --topic implementation/{topic}
 ```
 
 → Return to **[the skill](../SKILL.md)** for **Step 8**.

--- a/skills/workflow-implementation-process/references/conclude-implementation.md
+++ b/skills/workflow-implementation-process/references/conclude-implementation.md
@@ -35,7 +35,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit
 
 Commit:
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): complete implementation"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): complete implementation" --topic implementation/{topic}
 ```
 
 **Pipeline continuation**:

--- a/skills/workflow-implementation-process/references/consolidation-pass.md
+++ b/skills/workflow-implementation-process/references/consolidation-pass.md
@@ -78,7 +78,7 @@ The pass ran; only the phase record is outstanding.
 When the finder wrote its file, commit the findings (the scoped commit covers the file and the manifest):
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): phase {N} consolidation — findings"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): phase {N} consolidation — findings" --topic implementation/{topic}
 ```
 
 #### If `STATUS` is `clean`

--- a/skills/workflow-implementation-process/references/task-loop.md
+++ b/skills/workflow-implementation-process/references/task-loop.md
@@ -440,13 +440,27 @@ node .claude/skills/workflow-engine/scripts/engine.cjs task complete {work_unit}
 
 **If the planning item carries no `storage_paths`** (a plan initialised before the field existed): record it now — read the format's authoring.md → Storage Pathspecs and copy the fenced array (`node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.planning.{topic} storage_paths '{format storage pathspecs}'`).
 
-**Commit all changes** with raw git — stage the task's code and tests, the plan's task state (the files the format's **updating.md** touched, plus the `storage_paths` pathspecs recorded on the planning item for storage outside the work unit), the work unit's manifest, and the task's fix-tracking file when one exists (`.workflows/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md`), then commit:
+**Commit the task** — each scope through the verb that owns it, state before code, so the code commit's answer names only code:
 
-```
-impl({work_unit}): T{internal_id} — {brief description}
-```
+1. **The plan's task state** — the files the format's **updating.md** touched, the `storage_paths` recorded on the planning item for storage outside the work unit, and the work unit's manifest:
 
-One commit per approved task, staging the listed paths explicitly — never `git add -A` or `git add .`. The subject is exactly as fenced — `T` immediately followed by the internal id, no space (`impl(pay): Tpay-1-1 — …`); review's scope-grep finds task commits by this token. Never `engine commit` here — its scopes cover `.workflows` only, never code or the plan format's storage.
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): record T{internal_id}" --plan {topic}
+   ```
+
+2. **The task's fix tracking**, when the task took a fix round (`.workflows/{work_unit}/implementation/{topic}/fix-tracking-{internal_id}.md`):
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): record T{internal_id} fix rounds" --topic implementation/{topic}
+   ```
+
+3. **The task's code and tests** — name every file the task wrote; the engine validates each path, commits confined to them, and answers with `left_dirty`:
+
+   ```bash
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit --paths {code and test files} -m "impl({work_unit}): T{internal_id} — {brief description}" --for {work_unit} implementation/{topic}
+   ```
+
+   The subject is exactly as shown — `T` immediately followed by the internal id, no space (`impl(pay): Tpay-1-1 — …`); review's scope-grep finds task commits by this token, and this commit alone is what it reads the task's file list from, so nothing but code and tests belongs in it. Anything in the response's `left_dirty` that this task touched is a path you forgot: commit it now with a second `--paths` call before proceeding. Dirt that belongs to someone else — a concurrent doc session's files never appear there — is not yours to commit.
 
 #### If `{disposition}` is `boundary`
 

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: workflow-review-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(ls .workflows/), Bash(git log)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(ls .workflows/), Bash(git log), Bash(git status)
 hooks:
   SessionEnd:
     - hooks:

--- a/skills/workflow-review-process/SKILL.md
+++ b/skills/workflow-review-process/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: workflow-review-process
 user-invocable: false
-allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(ls .workflows/), Bash(git log), Bash(git add), Bash(git commit)
+allowed-tools: Bash(node .claude/skills/workflow-knowledge/scripts/knowledge.cjs), Bash(node .claude/skills/workflow-engine/scripts/engine.cjs), Bash(mkdir -p .workflows/), Bash(ls .workflows/), Bash(git log)
 hooks:
   SessionEnd:
     - hooks:
+        - type: command
+          command: 'node "$CLAUDE_PROJECT_DIR/.claude/skills/workflow-engine/scripts/engine.cjs" presence cleanup'
         - type: command
           command: 'node "$CLAUDE_PROJECT_DIR/.claude/skills/workflow-engine/scripts/engine.cjs" session cleanup'
 ---
@@ -143,7 +145,7 @@ Order matters — the review file is deleted last, so a crash mid-restart re-off
 6. Commit the deletions under the topics that held them, then the plan — `--plan` stages the planning topic, the manifests, and the plan's declared storage (the skip-markings live there):
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): restart review — clear reports and staging" --topic review/{topic}
-   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): restart review — clear staged proposals" --topic implementation/{topic}
+   node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): restart review — clear staged proposals" --topic implementation/{topic} --sweep
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): restart review" --plan {topic}
    ```
 

--- a/skills/workflow-review-process/references/apply-do-now.md
+++ b/skills/workflow-review-process/references/apply-do-now.md
@@ -74,12 +74,13 @@ Every action was skipped or reverted — there is nothing to commit. Carry that 
 
 #### Otherwise
 
-Commit the work as one body. The fixes touch project files outside the work unit, so the scoped helper cannot cover them — stage the touched files with raw git:
+Commit the work as one body — the code commit takes the paths you name, validates each, and answers with `left_dirty`:
 
 ```bash
-git add -- {files the fixes touched}
-git commit -m "review({work_unit}): apply do-now findings"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --paths {files the fixes touched} -m "review({work_unit}): apply do-now findings" --for {work_unit} review/{topic}
 ```
+
+Anything in `left_dirty` that these fixes touched is a path you forgot: commit it now with a second `--paths` call before carrying the outcome forward.
 
 Carry the outcome forward for the report and the presentation: applied count, anything skipped or reverted with its reason, and the suite's final state.
 

--- a/skills/workflow-review-process/references/invoke-review-synthesizer.md
+++ b/skills/workflow-review-process/references/invoke-review-synthesizer.md
@@ -50,10 +50,10 @@ If the agent fails (error, timeout), record the failure and report "synthesis fa
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.review.{topic} staging.c{N}.gate_mode=gated staging.c{N}.tasks.1=pending … staging.c{N}.tasks.{TASKS_PROPOSED}=pending
 ```
 
-Commit the report and staging file (if created):
+Commit the report and staging file (if created) — both sit under the implementation topic, which this session is reviewing rather than working, so the commit leaves that topic's presence alone:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — findings"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — findings" --topic implementation/{topic} --sweep
 ```
 
 ---

--- a/skills/workflow-review-process/references/offer-out-of-scope.md
+++ b/skills/workflow-review-process/references/offer-out-of-scope.md
@@ -54,11 +54,10 @@ File what they chose, taking the next available number in each directory:
 
 Each file carries the finding's summary, the failure or gap it names, the files it concerns, and where it came from — `{work_unit}` review, and the source finding ids. An item arriving in the inbox months later is read by someone with none of this session's context, so it states the problem rather than referring to it.
 
-Commit any filed items — the inbox sits outside the work unit, so the scoped helper cannot cover it:
+Commit any filed items — the inbox has its own scope:
 
 ```bash
-git add -- .workflows/.inbox
-git commit -m "review({work_unit}): file out-of-scope findings to inbox"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit --inbox -m "review({work_unit}): file out-of-scope findings to inbox"
 ```
 
 Delete the field — offered and decided, whichever way each went:

--- a/skills/workflow-review-process/references/prep-findings.md
+++ b/skills/workflow-review-process/references/prep-findings.md
@@ -89,7 +89,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest push {work_unit}
 Commit the durable dirt of verification and prep — the per-task reports and the manifest — so the apply that follows starts from a clean tree and a crash from here forward loses nothing expensive:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): verification and prep"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): verification and prep" --topic review/{topic}
 ```
 
 The findings are never rewritten or deleted — the per-task reports stand as the record of what was raised. What prep produces is the layer above them: what survived, what merged, what was corrected, and what was discarded with its reason.

--- a/skills/workflow-review-process/references/produce-review.md
+++ b/skills/workflow-review-process/references/produce-review.md
@@ -45,7 +45,7 @@ Omit the entire `## Findings` section.
 Commit:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review" --topic review/{topic}
 ```
 
 Your review feedback can be:

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -41,7 +41,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit
 Commit the completion:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase" --topic review/{topic}
 ```
 
 **Pipeline continuation** — Invoke `/workflow-bridge {work_unit} review`.
@@ -101,7 +101,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit
 Commit the completion:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): complete review phase" --topic review/{topic}
 ```
 
 > *Output the next fenced block as a code block:*
@@ -201,7 +201,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs topic complete {work_unit
 Commit the cycle's decisions (the scoped commit covers the manifest):
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — tasks declined"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): synthesis cycle {N} — tasks declined" --topic review/{topic}
 ```
 
 **Pipeline continuation** — Invoke `/workflow-bridge {work_unit} review`.
@@ -227,7 +227,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 Commit the staging file with this topic's implementation artifacts, then the plan tasks and `task_map` updates — `--plan` stages the planning topic, the manifests, and the plan's declared storage:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): stage review remediation" --topic implementation/{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): stage review remediation" --topic implementation/{topic} --sweep
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): add review remediation ({K} tasks)" --plan {topic}
 ```
 
@@ -245,7 +245,7 @@ For each plan that received new tasks:
 2. Commit tracking changes:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): re-open implementation tracking"
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): re-open implementation tracking" --topic review/{topic}
 ```
 
 Then enter plan mode and write the following plan. Resolve `{work_type}` from the manifest when not already in context:

--- a/tests/prose/cases/implementation-adjudicates-a-challenge/assert.md
+++ b/tests/prose/cases/implementation-adjudicates-a-challenge/assert.md
@@ -37,7 +37,7 @@ The prose should have taken this path:
 10. progress lands for pay-1-1: frontmatter flips to completed,
     tasks remain in the phase (pay-1-2 is open) so the disposition
     is `continuing` — the engine records completion naming pay-1-2
-    as next with no --phase-complete, and one raw git commit lands
+    as next with no --phase-complete, and the code commit lands
     as impl(pay): Tpay-1-1
 11. the walk stops — pay-1-2 is never started
 

--- a/tests/prose/cases/implementation-adjudicates-a-challenge/case.json
+++ b/tests/prose/cases/implementation-adjudicates-a-challenge/case.json
@@ -53,7 +53,8 @@
       "render fix-gate pay.implementation.pay",
       "render task-gate pay.implementation.pay",
       "task complete pay pay pay-1-1 --phase 1 --next-task pay-1-2",
-      "impl(pay): Tpay-1-1"
+      "impl(pay): Tpay-1-1",
+      "commit --paths"
     ],
     "calls_in_order": [
       "render entry-gate pay.implementation.pay",

--- a/tests/prose/cases/implementation-consolidates-the-phase/assert.md
+++ b/tests/prose/cases/implementation-consolidates-the-phase/assert.md
@@ -27,7 +27,7 @@ The prose should have taken this path:
    remain, the work type is feature, the phase label is
    plan-authored, and consolidated_phases is absent — so the
    plan-side phase completion is deferred, the engine call carries
-   --next-task ~ WITHOUT --phase-complete, one raw git commit lands
+   --next-task ~ WITHOUT --phase-complete, the code commit lands
    as impl(pay): Tpay-1-2, and the stage routes to the consolidation
    pass
 9. the pass announces itself, reads consolidation_gate_mode (gated)
@@ -62,8 +62,8 @@ The prose should have taken this path:
     consolidated_phases contains 1 with the approved staged task
     present in the plan, so the disposition is `completing` — the
     plan-side phase completion runs (no action in this format), the
-    engine call carries --phase-complete, and one raw git commit
-    lands as impl(pay): Tpay-1-3
+    engine call carries --phase-complete, and the code commit lands
+    as impl(pay): Tpay-1-3
 17. retrieval finds no available and no open tasks, reports all
     tasks complete, and returns to the caller — the walk stops
     before the analysis loop

--- a/tests/prose/cases/implementation-consolidates-the-phase/case.json
+++ b/tests/prose/cases/implementation-consolidates-the-phase/case.json
@@ -58,6 +58,7 @@
       "render task-gate pay.implementation.pay",
       "task complete pay pay pay-1-2 --phase 1 --next-task ~",
       "impl(pay): Tpay-1-2",
+      "commit --paths",
       "manifest get pay.implementation.pay consolidation_gate_mode",
       "phase 1 consolidation — findings",
       "staging.p1.tasks.1=pending",

--- a/tests/prose/cases/implementation-executes-the-loop/assert.md
+++ b/tests/prose/cases/implementation-executes-the-loop/assert.md
@@ -42,8 +42,9 @@ The prose should have taken this path:
     scripted answer approves
 13. progress lands for pay-1-1: frontmatter status flips to completed,
     the phase is not yet complete (pay-1-2 remains), the engine
-    records completion naming pay-1-2 as next, and one raw git commit
-    lands as impl(pay): Tpay-1-1 with a brief description
+    records completion naming pay-1-2 as next, and the task's commits
+    land — the state through --plan, the code through --paths as
+    impl(pay): Tpay-1-1 with a brief description
 14. the loop returns to retrieval and selects pay-1-2, starts it,
     marks it in-progress, and presents its brief before the dispatch
 15. executor and reviewer stubs fire once each for pay-1-2; the fourth
@@ -52,7 +53,7 @@ The prose should have taken this path:
     disposition comes out `boundary` — no open tasks remain and
     consolidated_phases lacks phase 1 — so the plan-side phase
     completion is deferred, the engine call carries --next-task ~
-    WITHOUT --phase-complete, one raw git commit lands as
+    WITHOUT --phase-complete, the code commit lands as
     impl(pay): Tpay-1-2, and the stage routes to the consolidation
     pass
 17. the pass announces itself (marker and signpost), reads
@@ -80,9 +81,9 @@ Further claims:
   hand-drawn; both task-gate menus likewise via `render task-gate` at
   the gate itself, emitted verbatim and never carried from an earlier
   response
-- the per-task commits are raw git commits that include the task
-  file's status change alongside the code and tests — the plan's
-  state is not left uncommitted
+- each task lands as a pair of engine commits — the plan's task
+  state through --plan, the code and tests through --paths — so the
+  plan's state is not left uncommitted and no commit mixes the two
 - no fix-tracking file and no attempt-findings cache file exist; the
   task-brief and task-result payload cache files under
   .workflows/.cache are expected residue of the renders

--- a/tests/prose/cases/implementation-executes-the-loop/case.json
+++ b/tests/prose/cases/implementation-executes-the-loop/case.json
@@ -67,6 +67,7 @@
       "task complete pay pay pay-1-2 --phase 1 --next-task ~",
       "--phase-complete",
       "impl(pay): Tpay-1-1",
+      "commit --paths",
       "impl(pay): Tpay-1-2",
       "manifest get pay.implementation.pay consolidation_gate_mode",
       "manifest push pay.implementation.pay consolidated_phases 1"

--- a/tests/prose/cases/implementation-loops-on-auto/assert.md
+++ b/tests/prose/cases/implementation-loops-on-auto/assert.md
@@ -32,7 +32,8 @@ The prose should have taken this path:
 8. the fourth scripted answer opts into auto: task_gate_mode is set
    to auto and progress lands in the same turn — frontmatter flips to
    completed, the engine records completion naming pay-1-2 as next,
-   and one raw git commit lands as impl(pay): Tpay-1-1
+   and the task's commits land — the state through --plan, the code
+   through --paths as impl(pay): Tpay-1-1
 9. the loop returns to retrieval and selects pay-1-2, starts it,
    marks it in-progress, and renders its brief before the dispatch
 10. the executor completes pay-1-2; the reviewer's first firing for
@@ -48,7 +49,7 @@ The prose should have taken this path:
     continuation section emitted, and the commit proceeds in the same
     turn — the phase disposition comes out `boundary` (no open tasks,
     consolidated_phases lacks phase 1), so the engine call carries
-    next task ~ WITHOUT --phase-complete, one raw git commit lands as
+    next task ~ WITHOUT --phase-complete, the code commit lands as
     impl(pay): Tpay-1-2, and the stage routes to the consolidation
     pass
 12. the pass announces itself, reads consolidation_gate_mode and the

--- a/tests/prose/cases/implementation-loops-on-auto/case.json
+++ b/tests/prose/cases/implementation-loops-on-auto/case.json
@@ -65,6 +65,7 @@
       "task complete pay pay pay-1-2 --phase 1 --next-task ~",
       "--phase-complete",
       "impl(pay): Tpay-1-1",
+      "commit --paths",
       "impl(pay): Tpay-1-2",
       "manifest get pay.implementation.pay consolidation_gate_mode",
       "manifest push pay.implementation.pay consolidated_phases 1"

--- a/tests/prose/cases/implementation-retells-at-the-gate/assert.md
+++ b/tests/prose/cases/implementation-retells-at-the-gate/assert.md
@@ -44,7 +44,7 @@ The prose should have taken this path:
     again with no re-presented header or summary
 11. the fifth scripted answer approves; progress lands for pay-1-1:
     frontmatter status flips to completed, the engine records
-    completion naming pay-1-2 as next, and one raw git commit lands
+    completion naming pay-1-2 as next, and the code commit lands
     as impl(pay): Tpay-1-1
 12. pay-1-2 runs the plain path: brief, executor and reviewer stubs,
     result header, product summary, one gate fetch, and the sixth

--- a/tests/prose/cases/implementation-retells-at-the-gate/case.json
+++ b/tests/prose/cases/implementation-retells-at-the-gate/case.json
@@ -62,6 +62,7 @@
       "task complete pay pay pay-1-2 --phase 1 --next-task ~",
       "--phase-complete",
       "impl(pay): Tpay-1-1",
+      "commit --paths",
       "impl(pay): Tpay-1-2",
       "manifest get pay.implementation.pay consolidation_gate_mode",
       "manifest push pay.implementation.pay consolidated_phases 1"

--- a/tests/prose/cases/review-preps-and-applies-findings/assert.md
+++ b/tests/prose/cases/review-preps-and-applies-findings/assert.md
@@ -25,7 +25,8 @@ The prose should have taken this path:
 7. the do-now apply announces the corrections in prose, dispatches an
    applier — stubbed: both applied, nothing skipped — then the verifier
    over the uncommitted diff — stubbed: nothing to repair, suite green —
-   and commits the corrections with raw git as one body of work
+   and commits the corrections through the engine's code commit as
+   one body of work
 8. the review report is produced from the action list with a Pass
    verdict, its corrected section recording what was applied, and
    committed

--- a/tests/prose/cases/review-preps-and-applies-findings/case.json
+++ b/tests/prose/cases/review-preps-and-applies-findings/case.json
@@ -48,6 +48,7 @@
       "impl(pay): T",
       "push pay.review.pay reviewed_tasks",
       "review(pay): verification and prep",
+      "commit --paths",
       "render review-presentation pay.review.pay",
       "render review-gate pay.review.pay",
       "review(pay): complete review",


### PR DESCRIPTION
PR 6 of the concurrent-phases stack (design: #1027; engine: #1028; prior layers: #1029, #1031, #1032).

**The raw-git era ends.** The task loop's single whole-index commit becomes three scoped commits — state before code, so `left_dirty` means exactly "code this task forgot": plan state via `--plan`, fix-tracking via `--topic implementation/{topic}`, code + tests via `commit --paths … --for` with the reconcile line. The T-token subject stays on the code commit alone, so review's scope-grep now reads a *sharper* file list (verified empirically against all three commit shapes). The analysis loop's pre-analysis checkpoint — a previously unlisted whole-index code sweep — converts on all three branches; review's apply lane takes `--paths` and the out-of-scope filing takes `--inbox`. No raw-git write remains in either skill, and both frontmatters drop the `git add`/`git commit` grants (gaining the `git status` their prose already runs).

**Artifact commits**: 7 implementation + 6 review sites convert to `--topic {phase}/{topic}` (neither phase is KB-indexed — no `--kb`). The three cross-phase commits a review session makes under the implementation topic carry `--sweep` — a review session must not stamp a hold on a phase item it isn't running (P8).

**The sweep code/doc distinction holds structurally** — both conclude sweeps scan `.workflows` only and commit through a scope that cannot carry code; nothing needed changing.

Presence-cleanup hooks land on both skills. Prose-test pins: 6 assert.md "raw git" claims rewritten, 6 case.json gain positive `commit --paths` pins.

Gates: `npm test` 2511/0 · `npm run test:cli` 414/0 · `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)