### PR TITLE
feat(gates): the code slot has one gate, and the in-session confirm joins its family

### DIFF
--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -83,7 +83,7 @@ Match the user's input to its `ACTIONS` entry by `key` — a number, or a comman
 
 **If the selected entry carries an `(in session: …)` marker:**
 
-Another live session holds this topic open. Fetch and emit the `MENU: in-session gate — {key}` section for the selected entry:
+A live session holds what this entry would open — this topic for a document phase, or the one code slot for implementation and review. Fetch and emit the `MENU: in-session gate — {key}` section for the selected entry:
 
 ```bash
 node .claude/skills/workflow-continue-epic/scripts/gateway.cjs in-session-gate {work_unit} {key}
@@ -95,7 +95,7 @@ node .claude/skills/workflow-continue-epic/scripts/gateway.cjs in-session-gate {
 
 → Return to **A. State Display and Menu**.
 
-**If user chose `yes`:**
+**If user chose `proceed`:**
 
 Continue with the **Hard gate check** below.
 

--- a/skills/workflow-continue-epic/references/epic-display-and-menu.md
+++ b/skills/workflow-continue-epic/references/epic-display-and-menu.md
@@ -81,9 +81,11 @@ Match the user's input to its `ACTIONS` entry by `key` — a number, or a comman
 
 #### Otherwise
 
+A `(code session: …)` marker needs no gate here — implementation and review are gated at their entry skill, which reads the whole checkout's code slot; the marked row routes like any other.
+
 **If the selected entry carries an `(in session: …)` marker:**
 
-A live session holds what this entry would open — this topic for a document phase, or the one code slot for implementation and review. Fetch and emit the `MENU: in-session gate — {key}` section for the selected entry:
+Another live session holds this topic open. Fetch and emit the `MENU: in-session gate — {key}` section for the selected entry:
 
 ```bash
 node .claude/skills/workflow-continue-epic/scripts/gateway.cjs in-session-gate {work_unit} {key}

--- a/skills/workflow-continue-epic/scripts/gateway.cjs
+++ b/skills/workflow-continue-epic/scripts/gateway.cjs
@@ -242,7 +242,11 @@ function view(workUnit, newArrivalsJson) {
     if (k.recommended) line += '  (recommended)';
     if (k.in_session) {
       const holder = k.session_holder ? `${k.session_holder.work_unit}/${k.session_holder.topic}, ` : '';
-      line += `  (in session: ${holder}last active ${engine.presence.fmtAge(k.session_age || 0)} ago)`;
+      // A code entry reads as the checkout's slot, not this topic's session:
+      // its own marker keeps the menu's in-session gate from firing, because
+      // the entry skill's code gate owns that stop.
+      const label = k.code_session ? 'code session' : 'in session';
+      line += `  (${label}: ${holder}last active ${engine.presence.fmtAge(k.session_age || 0)} ago)`;
     }
     dataLines.push(line);
   }
@@ -276,6 +280,9 @@ function inSessionGate(workUnit, key) {
   }
   if (!entry.in_session) {
     return engine.gateway.dataBlock({ work_unit: e.name, error: `entry "${key}" is not held by another session — no gate to render` });
+  }
+  if (entry.code_session) {
+    return engine.gateway.dataBlock({ work_unit: e.name, error: `entry "${key}" is a code phase — the code slot is gated at the entry skill (render code-gate), never here` });
   }
   return engine.project.epicInSessionGate(e.name, entry);
 }

--- a/skills/workflow-continue-epic/scripts/gateway.cjs
+++ b/skills/workflow-continue-epic/scripts/gateway.cjs
@@ -206,8 +206,11 @@ function view(workUnit, newArrivalsJson) {
   // ACTIONS markers the in-session confirm gate reads.
   const presence = engine.presence.scanPresence(process.cwd(), e.name).sessions;
   const held = presence.filter((r) => r.held);
+  // Code takes one slot per checkout, so the code entries read the whole
+  // project's held rows, not just this epic's.
+  const codeHeld = engine.presence.heldCodeSessions(process.cwd());
 
-  const menu = engine.project.epicMenu(e.name, d, { presence });
+  const menu = engine.project.epicMenu(e.name, d, { presence, codeHeld });
 
   const dataLines = [];
   dataLines.push(`work_unit: ${e.name}`);
@@ -237,7 +240,10 @@ function view(workUnit, newArrivalsJson) {
   for (const k of menu.keys) {
     let line = `  ${k.key}  ${k.action}  ${k.topic || '—'}  → ${k.route || '(internal)'}`;
     if (k.recommended) line += '  (recommended)';
-    if (k.in_session) line += `  (in session: last active ${engine.presence.fmtAge(k.session_age || 0)} ago)`;
+    if (k.in_session) {
+      const holder = k.session_holder ? `${k.session_holder.work_unit}/${k.session_holder.topic}, ` : '';
+      line += `  (in session: ${holder}last active ${engine.presence.fmtAge(k.session_age || 0)} ago)`;
+    }
     dataLines.push(line);
   }
 
@@ -262,7 +268,8 @@ function inSessionGate(workUnit, key) {
     return engine.gateway.dataBlock({ work_unit: workUnit || '(missing)', error: 'no active epic with this name' });
   }
   const presence = engine.presence.scanPresence(process.cwd(), e.name).sessions;
-  const menu = engine.project.epicMenu(e.name, e.detail, { presence });
+  const codeHeld = engine.presence.heldCodeSessions(process.cwd());
+  const menu = engine.project.epicMenu(e.name, e.detail, { presence, codeHeld });
   const entry = menu.keys.find((k) => k.key === key);
   if (!entry) {
     return engine.gateway.dataBlock({ work_unit: e.name, error: `no menu entry with key "${key}"` });
@@ -270,7 +277,7 @@ function inSessionGate(workUnit, key) {
   if (!entry.in_session) {
     return engine.gateway.dataBlock({ work_unit: e.name, error: `entry "${key}" is not held by another session — no gate to render` });
   }
-  return engine.project.epicInSessionGate(entry);
+  return engine.project.epicInSessionGate(e.name, entry);
 }
 
 // One selection sub-view (sections D–G): the keys table as DATA, the view's

--- a/skills/workflow-engine/scripts/domain/presence.cjs
+++ b/skills/workflow-engine/scripts/domain/presence.cjs
@@ -35,6 +35,8 @@ const { section, CONTINUE_INSTRUCTION, callout } = require('./projections/surfac
 
 const STALE_AFTER_SECONDS = 900;
 const PHASES = ['research', 'discussion', 'investigation', 'scoping', 'specification', 'planning', 'implementation', 'review'];
+// The phases that write the tree and the index — the unpartitionable pair.
+const CODE_PHASES = ['implementation', 'review'];
 
 /** @param {string} cwd @param {string} wu @param {string} phase @param {string} topic */
 function presencePath(cwd, wu, phase, topic) {
@@ -145,6 +147,7 @@ function clearQuietly(cwd, workUnit, phase, topic) {
  *                           mtime-fallback when the record carries none)
  * @property {boolean} live  held and beaten within the staleness window
  * @property {string|null} session_id
+ * @property {number|null} pid  the owning Claude process, when the record carries one
  */
 
 /**
@@ -194,6 +197,7 @@ function collectRows(cwd, workUnit, startOf) {
         phase, topic, age_seconds: age,
         held, live: held && age < STALE_AFTER_SECONDS,
         session_id: record ? record.session_id || null : null,
+        pid: record ? record.pid ?? null : null,
       });
     }
   }
@@ -248,6 +252,26 @@ function scanProject(cwd) {
     held: sessions.filter((r) => r.held).length,
     sessions,
   };
+}
+
+/**
+ * Every held implementation or review heartbeat in the project, minus the
+ * calling session's own — the code gate's read. Code is the one resource
+ * that does not partition by topic: one tree, one index, one checkout, so
+ * one code session at a time whatever work unit or topic it sits in. A row
+ * this session owns is its own hold — a resumed session must never gate
+ * against itself.
+ * @param {string} cwd
+ * @returns {(PresenceRow & {work_unit: string})[]}
+ */
+function heldCodeSessions(cwd) {
+  const mySession = process.env.CLAUDE_CODE_SESSION_ID || null;
+  const myPid = Number(process.env.CLAUDE_PID) || null;
+  const ownedHere = (/** @type {PresenceRow} */ row) =>
+    (mySession !== null && row.session_id === mySession) || (myPid !== null && row.pid === myPid);
+  return scanProject(cwd).sessions.filter((row) => row.held
+    && CODE_PHASES.includes(row.phase)
+    && !ownedHere(row));
 }
 
 /**
@@ -310,6 +334,6 @@ function deferralSection(scan) {
 
 module.exports = {
   beatPresence, clearPresence, beatQuietly, clearQuietly,
-  scanPresence, scanProject, cleanupPresence, deferralSection,
-  fmtAge, PHASES, STALE_AFTER_SECONDS,
+  scanPresence, scanProject, heldCodeSessions, cleanupPresence, deferralSection,
+  fmtAge, PHASES, CODE_PHASES, STALE_AFTER_SECONDS,
 };

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -14,7 +14,7 @@ const { signpost, box, renderTree, wrap, wrapWithPrefix } = require('../../kerne
 const { WORK_TYPE_PIPELINES } = require('../../kernel/manifest-schema.cjs');
 const { TREE_WIDTH, treeHeader, titlecase, title, derivedFrom, stateNote, materialBlock, discoveryGlyph, discoveryLifecycleLabel } = require('../conventions.cjs');
 const { section, menuFrame, cmdOption, callout } = require('./surfaces.cjs');
-const { fmtAge } = require('../presence.cjs');
+const { fmtAge, CODE_PHASES } = require('../presence.cjs');
 const { buildOrderLive } = require('../build-order.cjs');
 
 /** @typedef {import('../epic-detail.cjs').EpicDetail} EpicDetail */
@@ -41,6 +41,7 @@ const { buildOrderLive } = require('../build-order.cjs');
  * @property {boolean} [input_moved]   the entry's item (or its source item) carries a live reconcile flag
  * @property {boolean} [in_session]    a held session elsewhere occupies this topic's phase
  * @property {number} [session_age]    that session's last-active age in seconds
+ * @property {{work_unit: string, phase: string, topic: string}} [session_holder] the held code row taking the slot, when it is not this entry's own topic
  */
 
 /** @typedef {import('../presence.cjs').PresenceRow} PresenceRow */
@@ -644,8 +645,10 @@ function pickRecommendation(detail, numbered, options, hasMap) {
     // settled — first build-phase next_phase_ready entry in pipeline order.
     // An input-moved entry is never the recommendation: recommending a start
     // that propagates known-stale input contradicts its own cue — the
-    // reconcile (via the flagged item's entry flow) comes first.
-    const build = numbered.find((e) => e.action.startsWith('start_') && !e.input_moved
+    // reconcile (via the flagged item's entry flow) comes first. Nor is an
+    // entry a held session occupies — recommending the row the menu has
+    // struck through would be the display arguing with itself.
+    const build = numbered.find((e) => e.action.startsWith('start_') && !e.input_moved && !e.in_session
       && BUILD_PHASES.includes(ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (e.action)]));
     if (build) return build;
     // With a flagged completed item and nothing else to start, the reconcile
@@ -691,17 +694,24 @@ function pickRecommendation(detail, numbered, options, hasMap) {
 }
 
 /**
- * Mark entries whose (phase, topic) a held session elsewhere occupies —
- * research and discussion actions only, the phases presence tracks.
+ * Mark entries a held session elsewhere occupies. A doc entry is marked by a
+ * row on its own (phase, topic); a code entry is marked by any held
+ * implementation or review row in the project, because code does not
+ * partition — one tree, one index, one slot, whatever work unit holds it.
  * @param {MenuKey[]} numbered @param {PresenceRow[]} held
+ * @param {(PresenceRow & {work_unit: string})[]} [codeHeld] project-wide held code rows
  */
-function markHeldEntries(numbered, held) {
+function markHeldEntries(numbered, held, codeHeld = []) {
   for (const e of numbered) {
     const phase = ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (e.action)];
-    const row = held.find((r) => r.phase === phase && r.topic === e.topic);
-    if (row) {
-      e.in_session = true;
-      e.session_age = row.age_seconds;
+    const own = held.find((r) => r.phase === phase && r.topic === e.topic);
+    const foreign = own || !CODE_PHASES.includes(phase) ? undefined : codeHeld[0];
+    const row = own || foreign;
+    if (!row) continue;
+    e.in_session = true;
+    e.session_age = row.age_seconds;
+    if (foreign) {
+      e.session_holder = { work_unit: foreign.work_unit, phase: foreign.phase, topic: foreign.topic };
     }
   }
 }
@@ -711,7 +721,7 @@ function markHeldEntries(numbered, held) {
  * (skills route on these); `rendered` is the dotted-gate markdown block.
  * @param {string} workUnit
  * @param {EpicDetail} detail
- * @param {{presence?: PresenceRow[]}} [opts]
+ * @param {{presence?: PresenceRow[], codeHeld?: (PresenceRow & {work_unit: string})[]}} [opts]
  * @returns {{keys: MenuKey[], rendered: string}}
  */
 function epicMenu(workUnit, detail, opts = {}) {
@@ -750,7 +760,7 @@ function epicMenu(workUnit, detail, opts = {}) {
     }
   }
 
-  markHeldEntries(numbered, heldSessions(opts.presence));
+  markHeldEntries(numbered, heldSessions(opts.presence), opts.codeHeld || []);
 
   const options = commandOptions(workUnit, detail, hasMap);
 
@@ -771,7 +781,9 @@ function epicMenu(workUnit, detail, opts = {}) {
   const lines = ['What would you like to do?', ''];
   for (const e of numbered) {
     const label = e.in_session
-      ? `~~${e.label}~~ · in session (last active ${fmtAge(e.session_age ?? 0)} ago)`
+      ? `~~${e.label}~~ · ${e.session_holder
+        ? `code session in ${e.session_holder.work_unit}/${e.session_holder.topic}`
+        : 'in session'} (last active ${fmtAge(e.session_age ?? 0)} ago)`
       : e.label;
     lines.push(cmdOption(e.key, null, `${label}${e.recommended ? ' (recommended)' : ''}`));
   }
@@ -785,22 +797,36 @@ function epicMenu(workUnit, detail, opts = {}) {
 /**
  * Labelled confirm-gate section for one menu entry a held session occupies —
  * served by the gateway's `in-session-gate` verb, fetched by the flow at the
- * gate that displays it.
+ * gate that displays it. Never blocks: the machine can verify that a process
+ * still runs, never that its session still matters, so the gate states the
+ * fact, names the consequence and the release, and lets the user decide. One
+ * shape, two consequences — a doc phase risks conflicting work on one topic,
+ * a code phase risks two writers on one tree.
+ * @param {string} workUnit  this epic — the holder whenever the entry's own topic is the held one
  * @param {MenuKey} entry
  * @returns {string} one labelled MENU section
  */
-function epicInSessionGate(entry) {
+function epicInSessionGate(workUnit, entry) {
   const phase = ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (entry.action)];
+  const holder = entry.session_holder || { work_unit: workUnit, phase, topic: entry.topic || '' };
+  const age = fmtAge(entry.session_age ?? 0);
+  const fact = entry.session_holder
+    ? `Another session is ${holder.phase === 'review' ? 'reviewing' : 'implementing'} "${titlecase(holder.topic)}" (${holder.work_unit}) — last active ${age} ago.`
+    : `"${titlecase(entry.topic || '')}" is open in another session — last active ${age} ago.`;
+  const consequence = CODE_PHASES.includes(phase)
+    ? 'Code phases run one at a time — concurrent sessions write the same files, and even worktrees end in merge conflicts.'
+    : `Proceeding starts a second concurrent session on the same ${phase}; its work could conflict with that session's.`;
+  const release = `node .claude/skills/workflow-engine/scripts/engine.cjs presence clear ${holder.work_unit} ${holder.phase} ${holder.topic}`;
   return section(
     `MENU: in-session gate — ${entry.key}`,
     "emit verbatim as markdown, then STOP for the user's response",
     menuFrame([
-      `"${titlecase(entry.topic || '')}" is open in another session — last active ${fmtAge(entry.session_age ?? 0)} ago. Proceeding starts a second concurrent session on the same ${phase}; its work could conflict with that session's.`,
+      `${fact} ${consequence} Only proceed if you know that session is no longer working; if it is wedged but alive, release its hold with \`${release}\`.`,
       '',
       '**`◆ Proceed anyway?`**',
       '',
-      cmdOption('y', 'yes', 'Proceed anyway'),
-      cmdOption('b', 'back', 'Return to menu'),
+      cmdOption('b', 'back', 'Return to menu (recommended)'),
+      cmdOption('p', 'proceed', 'Proceed anyway'),
     ]),
   );
 }

--- a/skills/workflow-engine/scripts/domain/projections/epic.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/epic.cjs
@@ -42,6 +42,7 @@ const { buildOrderLive } = require('../build-order.cjs');
  * @property {boolean} [in_session]    a held session elsewhere occupies this topic's phase
  * @property {number} [session_age]    that session's last-active age in seconds
  * @property {{work_unit: string, phase: string, topic: string}} [session_holder] the held code row taking the slot, when it is not this entry's own topic
+ * @property {boolean} [code_session]  the hold is the checkout's code slot — gated at the entry skill, never by this menu
  */
 
 /** @typedef {import('../presence.cjs').PresenceRow} PresenceRow */
@@ -710,6 +711,10 @@ function markHeldEntries(numbered, held, codeHeld = []) {
     if (!row) continue;
     e.in_session = true;
     e.session_age = row.age_seconds;
+    // A code entry's hold is the checkout's one slot, and its gate lives at
+    // the entry skill — the marker says so, so the menu's own in-session gate
+    // never fires for it and the user meets one gate per attempt.
+    if (CODE_PHASES.includes(phase)) e.code_session = true;
     if (foreign) {
       e.session_holder = { work_unit: foreign.work_unit, phase: foreign.phase, topic: foreign.topic };
     }
@@ -799,24 +804,20 @@ function epicMenu(workUnit, detail, opts = {}) {
  * served by the gateway's `in-session-gate` verb, fetched by the flow at the
  * gate that displays it. Never blocks: the machine can verify that a process
  * still runs, never that its session still matters, so the gate states the
- * fact, names the consequence and the release, and lets the user decide. One
- * shape, two consequences — a doc phase risks conflicting work on one topic,
- * a code phase risks two writers on one tree.
- * @param {string} workUnit  this epic — the holder whenever the entry's own topic is the held one
+ * fact, names the consequence and the release, and lets the user decide.
+ * Document phases only — a code entry's hold is the checkout's one slot, and
+ * the `code-gate` surface at the entry skill owns that conversation, so the
+ * user meets one gate per attempt.
+ * @param {string} workUnit  this epic — the holder of the topic this entry would open
  * @param {MenuKey} entry
  * @returns {string} one labelled MENU section
  */
 function epicInSessionGate(workUnit, entry) {
   const phase = ACTION_PHASE[/** @type {keyof typeof ACTION_PHASE} */ (entry.action)];
-  const holder = entry.session_holder || { work_unit: workUnit, phase, topic: entry.topic || '' };
-  const age = fmtAge(entry.session_age ?? 0);
-  const fact = entry.session_holder
-    ? `Another session is ${holder.phase === 'review' ? 'reviewing' : 'implementing'} "${titlecase(holder.topic)}" (${holder.work_unit}) — last active ${age} ago.`
-    : `"${titlecase(entry.topic || '')}" is open in another session — last active ${age} ago.`;
-  const consequence = CODE_PHASES.includes(phase)
-    ? 'Code phases run one at a time — concurrent sessions write the same files, and even worktrees end in merge conflicts.'
-    : `Proceeding starts a second concurrent session on the same ${phase}; its work could conflict with that session's.`;
-  const release = `node .claude/skills/workflow-engine/scripts/engine.cjs presence clear ${holder.work_unit} ${holder.phase} ${holder.topic}`;
+  const topic = entry.topic || '';
+  const fact = `"${titlecase(topic)}" is open in another session — last active ${fmtAge(entry.session_age ?? 0)} ago.`;
+  const consequence = `Proceeding starts a second concurrent session on the same ${phase}; its work could conflict with that session's.`;
+  const release = `node .claude/skills/workflow-engine/scripts/engine.cjs presence clear ${workUnit} ${phase} ${topic}`;
   return section(
     `MENU: in-session gate — ${entry.key}`,
     "emit verbatim as markdown, then STOP for the user's response",

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -24,6 +24,7 @@ const {
   baselineOfferGate,
 } = require('./projections/baseline.cjs');
 const { baselineState } = require('./baseline.cjs');
+const { heldCodeSessions, fmtAge, CODE_PHASES } = require('./presence.cjs');
 const { roadmapState } = require('./roadmap.cjs');
 const {
   roadmapMapView,
@@ -3190,6 +3191,59 @@ function entryGate(cwd, { dotpath, own }) {
 }
 
 // ---------------------------------------------------------------------------
+// code-gate — the one-code-session rule at the entry chokepoint. Everything
+// else in the system partitions by topic; the tree and the index do not, so
+// a second implementation or review session anywhere in the checkout writes
+// the same files as the first. The gate states who holds the slot and lets
+// the user through anyway — the machine can verify that a process still
+// runs, never that its session still matters. An empty response means the
+// slot is free.
+// ---------------------------------------------------------------------------
+
+/** @param {string} phase */
+function codeVerb(phase) {
+  return phase === 'review' ? 'reviewing' : 'implementing';
+}
+
+/**
+ * @param {string} cwd
+ * @param {{dotpath: string}} args
+ * @returns {string} the gate's sections, or '' when no other session holds code
+ */
+function codeGate(cwd, { dotpath }) {
+  const { phase } = resolveAddress(cwd, dotpath, 'code-gate');
+  if (!CODE_PHASES.includes(phase)) {
+    throw new Error(`render code-gate: the code rule covers ${CODE_PHASES.join('|')} only, got "${phase}"`);
+  }
+  const holders = heldCodeSessions(cwd);
+  if (holders.length === 0) return '';
+
+  const facts = holders.map((h) =>
+    `⚑ Another session is ${codeVerb(h.phase)} "${titlecase(h.topic)}" (${h.work_unit}) — last active ${fmtAge(h.age_seconds)} ago.`);
+  const first = holders[0];
+  return [
+    section(
+      'DISPLAY: code gate',
+      'emit verbatim as a properties code block — ```properties fence',
+      facts.join('\n'),
+    ),
+    section(
+      'MENU: code gate',
+      "emit verbatim as markdown, then STOP for the user's response",
+      menuFrame([
+        'Code phases run one at a time — concurrent sessions write the same files, and even worktrees end in merge conflicts. Only proceed if you know that session is no longer working; if it is wedged but alive, release its hold with '
+          + `\`node .claude/skills/workflow-engine/scripts/engine.cjs presence clear ${first.work_unit} ${first.phase} ${first.topic}\`.`,
+        '',
+        '**`◆ Proceed anyway?`**',
+        '',
+        cmdOption('b', 'back', 'Leave that session to it (recommended)'),
+        cmdOption('p', 'proceed', 'Enter anyway — two sessions on one code base'),
+      ]),
+    ),
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
 // Task-loop surfaces — the brief, the result header, and the gates, fetched
 // by the implementation loop at the exact stage that displays them, so the
 // section always sits in the tool result directly above its emission.
@@ -3853,6 +3907,7 @@ const SURFACES = {
   'phase-completed': phaseCompleted,
   'phase-note': phaseNote,
   'entry-gate': entryGate,
+  'code-gate': codeGate,
   'early-completion-gate': earlyCompletionGate,
   'revisit-gate': revisitGate,
   'cancel-gate': cancelGate,

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -246,6 +246,7 @@ Commands:
   render phase-completed   <wu> --phase <phase> [--paths]
   render phase-note        <wu.phase.topic> --verb <Word> [--noun <word>]
   render entry-gate        <wu.phase.topic> [--own]  (planning|implementation|review|specification)
+  render code-gate         <wu.phase.topic>          (implementation|review — empty when the code slot is free)
   render early-completion-gate <wu>
   render revisit-gate      <wu> --prev <phase> --next <phase>
   render cancel-gate <wu.phase.topic>

--- a/skills/workflow-engine/scripts/lib.cjs
+++ b/skills/workflow-engine/scripts/lib.cjs
@@ -100,6 +100,7 @@ module.exports = {
   presence: {
     scanPresence: presence.scanPresence,
     scanProject: presence.scanProject,
+    heldCodeSessions: presence.heldCodeSessions,
     fmtAge: presence.fmtAge,
   },
   detail: {

--- a/skills/workflow-implementation-entry/SKILL.md
+++ b/skills/workflow-implementation-entry/SKILL.md
@@ -56,6 +56,14 @@ Load **[validate-dependencies.md](references/validate-dependencies.md)** and fol
 
 ---
 
-## Step 4: Invoke the Skill
+## Step 4: Check the Code Slot
+
+Load **[code-session-gate.md](../workflow-shared/references/code-session-gate.md)** with phase = `implementation`.
+
+→ On return, proceed to **Step 5**.
+
+---
+
+## Step 5: Invoke the Skill
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-review-entry/SKILL.md
+++ b/skills/workflow-review-entry/SKILL.md
@@ -48,6 +48,14 @@ Load **[validate-phase.md](references/validate-phase.md)** and follow its instru
 
 ---
 
-## Step 3: Invoke the Skill
+## Step 3: Check the Code Slot
+
+Load **[code-session-gate.md](../workflow-shared/references/code-session-gate.md)** with phase = `review`.
+
+→ On return, proceed to **Step 4**.
+
+---
+
+## Step 4: Invoke the Skill
 
 Load **[invoke-skill.md](references/invoke-skill.md)** and follow its instructions as written.

--- a/skills/workflow-shared/references/code-session-gate.md
+++ b/skills/workflow-shared/references/code-session-gate.md
@@ -1,0 +1,39 @@
+# Code Session Gate
+
+*Shared reference. Loaded by workflow-implementation-entry and workflow-review-entry.*
+
+---
+
+Implementation and review write the code tree and the git index, and neither partitions by topic the way documents do — so they run one session at a time per checkout, whatever work unit or topic the other session sits in. The engine reads the whole project's heartbeats and answers with the gate; an empty response means the slot is free.
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs render code-gate {work_unit}.{phase}.{topic}
+```
+
+#### If the response is empty
+
+No other session holds the code slot.
+
+→ Return to caller.
+
+#### If the response carried `DISPLAY: code gate`
+
+Emit both sections verbatim per their markers — the blocking fact, then the menu.
+
+**STOP.** Wait for user response.
+
+**If `back`:**
+
+> *Output the next fenced block as markdown (not a code block):*
+
+```
+> Left as it is — come back once that session has finished, or release its hold if you know it is done.
+```
+
+**STOP.** Do not proceed — terminal condition.
+
+**If `proceed`:**
+
+The user owns the consequence; nothing further is said about it.
+
+→ Return to caller.

--- a/skills/workflow-shared/references/code-session-gate.md
+++ b/skills/workflow-shared/references/code-session-gate.md
@@ -4,7 +4,7 @@
 
 ---
 
-Implementation and review write the code tree and the git index, and neither partitions by topic the way documents do — so they run one session at a time per checkout, whatever work unit or topic the other session sits in. The engine reads the whole project's heartbeats and answers with the gate; an empty response means the slot is free.
+Implementation and review run one session at a time per checkout, whatever work unit or topic the other session sits in — so the check reads the whole project, not this work unit. An empty response means the slot is free.
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render code-gate {work_unit}.{phase}.{topic}

--- a/tests/prose/cases/bridge-completes-the-feature/case.json
+++ b/tests/prose/cases/bridge-completes-the-feature/case.json
@@ -10,6 +10,7 @@
     "skills/workflow-shared/references/voice.md",
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-review-entry/references/validate-phase.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-review-entry/references/invoke-skill.md",
     "skills/workflow-review-process/SKILL.md",
     "skills/workflow-review-process/references/read-plans.md",

--- a/tests/prose/cases/implementation-adjudicates-a-challenge/case.json
+++ b/tests/prose/cases/implementation-adjudicates-a-challenge/case.json
@@ -11,6 +11,7 @@
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-implementation-entry/references/validate-phase.md",
     "skills/workflow-implementation-entry/references/validate-dependencies.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-implementation-entry/references/invoke-skill.md",
     "skills/workflow-implementation-process/SKILL.md",
     "skills/workflow-implementation-process/references/environment-setup.md",

--- a/tests/prose/cases/implementation-consolidates-the-phase/case.json
+++ b/tests/prose/cases/implementation-consolidates-the-phase/case.json
@@ -11,6 +11,7 @@
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-implementation-entry/references/validate-phase.md",
     "skills/workflow-implementation-entry/references/validate-dependencies.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-implementation-entry/references/invoke-skill.md",
     "skills/workflow-implementation-process/SKILL.md",
     "skills/workflow-implementation-process/references/environment-setup.md",

--- a/tests/prose/cases/implementation-executes-the-loop/case.json
+++ b/tests/prose/cases/implementation-executes-the-loop/case.json
@@ -11,6 +11,7 @@
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-implementation-entry/references/validate-phase.md",
     "skills/workflow-implementation-entry/references/validate-dependencies.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-implementation-entry/references/invoke-skill.md",
     "skills/workflow-implementation-process/SKILL.md",
     "skills/workflow-implementation-process/references/environment-setup.md",

--- a/tests/prose/cases/implementation-finds-no-project-skills/case.json
+++ b/tests/prose/cases/implementation-finds-no-project-skills/case.json
@@ -10,6 +10,7 @@
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-implementation-entry/references/validate-phase.md",
     "skills/workflow-implementation-entry/references/validate-dependencies.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-implementation-entry/references/invoke-skill.md",
     "skills/workflow-implementation-process/SKILL.md",
     "skills/workflow-implementation-process/references/environment-setup.md",

--- a/tests/prose/cases/implementation-loops-on-auto/case.json
+++ b/tests/prose/cases/implementation-loops-on-auto/case.json
@@ -11,6 +11,7 @@
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-implementation-entry/references/validate-phase.md",
     "skills/workflow-implementation-entry/references/validate-dependencies.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-implementation-entry/references/invoke-skill.md",
     "skills/workflow-implementation-process/SKILL.md",
     "skills/workflow-implementation-process/references/environment-setup.md",

--- a/tests/prose/cases/implementation-picks-first-task/case.json
+++ b/tests/prose/cases/implementation-picks-first-task/case.json
@@ -12,6 +12,7 @@
     "skills/workflow-implementation-entry/references/validate-dependencies.md",
     "skills/workflow-implementation-process/SKILL.md",
     "skills/workflow-implementation-process/references/environment-setup.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-implementation-entry/references/invoke-skill.md"
   ],
   "answers": [

--- a/tests/prose/cases/implementation-records-an-adhoc-task/case.json
+++ b/tests/prose/cases/implementation-records-an-adhoc-task/case.json
@@ -11,6 +11,7 @@
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-implementation-entry/references/validate-phase.md",
     "skills/workflow-implementation-entry/references/validate-dependencies.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-implementation-entry/references/invoke-skill.md",
     "skills/workflow-implementation-process/SKILL.md",
     "skills/workflow-implementation-process/references/environment-setup.md",

--- a/tests/prose/cases/implementation-retells-at-the-gate/case.json
+++ b/tests/prose/cases/implementation-retells-at-the-gate/case.json
@@ -11,6 +11,7 @@
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-implementation-entry/references/validate-phase.md",
     "skills/workflow-implementation-entry/references/validate-dependencies.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-implementation-entry/references/invoke-skill.md",
     "skills/workflow-implementation-process/SKILL.md",
     "skills/workflow-implementation-process/references/environment-setup.md",

--- a/tests/prose/cases/review-approves-the-work/case.json
+++ b/tests/prose/cases/review-approves-the-work/case.json
@@ -10,6 +10,7 @@
     "skills/workflow-shared/references/voice.md",
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-review-entry/references/validate-phase.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-review-entry/references/invoke-skill.md",
     "skills/workflow-review-process/SKILL.md",
     "skills/workflow-review-process/references/read-plans.md",

--- a/tests/prose/cases/review-entry-fresh/assert.md
+++ b/tests/prose/cases/review-entry-fresh/assert.md
@@ -5,7 +5,9 @@ The prose should have taken this path:
    implementation are complete, so nothing blocks entry
 3. no review item exists, so the fresh path is taken — nothing is
    reopened and no resume is announced
-4. hands off to the review processing skill for pay
+4. the code-slot check renders empty — no other session is in
+   implementation or review — so nothing is emitted and nothing stops
+5. hands off to the review processing skill for pay
 
 Further claims:
 

--- a/tests/prose/cases/review-entry-fresh/case.json
+++ b/tests/prose/cases/review-entry-fresh/case.json
@@ -9,11 +9,13 @@
     "skills/workflow-shared/references/voice.md",
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-review-entry/references/validate-phase.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-review-entry/references/invoke-skill.md"
   ],
   "invariants": {
     "calls_include": [
-      "render entry-gate pay.review.pay"
+      "render entry-gate pay.review.pay",
+      "render code-gate pay.review.pay"
     ],
     "calls_exclude": [
       "topic reopen",

--- a/tests/prose/cases/review-preps-and-applies-findings/case.json
+++ b/tests/prose/cases/review-preps-and-applies-findings/case.json
@@ -10,6 +10,7 @@
     "skills/workflow-shared/references/voice.md",
     "skills/workflow-shared/references/ask-or-decide.md",
     "skills/workflow-review-entry/references/validate-phase.md",
+    "skills/workflow-shared/references/code-session-gate.md",
     "skills/workflow-review-entry/references/invoke-skill.md",
     "skills/workflow-review-process/SKILL.md",
     "skills/workflow-review-process/references/read-plans.md",

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -747,19 +747,26 @@ describe('epic projections: presence join', () => {
     assert.match(rendered.replace(/\n\u00a0+/g, ' '), /~~[^~]*~~ · code session in ship\/checkout-flow \(last active 5m ago\)/,
       `the struck row names the holder:\n${rendered}`);
     assert.ok(!code.recommended, 'a struck row is never the recommendation');
+    assert.strictEqual(code.code_session, true, 'the marker says the slot, so this menu never gates it');
     assert.ok(!keys.some((k) => k.action !== 'start_implementation' && k.in_session),
       'doc entries are untouched by the code slot');
   });
 
-  it('the code gate\'s wording replaces the doc consequence for a code entry', () => {
+  it('a code entry is marked by its own held topic too, and still carries the slot marker', () => {
     const d = readyToImplementDetail();
-    const codeRow = { work_unit: 'ship', phase: 'review', topic: 'checkout-flow', age_seconds: 60, held: true, live: true, session_id: 'peer' };
+    const codeRow = { work_unit: 'v1', phase: 'implementation', topic: 'topic-a', age_seconds: 30, held: true, live: true, session_id: 'peer' };
     const { keys } = epicMenu('v1', d, { presence: [], codeHeld: [codeRow] });
-    const gate = epicInSessionGate('v1', keys.find((k) => k.action === 'start_implementation'));
-    assert.match(gate, /Another session is reviewing "Checkout Flow" \(ship\) — last active 60s ago\./);
-    assert.match(gate, /Code phases run one at a time — concurrent sessions write the same files/);
-    assert.match(gate, /presence clear ship review checkout-flow/, 'the release names the holder, not the entrant');
-    assert.doesNotMatch(gate, /second concurrent session on the same/, 'the doc consequence is not used for code');
+    const code = keys.find((k) => k.action === 'start_implementation');
+    assert.strictEqual(code.in_session, true);
+    assert.strictEqual(code.code_session, true, 'own-topic or elsewhere, a code hold is the one slot');
+  });
+
+  it('the in-session gate speaks for document phases alone — a code entry never reaches it', () => {
+    const d = twoTopicDetail();
+    const { keys } = epicMenu('v1', d, { presence: [heldRow] });
+    const gate = epicInSessionGate('v1', keys.find((k) => k.in_session));
+    assert.match(gate, /second concurrent session on the same discussion/, 'the doc consequence is the only one left');
+    assert.doesNotMatch(gate, /Code phases run one at a time/, 'the code wording belongs to the code-gate surface');
   });
 
   it('the dashboard cues held map rows on their ↳ state lines (no key legend needed)', () => {

--- a/tests/scripts/test-engine-epic-projections.cjs
+++ b/tests/scripts/test-engine-epic-projections.cjs
@@ -708,17 +708,58 @@ describe('epic projections: presence join', () => {
   it('renders the in-session confirm gate as a labelled MENU section, byte-for-byte', () => {
     const { keys } = epicMenu('v1', twoTopicDetail(), { presence: [heldRow] });
     const marked = keys.find((k) => k.in_session);
-    assert.strictEqual(epicInSessionGate(marked), [
+    assert.strictEqual(epicInSessionGate('v1', marked), [
       '=== MENU: in-session gate — 1 (emit verbatim as markdown, then STOP for the user\'s response) ===',
       '· · · · · · · · · · · ·',
-      '"Topic A" is open in another session — last active 2m ago. Proceeding starts a second concurrent session on the same discussion; its work could conflict with that session\'s.',
+      '"Topic A" is open in another session — last active 2m ago. Proceeding starts a second concurrent session on the same discussion; its work could conflict with that session\'s. Only proceed if you know that session is no longer working; if it is wedged but alive, release its hold with `node .claude/skills/workflow-engine/scripts/engine.cjs presence clear v1 discussion topic-a`.',
       '',
       '**`◆ Proceed anyway?`**',
       '',
-      '**`y/yes`**  → Proceed anyway',
-      '**`b/back`** → Return to menu',
+      '**`b/back`**    → Return to menu (recommended)',
+      '**`p/proceed`** → Proceed anyway',
       '',
     ].join('\n'));
+  });
+
+  // A plan ready to implement — the state a code entry needs on the menu.
+  function readyToImplementDetail() {
+    return detailFor(dir, 'v1', {
+      work_type: 'epic',
+      phases: {
+        discovery: { items: { 'topic-a': { routing: 'discussion', source: 'discovery', order: 1 } } },
+        discussion: { items: { 'topic-a': { status: 'completed' } } },
+        specification: { items: { 'topic-a': { status: 'completed', order: 1, sources: { 'topic-a': { status: 'incorporated' } } } } },
+        planning: { items: { 'topic-a': { status: 'completed', format: 'local-markdown' } } },
+      },
+    });
+  }
+
+  it('a held code row anywhere in the project marks every code entry, naming the holder', () => {
+    const d = readyToImplementDetail();
+    // A code session holding a different work unit's topic — one slot, one
+    // checkout.
+    const codeRow = { work_unit: 'ship', phase: 'implementation', topic: 'checkout-flow', age_seconds: 300, held: true, live: true, session_id: 'peer' };
+    const { keys, rendered } = epicMenu('v1', d, { presence: [], codeHeld: [codeRow] });
+    const code = keys.find((k) => k.action === 'start_implementation');
+    assert.ok(code, 'the implementation entry is on the menu');
+    assert.strictEqual(code.in_session, true, 'the code entry is marked though the holder is elsewhere');
+    assert.deepStrictEqual(code.session_holder, { work_unit: 'ship', phase: 'implementation', topic: 'checkout-flow' });
+    assert.match(rendered.replace(/\n\u00a0+/g, ' '), /~~[^~]*~~ · code session in ship\/checkout-flow \(last active 5m ago\)/,
+      `the struck row names the holder:\n${rendered}`);
+    assert.ok(!code.recommended, 'a struck row is never the recommendation');
+    assert.ok(!keys.some((k) => k.action !== 'start_implementation' && k.in_session),
+      'doc entries are untouched by the code slot');
+  });
+
+  it('the code gate\'s wording replaces the doc consequence for a code entry', () => {
+    const d = readyToImplementDetail();
+    const codeRow = { work_unit: 'ship', phase: 'review', topic: 'checkout-flow', age_seconds: 60, held: true, live: true, session_id: 'peer' };
+    const { keys } = epicMenu('v1', d, { presence: [], codeHeld: [codeRow] });
+    const gate = epicInSessionGate('v1', keys.find((k) => k.action === 'start_implementation'));
+    assert.match(gate, /Another session is reviewing "Checkout Flow" \(ship\) — last active 60s ago\./);
+    assert.match(gate, /Code phases run one at a time — concurrent sessions write the same files/);
+    assert.match(gate, /presence clear ship review checkout-flow/, 'the release names the holder, not the entrant');
+    assert.doesNotMatch(gate, /second concurrent session on the same/, 'the doc consequence is not used for code');
   });
 
   it('the dashboard cues held map rows on their ↳ state lines (no key legend needed)', () => {

--- a/tests/scripts/test-engine-presence.cjs
+++ b/tests/scripts/test-engine-presence.cjs
@@ -218,6 +218,29 @@ describe('engine presence', () => {
     assert.strictEqual(engineWith(dir, ['presence', 'scan', 'pay']).sessions[0].held, true);
   });
 
+  it('the code-slot read takes held implementation and review rows, never the caller\'s own', () => {
+    const { heldCodeSessions } = require('../../skills/workflow-engine/scripts/domain/presence.cjs');
+    fs.mkdirSync(path.join(dir, '.workflows', 'ship'), { recursive: true });
+    craftRecord(dir, 'implementation', 'alpha', { pid: null, pid_start: null, session_id: 'peer' });
+    craftRecord(dir, 'discussion', 'beta', { pid: null, pid_start: null, session_id: 'peer' });
+    const shipRow = path.join(dir, '.workflows/.cache/ship/review/gamma/presence');
+    fs.mkdirSync(path.dirname(shipRow), { recursive: true });
+    fs.writeFileSync(shipRow, JSON.stringify({ pid: null, pid_start: null, session_id: 'mine' }) + '\n');
+
+    const before = process.env.CLAUDE_CODE_SESSION_ID;
+    process.env.CLAUDE_CODE_SESSION_ID = 'mine';
+    try {
+      const rows = heldCodeSessions(dir);
+      assert.deepStrictEqual(rows.map((r) => `${r.work_unit}/${r.phase}/${r.topic}`), ['pay/implementation/alpha'],
+        'a doc row never takes the slot, and the caller\'s own hold is not a gate against itself');
+      process.env.CLAUDE_CODE_SESSION_ID = 'other';
+      assert.strictEqual(heldCodeSessions(dir).length, 2, 'from another session both code rows are holders');
+    } finally {
+      if (before === undefined) delete process.env.CLAUDE_CODE_SESSION_ID;
+      else process.env.CLAUDE_CODE_SESSION_ID = before;
+    }
+  });
+
   it('cleanup sweeps only the named session, argv or stdin, across work units', () => {
     fs.mkdirSync(path.join(dir, '.workflows', 'ship'), { recursive: true });
     craftRecord(dir, 'discussion', 'alpha', { pid: null, pid_start: null, session_id: 'sess-a' });

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -2763,6 +2763,84 @@ describe('render phase-note', () => {
   });
 });
 
+describe('render code-gate', () => {
+  let dir;
+  beforeEach(() => {
+    dir = setup();
+    writeManifest(dir, 'pay', { work_type: 'feature', phases: { implementation: { items: { pay: { status: 'in-progress' } } } } });
+    writeManifest(dir, 'ship', { work_type: 'feature', phases: {} });
+  });
+  afterEach(() => teardown(dir));
+
+  /** A held heartbeat owned by another session. */
+  function holdCode(workUnit, phase, topic, ageSeconds = 0) {
+    const file = path.join(dir, '.workflows', '.cache', workUnit, phase, topic, 'presence');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify({ pid: null, pid_start: null, session_id: 'peer' }) + '\n');
+    if (ageSeconds) {
+      const when = new Date(Date.now() - ageSeconds * 1000);
+      fs.utimesSync(file, when, when);
+    }
+    return file;
+  }
+
+  it('renders nothing when no session holds the code slot', () => {
+    assert.strictEqual(renderSurface(dir, 'code-gate', { dotpath: 'pay.implementation.pay' }), '');
+  });
+
+  it('states the holder in the red register and offers back first, proceed second', () => {
+    holdCode('ship', 'implementation', 'checkout-flow', 120);
+    const out = renderSurface(dir, 'code-gate', { dotpath: 'pay.implementation.pay' });
+
+    assert.match(out, /=== DISPLAY: code gate \(emit verbatim as a properties code block/, out);
+    assert.match(out, /⚑ Another session is implementing "Checkout Flow" \(ship\) — last active 2m ago\./, out);
+    assert.match(out, /=== MENU: code gate \(emit verbatim as markdown, then STOP/, out);
+    const menu = unwrap(out);
+    assert.match(menu, /Code phases run one at a time — concurrent sessions write the same files/, menu);
+    assert.match(menu, /Only proceed if you know that session is no longer working/, menu);
+    assert.match(menu, /presence clear ship implementation checkout-flow/, menu);
+    assert.match(menu, /\*\*`◆ Proceed anyway\?`\*\*/, menu);
+    assert.ok(menu.indexOf('`b/back`') < menu.indexOf('`p/proceed`'), 'back leads');
+    assert.match(menu, /`b\/back`\*\* +→ Leave that session to it \(recommended\)/, menu);
+  });
+
+  it('a review holder reads as reviewing, and any work unit takes the one slot', () => {
+    holdCode('ship', 'review', 'checkout-flow');
+    const out = renderSurface(dir, 'code-gate', { dotpath: 'pay.review.pay' });
+    assert.match(out, /Another session is reviewing "Checkout Flow" \(ship\)/, out);
+    assert.match(unwrap(out), /presence clear ship review checkout-flow/, out);
+  });
+
+  it('a doc-phase hold never takes the code slot', () => {
+    holdCode('ship', 'discussion', 'checkout-flow');
+    assert.strictEqual(renderSurface(dir, 'code-gate', { dotpath: 'pay.implementation.pay' }), '');
+  });
+
+  it('the calling session\'s own hold is not a gate against itself', () => {
+    holdCode('pay', 'implementation', 'pay');
+    const before = process.env.CLAUDE_CODE_SESSION_ID;
+    process.env.CLAUDE_CODE_SESSION_ID = 'peer';
+    try {
+      assert.strictEqual(renderSurface(dir, 'code-gate', { dotpath: 'pay.implementation.pay' }), '');
+    } finally {
+      if (before === undefined) delete process.env.CLAUDE_CODE_SESSION_ID;
+      else process.env.CLAUDE_CODE_SESSION_ID = before;
+    }
+  });
+
+  it('names every holder when more than one slot is somehow held', () => {
+    holdCode('ship', 'implementation', 'checkout-flow');
+    holdCode('pay', 'review', 'pay');
+    const out = renderSurface(dir, 'code-gate', { dotpath: 'pay.implementation.pay' });
+    assert.match(out, /⚑ Another session is [\s\S]*⚑ Another session is /, out);
+  });
+
+  it('refuses an address outside the code phases', () => {
+    assert.throws(() => renderSurface(dir, 'code-gate', { dotpath: 'pay.discussion.pay' }),
+      /the code rule covers implementation\|review only/);
+  });
+});
+
 describe('render entry-gate', () => {
   let dir;
   beforeEach(() => { dir = setup(); });
@@ -2958,7 +3036,7 @@ describe('catalogue dispatch', () => {
   });
 
   it('unknown surface errors with the catalogue listing', () => {
-    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-announce, finding-batch, finding, review-presentation, review-gate, spec-review-gate, spec-completion-gate, convergence-diagnostic, carry-note-gate, hypothesis-board, fix-direction, validation-gate, validation-report, project-skills, linters, triage-announce, triage-offer, triage-block, requeue-offer, reroute-offer, research-conclude-gate, deep-dive-offer, in-flight-agents-gate, reroute-candidates, off-topic-offer, map-op-gate, candidate-gate, topic-collision-gate, triage-closed-target, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, early-completion-gate, revisit-gate, cancel-gate, epic-all-done-gate, epic-soft-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, roadmap-view, roadmap-add-gate, roadmap-session-receipt, roadmap-harvest-gate, roadmap-parks-gate, roadmap-shape-gate, roadmap-conclude-gate, name-gate, shape-gate, synthesis-gate, query-failure-gate, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick, baseline-offer-gate\)/);
+    assert.throws(() => renderSurface('/tmp', 'nope', { dotpath: 'a.b.c' }), /unknown surface "nope" \(surfaces: resume-gate, task-list, findings-summary, finding-announce, finding-batch, finding, review-presentation, review-gate, spec-review-gate, spec-completion-gate, convergence-diagnostic, carry-note-gate, hypothesis-board, fix-direction, validation-gate, validation-report, project-skills, linters, triage-announce, triage-offer, triage-block, requeue-offer, reroute-offer, research-conclude-gate, deep-dive-offer, in-flight-agents-gate, reroute-candidates, off-topic-offer, map-op-gate, candidate-gate, topic-collision-gate, triage-closed-target, proposed-task, incoherence-gate, cancel-cascade-gate, resurface-gate, construction-gate, tasks-overview, author-task-gate, phase-tree, phase-completed, phase-note, entry-gate, code-gate, early-completion-gate, revisit-gate, cancel-gate, epic-all-done-gate, epic-soft-gate, task-brief, task-result, task-gate, fix-gate, blocked-tasks, cycle-limit, cycle-gate, workunit-receipt, topic-receipt, absorb-receipt, promote-receipt, pivot-continuation, session-receipt, absorb-target, plan-topics, revisit-phases, roadmap-view, roadmap-add-gate, roadmap-session-receipt, roadmap-harvest-gate, roadmap-parks-gate, roadmap-shape-gate, roadmap-conclude-gate, name-gate, shape-gate, synthesis-gate, query-failure-gate, baseline-progress, baseline-area-gate, baseline-paused, baseline-receipt, baseline-scope-gate, baseline-round, baseline-doc-gate, baseline-manage-gate, baseline-doc-pick, baseline-offer-gate\)/);
   });
 });
 

--- a/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
@@ -1864,7 +1864,9 @@ describe('workflow-continue-epic CLI dispatch', () => {
     assert.ok(gate.stdout.includes(
       "=== MENU: in-session gate — 1 (emit verbatim as markdown, then STOP for the user's response) ==="
     ), gate.stdout);
-    assert.ok(gate.stdout.includes('"Auth" is open in another session — last active 2m ago. Proceeding starts a second concurrent session on the same discussion; its work could conflict with that session\'s.'), gate.stdout);
+    const gateText = gate.stdout.replace(/\n\u00a0+/g, ' ');
+    assert.ok(gateText.includes('"Auth" is open in another session — last active 2m ago. Proceeding starts a second concurrent session on the same discussion; its work could conflict with that session\'s. Only proceed if you know that session is no longer working; if it is wedged but alive, release its hold with `node .claude/skills/workflow-engine/scripts/engine.cjs presence clear v1 discussion auth`.'), gateText);
+    assert.ok(gateText.indexOf('`b/back`') < gateText.indexOf('`p/proceed`'), 'back leads the family\'s options');
     const unheld = run(['in-session-gate', 'v1', 'r']);
     assert.ok(unheld.stdout.includes('is not held by another session'), unheld.stdout);
 
@@ -1873,6 +1875,40 @@ describe('workflow-continue-epic CLI dispatch', () => {
     const freed = run(['view', 'v1']);
     assert.ok(freed.stdout.includes('sessions_in_progress: (none)'), freed.stdout);
     assert.ok(!freed.stdout.includes('in session'), freed.stdout);
+  });
+
+  it('a code session anywhere in the project marks this epic\'s code entries', () => {
+    const fs = require('fs');
+    epicFixture();
+    // A ready-to-implement plan in this epic, and a peer session holding the
+    // code slot in a different work unit entirely.
+    const mpath = path.join(dir, '.workflows/v1/manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(mpath, 'utf8'));
+    manifest.phases.specification = { items: { auth: { status: 'completed', order: 1, sources: { auth: { status: 'incorporated' } } } } };
+    manifest.phases.planning = { items: { auth: { status: 'completed', format: 'local-markdown' } } };
+    manifest.phases.discussion.items.auth.status = 'completed';
+    fs.writeFileSync(mpath, JSON.stringify(manifest, null, 2));
+    fs.mkdirSync(path.join(dir, '.workflows/ship'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.workflows/ship/manifest.json'), JSON.stringify({
+      name: 'ship', work_type: 'feature', status: 'in-progress', phases: {},
+    }, null, 2));
+    const peer = path.join(dir, '.workflows/.cache/ship/implementation/checkout-flow/presence');
+    fs.mkdirSync(path.dirname(peer), { recursive: true });
+    fs.writeFileSync(peer, JSON.stringify({ pid: process.pid, pid_start: null, session_id: 'peer' }) + '\n');
+
+    const res = run(['view', 'v1']);
+    assert.strictEqual(res.status, 0, res.stderr);
+    assert.ok(res.stdout.includes('(in session: ship/checkout-flow, last active'),
+      `the ACTIONS marker names the holder:\n${res.stdout}`);
+    assert.match(res.stdout.replace(/\n\u00a0+/g, ' '), /~~[^~]*~~ · code session in ship\/checkout-flow/, res.stdout);
+
+    const key = res.stdout.split('\n').find((l) => l.includes('start_implementation')).trim().split(/\s+/)[0];
+    const gate = run(['in-session-gate', 'v1', key]);
+    assert.strictEqual(gate.status, 0, gate.stderr);
+    const text = gate.stdout.replace(/\n\u00a0+/g, ' ');
+    assert.ok(text.includes('Another session is implementing "Checkout Flow" (ship)'), text);
+    assert.ok(text.includes('Code phases run one at a time'), text);
+    assert.ok(text.includes('presence clear ship implementation checkout-flow'), text);
   });
 
   it('view without a work unit errors instead of rendering the first epic', () => {

--- a/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
+++ b/tests/scripts/test-gateway-for-workflow-continue-epic.cjs
@@ -1898,17 +1898,18 @@ describe('workflow-continue-epic CLI dispatch', () => {
 
     const res = run(['view', 'v1']);
     assert.strictEqual(res.status, 0, res.stderr);
-    assert.ok(res.stdout.includes('(in session: ship/checkout-flow, last active'),
-      `the ACTIONS marker names the holder:\n${res.stdout}`);
+    assert.ok(res.stdout.includes('(code session: ship/checkout-flow, last active'),
+      `the ACTIONS marker names the slot and its holder:\n${res.stdout}`);
     assert.match(res.stdout.replace(/\n\u00a0+/g, ' '), /~~[^~]*~~ · code session in ship\/checkout-flow/, res.stdout);
 
+    // One gate per attempt: the marker is the menu's awareness signal, and the
+    // stop belongs to the entry skill's code gate — asking here refuses.
+    assert.ok(!res.stdout.includes('(in session:'), `a code row never wears the doc marker:\n${res.stdout}`);
     const key = res.stdout.split('\n').find((l) => l.includes('start_implementation')).trim().split(/\s+/)[0];
     const gate = run(['in-session-gate', 'v1', key]);
     assert.strictEqual(gate.status, 0, gate.stderr);
-    const text = gate.stdout.replace(/\n\u00a0+/g, ' ');
-    assert.ok(text.includes('Another session is implementing "Checkout Flow" (ship)'), text);
-    assert.ok(text.includes('Code phases run one at a time'), text);
-    assert.ok(text.includes('presence clear ship implementation checkout-flow'), text);
+    assert.ok(!gate.stdout.includes('MENU: in-session gate'), `no gate section for a code entry:\n${gate.stdout}`);
+    assert.ok(gate.stdout.includes('the code slot is gated at the entry skill'), gate.stdout);
   });
 
   it('view without a work unit errors instead of rendering the first epic', () => {

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -209,7 +209,10 @@ class Sim {
     // Hermetic session-label environment: the config dir pins into the
     // sandbox and the tmux identity is stripped, so `session label` can
     // never read the developer's real opt-in or rename their real session.
-    this.env = { ...process.env, WORKFLOWS_CONFIG_DIR: path.join(this.dir, '.wf-config') };
+    // A real session always carries its identity, and presence reads it to
+    // tell its own holds from a peer's — pin one so the sim never gates
+    // against itself, whatever the host environment carries.
+    this.env = { ...process.env, WORKFLOWS_CONFIG_DIR: path.join(this.dir, '.wf-config'), CLAUDE_CODE_SESSION_ID: 'sim-session' };
     delete this.env.TMUX;
     delete this.env.TMUX_PANE;
   }
@@ -266,12 +269,12 @@ class Sim {
 
   /** Bare-stdout read (manifest get / exists / resolve …). */
   read(args) {
-    return execFileSync('node', [ENGINE, ...args], { cwd: this.dir, encoding: 'utf8' }).trim();
+    return execFileSync('node', [ENGINE, ...args], { cwd: this.dir, encoding: 'utf8', env: this.env }).trim();
   }
 
   /** Render surface: must exit 0 (an entry-gate that passes renders empty). */
   render(args, { expect } = {}) {
-    const res = spawnSync('node', [ENGINE, 'render', ...args], { cwd: this.dir, encoding: 'utf8' });
+    const res = spawnSync('node', [ENGINE, 'render', ...args], { cwd: this.dir, encoding: 'utf8', env: this.env });
     assert.strictEqual(res.status, 0,
       `[render ${args.join(' ')}] crashed or refused\nstdout: ${res.stdout}\nstderr: ${res.stderr}`);
     if (expect === 'content') {
@@ -383,6 +386,9 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
 
   // Implementation — no `topic start` in prose; task init creates.
   sim.render(['entry-gate', `${wu}.implementation.${topic}`], { expect: 'empty' });
+  // The entry chokepoint's code-slot read: nothing else in this sim holds
+  // implementation or review, so the slot is free and the gate renders empty.
+  sim.render(['code-gate', `${wu}.implementation.${topic}`], { expect: 'empty' });
   label(sim, wu, 'implementation', topic);
   const implInit = sim.run(['task', 'init', wu, topic]);
   assert.strictEqual(implInit.mode, 'created', 'fresh implementation takes the created arm');
@@ -428,6 +434,7 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
   // its surfaces, and the pass completes the phase. The offer at a pass
   // consumes the banked set and deletes the field.
   sim.render(['entry-gate', `${wu}.review.${topic}`], { expect: 'empty' });
+  sim.render(['code-gate', `${wu}.review.${topic}`], { expect: 'empty' });
   label(sim, wu, 'review', topic);
   sim.run(['topic', 'start', wu, 'review', topic]);
   sim.run(['manifest', 'push', `${wu}.review.${topic}`, 'reviewed_tasks', `${topic}-1-1`]);


### PR DESCRIPTION
PR 7 of the concurrent-phases stack (design: #1027; prior layers: #1028–#1033).

**The code gate.** One code session per checkout — implementation or review, any work unit. The gate lives at the one chokepoint every route crosses: a shared `code-session-gate.md` loaded by both entry skills, backed by `render code-gate` — the entrant's address in, the holder resolved engine-side from the project scan, empty when the slot is free. The blocking fact renders red (properties fence), the menu names the consequence, the explicit condition ("only proceed if you know that session is no longer working"), and the `presence clear` release for a wedged-but-alive holder. back (recommended) / proceed — soft, always overridable, per the design. Own-session holds are excluded by session id and pid, so a resumed session never gates against its own heartbeat.

**One stop per attempt.** Epic-menu code entries wear a distinct `(code session: {wu}/{topic}, …)` marker — struck through, holder named, never recommended — and route straight through to the entry skill's gate; the gateway refuses to render the menu-level gate for a code entry, so the double stop is pinned unreachable. Doc-phase entries keep the menu's in-session gate, upgraded to the family's wording: the condition line and the release command join the confirm.

Tests: +12 across render-surfaces, epic-projections, gateway, presence, and the simulation (both entry points exercise the gate). Two latent sim-infrastructure bugs fixed en route (renders spawned without the sim env; no pinned session id — green locally, red in CI). 12 prose cases gain the shared reference in their file pins; `review-entry-fresh` pins the empty-gate call.

Gates: `npm test` 2523/0 · `npm run test:cli` 414/0 · `npm run typecheck` clean. All 93 snapshot worlds rebuilt byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)