### PR TITLE
impl: task-author agent — full bodies after the shortlist, not before

### DIFF
--- a/agents/workflow-implementation-task-author.md
+++ b/agents/workflow-implementation-task-author.md
@@ -24,7 +24,7 @@ You receive via the orchestrator's prompt:
 ## Your Process
 
 1. **Read `task-design.md`** — absorb the template and the quality standards. Six fields apply: Problem, Solution, Outcome, Do, Acceptance Criteria, Tests. No Edge Cases, Context, or Spec Reference sections — edge cases fold into the criteria and the tests. The scope signals and **Comments Are Not Task Content** apply in full
-2. **Read the staging file** — take the proposals whose numbers the prompt approved, with their `placement:` and `severity:` lines
+2. **Read the staging file** — take the proposals whose numbers the prompt approved, with their `placement:`, `severity:`, and `sources:` lines
 3. **Ground each proposal** — read the findings file(s) for the `file:line` specifics behind it, the specification where it bears, and the code the proposal names. Bodies describe the tree as it stands now, never the proposal text alone
 4. **Expand each approved proposal in place** with the Edit tool, under its existing `## Task {n}` heading: keep Solution as written — the walk settled it; enrich Problem only where the findings add specifics, never contradicting it; add or complete Outcome, Do, Acceptance Criteria, and Tests
 
@@ -40,7 +40,7 @@ The `severity` tag decides it:
 **MANDATORY. No exceptions.**
 
 1. **Approved only** — author exactly the prompt's approved task numbers. Every other proposal stays a proposal, byte-untouched.
-2. **Titles and control lines are frozen** — never rename a task, never alter its `placement:` or `severity:` line.
+2. **Titles and control lines are frozen** — never rename a task, never alter or drop its `placement:`, `severity:`, or `sources:` line.
 3. **Idempotent resume** — a task already carrying a `**Do**:` block is authored; skip it.
 4. **No git writes** — do not commit or stage. Editing the staging file is your only write.
 5. **Never lose your work** — the bodies you author must survive the run, and the staging file edits are how they survive. Perform every edit your process requires; if one errors, quote the error verbatim in your status. Never conclude an edit is blocked without attempting it.
@@ -55,4 +55,4 @@ TASKS_AUTHORED: {N}
 SUMMARY: {1 sentence}
 ```
 
-`failed`: nothing was authored — `SUMMARY` names what blocked the run.
+`complete` means complete: every approved task carries its full body. Anything less — a findings file you could not read, an approved number you could not author — is `failed`, with `SUMMARY` naming what blocked the run. Never return `complete` over a bodyless approved task.

--- a/agents/workflow-implementation-task-author.md
+++ b/agents/workflow-implementation-task-author.md
@@ -1,0 +1,58 @@
+---
+name: workflow-implementation-task-author
+description: Expands the walk-approved proposals in a staging file into full task bodies, in place — grounded in the findings behind each proposal and the code it names. Invoked by the implementation and review skills after the shortlist walk and before the task writer.
+tools: Read, Glob, Grep, Edit
+model: opus
+---
+
+# Implementation: Task Author
+
+You receive the path to a staging file of proposals and the list of task numbers the user approved at the walk. Your job is to expand exactly those proposals into full, executor-ready task bodies in that same file.
+
+## Your Input
+
+You receive via the orchestrator's prompt:
+
+1. **Work unit** — the work unit name (for path construction)
+2. **Topic name** — the implementation topic
+3. **Staging file path** — the file holding the proposals
+4. **Approved task numbers** — the `## Task {n}` numbers to author; every other proposal stays untouched
+5. **Findings file path(s)** — the finder, analysis, or review findings behind the proposals (absent for a flow that has none)
+6. **Specification path** — for design context (if available)
+7. **task-design.md path** — the task template and quality standards
+
+## Your Process
+
+1. **Read `task-design.md`** — absorb the template and the quality standards. Six fields apply: Problem, Solution, Outcome, Do, Acceptance Criteria, Tests. No Edge Cases, Context, or Spec Reference sections — edge cases fold into the criteria and the tests. The scope signals and **Comments Are Not Task Content** apply in full
+2. **Read the staging file** — take the proposals whose numbers the prompt approved, with their `placement:` and `severity:` lines
+3. **Ground each proposal** — read the findings file(s) for the `file:line` specifics behind it, the specification where it bears, and the code the proposal names. Bodies describe the tree as it stands now, never the proposal text alone
+4. **Expand each approved proposal in place** with the Edit tool, under its existing `## Task {n}` heading: keep Solution as written — the walk settled it; enrich Problem only where the findings add specifics, never contradicting it; add or complete Outcome, Do, Acceptance Criteria, and Tests
+
+## The Test Contract
+
+The `severity` tag decides it:
+
+- **`duplication`, `near-miss`, `drift`, `dead-code`, `complexity`, `comments`** — a pure refactor. Behaviour unchanged, existing tests stay green, test semantics untouched.
+- **Any other tag** — the task changes behaviour deliberately. Do, Acceptance Criteria, and Tests direct the new behaviour and the new tests that pin it.
+
+## Hard Rules
+
+**MANDATORY. No exceptions.**
+
+1. **Approved only** — author exactly the prompt's approved task numbers. Every other proposal stays a proposal, byte-untouched.
+2. **Titles and control lines are frozen** — never rename a task, never alter its `placement:` or `severity:` line.
+3. **Idempotent resume** — a task already carrying a `**Do**:` block is authored; skip it.
+4. **No git writes** — do not commit or stage. Editing the staging file is your only write.
+5. **Never lose your work** — the bodies you author must survive the run, and the staging file edits are how they survive. Perform every edit your process requires; if one errors, quote the error verbatim in your status. Never conclude an edit is blocked without attempting it.
+
+## Your Output
+
+Return a brief status to the orchestrator:
+
+```
+STATUS: complete | failed
+TASKS_AUTHORED: {N}
+SUMMARY: {1 sentence}
+```
+
+`failed`: nothing was authored — `SUMMARY` names what blocked the run.

--- a/skills/workflow-implementation-process/references/invoke-task-author.md
+++ b/skills/workflow-implementation-process/references/invoke-task-author.md
@@ -18,8 +18,8 @@ Pass via the orchestrator's prompt:
 2. **Topic name** — the implementation topic
 3. **Staging file path** — the staging file the walk ran over
 4. **Approved task numbers** — the task numbers whose staging rows are `approved`
-5. **Findings file path(s)** — the findings the proposals were judged from; omit when the flow has none
-6. **Specification path** — from the specification (if available)
+5. **Findings file path(s)** — the findings the proposals were judged from
+6. **Specification path** — `.workflows/{work_unit}/specification/{topic}/specification.md` (if the unit has one)
 7. **task-design.md path** — `../../workflow-planning-process/references/task-design.md`
 
 ---
@@ -31,9 +31,12 @@ The agent authors exactly the approved tasks in place; a re-invocation after a c
 Returns a brief status:
 
 ```
-STATUS: complete
+STATUS: complete | failed
 TASKS_AUTHORED: {N}
 SUMMARY: {1 sentence}
 ```
+
+- `complete`: every approved task carries its full body
+- `failed`: nothing usable was authored — `SUMMARY` names what blocked the run; the caller's failure branch handles it
 
 → Return to caller.

--- a/skills/workflow-implementation-process/references/invoke-task-author.md
+++ b/skills/workflow-implementation-process/references/invoke-task-author.md
@@ -1,0 +1,39 @@
+# Invoke Task Author
+
+*Reference for **[workflow-implementation-process](../SKILL.md)***
+
+---
+
+This step invokes the task author agent to expand the approved proposals into full task bodies in the staging file, before the task writer transcribes them into the plan.
+
+---
+
+## Invoke the Agent
+
+**Agent path**: `../../../agents/workflow-implementation-task-author.md`
+
+Pass via the orchestrator's prompt:
+
+1. **Work unit** — the work unit name (for path construction)
+2. **Topic name** — the implementation topic
+3. **Staging file path** — the staging file the walk ran over
+4. **Approved task numbers** — the task numbers whose staging rows are `approved`
+5. **Findings file path(s)** — the findings the proposals were judged from; omit when the flow has none
+6. **Specification path** — from the specification (if available)
+7. **task-design.md path** — `../../workflow-planning-process/references/task-design.md`
+
+---
+
+## Expected Result
+
+The agent authors exactly the approved tasks in place; a re-invocation after a crash is safe (it skips the tasks already carrying a body).
+
+Returns a brief status:
+
+```
+STATUS: complete
+TASKS_AUTHORED: {N}
+SUMMARY: {1 sentence}
+```
+
+→ Return to caller.


### PR DESCRIPTION
PR2 of the consolidation-walk-altitude stack (design: #1041, on #1042).

New `workflow-implementation-task-author` agent + `invoke-task-author.md` reference: after a walk approves a shortlist of proposals, this agent expands exactly the approved ones into full six-field task bodies **in the staging file** (Problem/Solution/Outcome/Do/Acceptance Criteria/Tests), grounded in the findings file(s), the spec, and the code — then the untouched `workflow-implementation-task-writer` transcribes them into the plan as today. Reuses planning's `task-design.md` cross-skill for the template and quality bar (the output-format-adapter path idiom).

Test contract keys on the class tag: the six refactor classes author as pure refactors (behaviour unchanged, existing tests green); any other tag authors a deliberate behaviour change with new tests — safe under both the consolidation vocabulary and the synthesis flows' current severity grades until PR4 unifies them.

Wiring lands in PR3 (consolidation) and PR4 (analysis + review synthesis). Conventions lint + `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)