### PR TITLE
engine(tasks): a closed phase leaves no task in flight — walk findings

### DIFF
--- a/skills/workflow-engine/scripts/domain/tasks.cjs
+++ b/skills/workflow-engine/scripts/domain/tasks.cjs
@@ -381,6 +381,13 @@ function completeTask(cwd, workUnit, topic, { internalId = null, externalId = nu
       const n = phase !== undefined ? phase : phaseOfInternalId(id);
       pushTo(item, 'completed_phases', n);
       recorded.completed_phase = n;
+      // A completed phase leaves no task in flight — the closing record
+      // clears a pointer still holding this task, unless the caller set
+      // the next task explicitly.
+      if (nextTask === undefined && item.current_task === id) {
+        item.current_task = null;
+        recorded.current_task = null;
+      }
     }
     saveWorkUnitManifest(cwd, workUnit, manifest);
 

--- a/skills/workflow-review-process/references/prep-findings.md
+++ b/skills/workflow-review-process/references/prep-findings.md
@@ -18,16 +18,18 @@ Each finding arrives carrying its scope (`[in-scope]` or `[out-of-scope]`), its 
 
 Give each finding a stable id of `{phase_id}-{task_id}-{n}` — its report's task suffix plus its position in that report's list, so an action always traces back to the verifier that raised it.
 
-Write two payloads with the Write tool:
-
-- `.workflows/.cache/{work_unit}/review/{topic}/findings.txt` — one block per finding, opening with `[{id}]`, carrying the finding verbatim
-- `.workflows/.cache/{work_unit}/review/{topic}/findings-index.txt` — the same findings grouped under `### {file}` headings by the file each targets, one summary line each
-
 #### If no findings were collected
+
+Nothing is written — the payloads exist only for findings.
 
 → Return to caller.
 
 #### Otherwise
+
+Write two payloads with the Write tool:
+
+- `.workflows/.cache/{work_unit}/review/{topic}/findings.txt` — one block per finding, opening with `[{id}]`, carrying the finding verbatim
+- `.workflows/.cache/{work_unit}/review/{topic}/findings-index.txt` — the same findings grouped under `### {file}` headings by the file each targets, one summary line each
 
 → Proceed to **B. Assess**.
 

--- a/skills/workflow-shared/references/correcting-historical-artifacts.md
+++ b/skills/workflow-shared/references/correcting-historical-artifacts.md
@@ -135,7 +135,7 @@ Apply it silently — no gate, no raise. This is the one place a downstream phas
    node .claude/skills/workflow-knowledge/scripts/knowledge.cjs index {specification path}
    ```
 
-4. **Commit.** Scoped to the corrected topic — one specification file and the store the re-index dirtied. `--kb` carries the store; `--sweep` says the specification topic is not the one this session is working:
+4. **Commit.** Scoped to the corrected topic — one specification file and the store the re-index dirtied. `--kb` carries the store; `--sweep` always rides here — the session's working topic is its own implementation or review topic, never this specification topic:
 
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {owning_work_unit} -m "specification({owning_work_unit}): corrigendum from {correcting_phase}" --topic specification/{topic} --kb --sweep

--- a/tests/prose/cases/implementation-consolidates-the-phase/case.json
+++ b/tests/prose/cases/implementation-consolidates-the-phase/case.json
@@ -33,7 +33,8 @@
     "skills/workflow-implementation-process/references/consolidation-pass.md",
     "skills/workflow-implementation-process/references/invoke-consolidation-finder.md",
     "skills/workflow-implementation-process/references/invoke-task-author.md",
-    "skills/workflow-shared/references/reconcile-advisory.md"
+    "skills/workflow-shared/references/reconcile-advisory.md",
+    "skills/workflow-implementation-process/references/report-register.md"
   ],
   "answers": [
     "y — skip project skills again",

--- a/tests/prose/cases/implementation-records-an-adhoc-task/case.json
+++ b/tests/prose/cases/implementation-records-an-adhoc-task/case.json
@@ -72,7 +72,6 @@
       "staging.ad-hoc-1.tasks.1 approved",
       "write:.workflows/pay/planning/pay/tasks/pay-1-4",
       "write:.workflows/pay/planning/pay/planning.md",
-      "task_map.pay-1-4",
       "impl(pay): add 1 ad hoc task(s)",
       "render task-gate pay.implementation.pay"
     ],

--- a/tests/prose/cases/implementation-runs-the-analysis-walk/assert.md
+++ b/tests/prose/cases/implementation-runs-the-analysis-walk/assert.md
@@ -46,7 +46,9 @@ The prose should have taken this path:
 10. the spec defect is settled before the overview renders. The
     specification is this work unit's own and this session's phase is
     implementation, so the correction routes through that arm: the item's
-    status reads completed and the presence scan returns no rows, so
+    status reads completed and the presence scan shows no
+    specification-topic row (the session's own implementation
+    heartbeat may appear), so
     neither early return fires. The record settles the claim — the path
     is a value the tree measures — so it lands silently: the wrong path
     replaced in place, one dated corrigendum attributed to

--- a/tests/prose/cases/implementation-walks-a-decision-proposal/case.json
+++ b/tests/prose/cases/implementation-walks-a-decision-proposal/case.json
@@ -34,7 +34,8 @@
     "skills/workflow-implementation-process/references/invoke-consolidation-finder.md",
     "skills/workflow-implementation-process/references/invoke-task-author.md",
     "skills/workflow-shared/references/correcting-historical-artifacts.md",
-    "skills/workflow-shared/references/reconcile-advisory.md"
+    "skills/workflow-shared/references/reconcile-advisory.md",
+    "skills/workflow-implementation-process/references/report-register.md"
   ],
   "answers": [
     "y — skip project skills again",

--- a/tests/scripts/test-engine-tasks.cjs
+++ b/tests/scripts/test-engine-tasks.cjs
@@ -419,6 +419,27 @@ describe('engine task complete', () => {
     assert.deepStrictEqual(implItem(dir).completed_phases, [2]);
   });
 
+  it('--phase-complete clears a pointer still holding the completed task — a closed phase leaves nothing in flight', () => {
+    engine(dir, ['start', 'auth', 'auth-flow', 'auth-flow-1-2']);
+    const res = engine(dir, ['complete', 'auth', 'auth-flow', 'auth-flow-1-2', '--phase', '1', '--phase-complete']);
+    assert.strictEqual(res.recorded.current_task, null);
+    assert.strictEqual(implItem(dir).current_task, null);
+  });
+
+  it('--phase-complete leaves a pointer holding a different task untouched', () => {
+    engine(dir, ['start', 'auth', 'auth-flow', 'auth-flow-2-1']);
+    const res = engine(dir, ['complete', 'auth', 'auth-flow', 'auth-flow-1-2', '--phase', '1', '--phase-complete']);
+    assert.strictEqual(res.recorded.current_task, undefined);
+    assert.strictEqual(implItem(dir).current_task, 'auth-flow-2-1');
+  });
+
+  it('--phase-complete defers to an explicit --next-task', () => {
+    engine(dir, ['start', 'auth', 'auth-flow', 'auth-flow-1-2']);
+    const res = engine(dir, ['complete', 'auth', 'auth-flow', 'auth-flow-1-2', '--phase', '1', '--next-task', 'auth-flow-2-1', '--phase-complete']);
+    assert.strictEqual(res.recorded.current_task, 'auth-flow-2-1');
+    assert.strictEqual(implItem(dir).current_task, 'auth-flow-2-1');
+  });
+
   it('appends to existing progress arrays', () => {
     engine(dir, ['complete', 'auth', 'auth-flow', 'auth-flow-1-1']);
     engine(dir, ['complete', 'auth', 'auth-flow', 'auth-flow-1-2', '--phase-complete']);

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -474,6 +474,8 @@ function walkDeliveryPhases(sim, wu, topic, { sources }) {
   sim.run(['task', 'complete', wu, topic, `${topic}-1-1`, '--phase', '1', '--next-task', '~']);
   sim.run(['manifest', 'push', `${wu}.implementation.${topic}`, 'consolidated_phases', '1']);
   sim.run(['task', 'complete', wu, topic, `${topic}-1-1`, '--phase', '1', '--phase-complete']);
+  assert.strictEqual(sim.manifest(wu).phases.implementation.items[topic].current_task, null,
+    'a closed phase leaves no task in flight');
   // The analysis loop's synthesizer consumes the residue (invoke-synthesizer.md);
   // conclude's hygiene covers a loop that never got its verdicts in.
   sim.run(['manifest', 'delete', `${wu}.implementation.${topic}`, 'bank']);


### PR DESCRIPTION
Post-merge walk findings from stack #1044's six-case validation run.

**The confirmed FAIL**: `task complete --phase-complete` left `current_task` pointing at the phase's last task (the normal-loop completion clears it via `--next-task '~'`; the closing re-record passed none). Reproduced identically from two fresh worlds by `implementation-consolidates-the-phase`. Fix: on `--phase-complete`, a pointer still holding the completed id clears; an explicit `--next-task` wins; a pointer holding a different task is untouched. Three engine tests + a simulation assertion.

**The FLAKY**: the ad-hoc case pinned the task-writer's `task_map` write into the ordered chain; walkers vary that internal ordering with identical plan content — the link is dropped (the call stays required via `calls_include`).

**Riders** (all from the run's markers): the two boundary cases declare `report-register.md` (scope ratchet); the analysis case's presence-scan claim allows the walking session's own heartbeat row; entry B's `--sweep` gloss no longer invites a second reading; `prep-findings.md`'s no-findings guard now precedes the payload writes it guards (the run's AMBIGUOUS marker).

Gates: `npm test` 2597 pass, typecheck clean, snapshots byte-identical. Reruns of the two cases follow on this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)