### PR TITLE
impl+review(synthesis): commit messages say cycle, and one task is not plural

### DIFF
--- a/skills/workflow-implementation-process/references/analysis-loop.md
+++ b/skills/workflow-implementation-process/references/analysis-loop.md
@@ -377,8 +377,8 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 Commit the staging file with this topic's implementation artifacts, then the tasks — `--plan` stages the planning topic, the manifests, and the plan's declared storage:
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis phase {N} — staged tasks" --topic implementation/{topic}
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): add analysis phase {N} ({K} tasks)" --plan {topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): analysis cycle {N} — staged tasks" --topic implementation/{topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "impl({work_unit}): add analysis cycle {N} — {K} task(s)" --plan {topic}
 ```
 
 → Return to caller.

--- a/skills/workflow-review-process/references/review-actions-loop.md
+++ b/skills/workflow-review-process/references/review-actions-loop.md
@@ -295,7 +295,7 @@ Commit the staging file with this topic's implementation artifacts, then the pla
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): stage review remediation" --topic implementation/{topic} --sweep
-node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): add review remediation ({K} tasks)" --plan {topic}
+node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} -m "review({work_unit}): add review remediation — {K} task(s)" --plan {topic}
 ```
 
 → On return, proceed to **G. Re-open Implementation**.

--- a/tests/prose/cases/implementation-runs-the-analysis-walk/case.json
+++ b/tests/prose/cases/implementation-runs-the-analysis-walk/case.json
@@ -75,8 +75,8 @@
       "staging.c1.tasks.1 approved",
       "staging.c1.tasks.2 skipped",
       "manifest set pay.planning.pay task_map.pay-2-1",
-      "impl(pay): analysis phase 1 — staged tasks",
-      "impl(pay): add analysis phase 1",
+      "impl(pay): analysis cycle 1 — staged tasks",
+      "impl(pay): add analysis cycle 1",
       "--plan pay"
     ],
     "calls_in_order": [
@@ -96,7 +96,7 @@
       "staging.c1.tasks.2 skipped",
       "write:.workflows/pay/planning/pay/tasks/pay-2-1.md",
       "manifest set pay.planning.pay task_map.pay-2-1",
-      "impl(pay): analysis phase 1 — staged tasks",
+      "impl(pay): analysis cycle 1 — staged tasks",
       "--plan pay"
     ],
     "calls_exclude": [


### PR DESCRIPTION
The last two cosmetics from the walk run's markers: `impl({wu}): analysis phase {N}` → `analysis cycle {N}` (the loop's own vocabulary — its git records read "analysis phase 1" beside "analysis cycle 1 — findings" for the same cycle, while the plan phase created is a different number), and both task-creation commits take the consolidation boundary's `— {K} task(s)` form so a count of one stops reading `(1 tasks)`. The analysis case's two pinned strings updated to match.

Gates: `npm test` 2597 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)