### PR TITLE
impl(setup): confirm gates compact from the project default, silent on resume

### DIFF
--- a/skills/workflow-engine/scripts/domain/projections/worklist.cjs
+++ b/skills/workflow-engine/scripts/domain/projections/worklist.cjs
@@ -140,4 +140,4 @@ function worklist({ heading, intro, items, walked = false, walkLine = false }) {
   return lines.join('\n');
 }
 
-module.exports = { worklist };
+module.exports = { worklist, escapeMarkdown };

--- a/skills/workflow-engine/scripts/domain/render.cjs
+++ b/skills/workflow-engine/scripts/domain/render.cjs
@@ -18,7 +18,7 @@ const { loadManifest, loadProjectManifest } = require('./reads.cjs');
 const { titlecase, WORKLIST_GLYPH, DISCOVERY_GLYPH, discoveryLifecycleLabel } = require('./conventions.cjs');
 const { section, CONTINUE_INSTRUCTION, CONTINUE_MARKDOWN_INSTRUCTION, AUTO_GATE_INSTRUCTION, menu, menuFrame, MENU_GLYPH, cmdOption, bareOption, promptOption, callout, indentedBody, bulletRow, subDetail, treeList } = require('./projections/surfaces.cjs');
 const { buildOrderLive } = require('./build-order.cjs');
-const { worklist } = require('./projections/worklist.cjs');
+const { worklist, escapeMarkdown } = require('./projections/worklist.cjs');
 const { blockedTasksMenu, taskGateSection, fixGateSection, cycleLimitDisplay, cycleGateMenu } = require('./projections/tasks.cjs');
 const { workunitReceipt, topicReceipt, absorbReceipt, promoteReceipt, pivotContinuationMenu, sessionReceipt } = require('./projections/transactions.cjs');
 const { absorbTargetMenu, planTopicsMenu } = require('./projections/start.cjs');
@@ -1094,13 +1094,33 @@ function validationReport(cwd, { dotpath, file, variant }) {
 }
 
 // ---------------------------------------------------------------------------
-// project-skills / linters — implementation's two setup discoveries. Each is
-// asked twice: confirm a set already stored, or approve one just discovered.
-// Same list shape both times, so the difference is the menu and, for a fresh
-// linter discovery, the installed-state tag and the install recommendations.
+// project-skills / linters — implementation's two setup discoveries. A fresh
+// discovery renders the full worklist (name — detail rows, plus the
+// installed-state tag and install recommendations for linters); confirming a
+// project default renders compact — a count line over one comma run of
+// names, because the set was already approved once and only needs to be
+// seen, not studied.
 // ---------------------------------------------------------------------------
 
 const SETUP_VARIANTS = ['confirm', 'discovery', 'skipped'];
+
+/**
+ * Validate a name list and render the compact confirm body — the stored,
+ * already-approved set as one comma run under a count line.
+ * @param {unknown} v @param {string} surface @param {string} field @param {string} label
+ * @returns {string}
+ */
+function setupNameRun(v, surface, field, label) {
+  if (!Array.isArray(v) || v.length === 0) {
+    throw new Error(`render ${surface}: "${field}" must be a non-empty array of names`);
+  }
+  const names = v.map((row, i) => {
+    if (!isFilled(row)) throw new Error(`render ${surface}: ${field}[${i}] must be a non-empty string`);
+    return escapeMarkdown(row);
+  });
+  // One authored line — the display's renderer soft-wraps the run.
+  return [`**${label}** — ${names.length} from the project default`, '', names.join(', ')].join('\n');
+}
 
 /**
  * Validate a `{name, detail}` list and render it as the batch worklist.
@@ -1147,8 +1167,10 @@ function projectSkills(cwd, { dotpath, file, variant }) {
   }
   if (!file) throw new Error('render project-skills: --file <payload.json> is required');
   const p = readJsonPayload(cwd, file, 'project-skills');
-  const body = setupList(p.skills, 'project-skills', 'skills', 'Project skills', 'skill');
   const confirm = variant === 'confirm';
+  const body = confirm
+    ? setupNameRun(p.skills, 'project-skills', 'skills', 'Project skills')
+    : setupList(p.skills, 'project-skills', 'skills', 'Project skills', 'skill');
   return [
     section(`DISPLAY: project skills ${variant}`, 'emit verbatim as markdown', body),
     section(`MENU: project skills ${variant} gate`, STOP_FOR_RESPONSE, confirm
@@ -1190,16 +1212,15 @@ function linters(cwd, { dotpath, file, variant }) {
   const p = readJsonPayload(cwd, file, 'linters');
   const discovery = variant === 'discovery';
   // A fresh discovery reports what is actually on the machine; a stored set
-  // was already approved, so its rows carry no installed state to re-assert.
-  const body = setupList(p.linters, 'linters', 'linters', discovery ? 'Linter discovery' : 'Linters', 'linter',
-    discovery
-      ? (row) => {
-        if (typeof row.installed !== 'boolean') {
-          throw new Error('render linters: every row of a discovery needs "installed" (true or false)');
-        }
-        return row.installed ? 'installed' : 'missing';
+  // was already approved, so it renders compact with nothing to re-assert.
+  const body = discovery
+    ? setupList(p.linters, 'linters', 'linters', 'Linter discovery', 'linter', (row) => {
+      if (typeof row.installed !== 'boolean') {
+        throw new Error('render linters: every row of a discovery needs "installed" (true or false)');
       }
-      : undefined);
+      return row.installed ? 'installed' : 'missing';
+    })
+    : setupNameRun(p.linters, 'linters', 'linters', 'Linters');
   const parts = [body];
   if (discovery && p.recommendations !== undefined) {
     if (!isFilled(p.recommendations)) throw new Error('render linters: "recommendations" must be a non-empty string when present');

--- a/skills/workflow-implementation-process/references/linter-setup.md
+++ b/skills/workflow-implementation-process/references/linter-setup.md
@@ -18,9 +18,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 #### If `linters` is populated
 
-Set `source` = `topic`.
+The set was confirmed when this topic stored it — use it without re-asking.
 
-→ Proceed to **B. Confirm Linters**.
+→ Return to caller.
 
 #### Otherwise
 
@@ -35,8 +35,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defa
 → Proceed to **C. Discovery**.
 
 **If output is a populated array:**
-
-Set `source` = `project`.
 
 → Proceed to **B. Confirm Linters**.
 
@@ -62,7 +60,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render linters {work_unit
 
 ## B. Confirm Linters
 
-Write the linters returned by the `source` level manifest query to `.workflows/.cache/{work_unit}/implementation/{topic}/linters.json` with the Write tool — `{"linters": [{"name": "{name}", "detail": "{command}"}]}` — then fetch the gate, emitting each section verbatim at its marked instruction:
+Write the linter names from the project default to `.workflows/.cache/{work_unit}/implementation/{topic}/linters.json` with the Write tool — `{"linters": ["{name}", ...]}` — then fetch the gate, emitting each section verbatim at its marked instruction:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render linters {work_unit}.implementation.{topic} --file .workflows/.cache/{work_unit}/implementation/{topic}/linters.json --variant confirm
@@ -72,8 +70,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render linters {work_unit
 
 #### If `yes`
 
-**If `source` is `project`:**
-
 Copy to topic level:
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} linters '[{project-level values}]'
@@ -81,16 +77,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 
 → Return to caller.
 
-**If `source` is `topic`:**
-
-→ Return to caller.
-
 #### If `no`
-
-Clear topic-level `linters` before re-discovery:
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} linters '[]'
-```
 
 → Proceed to **C. Discovery**.
 

--- a/skills/workflow-implementation-process/references/project-skills-discovery.md
+++ b/skills/workflow-implementation-process/references/project-skills-discovery.md
@@ -14,9 +14,9 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 #### If `project_skills` is populated
 
-Set `source` = `topic`.
+The set was confirmed when this topic stored it — use it without re-asking.
 
-→ Proceed to **B. Confirm Skills**.
+→ Return to caller.
 
 #### Otherwise
 
@@ -32,8 +32,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get project.defa
 → Proceed to **C. Discovery**.
 
 **If `true` and project default is populated:**
-
-Set `source` = `project`.
 
 → Proceed to **B. Confirm Skills**.
 
@@ -59,7 +57,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render project-skills {wo
 
 ## B. Confirm Skills
 
-Write the skills returned by the `source` level manifest query to `.workflows/.cache/{work_unit}/implementation/{topic}/project-skills.json` with the Write tool — `{"skills": [{"name": "{skill-name}", "detail": "{path}"}]}` — then fetch the gate, emitting each section verbatim at its marked instruction:
+Write the skill names from the project default — each path's last segment — to `.workflows/.cache/{work_unit}/implementation/{topic}/project-skills.json` with the Write tool — `{"skills": ["{skill-name}", ...]}` — then fetch the gate, emitting each section verbatim at its marked instruction:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs render project-skills {work_unit}.implementation.{topic} --file .workflows/.cache/{work_unit}/implementation/{topic}/project-skills.json --variant confirm
@@ -69,8 +67,6 @@ node .claude/skills/workflow-engine/scripts/engine.cjs render project-skills {wo
 
 #### If `yes`
 
-**If `source` is `project`:**
-
 Copy to topic level:
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} project_skills '[{project-level values}]'
@@ -78,16 +74,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.
 
 → Return to caller.
 
-**If `source` is `topic`:**
-
-→ Return to caller.
-
 #### If `no`
-
-Clear topic-level `project_skills` before re-discovery:
-```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest set {work_unit}.implementation.{topic} project_skills '[]'
-```
 
 → Proceed to **C. Discovery**.
 

--- a/tests/scripts/test-engine-render-surfaces.cjs
+++ b/tests/scripts/test-engine-render-surfaces.cjs
@@ -1759,13 +1759,15 @@ describe('render project-skills / linters', () => {
     dotpath: imp, variant, file: payload && writePayload(dir, `${surface}-${variant}.json`, payload),
   });
 
-  it('project skills: a stored set is confirmed, a fresh scan is chosen from', () => {
-    const c = render('project-skills', 'confirm', { skills: [{ name: 'laravel-conventions', detail: '.claude/skills/laravel-conventions' }] });
-    assert.ok(c.includes('**Project skills** — 1 skill'));
-    assert.ok(c.includes('1\\. laravel-conventions — .claude/skills/laravel-conventions'));
+  it('project skills: a stored set confirms compact, a fresh scan is chosen from the full list', () => {
+    const c = render('project-skills', 'confirm', { skills: ['laravel-conventions', 'laravel-testing'] });
+    assert.ok(c.includes('**Project skills** — 2 from the project default'));
+    assert.ok(c.includes('laravel-conventions, laravel-testing'));
+    assert.ok(!c.includes('1\\.'), 'a confirm is a comma run, not a numbered worklist');
     assert.ok(c.includes('**`◆ Use these project skills?`**'));
     const d = render('project-skills', 'discovery', { skills: [{ name: 'a', detail: 'x' }, { name: 'b', detail: 'y' }] });
     assert.ok(d.includes('**Project skills** — 2 skills'));
+    assert.ok(d.includes('1\\. a — x'));
     assert.ok(d.includes('**`◆ Which project skills should be used?`**'));
     assert.ok(unwrap(d).includes('**List the ones you want** → Name them — e.g. "golang-pro, react-patterns"'));
   });
@@ -1783,9 +1785,10 @@ describe('render project-skills / linters', () => {
     assert.ok(/\*\*`s\/skip`\*\* +→ Skip linter setup \(no linting during TDD\)/.test(out));
   });
 
-  it('linters: a stored set re-asserts no installed state and carries no recommendations', () => {
-    const out = render('linters', 'confirm', { linters: [{ name: 'pint', detail: 'vendor/bin/pint' }] });
-    assert.ok(out.includes('**Linters** — 1 linter'));
+  it('linters: a stored set confirms compact with no installed state and no recommendations', () => {
+    const out = render('linters', 'confirm', { linters: ['pint', 'phpstan'] });
+    assert.ok(out.includes('**Linters** — 2 from the project default'));
+    assert.ok(out.includes('pint, phpstan'));
     assert.ok(!out.includes('`[installed]`'), 'an approved set was already checked');
     assert.ok(out.includes('**`◆ Use these linters?`**'));
     assert.throws(
@@ -1809,8 +1812,9 @@ describe('render project-skills / linters', () => {
     assert.throws(() => renderSurface(dir, 'linters', { dotpath: imp }), /--variant must be one of confirm\/discovery\/skipped/);
     assert.throws(() => renderSurface(dir, 'linters', { dotpath: imp, variant: 'confirm' }), /--file <payload\.json> is required/);
     assert.throws(() => render('linters', 'confirm', { linters: [] }), /"linters" must be a non-empty array/);
-    assert.throws(() => render('project-skills', 'confirm', { skills: [{ name: 'a' }] }), /skills\[0\] is missing "detail"/);
-    assert.throws(() => render('project-skills', 'confirm', { skills: [{ detail: 'a' }] }), /skills\[0\] is missing "name"/);
+    assert.throws(() => render('project-skills', 'confirm', { skills: [{ name: 'a', detail: 'b' }] }), /skills\[0\] must be a non-empty string/);
+    assert.throws(() => render('project-skills', 'discovery', { skills: [{ name: 'a' }] }), /skills\[0\] is missing "detail"/);
+    assert.throws(() => render('project-skills', 'discovery', { skills: [{ detail: 'a' }] }), /skills\[0\] is missing "name"/);
     writeManifest(dir, 'hooks', { work_type: 'bugfix', phases: { planning: { items: { crash: { status: 'in-progress' } } } } });
     assert.throws(
       () => renderSurface(dir, 'project-skills', { dotpath: 'hooks.planning.crash', variant: 'skipped' }),


### PR DESCRIPTION
The implementation entry's two setup gates (project skills, linters) asked the same question at every altitude: a 14-row worklist to re-approve a set the user had already approved, at every session entry, resume included.

Now the altitude matches the question:

- **Resume of an in-progress topic** (topic-level value stored): silent — section A returns to caller with no gate and no output. The set was confirmed when the topic stored it, and review already loads the same value silently.
- **New topic adopting the project default**: the gate stays, but compact — a count line (`**Project skills** — 14 from the project default`) over one comma-joined name run, soft-wrapped by the renderer. Same y/n menu.
- **Fresh discovery**: unchanged — full worklist with name/detail rows, installed tags, and install recommendations, where the detail informs the choice.

Engine: `render project-skills`/`render linters` confirm variants take a bare name array and render via a new `setupNameRun`; discovery keeps `setupList`. `escapeMarkdown` exported from the worklist projection.

Prose: `project-skills-discovery.md` and `linter-setup.md` drop the `source` bookkeeping and the pre-re-discovery clear (both only served the deleted topic-source confirm); confirm's `y` still copies the project default to topic level, so downstream loads are unaffected.

Tests: render-surfaces suite re-pinned for the compact confirms; payload validation asserts split per variant. Full `npm test` + typecheck green. Intersecting prose cases only exercise the unchanged skipped route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)