### PR TITLE
design: experiment phase — measured evidence for decisions

### DIFF
--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -243,14 +243,35 @@ lives with the record. Raw output is kept by default; genuinely bulky
 output may stay out of git with the report linking by path. Ephemeral
 working files use the cache (`.workflows/.cache/{wu}/experiment/{topic}/`).
 
-### Knowledge base
+### Not knowledge-base material
 
-Designs and reports index at the topic's phase conclusion under the
-`experiment` phase, with **standard decay** — no second golden class
-beside specs. A measurement describes the world at a commit; decay is
-correct behaviour. The append-only corrections discipline is a property
-of the file, independent of KB confidence.
-`correcting-historical-artifacts.md` stays spec-only.
+Experiments never enter the knowledge base — no indexing at any point,
+no removal scopes, no identity. Results take whatever shape the problem
+demands — tables, CSVs, images, JSON, zips, prose, any mix — and are
+consumed by the one consumer that exists: the spawning conversation,
+which digests them into its own artifact, and *that* artifact indexes
+when it concludes. Other sessions may read the files ad hoc; no
+machinery feeds experiments anywhere else — the gap analysis included.
+The append-only corrections discipline is a property of the report
+file. `correcting-historical-artifacts.md` stays spec-only.
+
+### Conclusion is per-experiment
+
+The experiment is the unit that concludes: the report is written, the
+verdict recorded, the record marked done, and the session routes back
+so the spawning phase can carry on with the results in hand. There is
+no ceremony above that — the topic's phase item is derived bookkeeping
+over the rows, never a thing the user closes. Nothing strands: every
+experiment locks its spawning conversation, and locks release only on
+terminal records, so all conversations concluded implies all
+experiments finished.
+
+### Availability
+
+The spawn is offered in research and discussion sessions — the work
+types that carry those phases (epic, feature, cross-cutting).
+Investigation and scoping never spawn; bugfix and quick-fix have no
+laboratory.
 
 ## What deliberately does not change
 
@@ -262,7 +283,11 @@ of the file, independent of KB confidence.
 - **`deferred` semantics** — untouched; the lock is a distinct state
   ("blocked pending evidence", never "parked by choice").
 - **Bugfix and quick-fix pipelines** — untouched.
-- **KB decay classes** — specs remain the only golden record.
+- **The knowledge base** — experiments never enter it; the store's
+  phases, decay classes, and golden-record rule are exactly what they
+  were.
+- **Gap analysis** — reads completed research and discussions, as
+  before; never experiments.
 - **No cost machinery** — anywhere, ever.
 - **The bridge** — phase-completion walls only; never a context
   carrier for spawns.
@@ -297,10 +322,10 @@ process substance carry forward; its routing, triage, and session-loop
 machinery does not):
 
 1. **PR1 — engine.** The surviving core (series records, verbs, locks,
-   register, gates, KB identity) plus: lock symmetry on research items,
+   register, approval gate) plus: lock symmetry on research items,
    sub-experiment ids, per-experiment menu entries, the review pass's
-   engine fixes, and the removal of routing/triage/lifecycle machinery
-   the model excludes. Simulation + suites.
+   engine fixes, and the removal of routing/triage/lifecycle/KB
+   machinery the model excludes. Simulation + suites.
 2. **PR2 — skills.** `workflow-experiment-entry` (per-record contract)
    and `workflow-experiment-process` (linear: initialize → design →
    briefing/freeze → run → report → verdict → bridge), authored fresh;
@@ -308,8 +333,8 @@ machinery does not):
 3. **PR3 — integration.** The spawn offer in research and discussion,
    the now-or-later exit, menu entries and recommendation ranking,
    re-entry evidence surfacing, release edges in the continue flows.
-4. **PR4 — cross-cutting.** KB wiring verification, absorption, docs
-   (full pass + experiments chapter), prose cases, CLAUDE.md/README.
+4. **PR4 — cross-cutting.** Absorption, docs (full pass + experiments
+   chapter), prose cases, CLAUDE.md/README.
 
 ## Implementation record — 2026-08-30 (superseded stack)
 
@@ -331,7 +356,9 @@ mid-session; the bridge is not the spawn's carrier; the menu is the
 router and the laboratory always begins fresh). The spawn became id +
 problem file + lock, recorded in the spawning session — design is the
 experiment phase's job (the laboratory model). Per-experiment menu
-entries. Research locks identically to discussion. The
+entries. Research locks identically to discussion — every spawn locks
+its spawning item, so a spawn at research's end pauses research rather
+than concluding around it; no lock-free path exists. The
 one-live-experiment-at-a-time rule deleted. Superseded machinery from
 the first stack: the `Spawned from:` handoff lines, the walk's
 spawn-await conditional, the session-loop spawned-arrival logic, both
@@ -356,3 +383,20 @@ this shape; the first stack's routing surfaces (three-way discovery
 routing, the first-phase gate's experiment arm, `x/experiment`,
 map-lifecycle routing legs, roadmap pull-forward widening) and its
 triage/off-topic machinery are superseded wholesale.
+
+## Amendment — 2026-08-31 (third): no knowledge base, conclusion per-experiment, sub-ids confirmed
+
+Owner rulings: experiments are torn out of the knowledge base entirely
+— no indexing at any point, no identity, no removal scopes; results
+take whatever shape the problem demands, the spawning conversation is
+their one consumer, and its own artifact is what indexes when it
+concludes; nothing else reads them mechanically, the gap analysis
+included. The experiment is the unit that concludes — report written,
+verdict recorded, route back; the topic's phase item is derived
+bookkeeping, never a user-closed thing, so the first stack's
+topic-level conclude gate, dead-end row, and conclude-time indexing are
+superseded. Sub-experiment ids (E{n}.{m}) confirmed — decomposition is
+the laboratory's prerogative, inside the one spawned experiment. The
+test footprint's KB bullets and the rebuild plan's KB scope were
+removed accordingly, and availability was made explicit: spawns exist
+in research and discussion sessions only.

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -3,8 +3,7 @@
 A tool used by research and discussion: controlled experiments against
 real systems or processes, designed before they are measured, producing
 dependable results that feed back into the conversation that asked for
-them. This is the design log. Opened 2026-08-30; model rewritten
-2026-08-31 to the corrected shape (see the amendments for the record).
+them. This is the design log. Opened 2026-08-30.
 
 ## Motivation
 
@@ -245,13 +244,13 @@ working files use the cache (`.workflows/.cache/{wu}/experiment/{topic}/`).
 
 ### Not knowledge-base material
 
-Experiments never enter the knowledge base — no indexing at any point,
-no removal scopes, no identity. Results take whatever shape the problem
-demands — tables, CSVs, images, JSON, zips, prose, any mix — and are
-consumed by the one consumer that exists: the spawning conversation,
-which digests them into its own artifact, and *that* artifact indexes
-when it concludes. Other sessions may read the files ad hoc; no
-machinery feeds experiments anywhere else — the gap analysis included.
+Experiments deliberately never enter the knowledge base. Results take
+whatever shape the problem demands — tables, CSVs, images, JSON, zips,
+prose, any mix — which no chunker serves well, and they have exactly
+one consumer: the spawning conversation, which digests them into its
+own artifact — and *that* artifact indexes when it concludes. Other
+sessions may read the files ad hoc; no machinery feeds experiments
+anywhere else — the gap analysis included.
 The append-only corrections discipline is a property of the report
 file. `correcting-historical-artifacts.md` stays spec-only.
 
@@ -275,19 +274,17 @@ laboratory.
 
 ## What deliberately does not change
 
-- **Triage** — untouched entirely, in every direction. The phase
-  borrows the *idea* of a queue, nothing of the machinery.
+- **Triage** — the phase has no contact with it in either direction;
+  it borrows the *idea* of a queue, nothing of the machinery.
 - **Discovery** — routes topics to research or discussion only;
   unaware the laboratory exists.
 - **No experiment→spec edge.** Specs source discussions only.
 - **`deferred` semantics** — untouched; the lock is a distinct state
   ("blocked pending evidence", never "parked by choice").
 - **Bugfix and quick-fix pipelines** — untouched.
-- **The knowledge base** — experiments never enter it; the store's
-  phases, decay classes, and golden-record rule are exactly what they
-  were.
-- **Gap analysis** — reads completed research and discussions, as
-  before; never experiments.
+- **The knowledge base** — experiments never enter it.
+- **Gap analysis** — reads completed research and discussions; never
+  experiments.
 - **No cost machinery** — anywhere, ever.
 - **The bridge** — phase-completion walls only; never a context
   carrier for spawns.
@@ -316,87 +313,19 @@ laboratory.
 
 ## Implementation plan
 
-PR0 is this document, standalone. Rebuilt as a fresh stack (the first
-stack, #1058–#1063, is closed and superseded — its engine core and
-process substance carry forward; its routing, triage, and session-loop
-machinery does not):
+PR0 is this document, standalone. The stack:
 
-1. **PR1 — engine.** The surviving core (series records, verbs, locks,
-   register, approval gate) plus: lock symmetry on research items,
-   sub-experiment ids, per-experiment menu entries, the review pass's
-   engine fixes, and the removal of routing/triage/lifecycle/KB
-   machinery the model excludes. Simulation + suites.
+1. **PR1 — engine.** Series records and the guarded container, the
+   verb family (`approve` its own verb — the freeze is never a step a
+   loop drifts past), locks symmetric across research and discussion,
+   sub-experiment ids, the register and approval-gate surfaces,
+   per-experiment menu entries. Simulation + suites.
 2. **PR2 — skills.** `workflow-experiment-entry` (per-record contract)
    and `workflow-experiment-process` (linear: initialize → design →
-   briefing/freeze → run → report → verdict → bridge), authored fresh;
-   templates, conduct, amendment protocol carried forward.
+   briefing/freeze → run → report → verdict → bridge); templates,
+   conduct, amendment protocol.
 3. **PR3 — integration.** The spawn offer in research and discussion,
    the now-or-later exit, menu entries and recommendation ranking,
    re-entry evidence surfacing, release edges in the continue flows.
 4. **PR4 — cross-cutting.** Absorption, docs (full pass + experiments
    chapter), prose cases, CLAUDE.md/README.
-
-## Implementation record — 2026-08-30 (superseded stack)
-
-Landed as stack #1060 off main: #1058 engine state → #1059 render
-surfaces → #1061 skills → #1062 integration prose → #1063
-cross-cutting + docs. The stack implemented the model as first written;
-the review pass and the owner walk that followed corrected the model
-(see the amendments), and the stack was closed in favour of the rebuild
-above. Decisions from it that stand: the keyed series records and
-guarded container, `approve` as its own verb, the KB identity shape
-with per-canonical-path replacement, no migration needed, and the
-engine fixes the review pass verified.
-
-## Amendment — 2026-08-31: the spawn seam rebuilt — menu-routed, problem-first, phase-symmetric
-
-The review pass exposed the mid-discussion exit as mis-designed. Direct
-invocation retired (nothing enters another phase's processing skill
-mid-session; the bridge is not the spawn's carrier; the menu is the
-router and the laboratory always begins fresh). The spawn became id +
-problem file + lock, recorded in the spawning session — design is the
-experiment phase's job (the laboratory model). Per-experiment menu
-entries. Research locks identically to discussion — every spawn locks
-its spawning item, so a spawn at research's end pauses research rather
-than concluding around it; no lock-free path exists. The
-one-live-experiment-at-a-time rule deleted. Superseded machinery from
-the first stack: the `Spawned from:` handoff lines, the walk's
-spawn-await conditional, the session-loop spawned-arrival logic, both
-direct `/workflow-experiment-entry` invocations.
-
-## Amendment — 2026-08-31 (second): the umbrella ruling — narrow remit, no routing, no loop
-
-The owner walk that followed settled the phase's nature: an addendum
-tool used by research and discussion, separated for context isolation
-as a scientific control — not a peer phase. Rulings: the remit is
-instructions in → design → perform → results → feed back, nothing
-else — no off-topic rerouting, no roadmap parks, no inbox capture, no
-session loop; triage is untouched in every direction (a measurable
-concern rerouted between topics lands in research or discussion, which
-decides whether to spawn); discovery never routes to experiment — the
-spawn is the phase's one door; splits are sub-experiments (E{n}.{m})
-under the spawned id, the lock never churning; execution shape is the
-orchestrator's empowered choice (direct, deterministic code doing the
-work, background shells and monitors, ad-hoc sub-agents — no custom
-workflow agents). The model sections above were rewritten in place to
-this shape; the first stack's routing surfaces (three-way discovery
-routing, the first-phase gate's experiment arm, `x/experiment`,
-map-lifecycle routing legs, roadmap pull-forward widening) and its
-triage/off-topic machinery are superseded wholesale.
-
-## Amendment — 2026-08-31 (third): no knowledge base, conclusion per-experiment, sub-ids confirmed
-
-Owner rulings: experiments are torn out of the knowledge base entirely
-— no indexing at any point, no identity, no removal scopes; results
-take whatever shape the problem demands, the spawning conversation is
-their one consumer, and its own artifact is what indexes when it
-concludes; nothing else reads them mechanically, the gap analysis
-included. The experiment is the unit that concludes — report written,
-verdict recorded, route back; the topic's phase item is derived
-bookkeeping, never a user-closed thing, so the first stack's
-topic-level conclude gate, dead-end row, and conclude-time indexing are
-superseded. Sub-experiment ids (E{n}.{m}) confirmed — decomposition is
-the laboratory's prerogative, inside the one spawned experiment. The
-test footprint's KB bullets and the rebuild plan's KB scope were
-removed accordingly, and availability was made explicit: spawns exist
-in research and discussion sessions only.

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -127,10 +127,12 @@ entered fresh.
 
 ### The menu is experiment-shaped
 
-Each queued or live experiment renders its own menu entry
-(`Enter E1 {slug} — {Topic} · experiment`), appearing at spawn and retiring
-at conclusion. Experiments rank above other recommendations; the pick
-stays the user's — working E1 then E2, or E1 then the half-unblocked
+On the epic dashboard each queued or live experiment renders its own
+menu entry (`Enter E1 {slug} — {Topic} · experiment`), appearing at
+spawn and retiring at conclusion; a linear work unit's menu surfaces
+the laboratory through its continue row, the record picked at entry.
+Experiments rank above other recommendations; the pick stays the
+user's — working E1 then E2, or E1 then the half-unblocked
 conversation, are both legitimate orders. Cancelling a
 no-longer-needed experiment releases its lock, and a phase whose locks
 have all released becomes the recommendation again.

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -442,3 +442,81 @@ at implementation time:
   front) and the frozen migrations. Prose walks not run pre-merge, per
   convention; four experiment cases authored and green on the
   deterministic perimeter.
+
+## Amendment — 2026-08-31: the spawn seam rebuilt — menu-routed, problem-first, phase-symmetric
+
+The review pass exposed the mid-discussion exit as mis-designed, and the
+walk of it with the owner replaced the seam wholesale. What follows
+supersedes the birth-route 3 language in The model, the exit description
+in The waiting state, and the implementation record's exit write-order
+bullet. The wait machinery, the experiment process itself (design →
+freeze → run → report → verdict), the register, and the release edges
+all stand.
+
+**Direct invocation is retired.** Nothing enters another phase's
+processing skill mid-session: the straight-through §J invoke and the
+research conclude-arm's direct invoke were wrong — a session deep
+enough to hit an empirical wall is the session closest to compaction,
+and a second phase's instruction set does not belong in it. The bridge
+is not the carrier either: it crosses phase walls at phase completion
+with a deliberately minimal template, and enrichment poisons it. The
+router is the menu (epic) or the work type's continue machinery, and
+the experiment phase always begins in fresh context.
+
+**The spawn, symmetric across research and discussion.** A measurable
+point surfacing mid-conversation is *offered*, never prescribed.
+Declined → ad-hoc inline measurement remains valid, and stays labelled
+exploratory. Accepted → the session records the spawn right there:
+
+1. `experiment create` allocates the id — E{n}, increment off the
+   manifest series — with a kebab slug derived from the problem.
+2. A **problem file** lands in the record's directory: the problem in
+   plain terms — what we need to pick or learn, the space around it,
+   what we hope — with a provenance line naming the phase, topic,
+   point, and date it was born from. **No design content.** The
+   spawning phase is the client at the laboratory door: it states the
+   problem and stops. Question refinement, prediction, decision rule,
+   setup — all of it is the experiment phase's job.
+3. The **lock**: `awaiting_experiments` gains E{n} on the spawning
+   phase's own item — research and discussion identically. `topic
+   complete` refuses on both while any lock is live; conclude, abandon,
+   and cancel release per-id and flag the owning item. Research is not
+   a special case: the lock means "this phase raised a question it
+   needs answered before it can honestly conclude", which applies to a
+   research record exactly as to a discussion.
+4. The choice: **go now** — the session pauses mid-phase and routes
+   back to the menu, closing ceremony skipped — or **later** — the
+   session continues, conclusion stays blocked, and it pauses at a
+   natural end the same way. Both roads end at the menu with the
+   experiment queued.
+
+**The menu is experiment-shaped.** Each queued or live experiment
+renders its own entry (`E1 {slug} — {Topic} · experiment`), appearing
+at spawn and retiring at conclusion; the register remains the topic's
+full history. Experiments rank above other recommendations; the pick
+stays the user's — working E1 then E2, or E1 then the half-unblocked
+discussion, are both legitimate orders, and cancelling a
+no-longer-needed E2 releases its lock and unblocks conclusion. Once a
+phase's locks all release, the paused phase becomes the recommendation.
+
+**Entry is per-experiment.** `workflow-experiment-entry` takes the
+record id — the session enters to deal with E1, the way a discussion is
+entered for a topic. Initialisation reads the problem file, then —
+provenance-driven — the spawning artifact **on disk, in full**: the
+source document is mid-flight, unconcluded and unindexed, so the
+knowledge base cannot serve it. Linked research, briefs, and seeds
+surface as before. Design is then authored collaboratively in-phase —
+the laboratory asking its own questions — and the walk from the
+briefing gate onward is unchanged.
+
+**Concurrency.** The one-live-experiment-at-a-time rule is deleted; the
+engine never had it. Any number of records in any states; a session
+works the experiment it entered for.
+
+**Superseded machinery** (built by the stack, removed by this
+amendment): the `Spawned from:` handoff lines, the walk's spawn-await
+conditional and its recorded-wait disambiguator, the session-loop
+spawned-arrival logic, and both direct `/workflow-experiment-entry`
+invocations (discussion §J, research conclude-arm — the arm survives as
+a spawn without a lock-free special case, concluding research clean
+with its experiments queued on the menu).

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -1,0 +1,395 @@
+# Experiment phase — measured evidence for decisions
+
+A new pipeline phase beside research and discussion: controlled
+experiments against real systems or processes, designed before they are
+measured, producing dependable results that feed decisions. This is the
+design log. Opened 2026-08-30.
+
+## Motivation
+
+### The incident this starts from
+
+During Fumi's space-homing research, window-placement behaviour was
+tested hands-on inside research sessions — no pre-stated question, no
+decision rule, no controlled setup. The numbers exist, but they were
+collected exploratorily, and now they carry decision-bearing weight
+they were never built for: the layouts covered are unclear, the rule
+that would settle the choice was never written, and the gaps are making
+the decision harder than the testing was. The counterfactual is exactly
+what this phase supplies: a thirty-second design (question, prediction,
+decision rule, setup) written and confirmed before the first
+measurement, then results that mean something against it.
+
+### The prior art
+
+Two bodies of practice were studied (2026-08-30) before this design:
+
+- **The dex experiment system** (`dex/business/experiments/`) — a
+  working small-scale lab: a register of experiments conceived-to-
+  verdict, a governing METHOD accreted from real failures, reports in
+  scientific-method order with pre-registered decision rules, a
+  research ledger and lab journal giving every decision a traceable
+  evidence chain. Its scars are the syllabus: rules changed after data
+  void the run (E9: "rules change → fresh run, never re-applied to
+  this data"); instruments freeze before measuring; a model never
+  marks a test the model cannot pass; controls are concurrent, never
+  historical; corrections are append-only and planned, never
+  reflexive.
+- **The external record** — pre-registration and registered reports
+  (the frozen Stage-1 plan, In-Principle Acceptance, graded deviation
+  routes, the amendment window closing at first result), ELN practice
+  (append-only records, deviations logged as they happen), ML
+  experiment tracking (the run as first-class record, named baselines,
+  the comparison as the deliverable), and industry experimentation
+  culture (pre-declared decision maps, "experiments do not fail —
+  hypotheses are proven wrong", execution-first triage of a disproven
+  hypothesis, one primary measure with few guardrails).
+
+Both converge on one temporal invariant: **the design exists before the
+data**. Everything else — decision rules, confirmatory/exploratory
+labels, amendment discipline — is that invariant applied to a
+different moment of the lifecycle.
+
+### The boundary with research
+
+Research is exploratory; experiment is confirmatory. Research still
+pokes at things hands-on — legitimate, and its numbers stay labelled
+as exploratory sightings. The moment a number is going to bear a
+decision, it graduates: an experiment item, a design (however light),
+then the measurement. The phase's value is turning "we poked at it and
+saw things" into "we planned it, measured it, and the rule we wrote
+beforehand says what it means".
+
+## The model
+
+### Placement
+
+A phase in the Discovery stage, beside research and discussion, for
+the research-bearing work types: **epic, feature, cross-cutting**.
+Pipeline position between research and discussion — research produces
+hypotheses, experiments prove or disprove them, discussions consume
+the evidence. Bugfix and quick-fix stay out: investigation is already
+the bugfix's empirical phase, and a bug that genuinely needs a
+controlled experiment is usually the signal it isn't a bugfix.
+
+### Experiments measure; discussions decide
+
+An experiment never decides. Its pre-registered decision rule executes
+in the report's conclusion ("rule said: adopt if all six layouts place
+correctly; layout 4 failed; not adopted"), but the record of the
+decision lives in the topic's discussion, which reads the report as
+seed material — like completed research — and can override the
+result. Specifications keep sourcing discussions only; there is no
+experiment→spec edge, for the same reason there is no research→spec
+edge. This keeps source gating, `incorporated`/`stale`, staleness
+hops, and cascade-cancel machinery uniform, and it means a report
+whose rules misfired (dex's E9) never flows into a spec as if its
+verdict were clean.
+
+### One process, scaling depth
+
+No light/heavy fork, no second tier. Every experiment answers the same
+skeleton before measuring — **question, prediction with its reason,
+decision rule, setup** — and only the length of the answers scales. A
+ten-minute local test writes four lines; a multi-day multi-arm run
+writes pages and adds the sections its shape calls for (staged
+smoke-then-full runs, variance repeats, controls declarations). The
+skill prompts for the heavier sections when the design's shape warrants
+them and not otherwise. The one thing that never scales down is the
+ordering: the skeleton is written and user-confirmed **before the
+first measurement**. That gate is the phase.
+
+### Framework, not content
+
+The workflows supply structure, gates, and logging discipline — as
+strict as the work needs. Measures are the design's own declarations:
+cost, latency, coverage, correctness — all equally declarable, none
+imposed. The workflows never track, cap, or mention cost themselves;
+that is the user's concern and the experiment's subject matter, never
+the framework's.
+
+### The series
+
+A topic holds a **series** of experiments, not one. Each experiment is
+a frozen design plus a report; a report's learnings seed the next
+design; the chain runs E1 → E2 → … like dex's register. Numbering is
+per-topic. The register — id, name, status, one-line verdict per row,
+abandoned rows kept with their reason — is a render surface off the
+manifest, never a hand-maintained file. The phase concludes when the
+user judges the question has enough evidence to feed the discussion —
+a conclude gate like research's, not an automatic "the last experiment
+finished".
+
+### Lifecycle of one experiment
+
+```
+conceived → designed → [briefing + user confirm] → approved → running
+                                                        → concluded | abandoned
+```
+
+- **Design** (`design.md`): question (one line, plus what decision it
+  feeds), hypothesis and prediction with the reason and expected
+  values where possible, the decision rule ("if X, we do A; if Y, B"),
+  setup (method, instruments and their versions, sample/layouts,
+  environment), declared controls and biases, and what the experiment
+  does **not** measure. Frozen at the confirm gate.
+- **Briefing**: before the confirm, the user gets the design in plain
+  terms — what we'll do, what we expect and why, what each outcome
+  triggers. The user's challenges are part of the method; changes fold
+  in before the freeze.
+- **Report** (`report.md`): results (every number traceable to a file
+  or a named source), reading (kept separate from measurement),
+  conclusion with the decision rule's verdict, reproduce notes, and a
+  dated append-only corrections section. Any measure conceived after
+  seeing data is labelled **exploratory** — it can motivate the next
+  experiment, never settle this one.
+- **Abandoned** is a first-class terminal: the row and its reason
+  persist in the register; any waiting discussion point is released
+  (see below).
+
+### Amendments and deviations
+
+Two temporal rules plus honest logging:
+
+1. **Before any results are visible**: the design can change — as a
+   dated, recorded amendment re-confirmed with the user, never a
+   silent edit.
+2. **Once results are visible**: the design is frozen permanently.
+   Flaws found after go in the report's corrections and trigger the
+   *next* experiment with the fixed design. Old data is never
+   re-scored under new rules.
+
+Execution deviations (harness broke, environment surprised) are logged
+in the report as they happen, so the record shows the run as it went.
+
+### Birth routes
+
+Three same-topic births, plus the existing cross-topic route:
+
+1. **Discovery curation** (epic): the routing question becomes "do we
+   answer this by reading, by talking, or by measuring?" — map items
+   gain `routing: experiment`.
+2. **Research conclusion**: the conclude flow asks whether anything
+   found needs measuring before it is discussion-worthy; a hypothesis
+   worth testing spawns the same-topic experiment item
+   (researching → experimenting → discussing).
+3. **Mid-discussion**: a point hits the empirical wall. The point
+   moves to a **waiting-on-experiment** state, the experiment item is
+   created, and the session exits straight into the experiment design
+   with context hot — the specification gap-exit precedent (pause
+   in-progress, route onward with the item named). The menu re-entry
+   path remains for when the user would rather break.
+4. **Cross-topic**, any session: a concern needing an experiment in
+   another topic rides the existing off-topic reroute/triage flow,
+   landing with reroute provenance. Nothing new.
+
+### The waiting state
+
+Waiting-on-experiment is distinct from `deferred`:
+
+- `deferred` stays *parked by choice* — a legitimate way to conclude
+  around a point.
+- waiting-on-experiment is *blocked pending evidence* — the decision
+  is live, the input isn't in. A discussion holding one **cannot
+  conclude**; the conclude gate refuses engine-side, like
+  `topic complete` refusing over `pending`/`stale` source rows.
+
+The gating chain then holds itself: the discussion can't conclude →
+spec entry's existing hard-block on open discussions keeps the spec
+shut → the experiment is load-bearing in the chain. When it concludes,
+discussion re-entry surfaces the report (reconcile-cue shape), the
+waiting point reopens with evidence, settles, and the chain unblocks.
+The epic dashboard cues it per-item ("discussing · awaiting E1").
+
+Release edges — a wait must never dangle:
+
+- **Experiment abandoned**: the point reverts to open, the
+  abandonment surfaced at re-entry with its reason; the discussion
+  settles another way or spawns the successor.
+- **Experiment cancelled from outside**: same release, and the cancel
+  confirm names the waiting discussion (softer than the spec-source
+  cascade — nothing collapses).
+
+### Artifacts and storage
+
+```
+.workflows/{wu}/experiment/{topic}/
+├── E1-window-placement/
+│   ├── design.md      frozen at the confirm gate
+│   ├── report.md      grows during/after the run; corrections append-only
+│   ├── data/          curated extracts the report cites
+│   └── …              harness scripts, fixtures — instruments live with the record
+├── E2-multi-monitor/
+```
+
+Harness code an experiment builds is instrument, not product code — it
+lives with the record, beside the design that froze it. Raw bulk
+output is kept by default (a report whose numbers can't be traced to
+files is the failure mode); genuinely bulky output may stay out of git
+with the report linking by path. Ephemeral working files use the
+existing cache (`.workflows/.cache/{wu}/experiment/{topic}/`) —
+machine-local, purged at work-unit close.
+
+### Knowledge base
+
+Reports index at the topic's phase conclusion like research and
+discussion, under a new `experiment` phase, with **standard decay** —
+no second golden class beside specs. A measurement describes the world
+at a commit; decay is correct behaviour. The append-only corrections
+discipline is a property of the file, independent of KB confidence.
+`correcting-historical-artifacts.md` stays spec-only.
+
+## What changes
+
+### 1. Engine — schema and state
+
+- `kernel/manifest-schema.cjs`: `WORK_TYPE_PIPELINES` gains
+  `experiment` between `research` and `discussion` for epic, feature,
+  cross-cutting; `VALID_ROUTINGS` gains `experiment`;
+  `VALID_PHASE_STATUSES.experiment` defined. Phase items keep the
+  unified per-topic structure; the series lives on the item (per-
+  experiment records: id, slug, status, verdict — exact field shape at
+  implementation).
+- `transitions.cjs`: `MAP_LIFECYCLE_PHASES` join (map lifecycle gains
+  `experimenting` / `evidence ready`); `flagDownstream` learns the
+  hop — a concluded/reopened experiment flags the same-topic
+  discussion; `topic complete` on a discussion refuses while any
+  waiting-on-experiment marker is live; experiment cancel/abandon
+  releases waits and names the waiting discussion in the refusal/
+  confirm payload.
+- `derivations.cjs`: `computeNextPhase` learns the slot — experiment
+  item present and unconcluded routes there; a discussion holding a
+  waiting point routes back out to the experiment.
+- Waiting marker: engine-owned field on the discussion item (written
+  by the exit flow, released by conclude/abandon/cancel), never
+  prose-tracked.
+- Presence, commit door (`--topic experiment/{topic}` layout scope),
+  cache layout, session labels: the new phase joins each existing
+  mechanism; no new machinery.
+
+### 2. Engine — render surfaces
+
+- Register render: the series table for a topic (id, name, status,
+  verdict; abandoned rows with reasons).
+- Design/confirm gate render (the briefing gate), conclude-gate
+  surface for the phase, epic dashboard rows and cues
+  ("experimenting", "discussing · awaiting E1"), soft-gate row
+  (unfinished experiments count upstream of discussion/spec), menu
+  entries in `workflow-continue-epic` and the bridge.
+- All menus engine-rendered per the standing rule — no prose menus.
+
+### 3. New skills
+
+- `workflow-experiment-entry`: phase entry — validation, new/resume/
+  reopen, invoked by discovery, `workflow-continue-*`, the bridge,
+  and the discussion exit.
+- `workflow-experiment-process`: the processing skill — design
+  conversation, briefing + confirm gate, run discipline, report
+  authoring, amendment protocol, series continuation, conclude gate.
+  References carry the conduct rules distilled from dex's METHOD and
+  the external record: design-before-data, instruments named and
+  frozen in the design, decision rules pre-registered, exploratory
+  labelling, deviations logged live, corrections append-only,
+  controls concurrent, mechanical scoring before close reading where
+  scoring exists. Durable phase inputs (seed, brief, completed
+  research) read at initialisation per the fetch-at-initialisation
+  rule.
+
+### 4. Discovery
+
+- Routing question widens to three answers; map operations accept the
+  new routing; lifecycle phrases and tags updated
+  (`discovery-map.cjs`, `derivations.cjs`, render projections).
+
+### 5. Research
+
+- Conclude flow gains the "needs measuring" arm: hypothesis worth
+  testing → same-topic experiment item created, confirmed with the
+  user.
+- Research prose names the boundary: hands-on sightings stay
+  exploratory and are labelled as such; decision-bearing measurement
+  graduates to the phase.
+
+### 6. Discussion
+
+- Waiting-on-experiment state (map + manifest marker), the
+  straight-through exit into experiment design, re-entry surfacing of
+  concluded/abandoned experiments (reconcile-advisory shape), conclude
+  gate refusal.
+
+### 7. Cross-cutting integration
+
+- Gap analysis (epics) reads completed experiment reports alongside
+  research and discussions.
+- Absorption allowlist gains the experiment directory and fields;
+  pivot inherits items as-is.
+- Epic topic cancel: experiment items follow topic cancellation like
+  research items; the wait-release edge rides the same transaction.
+- KB: `experiment` phase indexing at conclusion; `knowledge remove`
+  scopes.
+
+### 8. Migration
+
+Likely none — the phase is additive and absent nodes are tolerated;
+confirm at implementation, and add one only if a validator or
+projection requires the node to exist.
+
+### 9. Docs
+
+CLAUDE.md (phases, layout, conventions), README, CONVENTIONS.md only
+if a new authoring pattern emerges.
+
+## What deliberately does not change
+
+- **No experiment→spec edge.** Specs source discussions only.
+- **`deferred` semantics** — untouched; waiting is a new, distinct
+  state.
+- **Bugfix and quick-fix pipelines** — untouched; investigation keeps
+  its own empirical machinery.
+- **KB decay classes** — specs remain the only golden record.
+- **No cost machinery** — anywhere, ever. Cost is experiment content
+  when a design declares it, never framework.
+- **Triage/reroute** — the cross-topic carrier is the existing one.
+- **Spec-side coherence, staleness hops, cascade-cancel** — extended
+  to know the new phase, not reshaped.
+
+## Banked
+
+- **Per-project conduct accretion**: dex's METHOD accretes
+  project-specific scar rules over time. A per-project method addendum
+  the skill reads (linter/project-skills discovery shape) is plausible
+  but undesigned — bank until real usage shows the need.
+- **Exploratory-sighting labelling in research** beyond a prose rule
+  (e.g. a structured marker the experiment phase could query) — start
+  with prose, revisit.
+
+## Test footprint
+
+- Pipeline simulation: experiment mainline for epic and feature
+  (design → confirm → run → conclude → discussion reads report),
+  waiting-state permutations (conclude refusal, abandon release,
+  cancel release), series continuation, routing/lifecycle joins.
+- Engine suites: schema, transitions, derivations, render surfaces,
+  register/gate projections; goldens for new renders.
+- Prose cases: mid-discussion exit and return; research-conclusion
+  spawn; the confirm gate refusing measurement before the design;
+  amendment before results vs frozen after.
+- Docs lint / conventions suites as touched.
+
+## Implementation plan
+
+PR0 is this document, standalone. The stack:
+
+1. **PR1 — engine: schema + state.** Pipelines, routings, statuses,
+   series records, waiting marker, transitions (hops, refusals,
+   releases), `computeNextPhase`. Simulation + engine suites.
+2. **PR2 — engine: render surfaces.** Register, gates, dashboard
+   rows/cues, soft-gate row, menus. Goldens.
+3. **PR3 — skills.** `workflow-experiment-entry`,
+   `workflow-experiment-process` + references (templates, conduct,
+   amendment protocol).
+4. **PR4 — integration prose.** Discovery routing, research conclude
+   arm, discussion waiting/exit/re-entry, epic display + menu, bridge.
+5. **PR5 — cross-cutting + docs.** Gap analysis, absorption, cancel
+   edges, KB wiring, CLAUDE.md/README, prose cases, `select --diff`
+   sweep.

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -128,7 +128,8 @@ entered fresh.
 ### The menu routes at topic grain
 
 The laboratory appears on every menu the way any phase does: one row
-per topic with live experiments, in the standard continue form,
+per topic with live experiments, in the house verb-and-tail form —
+the row's own verb; the shape, not the verb, is what's standard —
 appearing at the first spawn and retiring when the series holds no
 live record. No phase is special in the skeleton — the row's route is
 the uniform entry contract, and which experiment to work is the

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -1,9 +1,10 @@
 # Experiment phase — measured evidence for decisions
 
-A new pipeline phase beside research and discussion: controlled
-experiments against real systems or processes, designed before they are
-measured, producing dependable results that feed decisions. This is the
-design log. Opened 2026-08-30.
+A tool used by research and discussion: controlled experiments against
+real systems or processes, designed before they are measured, producing
+dependable results that feed back into the conversation that asked for
+them. This is the design log. Opened 2026-08-30; model rewritten
+2026-08-31 to the corrected shape (see the amendments for the record).
 
 ## Motivation
 
@@ -15,9 +16,8 @@ decision rule, no controlled setup. The numbers exist, but they were
 collected exploratorily, and now they carry decision-bearing weight
 they were never built for: the layouts covered are unclear, the rule
 that would settle the choice was never written, and the gaps are making
-the decision harder than the testing was. The counterfactual is exactly
-what this phase supplies: a thirty-second design (question, prediction,
-decision rule, setup) written and confirmed before the first
+the decision harder than the testing was. The counterfactual is what
+this phase supplies: a design written and confirmed before the first
 measurement, then results that mean something against it.
 
 ### The prior art
@@ -27,496 +27,332 @@ Two bodies of practice were studied (2026-08-30) before this design:
 - **The dex experiment system** (`dex/business/experiments/`) — a
   working small-scale lab: a register of experiments conceived-to-
   verdict, a governing METHOD accreted from real failures, reports in
-  scientific-method order with pre-registered decision rules, a
-  research ledger and lab journal giving every decision a traceable
-  evidence chain. Its scars are the syllabus: rules changed after data
-  void the run (E9: "rules change → fresh run, never re-applied to
-  this data"); instruments freeze before measuring; a model never
-  marks a test the model cannot pass; controls are concurrent, never
-  historical; corrections are append-only and planned, never
-  reflexive.
+  scientific-method order with pre-registered decision rules. Its scars
+  are the syllabus: rules changed after data void the run; instruments
+  freeze before measuring; controls are concurrent, never historical;
+  corrections are append-only and planned, never reflexive. Its
+  execution pattern carries too: the agent writes deterministic code
+  and the code does the work — calls, parsing, measurement — with the
+  agent running and observing it, not assessing by feel.
 - **The external record** — pre-registration and registered reports
-  (the frozen Stage-1 plan, In-Principle Acceptance, graded deviation
-  routes, the amendment window closing at first result), ELN practice
-  (append-only records, deviations logged as they happen), ML
-  experiment tracking (the run as first-class record, named baselines,
-  the comparison as the deliverable), and industry experimentation
+  (the frozen plan, graded deviation routes, the amendment window
+  closing at first result), ELN practice (append-only records,
+  deviations logged as they happen), ML experiment tracking (the run as
+  first-class record, named baselines), and industry experimentation
   culture (pre-declared decision maps, "experiments do not fail —
-  hypotheses are proven wrong", execution-first triage of a disproven
-  hypothesis, one primary measure with few guardrails).
+  hypotheses are proven wrong", one primary measure).
 
 Both converge on one temporal invariant: **the design exists before the
-data**. Everything else — decision rules, confirmatory/exploratory
-labels, amendment discipline — is that invariant applied to a
-different moment of the lifecycle.
-
-### The boundary with research
-
-Research is exploratory; experiment is confirmatory. Research still
-pokes at things hands-on — legitimate, and its numbers stay labelled
-as exploratory sightings. The moment a number is going to bear a
-decision, it graduates: an experiment item, a design (however light),
-then the measurement. The phase's value is turning "we poked at it and
-saw things" into "we planned it, measured it, and the rule we wrote
-beforehand says what it means".
+data**. Everything else is that invariant applied to a different moment
+of the lifecycle.
 
 ## The model
 
-### Placement
+### An addendum, not a peer phase
 
-A phase in the Discovery stage, beside research and discussion, for
-the research-bearing work types: **epic, feature, cross-cutting**.
-Pipeline position between research and discussion — research produces
-hypotheses, experiments prove or disprove them, discussions consume
-the evidence. Bugfix and quick-fix stay out: investigation is already
-the bugfix's empirical phase, and a bug that genuinely needs a
-controlled experiment is usually the signal it isn't a bugfix.
+Experiment is not a stage of the pipeline the way specification or
+planning are. It is an **umbrella tool that research and discussion
+use**: a conversation hits a question that talking cannot settle, and
+hands it to the laboratory. The phase machinery — its own entry, its
+own skill, bridge-routed transitions — exists for one reason: **context
+isolation as a scientific control**. An experiment run inside the
+conversation that spawned it would know what the conversation hopes
+for, and that biases the result; a session deep enough to hit an
+empirical wall is also the session closest to compaction. So the
+laboratory always begins in fresh context, knowing the problem but not
+the hopes, and the conversation's context is never polluted with a
+second phase's instructions.
 
-### Experiments measure; discussions decide
+Consequences, all deliberate:
 
-An experiment never decides. Its pre-registered decision rule executes
-in the report's conclusion ("rule said: adopt if all six layouts place
-correctly; layout 4 failed; not adopted"), but the record of the
-decision lives in the topic's discussion, which reads the report as
-seed material — like completed research — and can override the
-result. Specifications keep sourcing discussions only; there is no
-experiment→spec edge, for the same reason there is no research→spec
-edge. This keeps source gating, `incorporated`/`stale`, staleness
-hops, and cascade-cancel machinery uniform, and it means a report
-whose rules misfired (dex's E9) never flows into a spec as if its
-verdict were clean.
+- **Experiments are never a topic's first phase.** Discovery routes
+  every topic to research or discussion — a topic cannot be born
+  measurement-first, because at discovery nothing is shaped enough to
+  warrant an experiment. The only door into the phase is the spawn.
+- **The remit is narrow.** Instructions in → design (collaborative) →
+  perform → results recorded → verdict fed back. Nothing else: no
+  off-topic rerouting, no roadmap parks, no inbox capture, no triage
+  queues, no session loop. A stray thought mid-experiment is out of
+  remit; the spawning conversation owns everything that is not this
+  experiment. Triage in particular is untouched by this phase in every
+  direction — concerns never land in an experiment, and an experiment
+  never reroutes one. A concern that *feels* measurable still lands in
+  the target topic's research or discussion; that conversation decides
+  whether to spawn.
+- **Narrow does not mean small.** An experiment can run for hours or
+  days, spin background processes, and produce substantial artifacts.
+  The scope is narrow; the work inside it is not.
 
-### One process, scaling depth
+### Exploratory and confirmatory
 
-No light/heavy fork, no second tier. Every experiment answers the same
-skeleton before measuring — **question, prediction with its reason,
-decision rule, setup** — and only the length of the answers scales. A
-ten-minute local test writes four lines; a multi-day multi-arm run
-writes pages and adds the sections its shape calls for (staged
-smoke-then-full runs, variance repeats, controls declarations). The
-skill prompts for the heavier sections when the design's shape warrants
-them and not otherwise. The one thing that never scales down is the
-ordering: the skeleton is written and user-confirmed **before the
-first measurement**. That gate is the phase.
+Research and discussion still poke at things hands-on — legitimate, and
+those sightings stay labelled exploratory. The moment a number is going
+to bear a decision, the sessions **offer** the experiment — never
+prescribe it. Declining is always valid: an ad-hoc inline measurement,
+no ceremony, remains part of the conversation. Accepting graduates the
+question to the laboratory, where the design-before-data invariant
+takes over.
+
+### The spawn — the phase's one door
+
+Mid-conversation in research or discussion, a measurable point is
+offered. On yes, the session records the spawn right there, while the
+conversation still holds the knowledge:
+
+1. **The id.** `experiment create` allocates E{n} — increment off the
+   manifest series — with a kebab slug derived from the problem.
+2. **The problem file**, in the record's directory: the problem in
+   plain terms — what we need to pick or learn, the space around it,
+   what we hope — with a provenance line naming the phase, topic,
+   point, and date it was born from. **No design content.** The
+   spawning phase is the client at the laboratory door: it states the
+   problem and stops. Question refinement, prediction, decision rule,
+   setup — all the laboratory's job. The client is not expected to
+   speak the laboratory's language.
+3. **The lock.** `awaiting_experiments` gains E{n} on the spawning
+   phase's own item — research and discussion identically. A locked
+   phase cannot conclude (`topic complete` refuses engine-side); the
+   lock means "this phase raised a question it needs answered before it
+   can honestly conclude", and that applies to a research record
+   exactly as to a discussion.
+4. **The choice**: go now — the session pauses mid-phase and routes
+   back to the menu, closing ceremony skipped — or later — the session
+   continues, conclusion stays blocked, and it pauses at a natural end
+   the same way. Both roads end at the menu with the experiment queued.
+
+Nothing enters another phase's processing skill mid-session, and the
+bridge is not the spawn's carrier either — it crosses phase walls at
+phase completion with a deliberately minimal template. The **menu is
+the router**: the spawning session ends its turn; the laboratory is
+entered fresh.
+
+### The menu is experiment-shaped
+
+Each queued or live experiment renders its own menu entry
+(`E1 {slug} — {Topic} · experiment`), appearing at spawn and retiring
+at conclusion. Experiments rank above other recommendations; the pick
+stays the user's — working E1 then E2, or E1 then the half-unblocked
+conversation, are both legitimate orders. Cancelling a
+no-longer-needed experiment releases its lock, and a phase whose locks
+have all released becomes the recommendation again.
+
+### Entry is per-experiment
+
+`workflow-experiment-entry` takes the record id — the session enters to
+deal with E1, the way a discussion is entered for a topic.
+Initialisation reads the problem file, then — provenance-driven — the
+spawning artifact **on disk, in full**: the source document is
+mid-flight, unconcluded and unindexed, so the knowledge base cannot
+serve it. Linked research, briefs, and seeds surface as usual. Then the
+laboratory designs, collaboratively — asking the user its own
+questions, reading whatever else it needs.
+
+### The lifecycle of one experiment
+
+```
+conceived (the spawn) → designed → approved (the freeze) → running
+                                          → concluded | abandoned
+```
+
+- **Design** (`design.md`): question, hypothesis and prediction with
+  the reason and expected values where possible, the decision rule
+  ("if X, we do A; if Y, B" — executable by a third party), setup
+  (method, instruments and their versions, sample, environment), plus
+  controls-and-biases and what-this-does-not-measure sections when the
+  shape warrants them (stochastic outputs, destructive operations,
+  multi-arm comparisons). Depth scales; ceremony doesn't fork. One
+  primary question — a second primary question is a split.
+- **The briefing**: the design presented in plain terms — what we'll
+  do, what we expect and why, what each outcome triggers — and the
+  user's confirm freezes it. From the freeze, changes happen only
+  through the amendment protocol: dated amendments re-confirmed before
+  results are visible; frozen permanently after. Old data is never
+  re-scored under new rules.
+- **The run**: mostly autonomous, by design — the collaboration was
+  front-loaded into the design. The orchestrating session is empowered
+  to choose the execution shape that produces the most dependable
+  results: doing it directly, writing deterministic code that does the
+  work while the agent runs and observes it, background shells with
+  monitors, or ad-hoc sub-agents. No custom workflow agents exist for
+  the phase; the shape of the experiment follows the shape of the
+  problem, proposed at design time. Deviations are logged as they
+  happen.
+- **The report** (`report.md`): results (every number traceable to a
+  file in the record's directory or a named source), reading kept
+  separate from measurement, the conclusion executing the
+  pre-registered rule, reproduce notes, corrections append-only and
+  dated. A measure conceived after seeing data is labelled
+  exploratory — it can motivate a successor, never settle this run.
+- **Abandoned** is a first-class terminal: the row and its reason
+  persist; the lock releases.
+
+### Splits
+
+A running experiment may discover its question decomposes. That is the
+laboratory's internal method, and it never leaks back into the spawning
+phase's state: the parts become **sub-experiments** — E1.1, E1.2 — each
+walking design → freeze → run → report in miniature, with E1's verdict
+synthesising them. The lock stays on E1 and releases once, when E1 as a
+whole concludes.
+
+### The return leg
+
+An experiment concludes with its one-line verdict and routes back via
+the bridge to the menu. The lock releases and flags the spawning item;
+the paused conversation becomes the recommendation once unblocked, and
+its re-entry surfaces the evidence — the register, the reports read in
+full — before the waiting point settles. **Experiments measure;
+conversations decide.** The verdict is the rule's mechanical outcome,
+and the discussion that reads it can override it. Specs keep sourcing
+discussions only; there is no experiment→spec edge.
+
+An abandonment surfaces the same way, with its reason, and the waiting
+point reverts to open — the conversation settles it another way or
+spawns a successor.
+
+### The series and the register
+
+A topic accumulates a series — every experiment its conversations ever
+spawned, E1 → E2 → …, numbered per-topic off the manifest. The register
+(id, slug, status, verdict or reason per row; abandoned rows kept) is a
+render surface off the manifest, never a hand-maintained file, and is
+the topic's full measurement history.
 
 ### Framework, not content
 
-The workflows supply structure, gates, and logging discipline — as
-strict as the work needs. Measures are the design's own declarations:
-cost, latency, coverage, correctness — all equally declarable, none
-imposed. The workflows never track, cap, or mention cost themselves;
-that is the user's concern and the experiment's subject matter, never
-the framework's.
-
-### The series
-
-A topic holds a **series** of experiments, not one. Each experiment is
-a frozen design plus a report; a report's learnings seed the next
-design; the chain runs E1 → E2 → … like dex's register. Numbering is
-per-topic. The register — id, name, status, one-line verdict per row,
-abandoned rows kept with their reason — is a render surface off the
-manifest, never a hand-maintained file. The phase concludes when the
-user judges the question has enough evidence to feed the discussion —
-a conclude gate like research's, not an automatic "the last experiment
-finished".
-
-### Lifecycle of one experiment
-
-```
-conceived → designed → [briefing + user confirm] → approved → running
-                                                        → concluded | abandoned
-```
-
-- **Design** (`design.md`): question (one line, plus what decision it
-  feeds), hypothesis and prediction with the reason and expected
-  values where possible, the decision rule ("if X, we do A; if Y, B"),
-  setup (method, instruments and their versions, sample/layouts,
-  environment), declared controls and biases, and what the experiment
-  does **not** measure. Frozen at the confirm gate.
-- **Briefing**: before the confirm, the user gets the design in plain
-  terms — what we'll do, what we expect and why, what each outcome
-  triggers. The user's challenges are part of the method; changes fold
-  in before the freeze.
-- **Report** (`report.md`): results (every number traceable to a file
-  or a named source), reading (kept separate from measurement),
-  conclusion with the decision rule's verdict, reproduce notes, and a
-  dated append-only corrections section. Any measure conceived after
-  seeing data is labelled **exploratory** — it can motivate the next
-  experiment, never settle this one.
-- **Abandoned** is a first-class terminal: the row and its reason
-  persist in the register; any waiting discussion point is released
-  (see below).
-
-### Amendments and deviations
-
-Two temporal rules plus honest logging:
-
-1. **Before any results are visible**: the design can change — as a
-   dated, recorded amendment re-confirmed with the user, never a
-   silent edit.
-2. **Once results are visible**: the design is frozen permanently.
-   Flaws found after go in the report's corrections and trigger the
-   *next* experiment with the fixed design. Old data is never
-   re-scored under new rules.
-
-Execution deviations (harness broke, environment surprised) are logged
-in the report as they happen, so the record shows the run as it went.
-
-### Birth routes
-
-Three same-topic births, plus the existing cross-topic route:
-
-1. **Discovery curation** (epic): the routing question becomes "do we
-   answer this by reading, by talking, or by measuring?" — map items
-   gain `routing: experiment`.
-2. **Research conclusion**: the conclude flow asks whether anything
-   found needs measuring before it is discussion-worthy; a hypothesis
-   worth testing spawns the same-topic experiment item
-   (researching → experimenting → discussing).
-3. **Mid-discussion**: a point hits the empirical wall. The point
-   moves to a **waiting-on-experiment** state, the experiment item is
-   created, and the session exits straight into the experiment design
-   with context hot — the specification gap-exit precedent (pause
-   in-progress, route onward with the item named). The menu re-entry
-   path remains for when the user would rather break.
-4. **Cross-topic**, any session: a concern needing an experiment in
-   another topic rides the existing off-topic reroute/triage flow,
-   landing with reroute provenance. Nothing new.
-
-### The waiting state
-
-Waiting-on-experiment is distinct from `deferred`:
-
-- `deferred` stays *parked by choice* — a legitimate way to conclude
-  around a point.
-- waiting-on-experiment is *blocked pending evidence* — the decision
-  is live, the input isn't in. A discussion holding one **cannot
-  conclude**; the conclude gate refuses engine-side, like
-  `topic complete` refusing over `pending`/`stale` source rows.
-
-The gating chain then holds itself: the discussion can't conclude →
-spec entry's existing hard-block on open discussions keeps the spec
-shut → the experiment is load-bearing in the chain. When it concludes,
-discussion re-entry surfaces the report (reconcile-cue shape), the
-waiting point reopens with evidence, settles, and the chain unblocks.
-The epic dashboard cues it per-item ("discussing · awaiting E1").
-
-Release edges — a wait must never dangle:
-
-- **Experiment abandoned**: the point reverts to open, the
-  abandonment surfaced at re-entry with its reason; the discussion
-  settles another way or spawns the successor.
-- **Experiment cancelled from outside**: same release, and the cancel
-  confirm names the waiting discussion (softer than the spec-source
-  cascade — nothing collapses).
+The workflows supply structure, gates, and logging discipline. Measures
+are the design's own declarations — the framework never imposes,
+tracks, or mentions cost; that is the user's concern and, where
+declared, the experiment's subject matter.
 
 ### Artifacts and storage
 
 ```
 .workflows/{wu}/experiment/{topic}/
 ├── E1-window-placement/
+│   ├── problem.md     the spawn's problem statement + provenance
 │   ├── design.md      frozen at the confirm gate
 │   ├── report.md      grows during/after the run; corrections append-only
 │   ├── data/          curated extracts the report cites
-│   └── …              harness scripts, fixtures — instruments live with the record
+│   └── …              instruments live with the record
 ├── E2-multi-monitor/
 ```
 
 Harness code an experiment builds is instrument, not product code — it
-lives with the record, beside the design that froze it. Raw bulk
-output is kept by default (a report whose numbers can't be traced to
-files is the failure mode); genuinely bulky output may stay out of git
-with the report linking by path. Ephemeral working files use the
-existing cache (`.workflows/.cache/{wu}/experiment/{topic}/`) —
-machine-local, purged at work-unit close.
+lives with the record. Raw output is kept by default; genuinely bulky
+output may stay out of git with the report linking by path. Ephemeral
+working files use the cache (`.workflows/.cache/{wu}/experiment/{topic}/`).
 
 ### Knowledge base
 
-Reports index at the topic's phase conclusion like research and
-discussion, under a new `experiment` phase, with **standard decay** —
-no second golden class beside specs. A measurement describes the world
-at a commit; decay is correct behaviour. The append-only corrections
-discipline is a property of the file, independent of KB confidence.
+Designs and reports index at the topic's phase conclusion under the
+`experiment` phase, with **standard decay** — no second golden class
+beside specs. A measurement describes the world at a commit; decay is
+correct behaviour. The append-only corrections discipline is a property
+of the file, independent of KB confidence.
 `correcting-historical-artifacts.md` stays spec-only.
-
-## What changes
-
-### 1. Engine — schema and state
-
-- `kernel/manifest-schema.cjs`: `WORK_TYPE_PIPELINES` gains
-  `experiment` between `research` and `discussion` for epic, feature,
-  cross-cutting; `VALID_ROUTINGS` gains `experiment`;
-  `VALID_PHASE_STATUSES.experiment` defined. Phase items keep the
-  unified per-topic structure; the series lives on the item (per-
-  experiment records: id, slug, status, verdict — exact field shape at
-  implementation).
-- `transitions.cjs`: `MAP_LIFECYCLE_PHASES` join (map lifecycle gains
-  `experimenting` / `evidence ready`); `flagDownstream` learns the
-  hop — a concluded/reopened experiment flags the same-topic
-  discussion; `topic complete` on a discussion refuses while any
-  waiting-on-experiment marker is live; experiment cancel/abandon
-  releases waits and names the waiting discussion in the refusal/
-  confirm payload.
-- `derivations.cjs`: `computeNextPhase` learns the slot — experiment
-  item present and unconcluded routes there; a discussion holding a
-  waiting point routes back out to the experiment.
-- Waiting marker: engine-owned field on the discussion item (written
-  by the exit flow, released by conclude/abandon/cancel), never
-  prose-tracked.
-- Presence, commit door (`--topic experiment/{topic}` layout scope),
-  cache layout, session labels: the new phase joins each existing
-  mechanism; no new machinery.
-
-### 2. Engine — render surfaces
-
-- Register render: the series table for a topic (id, name, status,
-  verdict; abandoned rows with reasons).
-- Design/confirm gate render (the briefing gate), conclude-gate
-  surface for the phase, epic dashboard rows and cues
-  ("experimenting", "discussing · awaiting E1"), soft-gate row
-  (unfinished experiments count upstream of discussion/spec), menu
-  entries in `workflow-continue-epic` and the bridge.
-- All menus engine-rendered per the standing rule — no prose menus.
-
-### 3. New skills
-
-- `workflow-experiment-entry`: phase entry — validation, new/resume/
-  reopen, invoked by discovery, `workflow-continue-*`, the bridge,
-  and the discussion exit.
-- `workflow-experiment-process`: the processing skill — design
-  conversation, briefing + confirm gate, run discipline, report
-  authoring, amendment protocol, series continuation, conclude gate.
-  References carry the conduct rules distilled from dex's METHOD and
-  the external record: design-before-data, instruments named and
-  frozen in the design, decision rules pre-registered, exploratory
-  labelling, deviations logged live, corrections append-only,
-  controls concurrent, mechanical scoring before close reading where
-  scoring exists. Durable phase inputs (seed, brief, completed
-  research) read at initialisation per the fetch-at-initialisation
-  rule.
-
-### 4. Discovery
-
-- Routing question widens to three answers; map operations accept the
-  new routing; lifecycle phrases and tags updated
-  (`discovery-map.cjs`, `derivations.cjs`, render projections).
-
-### 5. Research
-
-- Conclude flow gains the "needs measuring" arm: hypothesis worth
-  testing → same-topic experiment item created, confirmed with the
-  user.
-- Research prose names the boundary: hands-on sightings stay
-  exploratory and are labelled as such; decision-bearing measurement
-  graduates to the phase.
-
-### 6. Discussion
-
-- Waiting-on-experiment state (map + manifest marker), the
-  straight-through exit into experiment design, re-entry surfacing of
-  concluded/abandoned experiments (reconcile-advisory shape), conclude
-  gate refusal.
-
-### 7. Cross-cutting integration
-
-- Gap analysis (epics) reads completed experiment reports alongside
-  research and discussions.
-- Absorption allowlist gains the experiment directory and fields;
-  pivot inherits items as-is.
-- Epic topic cancel: experiment items follow topic cancellation like
-  research items; the wait-release edge rides the same transaction.
-- KB: `experiment` phase indexing at conclusion; `knowledge remove`
-  scopes.
-
-### 8. Migration
-
-Likely none — the phase is additive and absent nodes are tolerated;
-confirm at implementation, and add one only if a validator or
-projection requires the node to exist.
-
-### 9. Docs
-
-CLAUDE.md (phases, layout, conventions), README, CONVENTIONS.md only
-if a new authoring pattern emerges.
 
 ## What deliberately does not change
 
+- **Triage** — untouched entirely, in every direction. The phase
+  borrows the *idea* of a queue, nothing of the machinery.
+- **Discovery** — routes topics to research or discussion only;
+  unaware the laboratory exists.
 - **No experiment→spec edge.** Specs source discussions only.
-- **`deferred` semantics** — untouched; waiting is a new, distinct
-  state.
-- **Bugfix and quick-fix pipelines** — untouched; investigation keeps
-  its own empirical machinery.
+- **`deferred` semantics** — untouched; the lock is a distinct state
+  ("blocked pending evidence", never "parked by choice").
+- **Bugfix and quick-fix pipelines** — untouched.
 - **KB decay classes** — specs remain the only golden record.
-- **No cost machinery** — anywhere, ever. Cost is experiment content
-  when a design declares it, never framework.
-- **Triage/reroute** — the cross-topic carrier is the existing one.
-- **Spec-side coherence, staleness hops, cascade-cancel** — extended
-  to know the new phase, not reshaped.
+- **No cost machinery** — anywhere, ever.
+- **The bridge** — phase-completion walls only; never a context
+  carrier for spawns.
 
 ## Banked
 
-- **Per-project conduct accretion**: dex's METHOD accretes
-  project-specific scar rules over time. A per-project method addendum
-  the skill reads (linter/project-skills discovery shape) is plausible
-  but undesigned — bank until real usage shows the need.
-- **Exploratory-sighting labelling in research** beyond a prose rule
-  (e.g. a structured marker the experiment phase could query) — start
-  with prose, revisit.
+- **Per-project conduct accretion**: a per-project method addendum the
+  skill reads (linter-discovery shape) — bank until real usage shows
+  the need.
+- **A document-review analogue at series conclusion** — deliberately
+  absent ahead of evidence from real usage.
 
 ## Test footprint
 
-- Pipeline simulation: experiment mainline for epic and feature
-  (design → confirm → run → conclude → discussion reads report),
-  waiting-state permutations (conclude refusal, abandon release,
-  cancel release), series continuation, routing/lifecycle joins.
+- Pipeline simulation: the spawn (create + problem + lock) from both
+  research and discussion, now-and-later exits, per-experiment menu
+  entries, the walk to verdict, release/flag edges, abandonment and
+  cancellation releases, splits, series continuation, reopen.
 - Engine suites: schema, transitions, derivations, render surfaces,
-  register/gate projections; goldens for new renders.
-- Prose cases: mid-discussion exit and return; research-conclusion
-  spawn; the confirm gate refusing measurement before the design;
-  amendment before results vs frozen after.
-- Docs lint / conventions suites as touched.
+  register/gate projections, lock symmetry.
+- Prose cases: the spawn-and-return round trip for each phase, the
+  freeze, the amendment boundary (before results vs after), the
+  abandonment return.
+- Full `docs/` pass, including the experiments chapter, once the
+  implementation lands.
 
 ## Implementation plan
 
-PR0 is this document, standalone. The stack:
+PR0 is this document, standalone. Rebuilt as a fresh stack (the first
+stack, #1058–#1063, is closed and superseded — its engine core and
+process substance carry forward; its routing, triage, and session-loop
+machinery does not):
 
-1. **PR1 — engine: schema + state.** Pipelines, routings, statuses,
-   series records, waiting marker, transitions (hops, refusals,
-   releases), `computeNextPhase`. Simulation + engine suites.
-2. **PR2 — engine: render surfaces.** Register, gates, dashboard
-   rows/cues, soft-gate row, menus. Goldens.
-3. **PR3 — skills.** `workflow-experiment-entry`,
-   `workflow-experiment-process` + references (templates, conduct,
-   amendment protocol).
-4. **PR4 — integration prose.** Discovery routing, research conclude
-   arm, discussion waiting/exit/re-entry, epic display + menu, bridge.
-5. **PR5 — cross-cutting + docs.** Gap analysis, absorption, cancel
-   edges, KB wiring, CLAUDE.md/README, prose cases, `select --diff`
-   sweep.
+1. **PR1 — engine.** The surviving core (series records, verbs, locks,
+   register, gates, KB identity) plus: lock symmetry on research items,
+   sub-experiment ids, per-experiment menu entries, the review pass's
+   engine fixes, and the removal of routing/triage/lifecycle machinery
+   the model excludes. Simulation + suites.
+2. **PR2 — skills.** `workflow-experiment-entry` (per-record contract)
+   and `workflow-experiment-process` (linear: initialize → design →
+   briefing/freeze → run → report → verdict → bridge), authored fresh;
+   templates, conduct, amendment protocol carried forward.
+3. **PR3 — integration.** The spawn offer in research and discussion,
+   the now-or-later exit, menu entries and recommendation ranking,
+   re-entry evidence surfacing, release edges in the continue flows.
+4. **PR4 — cross-cutting.** KB wiring verification, absorption, docs
+   (full pass + experiments chapter), prose cases, CLAUDE.md/README.
 
-## Implementation record — 2026-08-30
+## Implementation record — 2026-08-30 (superseded stack)
 
-Landed as stack #1060 off main (this design PR stays standalone):
-#1058 engine state → #1059 render surfaces → #1061 skills →
-#1062 integration prose → #1063 cross-cutting + docs. Decisions made
-at implementation time:
-
-- **Series records** are a keyed map (`experiments.{E{n}}: {slug,
-  status[, verdict][, reason]}`, spec-sources precedent), guarded
-  container on the field surface; ids per-topic, order derived from the
-  id. `approve` is its own verb — the briefing freeze is never a step
-  `advance` drifts past.
-- **The wait** is `awaiting_experiments` on the same-topic discussion
-  item. Conclude/abandon release it and set `reconcile_needed:
-  "experiment"` (existing flag never clobbered); a bare `topic cancel`
-  on an awaited experiment refuses naming the waiting discussion,
-  `--cascade` cancels and releases in one transaction. `topic complete`
-  on the experiment phase refuses while any row is unfinished — no wait
-  can outlive the phase.
-- **`flagDownstream` walks past phases the topic never entered**,
-  flagging the nearest downstream item — inserting an optional phase
-  must not sever the research→discussion hop.
-- **The mid-discussion exit's write order**: doc note + discussion
-  commit → straight-through entry invocation carrying the spawning
-  point → the walk's first conceive runs `create` → `await` → one
-  commit. The unrecorded-wait window is one tool call wide and the
-  pre-await crash state is benign (open point, conclusion blocked by
-  the unresolved subtopic).
-- **Research's arm concludes fully first** (completed, indexed,
-  committed), then routes into the experiment entry — the evidence
-  trail is never truncated by the route.
-- **Amendment re-confirm is a conversational ask** (no enumerated
-  options), not an engine surface; a dedicated surface is banked until
-  usage argues for it. Likewise a document-review analogue at series
-  conclusion — deliberately absent ahead of evidence.
-- **KB identity**: both record files share the topic's identity;
-  replacement is keyed per canonical source path, not per identity
-  (indexing a report must not wipe its design's chunks). Confidence
-  medium, investigation's sibling.
-- **Adopted along the way** under the touch-adopts-menus rule:
-  the quick-fix complexity promotion menu (`complexity-gate`) and the
-  feature/cross-cutting first-phase choice (`first-phase-gate`) became
-  engine surfaces; the map header renamed `DISCOVERY MAP`.
-- **Deliberately still two-way**: the requeue pair (no flow produces an
-  experiment requeue; the widened landing judgment aims concerns up
-  front) and the frozen migrations. Prose walks not run pre-merge, per
-  convention; four experiment cases authored and green on the
-  deterministic perimeter.
+Landed as stack #1060 off main: #1058 engine state → #1059 render
+surfaces → #1061 skills → #1062 integration prose → #1063
+cross-cutting + docs. The stack implemented the model as first written;
+the review pass and the owner walk that followed corrected the model
+(see the amendments), and the stack was closed in favour of the rebuild
+above. Decisions from it that stand: the keyed series records and
+guarded container, `approve` as its own verb, the KB identity shape
+with per-canonical-path replacement, no migration needed, and the
+engine fixes the review pass verified.
 
 ## Amendment — 2026-08-31: the spawn seam rebuilt — menu-routed, problem-first, phase-symmetric
 
-The review pass exposed the mid-discussion exit as mis-designed, and the
-walk of it with the owner replaced the seam wholesale. What follows
-supersedes the birth-route 3 language in The model, the exit description
-in The waiting state, and the implementation record's exit write-order
-bullet. The wait machinery, the experiment process itself (design →
-freeze → run → report → verdict), the register, and the release edges
-all stand.
+The review pass exposed the mid-discussion exit as mis-designed. Direct
+invocation retired (nothing enters another phase's processing skill
+mid-session; the bridge is not the spawn's carrier; the menu is the
+router and the laboratory always begins fresh). The spawn became id +
+problem file + lock, recorded in the spawning session — design is the
+experiment phase's job (the laboratory model). Per-experiment menu
+entries. Research locks identically to discussion. The
+one-live-experiment-at-a-time rule deleted. Superseded machinery from
+the first stack: the `Spawned from:` handoff lines, the walk's
+spawn-await conditional, the session-loop spawned-arrival logic, both
+direct `/workflow-experiment-entry` invocations.
 
-**Direct invocation is retired.** Nothing enters another phase's
-processing skill mid-session: the straight-through §J invoke and the
-research conclude-arm's direct invoke were wrong — a session deep
-enough to hit an empirical wall is the session closest to compaction,
-and a second phase's instruction set does not belong in it. The bridge
-is not the carrier either: it crosses phase walls at phase completion
-with a deliberately minimal template, and enrichment poisons it. The
-router is the menu (epic) or the work type's continue machinery, and
-the experiment phase always begins in fresh context.
+## Amendment — 2026-08-31 (second): the umbrella ruling — narrow remit, no routing, no loop
 
-**The spawn, symmetric across research and discussion.** A measurable
-point surfacing mid-conversation is *offered*, never prescribed.
-Declined → ad-hoc inline measurement remains valid, and stays labelled
-exploratory. Accepted → the session records the spawn right there:
-
-1. `experiment create` allocates the id — E{n}, increment off the
-   manifest series — with a kebab slug derived from the problem.
-2. A **problem file** lands in the record's directory: the problem in
-   plain terms — what we need to pick or learn, the space around it,
-   what we hope — with a provenance line naming the phase, topic,
-   point, and date it was born from. **No design content.** The
-   spawning phase is the client at the laboratory door: it states the
-   problem and stops. Question refinement, prediction, decision rule,
-   setup — all of it is the experiment phase's job.
-3. The **lock**: `awaiting_experiments` gains E{n} on the spawning
-   phase's own item — research and discussion identically. `topic
-   complete` refuses on both while any lock is live; conclude, abandon,
-   and cancel release per-id and flag the owning item. Research is not
-   a special case: the lock means "this phase raised a question it
-   needs answered before it can honestly conclude", which applies to a
-   research record exactly as to a discussion.
-4. The choice: **go now** — the session pauses mid-phase and routes
-   back to the menu, closing ceremony skipped — or **later** — the
-   session continues, conclusion stays blocked, and it pauses at a
-   natural end the same way. Both roads end at the menu with the
-   experiment queued.
-
-**The menu is experiment-shaped.** Each queued or live experiment
-renders its own entry (`E1 {slug} — {Topic} · experiment`), appearing
-at spawn and retiring at conclusion; the register remains the topic's
-full history. Experiments rank above other recommendations; the pick
-stays the user's — working E1 then E2, or E1 then the half-unblocked
-discussion, are both legitimate orders, and cancelling a
-no-longer-needed E2 releases its lock and unblocks conclusion. Once a
-phase's locks all release, the paused phase becomes the recommendation.
-
-**Entry is per-experiment.** `workflow-experiment-entry` takes the
-record id — the session enters to deal with E1, the way a discussion is
-entered for a topic. Initialisation reads the problem file, then —
-provenance-driven — the spawning artifact **on disk, in full**: the
-source document is mid-flight, unconcluded and unindexed, so the
-knowledge base cannot serve it. Linked research, briefs, and seeds
-surface as before. Design is then authored collaboratively in-phase —
-the laboratory asking its own questions — and the walk from the
-briefing gate onward is unchanged.
-
-**Concurrency.** The one-live-experiment-at-a-time rule is deleted; the
-engine never had it. Any number of records in any states; a session
-works the experiment it entered for.
-
-**Superseded machinery** (built by the stack, removed by this
-amendment): the `Spawned from:` handoff lines, the walk's spawn-await
-conditional and its recorded-wait disambiguator, the session-loop
-spawned-arrival logic, and both direct `/workflow-experiment-entry`
-invocations (discussion §J, research conclude-arm — the arm survives as
-a spawn without a lock-free special case, concluding research clean
-with its experiments queued on the menu).
+The owner walk that followed settled the phase's nature: an addendum
+tool used by research and discussion, separated for context isolation
+as a scientific control — not a peer phase. Rulings: the remit is
+instructions in → design → perform → results → feed back, nothing
+else — no off-topic rerouting, no roadmap parks, no inbox capture, no
+session loop; triage is untouched in every direction (a measurable
+concern rerouted between topics lands in research or discussion, which
+decides whether to spawn); discovery never routes to experiment — the
+spawn is the phase's one door; splits are sub-experiments (E{n}.{m})
+under the spawned id, the lock never churning; execution shape is the
+orchestrator's empowered choice (direct, deterministic code doing the
+work, background shells and monitors, ad-hoc sub-agents — no custom
+workflow agents). The model sections above were rewritten in place to
+this shape; the first stack's routing surfaces (three-way discovery
+routing, the first-phase gate's experiment arm, `x/experiment`,
+map-lifecycle routing legs, roadmap pull-forward widening) and its
+triage/off-topic machinery are superseded wholesale.

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -125,22 +125,29 @@ phase completion with a deliberately minimal template. The **menu is
 the router**: the spawning session ends its turn; the laboratory is
 entered fresh.
 
-### The menu is experiment-shaped
+### The menu routes at topic grain
 
-On the epic dashboard each queued or live experiment renders its own
-menu entry (`Enter E1 {slug} — {Topic} · experiment`), appearing at
-spawn and retiring at conclusion; a linear work unit's menu surfaces
-the laboratory through its continue row, the record picked at entry.
-Experiments rank above other recommendations; the pick stays the
-user's — working E1 then E2, or E1 then the half-unblocked
-conversation, are both legitimate orders. Cancelling a
-no-longer-needed experiment releases its lock, and a phase whose locks
-have all released becomes the recommendation again.
+The laboratory appears on every menu the way any phase does: one row
+per topic with live experiments, in the standard continue form,
+appearing at the first spawn and retiring when the series holds no
+live record. No phase is special in the skeleton — the row's route is
+the uniform entry contract, and which experiment to work is the
+phase's own question, answered inside it. Topics with queued
+experiments rank above other recommendations; the pick stays the
+user's — working the laboratory, or the half-unblocked conversation,
+are both legitimate orders. Abandoning a no-longer-needed experiment
+releases its lock, and a phase whose locks have all released becomes
+the recommendation again.
 
-### Entry is per-experiment
+### Entry is per-topic; the work is per-record
 
-`workflow-experiment-entry` takes the record id — the session enters to
-deal with E1, the way a discussion is entered for a topic.
+`workflow-experiment-entry` takes the same arguments every entry
+takes — work type, work unit, topic. Inside, the record resolves:
+one live experiment and the session proceeds into it automatically;
+several and the register renders with a picker — the first time the
+user is asked, because nothing upstream chose a record. From there the
+session works that one experiment, the way a discussion session works
+its topic.
 Initialisation reads the problem file, then — provenance-driven — the
 spawning artifact **on disk, in full**: the source document is
 mid-flight, unconcluded and unindexed, so the knowledge base cannot
@@ -198,8 +205,10 @@ whole concludes.
 
 ### The return leg
 
-An experiment concludes with its one-line verdict and routes back via
-the bridge to the menu. The lock releases and flags the spawning item;
+An experiment concludes with its one-line verdict. While the series
+still holds live records the session offers the next one — E1 then E2
+in one sitting — or the exit; the exit routes back via the bridge to
+the menu, where the still-live topic row reappears. The lock releases and flags the spawning item;
 the paused conversation becomes the recommendation once unblocked, and
 its re-entry surfaces the evidence — the register, the reports read in
 full — before the waiting point settles. **Experiments measure;
@@ -302,8 +311,8 @@ laboratory.
 ## Test footprint
 
 - Pipeline simulation: the spawn (create + problem + lock) from both
-  research and discussion, now-and-later exits, per-experiment menu
-  entries, the walk to verdict, release/flag edges, abandonment and
+  research and discussion, now-and-later exits, the topic-grain menu
+  rows, the walk to verdict, release/flag edges, abandonment and
   cancellation releases, splits, series continuation, reopen.
 - Engine suites: schema, transitions, derivations, render surfaces,
   register/gate projections, lock symmetry.
@@ -321,8 +330,8 @@ PR0 is this document, standalone. The stack:
    verb family (`approve` its own verb — the freeze is never a step a
    loop drifts past), locks symmetric across research and discussion,
    sub-experiment ids, the register and approval-gate surfaces,
-   per-experiment menu entries. Simulation + suites.
-2. **PR2 — skills.** `workflow-experiment-entry` (per-record contract)
+   the topic-grain menu rows. Simulation + suites.
+2. **PR2 — skills.** `workflow-experiment-entry` (uniform entry contract; in-phase record resolution)
    and `workflow-experiment-process` (linear: initialize → design →
    briefing/freeze → run → report → verdict → bridge); templates,
    conduct, amendment protocol.

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -393,3 +393,52 @@ PR0 is this document, standalone. The stack:
 5. **PR5 — cross-cutting + docs.** Gap analysis, absorption, cancel
    edges, KB wiring, CLAUDE.md/README, prose cases, `select --diff`
    sweep.
+
+## Implementation record — 2026-08-30
+
+Landed as stack #1060 off main (this design PR stays standalone):
+#1058 engine state → #1059 render surfaces → #1061 skills →
+#1062 integration prose → #1063 cross-cutting + docs. Decisions made
+at implementation time:
+
+- **Series records** are a keyed map (`experiments.{E{n}}: {slug,
+  status[, verdict][, reason]}`, spec-sources precedent), guarded
+  container on the field surface; ids per-topic, order derived from the
+  id. `approve` is its own verb — the briefing freeze is never a step
+  `advance` drifts past.
+- **The wait** is `awaiting_experiments` on the same-topic discussion
+  item. Conclude/abandon release it and set `reconcile_needed:
+  "experiment"` (existing flag never clobbered); a bare `topic cancel`
+  on an awaited experiment refuses naming the waiting discussion,
+  `--cascade` cancels and releases in one transaction. `topic complete`
+  on the experiment phase refuses while any row is unfinished — no wait
+  can outlive the phase.
+- **`flagDownstream` walks past phases the topic never entered**,
+  flagging the nearest downstream item — inserting an optional phase
+  must not sever the research→discussion hop.
+- **The mid-discussion exit's write order**: doc note + discussion
+  commit → straight-through entry invocation carrying the spawning
+  point → the walk's first conceive runs `create` → `await` → one
+  commit. The unrecorded-wait window is one tool call wide and the
+  pre-await crash state is benign (open point, conclusion blocked by
+  the unresolved subtopic).
+- **Research's arm concludes fully first** (completed, indexed,
+  committed), then routes into the experiment entry — the evidence
+  trail is never truncated by the route.
+- **Amendment re-confirm is a conversational ask** (no enumerated
+  options), not an engine surface; a dedicated surface is banked until
+  usage argues for it. Likewise a document-review analogue at series
+  conclusion — deliberately absent ahead of evidence.
+- **KB identity**: both record files share the topic's identity;
+  replacement is keyed per canonical source path, not per identity
+  (indexing a report must not wipe its design's chunks). Confidence
+  medium, investigation's sibling.
+- **Adopted along the way** under the touch-adopts-menus rule:
+  the quick-fix complexity promotion menu (`complexity-gate`) and the
+  feature/cross-cutting first-phase choice (`first-phase-gate`) became
+  engine surfaces; the map header renamed `DISCOVERY MAP`.
+- **Deliberately still two-way**: the requeue pair (no flow produces an
+  experiment requeue; the widened landing judgment aims concerns up
+  front) and the frozen migrations. Prose walks not run pre-merge, per
+  convention; four experiment cases authored and green on the
+  deterministic perimeter.

--- a/design/experiment-phase.md
+++ b/design/experiment-phase.md
@@ -128,7 +128,7 @@ entered fresh.
 ### The menu is experiment-shaped
 
 Each queued or live experiment renders its own menu entry
-(`E1 {slug} — {Topic} · experiment`), appearing at spawn and retiring
+(`Enter E1 {slug} — {Topic} · experiment`), appearing at spawn and retiring
 at conclusion. Experiments rank above other recommendations; the pick
 stays the user's — working E1 then E2, or E1 then the half-unblocked
 conversation, are both legitimate orders. Cancelling a


### PR DESCRIPTION
Design log for the experiment phase: a new pipeline phase beside research and discussion in the Discovery stage (epic, feature, cross-cutting). Controlled experiments against real systems — a design (question, prediction with reason, decision rule, setup) written and confirmed **before the first measurement**, a series per topic, append-only reports, and results feeding decisions through the topic's discussion, which can override.

Settled in discussion 2026-08-30. Prior art studied: the dex experiment system (`dex/business/experiments/`) and the external record (pre-registration / registered reports, ELN practice, ML experiment tracking, industry experimentation culture).

Standalone design PR per the living-document rule — the implementation stack bases on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)