### PR TITLE
planning(prose): the choice bar — a verdict earned by searching

### DIFF
--- a/skills/workflow-planning-process/references/process-review-findings.md
+++ b/skills/workflow-planning-process/references/process-review-findings.md
@@ -57,7 +57,7 @@ Work through each unresolved finding **sequentially** — a finding whose Resolu
 
 → Proceed to **C. After All Findings Processed**.
 
-Read the next unresolved finding's **Move** before presenting it — it decides the shape. Where the finding names none, classify it and record it in the tracking file: exactly one defensible answer in the specification or the record → `settled`; real options between which only the user can pick → `choice`.
+Read the next unresolved finding's **Move** before presenting it — it decides the shape. Where the finding names none, classify it and record it in the tracking file: exactly one defensible answer the specification, the plan's own shape, or a measurement yields → `settled`, the derivation carried as the Proposal's reasoning; real options the search genuinely leaves to the user → `choice`, naming what was searched.
 
 Then confirm that move against the live session. A `settled` finding whose stated derivation no longer holds, or whose fix you cannot yourself stand behind, is a `choice`: update the Move, replace its fix with options, and present it that way. Reclassification only ever moves toward the user; a `choice` is never demoted to `settled` to save a stop.
 

--- a/skills/workflow-planning-process/references/review-integrity.md
+++ b/skills/workflow-planning-process/references/review-integrity.md
@@ -78,14 +78,14 @@ Read the plan end-to-end — carefully, as if you were about to implement it. Fo
 Every finding names the **move** it owes the reader — what they have to do about it. The move, never the category, decides how the finding is presented.
 
 - **settled** — the record admits exactly one defensible answer. Write the **Proposal**: the call and what determined it. Most findings are this.
-- **choice** — real options exist and only the reader can pick between them. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
+- **choice** — real options exist and only the reader can pick between them — a verdict earned by searching, never a default: anything the specification, the plan's own conventions, or a measurement yields is `settled`, that derivation its Proposal. A staged choice names what was searched and where the record ran out. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
 - Planning findings never route: the plan is the document under review, and its answers live in the specification or the record.
 
 A call you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.
 
 The **Problem** is what is wrong in the terms the reader cares about — the product, the end result. Never the analysis that found it, and never the document's own wording read back at them.
 
-A plan defect the specification or the plan's own conventions determine is **settled**. Where the plan could go two defensible ways — how to split a task, which phase owns a slice — it is a **choice**.
+A plan defect the specification or the plan's own conventions determine is **settled**. Where the plan could go two defensible ways that survive the search — how to split a task, which phase owns a slice — it is a **choice**: name what was searched, and take a stance.
 
 ## Tracking File
 

--- a/skills/workflow-planning-process/references/review-traceability.md
+++ b/skills/workflow-planning-process/references/review-traceability.md
@@ -63,7 +63,7 @@ Is everything in the plan actually from the specification? This is the anti-hall
 Every finding names the **move** it owes the reader — what they have to do about it. The move, never the Type, decides how the finding is presented.
 
 - **settled** — the record admits exactly one defensible answer. Write the **Proposal**: the fix and what determined it. Most traceability findings are this: the specification already decided, and carrying its decision into the plan is not a new decision.
-- **choice** — real options exist and only the reader can pick between them. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
+- **choice** — real options exist and only the reader can pick between them — a verdict earned by searching, never a default: anything the specification or the plan's own shape yields is `settled`, that derivation its Proposal. A staged choice names what was searched and where the record ran out. Write the **Options**, one line each, at most one marked `(recommended)`. Write no Proposal: a choice dressed as a decision already made is the failure this field exists to prevent.
 - Planning findings never route: the plan is the document under review, and its answers live in the specification or the record.
 
 A fix you cannot yourself stand behind is a **choice**, never a settled answer written on the reader's behalf. Classification only ever moves toward the reader.


### PR DESCRIPTION
Follow-up to stack #1067 (the decision-bar programme), as ruled there: the planning review loop gets the same tightened `settled`/`choice` bar as specification — planning sits deeper in the collaboration cone, so the bar applies at least as strongly. Independent of the stack (different files); mergeable either side of it.

- The `choice` Move in both criteria references (`review-traceability.md`, `review-integrity.md`) becomes a verdict earned by searching, never a default — anything the specification, the plan's own shape/conventions, or a measurement yields is `settled` with its derivation as the Proposal; a staged choice names what was searched and where the record ran out.
- The findings walk's classification line gets the same boundary.
- Untouched by design: the never-demote rule (reclassification only moves toward the reader), planning's no-route model, the auto/gate machinery, and the agents (they read the criteria references in full — the definitions live there).

Gates: `npm test` 2598/2598, typecheck clean. Suggested walks: `planning-declines-and-picks-a-choice`, `planning-resumes-a-review-mid-walk`, `planning-reviews-and-concludes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)