### PR TITLE
spec(prose): the repair tier names its landing shape

### DIFF
--- a/skills/workflow-specification-process/references/resolve-source-incoherence.md
+++ b/skills/workflow-specification-process/references/resolve-source-incoherence.md
@@ -24,7 +24,7 @@ Tell the user in one line what was measured and what it corrects — no gate; th
 
 **If the corrected value undermines a conclusion but itself determines how it falls** — the conclusion re-derives from the corrected value alone, nothing new committed and no live alternative picked between:
 
-A repair the record supports. Tell the user in one line what was measured and how the conclusion re-lands — no gate; the measurement made the choice.
+A repair the record supports. Tell the user in one line what was measured and how the conclusion re-lands — no gate; the measurement made the choice. The repair revises what the document concluded: a conclusion recorded in a Decision block takes C's dated timeline revision, the failed measurement as its trigger — never an in-place value substitution; only restatements outside the block are repaired in place.
 
 → Proceed to **C. Landing a Resolution** with resolution = `{the corrected claim and the conclusion repaired against it, carrying its command and result}`, doc = `{the owning source's topic}`.
 


### PR DESCRIPTION
Fix from the decision-bar walk run: `spec-repairs-a-measured-conclusion` FAILed, confirmed from a fresh world — both walks took the repair tier correctly, then landed the repair as in-place value substitutions inside the discussion's Decision block (no dated timeline entry, no `#### Initial`, no `Trigger:` line).

The seam: the repair-tier arm said "the conclusion repaired against it" but never said which C.2 shape that takes. One sentence closes it — a conclusion recorded in a Decision block takes the dated timeline revision (failed measurement as trigger), never a value substitution; only restatements outside the block repair in place.

The covering case exists and caught this; a re-walk of `spec-repairs-a-measured-conclusion` after merge confirms the seam is closed. Conventions lint 37/37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)