### PR TITLE
experiment: the freeze guards the outcome — walk findings

### DIFF
--- a/skills/workflow-experiment-process/references/design-template.md
+++ b/skills/workflow-experiment-process/references/design-template.md
@@ -53,6 +53,6 @@ doesn't.}
 - **Frozen at the confirm gate.** After approval the design changes only by the amendment protocol — a dated `## Amendments` section appended when one lands, never a rewrite of what's above it.
 - Instruments named here freeze with the design — name the exact script, tool, and version that will do the measuring.
 - Experiment status is tracked in the work unit manifest, not in the document.
-- **Measured claims**: a load-bearing setup claim (what an instrument does, what the sample contains) is measured when written, the command recorded with its result, the command alone in its span so it re-runs by copy (`` `rg -l 'pattern' | wc -l` → 14 ``).
+- **Measured claims**: a load-bearing setup fact — what an instrument does, how large the sample is, what the environment holds — is measured when written, the command recorded with its result, the command alone in its span so it re-runs by copy (`` `rg -l 'pattern' | wc -l` → 14 ``). **The outcome is never one of them**: nothing the question, prediction, or decision rule turns on is measured before the freeze — the design predicts it, the run measures it.
 
 → Return to caller.

--- a/skills/workflow-shared/references/experiment-spawn.md
+++ b/skills/workflow-shared/references/experiment-spawn.md
@@ -38,7 +38,7 @@ Continue the conversation. An inline measurement, no ceremony, stays part of the
 
    → Return to caller for **B. Session Loop**.
 
-3. Note the handed-off question in the session's own document — the waiting point the evidence returns to, named as awaiting `{id}` — and commit with the session's cadence:
+3. Note the handed-off question in the session's own document — a dated entry at the waiting point the evidence returns to, named as awaiting `{id}` — and commit with the session's cadence:
 
    ```bash
    node .claude/skills/workflow-engine/scripts/engine.cjs commit {work_unit} --topic {phase}/{topic} -m "{phase}({work_unit}/{topic}): spawn {id} {slug}"

--- a/tests/prose/cases/discussion-spawns-an-experiment-and-continues/case.json
+++ b/tests/prose/cases/discussion-spawns-an-experiment-and-continues/case.json
@@ -66,8 +66,7 @@
       "render conclude-gate pay.discussion.pay",
       "--kind perspective",
       "topic triage",
-      "render closing-gate pay.discussion.pay",
-      "gateway.cjs map pay pay"
+      "render closing-gate pay.discussion.pay"
     ]
   }
 }

--- a/tests/prose/cases/experiment-abandoned-returns-open/assert.md
+++ b/tests/prose/cases/experiment-abandoned-returns-open/assert.md
@@ -23,14 +23,17 @@ The prose should have taken this path:
    that E1 was abandoned and why the point was settled without
    measurement — the awaiting note gives way to the decision, the map
    records the subtopic decided, and the write commits
-5. the user wraps; the ceremony's evidence-wait check reads empty —
+5. along the way the review cadence arms its free first pass — a
+   review dispatches at a natural break, the stubbed report returns
+   clean and is drained — so by the wrap the record already holds an
+   incorporated review
+6. the user wraps; the ceremony's evidence-wait check reads empty —
    no wait gate, the release already happened — every subtopic is
    settled, and the closing gates run: the triage queue reads empty
-   and the review classification finds no review has ever run, so the
-   mandatory gate asks and the user agrees
-6. the final review dispatches, the stubbed report returns clean and
-   is acknowledged; document review reconciles the file against the
-   session; the compliance check passes
+   and the classification finds the review satisfied (nothing moved
+   since it drained), so no mandatory gate is owed; document review
+   reconciles the file against the session; the compliance check
+   passes
 7. the conclude gate renders and the user confirms; the completion the
    wait once blocked now passes — the engine accepts `topic complete`
    — and the conclusion commits with the knowledge index riding

--- a/tests/prose/cases/experiment-amended-before-results/assert.md
+++ b/tests/prose/cases/experiment-amended-before-results/assert.md
@@ -64,7 +64,9 @@ the series row and the experiment item `completed`; `design.md`
 extended by the `## Amendments` section alone (one struck dated entry,
 one standing dated entry); `report.md` (results with the secondary
 listing, deviations, reading, conclusion, reproduce) under
-`experiment/synonym-handling/E1-reformulation-recovery/`; the research
+`experiment/synonym-handling/E1-reformulation-recovery/`, possibly
+beside instrument scripts and curated `data/` extracts — the run
+leg's own artifacts, present or absent without prejudice; the research
 item still `in-progress`, its wait removed and
 `reconcile_needed: "experiment"` set; the research document itself
 unchanged.

--- a/tests/prose/cases/experiment-series-continues-at-the-gate/assert.md
+++ b/tests/prose/cases/experiment-series-continues-at-the-gate/assert.md
@@ -45,9 +45,11 @@ Further claims:
 - both records end `concluded`, each with a one-line verdict on its
   register row; the item's derived status is `completed`, and nothing
   above the records was completed by hand
-- each design froze before its own measurement: `approve` is the only
-  transition between designed and running on both records, and no
-  number from the log appears in either `design.md`
+- each design froze before its own outcome was measured: `approve` is
+  the only transition between designed and running on both records,
+  and no number either record's question, prediction, or decision rule
+  turns on appears in its `design.md` — setup facts may carry their
+  measuring commands
 - the research item's `awaiting_experiments` is gone — both waits
   released — and it carries `reconcile_needed: "experiment"`, its
   status still `in-progress`

--- a/tests/prose/cases/experiment-walks-to-verdict/assert.md
+++ b/tests/prose/cases/experiment-walks-to-verdict/assert.md
@@ -50,9 +50,10 @@ The prose should have taken this path:
 
 Further claims:
 
-- the design was frozen before anything was measured: no number from
-  the log appears in `design.md`, and the design commit precedes every
-  report write
+- the design froze before the outcome was measured: setup facts (the
+  sample's size and shape) may carry their measuring commands, but no
+  number the question, prediction, or decision rule turns on appears
+  in `design.md`, and the design commit precedes every report write
 - `approve` is the only transition between designed and running —
   advance never crossed the freeze
 - the record ends `concluded` with a one-line verdict on the register


### PR DESCRIPTION
Fixes from the eight-case prose-walk pass over the merged experiment phase (3 PASS, 2 FLAKY, 3 FAIL — every failure reproduced or explained, archives kept).

## The finding that mattered

Across three cases and five walks, walkers measured the sample log before the freeze and recorded numbers in `design.md` — in the worst walk, the actual outcome metric. The trail led to the design template's own measured-claims rule, which invited it. The rule now stops at setup facts: what an instrument does, how large the sample is, what the environment holds. **The outcome is never one of them** — nothing the question, prediction, or decision rule turns on is measured before the freeze; the design predicts it, the run measures it.

## Prose

- `design-template.md` — the measured-claims rule scoped as above.
- `experiment-spawn.md` — the waiting-point note is a **dated** entry (the convention of the documents it lands in; the walks wrote it undated because the prose never said).

## Cases

- `discussion-spawns-an-experiment-and-continues` — the map gateway leaves `calls_exclude`: it fires legitimately at resume, and the exclusion (added to pin "the wait gate outruns the defer sweep") banned a call the prose rightly makes; the closing-gate exclusions still carry that claim.
- `experiment-walks-to-verdict` + `experiment-series-continues-at-the-gate` — the freeze claims scope to the outcome, matching the corrected rule.
- `experiment-abandoned-returns-open` — the close's expected path now accounts for the review cadence's free first pass arming mid-session: by the wrap the review is drained and `satisfied`, so no mandatory gate is owed (the walks' actual, legitimate path — twice).
- `experiment-amended-before-results` — the expected world admits instrument scripts and curated `data/` extracts, the run leg's own artifacts, closing the asserter variance.

Gates: `npm test` 2719/2719 (prose corpus + snapshot goldens included) · conventions lint 37/37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)