### PR TITLE
fix(engine): presence reads refresh an owned hold — never create one

### DIFF
--- a/design/concurrent-phases.md
+++ b/design/concurrent-phases.md
@@ -152,8 +152,11 @@ Beats become side effects of self-referential verbs:
   log already establishes the `--kb` rider as the one terminal
   session-cadence commit; if it beat, it would re-stamp presence
   after the conclusion and the topic would read held forever.
-- `topic queue` — beats (polled by the session loops' findings check
-  every iteration: turn coverage with no writes).
+- `topic queue` — refreshes an owned hold only (polled by the session
+  loops' findings check every iteration: turn coverage with no
+  writes). Reads are reachable for any topic — a session legitimately
+  checks a foreign queue — so a read never creates a hold and never
+  overwrites a peer's record; `agent scan` takes the same rule.
 - Three-segment `manifest set`/`apply` on a presence phase — beats
   (every state transition heartbeats).
 - Agent-store writes — beat.

--- a/skills/workflow-engine/references/commands.md
+++ b/skills/workflow-engine/references/commands.md
@@ -170,7 +170,7 @@ engine sources stale <work-unit> <discussion> [--except <spec-topic>]
 
 **`presence`** — the per-topic session heartbeat, cache-resident (`.workflows/.cache/{wu}/{phase}/{topic}/presence`, gitignored). Awareness, never mutual exclusion. Every phase a session sits in carries one — research, experiment, discussion, investigation, scoping, specification, planning, implementation, review — except discovery, which `discovery-session open` already serialises to one session per epic.
 
-**Beats are mechanical, and no prose ever issues one.** The engine stamps the heartbeat as a side effect of the verbs a session already runs, and only where the verb is structurally self-referential — the session acting on its own topic. A beat writes *this* process's identity, so a beat from a verb acting on another topic would manufacture a false hold there.
+**Beats are mechanical, and no prose ever issues one.** The engine stamps the heartbeat as a side effect of the verbs a session already runs, and only where the verb is structurally self-referential — the session acting on its own topic. A beat writes *this* process's identity, so a beat from a verb acting on another topic would manufacture a false hold there. The read verbs (`topic queue`, `agent scan`) are reachable for any topic — a session legitimately checks a foreign queue — so they **refresh** instead: re-stamp a heartbeat this session already owns, never create one, never overwrite a peer's.
 
 | Verb | Beat |
 |---|---|
@@ -181,13 +181,14 @@ engine sources stale <work-unit> <discussion> [--except <spec-topic>]
 | `render code-gate` (empty) | beats — reading a free code slot is how a session claims it, so the hold starts at entry rather than at the first code commit; a gated read stamps nothing |
 | `render phase-note` | beats — only ever rendered by an entry skill for its own phase, so announcing the entry is the same act as claiming the slot |
 | `commit --paths … --for {wu} {phase}/{topic}` | beats the named code topic |
-| `topic queue` | beats — the session loops' findings check polls it every turn, so a turn with no writes still registers |
+| `topic queue` | refreshes — the session loops' findings check polls its own topic every turn, so a turn with no writes still registers; a read of another topic's queue stamps nothing |
 | `topic start` · `topic absorb` | beat — opening the session's own topic, and folding a concern into its document |
 | `experiment create --from` | beats the **spawning** research or discussion — the conversation recording the spawn on its own item |
 | `experiment create --parent` · `advance` · `approve` | beat the experiment topic — the laboratory session working its own record |
 | `experiment conclude` · `abandon` (top-level id) | **clear** — the last record's close settles the item, so the record's close is the release; a cadence commit while records remain re-claims (that is the session still in the laboratory); a sub-experiment's beats instead (the parent still runs) |
 | `topic complete` | **clears** — the close is the release; the slot opens the moment the topic is finished |
-| `agent dispatch` · `scan` · `ack` · `announce` · `surface` · `incorporate` | beat — the session's own background agents |
+| `agent dispatch` · `ack` · `announce` · `surface` · `incorporate` | beat — the session's own background agents |
+| `agent scan` | refreshes — a read of the store, so it re-stamps an owned hold and creates nothing |
 | `topic triage` | never — delivery acts on the **target** topic from the origin's session |
 | `manifest set` · `apply` | never — a three-segment `set` looks self-referential and frequently is not: storage-path backfills, review's `updated` stamp and the epic menu's unblock all write one phase's item from another phase's session. The session's cadence commit is its heartbeat |
 | `topic requeue` · `cancel` · `reactivate` · `supersede` · `reopen` · `sources stale` | never — analysis and navigation actors reaching across topics |

--- a/skills/workflow-engine/scripts/domain/presence.cjs
+++ b/skills/workflow-engine/scripts/domain/presence.cjs
@@ -19,9 +19,11 @@
 // a session already runs on its own topic (`beatQuietly`), and the terminal
 // conclusion commit clears (`clearQuietly`). A beat writes THIS process's
 // identity, so only a structurally self-referential verb may beat — stamping
-// it from a verb acting on another topic manufactures a false hold. The
-// SessionEnd hook on the session skills sweeps by session id for the exits
-// that keep the process alive (/clear, logout).
+// it from a verb acting on another topic manufactures a false hold. Read
+// verbs are reachable for any topic, so they take `refreshQuietly` instead:
+// re-stamp a heartbeat this session already owns, never create one, never
+// overwrite a peer's. The SessionEnd hook on the session skills sweeps by
+// session id for the exits that keep the process alive (/clear, logout).
 //
 // Every phase a session sits in carries presence except discovery:
 // `discovery-session open` already refuses a second session per epic
@@ -128,6 +130,26 @@ function clearPresence(cwd, workUnit, phase, topic) {
 function beatQuietly(cwd, workUnit, phase, topic) {
   try {
     if (!PHASES.includes(phase)) return;
+    beatPresence(cwd, workUnit, phase, topic);
+  } catch { /* liveness is advisory — never fail a verb over it */ }
+}
+
+/**
+ * The read verbs' beat: re-stamp a heartbeat this session already owns, and
+ * only that. A read (`topic queue`, `agent scan`) is reachable for any topic
+ * — a foreign topic's queue is legitimately checked from another session —
+ * so creating a hold here would manufacture a phantom, and stamping over a
+ * peer's record would re-attribute a live hold. Ownership was established by
+ * the write-shaped verbs that are self-referential by construction (`topic
+ * start`, the entry renders, the cadence commit); this keeps that hold live
+ * through quiet polling turns. Same silence as `beatQuietly`.
+ * @param {string} cwd @param {string} workUnit @param {string} phase @param {string} topic
+ */
+function refreshQuietly(cwd, workUnit, phase, topic) {
+  try {
+    if (!PHASES.includes(phase)) return;
+    const record = readRecord(presencePath(cwd, workUnit, phase, topic));
+    if (!record || !ownsRow(record)) return;
     beatPresence(cwd, workUnit, phase, topic);
   } catch { /* liveness is advisory — never fail a verb over it */ }
 }
@@ -269,7 +291,7 @@ function scanProject(cwd) {
  * pid where the record predates a session id. The one home for the question,
  * because every surface that marks or gates on a peer's hold must exclude the
  * caller's own — a session must never gate against, or strike through, itself.
- * @param {PresenceRow} row
+ * @param {{session_id?: string|null, pid?: number|null}} row
  * @returns {boolean}
  */
 function ownsRow(row) {
@@ -353,7 +375,7 @@ function deferralSection(scan) {
 }
 
 module.exports = {
-  beatPresence, clearPresence, beatQuietly, clearQuietly,
+  beatPresence, clearPresence, beatQuietly, refreshQuietly, clearQuietly,
   scanPresence, scanProject, heldCodeSessions, cleanupPresence, deferralSection,
   fmtAge, ownsRow, CODE_PHASES, STALE_AFTER_SECONDS,
 };

--- a/skills/workflow-engine/scripts/engine.cjs
+++ b/skills/workflow-engine/scripts/engine.cjs
@@ -32,7 +32,7 @@ const { archiveItems, restoreItems, deleteItems } = require('./domain/inbox.cjs'
 const { stampAnalysisCache } = require('./domain/cache.cjs');
 const agentState = require('./domain/agent-state.cjs');
 const { boot } = require('./domain/boot.cjs');
-const { beatPresence, clearPresence, beatQuietly, clearQuietly, scanPresence, scanProject, cleanupPresence, deferralSection, CODE_PHASES } = require('./domain/presence.cjs');
+const { beatPresence, clearPresence, beatQuietly, refreshQuietly, clearQuietly, scanPresence, scanProject, cleanupPresence, deferralSection, CODE_PHASES } = require('./domain/presence.cjs');
 const { applySessionLabel, restoreSessionLabel, repairSessionLabels, setLabelConfig } = require('./domain/session-label.cjs');
 const { createWorkUnit } = require('./domain/workunit-create.cjs');
 const { completeWorkUnit, cancelWorkUnit, reactivateWorkUnit, pivotWorkUnit } = require('./domain/workunit-lifecycle.cjs');
@@ -836,7 +836,10 @@ function runTopic(argv) {
         throw new Error('Usage: engine topic queue <work-unit> <phase> <topic>');
       }
       const status = queueStatus(process.cwd(), workUnit, phase, topic);
-      beatQuietly(process.cwd(), workUnit, phase, topic);
+      // A read is reachable for any topic — a foreign queue is legitimately
+      // checked from another session — so it refreshes an owned hold only,
+      // never creates one.
+      refreshQuietly(process.cwd(), workUnit, phase, topic);
       respond(status);
       return;
     }
@@ -1241,8 +1244,9 @@ function runCache(argv) {
 
 // ---------------------------------------------------------------------------
 // agent — the background-agent lifecycle store (domain/agent-state.cjs).
-// Every verb addresses the session's own topic — dispatching, scanning, and
-// walking its own agents' findings — so every one heartbeats.
+// The write verbs address the session's own topic — dispatching and walking
+// its own agents' findings — so every one heartbeats. `scan` is a read,
+// reachable for any topic, so it refreshes an owned hold only.
 // ---------------------------------------------------------------------------
 
 /** @param {string[]} argv */
@@ -1268,7 +1272,9 @@ function runAgent(argv) {
       if (!workUnit || !phase || !topic || positional.length !== 3) {
         throw new Error('Usage: engine agent scan <work-unit> <phase> <topic>');
       }
-      answer(agentState.scanAgents(cwd, workUnit, phase, topic));
+      const scanned = agentState.scanAgents(cwd, workUnit, phase, topic);
+      refreshQuietly(cwd, workUnit, phase, topic);
+      respond(scanned);
       return;
     }
     if (command === 'ack') {

--- a/tests/scripts/test-engine-commit-door.cjs
+++ b/tests/scripts/test-engine-commit-door.cjs
@@ -658,24 +658,35 @@ describe('mechanical heartbeats: the self-referential rule', () => {
     assert.match(engineFails(dir, ['commit', 'payments', '-m', 'x', '--kb', '--sweep']).error, /Usage/);
   });
 
-  it('the topic verbs a session runs on its own topic beat — and triage never does', () => {
-    engine(dir, ['topic', 'queue', 'payments', 'discussion', 'topic-a']);
-    assert.ok(beaten('discussion', 'topic-a'), 'the per-turn queue poll is turn coverage');
+  it('the topic verbs a session runs on its own topic beat — and the reads and triage never create one', () => {
+    const me = { CLAUDE_PID: String(process.pid), CLAUDE_CODE_SESSION_ID: 'door-sess' };
+    // The queue read is reachable for any topic — a session checking a
+    // foreign queue must not manufacture a hold there.
+    engine(dir, ['topic', 'queue', 'payments', 'discussion', 'topic-a'], me);
+    assert.ok(!beaten('discussion', 'topic-a'), 'a queue read never creates a heartbeat');
 
-    engine(dir, ['topic', 'start', 'payments', 'planning', 'topic-a']);
+    engine(dir, ['topic', 'start', 'payments', 'planning', 'topic-a'], me);
     assert.ok(beaten('planning', 'topic-a'), 'start opens the session\'s own topic');
 
     writeFile(dir, '.workflows/payments/discussion/.triage/topic-a/001-first.md', '### First\nbody\n');
     commitAll(dir, 'a delivered concern');
     engine(dir, ['topic', 'absorb', 'payments', 'discussion', 'topic-a', '--file', '001-first.md',
-      '--subtopic', 'first', '-m', 'discussion(payments/topic-a): absorb 001-first (from topic-b)']);
+      '--subtopic', 'first', '-m', 'discussion(payments/topic-a): absorb 001-first (from topic-b)'], me);
     assert.ok(beaten('discussion', 'topic-a'), 'absorb folds a concern into the session\'s own document');
+
+    // The per-turn queue poll on the session's own topic is turn coverage:
+    // it refreshes the hold the write-shaped verbs established.
+    const own = beatFile('discussion', 'topic-a');
+    const past = new Date(Date.now() - 20 * 60 * 1000);
+    fs.utimesSync(own, past, past);
+    engine(dir, ['topic', 'queue', 'payments', 'discussion', 'topic-a'], me);
+    assert.ok(fs.statSync(own).mtimeMs > Date.now() - 60 * 1000, 'the poll keeps the owned hold live');
 
     // Delivery acts on the TARGET topic from the origin's session — a beat
     // there would manufacture a hold on a topic no session is in.
     writeFile(dir, '.workflows/.cache/scratch/c.md', '### Q\n*From: topic-a · discussion · d*\n\nBody.\n');
     engine(dir, ['topic', 'triage', 'payments', 'discussion', 'topic-b',
-      '--concern', '.workflows/.cache/scratch/c.md', '--slug', 'q', '-m', 'discussion(payments/topic-a): reroute to topic-b']);
+      '--concern', '.workflows/.cache/scratch/c.md', '--slug', 'q', '-m', 'discussion(payments/topic-a): reroute to topic-b'], me);
     assert.ok(!beaten('discussion', 'topic-b'), 'triage never beats the target');
   });
 

--- a/tests/scripts/test-engine-presence.cjs
+++ b/tests/scripts/test-engine-presence.cjs
@@ -324,4 +324,62 @@ describe('engine presence', () => {
     assert.deepStrictEqual(engineWith(dir, ['presence', 'cleanup'], { input: '{}' }).cleared, []);
     assert.ok(fs.existsSync(presenceFile(dir, 'discussion', 'alpha')), 'nothing swept without an owner match');
   });
+
+  it('a queue read stamps nothing where no heartbeat exists — reads never manufacture a hold', () => {
+    const res = engineWith(dir, ['topic', 'queue', 'pay', 'discussion', 'alpha'],
+      { env: { CLAUDE_PID: String(process.pid), CLAUDE_CODE_SESSION_ID: 'sess-one' } });
+    assert.strictEqual(res.count, 0);
+    assert.ok(!fs.existsSync(presenceFile(dir, 'discussion', 'alpha')),
+      'a foreign topic\'s queue check leaves no presence behind');
+  });
+
+  it('a queue read refreshes a heartbeat this session owns', () => {
+    craftRecord(dir, 'discussion', 'alpha', { pid: null, pid_start: null, session_id: 'sess-one' });
+    const p = presenceFile(dir, 'discussion', 'alpha');
+    const past = new Date(Date.now() - 20 * 60 * 1000);
+    fs.utimesSync(p, past, past);
+
+    engineWith(dir, ['topic', 'queue', 'pay', 'discussion', 'alpha'],
+      { env: { CLAUDE_PID: String(process.pid), CLAUDE_CODE_SESSION_ID: 'sess-one' } });
+    const record = JSON.parse(fs.readFileSync(p, 'utf8'));
+    assert.strictEqual(record.session_id, 'sess-one');
+    assert.strictEqual(record.pid, process.pid, 'the refresh re-stamps the full identity');
+    const row = engineWith(dir, ['presence', 'scan', 'pay']).sessions[0];
+    assert.strictEqual(row.live, true, 'the quiet-turn poll keeps the own hold live');
+  });
+
+  it('a queue read never overwrites a peer\'s heartbeat', () => {
+    craftRecord(dir, 'discussion', 'alpha', { pid: null, pid_start: null, session_id: 'peer-sess' });
+    const p = presenceFile(dir, 'discussion', 'alpha');
+    const past = new Date(Date.now() - 20 * 60 * 1000);
+    fs.utimesSync(p, past, past);
+
+    engineWith(dir, ['topic', 'queue', 'pay', 'discussion', 'alpha'],
+      { env: { CLAUDE_PID: String(process.pid), CLAUDE_CODE_SESSION_ID: 'sess-one' } });
+    const record = JSON.parse(fs.readFileSync(p, 'utf8'));
+    assert.strictEqual(record.session_id, 'peer-sess', 'the peer\'s identity stands');
+    assert.strictEqual(record.pid, null);
+    assert.ok(fs.statSync(p).mtimeMs < Date.now() - 15 * 60 * 1000, 'and its activity signal is untouched');
+  });
+
+  it('an identity-less heartbeat is not refreshed by a read — degraded mode ages by mtime alone', () => {
+    craftRecord(dir, 'discussion', 'alpha', { pid: null, pid_start: null, session_id: null });
+    const p = presenceFile(dir, 'discussion', 'alpha');
+    const past = new Date(Date.now() - 20 * 60 * 1000);
+    fs.utimesSync(p, past, past);
+
+    engineWith(dir, ['topic', 'queue', 'pay', 'discussion', 'alpha'],
+      { env: { CLAUDE_PID: String(process.pid), CLAUDE_CODE_SESSION_ID: 'sess-one' } });
+    assert.ok(fs.statSync(p).mtimeMs < Date.now() - 15 * 60 * 1000, 'an unowned record is never claimed');
+  });
+
+  it('an agent-store scan stamps nothing where no heartbeat exists', () => {
+    fs.writeFileSync(path.join(dir, '.workflows', 'pay', 'manifest.json'), JSON.stringify({
+      name: 'pay', work_type: 'epic', status: 'in-progress', phases: {},
+    }, null, 2));
+    engineWith(dir, ['agent', 'scan', 'pay', 'discussion', 'alpha'],
+      { env: { CLAUDE_PID: String(process.pid), CLAUDE_CODE_SESSION_ID: 'sess-one' } });
+    assert.ok(!fs.existsSync(presenceFile(dir, 'discussion', 'alpha')),
+      'reading a foreign topic\'s agents leaves no presence behind');
+  });
 });

--- a/tests/scripts/test-pipeline-simulation.cjs
+++ b/tests/scripts/test-pipeline-simulation.cjs
@@ -851,11 +851,18 @@ describe('pipeline simulation', () => {
     const queue = sim.run(['topic', 'queue', wu, 'research', 'delta']);
     assert.strictEqual(queue.count, 1);
     assert.deepStrictEqual(queue.files, [parked.concern_path], 'the read verb lists the delivered concern');
+    // The queue read is reachable for any topic — a session checking a
+    // foreign queue must not manufacture a hold there. No verb has yet
+    // acted on delta from this session, so the read stamps nothing.
+    assert.ok(!fs.existsSync(path.join(sim.dir, `.workflows/.cache/${wu}/research/delta/presence`)),
+      'a queue read never creates a heartbeat');
     // The dispatch gate: a review never launches over a non-empty queue —
     // each queued concern is a pending change to the document a review
     // would read. Other kinds stay ungated.
     sim.refuses(['agent', 'dispatch', wu, 'research', 'delta', '--kind', 'review'], /review dispatch blocked/);
     sim.run(['agent', 'dispatch', wu, 'research', 'delta', '--kind', 'deep-dive', '--label', 'scope']);
+    assert.ok(fs.existsSync(path.join(sim.dir, `.workflows/.cache/${wu}/research/delta/presence`)),
+      'the write-shaped verb is what claims the slot');
     // topic absorb — the delivery's mirror: deliver a second concern, absorb
     // it, and the self-committing response answers what remains.
     sim.write('.workflows/.cache/scratch/concern-scratch.md',


### PR DESCRIPTION
## Problem

`topic queue` called `beatQuietly` unconditionally on whatever topic it named. The verb is a **read**, reachable for any topic — so a session verifying another topic's queue (observed live on fumi: a `note-window` discussion session checking `management-window`'s carry-notes) manufactured a phantom presence hold there, owned by the reader. Consequences:

- boot-time gap/grouping analyses deferred against a session that doesn't exist (`live` for 900s after the read)
- other sessions' epic menus struck the topic through and confirm-gated entry (`held` for the reader's whole process lifetime)
- worse, unobserved: a read over a topic a **real peer** holds overwrote the peer's identity record — the reader's SessionEnd cleanup would then delete the peer's live hold

`agent scan` carried the same read-shaped exposure. The presence doctrine already condemned this ("only a structurally self-referential verb may beat"); `topic queue` was the one verb breaking it.

## Fix

New `refreshQuietly` in `domain/presence.cjs`: stamp only when the presence file exists **and** `ownsRow` says it's this session's. `topic queue` and `agent scan` use it. Own-topic quiet-turn polling still works — the hold is established by the write-shaped verbs (`topic start`, `absorb`, the entry renders, the cadence commit) and the poll refreshes it. A foreign read stamps nothing; a peer's or identity-less record is never claimed.

No flags, no prose changes, no new state — the row's own identity record answers the ownership question.

## Coverage

- `test-engine-presence.cjs`: no-create on foreign read, refresh on owned record, peer record untouched, identity-less record untouched, `agent scan` no-create
- `test-engine-commit-door.cjs`: the self-referential-rule test re-pinned to refresh semantics
- `test-pipeline-simulation.cjs`: foreign queue read stamps nothing; the write-shaped verb claims the slot
- docs: `commands.md` presence table + doctrine line, `design/concurrent-phases.md`

Gates: `npm test` 2724/2724, `npm run test:cli` 5/5, `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)