### PR TITLE
tests(prose): the raise case's world claim accounts for cache machinery

### DIFF
--- a/tests/prose/cases/discussion-raises-problem-then-position/assert.md
+++ b/tests/prose/cases/discussion-raises-problem-then-position/assert.md
@@ -59,6 +59,8 @@ Further claims:
 - no subtopic is added to the map before the user engages
 - the walk stops with the raise pending; the user never answers it
 
-EXPECTED WORLD — the fixture plus exactly one change: the agent store
-row `review-001` has the payment-intent finding surfaced and stands
-`acknowledged` with the other remaining.
+EXPECTED WORLD — the fixture plus exactly one durable change: the
+agent store row `review-001` has the payment-intent finding surfaced
+and stands `acknowledged` with the other remaining. Render payloads
+and per-turn heartbeats under `.workflows/.cache/` are machinery, not
+changes.


### PR DESCRIPTION
One-line follow-up from the decision-raise walk run (5/5 PASS): the `discussion-raises-problem-then-position` asserter noted the case's EXPECTED WORLD claim — "the fixture plus exactly one change" — doesn't account for the announce payload the prescribed render verb writes under `.workflows/.cache/`, nor the per-turn heartbeats. The claim meant durable change; it now says so, mirroring the parenthetical the case's own path claims already carry for heartbeats. Corpus validation green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)