### PR TITLE
test(prose): the two baseline cases declare altitude.md in their scope

### DIFF
--- a/tests/prose/cases/start-offers-the-baseline-on-a-predating-codebase/case.json
+++ b/tests/prose/cases/start-offers-the-baseline-on-a-predating-codebase/case.json
@@ -1,5 +1,5 @@
 {
-  "origin": "the baseline judgment's other verdict — a codebase built before the workflows arrived gets the offer, once, and a decline is recorded through the same verb; the walk the design owed for the offer",
+  "origin": "the baseline judgment's other verdict \u2014 a codebase built before the workflows arrived gets the offer, once, and a decline is recorded through the same verb; the walk the design owed for the offer",
   "entry": "workflow-start",
   "files": [
     "skills/workflow-start/SKILL.md",
@@ -8,6 +8,7 @@
     "skills/workflow-shared/references/casing-conventions.md",
     "skills/workflow-shared/references/voice.md",
     "skills/workflow-shared/references/ask-or-decide.md",
+    "skills/workflow-shared/references/altitude.md",
     "skills/workflow-start/references/empty-state.md"
   ],
   "answers": [

--- a/tests/prose/cases/start-records-a-native-verdict/case.json
+++ b/tests/prose/cases/start-records-a-native-verdict/case.json
@@ -1,5 +1,5 @@
 {
-  "origin": "the baseline offer fired on Folio, a project that grew up on the workflows — the judgment had no home, so every boot re-rolled it from nothing; this is Folio's shape: scaffolding commits before the arrival, read as evidence",
+  "origin": "the baseline offer fired on Folio, a project that grew up on the workflows \u2014 the judgment had no home, so every boot re-rolled it from nothing; this is Folio's shape: scaffolding commits before the arrival, read as evidence",
   "entry": "workflow-start",
   "files": [
     "skills/workflow-start/SKILL.md",
@@ -8,6 +8,7 @@
     "skills/workflow-shared/references/casing-conventions.md",
     "skills/workflow-shared/references/voice.md",
     "skills/workflow-shared/references/ask-or-decide.md",
+    "skills/workflow-shared/references/altitude.md",
     "skills/workflow-start/references/active-work.md"
   ],
   "invariants": {


### PR DESCRIPTION
## Summary

#1092 added `altitude.md` to framework.md's load chain and declared it in every case's `files`; `start-records-a-native-verdict` and `start-offers-the-baseline-on-a-predating-codebase` (#1090) were authored before it merged and were the only two out of step. Both walks passed and both flagged it as undeclared prose. One line each.

## Test plan

- [x] `node --test tests/scripts/test-prose-cases.cjs` — corpus validation green
- [x] Both cases walked PASS on main before this change (the scope line was the only finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)