### PR TITLE
fix(prose): the raise opens on the product, and research still leans

### DIFF
--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -32,7 +32,7 @@ Do not fire for quick lookups, single searches, or questions that inform the nex
 
 Deep-dive findings are all walked — no batch lanes. Raises render under the heading `Needs Investigation`.
 
-Most deep-dive findings are knowledge, not asks — research surfaces material and holds decisions for discussion — so a raise here usually closes by saying nothing needs a call from the user and offering the pause. A finding that converges on a design call records the options and the lean as material for the discussion phase rather than asking the user to settle it now; the raise's genuine question is reserved for what only the user holds — their expectations, their environment, their intent for the product.
+Most deep-dive findings are knowledge, not asks — research surfaces material and holds decisions for discussion — so a raise here usually closes by saying nothing needs a call from the user and offering the pause. A finding that converges on a design call records the options and the lean as material for the discussion phase rather than asking the user to settle it now; the raise's genuine question is reserved for what only the user holds — their expectations, their environment, their intent for the product — and it is asked with a lean beside it: the position is owed whatever the phase, only the settling waits.
 
 ## A. Offer Deep Dive
 

--- a/skills/workflow-research-process/references/review-agent.md
+++ b/skills/workflow-research-process/references/review-agent.md
@@ -35,7 +35,7 @@ At natural conversational breaks, check for completed results.
 
 The shared surfacing protocol reads this declaration when presenting this phase's findings.
 
-- `explore` — the walked lane. Raises render under the heading `Needs Investigation`, and the raise's move is investigation: offer a deep-dive on the thread, never dispatched without the user's say. Research surfaces material and holds decisions for discussion — a raise here never asks the user to settle a design call; converged options land in the file as material.
+- `explore` — the walked lane. Raises render under the heading `Needs Investigation`, and the raise's move is investigation: offer a deep-dive on the thread, never dispatched without the user's say. Research surfaces material and holds decisions for discussion — a raise here never asks the user to settle a design call; converged options land in the file as material. Holding the decision withholds no lean: the raise still says where you stand and why, at the firmness earned — a lean on what the product should do is a position, not a decision — and a fork that is the user's own product intent is asked with the lean beside it.
 - `apply` — approving lands each fix as a pure correction: amend the affected sites in place, each amendment a dated note naming the source or finding that determines it. The confirmation says amended, never removed.
 - `route` — approving delivers each finding to its owning topic through the shared triage landing.
 

--- a/skills/workflow-shared/references/composing-a-raise.md
+++ b/skills/workflow-shared/references/composing-a-raise.md
@@ -14,7 +14,7 @@ Three beats, composed in order, then held until the caller emits the raise.
 
 ## A. The Problem
 
-Made immediately graspable, from zero. Say where it came from (the background {agent_type}) and what it observed — for a synthesis, the two positions in tension — then make the problem land before your position arrives: the product's behaviour first, one to three devices, technical depth only as deep as seeing the problem needs. For the devices and the test:
+Made immediately graspable, from zero. The product's situation opens — what its user meets and what happens to them — before anything else: the first sentence is about the product, never about the report. Where the finding came from (the background {agent_type}) and what it observed ride in a clause once the situation is on the page — for a synthesis, the two positions in tension; a raise that opens on the report being back, or on what it looked at, has opened on the wrong thing. Make the problem land before your position arrives: one to three devices, technical depth only as deep as seeing the problem needs. For the devices and the test:
 
 → Load **[making-it-land.md](making-it-land.md)** and follow its instructions as written.
 


### PR DESCRIPTION
## What

`research-raises-a-code-shaped-finding` (the case #1092 shipped) failed twice on the same two points, with every deterministic check and the world green. The code did translate — no identifiers, mechanisms told as product behaviours, a literal question — but the raise opened on "the deep dive is back, it looked at three stacks" with the shop's situation last, and it declined to lean.

## Changes

- **`composing-a-raise.md` §A** — the product's situation opens the raise; where the finding came from and what it observed ride in a clause once the situation is on the page. The old wording ordered provenance ahead of the product, a seam carried over from the surfacing protocol's §G.
- **Research `review-agent.md` and `deep-dive-agent.md` Lanes** — holding the decision for discussion withholds no lean: a lean on what the product should do is a position, not a decision, and a fork that is the user's own product intent is asked with the lean beside it.

## Gate

`npm test` green. Walks run from this branch after the PR: `research-raises-a-code-shaped-finding`, `discussion-raises-problem-then-position`, `research-review-walks-the-lanes` — results in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
