### PR TITLE
fix(prose): a raise's first sentence names the user's moment, and a side never carries a tuning number

### DIFF
--- a/skills/workflow-research-process/references/research-guidelines.md
+++ b/skills/workflow-research-process/references/research-guidelines.md
@@ -31,7 +31,7 @@ Don't constrain yourself. Research goes wherever it needs to go.
 
 **The conversation runs at product altitude** ([altitude.md](../../workflow-shared/references/altitude.md), in context): research answers what is possible and what it would mean for the product. A measurement reaches the user as its consequence, in a line — the command and its result are the document's. How the code would achieve the behaviour is the implementer's question, entered only where feasibility or an edge case genuinely turns on it; a deep-dive brief says which product question the thread serves, so the report comes back answering it.
 
-**Explore, don't decide**: Your job is to surface options, tradeoffs, and understanding — not to pick winners. Synthesis is welcome ("the tradeoffs are X, Y, Z"), conclusions are not ("therefore we should do Y"). Decisions belong elsewhere — your job is to explore.
+**Explore, don't decide**: Your job is to surface options, tradeoffs, and understanding — not to pick winners. Synthesis is welcome ("the tradeoffs are X, Y, Z"), conclusions are not ("therefore we should do Y"). Decisions belong elsewhere — your job is to explore. This governs the record, never your voice: in conversation you still say where you lean and why — a lean is a position, not a conclusion, and the file takes the landscape with the lean on it as material. "That's yours to weigh, not mine" is an interviewer's line, not a research partner's.
 
 **Divergent/convergent rhythm**: Early research is divergent — explore widely, generate ideas, follow tangents, let the space expand. As understanding builds, it naturally converges — threads connect, patterns emerge, the landscape becomes clearer. Be aware of which mode you're in. Don't converge too early — premature focus kills discovery. But don't stay divergent forever — synthesis has value.
 
@@ -51,7 +51,7 @@ When you notice these signals, flag it. Research surfaces options — decisions 
 
 **Decision** (discussion): "We should go with B because scaling matters more than simplicity for this project."
 
-Synthesis is your job. Decisions are not. Present the landscape, don't pick the destination.
+Synthesis is your job. Decisions are not. Present the landscape with your lean on it; the destination is discussion's to pick.
 
 ## Questioning
 

--- a/skills/workflow-shared/references/composing-a-raise.md
+++ b/skills/workflow-shared/references/composing-a-raise.md
@@ -8,7 +8,7 @@
 
 - `agent_type` — `review` | `synthesis` | `deep-dive` — the report's kind, named in the raise as where the finding came from
 
-A raise is an opener, never a case: its whole job is to put the user in front of the problem and say where you stand. Everything else — the report's full case, your own supporting analysis, the costs, secondary consequences — stays back and enters the conversation as responses, when the user's reply calls for it. The report is the record, never the script: digest it, and digest it upward — a finding written in code is retold as what the product does, at the level [altitude.md](altitude.md) sets, whatever level the report chose.
+A raise is an opener, never a case: its whole job is to put the user in front of the problem and say where you stand. Everything else — the report's full case, your own supporting analysis, the costs, secondary consequences — stays back and enters the conversation as responses, when the user's reply calls for it. The report is the record, never the script: digest it, and digest it upward — a finding written in code is retold as what the product does, at the level [altitude.md](altitude.md) sets, whatever level the report chose. A mechanism is retold as the behaviour it produces, wherever in the raise it appears; its tuning — a weight, a threshold, a window — stays in the record.
 
 Three beats, composed in order, then held until the caller emits the raise.
 
@@ -42,7 +42,7 @@ The position answers the finding's own question, never its bookkeeping: proposin
 
 The raise ends by saying what kind of reply moves things forward. One of three shapes:
 
-- **A question**, where the position turns on something only the user holds. A literal question, composed as altitude prescribes: the situation the user would be in, then what the product is or does on each side — one line per side where there are sides to choose between, so a number or a word answers it — and the one question mark that asks. Each side names what the product does, never the number that tunes it: a weight, a threshold, a window is the record's, and a side that carries one has leaked the case. Sides that cannot be composed as product end states mean the raise has no question for the user: it is material for the record, and the close takes the third shape instead.
+- **A question**, where the position turns on something only the user holds. A literal question, composed as altitude prescribes: the situation the user would be in, then what the product is or does on each side — one line per side where there are sides to choose between, so a number or a word answers it — and the one question mark that asks. Each side names what the product does, never the number that tunes it. Sides that cannot be composed as product end states mean the raise has no question for the user: it is material for the record, and the close takes the third shape instead.
 - **An invitation to push back**, where a real choice exists — pointing at the load-bearing reason the opener already gave as what a different reading would have to move, so the invitation belongs to this finding rather than to politeness.
 - **Nothing needs a call** — say so plainly and offer the pause: they are free to read and weigh in, and a word from them moves the walk on.
 

--- a/skills/workflow-shared/references/composing-a-raise.md
+++ b/skills/workflow-shared/references/composing-a-raise.md
@@ -14,7 +14,7 @@ Three beats, composed in order, then held until the caller emits the raise.
 
 ## A. The Problem
 
-Made immediately graspable, from zero. The product's situation opens — what its user meets and what happens to them — before anything else: the first sentence is about the product, never about the report. Where the finding came from (the background {agent_type}) and what it observed ride in a clause once the situation is on the page — for a synthesis, the two positions in tension; a raise that opens on the report being back, or on what it looked at, has opened on the wrong thing. Make the problem land before your position arrives: one to three devices, technical depth only as deep as seeing the problem needs. For the devices and the test:
+Made immediately graspable, from zero. The product's situation opens — what its user meets and what happens to them — before anything else: the first sentence names the product's user and their moment, and names no report, agent, deep dive, or finding. Where the finding came from (the background {agent_type}) and what it observed ride in a clause once the situation is on the page — for a synthesis, the two positions in tension; a raise that opens on the report being back, or on what it looked at, has opened on the wrong thing. Make the problem land before your position arrives: one to three devices, technical depth only as deep as seeing the problem needs. For the devices and the test:
 
 → Load **[making-it-land.md](making-it-land.md)** and follow its instructions as written.
 
@@ -42,12 +42,12 @@ The position answers the finding's own question, never its bookkeeping: proposin
 
 The raise ends by saying what kind of reply moves things forward. One of three shapes:
 
-- **A question**, where the position turns on something only the user holds. A literal question, composed as altitude prescribes: the situation the user would be in, then what the product is or does on each side — one line per side where there are sides to choose between, so a number or a word answers it — and the one question mark that asks. Sides that cannot be composed as product end states mean the raise has no question for the user: it is material for the record, and the close takes the third shape instead.
+- **A question**, where the position turns on something only the user holds. A literal question, composed as altitude prescribes: the situation the user would be in, then what the product is or does on each side — one line per side where there are sides to choose between, so a number or a word answers it — and the one question mark that asks. Each side names what the product does, never the number that tunes it: a weight, a threshold, a window is the record's, and a side that carries one has leaked the case. Sides that cannot be composed as product end states mean the raise has no question for the user: it is material for the record, and the close takes the third shape instead.
 - **An invitation to push back**, where a real choice exists — pointing at the load-bearing reason the opener already gave as what a different reading would have to move, so the invitation belongs to this finding rather than to politeness.
 - **Nothing needs a call** — say so plainly and offer the pause: they are free to read and weigh in, and a word from them moves the walk on.
 
 A dead stop is not an ending: a raise that trails off after its position leaves the user unsure whether a reply is owed or the conversation broke. No keyed menu, no bundled follow-ups, no stock closer: "what do you think?" is never the ask, and a closing beat repeated verbatim across the walk reads as chrome, not a colleague — phrase it from the finding just raised. The beat draws only on what the opener already said — reaching into the held-back depth for a concrete pivot is how the case leaks back in one clause at a time.
 
-**The test**, before the raise goes out — read it as the user will, cold, in one glance: they can picture the behaviour, they know where you stand, and they know what reply is wanted, with no code identifier in front of them. A raise that fails is recomposed at altitude, never sent and explained after.
+**The test**, before the raise goes out — read it as the user will, cold, in one glance: they can picture the behaviour, they know where you stand, and they know what reply is wanted, with no code identifier, no report named ahead of their situation, and no tuning number in front of them. A raise that fails is recomposed at altitude, never sent and explained after.
 
 → Return to caller.

--- a/tests/prose/cases/research-raises-a-code-shaped-finding/assert.md
+++ b/tests/prose/cases/research-raises-a-code-shaped-finding/assert.md
@@ -23,8 +23,8 @@ The prose should have taken this path:
 7. the raise is composed at product altitude from a report written in
    code: the problem lands as the shop's situation — a ranking change
    goes out, most searches get better, searches for rare products get
-   worse — then the three behaviours as what the product does at
-   release, then a position with one reason, then one literal question
+   worse — then the behaviours as what the product does at release,
+   then a position at its earned firmness, then one literal question
    for the user, and the turn ends awaiting them
 
 Presentation claims — the translation is the behaviour under test:
@@ -39,20 +39,28 @@ Presentation claims — the translation is the behaviour under test:
   guard function, the exception, the weights request, the feature flag,
   the rollout file, the slice list, nor any snippet or path; the
   mechanisms are told only as what the product does
-- the three shapes are stated as product end states, one per side —
-  the change never ships until rare-product searches hold; it ships
-  when the loss on rare searches is outweighed, those searches counting
-  for more; it ships and is pulled back once rare searches have
-  suffered for a while — so a number or a word answers
-- the raise states a position — a lean with one load-bearing reason —
-  never a neutral survey of the three
+- the release behaviours the deep dive found are told as what the
+  product does — the change never ships until rare-product searches
+  hold; it ships when the loss on rare searches is outweighed, those
+  searches counting for more; it ships and is pulled back once rare
+  searches have suffered for a while — and the sides put to the user
+  are product end states, two or three, so a number or a word answers;
+  a raise that compresses the behaviours into "in different ways" and
+  shows the user none of them fails this claim
+- the raise states a position at its earned firmness — a lean with one
+  load-bearing reason, or, where the user alone holds the answer, what
+  the raise would need to know from them — never a neutral survey, and
+  never an abdication ("that's yours to weigh, not mine")
 - the raise ends on a single literal question, the one thing only the
   user holds: which of those the product should do, or how much of a
   regression on rare searches they will let reach shoppers — never
   "what do you think?", never a keyed menu, and never a request to
   settle how the harness would be built
-- the report's depth stays back: tolerances, weights, alarm windows,
-  and the slice-list refresh cadence appear nowhere in the raise
+- the report's tuning stays back: no numeric weight (the two-and-a-
+  half-times multiplier), tolerance (the half-point), or refresh
+  cadence (quarterly) appears in the raise; a behaviour told as the
+  user meets it — a change pulled back after a couple of hours of
+  worse results — is the product level, not a leak
 - no outcome is documented in the raise's turn: nothing is written to
   the research file and no direction is recorded as chosen
 


### PR DESCRIPTION
## What

The re-walk of `research-raises-a-code-shaped-finding` on #1096 came back FLAKY: one run still opened on "the deep dive came back", and one carried the report's weight (2.5×) and alarm window into the sides. The wording allowed both.

## Changes

Three lines in `composing-a-raise.md`:

- §A — the first sentence names the product's user and their moment, and names no report, agent, deep dive, or finding.
- §C — each side names what the product does, never the number that tunes it; a weight, a threshold, a window is the record's.
- §C test — no code identifier, no report named ahead of the situation, and no tuning number in front of the user.

## Gate

`npm test` green. Walk of `research-raises-a-code-shaped-finding` run against this branch — result in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
