### PR TITLE
fix(prose): a landed research is put to the user, never written onto the map

### DIFF
--- a/skills/workflow-shared/references/reconcile-advisory.md
+++ b/skills/workflow-shared/references/reconcile-advisory.md
@@ -30,7 +30,7 @@ node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.
 
 **If `completed`:**
 
-The research has landed. Surface the advisory, read the topic's research file fresh into context, and clear the flag.
+The research has landed. Surface the advisory, read the topic's research file fresh into context, and clear the flag. What it re-examines is carried into the session as ground to put to the user — decisions here are theirs to revisit, and nothing on the discussion map moves until they do.
 
 > *Output the next fenced block as a code block:*
 

--- a/tests/prose/cases/discussion-spawns-an-experiment-and-continues/assert.md
+++ b/tests/prose/cases/discussion-spawns-an-experiment-and-continues/assert.md
@@ -58,9 +58,9 @@ Further claims:
 - the document holds the refund decision written up in full, the dated
   awaiting-E1 note in the webhook-timing section, and no invented
   timing number anywhere
-- no review walk blocked the close: the wait gate fired before the
-  ceremony's review machinery, so whatever background review ran
-  stayed background
+- no review walk blocked the close: whatever background review ran
+  came back clean and raised nothing, so the wait gate was the first
+  and only block the wrap-up met
 - git history holds the spawn commit, the sweep-marked record commit,
   and the refund decision's commit
 

--- a/tests/prose/cases/discussion-sweeps-a-dead-peers-leavings/case.json
+++ b/tests/prose/cases/discussion-sweeps-a-dead-peers-leavings/case.json
@@ -24,6 +24,7 @@
     "skills/workflow-shared/references/rerouted-concerns.md",
     "skills/workflow-discussion-process/references/discussion-session.md",
     "skills/workflow-discussion-process/references/closing-gates.md",
+    "skills/workflow-shared/references/closing-recap.md",
     "skills/workflow-discussion-process/references/review-agent.md",
     "skills/workflow-discussion-process/references/perspective-agents.md",
     "skills/workflow-shared/references/background-agent-surfacing.md",

--- a/tests/prose/cases/experiment-abandoned-returns-open/case.json
+++ b/tests/prose/cases/experiment-abandoned-returns-open/case.json
@@ -30,6 +30,7 @@
     "skills/workflow-shared/references/background-agent-surfacing.md",
     "skills/workflow-shared/references/composing-a-raise.md",
     "skills/workflow-shared/references/making-it-land.md",
+    "skills/workflow-shared/references/experiment-spawn.md",
     "skills/workflow-shared/references/natural-breaks.md",
     "skills/workflow-discussion-process/references/final-review.md",
     "skills/workflow-shared/references/final-review-menu.md",

--- a/tests/prose/cases/research-resumes-on-the-verdict/assert.md
+++ b/tests/prose/cases/research-resumes-on-the-verdict/assert.md
@@ -19,7 +19,8 @@ The prose should have taken this path:
 4. the evidence lands in the file: the measured share, what it rests
    on, and behaviour-driven expansion as the leading candidate — held
    as material for the discussion, never decided here — and the waiting
-   note gives way to the answered number
+   note is answered beneath it — a dated entry carrying the number,
+   the waiting line kept as the record of the wait
 5. the user wraps; the triage queue reads empty and the wait-gate
    fetch comes back empty — the release already happened, so no gate
    is emitted and nothing blocks
@@ -51,7 +52,8 @@ Further claims:
 
 EXPECTED WORLD — the fixture plus: the research item `completed` with
 the reconcile flag absent; the research document carrying the measured
-share, its provenance, and the leading-candidate note in place of the
-awaiting note; the stubbed review report in the topic's cache with its
+share, its provenance, and the leading-candidate note as a dated entry
+beneath the awaiting note, which stays as the record of the wait; the
+stubbed review report in the topic's cache with its
 agent row closed; the experiment item and E1's row byte-unchanged; the
 research indexed into the knowledge store by the completion.


### PR DESCRIPTION
## What

Follow-up from walking the nine prose cases the research-wait stack (#1091, #1093) intersects. Six passed clean, one flaked on walk timing, two failed the same way on both runs.

## Fixes

- **`reconcile-advisory.md`, landed branch.** Both walks of `discussion-resumes-on-landed-research` read the landed research, cleared the flag, then flipped the `signal-weighting` subtopic from decided to exploring with `discussion-map set` before the session's first turn to the user. The branch now says what the research re-examines is carried into the session as ground for the user, and nothing on the discussion map moves until they revisit a decision. That is the discussion phase's own rule made explicit at the one place a landed input arrives.
- **`research-resumes-on-the-verdict`.** Both walks kept the "awaiting E1" line and appended a dated "Settled" entry beneath it; the case expected the note replaced. Appending a dated entry over the original is the record convention elsewhere, so the case's expectation moves to match.
- **`discussion-spawns-an-experiment-and-continues`.** Its further claim said the wait gate fires before the review machinery; the record shows the review scanned and acked clean first. The claim now states the operative outcome.
- **Scope ratchet.** `discussion-sweeps-a-dead-peers-leavings` declares `closing-recap.md`; `experiment-abandoned-returns-open` declares `experiment-spawn.md`. Both were read on the walks.

## Not changed

`experiment-abandoned-returns-open` FLAKY: the review dispatch and the wrap landed in one natural break on the first run so the findings-owed gate fired; the rerun drained first and passed 8/8. All four coded checks passed both times. Timing in the walk, not the prose.

## Verification

Prose perimeter (`test-prose-cases`, `test-prose-invariants`, `test-prose-snapshots`, `test-conventions-lint`): 228 pass. `node tests/prose/run.cjs select --diff main` intersects 53 cases; the one worth re-walking is `discussion-resumes-on-landed-research`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)