### PR TITLE
impl(prose): a verifier records what reading cannot settle, and coverage lands per batch

### DIFF
--- a/agents/workflow-review-task-verifier.md
+++ b/agents/workflow-review-task-verifier.md
@@ -65,6 +65,8 @@ Search the codebase:
 
 **The code is the source of truth.** Implementations legitimately move past the plan's text, and the spec is not always updated to follow — nor should it be. A divergence from the spec or the task's wording is a question, never automatically a finding: judge whether the change is sound, consistent with the record, and better than or equal to what was written. Report a divergence only when it is a loss — behaviour the intent still needs, gone, or a change with no defensible reason — never because the words no longer match.
 
+**A criterion reading cannot settle is recorded, never passed over.** Some criteria hold only under something run or observed — a suite run, a repeated-run stability check, a cache experiment, a live server. Judge such a criterion neither way: quote it under `UNSETTLED` with what would have to be run or observed to settle it. It is never a finding and never a blocking issue, and it moves `STATUS` nowhere — the status is judged over what reading settled.
+
 **For quick-fix work**: Instead of acceptance criteria, verify completeness against the task's Verification section:
 - Are all target files updated?
 - Do any occurrences of the old pattern remain in scope?
@@ -142,7 +144,9 @@ Every finding carries a `file:line` anchor, and every claim inside it must hold 
 
 ## Output File Format
 
-Write to `.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md` — in two steps: write the content to the same path with a `.txt` extension using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context. Use this format:
+Write to `.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md` — in two steps: write the content to the same path with a `.txt` extension using the Write tool, then immediately rename it with Bash from the project root (`mv {path}.txt {path}.md`). Report the final `.md` path in your status. Do NOT write the `.md` directly with the Write tool — the harness blocks report-shaped `.md` writes from sub-agents; the `.txt`-then-rename keeps the file out of the orchestrator's context.
+
+`STATUS` is one of three values — `complete`: delivered, nothing to report; `issues_found`: delivered, non-blocking findings present; `incomplete`: a blocking issue — an acceptance criterion unmet in substance, or behaviour broken. A list heading with nothing under it carries `- None`. Use this format:
 
 ```
 TASK: [Task name/description]
@@ -176,6 +180,9 @@ BLOCKING ISSUES:
 
 FINDINGS:
 - [{in-scope|out-of-scope}] [{contained|spreading}] {file:line} — {what is wrong and the change that fixes it} — FAILS: {the concrete consequence of leaving it}
+
+UNSETTLED:
+- "{the acceptance criterion, quoted}" — {what would have to be run or observed to settle it}
 ```
 
 ## Your Output
@@ -195,6 +202,6 @@ SUMMARY: {1 sentence}
 3. **Be specific** — include file paths and line numbers, verified per **Citation Discipline**
 4. **Balanced test review** — flag both under-testing AND over-testing
 5. **Report findings** — don't fix anything, just report what you find
-6. **No test execution** — Bash is solely for the output-file rename. Judge test adequacy by reading the test code; never try to run the suite or any other command
+6. **No test execution** — Bash is solely for the output-file rename. Judge test adequacy by reading the test code; never try to run the suite or any other command. You read; an executing pass over the whole change-set runs after the verifier batches and measures what reading could not settle — which is why a criterion you cannot settle is recorded under `UNSETTLED` for that pass, never judged either way
 7. **No git writes** — writing the output file is your only file write
 8. **Never lose your work** — the knowledge you generate must survive the run, and the output file is how it survives. Produce the file via the `.txt`-then-rename mechanism; if a step errors, quote the error verbatim in your status. Never conclude the write is blocked without attempting it. Only if the write itself has errored may you return the full content in your final message for the orchestrator to persist — an absolute last resort, never an alternative to writing.

--- a/skills/workflow-review-process/references/invoke-task-verifiers.md
+++ b/skills/workflow-review-process/references/invoke-task-verifiers.md
@@ -74,12 +74,22 @@ Dispatch verifiers in **batches of 5** via the Task tool.
 
 - **Agent path**: `../../../agents/workflow-review-task-verifier.md`
 
-1. Group tasks into batches of 5
+Before the first batch, read the recorded coverage once and hold it as a local set — `push` appends unconditionally, so a crash-resume re-run must never double-record (empty stdout means none):
+
+```bash
+node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.review.{topic} reviewed_tasks
+```
+
+1. Group tasks into batches of 5 — no task to verify is no batch, and the step falls through to the excluded tasks and the aggregation, which re-reads the reports already on disk
 2. For each batch:
    - Dispatch all agents in the batch in parallel
    - Wait for all agents in the batch to return
    - Record statuses
-3. After all batches complete, proceed to aggregation
+   - Push the internal ID of each task whose verifier returned and that is not already in the set, and add it to the set — coverage lands per batch, so a crash mid-verification resumes from the batch it lost, never from the start; a failed verifier's task stays unrecorded, so the next session picks it up:
+     ```bash
+     node .claude/skills/workflow-engine/scripts/engine.cjs manifest push {work_unit}.review.{topic} reviewed_tasks "{internal_id}"
+     ```
+3. After all batches complete, proceed to the excluded tasks
 
 Each verifier receives:
 
@@ -106,20 +116,17 @@ SUMMARY: {1 sentence}
 
 Full findings are written to `.workflows/{work_unit}/review/{topic}/report-{phase_id}-{task_id}.md`.
 
-→ Proceed to **F. Update Reviewed Tasks**.
+→ Proceed to **F. Record Excluded Tasks**.
 
 ---
 
-## F. Update Reviewed Tasks
+## F. Record Excluded Tasks
 
-After all verifiers complete, read `reviewed_tasks` once and push each verified task's internal ID that is not already recorded — `push` appends unconditionally, so a crash-resume re-run must not double-record. Push the ids excluded as skipped/cancelled at extraction too (excluded-by-design is covered — without this, the resume gate counts them unreviewed forever):
+Push the ids excluded as skipped/cancelled at extraction — excluded-by-design is covered; without this, the resume gate counts them unreviewed forever. `push` appends unconditionally: skip any id already in the set.
 
 ```bash
-node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.review.{topic} reviewed_tasks
 node .claude/skills/workflow-engine/scripts/engine.cjs manifest push {work_unit}.review.{topic} reviewed_tasks "{internal_id}"
 ```
-
-This enables incremental review detection on subsequent review sessions.
 
 → Proceed to **G. Aggregate Findings**.
 
@@ -129,11 +136,12 @@ This enables incremental review detection on subsequent review sessions.
 
 1. Read every `.workflows/{work_unit}/review/{topic}/report-*.md` file from disk — the aggregation draws from the files as they stand, never from memory of the dispatches that produced them. Make each Read before aggregating; a read not actually made is never claimed or paraphrased from the dispatch summaries
 2. Synthesize findings from file contents:
-   - Collect all tasks with `STATUS: incomplete` or `STATUS: issues_found` as blocking issues
+   - Collect the blocking issues from each report's `BLOCKING ISSUES` section — every entry other than `- None`. Never infer one from `STATUS`: `issues_found` is a delivered task with non-blocking findings
    - Collect all test issues (under/over-tested)
    - Collect all code quality concerns
    - Include specific file:line references
    - Check overall plan completion (see [review-checklist.md](review-checklist.md) — Plan Completion Check)
+3. Collect every `UNSETTLED` entry other than `- None` into `.workflows/.cache/{work_unit}/review/{topic}/unsettled.txt` with the Write tool — one block per criterion, opening with `[{task suffix}]` and carrying the entry verbatim. When there are none, delete any `unsettled.txt` an earlier run left there and write nothing: the executing pass treats an absent file as no unsettled criteria
 
 > **CHECKPOINT**: Do not proceed until ALL task verifiers have returned and findings are aggregated.
 

--- a/tests/prose/stubs/review-task-1-1-flags-assertion.md
+++ b/tests/prose/stubs/review-task-1-1-flags-assertion.md
@@ -37,7 +37,10 @@ CODE QUALITY:
 - Issues: one assertion that cannot fail
 
 BLOCKING ISSUES:
-- none
+- None
 
 FINDINGS:
 - [in-scope] [contained] tests/checkout/payment-intent.test.js:5-6 — the test builds `intent` locally and asserts its own literal back; build it through `createPaymentIntent(order)` and assert the gateway payload instead — FAILS: the test stays green whatever the intent builder sends
+
+UNSETTLED:
+- None

--- a/tests/prose/stubs/review-task-1-2-flags-claim.md
+++ b/tests/prose/stubs/review-task-1-2-flags-claim.md
@@ -37,7 +37,10 @@ CODE QUALITY:
 - Issues: one comment claim the code falsifies
 
 BLOCKING ISSUES:
-- none
+- None
 
 FINDINGS:
 - [in-scope] [contained] src/webhooks/capture.js:2-3 — the comment claims a missing delivery is recovered "by polling the gateway on a timer"; no polling path exists and the spec pins capture as webhook-only — delete the recovery clause, leaving the webhook sentence — FAILS: a reader trusts the comment and hunts for a polling fallback that does not exist
+
+UNSETTLED:
+- None

--- a/tests/prose/stubs/review-task-verified.md
+++ b/tests/prose/stubs/review-task-verified.md
@@ -39,7 +39,10 @@ CODE QUALITY:
 - Issues: none
 
 BLOCKING ISSUES:
-- none
+- None
 
 FINDINGS:
-- none
+- None
+
+UNSETTLED:
+- None


### PR DESCRIPTION
## Summary

PR2 of the review executing-pass stack (design #1109, on #1110). The verification side:

- **A criterion reading cannot settle is recorded, never passed over.** The verifier's report gains an `UNSETTLED:` section — each such criterion quoted, with what would have to be run or observed to settle it. It is never a finding, never a blocking issue, and moves `STATUS` nowhere. The reason is stated once beside the no-execution rule, which stays intact: the executing pass after the batches measures what reading could not.
- **`STATUS` defined**: `complete`, `issues_found` (delivered, non-blocking findings), `incomplete` (a blocking issue).
- **Aggregation reads the `BLOCKING ISSUES` section, never `STATUS`** — in the live run `issues_found` was read as blocking for a status eleven clean reports also used. Unsettled entries are collected into one cache file for the pass to read.
- **Coverage lands per batch.** `reviewed_tasks` is pushed after every batch, not once at the end; the live run hit a session rate limit at task 180 of 190 with nothing durable.

The three shared verifier stubs carry the new section so the existing review cases stand in for the current contract.

## Verification

`npm test` 2830/2830 (corpus validation and snapshot goldens, no world moved), `npm run test:cli` green, `npm run typecheck` clean. No case invariant changed: with one batch, the coverage push still lands before the prep commit. `select --diff main` names `bridge-completes-the-feature`, `review-approves-the-work`, `review-preps-and-applies-findings`; not walked.

## Review pass (2026-09-10)

Rebased onto main. The aggregation collects only `UNSETTLED` entries other than `- None`, deletes a stale `unsettled.txt` when there are none, and a re-entry with no task to verify falls through the batch loop to the aggregation, which re-reads the reports on disk (the crash-resume arm now routes through the whole verification step with an empty set rather than landing on the pass without its inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
