### PR TITLE
impl(prose): the finding floor holds what every finder shares; the comment-correction shape moves to the code standard

### DIFF
--- a/agents/workflow-implementation-analysis-architecture.md
+++ b/agents/workflow-implementation-analysis-architecture.md
@@ -73,7 +73,7 @@ COMMENT_CORRECTIONS:
 SUMMARY: {1-3 sentences}
 ```
 
-COMMENT_CORRECTIONS holds each comment whose entire remedy is comment text — never a FINDING (finding-floor.md → Comment-Only Remedies); omit the section when there are none. `FINDINGS: none` when no candidate clears the floor — a file may carry corrections and no findings.
+COMMENT_CORRECTIONS holds each comment whose entire remedy is comment text — never a FINDING (code-quality.md → Comment corrections); omit the section when there are none. `FINDINGS: none` when no candidate clears the floor — a file may carry corrections and no findings.
 
 ## Your Output
 

--- a/agents/workflow-implementation-analysis-duplication.md
+++ b/agents/workflow-implementation-analysis-duplication.md
@@ -69,7 +69,7 @@ COMMENT_CORRECTIONS:
 SUMMARY: {1-3 sentences}
 ```
 
-COMMENT_CORRECTIONS holds each comment whose entire remedy is comment text — never a FINDING (finding-floor.md → Comment-Only Remedies); omit the section when there are none. `FINDINGS: none` when no candidate clears the floor — a file may carry corrections and no findings.
+COMMENT_CORRECTIONS holds each comment whose entire remedy is comment text — never a FINDING (code-quality.md → Comment corrections); omit the section when there are none. `FINDINGS: none` when no candidate clears the floor — a file may carry corrections and no findings.
 
 ## Your Output
 

--- a/agents/workflow-implementation-analysis-standards.md
+++ b/agents/workflow-implementation-analysis-standards.md
@@ -69,7 +69,7 @@ COMMENT_CORRECTIONS:
 SUMMARY: {1-3 sentences}
 ```
 
-COMMENT_CORRECTIONS holds each comment whose entire remedy is comment text — never a FINDING (finding-floor.md → Comment-Only Remedies); omit the section when there are none. `FINDINGS: none` when no candidate clears the floor — a file may carry corrections and no findings.
+COMMENT_CORRECTIONS holds each comment whose entire remedy is comment text — never a FINDING (code-quality.md → Comment corrections); omit the section when there are none. `FINDINGS: none` when no candidate clears the floor — a file may carry corrections and no findings.
 
 ## Your Output
 

--- a/skills/workflow-implementation-process/references/code-quality.md
+++ b/skills/workflow-implementation-process/references/code-quality.md
@@ -56,6 +56,10 @@ Code shows what; a comment earns its place only by carrying what the code cannot
 
 When a change makes a nearby comment false, fix it in the same edit — and prefer deleting the claim to re-arguing it.
 
+### Comment corrections
+
+Where an output format names a comment-correction shape, a finding whose entire remedy is comment text is reported there — the file and line, what is wrong, the OLD text verbatim, the NEW text (empty to delete) — never as a finding. A correction must itself clear the bar above: a comment earns its place only by carrying what the code cannot, and a comment that cannot is deleted, never reworded.
+
 ## Anti-Patterns to Avoid
 - God classes
 - Magic numbers/strings

--- a/skills/workflow-implementation-process/references/finding-floor.md
+++ b/skills/workflow-implementation-process/references/finding-floor.md
@@ -1,10 +1,10 @@
 # Finding Floor
 
-*Reference for **[workflow-implementation-process](../SKILL.md)***
+*Reference for **[workflow-implementation-process](../SKILL.md)** — also loaded by the review phase's change-set verifiers*
 
 ---
 
-Every implementation finding clears this floor before it is written — an analysis finding, a consolidation finding, a BANK entry, a staged proposal — and every party that judges one re-applies it.
+Every finding clears this floor before it is written — an analysis finding, a consolidation finding, a BANK entry, a staged proposal, a review change-set finding — and every party that judges one re-applies it.
 
 ## The Floor
 
@@ -17,9 +17,5 @@ Duplication is a finding only when the copies encode a rule whose divergence wou
 ## Test Files
 
 A test file is in scope only for a failure-mode finding — a guard that passes while checking nothing, an isolation hole that reaches the developer's machine, a reproduced flake on the thing being shipped. Never for reuse, naming, or symmetry.
-
-## Comment-Only Remedies
-
-A finding whose entire remedy is comment text is not a finding. Report it as a comment correction — the file and line, what is wrong, the OLD text verbatim, the NEW text (empty to delete) — in the shape your output format names. A correction must itself clear the comment bar in **[code-quality.md](code-quality.md)** → Comments: a comment earns its place only by carrying what the code cannot, and a comment that cannot is deleted, never reworded.
 
 → Return to caller.


### PR DESCRIPTION
## Summary

Inserted between #1111 and #1112 by the review pass. The review's change-set verifiers load the shared finding floor (`finding-floor.md`), but its fourth rule — a finding whose entire remedy is comment text is reported as a comment correction, never as a finding — contradicts how the review routes such findings (do-now, never blocking; a comment remedy standing in for a code defect re-aimed at the code). That rule belongs to the finders whose output format names a comment-correction shape.

- `finding-floor.md` keeps the three rules every finder shares (the failure named, duplication only when its divergence would be silent, test files only for failure-mode findings) and states that the review's change-set verifiers load it too.
- The comment-correction shape moves into `code-quality.md`'s Comments section as `### Comment corrections`, which every implementation finder already reads, so no dispatch changes.
- The three analysis agents' citations point at the new home.

## Verification

`npm test` 2848/2848, `npm run test:cli` green, `npm run typecheck` clean on the stack top. The seven implementation prose cases `select --diff main` names are not walked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)