### PR TITLE
impl(prose): one specification body — the scoping skill writes the shape every other work type writes

### DIFF
--- a/agents/workflow-review-change-set-verifier.md
+++ b/agents/workflow-review-change-set-verifier.md
@@ -12,7 +12,7 @@ Act as a **senior software architect** with deep experience in code review. Ever
 ## Your Input
 
 You receive:
-1. **Section**: its name and its content — one of the specification's numbered sections, the `test surface` (the change-set's test files, held against everything the specification asks them to guard), or a quick-fix's whole scoping document
+1. **Section**: its name and its content — one of the specification's numbered sections, the `test surface` (the change-set's test files, held against everything the specification asks them to guard), or a quick-fix's whole specification
 2. **Specification path**: read your section in full, and the `## Corrigenda` section at the end of the document when one exists — corrigenda override the body
 3. **Plan path**: the plan, for context on how the work was staged
 4. **Change-set**: the list of files the task commits touched and the commit range — from the parent of the first task commit to `HEAD` — the boundary of everything you judge

--- a/skills/workflow-review-process/references/invoke-change-set-verifiers.md
+++ b/skills/workflow-review-process/references/invoke-change-set-verifiers.md
@@ -12,7 +12,10 @@ This step dispatches `workflow-review-change-set-verifier` agents once per revie
 
 The cycle number `{N}` is the one **[invoke-review-synthesizer.md](invoke-review-synthesizer.md)** → Determine Cycle Number derives — the count of `review-report-c*.md` files in `.workflows/{work_unit}/implementation/{topic}/` plus one. Every file this step writes or reads carries it, so a later cycle measures the change-set as it then stands rather than reading the previous cycle's files.
 
-Read the specification at `.workflows/{work_unit}/specification/{topic}/specification.md`. The split is its numbered sections — each `### N.` heading beneath `## Specification` with everything under it — plus one section named `test surface`, over the change-set's test files held against everything the specification asks them to guard. A document with no numbered sections is one section named for the document, slug `specification`; for a quick-fix that section is the whole split, with no test surface — its scoping document carries its own verification.
+Read the specification at `.workflows/{work_unit}/specification/{topic}/specification.md`. The split keys on the work type read in **[invoke-task-verifiers.md](invoke-task-verifiers.md)** → B. Extract All Tasks, never on the document's headings:
+
+- **Quick-fix** — one section over the whole document, slug `specification`, and no test surface: the document carries its own verification.
+- **Every other work type** — the document's numbered sections, each `### N.` heading beneath `## Specification` with everything under it, plus one section named `test surface`, over the change-set's test files held against everything the specification asks them to guard. A document with no numbered sections is one section named for the document, slug `specification`, plus the test surface.
 
 When the numbered sections exceed four, merge adjacent sections from the lowest numbers up — the first with the second, then the next two — until four remain, so that with the test surface there are at most five. A merged section carries both names and both bodies.
 

--- a/skills/workflow-scoping-process/references/write-specification.md
+++ b/skills/workflow-scoping-process/references/write-specification.md
@@ -8,31 +8,39 @@ Write a lightweight specification directly. No agents, no review cycles — the 
 
 ## A. Write the Spec
 
-Create the specification file at `.workflows/{work_unit}/specification/{topic}/specification.md`:
+→ Load **[specification-body.md](../../workflow-shared/references/specification-body.md)** and follow its instructions as written.
+
+Create the specification file at `.workflows/{work_unit}/specification/{topic}/specification.md` in the body's shape — four numbered sections beneath `## Specification`, `## Working Notes` empty:
 
 ```markdown
 # Specification: {Topic:(titlecase)}
 
-## Change Description
+## Specification
+
+### 1. Change Description
 
 {What is being changed and why — 2-3 sentences}
 
-## Scope
+### 2. Scope
 
 {Files, directories, or patterns affected. Be specific:}
 {- "All .go files in pkg/" or "grep -r 'interface{}' --include='*.go'"}
 {- Include file counts or pattern matches if known}
 
-## Exclusions
+### 3. Exclusions
 
 {Anything explicitly excluded from the change, or "None"}
 
-## Verification
+### 4. Verification
 
 {How to verify the change is correct — typically:}
 {- All existing tests pass after the change}
 {- No occurrences of the old pattern remain in scope}
 {- Any additional checks specific to this change}
+
+---
+
+## Working Notes
 ```
 
 Confirm the spec was written:
@@ -42,6 +50,8 @@ Confirm the spec was written:
 ```
 Specification written: .workflows/{work_unit}/specification/{topic}/specification.md
 ```
+
+→ On return, proceed to **B. Register in Manifest**.
 
 ## B. Register in Manifest
 

--- a/skills/workflow-shared/references/specification-body.md
+++ b/skills/workflow-shared/references/specification-body.md
@@ -1,0 +1,29 @@
+# Specification Body
+
+*Shared reference. Loaded by workflow-specification-process and workflow-scoping-process.*
+
+---
+
+The body of every specification file (`.workflows/{work_unit}/specification/{topic}/specification.md`):
+
+```markdown
+# Specification: [Topic Name]
+
+## Specification
+
+[Validated content accumulates here, organized by topic/phase]
+
+---
+
+## Working Notes
+
+[Optional - capture in-progress discussion if needed]
+```
+
+Bracketed lines are placeholders, not content — never copy placeholder text into the file; a section not yet written carries its heading alone. Topic content nests beneath `## Specification` as numbered `###` sections (`### 3. Sweep Scope`), subdivided where a section has distinct parts as decimal `####` subsections (`#### 3.2 The in-scope set`) — never as sibling `##` headings.
+
+Sections are stable — the number is the address, not the position. Wrong content in `3.2` is edited in place; new knowledge belonging to section 3 appends as its next subsection (`3.4`); a new top-level section appends at the end (`### 7.`) — order doesn't matter. Only when placement genuinely matters does a section slot in mid-sequence, and then the renumbering is careful: every displaced number and every `§` reference to it updates in the same edit. The document's furniture — `## Working Notes`, an epic's `## Dependencies`, a `## Corrigenda` — sits outside the numbering.
+
+A specification corrected after its own phase concluded may additionally carry a `## Corrigenda` section as its final section — the durable record of post-conclusion amendments, written only through **[correcting-historical-artifacts.md](correcting-historical-artifacts.md)**, never during specification work. A specification session that finds one leaves it exactly where it stands — it is the audit trail of corrections made from downstream, and it survives every later edit as the file's last section.
+
+→ Return to caller.

--- a/skills/workflow-specification-process/references/specification-format.md
+++ b/skills/workflow-specification-process/references/specification-format.md
@@ -48,25 +48,7 @@ Lifecycle `status` transitions go through the engine, not `set` — `engine topi
 
 ## Body
 
-```markdown
-# Specification: [Topic Name]
-
-## Specification
-
-[Validated content accumulates here, organized by topic/phase]
-
----
-
-## Working Notes
-
-[Optional - capture in-progress discussion if needed]
-```
-
-Bracketed lines are placeholders, not content — create the file with the headings and leave the sections empty; never copy placeholder text into the file. Topic content nests beneath `## Specification` as numbered `###` sections (`### 3. Sweep Scope`), subdivided where a section has distinct parts as decimal `####` subsections (`#### 3.2 The in-scope set`) — never as sibling `##` headings.
-
-Sections are stable — the number is the address, not the position. Wrong content in `3.2` is edited in place; new knowledge belonging to section 3 appends as its next subsection (`3.4`); a new top-level section appends at the end (`### 7.`) — order doesn't matter. Only when placement genuinely matters does a section slot in mid-sequence, and then the renumbering is careful: every displaced number and every `§` reference to it updates in the same approved edit. The document's furniture — `## Working Notes`, an epic's `## Dependencies`, a `## Corrigenda` — sits outside the numbering.
-
-A specification corrected after its own phase concluded may additionally carry a `## Corrigenda` section as its final section — the durable record of post-conclusion amendments, written only through `workflow-shared/references/correcting-historical-artifacts.md`, never during specification work. A specification session that finds one leaves it exactly where it stands — it is the audit trail of corrections made from downstream, and it survives every later edit as the file's last section.
+→ Load **[specification-body.md](../../workflow-shared/references/specification-body.md)** and follow its instructions as written.
 
 ---
 

--- a/tests/prose/cases/bridge-hands-off-to-planning/case.json
+++ b/tests/prose/cases/bridge-hands-off-to-planning/case.json
@@ -17,6 +17,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/scoping-defines-the-quickfix/assert.md
+++ b/tests/prose/cases/scoping-defines-the-quickfix/assert.md
@@ -32,8 +32,10 @@ EXPECTED WORLD — from a work unit holding only its discovery carrier:
 
 - a specification at
   `.workflows/support-email/specification/support-email/specification.md`
-  carrying the scoping shape — change description, scope, exclusions,
-  verification — and naming both the old and new addresses
+  in the shape every specification carries — `## Specification` holding
+  four numbered sections (change description, scope, exclusions,
+  verification) and an empty `## Working Notes` — naming both the old
+  and new addresses
 - the scope reflecting what the user actually said: the checkout footer
   and contact page as known sites, the transactional template as
   suspected, with the exact locations left to implementation to confirm

--- a/tests/prose/cases/scoping-defines-the-quickfix/case.json
+++ b/tests/prose/cases/scoping-defines-the-quickfix/case.json
@@ -16,6 +16,7 @@
     "skills/workflow-scoping-process/references/gather-context.md",
     "skills/workflow-scoping-process/references/complexity-check.md",
     "skills/workflow-scoping-process/references/write-specification.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-scoping-process/references/select-format.md",
     "skills/workflow-scoping-process/references/write-tasks.md",
     "skills/workflow-scoping-process/references/conclude-scoping.md",

--- a/tests/prose/cases/spec-auto-applies-settled-stops-on-choice/case.json
+++ b/tests/prose/cases/spec-auto-applies-settled-stops-on-choice/case.json
@@ -18,6 +18,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-completes-the-cross-cutting/case.json
+++ b/tests/prose/cases/spec-completes-the-cross-cutting/case.json
@@ -17,6 +17,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-derives-an-unsourced-decision/case.json
+++ b/tests/prose/cases/spec-derives-an-unsourced-decision/case.json
@@ -18,6 +18,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-discusses-and-declines-a-finding/case.json
+++ b/tests/prose/cases/spec-discusses-and-declines-a-finding/case.json
@@ -18,6 +18,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-extracts-the-discussion/case.json
+++ b/tests/prose/cases/spec-extracts-the-discussion/case.json
@@ -17,6 +17,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-measures-a-false-claim/case.json
+++ b/tests/prose/cases/spec-measures-a-false-claim/case.json
@@ -17,6 +17,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-repairs-a-measured-conclusion/case.json
+++ b/tests/prose/cases/spec-repairs-a-measured-conclusion/case.json
@@ -17,6 +17,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-resolves-a-source-conflict/case.json
+++ b/tests/prose/cases/spec-resolves-a-source-conflict/case.json
@@ -17,6 +17,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-review-routes-a-source-defect/case.json
+++ b/tests/prose/cases/spec-review-routes-a-source-defect/case.json
@@ -18,6 +18,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-routes-a-gap-to-discussion/case.json
+++ b/tests/prose/cases/spec-routes-a-gap-to-discussion/case.json
@@ -16,6 +16,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",

--- a/tests/prose/cases/spec-routes-an-unsourced-decision/case.json
+++ b/tests/prose/cases/spec-routes-an-unsourced-decision/case.json
@@ -18,6 +18,7 @@
     "skills/workflow-specification-process/references/verify-source-material.md",
     "skills/workflow-specification-process/references/initialize-specification.md",
     "skills/workflow-specification-process/references/specification-format.md",
+    "skills/workflow-shared/references/specification-body.md",
     "skills/workflow-specification-process/references/session-setup.md",
     "skills/workflow-specification-process/references/specification-principles.md",
     "skills/workflow-specification-process/references/spec-construction.md",


### PR DESCRIPTION
## Summary

A quick-fix never enters the specification phase; its scoping skill wrote the document itself in its own four-section shape, while every other work type's document is `## Specification` with numbered sections. A missed update, not a design.

- The specification body — the template, the numbered-section and stable-numbering rules, the corrigenda rule — moves out of `specification-format.md` into a shared reference, `workflow-shared/references/specification-body.md`, which the specification phase and the scoping skill both load. The format file keeps its manifest-field table and loads the body.
- The scoping skill writes `## Specification` with `### 1. Change Description` … `### 4. Verification`, then `## Working Notes`, guidance unchanged.
- The review's executing pass keys its quick-fix rule on the work type, never on the document's headings: a quick-fix dispatches one section over the whole document, no test surface; every other type splits by its numbered sections plus the test surface.
- The scoping case asserts the shared shape; the 13 specification cases and the scoping case declare the shared reference in their `files`.

No existing quick-fix document is migrated: the pass keys on work type whatever the headings, so old-shaped documents still take the quick-fix branch.

## Verification

`npm test` 2848/2848, `npm run test:cli` green, `npm run typecheck` clean, `run.cjs verify` no drift. Not walked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)