### PR TITLE
impl(prose): the change-set pass reads its cycle number with the synthesizer's command, and hands the floor on unread

### DIFF
--- a/skills/workflow-review-process/references/invoke-change-set-verifiers.md
+++ b/skills/workflow-review-process/references/invoke-change-set-verifiers.md
@@ -10,7 +10,13 @@ This step dispatches `workflow-review-change-set-verifier` agents once per revie
 
 ## A. Derive Sections
 
-The cycle number `{N}` is the one **[invoke-review-synthesizer.md](invoke-review-synthesizer.md)** → Determine Cycle Number derives — the count of `review-report-c*.md` files in `.workflows/{work_unit}/implementation/{topic}/` plus one. Every file this step writes or reads carries it, so a later cycle measures the change-set as it then stands rather than reading the previous cycle's files.
+The cycle number `{N}` is the one **[invoke-review-synthesizer.md](invoke-review-synthesizer.md)** → Determine Cycle Number derives — the count of `review-report-c*.md` files in the implementation directory plus one, the count reading zero when the directory does not exist yet:
+
+```bash
+ls .workflows/{work_unit}/implementation/{topic}/review-report-c*.md 2>/dev/null | wc -l
+```
+
+Every file this step writes or reads carries it, so a later cycle measures the change-set as it then stands rather than reading the previous cycle's files.
 
 Read the specification at `.workflows/{work_unit}/specification/{topic}/specification.md`. The split keys on the work type read in **[invoke-task-verifiers.md](invoke-task-verifiers.md)** → B. Extract All Tasks, never on the document's headings:
 
@@ -46,7 +52,7 @@ Every agent receives the same change-set and the same project conventions.
    node .claude/skills/workflow-engine/scripts/engine.cjs manifest get {work_unit}.implementation.{topic} linters
    ```
 3. **The project conventions** — the project's `CLAUDE.md` when one exists at the project root, and the project skill paths from Step 3
-4. **The finding floor** — `.claude/skills/workflow-implementation-process/references/finding-floor.md`
+4. **The finding floor** — the path `.claude/skills/workflow-implementation-process/references/finding-floor.md`, handed on unread; the agents load it
 5. **The unsettled criteria** — `.workflows/.cache/{work_unit}/review/{topic}/unsettled.txt`; absent means the task verifiers settled every criterion by reading, and the agents are told so
 
 → Proceed to **C. Dispatch**.

--- a/tests/prose/cases/review-approves-the-work/assert.md
+++ b/tests/prose/cases/review-approves-the-work/assert.md
@@ -17,7 +17,9 @@ The prose should have taken this path:
 5. both verified task ids are pushed onto the reviewed list, and the
    aggregation reads every per-task report — no criterion was recorded
    as unsettled, so no unsettled file is written
-6. the change-set verification derives its sections from the
+6. the change-set verification reads the cycle number as 1 — the
+   implementation directory does not exist, the count reads zero, no
+   error to recover from — derives its sections from the
    specification's numbered headings — the payment-intent section, the
    capture section, and the test surface — finds none of this cycle's
    files (`change-set-c1-…`) already written, gathers the brief (the

--- a/tests/prose/cases/review-measures-the-change-set/assert.md
+++ b/tests/prose/cases/review-measures-the-change-set/assert.md
@@ -78,7 +78,8 @@ Further claims:
 - the section agents are given the specification path, the change-set,
   the project's conventions — the root `CLAUDE.md` among them — the
   finding floor path and the unsettled file path — never a per-task
-  report
+  report; the floor travels as a path, which the review itself never
+  reads
 - the working tree is checked after the section agents return, and the
   review continues only because nothing outside `.workflows/` is
   modified or untracked — the review's own uncommitted reports and


### PR DESCRIPTION
## Summary

Two findings from the re-walks after #1121, both in `invoke-change-set-verifiers.md`.

- **Cycle-number lookup on a first review.** The pass derived the cycle by prose alone — "the count of `review-report-c*.md` files in the implementation directory plus one" — so every walker improvised an `ls` against a directory that does not exist yet and recovered from the error; five occurrences across two runs. The section now carries the synthesizer's own command, whose count reads zero on a missing directory.
- **The finding floor read by the orchestrator.** The brief item listed the floor's path under "Gather the Brief", which one walker read as "read it" and pulled the file into the review's own context (an undeclared scope hit). The item now says the path is handed on unread and the agents load it.

Cases: `review-approves-the-work` claims cycle 1 is read from the absent directory with no error to recover from; `review-measures-the-change-set` claims the review itself never reads the floor.

## Verification

`npm test` 2848/2848. No engine change. Intersecting cases: the four review walks and `bridge-completes-the-feature` — not walked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)