### PR TITLE
impl(prose): the blocking tag is written where the prep payloads are written

### DIFF
--- a/skills/workflow-review-process/references/prep-findings.md
+++ b/skills/workflow-review-process/references/prep-findings.md
@@ -10,7 +10,7 @@ Every agent here is read-only. They judge; nothing is edited.
 
 ## A. Collect the Findings
 
-Read the `report-*.md` files and this cycle's `change-set-c{N}-*.md` files in `.workflows/{work_unit}/review/{topic}/` — `{N}` as **A. Derive Sections** of **[invoke-change-set-verifiers.md](invoke-change-set-verifiers.md)** derives it — and collect from both streams: every `FINDINGS` entry, and every `BLOCKING ISSUES` entry other than `- None`. A blocking entry joins the payloads marked `[blocking]` in place of the scope and radius tags. It usually pairs with a `FINDINGS` line in the same report that prescribes its remedy — carry both; the relationships agent sees the pair as one group, and synthesis routes the blocking issue by the remedy's radius.
+Read the `report-*.md` files and this cycle's `change-set-c{N}-*.md` files in `.workflows/{work_unit}/review/{topic}/` — `{N}` as **A. Derive Sections** of **[invoke-change-set-verifiers.md](invoke-change-set-verifiers.md)** derives it — and collect from both streams: every `FINDINGS` entry, and every `BLOCKING ISSUES` entry other than `- None`. A blocking entry usually pairs with a `FINDINGS` line in the same report that prescribes its remedy — carry both; the relationships agent sees the pair as one group, and synthesis routes the blocking issue by the remedy's radius.
 
 **When `unreviewed_tasks` is set and the review file already exists** (a later cycle over remediation work), collect from those tasks' reports and from this cycle's change-set files — the earlier cycle's findings, its change-set files' included, were already resolved, and re-collecting them would redo decided work. With no review file on disk the cycle never completed: collect from every report and from this cycle's change-set files, whatever `unreviewed_tasks` holds.
 
@@ -28,8 +28,8 @@ Nothing is written — the payloads exist only for findings.
 
 Write two payloads with the Write tool:
 
-- `.workflows/.cache/{work_unit}/review/{topic}/findings.txt` — one block per finding, opening with `[{id}]`, carrying the finding verbatim
-- `.workflows/.cache/{work_unit}/review/{topic}/findings-index.txt` — the same findings grouped under `### {file}` headings by the file each targets, one summary line each
+- `.workflows/.cache/{work_unit}/review/{topic}/findings.txt` — one block per finding, opening with `[{id}]`, carrying the finding verbatim with its scope and radius tags; a blocking entry's block carries `[blocking]` where those tags would sit
+- `.workflows/.cache/{work_unit}/review/{topic}/findings-index.txt` — the same findings grouped under `### {file}` headings by the file each targets, one summary line each, a blocking entry's line carrying `[blocking]`
 
 → Proceed to **B. Assess**.
 

--- a/skills/workflow-review-process/references/template.md
+++ b/skills/workflow-review-process/references/template.md
@@ -25,7 +25,7 @@
 
 ### Plan Completion
 - [ ] Phase N acceptance criteria met, except any named below as not measured
-- [ ] All tasks completed or deliberately discarded (list any skipped/cancelled tasks here — discards are disclosed, never silent)
+- [ ] All tasks completed or deliberately discarded [any skipped or cancelled tasks named here — discards are disclosed, never silent]
 - [ ] No scope creep
 
 **Criteria not measured**

--- a/tests/prose/cases/review-corrects-a-blocking-issue/assert.md
+++ b/tests/prose/cases/review-corrects-a-blocking-issue/assert.md
@@ -34,7 +34,8 @@ The prose should have taken this path:
    is written
 6. findings prep collects three entries out of the per-task reports into
    its own payloads — the section files carry none — the blocking entry
-   marked [blocking], its id built from its task suffix and its position
+   marked `[blocking]` in both payloads, the tag written where a finding's
+   scope and radius tags sit, its id built from its task suffix and its position
    in that report's blocking list, and the two findings with ids built
    from their task suffixes and positions — then dispatches the
    assessment agents — assessor, guards and relationships — with

--- a/tests/prose/cases/review-preps-and-applies-findings/assert.md
+++ b/tests/prose/cases/review-preps-and-applies-findings/assert.md
@@ -46,7 +46,8 @@ The prose should have taken this path:
    verdict — its Specification Compliance carrying the three sections'
    coverage maps as their files record them, its Plan Completion's bold
    `Criteria not measured` line reading `none`, its corrected section
-   recording what was applied — and committed
+   recording what was applied, and none of the template's bracketed
+   authoring guidance carried into it — and committed
 10. the outcome renders through the review presentation surface as a
    pass — the corrections a count, nothing listed, since nothing in this
    review is the user's to decide — and at the review gate the user


### PR DESCRIPTION
## Summary

From the third re-walk of the review cases after #1122.

- **`[blocking]` dropped from the prep payloads** (`review-corrects-a-blocking-issue` FLAKY, second occurrence in four walks). `prep-findings.md` stated the rule in its collect paragraph and, four paragraphs later, told the payload write to carry each finding "verbatim" — so the write forgot the tag. Every downstream agent keys on it: relationships pairs by it, the assessor judges by it, synthesis sets the action's `blocking` flag by it; a live pipeline that drops it loses the blocking status silently. The rule now sits on the two payload bullets themselves, stated once.
- **Template authoring note copied into the report.** The Plan Completion line's parenthetical "(list any skipped/cancelled tasks here …)" was plain text, so one walk carried it verbatim into `report.md`. It is now a bracketed placeholder like the rest of the template.

Cases: the blocking walk claims the tag in both payloads where the scope and radius tags sit; the applying walk claims no authoring guidance reaches the report.

Not addressed here: `review-preps-and-applies-findings` FAIL — the walker skipped the step chrome and the compliance re-reads on two different runs, its own self-check admitting both; walker discipline, not prose. One Opus walk owed to confirm the prose holds when followed.

## Verification

`npm test` 2848/2848. No engine change. Intersecting cases: the four review walks and `bridge-completes-the-feature` — not walked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)