### PR TITLE
test(prose): the requeue case expects the announcement the prose prescribes

### DIFF
--- a/tests/prose/cases/discussion-requeues-a-research-concern/assert.md
+++ b/tests/prose/cases/discussion-requeues-a-research-concern/assert.md
@@ -19,8 +19,10 @@ The prose should have taken this path:
 4. the user takes the move; one `topic requeue` transaction renumbers
    the file into synonym-handling's research queue, creates the
    research item as `triaged` (parked, never started), and commits
-   action-scoped; the session announces where the concern now waits
-   and, the queue being empty, emits the clear line
+   action-scoped; the session announces where the concern now waits —
+   that this discussion cannot conclude, nor be re-entered once this
+   session closes, until the research lands, the menu carrying the way
+   in — and, the queue being empty, emits the clear line
 5. the concern never becomes session material: no subtopic is added
    for it, no breakdown is presented, nothing about it is written
    into the discussion document


### PR DESCRIPTION
Walk finding from the research-entry stack (#1123/#1125). `discussion-requeues-a-research-concern` PASSed, but its asserter flagged the walker's move announcement — "cannot conclude, nor be re-entered once this session closes, until the research lands" — as unsupported. That line is what `rerouted-concerns.md` §F prescribes, and the entry gate does hold re-entry. The expected path now names it so the next judge does not repeat the note.

No prose change. `test-prose-cases` + `test-prose-invariants` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)