### PR TITLE
test(prose): the scope ratchet counts only reads that returned

### DIFF
--- a/tests/prose/lib/invariants.cjs
+++ b/tests/prose/lib/invariants.cjs
@@ -88,11 +88,15 @@ const NAMES = ['engine_before_write', 'calls_include', 'calls_exclude', 'calls_i
  *
  * A world holds the skills at `.claude/skills/`; the corpus names them at
  * `skills/`. Same file, two addresses, so one is translated to the other.
+ *
+ * Only a read that returned counts. A walker guessing at a path leaves a
+ * PreToolUse row and a FAILED row for a file that does not exist; the
+ * PostToolUse row is the one a file it actually opened leaves.
  */
 function proseRead(rows) {
   const seen = new Set();
   for (const row of rows) {
-    if (row.tool !== 'Read') continue;
+    if (row.tool !== 'Read' || row.event !== 'PostToolUse') continue;
     const m = row.detail.match(/\.claude\/skills\/(.+\.md)$/);
     if (m) seen.add(`skills/${m[1]}`);
   }

--- a/tests/scripts/test-prose-invariants.cjs
+++ b/tests/scripts/test-prose-invariants.cjs
@@ -525,7 +525,7 @@ describe('entry points — where a walk may begin', () => {
 });
 
 describe('undeclared prose — the case list against what the walk opened', () => {
-  const rd = (detail) => ({ event: 'PreToolUse', tool: 'Read', detail });
+  const rd = (detail) => ({ event: 'PostToolUse', tool: 'Read', detail, outcome: 'ok' });
 
   it('names prose the walk opened that the case never declared', () => {
     const rows = [
@@ -557,5 +557,17 @@ describe('undeclared prose — the case list against what the walk opened', () =
     const f = './.claude/skills/workflow-start/references/active-work.md';
     assert.deepEqual(invariants.undeclaredProse([rd(f), rd(f)], []),
       ['skills/workflow-start/references/active-work.md']);
+  });
+
+  it('ignores a read that failed — a guessed path is not prose the walk opened', () => {
+    const guess = './.claude/skills/shared/references/instructions.md';
+    const rows = [
+      { event: 'PreToolUse', tool: 'Read', detail: guess },
+      { event: 'PostToolUseFailure', tool: 'Read', detail: guess, outcome: 'FAILED' },
+      { event: 'PreToolUse', tool: 'Read', detail: './.claude/skills/workflow-shared/references/instructions.md' },
+      rd('./.claude/skills/workflow-shared/references/instructions.md'),
+    ];
+    assert.deepEqual(invariants.undeclaredProse(rows, []),
+      ['skills/workflow-shared/references/instructions.md']);
   });
 });


### PR DESCRIPTION
From the fourteen-case walk run after #1130. `spec-routes-an-unsourced-decision` reported `skills/shared/references/instructions.md` as undeclared prose — a path that does not exist. The walker guessed it, the read failed, and `proseRead` counted the PreToolUse row anyway.

`proseRead` now counts a Read only from its PostToolUse row, which only a read that returned leaves. The existing undeclared-prose tests move their helper to that row shape; one new test pins a failed guess beside the real read it was followed by.

Gates: `npm test` green, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)