### PR TITLE
test(prose): a resumed sitting is offered its queue at the door — the past-a-later case expects the offer, not an announce

### DIFF
--- a/tests/prose/cases/research-concludes-past-a-later/assert.md
+++ b/tests/prose/cases/research-concludes-past-a-later/assert.md
@@ -8,19 +8,18 @@ The prose should have taken this path:
    thread register once above resume detection, and the user continues;
    initialisation is skipped
 3. the walk routes into the epic research session; the loop's first
-   check finds the queue holding one concern and the sitting freshly
-   opened, so the triage announce renders and the session opens from
-   its own material without offering yet
-4. the user asks what is waiting — that is the user asking for the
-   queue, which satisfies the first offer's deferral — and the offer
-   renders; the user says later
-5. the user says their one thing (the metric they are taking forward),
-   which the session documents and commits; then the user says they are
-   done, and the wrapper routes to its conclusion handling: the fold
-   check finds nothing landed, nothing is in flight, and the walk enters
-   topic completion, whose first act is the queue check — it reads one
-   entry and renders the blocker, returning to the session loop
-6. back in the loop, the triage check judges the break: the user
+   check finds the queue holding one concern and the sitting resumed —
+   the artifact predates this session — so the offer renders before any
+   session output, no announce; the user says later
+4. the user says their one thing — the metric they are taking forward,
+   asked to be written down — which the session documents in the
+   research file and commits with the cadence message; then the user
+   says they are done, and the wrapper routes to its conclusion
+   handling: the fold check finds nothing landed, nothing is in flight,
+   and the walk enters topic completion, whose first act is the queue
+   check — it reads one entry and renders the blocker, returning to the
+   session loop
+5. back in the loop, the triage check judges the break: the user
    chose `later` one turn ago, and the checklist's deferral would hold —
    except the user is now concluding, which is the break the deferral
    was waiting for; the offer renders again in the same turn, and the

--- a/tests/prose/cases/research-concludes-past-a-later/case.json
+++ b/tests/prose/cases/research-concludes-past-a-later/case.json
@@ -32,26 +32,25 @@
     "c — continue",
     "l — later"
   ],
-  "conduct": "The user comes back to close the measurement research out. They open by asking what is waiting in the queue for this topic, hear the concern offered, and say later — they want to say one thing first: that NDCG@10 over click-derived judgments is the metric they will take into the discussion, nothing more to add. Then they say they are done and want to conclude. They run the shop and introduce no new material; when the queue is offered again after the blocker, the walk has reached its stop and they answer nothing.",
+  "conduct": "The user comes back to close the measurement research out. The queue's one concern is offered to them at the door and they say later — they want to say one thing first, and want it written down: that NDCG@10 over click-derived judgments is the metric they will take into the discussion; the file still calls it the leading candidate, and they are done weighing. Then they say they are done and want to conclude. They run the shop and introduce no new material beyond that one position; when the queue is offered again after the blocker, the walk has reached its stop and they answer nothing.",
   "invariants": {
     "engine_before_write": true,
     "calls_include": [
       "manifest get search-relevance.research.relevance-measurement status",
       "render resume-gate search-relevance.research.relevance-measurement",
       "topic queue search-relevance research relevance-measurement",
-      "render triage-announce search-relevance.research.relevance-measurement",
       "render triage-offer search-relevance.research.relevance-measurement",
       "render triage-block search-relevance.research.relevance-measurement"
     ],
     "calls_in_order": [
       "manifest get search-relevance.research.relevance-measurement status",
       "render resume-gate search-relevance.research.relevance-measurement",
-      "render triage-announce search-relevance.research.relevance-measurement",
       "render triage-offer search-relevance.research.relevance-measurement",
       "render triage-block search-relevance.research.relevance-measurement",
       "render triage-offer search-relevance.research.relevance-measurement"
     ],
     "calls_exclude": [
+      "render triage-announce",
       "topic absorb",
       "topic requeue",
       "topic complete",


### PR DESCRIPTION
## Summary

Fixes the reproduced FAIL on `research-concludes-past-a-later` (2/2 walks, 2026-09-12). Case-only: the prose is right.

- The triage check's first-consult branch offers the queue before any session output when the sitting resumed existing work (`rerouted-concerns.md § A`, in place since #723); the announce is the fresh-start arm. The case expected the announce on a resumed fixture. `calls_include`/`calls_in_order` drop `render triage-announce`, `calls_exclude` gains it, and the path reads offer → later → remark → done → blocker → re-offer.
- Both walks declined to write the user's closing remark because the file already named NDCG@10 as the leading candidate. The conduct now has the user ask for it written down as their position, so the expected world's documented remark is no longer a judgment call.

## Test plan

- [x] `test-prose-cases`, `test-prose-invariants`, `test-prose-snapshots` green
- [ ] Re-walk `research-concludes-past-a-later` on Lee's word

🤖 Generated with [Claude Code](https://claude.com/claude-code)