### PR TITLE
fix(research): no dive is offered on a thread the user is carrying out to the conclusion

### DIFF
--- a/skills/workflow-research-process/references/session-loop.md
+++ b/skills/workflow-research-process/references/session-loop.md
@@ -16,7 +16,7 @@ Not a rigid checklist — a natural cadence for productive research conversation
 
 2. **Explore** — Probe the topic from a relevant angle. Use the funnel technique: broad first, specific later. Choose your probe type deliberately. One question at a time — wait for the answer before asking the next. A number about to bear a decision — or a measurement thread on the register, a dive's Opened line — is the laboratory's cue: offer it through the session wrapper's **F. The Experiment Offer**.
 
-   A question neither of you can answer from the room, worth more than a lookup, is the deep dive's cue — offer it through **A. Offer** in **[deep-dive-agent.md](deep-dive-agent.md)**.
+   A question neither of you can answer from the room, worth more than a lookup, is the deep dive's cue — offer it through **A. Offer** in **[deep-dive-agent.md](deep-dive-agent.md)**. A thread the user is carrying out to the conclusion is not reached, it is handed on: no offer rides a done-signal.
 
 3. **Engage** — Don't just collect the answer. React to it. Challenge assumptions. Explore implications. Follow promising tangents. Connect what the user just said to something from earlier. This is where your value as a research partner lives — you're thinking alongside, not just recording.
 


### PR DESCRIPTION
## Summary

Fixes the FLAKY on `research-concludes-with-open-threads` (walk 1 rendered `deep-dive-offer` on the open label-freshness thread when the user came only to conclude — `calls_exclude` FAIL, a cache scratch left, an undeclared `natural-breaks.md` read; walk 2 clean 8/8). `session-loop.md` step 2's cue now carries its exception: a thread the user is carrying out to the conclusion is handed on, never offered. Covering case: the existing one.

## Test plan

- [x] conventions lint + prose corpus green
- [ ] Re-walk `research-concludes-with-open-threads` on Lee's word

🤖 Generated with [Claude Code](https://claude.com/claude-code)