### PR TITLE
fix(discussion): the raise's pre-send test checks the alternative for a second cost

### DIFF
--- a/skills/workflow-discussion-process/references/composing-a-raise.md
+++ b/skills/workflow-discussion-process/references/composing-a-raise.md
@@ -48,6 +48,6 @@ The raise ends by saying what kind of reply moves things forward. One of three s
 
 A dead stop is not an ending: a raise that trails off after its position leaves the user unsure whether a reply is owed or the conversation broke. No keyed menu, no bundled follow-ups, no stock closer: "what do you think?" is never the ask, and a closing beat repeated verbatim across the walk reads as chrome, not a colleague — phrase it from the finding just raised. The beat draws only on what the opener already said — reaching into the held-back depth for a concrete pivot is how the case leaks back in one clause at a time.
 
-**The test**, before the raise goes out — read it as the user will, cold, in one glance: they can picture the behaviour, they know where you stand, and they know what reply is wanted, with no code identifier, no report named ahead of their situation, and no tuning number in front of them. A raise that fails is recomposed at altitude, never sent and explained after.
+**The test**, before the raise goes out — read it as the user will, cold, in one glance: they can picture the behaviour, they know where you stand, and they know what reply is wanted, with no code identifier, no report named ahead of their situation, no tuning number in front of them, and no second cost on the alternative. A raise that fails is recomposed at altitude, never sent and explained after.
 
 → Return to caller.


### PR DESCRIPTION
## Summary

Fixes the FLAKY on `discussion-raises-problem-then-position` (walk 1's position clause costed the alternative twice — the double-charge window plus the orphaned-intent reconciliation burden; walk 2 held one clause). `composing-a-raise.md` B already forbids a second cost; the pre-send test in C now names it as a thing to read for, alongside the code identifier and the tuning number. Covering case: the existing one.

## Test plan

- [x] conventions lint + prose corpus green
- [ ] Re-walk `discussion-raises-problem-then-position` on Lee's word

🤖 Generated with [Claude Code](https://claude.com/claude-code)