### PR TITLE
fix(research): a reshaped thread is reframed at the dive offer, never added beside itself; the carrier read names its tool

### DIFF
--- a/skills/workflow-discussion-entry/SKILL.md
+++ b/skills/workflow-discussion-entry/SKILL.md
@@ -117,7 +117,7 @@ Decide whether a context interview is needed. The durable inputs — the carrier
 
 #### If `work_type` is not `epic`
 
-Single-phase work (feature, cross-cutting) shaped in discovery leaves its carrier in the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/sessions/session-001.md` and check its **Exploration** section. A legacy work unit may have no log, or a placeholder log whose **Exploration** is absent or `(none)`.
+Single-phase work (feature, cross-cutting) shaped in discovery leaves its carrier in the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/sessions/session-001.md` with the Read tool and check its **Exploration** section. A legacy work unit may have no log, or a placeholder log whose **Exploration** is absent or `(none)`.
 
 **If the log's `Exploration` section has content (not absent or `(none)`):**
 

--- a/skills/workflow-research-entry/SKILL.md
+++ b/skills/workflow-research-entry/SKILL.md
@@ -119,7 +119,7 @@ Decide whether a context interview is needed. The durable inputs — the carrier
 
 #### If `work_type` is not `epic`
 
-Single-phase work (feature, cross-cutting) shaped in discovery leaves its carrier in the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/sessions/session-001.md` and check its **Exploration** section. A legacy work unit may have no log, or a placeholder log whose **Exploration** is absent or `(none)`.
+Single-phase work (feature, cross-cutting) shaped in discovery leaves its carrier in the discovery session log. Single-phase work has exactly one, at a fixed path — it has no resumable loop to create others. Read `.workflows/{work_unit}/discovery/sessions/session-001.md` with the Read tool and check its **Exploration** section. A legacy work unit may have no log, or a placeholder log whose **Exploration** is absent or `(none)`.
 
 **If the log's `Exploration` section has content (not absent or `(none)`):**
 

--- a/skills/workflow-research-process/references/deep-dive-agent.md
+++ b/skills/workflow-research-process/references/deep-dive-agent.md
@@ -22,7 +22,7 @@ Two ids appear below: `{id}` is the row id the dispatch answers (`deep-dive-{NNN
 
 Offer a dive where the conversation reaches a question neither party can answer from the room and the answer is worth more than a lookup — a substantial thread, independent of what is being discussed right now, that dedicated tools (web search, source code, documentation) would serve. Quick lookups, single searches, and questions that inform the next conversational turn stay in the main thread.
 
-The register is the anchor: the offer names a thread. A question new to the register is added first — origin `user` when the user raised it, `conversation` otherwise:
+The register is the anchor: the offer names a thread. A question new to the register is added first — origin `user` when the user raised it, `conversation` otherwise; a question that reshapes a thread already on the register is that thread, reframed, never a second row beside it:
 
 ```bash
 node .claude/skills/workflow-engine/scripts/engine.cjs research-threads add {work_unit} {topic} {slug} --question "{the question, as asked}" --origin {user|conversation} [--parent {slug}]

--- a/tests/prose/cases/research-threads-bend/case.json
+++ b/tests/prose/cases/research-threads-bend/case.json
@@ -24,7 +24,8 @@
     "skills/workflow-research-process/references/feature-session.md",
     "skills/workflow-research-process/references/session-loop.md",
     "skills/workflow-research-process/references/deep-dive-agent.md",
-    "skills/workflow-shared/references/rerouted-concerns.md"
+    "skills/workflow-shared/references/rerouted-concerns.md",
+    "skills/workflow-research-process/references/topic-completion.md"
   ],
   "answers": [
     "c — continue",


### PR DESCRIPTION
## Summary

Re-walk of `research-threads-bend` after #1145 FAILed twice on different grounds.

- **Walk 1** reached the deep-dive offer holding the reshaped hosted-fields question and followed `deep-dive-agent.md § A`'s "a question new to the register is added first" — it added a second row for the reshaped question, then marked `hosted-fields` learned as "a distinct thread already on the register" (its own words). The offer now says a question that reshapes a thread already on the register is that thread, reframed, never a second row beside it. This is the seam #1145's session-loop clause did not reach.
- **Walk 2** skipped the entry's Step 4 carrier read of the discovery log (no Read of `.workflows/pay/discovery/` anywhere in the record). Both entry skills now say the read is a Read tool call, the form `rerouted-concerns.md § C` already uses for the queue file.
- The case declares `topic-completion.md`, which the walker opened to weigh the stepping-away line against the done-signal (flagged as undeclared scope).

## Test plan

- [x] prose corpus, conventions lint, snapshot goldens — 174/174
- [ ] Re-walk `research-threads-bend` on Lee's word

🤖 Generated with [Claude Code](https://claude.com/claude-code)